### PR TITLE
[Fix] gcc-wrap を .cpp 以外の拡張子にも対応する

### DIFF
--- a/src/gcc-wrap
+++ b/src/gcc-wrap
@@ -5,7 +5,7 @@ jp=$(grep "#define JP" autoconf.h | wc -l)
 if test $jp -eq 1; then
     # Prepare the various file paths.
     eval SRC_FILE=\${$#}
-    OBJ_FILE=$(dirname $SRC_FILE)/$(basename $SRC_FILE .cpp).o
+    OBJ_FILE=$(echo $SRC_FILE | sed -E 's/\..+$/\.o/')
     SRC_DIR=$(
         cd $(dirname $0)
         pwd


### PR DESCRIPTION
gcc-wrap に渡されたソースファイルに対応するオブジェクトファイルのパス文字列を作る時に、
ソースファイルの拡張子が .cpp である事を前提としているため、MacOS への移植 Fork に あるソースファイルの拡張子 .mm (Objective C++ 用の拡張子らしい) が渡された場合にオ ブジェクトファイルのパス文字列が正しく生成されず MacOS でビルドエラーとなっている。
sed により拡張子を決め打ちせずに .o に置換することで MacOS でも正常にビルドできるよ
うにする。