### PR TITLE
変愚「[Refactor] exe_spell 関数の戻り値の型を変更」のマージ

### DIFF
--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -243,7 +243,8 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
                     }
 
                     /* Dump the spell --(-- */
-                    strcat(psi_desc, format(" %-18s%2d %3d", exe_spell(player_ptr, REALM_HISSATSU, i, SpellProcessType::NAME), spell.slevel, spell.smana));
+                    const auto spell_name = exe_spell(player_ptr, REALM_HISSATSU, i, SpellProcessType::NAME);
+                    strcat(psi_desc, format(" %-18s%2d %3d", spell_name->data(), spell.slevel, spell.smana));
                     prt(psi_desc, y + (line % 17) + (line >= 17), x + (line / 17) * 30);
                     prt("", y + (line % 17) + (line >= 17) + 1, x + (line / 17) * 30);
                 }
@@ -403,7 +404,8 @@ void do_cmd_gain_hissatsu(PlayerType *player_ptr)
 
         player_ptr->spell_learned1 |= (1UL << i);
         player_ptr->spell_worked1 |= (1UL << i);
-        msg_format(_("%sの技を覚えた。", "You have learned the special attack of %s."), exe_spell(player_ptr, REALM_HISSATSU, i, SpellProcessType::NAME));
+        const auto spell_name = exe_spell(player_ptr, REALM_HISSATSU, i, SpellProcessType::NAME);
+        msg_format(_("%sの技を覚えた。", "You have learned the special attack of %s."), spell_name->data());
         int j;
         for (j = 0; j < 64; j++) {
             /* Stop at the first empty space */

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -670,7 +670,8 @@ void do_cmd_browse(PlayerType *player_ptr)
         term_erase(14, 12, 255);
         term_erase(14, 11, 255);
 
-        shape_buffer(exe_spell(player_ptr, use_realm, spell, SpellProcessType::DESCRIPTION), 62, temp, sizeof(temp));
+        const auto spell_desc = exe_spell(player_ptr, use_realm, spell, SpellProcessType::DESCRIPTION);
+        shape_buffer(spell_desc->data(), 62, temp, sizeof(temp));
 
         for (j = 0, line = 11; temp[j]; j += 1 + strlen(&temp[j])) {
             prt(&temp[j], line, 15);
@@ -855,23 +856,23 @@ void do_cmd_study(PlayerType *player_ptr)
     if (learned) {
         auto max_exp = PlayerSkill::spell_exp_at((spell < 32) ? PlayerSkillRank::MASTER : PlayerSkillRank::EXPERT);
         int old_exp = player_ptr->spell_exp[spell];
-        concptr name = exe_spell(player_ptr, increment ? player_ptr->realm2 : player_ptr->realm1, spell % 32, SpellProcessType::NAME);
+        const auto spell_name = exe_spell(player_ptr, increment ? player_ptr->realm2 : player_ptr->realm1, spell % 32, SpellProcessType::NAME);
 
         if (old_exp >= max_exp) {
             msg_format(_("その%sは完全に使いこなせるので学ぶ必要はない。", "You don't need to study this %s anymore."), p);
             return;
         }
 #ifdef JP
-        if (!get_check(format("%sの%sをさらに学びます。よろしいですか？", name, p))) {
+        if (!get_check(format("%sの%sをさらに学びます。よろしいですか？", spell_name->data(), p))) {
 #else
-        if (!get_check(format("You will study a %s of %s again. Are you sure? ", p, name))) {
+        if (!get_check(format("You will study a %s of %s again. Are you sure? ", p, spell_name->data()))) {
 #endif
             return;
         }
 
         auto new_rank = PlayerSkill(player_ptr).gain_spell_skill_exp_over_learning(spell);
         auto new_rank_str = PlayerSkill::skill_rank_str(new_rank);
-        msg_format(_("%sの熟練度が%sに上がった。", "Your proficiency of %s is now %s rank."), name, new_rank_str);
+        msg_format(_("%sの熟練度が%sに上がった。", "Your proficiency of %s is now %s rank."), spell_name->data(), new_rank_str);
     } else {
         /* Find the next open entry in "player_ptr->spell_order[]" */
         int i;
@@ -886,15 +887,16 @@ void do_cmd_study(PlayerType *player_ptr)
         player_ptr->spell_order[i++] = spell;
 
         /* Mention the result */
+        const auto spell_name = exe_spell(player_ptr, increment ? player_ptr->realm2 : player_ptr->realm1, spell % 32, SpellProcessType::NAME);
 #ifdef JP
         /* 英日切り替え機能に対応 */
         if (mp_ptr->spell_book == ItemKindType::MUSIC_BOOK) {
-            msg_format("%sを学んだ。", exe_spell(player_ptr, increment ? player_ptr->realm2 : player_ptr->realm1, spell % 32, SpellProcessType::NAME));
+            msg_format("%sを学んだ。", spell_name->data());
         } else {
-            msg_format("%sの%sを学んだ。", exe_spell(player_ptr, increment ? player_ptr->realm2 : player_ptr->realm1, spell % 32, SpellProcessType::NAME), p);
+            msg_format("%sの%sを学んだ。", spell_name->data(), p);
         }
 #else
-        msg_format("You have learned the %s of %s.", p, exe_spell(player_ptr, increment ? player_ptr->realm2 : player_ptr->realm1, spell % 32, SpellProcessType::NAME));
+        msg_format("You have learned the %s of %s.", p, spell_name->data());
 #endif
     }
 

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -100,7 +100,8 @@ void do_cmd_knowledge_spell_exp(PlayerType *player_ptr)
             }
             SUB_EXP spell_exp = player_ptr->spell_exp[i];
             auto skill_rank = PlayerSkill::spell_skill_rank(spell_exp);
-            fprintf(fff, "%-25s ", exe_spell(player_ptr, player_ptr->realm1, i, SpellProcessType::NAME));
+            const auto spell_name = exe_spell(player_ptr, player_ptr->realm1, i, SpellProcessType::NAME);
+            fprintf(fff, "%-25s ", spell_name->data());
             if (player_ptr->realm1 == REALM_HISSATSU) {
                 if (show_actual_value) {
                     fprintf(fff, "----/---- ");
@@ -141,7 +142,8 @@ void do_cmd_knowledge_spell_exp(PlayerType *player_ptr)
 
             SUB_EXP spell_exp = player_ptr->spell_exp[i + 32];
             auto skill_rank = PlayerSkill::spell_skill_rank(spell_exp);
-            fprintf(fff, "%-25s ", exe_spell(player_ptr, player_ptr->realm2, i, SpellProcessType::NAME));
+            const auto spell_name = exe_spell(player_ptr, player_ptr->realm2, i, SpellProcessType::NAME);
+            fprintf(fff, "%-25s ", spell_name->data());
             if (show_actual_value) {
                 fprintf(fff, "%4d/%4d ", spell_exp, PlayerSkill::spell_exp_at(PlayerSkillRank::MASTER));
             }

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -606,10 +606,11 @@ static void update_num_of_spells(PlayerType *player_ptr)
             which = player_ptr->realm2;
         }
 
+        const auto spell_name = exe_spell(player_ptr, which, j % 32, SpellProcessType::NAME);
 #ifdef JP
-        msg_format("%sの%sを忘れてしまった。", exe_spell(player_ptr, which, j % 32, SpellProcessType::NAME), p);
+        msg_format("%sの%sを忘れてしまった。", spell_name->data(), p);
 #else
-        msg_format("You have forgotten the %s of %s.", p, exe_spell(player_ptr, which, j % 32, SpellProcessType::NAME));
+        msg_format("You have forgotten the %s of %s.", p, spell_name->data());
 #endif
         player_ptr->new_spells++;
     }
@@ -650,10 +651,11 @@ static void update_num_of_spells(PlayerType *player_ptr)
             which = player_ptr->realm2;
         }
 
+        const auto spell_name = exe_spell(player_ptr, which, j % 32, SpellProcessType::NAME);
 #ifdef JP
-        msg_format("%sの%sを忘れてしまった。", exe_spell(player_ptr, which, j % 32, SpellProcessType::NAME), p);
+        msg_format("%sの%sを忘れてしまった。", spell_name->data(), p);
 #else
-        msg_format("You have forgotten the %s of %s.", p, exe_spell(player_ptr, which, j % 32, SpellProcessType::NAME));
+        msg_format("You have forgotten the %s of %s.", p, spell_name->data());
 #endif
         player_ptr->new_spells++;
     }
@@ -710,10 +712,11 @@ static void update_num_of_spells(PlayerType *player_ptr)
             which = player_ptr->realm2;
         }
 
+        const auto spell_name = exe_spell(player_ptr, which, j % 32, SpellProcessType::NAME);
 #ifdef JP
-        msg_format("%sの%sを思い出した。", exe_spell(player_ptr, which, j % 32, SpellProcessType::NAME), p);
+        msg_format("%sの%sを思い出した。", spell_name->data(), p);
 #else
-        msg_format("You have remembered the %s of %s.", p, exe_spell(player_ptr, which, j % 32, SpellProcessType::NAME));
+        msg_format("You have remembered the %s of %s.", p, spell_name->data());
 #endif
         player_ptr->new_spells--;
     }

--- a/src/realm/realm-arcane.cpp
+++ b/src/realm/realm-arcane.cpp
@@ -30,9 +30,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列ポインタを返す。SpellProcessType::CAST時はnullptr文字列を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
  */
-concptr do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool name = mode == SpellProcessType::NAME;
     bool desc = mode == SpellProcessType::DESCRIPTION;
@@ -61,7 +61,7 @@ concptr do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::ELEC, dir, damroll(dice, sides));
@@ -80,7 +80,7 @@ concptr do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
         {
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 wizard_lock(player_ptr, dir);
@@ -185,7 +185,7 @@ concptr do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
         {
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 destroy_door(player_ptr, dir);
@@ -472,7 +472,7 @@ concptr do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
         {
             if (cast) {
                 if (!ident_spell(player_ptr, false)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -497,7 +497,7 @@ concptr do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 wall_to_mud(player_ptr, dir, 20 + randint1(30));
@@ -523,7 +523,7 @@ concptr do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 msg_print(_("光線が放たれた。", "A line of light appears."));
@@ -595,7 +595,7 @@ concptr do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
         {
             if (cast) {
                 if (!get_check(_("本当に他の階にテレポートしますか？", "Are you sure? (Teleport Level)"))) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 teleport_level(player_ptr, 0);
             }
@@ -619,7 +619,7 @@ concptr do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_beam(player_ptr, AttributeType::AWAY_ALL, dir, power);
@@ -647,7 +647,7 @@ concptr do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
                 AttributeType type;
 
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 switch (randint1(4)) {
@@ -711,7 +711,7 @@ concptr do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!recall_player(player_ptr, randint0(21) + 15)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }

--- a/src/realm/realm-arcane.h
+++ b/src/realm/realm-arcane.h
@@ -2,6 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
+#include <optional>
+#include <string>
 
 class PlayerType;
-concptr do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-chaos.cpp
+++ b/src/realm/realm-chaos.cpp
@@ -30,9 +30,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列ポインタを返す。SpellProcessType::CAST時はnullptr文字列を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
  */
-concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool name = mode == SpellProcessType::NAME;
     bool desc = mode == SpellProcessType::DESCRIPTION;
@@ -61,7 +61,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::MISSILE, dir, damroll(dice, sides));
@@ -158,7 +158,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::MISSILE, dir, damroll(dice, sides) + base, rad);
@@ -190,7 +190,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::FIRE, dir, damroll(dice, sides));
@@ -216,7 +216,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::DISINTEGRATE, dir, damroll(dice, sides), 0);
@@ -261,7 +261,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
             if (cast) {
 
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 cast_wonder(player_ptr, dir);
@@ -287,7 +287,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::CHAOS, dir, damroll(dice, sides));
@@ -336,7 +336,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_beam(player_ptr, AttributeType::MANA, dir, damroll(dice, sides));
@@ -362,7 +362,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::FIRE, dir, dam, rad);
@@ -387,7 +387,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_beam(player_ptr, AttributeType::AWAY_ALL, dir, power);
@@ -431,7 +431,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::CHAOS, dir, dam, rad);
@@ -456,7 +456,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 poly_monster(player_ptr, dir, plev);
@@ -504,7 +504,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
             }
             if (cast) {
                 if (!recharge(player_ptr, power)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -528,7 +528,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::DISINTEGRATE, dir, dam, rad);
@@ -576,7 +576,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 msg_print(_("ロケット発射！", "You launch a rocket!"));
@@ -633,7 +633,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 fire_beam(player_ptr, AttributeType::GRAVITY, dir, damroll(dice, sides));
             }
@@ -714,7 +714,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
         {
             if (cast) {
                 if (!get_check(_("変身します。よろしいですか？", "You will polymorph yourself. Are you sure? "))) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 do_poly_self(player_ptr);
             }
@@ -739,7 +739,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 fire_ball(player_ptr, AttributeType::MANA, dir, dam, rad);
             }
@@ -764,7 +764,7 @@ concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::CHAOS, dir, dam, rad);

--- a/src/realm/realm-chaos.h
+++ b/src/realm/realm-chaos.h
@@ -2,6 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
+#include <optional>
+#include <string>
 
 class PlayerType;
-concptr do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-craft.cpp
+++ b/src/realm/realm-craft.cpp
@@ -24,9 +24,9 @@
  * @brief 匠領域魔法の各処理を行う
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列ポインタを返す。SpellProcessType::CAST時はnullptr文字列を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
  */
-concptr do_craft_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+std::optional<std::string> do_craft_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool name = mode == SpellProcessType::NAME;
     bool desc = mode == SpellProcessType::DESCRIPTION;
@@ -353,7 +353,7 @@ concptr do_craft_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!choose_ele_attack(player_ptr)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -540,7 +540,7 @@ concptr do_craft_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
         {
             if (cast) {
                 if (!mundane_spell(player_ptr, true)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -572,7 +572,7 @@ concptr do_craft_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
         {
             if (cast) {
                 if (!identify_fully(player_ptr, false)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -589,7 +589,7 @@ concptr do_craft_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
         {
             if (cast) {
                 if (!enchant_spell(player_ptr, randint0(4) + 1, randint0(4) + 1, 0)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -606,7 +606,7 @@ concptr do_craft_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
         {
             if (cast) {
                 if (!enchant_spell(player_ptr, 0, 0, randint0(3) + 2)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -657,7 +657,7 @@ concptr do_craft_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!choose_ele_immune(player_ptr, base + randint1(base))) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }

--- a/src/realm/realm-craft.h
+++ b/src/realm/realm-craft.h
@@ -2,6 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
+#include <optional>
+#include <string>
 
 class PlayerType;
-concptr do_craft_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+std::optional<std::string> do_craft_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-crusade.cpp
+++ b/src/realm/realm-crusade.cpp
@@ -37,9 +37,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列ポインタを返す。SpellProcessType::CAST時はnullptr文字列を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
  */
-concptr do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool name = mode == SpellProcessType::NAME;
     bool desc = mode == SpellProcessType::DESCRIPTION;
@@ -65,7 +65,7 @@ concptr do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
             }
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::ELEC, dir, damroll(dice, sides));
             }
@@ -119,7 +119,7 @@ concptr do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
             }
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 fear_monster(player_ptr, dir, power);
             }
@@ -179,7 +179,7 @@ concptr do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
             }
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 fire_blast(player_ptr, AttributeType::LITE, dir, dice, sides, 10, 3);
             }
@@ -219,7 +219,7 @@ concptr do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
             }
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 fire_ball(player_ptr, AttributeType::AWAY_EVIL, dir, power, 0);
             }
@@ -253,7 +253,7 @@ concptr do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::HOLY_FIRE, dir, damroll(dice, sides) + base, rad);
@@ -357,7 +357,7 @@ concptr do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 fire_bolt(player_ptr, AttributeType::ELEC, dir, dam);
             }
@@ -403,7 +403,7 @@ concptr do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
         {
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 destroy_door(player_ptr, dir);
@@ -428,7 +428,7 @@ concptr do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 stasis_evil(player_ptr, dir);
             }
@@ -533,7 +533,7 @@ concptr do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::LITE, dir, dam, rad);
@@ -691,7 +691,7 @@ concptr do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
 
             if (cast) {
                 if (!cast_wrath_of_the_god(player_ptr, dam, rad)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }

--- a/src/realm/realm-crusade.h
+++ b/src/realm/realm-crusade.h
@@ -2,6 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
+#include <optional>
+#include <string>
 
 class PlayerType;
-concptr do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-death.cpp
+++ b/src/realm/realm-death.cpp
@@ -32,9 +32,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列ポインタを返す。SpellProcessType::CAST時はnullptr文字列を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
  */
-concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool name = mode == SpellProcessType::NAME;
     bool desc = mode == SpellProcessType::DESCRIPTION;
@@ -86,7 +86,7 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 /*
@@ -156,7 +156,7 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::POIS, dir, dam, rad);
@@ -181,7 +181,7 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 sleep_monster(player_ptr, dir, plev);
@@ -228,7 +228,7 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fear_monster(player_ptr, dir, plev);
@@ -254,7 +254,7 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 control_one_undead(player_ptr, dir, plev);
@@ -288,7 +288,7 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::HYPODYNAMIA, dir, damroll(dice, sides) + base, rad);
@@ -314,7 +314,7 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::NETHER, dir, damroll(dice, sides));
@@ -361,7 +361,7 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball_hide(player_ptr, AttributeType::GENOCIDE, dir, power, 0);
@@ -406,7 +406,7 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
                 int dam = base + damroll(dice, sides);
 
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 if (hypodynamic_bolt(player_ptr, dir, dam)) {
@@ -510,7 +510,7 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 cast_invoke_spirits(player_ptr, dir);
@@ -536,7 +536,7 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::DARK, dir, damroll(dice, sides));
@@ -602,7 +602,7 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
                 int i;
 
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 chg_virtue(player_ptr, V_SACRIFICE, -1);
@@ -656,7 +656,7 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::DARK, dir, dam, rad);
@@ -675,7 +675,7 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
         {
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 death_ray(player_ptr, dir, plev);
@@ -707,11 +707,11 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
             if (cast) {
                 if (randint1(50) > plev) {
                     if (!ident_spell(player_ptr, false)) {
-                        return nullptr;
+                        return std::nullopt;
                     }
                 } else {
                     if (!identify_fully(player_ptr, false)) {
-                        return nullptr;
+                        return std::nullopt;
                     }
                 }
             }
@@ -796,7 +796,7 @@ concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::HELL_FIRE, dir, dam, rad);

--- a/src/realm/realm-death.h
+++ b/src/realm/realm-death.h
@@ -2,6 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
+#include <optional>
+#include <string>
 
 class PlayerType;
-concptr do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-demon.cpp
+++ b/src/realm/realm-demon.cpp
@@ -33,9 +33,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列ポインタを返す。SpellProcessType::CAST時はnullptr文字列を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
  */
-concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool name = mode == SpellProcessType::NAME;
     bool desc = mode == SpellProcessType::DESCRIPTION;
@@ -64,7 +64,7 @@ concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::MISSILE, dir, damroll(dice, sides));
@@ -154,7 +154,7 @@ concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fear_monster(player_ptr, dir, power);
@@ -181,7 +181,7 @@ concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::NETHER, dir, damroll(dice, sides));
@@ -232,7 +232,7 @@ concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::HELL_FIRE, dir, damroll(dice, sides) + base, rad);
@@ -257,7 +257,7 @@ concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 control_one_demon(player_ptr, dir, plev);
@@ -325,7 +325,7 @@ concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::PLASMA, dir, damroll(dice, sides));
@@ -351,7 +351,7 @@ concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::FIRE, dir, dam, rad);
@@ -392,7 +392,7 @@ concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::NETHER, dir, dam, rad);
@@ -505,7 +505,7 @@ concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::PLASMA, dir, dam, rad);
@@ -577,7 +577,7 @@ concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 fire_ball(player_ptr, AttributeType::NEXUS, dir, dam, rad);
             }
@@ -595,7 +595,7 @@ concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
         {
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 } else {
                     msg_print(_("<破滅の手>を放った！", "You invoke the Hand of Doom!"));
                 }
@@ -698,7 +698,7 @@ concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
         {
             if (cast) {
                 if (!cast_summon_greater_demon(player_ptr)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -722,7 +722,7 @@ concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::NETHER, dir, dam, rad);
@@ -749,7 +749,7 @@ concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball_hide(player_ptr, AttributeType::BLOOD_CURSE, dir, dam, rad);

--- a/src/realm/realm-demon.h
+++ b/src/realm/realm-demon.h
@@ -2,6 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
+#include <optional>
+#include <string>
 
 class PlayerType;
-concptr do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -62,9 +62,9 @@
  * @brief 呪術領域魔法の各処理を行う
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST / SPELL_CONT / SpellProcessType::STOP)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列ポインタを返す。SpellProcessType::CAST / SPELL_CONT / SpellProcessType::STOP 時はnullptr文字列を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST / SPELL_CONT / SpellProcessType::STOP 時は std::nullopt を返す。
  */
-concptr do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessType mode)
+std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessType mode)
 {
     auto name = mode == SpellProcessType::NAME;
     auto description = mode == SpellProcessType::DESCRIPTION;
@@ -273,7 +273,7 @@ concptr do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessT
 
             if (spell_hex.get_revenge_turn() > 0) {
                 msg_print(_("すでに我慢をしている。", "You are already biding your time for vengeance."));
-                return nullptr;
+                return std::nullopt;
             }
 
             spell_hex.set_revenge_type(SpellHexRevengeType::PATIENCE);
@@ -492,7 +492,7 @@ concptr do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessT
         }
         if (cast) {
             if (!recharge(player_ptr, power)) {
-                return nullptr;
+                return std::nullopt;
             }
             should_continue = false;
         }
@@ -610,10 +610,10 @@ concptr do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessT
 
             if (!o_ptr->bi_id) {
                 msg_print(_("クロークを身につけていない！", "You are not wearing a cloak."));
-                return nullptr;
+                return std::nullopt;
             } else if (!o_ptr->is_cursed()) {
                 msg_print(_("クロークは呪われていない！", "Your cloak is not cursed."));
-                return nullptr;
+                return std::nullopt;
             } else {
                 msg_print(_("影のオーラを身にまとった。", "You are enveloped by a shadowy aura!"));
             }
@@ -722,7 +722,8 @@ concptr do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessT
             }
 
             if (!flag) {
-                msg_format(_("%sの呪文の詠唱をやめた。", "Finish casting '%^s'."), exe_spell(player_ptr, REALM_HEX, HEX_RESTORE, SpellProcessType::NAME));
+                const auto spell_name = exe_spell(player_ptr, REALM_HEX, HEX_RESTORE, SpellProcessType::NAME);
+                msg_format(_("%sの呪文の詠唱をやめた。", "Finish casting '%^s'."), spell_name->data());
                 SpellHex spell_hex(player_ptr);
                 spell_hex.reset_casting_flag(HEX_RESTORE);
                 if (!spell_hex.is_spelling_any()) {
@@ -912,7 +913,7 @@ concptr do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessT
 
             if (spell_hex.get_revenge_turn() > 0) {
                 msg_print(_("すでに復讐は宣告済みだ。", "You've already declared your revenge."));
-                return nullptr;
+                return std::nullopt;
             }
 
             spell_hex.set_revenge_type(SpellHexRevengeType::REVENGE);

--- a/src/realm/realm-hex.h
+++ b/src/realm/realm-hex.h
@@ -3,6 +3,8 @@
 #include "realm/realm-hex-numbers.h"
 #include "spell/spells-util.h"
 #include "system/angband.h"
+#include <optional>
+#include <string>
 
 class PlayerType;
-concptr do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessType mode);
+std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessType mode);

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -64,9 +64,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 剣術ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC 時には文字列ポインタを返す。SpellProcessType::CAST時はnullptr文字列を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
  */
-concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool name = mode == SpellProcessType::NAME;
     bool desc = mode == SpellProcessType::DESCRIPTION;
@@ -87,7 +87,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
         if (cast) {
             project_length = 2;
             if (!get_aim_dir(player_ptr, &dir)) {
-                return nullptr;
+                return std::nullopt;
             }
 
             project_hook(player_ptr, AttributeType::ATTACK, dir, HISSATSU_2, PROJECT_STOP | PROJECT_KILL);
@@ -107,10 +107,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             for (cdir = 0; cdir < 8; cdir++) {
@@ -120,7 +120,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             }
 
             if (cdir == 8) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy_cdd[cdir];
@@ -160,7 +160,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
 
         if (cast) {
             if (!ThrowCommand(player_ptr).do_cmd_throw(1, true, -1)) {
-                return nullptr;
+                return std::nullopt;
             }
         }
         break;
@@ -177,10 +177,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -190,7 +190,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
                 do_cmd_attack(player_ptr, y, x, HISSATSU_FIRE);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return nullptr;
+                return std::nullopt;
             }
         }
         break;
@@ -220,10 +220,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -233,7 +233,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
                 do_cmd_attack(player_ptr, y, x, HISSATSU_MINEUCHI);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return nullptr;
+                return std::nullopt;
             }
         }
         break;
@@ -250,7 +250,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
         if (cast) {
             if (player_ptr->riding) {
                 msg_print(_("乗馬中には無理だ。", "You cannot do it when riding."));
-                return nullptr;
+                return std::nullopt;
             }
             msg_print(_("相手の攻撃に対して身構えた。", "You prepare to counterattack."));
             player_ptr->counter = true;
@@ -271,22 +271,22 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
 
             if (player_ptr->riding) {
                 msg_print(_("乗馬中には無理だ。", "You cannot do it when riding."));
-                return nullptr;
+                return std::nullopt;
             }
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
 
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
             if (!player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return nullptr;
+                return std::nullopt;
             }
 
             do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
@@ -317,10 +317,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -330,7 +330,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
                 do_cmd_attack(player_ptr, y, x, HISSATSU_POISON);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return nullptr;
+                return std::nullopt;
             }
         }
         break;
@@ -348,10 +348,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -361,7 +361,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
                 do_cmd_attack(player_ptr, y, x, HISSATSU_ZANMA);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return nullptr;
+                return std::nullopt;
             }
         }
         break;
@@ -378,10 +378,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -391,7 +391,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
                 do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return nullptr;
+                return std::nullopt;
             }
             if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
                 return "";
@@ -447,11 +447,11 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
         if (cast) {
             if (plev > 44) {
                 if (!identify_fully(player_ptr, true)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             } else {
                 if (!ident_spell(player_ptr, true)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -469,10 +469,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -505,10 +505,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -518,7 +518,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
                 do_cmd_attack(player_ptr, y, x, HISSATSU_COLD);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return nullptr;
+                return std::nullopt;
             }
         }
         break;
@@ -536,10 +536,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -549,7 +549,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
                 do_cmd_attack(player_ptr, y, x, HISSATSU_KYUSHO);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return nullptr;
+                return std::nullopt;
             }
         }
         break;
@@ -566,10 +566,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -579,7 +579,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
                 do_cmd_attack(player_ptr, y, x, HISSATSU_MAJIN);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return nullptr;
+                return std::nullopt;
             }
         }
         break;
@@ -597,10 +597,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -610,7 +610,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
                 do_cmd_attack(player_ptr, y, x, HISSATSU_SUTEMI);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return nullptr;
+                return std::nullopt;
             }
             player_ptr->sutemi = true;
         }
@@ -628,10 +628,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -641,7 +641,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
                 do_cmd_attack(player_ptr, y, x, HISSATSU_ELEC);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return nullptr;
+                return std::nullopt;
             }
         }
         break;
@@ -656,7 +656,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
 
         if (cast) {
             if (!rush_attack(player_ptr, nullptr)) {
-                return nullptr;
+                return std::nullopt;
             }
         }
         break;
@@ -709,10 +709,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -738,7 +738,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             int total_damage = 0, basedam, i;
             ItemEntity *o_ptr;
             if (!get_aim_dir(player_ptr, &dir)) {
-                return nullptr;
+                return std::nullopt;
             }
             msg_print(_("武器を大きく振り下ろした。", "You swing your weapon downward."));
             for (i = 0; i < 2; i++) {
@@ -801,10 +801,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             int i;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             for (i = 0; i < 3; i++) {
@@ -822,7 +822,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
                     do_cmd_attack(player_ptr, y, x, HISSATSU_3DAN);
                 } else {
                     msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
@@ -891,10 +891,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -904,7 +904,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
                 do_cmd_attack(player_ptr, y, x, HISSATSU_DRAIN);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return nullptr;
+                return std::nullopt;
             }
         }
         break;
@@ -959,7 +959,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             } while (player_ptr->csp > mana_cost_per_monster);
 
             if (is_new) {
-                return nullptr;
+                return std::nullopt;
             }
 
             /* Restore reserved mana */
@@ -980,7 +980,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!tgt_pt(player_ptr, &x, &y)) {
-                return nullptr;
+                return std::nullopt;
             }
 
             if (!cave_player_teleportable_bold(player_ptr, y, x, TELEPORT_SPONTANEOUS) || (distance(y, x, player_ptr->y, player_ptr->x) > MAX_PLAYER_SIGHT / 2) || !projectable(player_ptr, player_ptr->y, player_ptr->x, y, x)) {
@@ -1008,7 +1008,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION x, y;
 
             if (!get_rep_dir(player_ptr, &dir, false)) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -1022,7 +1022,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
                 }
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "You don't see any monster in this direction"));
-                return nullptr;
+                return std::nullopt;
             }
         }
         break;
@@ -1041,10 +1041,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             ItemEntity *o_ptr;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -1098,10 +1098,10 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             POSITION y, x;
 
             if (!get_direction(player_ptr, &dir, false, false)) {
-                return nullptr;
+                return std::nullopt;
             }
             if (dir == 5) {
-                return nullptr;
+                return std::nullopt;
             }
 
             y = player_ptr->y + ddy[dir];
@@ -1111,7 +1111,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
                 do_cmd_attack(player_ptr, y, x, HISSATSU_UNDEAD);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return nullptr;
+                return std::nullopt;
             }
             take_hit(player_ptr, DAMAGE_NOESCAPE, 100 + randint1(100), _("慶雲鬼忍剣を使った衝撃", "exhaustion on using Keiun-Kininken"));
         }
@@ -1128,7 +1128,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
         if (cast) {
             int i;
             if (!get_check(_("何もかも諦めますか? ", "Do you give up everything? "))) {
-                return nullptr;
+                return std::nullopt;
             }
             /* Special Verification for suicide */
             prt(_("確認のため '@' を押して下さい。", "Please verify SUICIDE by typing the '@' sign: "), 0, 0);
@@ -1137,7 +1137,7 @@ concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessT
             i = inkey();
             prt("", 0, 0);
             if (i != '@') {
-                return nullptr;
+                return std::nullopt;
             }
             if (w_ptr->total_winner) {
                 take_hit(player_ptr, DAMAGE_FORCE, 9999, "Seppuku");

--- a/src/realm/realm-hissatsu.h
+++ b/src/realm/realm-hissatsu.h
@@ -2,6 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
+#include <optional>
+#include <string>
 
 class PlayerType;
-concptr do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-life.cpp
+++ b/src/realm/realm-life.cpp
@@ -28,9 +28,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列ポインタを返す。SpellProcessType::CAST時はnullptr文字列を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
  */
-concptr do_life_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+std::optional<std::string> do_life_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool name = mode == SpellProcessType::NAME;
     bool desc = mode == SpellProcessType::DESCRIPTION;
@@ -97,7 +97,7 @@ concptr do_life_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType 
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 fire_ball_hide(player_ptr, AttributeType::WOUNDS, dir, damroll(dice, sides), 0);
             }
@@ -228,7 +228,7 @@ concptr do_life_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType 
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 fire_ball_hide(player_ptr, AttributeType::WOUNDS, dir, damroll(dice, sides), 0);
             }
@@ -374,7 +374,7 @@ concptr do_life_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType 
         {
             if (cast) {
                 if (!ident_spell(player_ptr, false)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -441,7 +441,7 @@ concptr do_life_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType 
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 fire_ball_hide(player_ptr, AttributeType::WOUNDS, dir, damroll(dice, sides), 0);
             }
@@ -467,7 +467,7 @@ concptr do_life_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType 
 
             if (cast) {
                 if (!recall_player(player_ptr, randint0(21) + 15)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -639,7 +639,7 @@ concptr do_life_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType 
         {
             if (cast) {
                 if (!identify_fully(player_ptr, false)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }

--- a/src/realm/realm-life.h
+++ b/src/realm/realm-life.h
@@ -2,6 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
+#include <optional>
+#include <string>
 
 class PlayerType;
-concptr do_life_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+std::optional<std::string> do_life_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-nature.cpp
+++ b/src/realm/realm-nature.cpp
@@ -47,9 +47,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列ポインタを返す。SpellProcessType::CAST時はnullptr文字列を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
  */
-concptr do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool name = mode == SpellProcessType::NAME;
     bool desc = mode == SpellProcessType::DESCRIPTION;
@@ -102,7 +102,7 @@ concptr do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
                 project_length = range;
 
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_beam(player_ptr, AttributeType::ELEC, dir, damroll(dice, sides));
@@ -201,7 +201,7 @@ concptr do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 charm_animal(player_ptr, dir, plev);
@@ -278,7 +278,7 @@ concptr do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 wall_to_mud(player_ptr, dir, 20 + randint1(30));
@@ -304,7 +304,7 @@ concptr do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::COLD, dir, damroll(dice, sides));
             }
@@ -356,7 +356,7 @@ concptr do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::FIRE, dir, damroll(dice, sides));
             }
@@ -381,7 +381,7 @@ concptr do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 msg_print(_("太陽光線が現れた。", "A line of sunlight appears."));
                 lite_line(player_ptr, dir, damroll(6, 8));
@@ -552,7 +552,7 @@ concptr do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
         {
             if (cast) {
                 if (!identify_fully(player_ptr, false)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -584,7 +584,7 @@ concptr do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
         {
             if (cast) {
                 if (!rustproof(player_ptr)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -642,7 +642,7 @@ concptr do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::COLD, dir, dam, rad);
@@ -668,7 +668,7 @@ concptr do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 fire_ball(player_ptr, AttributeType::ELEC, dir, dam, rad);
                 break;
@@ -694,7 +694,7 @@ concptr do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTyp
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 fire_ball(player_ptr, AttributeType::WATER, dir, dam, rad);
             }

--- a/src/realm/realm-nature.h
+++ b/src/realm/realm-nature.h
@@ -2,6 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
+#include <optional>
+#include <string>
 
 class PlayerType;
-concptr do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -54,9 +54,9 @@ static void start_singing(PlayerType *player_ptr, SPELL_IDX spell, int32_t song)
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 歌ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST / SpellProcessType::FAIL / SPELL_CONT / SpellProcessType::STOP)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列ポインタを返す。SpellProcessType::CAST / SpellProcessType::FAIL / SPELL_CONT / SpellProcessType::STOP 時はnullptr文字列を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST / SpellProcessType::FAIL / SPELL_CONT / SpellProcessType::STOP 時は std::nullopt を返す。
  */
-concptr do_music_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool name = mode == SpellProcessType::NAME;
     bool desc = mode == SpellProcessType::DESCRIPTION;
@@ -150,7 +150,7 @@ concptr do_music_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_bolt(player_ptr, AttributeType::SOUND, dir, damroll(dice, sides));
@@ -820,7 +820,7 @@ concptr do_music_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_beam(player_ptr, AttributeType::SOUND, dir, damroll(dice, sides));
@@ -1067,7 +1067,7 @@ concptr do_music_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_ball(player_ptr, AttributeType::SOUND, dir, damroll(dice, sides), rad);

--- a/src/realm/realm-song.h
+++ b/src/realm/realm-song.h
@@ -4,4 +4,4 @@
 #include "system/angband.h"
 
 class PlayerType;
-concptr do_music_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-sorcery.cpp
+++ b/src/realm/realm-sorcery.cpp
@@ -30,9 +30,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列ポインタを返す。SpellProcessType::CAST時はnullptr文字列を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
  */
-concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool name = mode == SpellProcessType::NAME;
     bool desc = mode == SpellProcessType::DESCRIPTION;
@@ -148,7 +148,7 @@ concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 confuse_monster(player_ptr, dir, power);
@@ -194,7 +194,7 @@ concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 sleep_monster(player_ptr, dir, plev);
@@ -219,7 +219,7 @@ concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
 
             if (cast) {
                 if (!recharge(player_ptr, power)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -257,7 +257,7 @@ concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
         {
             if (cast) {
                 if (!ident_spell(player_ptr, false)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -280,7 +280,7 @@ concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 slow_monster(player_ptr, dir, plev);
@@ -326,7 +326,7 @@ concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_beam(player_ptr, AttributeType::AWAY_ALL, dir, power);
@@ -389,7 +389,7 @@ concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
         {
             if (cast) {
                 if (!identify_fully(player_ptr, false)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -435,7 +435,7 @@ concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 charm_monster(player_ptr, dir, plev);
@@ -476,7 +476,7 @@ concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
         {
             if (cast) {
                 if (!tele_town(player_ptr)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -509,7 +509,7 @@ concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
         {
             if (cast) {
                 if (!get_check(_("本当に他の階にテレポートしますか？", "Are you sure? (Teleport Level)"))) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 teleport_level(player_ptr, 0);
             }
@@ -535,7 +535,7 @@ concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
 
             if (cast) {
                 if (!recall_player(player_ptr, randint0(21) + 15)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -559,7 +559,7 @@ concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
             if (cast) {
                 msg_print(_("次元の扉が開いた。目的地を選んで下さい。", "You open a dimensional gate. Choose a destination."));
                 if (!dimension_door(player_ptr)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -621,7 +621,7 @@ concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fetch_item(player_ptr, dir, weight, false);
@@ -691,7 +691,7 @@ concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessTy
         {
             if (cast) {
                 if (!alchemy(player_ptr)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }

--- a/src/realm/realm-sorcery.h
+++ b/src/realm/realm-sorcery.h
@@ -2,6 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
+#include <optional>
+#include <string>
 
 class PlayerType;
-concptr do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-trump.cpp
+++ b/src/realm/realm-trump.cpp
@@ -34,9 +34,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列ポインタを返す。SpellProcessType::CAST時はnullptr文字列を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
  */
-concptr do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool name = mode == SpellProcessType::NAME;
     bool desc = mode == SpellProcessType::DESCRIPTION;
@@ -119,7 +119,7 @@ concptr do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
         {
             if (cast) {
                 if (!reset_recall(player_ptr)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -185,7 +185,7 @@ concptr do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fire_beam(player_ptr, AttributeType::AWAY_ALL, dir, power);
@@ -231,7 +231,7 @@ concptr do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!get_aim_dir(player_ptr, &dir)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 fetch_item(player_ptr, dir, weight, false);
@@ -254,7 +254,7 @@ concptr do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
                 if (cast) {
                     if (!target_set(player_ptr, TARGET_KILL)) {
-                        return nullptr;
+                        return std::nullopt;
                     }
                     x = target_col;
                     y = target_row;
@@ -322,7 +322,7 @@ concptr do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
                 target_pet = old_target_pet;
 
                 if (!result) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 speed_monster(player_ptr, dir, plev);
@@ -341,7 +341,7 @@ concptr do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
         {
             if (cast) {
                 if (!get_check(_("本当に他の階にテレポートしますか？", "Are you sure? (Teleport Level)"))) {
-                    return nullptr;
+                    return std::nullopt;
                 }
                 teleport_level(player_ptr, 0);
             }
@@ -366,7 +366,7 @@ concptr do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
             if (cast) {
                 msg_print(_("次元の扉が開いた。目的地を選んで下さい。", "You open a dimensional gate. Choose a destination."));
                 if (!dimension_door(player_ptr)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -391,7 +391,7 @@ concptr do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
 
             if (cast) {
                 if (!recall_player(player_ptr, randint0(21) + 15)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -439,7 +439,7 @@ concptr do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
                 project_length = 0;
 
                 if (!result) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 teleport_swap(player_ptr, dir);
@@ -615,7 +615,7 @@ concptr do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
         {
             if (cast) {
                 if (!identify_fully(player_ptr, false)) {
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
@@ -649,7 +649,7 @@ concptr do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType
                 target_pet = old_target_pet;
 
                 if (!result) {
-                    return nullptr;
+                    return std::nullopt;
                 }
 
                 heal_monster(player_ptr, dir, heal);

--- a/src/realm/realm-trump.h
+++ b/src/realm/realm-trump.h
@@ -2,6 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
+#include <optional>
+#include <string>
 
 class PlayerType;
-concptr do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -160,8 +160,8 @@ void SpellHex::display_casting_spells_list()
     prt(_("     名前", "     Name"), y, x + 5);
     for (auto spell : this->casting_spells) {
         term_erase(x, y + n + 1, 255);
-        auto spell_result = exe_spell(this->player_ptr, REALM_HEX, spell, SpellProcessType::NAME);
-        put_str(format("%c)  %s", I2A(n), spell_result), y + n + 1, x + 2);
+        const auto spell_name = exe_spell(this->player_ptr, REALM_HEX, spell, SpellProcessType::NAME);
+        put_str(format("%c)  %s", I2A(n), spell_name->data()), y + n + 1, x + 2);
         n++;
     }
 }

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -312,7 +312,8 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
             continue;
         }
 
-        strcpy(info, exe_spell(player_ptr, use_realm, spell, SpellProcessType::INFO));
+        const auto spell_info = exe_spell(player_ptr, use_realm, spell, SpellProcessType::INFO);
+        strcpy(info, spell_info->data());
         concptr comment = info;
         byte line_attr = TERM_WHITE;
         if (pc.is_every_magic()) {
@@ -337,11 +338,12 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
             line_attr = TERM_L_GREEN;
         }
 
+        const auto spell_name = exe_spell(player_ptr, use_realm, spell, SpellProcessType::NAME);
         if (use_realm == REALM_HISSATSU) {
-            strcat(out_val, format("%-25s %2d %4d", exe_spell(player_ptr, use_realm, spell, SpellProcessType::NAME), s_ptr->slevel, need_mana));
+            strcat(out_val, format("%-25s %2d %4d", spell_name->data(), s_ptr->slevel, need_mana));
         } else {
             strcat(out_val,
-                format("%-25s%c%-4s %2d %4d %3d%% %s", exe_spell(player_ptr, use_realm, spell, SpellProcessType::NAME), (max ? '!' : ' '), ryakuji, s_ptr->slevel,
+                format("%-25s%c%-4s %2d %4d %3d%% %s", spell_name->data(), (max ? '!' : ' '), ryakuji, s_ptr->slevel,
                     need_mana, spell_chance(player_ptr, spell, use_realm), comment));
         }
 

--- a/src/spell/spells-execution.cpp
+++ b/src/spell/spells-execution.cpp
@@ -22,7 +22,7 @@
  * @param mode 求める処理
  * @return 各領域魔法に各種テキストを求めた場合は文字列参照ポインタ、そうでない場合はnullptrを返す。
  */
-concptr exe_spell(PlayerType *player_ptr, int16_t realm, SPELL_IDX spell, SpellProcessType mode)
+std::optional<std::string> exe_spell(PlayerType *player_ptr, int16_t realm, SPELL_IDX spell, SpellProcessType mode)
 {
     switch (realm) {
     case REALM_LIFE:
@@ -53,5 +53,5 @@ concptr exe_spell(PlayerType *player_ptr, int16_t realm, SPELL_IDX spell, SpellP
         return do_hex_spell(player_ptr, i2enum<spell_hex_type>(spell), mode);
     }
 
-    return nullptr;
+    return std::nullopt;
 }

--- a/src/spell/spells-execution.h
+++ b/src/spell/spells-execution.h
@@ -2,6 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
+#include <optional>
+#include <string>
 
 class PlayerType;
-concptr exe_spell(PlayerType *player_ptr, int16_t realm, SPELL_IDX spell, SpellProcessType mode);
+std::optional<std::string> exe_spell(PlayerType *player_ptr, int16_t realm, SPELL_IDX spell, SpellProcessType mode);

--- a/src/window/display-sub-window-spells.cpp
+++ b/src/window/display-sub-window-spells.cpp
@@ -150,7 +150,8 @@ static void display_spell_list(PlayerType *player_ptr)
                 s_ptr = &mp_ptr->info[((j < 1) ? player_ptr->realm1 : player_ptr->realm2) - 1][i % 32];
             }
 
-            strcpy(name, exe_spell(player_ptr, (j < 1) ? player_ptr->realm1 : player_ptr->realm2, i % 32, SpellProcessType::NAME));
+            const auto spell_name = exe_spell(player_ptr, (j < 1) ? player_ptr->realm1 : player_ptr->realm2, i % 32, SpellProcessType::NAME);
+            strcpy(name, spell_name->data());
 
             if (s_ptr->slevel >= 99) {
                 strcpy(name, _("(判読不能)", "(illegible)"));

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -226,8 +226,8 @@ static SpoilerOutputResultType spoil_player_spell(concptr fname)
             spoil_out("Name                     Lv Cst Dif Exp\n");
             for (SPELL_IDX i = 0; i < 32; i++) {
                 auto spell_ptr = &magic_ptr->info[r][i];
-                auto spell_name = exe_spell(&dummy_p, r, i, SpellProcessType::NAME);
-                sprintf(buf, "%-24s %2d %3d %3d %3d\n", spell_name, spell_ptr->slevel, spell_ptr->smana, spell_ptr->sfail, spell_ptr->sexp);
+                const auto spell_name = exe_spell(&dummy_p, r, i, SpellProcessType::NAME);
+                sprintf(buf, "%-24s %2d %3d %3d %3d\n", spell_name->data(), spell_ptr->slevel, spell_ptr->smana, spell_ptr->sfail, spell_ptr->sexp);
                 spoil_out(buf);
             }
             spoil_out("\n");


### PR DESCRIPTION
現在 exe_spell 関数の戻り値の型は concptr であり、SpellProcessType 型の引数の値 により関数の処理内容が切り替わるとともに戻り値の意味も変化する。
大雑把には魔法の名称や情報を得る時はその文字列（静的リテラルや format 関数の静的バッ
ファ）を指すポインタが返り、魔法を実行するときは実行したなら空文字列リテラルへのポイン
タ、キャンセルしたなら nullptr が返る。
format 関数の戻り値を std::string にすると exe_spell の戻り値も std::string に する必要があるが、std::string に nullptr を入れることはできない。そこで戻り値を std::optional<std::string> に変更してキャンセル時には std::nullopt を返すように 変更する。