### PR TITLE
[Fix] #2535 武器を構えた手が誤って表示されることがある

### DIFF
--- a/src/action/weapon-shield.cpp
+++ b/src/action/weapon-shield.cpp
@@ -44,7 +44,7 @@ void verify_equip_slot(PlayerType *player_ptr, INVENTORY_IDX item)
         new_o_ptr->copy_from(o_ptr);
         inven_item_increase(player_ptr, INVEN_SUB_HAND, -((int)o_ptr->number));
         inven_item_optimize(player_ptr, INVEN_SUB_HAND);
-        if (o_ptr->allow_two_hands_wielding() && can_two_hands_wielding(player_ptr)) {
+        if (new_o_ptr->allow_two_hands_wielding() && can_two_hands_wielding(player_ptr)) {
             msg_format(_("%sを両手で構えた。", "You are wielding %s with both hands."), o_name);
         } else {
             msg_format(_("%sを%sで構えた。", "You are wielding %s in your %s hand."), o_name, (left_hander ? _("左手", "left") : _("右手", "right")));


### PR DESCRIPTION
二刀流からメインの武器を外してサブの武器をメインに持ち替える処理で、両手持ちできるか
どうかの判定を行うアイテムを参照するポインタ変数が誤っている。
正しく持ち替えた武器を指すポインタ変数を使用するよう修正する。