### PR TITLE
変愚「[Fix] ヘッダのインクルード漏れ」のマージ

### DIFF
--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -16,6 +16,7 @@
 #include "view/display-messages.h"
 #include "world/world.h"
 #include <algorithm>
+#include <stdexcept>
 #include <string>
 #include <utility>
 

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -17,6 +17,7 @@
 #include "sv-definition/sv-rod-types.h"
 #include "sv-definition/sv-weapon-types.h"
 #include <set>
+#include <stdexcept>
 #include <unordered_map>
 
 namespace {

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -47,6 +47,7 @@
 #include "window/main-window-equipments.h"
 #include "window/main-window-util.h"
 #include "world/world.h"
+#include <algorithm>
 #include <mutex>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
VS 2022 でプリコンパイルヘッダ無しでビルドしたところ、いくつかヘッダのインクルード
漏れによるエラーが検出されたので必要なヘッダのインクルードを追加する。