### PR TITLE
変愚「[Fix] 必殺剣「ブーメラン」で何でも投げられてしまう #2633」のマージ

### DIFF
--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -335,11 +335,11 @@ bool ObjectThrowEntity::check_what_throw()
         return true;
     }
 
-    concptr q, s;
-    if (!this->check_throw_boomerang(&q, &s)) {
-        return false;
+    if (this->boomerang) {
+        return this->check_throw_boomerang();
     }
 
+    concptr q, s;
     q = _("どのアイテムを投げますか? ", "Throw which item? ");
     s = _("投げるアイテムがない。", "You have nothing to throw.");
     this->o_ptr = choose_object(this->player_ptr, &this->item, q, s, USE_INVEN | USE_FLOOR | USE_EQUIP);
@@ -351,16 +351,13 @@ bool ObjectThrowEntity::check_what_throw()
     return true;
 }
 
-bool ObjectThrowEntity::check_throw_boomerang(concptr *q, concptr *s)
+bool ObjectThrowEntity::check_throw_boomerang()
 {
-    if (!this->boomerang) {
-        return true;
-    }
-
     if (has_melee_weapon(this->player_ptr, INVEN_MAIN_HAND) && has_melee_weapon(this->player_ptr, INVEN_SUB_HAND)) {
-        *q = _("どの武器を投げますか? ", "Throw which item? ");
-        *s = _("投げる武器がない。", "You have nothing to throw.");
-        this->o_ptr = choose_object(this->player_ptr, &this->item, *q, *s, USE_EQUIP, FuncItemTester(&ObjectType::is_throwable));
+        concptr q, s;
+        q = _("どの武器を投げますか? ", "Throw which item? ");
+        s = _("投げる武器がない。", "You have nothing to throw.");
+        this->o_ptr = choose_object(this->player_ptr, &this->item, q, s, USE_EQUIP, FuncItemTester(&ObjectType::is_throwable));
         if (!this->o_ptr) {
             flush();
             return false;

--- a/src/object-use/throw-execution.h
+++ b/src/object-use/throw-execution.h
@@ -74,7 +74,7 @@ private:
     bool super_boomerang{};
 
     bool check_what_throw();
-    bool check_throw_boomerang(concptr *q, concptr *s);
+    bool check_throw_boomerang();
     bool check_racial_target_bold();
     void check_racial_target_seen();
     bool check_racial_target_monster();


### PR DESCRIPTION
[Fix] 必殺剣「ブーメラン」で何でも投げられてしまう
バージョン 2.2.1r では必殺剣「ブーメラン」では投げるアイテムを装備中の武器しか選択でき
なかったが、リファクタリング時のロジック変更ミスにより全ての持ち物・装備から投げるアイ
テムを選択可能になってしまっていた。
これにより装備中の武器以外を選択すると配列外参照を引き起こし、異常なダメージを与えること
があるというバグの原因となっている。
2.2.1r の頃の以下の挙動に戻す。

- 両手にそれぞれ武器を持っている場合はどちらを投げるか選択する
- 片手にしか武器を持っていない場合は選択せずにその武器を投げる

なお、どちらの手にも武器を持っていない場合はそもそも必殺剣を発動することができない。