### PR TITLE
[Fix] flag_insc_table のコンストラクタ引数 except_flag をconst参照にする

### DIFF
--- a/src/flavor/flag-inscriptions-table.h
+++ b/src/flavor/flag-inscriptions-table.h
@@ -12,7 +12,7 @@ enum tr_type : int32_t;
 /*! オブジェクトの特性表示記号テーブルの構造体 / Structs and tables for Auto Inscription for flags */
 struct flag_insc_table {
 #ifdef JP
-    flag_insc_table(concptr japanese, concptr english, tr_type flag, std::optional<tr_type> except_flag = std::nullopt)
+    flag_insc_table(concptr japanese, concptr english, tr_type flag, const std::optional<tr_type> &except_flag = std::nullopt)
         : japanese(japanese)
         , english(english)
         , flag(flag)
@@ -20,7 +20,7 @@ struct flag_insc_table {
     {
     }
 #else
-    flag_insc_table(concptr english, tr_type flag, std::optional<tr_type> except_flag = std::nullopt)
+    flag_insc_table(concptr english, tr_type flag, const std::optional<tr_type> &except_flag = std::nullopt)
         : english(english)
         , flag(flag)
         , except_flag(except_flag)


### PR DESCRIPTION
except_flag をコピー渡しすると MSVC の警告 C4868 にひっかかるため参照渡しにしておく。