### PR TITLE
[Fix] 既に反映していたようだが一応適用(DSKL) 特定アーティファクトドロップのデータ数の制限をなくす

### DIFF
--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -484,7 +484,6 @@ errr parse_r_info(std::string_view buf, angband_header *)
         info_set_value(a_idx, tokens[1]);
         info_set_value(chance, tokens[2]);
         r_ptr->drop_artifacts.emplace_back(a_idx, chance);
-
     } else if (tokens[0] == "V") {
         // V:arena_odds
         if (tokens.size() < 2) {


### PR DESCRIPTION
特定アーティファクトドロップのデータを std::vector で持つようにし、1体につき4種まで
の制限をなくす。
ほとんどのモンスターは特定アーティファクトドロップを持たないので、無駄なメモリ消費の削
減にもなる。
また、r_info.txt 上の特定アーティファクトドロップの定義が
A:artifact_idx:rarity:chance
となっているが、rarity はゲーム内で使用されておらず、紛らわしいので削除する。