### PR TITLE
Add mode, OD_BASE_NAME, for describe_flavor() which omits artifact, e…

### DIFF
--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -166,7 +166,6 @@ static bool check_activation_conditions(PlayerType *player_ptr, ae_type *ae_ptr)
  */
 static bool activate_artifact(PlayerType *player_ptr, ObjectType *o_ptr)
 {
-    concptr name = k_info[o_ptr->k_idx].name.c_str();
     auto tmp_act_ptr = find_activation_info(o_ptr);
     if (!tmp_act_ptr.has_value()) {
         msg_print("Activation information is not found.");
@@ -174,6 +173,8 @@ static bool activate_artifact(PlayerType *player_ptr, ObjectType *o_ptr)
     }
 
     auto *act_ptr = tmp_act_ptr.value();
+    GAME_TEXT name[MAX_NLEN];
+    describe_flavor(player_ptr, name, o_ptr, OD_NAME_ONLY | OD_OMIT_PREFIX | OD_BASE_NAME);
     if (!switch_activation(player_ptr, &o_ptr, act_ptr, name)) {
         return false;
     }

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -58,7 +58,7 @@ static void set_base_name(flavor_type *flavor_ptr)
         return;
     }
 
-    flavor_ptr->basenm = (flavor_ptr->known && (flavor_ptr->o_ptr->fixed_artifact_idx != 0)) ? a_info[flavor_ptr->o_ptr->fixed_artifact_idx].name.c_str() : flavor_ptr->kindname;
+    flavor_ptr->basenm = (flavor_ptr->known && (flavor_ptr->o_ptr->fixed_artifact_idx != 0) && !(flavor_ptr->mode & OD_BASE_NAME)) ? a_info[flavor_ptr->o_ptr->fixed_artifact_idx].name.c_str() : flavor_ptr->kindname;
 }
 
 #ifdef JP
@@ -82,7 +82,7 @@ static void describe_prefix_ja(flavor_type *flavor_ptr)
  */
 static void describe_artifact_prefix_ja(flavor_type *flavor_ptr)
 {
-    if (!flavor_ptr->known) {
+    if (!flavor_ptr->known || (flavor_ptr->mode & OD_BASE_NAME)) {
         return;
     }
 
@@ -100,7 +100,7 @@ static void describe_artifact_prefix_ja(flavor_type *flavor_ptr)
  */
 static void describe_artifact_ja(flavor_type *flavor_ptr)
 {
-    if (!flavor_ptr->known) {
+    if (!flavor_ptr->known || (flavor_ptr->mode & OD_BASE_NAME)) {
         return;
     }
 
@@ -204,7 +204,7 @@ static void describe_ego_body_ja(flavor_type *flavor_ptr)
  */
 static void describe_artifact_body_ja(flavor_type *flavor_ptr)
 {
-    if (!flavor_ptr->known) {
+    if (!flavor_ptr->known || (flavor_ptr->mode & OD_BASE_NAME)) {
         return;
     }
 
@@ -307,7 +307,7 @@ static void describe_basename_en(flavor_type *flavor_ptr)
 
 static void describe_artifact_body_en(flavor_type *flavor_ptr)
 {
-    if (!flavor_ptr->known || flavor_ptr->tr_flags.has(TR_FULL_NAME)) {
+    if (!flavor_ptr->known || flavor_ptr->tr_flags.has(TR_FULL_NAME) || (flavor_ptr->mode & OD_BASE_NAME)) {
         return;
     }
 
@@ -398,7 +398,7 @@ void describe_named_item(PlayerType *player_ptr, flavor_type *flavor_ptr)
 #endif
 
 #ifdef JP
-    if (flavor_ptr->o_ptr->is_smith()) {
+    if (flavor_ptr->o_ptr->is_smith() && !(flavor_ptr->mode & OD_BASE_NAME)) {
         flavor_ptr->t = object_desc_str(flavor_ptr->t, format("鍛冶師%sの", player_ptr->name));
     }
 
@@ -411,7 +411,7 @@ void describe_named_item(PlayerType *player_ptr, flavor_type *flavor_ptr)
 #ifdef JP
     describe_artifact_body_ja(flavor_ptr);
 #else
-    if (flavor_ptr->o_ptr->is_smith()) {
+    if (flavor_ptr->o_ptr->is_smith() && !(flavor_ptr->mode & OD_BASE_NAME)) {
         flavor_ptr->t = object_desc_str(flavor_ptr->t, format(" of %s the Smith", player_ptr->name));
     }
 

--- a/src/flavor/object-flavor-types.h
+++ b/src/flavor/object-flavor-types.h
@@ -9,5 +9,6 @@ enum object_description_type {
     OD_STORE = 0x00000020, /* Assume to be aware and known */
     OD_NO_FLAVOR = 0x00000040, /* Allow to hidden flavor */
     OD_FORCE_FLAVOR = 0x00000080, /* Get un-shuffled flavor name */
+    OD_BASE_NAME = 0x00000100, /* Use kind name without artifact, ego, or smithing details */
     OD_DEBUG = 0x10000000, /* Print for DEBUG */
 };


### PR DESCRIPTION
…go, and smithing details from the name.  Use that when constructing the name for activation messages.  Resolves https://github.com/hengband/hengband/issues/2555 .