### PR TITLE
変愚「[Fix] angband_terms の配列外参照」のマージ

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,14 +55,15 @@ static void quit_hook(concptr s)
     (void)s;
 
     /* Scan windows */
-    for (auto i = static_cast<int>(angband_terms.size()); i >= 0; i--) {
+    for (auto it = angband_terms.rbegin(); it != angband_terms.rend(); ++it) {
+        auto term = *it;
         /* Unused */
-        if (!angband_terms[i]) {
+        if (term == nullptr) {
             continue;
         }
 
         /* Nuke it */
-        term_nuke(angband_terms[i]);
+        term_nuke(term);
     }
 }
 


### PR DESCRIPTION
ゲーム終了時に angband_terms 配列が指している term_type 構造体を破棄する時逆順で 破棄しているが、最初の要素のインデクスが angband_terms.size() となっているため配列 外参照となっている。
単純に size() - 1 から始めるように修正してもいいが、逆順という意図を込めるため
リバースイテレータで処理するように変更する。