### PR TITLE
変愚「[Fix] github.io の自動生成スポイラーページの更新に失敗する」のマージ

### DIFF
--- a/.github/workflows/publish-spoiler-page.yml
+++ b/.github/workflows/publish-spoiler-page.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Install required packages
         run: |


### PR DESCRIPTION
スポイラー生成用バイナリのビルド時にサブモジュールディレクトリが存在しないためエラーと
なるのが原因。
サブモジュールも合わせてチェックアウトされるように GitHub Actions を修正する。