### PR TITLE
変愚「[Refactor] 画面に文字列を出力する関数のシグネチャ変更」のマージ

### DIFF
--- a/src/term/screen-processor.cpp
+++ b/src/term/screen-processor.cpp
@@ -77,36 +77,36 @@ void screen_load(ScreenLoadOptType opt)
  * At the given location, using the given attribute, if allowed,
  * add the given string.  Do not clear the line.
  */
-void c_put_str(TERM_COLOR attr, concptr str, TERM_LEN row, TERM_LEN col)
+void c_put_str(TERM_COLOR attr, std::string_view sv, TERM_LEN row, TERM_LEN col)
 {
-    term_putstr(col, row, -1, attr, str);
+    term_putstr(col, row, -1, attr, sv);
 }
 
 /*
  * As above, but in "white"
  */
-void put_str(concptr str, TERM_LEN row, TERM_LEN col)
+void put_str(std::string_view sv, TERM_LEN row, TERM_LEN col)
 {
-    term_putstr(col, row, -1, TERM_WHITE, str);
+    term_putstr(col, row, -1, TERM_WHITE, sv);
 }
 
 /*
  * Display a string on the screen using an attribute, and clear
  * to the end of the line.
  */
-void c_prt(TERM_COLOR attr, concptr str, TERM_LEN row, TERM_LEN col)
+void c_prt(TERM_COLOR attr, std::string_view sv, TERM_LEN row, TERM_LEN col)
 {
     term_erase(col, row, 255);
-    term_addstr(-1, attr, str);
+    term_addstr(-1, attr, sv);
 }
 
 /*
  * As above, but in "white"
  */
-void prt(concptr str, TERM_LEN row, TERM_LEN col)
+void prt(std::string_view sv, TERM_LEN row, TERM_LEN col)
 {
     /* Spawn */
-    c_prt(TERM_WHITE, str, row, col);
+    c_prt(TERM_WHITE, sv, row, col);
 }
 
 /*

--- a/src/term/screen-processor.h
+++ b/src/term/screen-processor.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <string_view>
 
 /** 画面情報保存スタックからの読み出しオプション */
 enum class ScreenLoadOptType {
@@ -12,10 +13,10 @@ void move_cursor(int row, int col);
 void flush(void);
 void screen_save();
 void screen_load(ScreenLoadOptType opt = ScreenLoadOptType::ONE);
-void c_put_str(TERM_COLOR attr, concptr str, TERM_LEN row, TERM_LEN col);
-void put_str(concptr str, TERM_LEN row, TERM_LEN col);
-void c_prt(TERM_COLOR attr, concptr str, TERM_LEN row, TERM_LEN col);
-void prt(concptr str, TERM_LEN row, TERM_LEN col);
+void c_put_str(TERM_COLOR attr, std::string_view sv, TERM_LEN row, TERM_LEN col);
+void put_str(std::string_view sv, TERM_LEN row, TERM_LEN col);
+void c_prt(TERM_COLOR attr, std::string_view sv, TERM_LEN row, TERM_LEN col);
+void prt(std::string_view sv, TERM_LEN row, TERM_LEN col);
 void c_roff(TERM_COLOR attr, concptr str);
 void roff(concptr str);
 void clear_from(int row);

--- a/src/term/z-term.h
+++ b/src/term/z-term.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <stack>
+#include <string_view>
 #include <vector>
 
 /*!
@@ -170,9 +171,9 @@ errr term_gotoxy(TERM_LEN x, TERM_LEN y);
 errr term_draw(TERM_LEN x, TERM_LEN y, TERM_COLOR a, char c);
 errr term_addch(TERM_COLOR a, char c);
 errr term_add_bigch(TERM_COLOR a, char c);
-errr term_addstr(int n, TERM_COLOR a, concptr s);
+errr term_addstr(int n, TERM_COLOR a, std::string_view sv);
 errr term_putch(TERM_LEN x, TERM_LEN y, TERM_COLOR a, char c);
-errr term_putstr(TERM_LEN x, TERM_LEN y, int n, TERM_COLOR a, concptr s);
+errr term_putstr(TERM_LEN x, TERM_LEN y, int n, TERM_COLOR a, std::string_view sv);
 errr term_erase(TERM_LEN x, TERM_LEN y, int n);
 errr term_clear(void);
 errr term_redraw(void);


### PR DESCRIPTION
Cスタイルの文字列(concptr)、std::string、std::string_view のいずれもシームレスに 受け取れるように、以下の関数の文字列を指定する引数を concptr から std::string_view に変更する:

- term_addstr
- term_putstr
- c_put_str/put_str
- c_prt/prt