### PR TITLE
変愚「GCU版で画面のちらつきの発生を抑制する」のマージ

### DIFF
--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -976,7 +976,7 @@ static errr game_term_xtra_gcu(int n, int v)
     /* Clear screen */
     case TERM_XTRA_CLEAR:
         touchwin(td->win);
-        (void)wclear(td->win);
+        (void)werase(td->win);
         return 0;
 
     /* Make a noise */


### PR DESCRIPTION
curses の wclear 関数は端末全体を一旦消去した後に描画しなおす。そのためサブウィンドウ の数だけ連続して wclear が呼ばれた時に画面全体が連続してちらついて見えることがある。

ウィンドウに表示している文字を消去するだけであれば werase 関数でも十分であり、wclear
と違い端末全体を消去して描画しなおすことがなくちらつきは発生しないので、werase 関数を
使用するようにする。