### PR TITLE
[add]オレンジ色の水晶像 / Orange crystal statue

### DIFF
--- a/lib/edit/r_info.txt
+++ b/lib/edit/r_info.txt
@@ -29786,6 +29786,24 @@ D:フェラチオザウルス(学名:Fellatiosaurus)は、
 D:紀元前1世紀(諸説あり)～現在(中生代白濁紀末期マスカカズシテモラウ)の地球全土に性交渉している肉食淫竜。
 D:非常に有名な淫竜で、『ディープ・スロート』等の陰茎をテーマにした各種のポルノ作品においては、前戯の象徴として描（後略）
 
+N:1576:オレンジ色の水晶像
+E:Orange crystal statue
+G:g:o
+I:120:800d1:50:100:5
+W:80:4:0:12000:0:0
+F:EVIL | NONLIVING | NEVER_BLOW | SMART | NO_STUN | NO_FEAR
+F:NO_CONF | NO_SLEEP | HURT_ROCK | IM_ELEC | IM_FIRE | IM_COLD
+F:IM_POIS | RES_NETH | RES_CHAO | RES_DISE | RES_GRAV | RES_TELE
+F:NEVER_MOVE | COLD_BLOOD | EMPTY_MIND
+S:1_IN_2
+S:DRAIN_MANA | BRAIN_SMASH | CONF | S_MONSTERS
+D:$An intricately carved idol of some nameless godling, hewn of translucent orange crystal.
+D:$Its lifeless eyes seem to glitter uncannily with a wicked intelligence.
+D:$It is capable of unleashing a powerful psychic assault upon the minds of any who approach it.
+D:半透明のオレンジ色の水晶で精巧に彫られた名もなき小神の彫像だ。
+D:その生命のない目は邪悪な知性で不思議なことに煌めいて見える。
+D:それは近づく者の心に強力な精神攻撃を解き放つだろう。（Dungeon Crawl)
+
 # N: serial number : monster name
 # G: symbol : color
 # I: speed : hit points : vision : armor class : alertness


### PR DESCRIPTION
Dungeon Crawlより、オレンジ色の水晶像を追加した。
大分えげつない性能であり、ほぼ無駄行動がないので80F相当の地下送りとしている。

こちらでざっと見て問題なければ変愚の深層辺りでも送ってみようかと思います。
ご確認をお願いいたします。