### PR TITLE
[Fix] 英語版でキャラクタダンプ出力時にクラッシュする

### DIFF
--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -556,19 +556,11 @@ static void dump_aux_home_museum(PlayerType *player_ptr, FILE *fff)
 
     TERM_LEN x = 1;
     for (int i = 0; i < store_ptr->stock_num; i++) {
-#ifdef JP
         if ((i % 12) == 0) {
-            fprintf(fff, "\n ( %d ページ )\n", x++);
+            fprintf(fff, _("\n ( %d ページ )\n", "\n ( page %d )\n"), x++);
         }
         describe_flavor(player_ptr, o_name, &store_ptr->stock[i], 0);
         fprintf(fff, "%c) %s\n", I2A(i % 12), o_name);
-#else
-        if ((i % 12) == 0) {
-            fprintf(fff, "\n ( page %d )\n", x++);
-        }
-        describe_flavor(player_ptr, o_name, &st_ptr->stock[i], 0);
-        fprintf(fff, "%c) %s\n", I2A(i % 12), o_name);
-#endif
     }
 
     fprintf(fff, "\n\n");


### PR DESCRIPTION
博物館のアイテムをキャラクタダンプに書き出す時に、store_ptr を使用すべき箇所で誤って
st_ptr を使用しているのが原因。
我が家のアイテム出力と同じように store_ptr を使用する箇所では日本語版と英語版を分け
ないコードに修正する。