### PR TITLE
[Refactor] calc_monrace_power() を MonsterRace のメンバ関数にする(+馬鹿馬鹿の戦力指数も織り込む)

### DIFF
--- a/src/alliance/alliance.cpp
+++ b/src/alliance/alliance.cpp
@@ -79,7 +79,7 @@ int64_t Alliance::calcCurrentPower()
     for (auto &[r_idx, r_ref] : r_info) {
         if (r_ref.alliance_idx == this->id) {
             if (r_ref.mob_num > 0) {
-                res += calc_monrace_eval(&r_ref) * r_ref.mob_num;
+                res += MonsterRace(r_idx).calc_eval() * r_ref.mob_num;
             }
         }
     }

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -248,7 +248,7 @@ static void generate_gambling_arena(PlayerType *player_ptr)
     build_battle(player_ptr, &y, &x);
     player_place(player_ptr, y, x);
     for (MONSTER_IDX i = 0; i < 4; i++) {
-        place_monster_aux(player_ptr, 0, player_ptr->y + 8 + (i / 2) * 4, player_ptr->x - 2 + (i % 2) * 4, battle_mon[i], (PM_NO_KAGE | PM_NO_PET));
+        place_monster_aux(player_ptr, 0, player_ptr->y + 8 + (i / 2) * 4, player_ptr->x - 2 + (i % 2) * 4, battle_mon_list[i], (PM_NO_KAGE | PM_NO_PET));
         set_friendly(&floor_ptr->m_list[floor_ptr->grid_array[player_ptr->y + 8 + (i / 2) * 4][player_ptr->x - 2 + (i % 2) * 4].m_idx]);
     }
 

--- a/src/knowledge/knowledge-alliance.cpp
+++ b/src/knowledge/knowledge-alliance.cpp
@@ -40,7 +40,7 @@ void do_cmd_knowledge_alliance(PlayerType *player_ptr)
 
         for (auto &[r_idx, r_ref] : r_info) {
             if (r_ref.alliance_idx == a.second->id) {
-                fprintf(fff, _("  %-40s レベル %3d 評価値 %9d", "  %-40s LEVEL %3d POW %9d"), r_ref.name.c_str(), r_ref.level, calc_monrace_eval(&r_ref));
+                fprintf(fff, _("  %-40s レベル %3d 評価値 %9d", "  %-40s LEVEL %3d POW %9d"), r_ref.name.c_str(), r_ref.level, MonsterRace(r_idx).calc_eval());
                 if (r_ref.max_num > 0) {
                     if (r_ref.mob_num > 0) {
                         fprintf(fff, "x %d\n", r_ref.mob_num);

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -63,7 +63,7 @@ void set_gambling_monsters(void)
 {
     const int max_gambling_monsters = 4;
     for (int i = 0; i < max_gambling_monsters; i++) {
-        battle_mon[i] = i2enum<MonsterRaceId>(rd_s16b());
+        battle_mon_list[i] = i2enum<MonsterRaceId>(rd_s16b());
         if (h_older_than(0, 3, 4)) {
             set_zangband_gambling_monsters(i);
         } else {

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -28,6 +28,8 @@
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include "world/world.h"
+#include <algorithm>
+#include <numeric>
 
 /*!
  * @brief 優勝時のメッセージを表示し、賞金を与える
@@ -211,7 +213,7 @@ void update_gambling_monsters(PlayerType *player_ptr)
                 }
 
                 for (j = 0; j < i; j++) {
-                    if (r_idx == battle_mon[j]) {
+                    if (r_idx == battle_mon_list[j]) {
                         break;
                     }
                 }
@@ -221,17 +223,15 @@ void update_gambling_monsters(PlayerType *player_ptr)
 
                 break;
             }
-            battle_mon[i] = r_idx;
+            battle_mon_list[i] = r_idx;
             if (r_info[r_idx].level < 45) {
                 tekitou = true;
             }
         }
 
-        for (i = 0; i < 4; i++) {
-            auto *r_ptr = &r_info[battle_mon[i]];
-            power[i] = calc_monrace_power(r_ptr);
-            total += power[i];
-        }
+        std::transform(std::begin(battle_mon_list), std::end(battle_mon_list), std::begin(power),
+            [](MonsterRace r_idx) { return MonsterRace(r_idx).calc_power(); });
+        total += std::reduce(std::begin(power), std::end(power));
 
         for (i = 0; i < 4; i++) {
             if (power[i] <= 0) {
@@ -288,7 +288,7 @@ bool monster_arena_comm(PlayerType *player_ptr)
     prt(_("モンスター                                                     倍率", "Monsters                                                       Odds"), 4, 4);
     for (int i = 0; i < 4; i++) {
         char buf[MAX_MONSTER_NAME];
-        auto *r_ptr = &r_info[battle_mon[i]];
+        auto *r_ptr = &r_info[battle_mon_list[i]];
 
         sprintf(buf, _("%d) %-58s  %4ld.%02ld倍", "%d) %-58s  %4ld.%02ld"), i + 1,
             _(format("%s%s", r_ptr->name.c_str(), r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? "もどき" : "      "),

--- a/src/monster-race/monster-race.cpp
+++ b/src/monster-race/monster-race.cpp
@@ -11,52 +11,6 @@
 /* The monster race arrays */
 std::map<MonsterRaceId, monster_race> r_info;
 
-int calc_monrace_eval(monster_race *r_ptr)
-{
-    return calc_monrace_power(r_ptr) * r_ptr->level;
-}
-
-int calc_monrace_power(monster_race *r_ptr)
-{
-    int ret = 0;
-    int num_taisei = EnumClassFlagGroup<MonsterResistanceType>(r_ptr->resistance_flags & RFR_EFF_IMMUNE_ELEMENT_MASK).count();
-
-    if (r_ptr->flags1 & RF1_FORCE_MAXHP) {
-        ret = r_ptr->hdice * r_ptr->hside * 2;
-    } else {
-        ret = r_ptr->hdice * (r_ptr->hside + 1);
-    }
-    ret = ret * (100 + r_ptr->level) / 100;
-    if (r_ptr->speed > 110) {
-        ret = ret * (r_ptr->speed * 2 - 110) / 100;
-    }
-    if (r_ptr->speed < 110) {
-        ret = ret * (r_ptr->speed - 20) / 100;
-    }
-    if (num_taisei > 2) {
-        ret = ret * (num_taisei * 2 + 5) / 10;
-    } else if (r_ptr->ability_flags.has(MonsterAbilityType::INVULNER)) {
-        ret = ret * 4 / 3;
-    } else if (r_ptr->ability_flags.has(MonsterAbilityType::HEAL)) {
-        ret = ret * 4 / 3;
-    } else if (r_ptr->ability_flags.has(MonsterAbilityType::DRAIN_MANA)) {
-        ret = ret * 11 / 10;
-    }
-    if (r_ptr->behavior_flags.has(MonsterBehaviorType::RAND_MOVE_25)) {
-        ret = ret * 9 / 10;
-    }
-    if (r_ptr->behavior_flags.has(MonsterBehaviorType::RAND_MOVE_50)) {
-        ret = ret * 9 / 10;
-    }
-    if (r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_ALL)) {
-        ret *= 100000;
-    }
-    if (r_ptr->arena_ratio) {
-        ret = ret * r_ptr->arena_ratio / 100;
-    }
-    return ret;
-}
-
 MonsterRace::MonsterRace(MonsterRaceId r_idx)
     : r_idx(r_idx)
 {
@@ -91,4 +45,58 @@ MonsterRaceId MonsterRace::pick_one_at_random()
 bool MonsterRace::is_valid() const
 {
     return this->r_idx != MonsterRaceId::PLAYER;
+}
+
+int MonsterRace::calc_eval() const
+{
+    const auto *r_ptr = &r_info[this->r_idx];
+    return this->calc_power() * r_ptr->level;
+}
+
+/*!
+ * @brief モンスター種族の総合的な強さを計算する。
+ * @details 現在はモンスター闘技場でのモンスターの強さの総合的な評価にのみ使用されている。
+ * @return 計算した結果のモンスター種族の総合的な強さの値を返す。
+ */
+int MonsterRace::calc_power() const
+{
+    int ret = 0;
+    const auto *r_ptr = &r_info[this->r_idx];
+    auto num_resistances = EnumClassFlagGroup<MonsterResistanceType>(r_ptr->resistance_flags & RFR_EFF_IMMUNE_ELEMENT_MASK).count();
+
+    if (r_ptr->flags1 & RF1_FORCE_MAXHP) {
+        ret = r_ptr->hdice * r_ptr->hside * 2;
+    } else {
+        ret = r_ptr->hdice * (r_ptr->hside + 1);
+    }
+    ret = ret * (100 + r_ptr->level) / 100;
+    if (r_ptr->speed > 110) {
+        ret = ret * (r_ptr->speed * 2 - 110) / 100;
+    }
+    if (r_ptr->speed < 110) {
+        ret = ret * (r_ptr->speed - 20) / 100;
+    }
+
+    if (num_resistances > 2) {
+        ret = ret * (num_resistances * 2 + 5) / 10;
+    } else if (r_ptr->ability_flags.has(MonsterAbilityType::INVULNER)) {
+        ret = ret * 4 / 3;
+    } else if (r_ptr->ability_flags.has(MonsterAbilityType::HEAL)) {
+        ret = ret * 4 / 3;
+    } else if (r_ptr->ability_flags.has(MonsterAbilityType::DRAIN_MANA)) {
+        ret = ret * 11 / 10;
+    }
+    if (r_ptr->behavior_flags.has(MonsterBehaviorType::RAND_MOVE_25)) {
+        ret = ret * 9 / 10;
+    }
+    if (r_ptr->behavior_flags.has(MonsterBehaviorType::RAND_MOVE_50)) {
+        ret = ret * 9 / 10;
+    }
+    if (r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_ALL)) {
+        ret *= 100000;
+    }
+    if (r_ptr->arena_ratio) {
+        ret = ret * r_ptr->arena_ratio / 100;
+    }
+    return ret;
 }

--- a/src/monster-race/monster-race.h
+++ b/src/monster-race/monster-race.h
@@ -7,9 +7,6 @@
 enum class MonsterRaceId : int16_t;
 struct monster_race;
 extern std::map<MonsterRaceId, monster_race> r_info;
-int calc_monrace_power(monster_race *r_ptr);
-int calc_monrace_eval(monster_race *r_ptr);
-bool is_valid_monster_race(MonsterRaceId r_idx);
 
 class MonsterRace {
 public:
@@ -18,6 +15,8 @@ public:
     static MonsterRaceId pick_one_at_random();
 
     bool is_valid() const;
+    int calc_eval() const;
+    int calc_power() const;
 
 private:
     const MonsterRaceId r_idx;

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -118,7 +118,7 @@ void wr_player(PlayerType *player_ptr)
     }
 
     for (int i = 0; i < 4; i++) {
-        wr_s16b(enum2i(battle_mon[i]));
+        wr_s16b(enum2i(battle_mon_list[i]));
         wr_u32b(mon_odds[i]);
     }
 

--- a/src/system/building-type-definition.cpp
+++ b/src/system/building-type-definition.cpp
@@ -1,4 +1,4 @@
 ﻿#include "system/building-type-definition.h"
 
 building_type building[MAX_BLDG];
-MonsterRaceId battle_mon[4];
+MonsterRaceId battle_mon_list[4];

--- a/src/system/building-type-definition.h
+++ b/src/system/building-type-definition.h
@@ -28,4 +28,4 @@ struct building_type {
 };
 
 extern building_type building[MAX_BLDG];
-extern MonsterRaceId battle_mon[4];
+extern MonsterRaceId battle_mon_list[4];


### PR DESCRIPTION
役割からして MonsterRace クラスのメンバ関数であるべき。
また、これを使用しているモンスター闘技場からの呼び出し部分を STL を使って書き直し、
battle_mon 配列を複数なので battle_mon_list に改名する。