### PR TITLE
[Fix] next_mirror で鏡のマスと同じ座標にある場合、抽選し直すように修正

### DIFF
--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -255,8 +255,10 @@ void SpellsMirrorMaster::next_mirror(int *next_y, int *next_x, int cury, int cur
         return;
     }
 
-    *next_y = cury + randint0(5) - 2;
-    *next_x = curx + randint0(5) - 2;
+    do {
+        *next_y = cury + randint0(5) - 2;
+        *next_x = curx + randint0(5) - 2;
+    } while ((*next_y == cury) && (*next_x == curx));
 }
 
 void SpellsMirrorMaster::project_seeker_ray(int target_x, int target_y, int dam)


### PR DESCRIPTION
抽選し直しは可読性を考え、do-whileで実装