### PR TITLE
[Refactor] 独自定義例外に継承コンストラクタを使用する

### DIFF
--- a/src/system/angband-exceptions.h
+++ b/src/system/angband-exceptions.h
@@ -4,8 +4,5 @@
 
 class SaveDataNotSupportedException : public std::runtime_error {
 public:
-    SaveDataNotSupportedException(const char *message)
-        : std::runtime_error(message)
-    {
-    }
+    using std::runtime_error::runtime_error;
 };


### PR DESCRIPTION
継承元の例外クラス (std::runtime_error等) のコンストラクタをすべて使えるようにする ため、自作のコンストラクタではなく継承コンストラクタを使用する。