### PR TITLE
[Fix] 死亡回数のダンプ抜け修正。時空崩壊度を小数点6桁までダンプで表示。

### DIFF
--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -232,6 +232,11 @@ errr parse_r_info(std::string_view buf, angband_header *)
                 continue;
             }
 
+            if (s_tokens.size() == 2 && s_tokens[0] == "COLLAPSE") {
+                info_set_value(r_ptr->plus_collapse, s_tokens[1]);
+                continue;
+            }
+
             if (s_tokens.size() == 6 && s_tokens[0] == "SPAWN") {
                 // 落とし子自動生成率
                 if (s_tokens[1] == "CREATURE" && s_tokens[3] == "IN") {

--- a/src/system/monster-race-definition.h
+++ b/src/system/monster-race-definition.h
@@ -92,6 +92,7 @@ struct monster_race {
     MONSTER_NUMBER max_num{}; //!< 動員基本最大数
     MONSTER_NUMBER mob_num{}; //!< 動員可能数
     MONSTER_NUMBER cur_num{}; //!< 階に現在いる数 / Monster population on current level
+    int32_t plus_collapse{}; //!< 死亡時の時空崩壊度進行値
     FLOOR_IDX floor_id{}; //!< 存在している保存階ID /  Location of unique monster
     MONSTER_NUMBER r_sights{}; //!< 見えている数 / Count sightings of this monster
     MONSTER_NUMBER r_deaths{}; //!< このモンスターに殺された人数 / Count deaths from this monster

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -256,6 +256,8 @@ static void display_playtime_in_game(player_type *player_ptr)
 
     display_player_one_line(ENTRY_DAY, buf, TERM_L_GREEN);
 
+    display_player_one_line(ENTRY_WORLD_COLLAPSE, format("%3d.%06d%%", w_ptr->collapse_degree / 1000000, w_ptr->collapse_degree % 1000000), TERM_L_GREEN);
+
     if (player_ptr->chp >= player_ptr->mhp)
         display_player_one_line(ENTRY_HP, format("%4d/%4d", player_ptr->chp, player_ptr->mhp), TERM_L_GREEN);
     else if (player_ptr->chp > (player_ptr->mhp * hitpoint_warn) / 10)

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -135,6 +135,7 @@ static void display_phisique(player_type *player_ptr)
 #endif
     std::string alg = PlayerAlignment(player_ptr).get_alignment_description();
     display_player_one_line(ENTRY_ALIGN, format("%s", alg.c_str()), TERM_L_BLUE);
+    display_player_one_line(ENTRY_DEATH_COUNT, format("%d  ", (int)player_ptr->death_count), TERM_L_BLUE);
 }
 
 /*!

--- a/src/view/display-util.cpp
+++ b/src/view/display-util.cpp
@@ -27,10 +27,10 @@ const std::vector<disp_player_line> disp_player_lines = {
     { 29, 15, 21, _("最大経験", "Max Exp") },
     { 29, 16, 21, _("次レベル", "Exp to Adv") },
     { 29, 17, 21, _("所持金", "Gold") },
-    { 29, 19, 21, _("日付", "Time") },
+    { 29, 18, 21, _("日付", "Time") },
     { 29, 10, 21, _("ＨＰ", "Hit point") },
     { 29, 11, 21, _("ＭＰ", "SP (Mana)") },
-    { 29, 20, 21, _("プレイ時間", "Play time") },
+    { 29, 19, 21, _("プレイ時間", "Play time") },
     { 53, 10, -1, _("打撃命中  :", "Fighting   : ") },
     { 53, 11, -1, _("射撃命中  :", "Bows/Throw : ") },
     { 53, 12, -1, _("魔法防御  :", "SavingThrow: ") },
@@ -58,6 +58,7 @@ const std::vector<disp_player_line> disp_player_lines = {
     { 29, 16, 21, _("次レベル", "Const to Adv") },
     { 53, 19, -1, _("掘削      :", "Digging    : ") },
 	{ 29,  8, 21, _("死亡回数" , "Dead")},
+    { 29, 21, 21, _("時空崩壊度", "W. Collapse") },
 };
 }
 

--- a/src/view/status-first-page.h
+++ b/src/view/status-first-page.h
@@ -51,5 +51,7 @@
 #define ENTRY_EXP_TO_ADV_ANDR 44
 
 #define ENTRY_DEATH_COUNT 46
+#define ENTRY_WORLD_COLLAPSE 47
+
 class player_type;
 void display_player_various(player_type *player_ptr);


### PR DESCRIPTION
細かい抜けなのでIssueはなし。