### PR TITLE
変愚「[Refactor] display_player_one_line 関数のシグネチャ変更」のマージ

### DIFF
--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -322,7 +322,7 @@ std::optional<int> display_player(PlayerType *player_ptr, const int tmp_mode)
     display_player_basic_info(player_ptr);
     display_magic_realms(player_ptr);
     if (PlayerClass(player_ptr).equals(PlayerClassType::CHAOS_WARRIOR) || (player_ptr->muta.has(PlayerMutationType::CHAOS_GIFT))) {
-        display_player_one_line(ENTRY_PATRON, patron_list[player_ptr->chaos_patron].name.data(), TERM_L_BLUE);
+        display_player_one_line(ENTRY_PATRON, patron_list[player_ptr->chaos_patron].name, TERM_L_BLUE);
     }
 
     display_phisique(player_ptr);

--- a/src/view/display-util.cpp
+++ b/src/view/display-util.cpp
@@ -68,7 +68,7 @@ const std::vector<disp_player_line> disp_player_lines = {
  * @param val 値を保管した文字列ポインタ
  * @param attr 項目表示の色
  */
-void display_player_one_line(int entry, concptr val, TERM_COLOR attr)
+void display_player_one_line(int entry, std::string_view val, TERM_COLOR attr)
 {
     auto head = disp_player_lines[entry].header;
     auto head_len = strlen(head);
@@ -77,17 +77,16 @@ void display_player_one_line(int entry, concptr val, TERM_COLOR attr)
     auto len = disp_player_lines[entry].len;
     term_putstr(col, row, -1, TERM_WHITE, head);
 
-    if (!val) {
-        return;
-    }
-
     if (len <= 0) {
         term_putstr(col + head_len, row, -1, attr, val);
         return;
     }
 
     int val_len = len - head_len;
-    char buf[40];
-    sprintf(buf, "%*.*s", val_len, val_len, val);
-    term_putstr(col + head_len, row, -1, attr, buf);
+    std::string str;
+    if (val_len > static_cast<int>(val.length())) {
+        str.append(val_len - val.length(), ' ');
+    }
+    str.append(val);
+    term_putstr(col + head_len, row, -1, attr, str);
 }

--- a/src/view/display-util.h
+++ b/src/view/display-util.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <string_view>
 
-void display_player_one_line(int entry, concptr val, TERM_COLOR attr);
+void display_player_one_line(int entry, std::string_view val, TERM_COLOR attr);

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -332,31 +332,31 @@ static void display_first_page(PlayerType *player_ptr, int xthb, int *damage, in
     int xdig = player_ptr->skill_dig;
 
     auto sd = likert(xthn, 12);
-    display_player_one_line(ENTRY_SKILL_FIGHT, sd.first.data(), sd.second);
+    display_player_one_line(ENTRY_SKILL_FIGHT, sd.first, sd.second);
 
     sd = likert(xthb, 12);
-    display_player_one_line(ENTRY_SKILL_SHOOT, sd.first.data(), sd.second);
+    display_player_one_line(ENTRY_SKILL_SHOOT, sd.first, sd.second);
 
     sd = likert(xsav, 7);
-    display_player_one_line(ENTRY_SKILL_SAVING, sd.first.data(), sd.second);
+    display_player_one_line(ENTRY_SKILL_SAVING, sd.first, sd.second);
 
     sd = likert((xstl > 0) ? xstl : -1, 1);
-    display_player_one_line(ENTRY_SKILL_STEALTH, sd.first.data(), sd.second);
+    display_player_one_line(ENTRY_SKILL_STEALTH, sd.first, sd.second);
 
     sd = likert(xfos, 6);
-    display_player_one_line(ENTRY_SKILL_PERCEP, sd.first.data(), sd.second);
+    display_player_one_line(ENTRY_SKILL_PERCEP, sd.first, sd.second);
 
     sd = likert(xsrh, 6);
-    display_player_one_line(ENTRY_SKILL_SEARCH, sd.first.data(), sd.second);
+    display_player_one_line(ENTRY_SKILL_SEARCH, sd.first, sd.second);
 
     sd = likert(xdis, 8);
-    display_player_one_line(ENTRY_SKILL_DISARM, sd.first.data(), sd.second);
+    display_player_one_line(ENTRY_SKILL_DISARM, sd.first, sd.second);
 
     sd = likert(xdev, 6);
-    display_player_one_line(ENTRY_SKILL_DEVICE, sd.first.data(), sd.second);
+    display_player_one_line(ENTRY_SKILL_DEVICE, sd.first, sd.second);
 
     sd = likert(xdig, 4);
-    display_player_one_line(ENTRY_SKILL_DIG, sd.first.data(), sd.second);
+    display_player_one_line(ENTRY_SKILL_DIG, sd.first, sd.second);
 
     if (!muta_att) {
         display_player_one_line(ENTRY_BLOWS, format("%d+%d", blows1, blows2), TERM_L_BLUE);


### PR DESCRIPTION
display_player_one_line 関数は format 関数の戻り値をダイレクトに渡している箇所が 多いので、format 関数の戻り値が std::string になっても変更しなくてすむように引数を concptr から std::string_view に変更する。
また、現在 std::string::data() メソッドを呼び出して渡している箇所は、data() の呼 び出しが不要になるので std::string オブジェクトをそのまま渡すようにする。