### PR TITLE
[Fix] 暗黒免疫があるにも関わらず暗黒属性の攻撃で盲目になる

### DIFF
--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -448,7 +448,12 @@ void effect_player_dark(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
     ep_ptr->dam = ep_ptr->dam * calc_dark_damage_rate(player_ptr, CALC_RAND) / 100;
 
-    if (!player_ptr->blind && !has_resist_dark(player_ptr) && !has_resist_blind(player_ptr) && !check_multishadow(player_ptr)) {
+    auto go_blind = player_ptr->blind == 0;
+    go_blind &= !has_resist_blind(player_ptr);
+    go_blind &= !(has_resist_dark(player_ptr) || has_immune_dark(player_ptr));
+    go_blind &= !check_multishadow(player_ptr);
+
+    if (go_blind) {
         (void)BadStatusSetter(player_ptr).mod_blindness(randint1(5) + 2);
     }
 


### PR DESCRIPTION
暗黒属性の攻撃を受けた時に、盲目効果を防げるかの判定で暗黒耐性のみを見ており暗黒免疫は
見ていないため、暗黒耐性がなく免疫のみを所持している時は盲目になってしまう。
暗黒免疫を持っているかどうかも判定に加えるようにする。