### PR TITLE
[Fix] #2395 異常なカメレオンが生成されるバグを修正

### DIFF
--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -234,7 +234,7 @@ static bool monster_hook_chameleon(PlayerType *player_ptr, MonsterRaceId r_idx)
     if (r_ptr->flags2 & RF2_MULTIPLY) {
         return false;
     }
-    if (r_ptr->behavior_flags.has(MonsterBehaviorType::FRIENDLY) && (r_ptr->flags7 & RF7_CHAMELEON)) {
+    if (r_ptr->behavior_flags.has(MonsterBehaviorType::FRIENDLY) || (r_ptr->flags7 & RF7_CHAMELEON)) {
         return false;
     }
 


### PR DESCRIPTION
#2164 にて変身していないカメレオンや友好的なモンスターに変身したカメレオンが生成されてしまうが、仕様通りではないので修正