### PR TITLE
変愚「GCU版のウインドウ数を最大8個表示できるようにする」のマージ

### DIFF
--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -216,7 +216,7 @@ struct term_data {
 };
 
 /* Max number of windows on screen */
-#define MAX_TERM_DATA 4
+#define MAX_TERM_DATA 8
 
 /* Minimum main term size */
 #define MIN_TERM0_LINES 24


### PR DESCRIPTION
レイアウトオプションの実装でサブウィンドウを4個以上表示可能になったので、表示可能最大数
である8個（メインウィンドウ含む）までウィンドウを表示できるようにする。