### PR TITLE
[Fix] #2577 松明の燃料残量が異様に大きな数値になる

### DIFF
--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -76,6 +76,9 @@ void torch_lost_fuel(ObjectType *o_ptr)
     }
 
     o_ptr->fuel -= FUEL_TORCH / 25;
+    if (o_ptr->fuel < 0) {
+        o_ptr->fuel = 0;
+    }
 }
 
 /*!

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -75,9 +75,10 @@ void torch_lost_fuel(ObjectType *o_ptr)
         return;
     }
 
-    o_ptr->fuel -= FUEL_TORCH / 25;
-    if (o_ptr->fuel < 0) {
+    if (o_ptr->fuel < FUEL_TORCH / 25) {
         o_ptr->fuel = 0;
+    } else {
+        o_ptr->fuel -= FUEL_TORCH / 25;
     }
 }
 


### PR DESCRIPTION
松明を投げつけた時に燃料残量を減らす処理で負の値になってもそのままにしているのが原因。
負の値になったときは強制的に 0 にするよう修正する。