### PR TITLE
[Fix] 地獄吸収で回復した際のメッセージが２回表示されてしまうバグを修正

### DIFF
--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -185,7 +185,6 @@ void effect_player_nether(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
     if (PlayerRace(player_ptr).equals(PlayerRaceType::SPECTRE)) {
         if (!evaded) {
-            msg_print(_("気分がよくなった。", "You feel invigorated!"));
             hp_player(player_ptr, ep_ptr->dam / 4);
         }
         ep_ptr->get_damage = 0;


### PR DESCRIPTION
作業量的に楽なため漢字の方に合わせました