### PR TITLE
(Alliance)[Implement] アライアンスの印象値要素追加

### DIFF
--- a/src/alliance/alliance.cpp
+++ b/src/alliance/alliance.cpp
@@ -141,6 +141,13 @@ int AllianceJural::calcImpressionPoint(PlayerType *creature_ptr) const
 {
     int impression = 0;
     impression += Alliance::calcPlayerPower(*creature_ptr, 5, 10);
+    impression -= r_info[MonsterRaceId::ALIEN_JURAL].r_akills * 5;
+    if (r_info[MonsterRaceId::JURAL_MONS].mob_num == 0) {
+        impression -= 300;
+    }
+    if (r_info[MonsterRaceId::JURAL_WITCHKING].mob_num == 0) {
+        impression -= 1230;
+    }
     return impression;
 }
 

--- a/src/alliance/alliance.cpp
+++ b/src/alliance/alliance.cpp
@@ -245,7 +245,17 @@ int AllianceTheShire::calcImpressionPoint([[maybe_unused]] PlayerType *creature_
 
 int AllianceDokachans::calcImpressionPoint([[maybe_unused]] PlayerType *creature_ptr) const
 {
-    return 0;
+    auto impression = 0;
+    if (r_info[MonsterRaceId::DOKACHAN].mob_num == 0) {
+        impression -= 1000;
+    }
+    if (r_info[MonsterRaceId::OLDMAN_60TY].mob_num == 0) {
+        impression -= 1000;
+    }
+    if (r_info[MonsterRaceId::BROTHER_45TH].mob_num == 0) {
+        impression -= 1000;
+    }
+    return impression;
 }
 
 bool AllianceDokachans::isAnnihilated()

--- a/src/monster-race/race-indice-types.h
+++ b/src/monster-race/race-indice-types.h
@@ -217,6 +217,7 @@ enum class MonsterRaceId : int16_t {
     CHEST_MIMIC_04 = 1530,
     CHEST_MIMIC_11 = 1531,
     SHITTO_MASK = 1546,
+    JURAL_MONS = 1583,
     BINZYOU_MUR = 1587,
     PRINCESS_KETHOLDETH = 1590,
 

--- a/src/monster-race/race-indice-types.h
+++ b/src/monster-race/race-indice-types.h
@@ -187,6 +187,8 @@ enum class MonsterRaceId : int16_t {
     MELKO = 1287,
     STOLENMAN = 1288,
     DOKACHAN = 1307,
+    OLDMAN_60TY = 1353,
+    BROTHER_45TH = 1354,
     YENDOR_WIZARD_1 = 1360,
     YENDOR_WIZARD_2 = 1361,
     DOPPIO = 1366,


### PR DESCRIPTION
 * 例の３人を殺害すると、岡山中高年男児糞尿愛好会の印象値が大幅悪化する。
 * ジュラル星人の印象値要素追加。ジュラル星人、ジュラルモンス、ジュラルの魔王撃破でそれぞれマイナス。