### PR TITLE
変愚「[Fix] mon-info.txt に出力される情報がおかしい」のマージ

### DIFF
--- a/src/wizard/monster-info-spoiler.cpp
+++ b/src/wizard/monster-info-spoiler.cpp
@@ -221,12 +221,7 @@ SpoilerOutputResultType spoil_mon_info(concptr fname)
         spoil_out(buf);
         sprintf(buf, "Rar:%d  ", r_ptr->rarity);
         spoil_out(buf);
-        if (r_ptr->speed >= 110) {
-            sprintf(buf, "Spd:+%d  ", (r_ptr->speed - 110));
-        } else {
-            sprintf(buf, "Spd:-%d  ", (110 - r_ptr->speed));
-        }
-
+        sprintf(buf, "Spd:%+d  ", r_ptr->speed - STANDARD_SPEED);
         spoil_out(buf);
         if (any_bits(r_ptr->flags1, RF1_FORCE_MAXHP) || (r_ptr->hside == 1)) {
             sprintf(buf, "Hp:%d  ", r_ptr->hdice * r_ptr->hside);


### PR DESCRIPTION
コミット 23d1bbe において「Spd:」の表示部分が誤って消されてしまっているので復活させる。