### PR TITLE
変愚「[Refactor] format 関数の戻り値を std::string にする」のマージ

### DIFF
--- a/src/autopick/autopick-command-menu.cpp
+++ b/src/autopick/autopick-command-menu.cpp
@@ -37,7 +37,6 @@ static void redraw_edit_command_menu(bool *redraw, int level, int start, char *l
     *menu_key = 0;
     for (int i = start; menu_data[i].level >= level; i++) {
         char com_key_str[3];
-        concptr str;
         if (menu_data[i].level > level) {
             continue;
         }
@@ -52,7 +51,7 @@ static void redraw_edit_command_menu(bool *redraw, int level, int start, char *l
             com_key_str[0] = '\0';
         }
 
-        str = format("| %c) %-*s %2s | ", *menu_key + 'a', max_len, menu_data[i].name, com_key_str);
+        const auto str = format("| %c) %-*s %2s | ", *menu_key + 'a', max_len, menu_data[i].name, com_key_str);
 
         term_putstr(col0, row1++, -1, TERM_WHITE, str);
 

--- a/src/autopick/autopick-describer.cpp
+++ b/src/autopick/autopick-describer.cpp
@@ -231,7 +231,7 @@ static void describe_autpick_jp(char *buff, autopick_type *entry, autopick_descr
     if (describer->insc) {
         char tmp[MAX_INSCRIPTION + 1] = "";
         angband_strcat(tmp, describer->insc, MAX_INSCRIPTION);
-        angband_strcat(buff, format("に「%s」", tmp), MAX_INSCRIPTION + 6);
+        angband_strcat(buff, format("に「%s」", tmp).data(), MAX_INSCRIPTION + 6);
 
         if (angband_strstr(describer->insc, "%%all")) {
             strcat(buff, "(%%allは全能力を表す英字の記号で置換)");
@@ -485,7 +485,7 @@ void describe_autopick_en(char *buff, autopick_type *entry, autopick_describer *
     }
 
     if (describer->insc) {
-        strncat(buff, format("and inscribe \"%s\"", describer->insc), 80);
+        strncat(buff, format("and inscribe \"%s\"", describer->insc).data(), 80);
 
         if (angband_strstr(describer->insc, "%all")) {
             strcat(buff, ", replacing %all with code string representing all abilities,");

--- a/src/autopick/autopick-drawer.cpp
+++ b/src/autopick/autopick-drawer.cpp
@@ -216,7 +216,7 @@ void draw_text_editor(PlayerType *player_ptr, text_body_type *tb)
     }
 
     autopick_type an_entry, *entry = &an_entry;
-    concptr str1 = nullptr, str2 = nullptr;
+    std::string str1, str2;
     for (int j = 0; j < DESCRIPT_HGT; j++) {
         term_erase(0, tb->hgt + 2 + j, tb->wid);
     }
@@ -293,10 +293,10 @@ void draw_text_editor(PlayerType *player_ptr, text_body_type *tb)
         }
     }
 
-    if (str1) {
+    if (!str1.empty()) {
         prt(str1, tb->hgt + 1 + 1, 0);
     }
-    if (str2) {
+    if (!str2.empty()) {
         prt(str2, tb->hgt + 1 + 2, 0);
     }
 }

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -566,13 +566,13 @@ concptr autopick_line_from_entry(autopick_type *entry)
 
     if (IS_FLG(FLG_MORE_DICE)) {
         ADD_KEY(KEY_MORE_THAN);
-        strcat(ptr, format("%d", entry->dice));
+        strcat(ptr, format("%d", entry->dice).data());
         ADD_KEY(KEY_DICE);
     }
 
     if (IS_FLG(FLG_MORE_BONUS)) {
         ADD_KEY(KEY_MORE_BONUS);
-        strcat(ptr, format("%d", entry->bonus));
+        strcat(ptr, format("%d", entry->bonus).data());
         ADD_KEY(KEY_MORE_BONUS2);
     }
 

--- a/src/autopick/autopick-finder.cpp
+++ b/src/autopick/autopick-finder.cpp
@@ -69,7 +69,7 @@ bool get_object_for_search(PlayerType *player_ptr, ItemEntity **o_handle, concpt
     string_free(*search_strp);
     char buf[MAX_NLEN + 20];
     describe_flavor(player_ptr, buf, *o_handle, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
-    *search_strp = string_make(format("<%s>", buf));
+    *search_strp = string_make(format("<%s>", buf).data());
     return true;
 }
 
@@ -86,7 +86,7 @@ bool get_destroyed_object_for_search(PlayerType *player_ptr, ItemEntity **o_hand
     string_free(*search_strp);
     char buf[MAX_NLEN + 20];
     describe_flavor(player_ptr, buf, *o_handle, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
-    *search_strp = string_make(format("<%s>", buf));
+    *search_strp = string_make(format("<%s>", buf).data());
     return true;
 }
 

--- a/src/autopick/autopick-inserter-killer.cpp
+++ b/src/autopick/autopick-inserter-killer.cpp
@@ -105,7 +105,7 @@ bool insert_macro_line(text_body_type *tb)
     tb->cx = 0;
     insert_return_code(tb);
     string_free(tb->lines_list[tb->cy]);
-    tb->lines_list[tb->cy] = string_make(format("P:%s", tmp));
+    tb->lines_list[tb->cy] = string_make(format("P:%s", tmp).data());
 
     i = macro_find_exact(buf);
     if (i == -1) {
@@ -116,7 +116,7 @@ bool insert_macro_line(text_body_type *tb)
 
     insert_return_code(tb);
     string_free(tb->lines_list[tb->cy]);
-    tb->lines_list[tb->cy] = string_make(format("A:%s", tmp));
+    tb->lines_list[tb->cy] = string_make(format("A:%s", tmp).data());
 
     return true;
 }
@@ -151,7 +151,7 @@ bool insert_keymap_line(text_body_type *tb)
     tb->cx = 0;
     insert_return_code(tb);
     string_free(tb->lines_list[tb->cy]);
-    tb->lines_list[tb->cy] = string_make(format("C:%d:%s", mode, tmp));
+    tb->lines_list[tb->cy] = string_make(format("C:%d:%s", mode, tmp).data());
 
     concptr act = keymap_act[mode][(byte)(buf[0])];
     if (act) {
@@ -160,7 +160,7 @@ bool insert_keymap_line(text_body_type *tb)
 
     insert_return_code(tb);
     string_free(tb->lines_list[tb->cy]);
-    tb->lines_list[tb->cy] = string_make(format("A:%s", tmp));
+    tb->lines_list[tb->cy] = string_make(format("A:%s", tmp).data());
 
     return true;
 }

--- a/src/autopick/autopick-reader-writer.h
+++ b/src/autopick/autopick-reader-writer.h
@@ -2,10 +2,11 @@
 
 #include "system/angband.h"
 
+#include <string>
 #include <vector>
 
 class PlayerType;
 void autopick_load_pref(PlayerType *player_ptr, bool disp_mes);
 std::vector<concptr> read_pickpref_text_lines(PlayerType *player_ptr, int *filename_mode_p);
 bool write_text_lines(concptr filename, concptr *lines_list);
-concptr pickpref_filename(PlayerType *player_ptr, int filename_mode);
+std::string pickpref_filename(PlayerType *player_ptr, int filename_mode);

--- a/src/autopick/autopick-registry.cpp
+++ b/src/autopick/autopick-registry.cpp
@@ -29,12 +29,12 @@ static const char autoregister_header[] = "?:$AUTOREGISTER";
 static bool clear_auto_register(PlayerType *player_ptr)
 {
     char pref_file[1024];
-    path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_WITH_PNAME));
+    path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_WITH_PNAME).data());
     FILE *pref_fff;
     pref_fff = angband_fopen(pref_file, "r");
 
     if (!pref_fff) {
-        path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_DEFAULT));
+        path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_DEFAULT).data());
         pref_fff = angband_fopen(pref_file, "r");
     }
 
@@ -146,11 +146,11 @@ bool autopick_autoregister(PlayerType *player_ptr, ItemEntity *o_ptr)
     char buf[1024];
     char pref_file[1024];
     FILE *pref_fff;
-    path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_WITH_PNAME));
+    path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_WITH_PNAME).data());
     pref_fff = angband_fopen(pref_file, "r");
 
     if (!pref_fff) {
-        path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_DEFAULT));
+        path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_DEFAULT).data());
         pref_fff = angband_fopen(pref_file, "r");
     }
 

--- a/src/avatar/avatar.cpp
+++ b/src/avatar/avatar.cpp
@@ -545,7 +545,8 @@ void dump_virtues(PlayerType *player_ptr, FILE *out_file)
         GAME_TEXT vir_name[20];
         int tester = player_ptr->virtues[v_nr];
         strcpy(vir_name, virtue[(player_ptr->vir_types[v_nr]) - 1]);
-        concptr vir_val = show_actual_value ? format(" (%d)", tester) : "";
+        const std::string vir_val_str = format(" (%d)", tester);
+        const auto vir_val = show_actual_value ? vir_val_str.data() : "";
         if (player_ptr->vir_types[v_nr] == 0 || player_ptr->vir_types[v_nr] > MAX_VIRTUE) {
             fprintf(out_file, _("おっと。%sの情報なし。", "Oops. No info about %s."), vir_name);
         }

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -68,7 +68,7 @@ static void write_birth_diary(PlayerType *player_ptr)
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
     if (player_ptr->realm1) {
         strnfmt(buf, sizeof(buf), _("%s魔法の領域に%s%sを選択した。", "%schose %s%s."), indent, realm_names[player_ptr->realm1],
-            player_ptr->realm2 ? format(_("と%s", " and %s realms"), realm_names[player_ptr->realm2]) : _("", " realm"));
+            player_ptr->realm2 ? format(_("と%s", " and %s realms"), realm_names[player_ptr->realm2]).data() : _("", " realm"));
         exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
     }
     if (player_ptr->element) {

--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -329,9 +329,10 @@ static void describe_blue_magic_name(PlayerType *player_ptr, int menu_line, cons
         const auto &mp = monster_powers.at(spell);
         auto need_mana = mod_need_mana(player_ptr, mp.smana, 0, REALM_NONE);
         auto chance = calculate_blue_magic_failure_probability(player_ptr, mp, need_mana);
-        char psi_desc[80];
-        close_blue_magic_name(psi_desc, sizeof(psi_desc), i, menu_line);
-        angband_strcat(psi_desc, format(" %-26s %3d %3d%%%s", mp.name, need_mana, chance, learnt_info(player_ptr, spell).data()), sizeof(psi_desc));
+        char header[80];
+        close_blue_magic_name(header, sizeof(header), i, menu_line);
+        const auto info = learnt_info(player_ptr, spell);
+        const auto psi_desc = format("%s %-26s %3d %3d%%%s", header, mp.name, need_mana, chance, info.data());
         prt(psi_desc, y_base + i + 1, x_base);
     }
 

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -244,7 +244,7 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
 
                     /* Dump the spell --(-- */
                     const auto spell_name = exe_spell(player_ptr, REALM_HISSATSU, i, SpellProcessType::NAME);
-                    strcat(psi_desc, format(" %-18s%2d %3d", spell_name->data(), spell.slevel, spell.smana));
+                    strcat(psi_desc, format(" %-18s%2d %3d", spell_name->data(), spell.slevel, spell.smana).c_str());
                     prt(psi_desc, y + (line % 17) + (line >= 17), x + (line / 17) * 30);
                     prt("", y + (line % 17) + (line >= 17) + 1, x + (line / 17) * 30);
                 }

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -92,7 +92,8 @@ static void racial_power_display_list(PlayerType *player_ptr, rc_type *rc_ptr)
         auto &rpi = rc_ptr->power_desc[ctr];
         strcat(dummy,
             format("%-30.30s %2d %4d %3d%% %s", rpi.racial_name.data(), rpi.min_level, rpi.cost, 100 - racial_chance(player_ptr, &rc_ptr->power_desc[ctr]),
-                rpi.info.data()));
+                rpi.info.data())
+                .data());
 
         prt(dummy, 2 + y, x);
     }

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -98,7 +98,7 @@ const uint32_t fake_spell_flags[4] = { 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff0
  * @param base 固定値
  * @return フォーマットに従い整形された文字列
  */
-concptr info_string_dice(concptr str, DICE_NUMBER dice, DICE_SID sides, int base)
+std::string info_string_dice(concptr str, DICE_NUMBER dice, DICE_SID sides, int base)
 {
     /* Fix value */
     if (!dice) {
@@ -123,7 +123,7 @@ concptr info_string_dice(concptr str, DICE_NUMBER dice, DICE_SID sides, int base
  * @param base 固定値
  * @return フォーマットに従い整形された文字列
  */
-concptr info_damage(DICE_NUMBER dice, DICE_SID sides, int base)
+std::string info_damage(DICE_NUMBER dice, DICE_SID sides, int base)
 {
     return info_string_dice(_("損傷:", "dam "), dice, sides, base);
 }
@@ -134,7 +134,7 @@ concptr info_damage(DICE_NUMBER dice, DICE_SID sides, int base)
  * @param sides ダイス目
  * @return フォーマットに従い整形された文字列
  */
-concptr info_duration(int base, DICE_SID sides)
+std::string info_duration(int base, DICE_SID sides)
 {
     return format(_("期間:%d+1d%d", "dur %d+1d%d"), base, sides);
 }
@@ -144,7 +144,7 @@ concptr info_duration(int base, DICE_SID sides)
  * @param range 効果範囲
  * @return フォーマットに従い整形された文字列
  */
-concptr info_range(POSITION range)
+std::string info_range(POSITION range)
 {
     return format(_("範囲:%d", "range %d"), range);
 }
@@ -156,7 +156,7 @@ concptr info_range(POSITION range)
  * @param base 固定値
  * @return フォーマットに従い整形された文字列
  */
-concptr info_heal(DICE_NUMBER dice, DICE_SID sides, int base)
+std::string info_heal(DICE_NUMBER dice, DICE_SID sides, int base)
 {
     return info_string_dice(_("回復:", "heal "), dice, sides, base);
 }
@@ -167,7 +167,7 @@ concptr info_heal(DICE_NUMBER dice, DICE_SID sides, int base)
  * @param sides ダイス目
  * @return フォーマットに従い整形された文字列
  */
-concptr info_delay(int base, DICE_SID sides)
+std::string info_delay(int base, DICE_SID sides)
 {
     return format(_("遅延:%d+1d%d", "delay %d+1d%d"), base, sides);
 }
@@ -177,7 +177,7 @@ concptr info_delay(int base, DICE_SID sides)
  * @param dam 固定値
  * @return フォーマットに従い整形された文字列
  */
-concptr info_multi_damage(int dam)
+std::string info_multi_damage(int dam)
 {
     return format(_("損傷:各%d", "dam %d each"), dam);
 }
@@ -188,7 +188,7 @@ concptr info_multi_damage(int dam)
  * @param sides ダイス目
  * @return フォーマットに従い整形された文字列
  */
-concptr info_multi_damage_dice(DICE_NUMBER dice, DICE_SID sides)
+std::string info_multi_damage_dice(DICE_NUMBER dice, DICE_SID sides)
 {
     return format(_("損傷:各%dd%d", "dam %dd%d each"), dice, sides);
 }
@@ -198,7 +198,7 @@ concptr info_multi_damage_dice(DICE_NUMBER dice, DICE_SID sides)
  * @param power 固定値
  * @return フォーマットに従い整形された文字列
  */
-concptr info_power(int power)
+std::string info_power(int power)
 {
     return format(_("効力:%d", "power %d"), power);
 }
@@ -212,7 +212,7 @@ concptr info_power(int power)
 /*
  * Generate power info string such as "power 1d100"
  */
-concptr info_power_dice(DICE_NUMBER dice, DICE_SID sides)
+std::string info_power_dice(DICE_NUMBER dice, DICE_SID sides)
 {
     return format(_("効力:%dd%d", "power %dd%d"), dice, sides);
 }
@@ -222,7 +222,7 @@ concptr info_power_dice(DICE_NUMBER dice, DICE_SID sides)
  * @param rad 効果半径
  * @return フォーマットに従い整形された文字列
  */
-concptr info_radius(POSITION rad)
+std::string info_radius(POSITION rad)
 {
     return format(_("半径:%d", "rad %d"), rad);
 }
@@ -232,7 +232,7 @@ concptr info_radius(POSITION rad)
  * @param weight 最大重量
  * @return フォーマットに従い整形された文字列
  */
-concptr info_weight(WEIGHT weight)
+std::string info_weight(WEIGHT weight)
 {
 #ifdef JP
     return format("最大重量:%d.%dkg", lb_to_kg_integer(weight), lb_to_kg_fraction(weight));

--- a/src/cmd-action/cmd-spell.h
+++ b/src/cmd-action/cmd-spell.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <string>
 
 extern concptr KWD_DAM; //!< 効果文字列: 損傷 / dam
 extern concptr KWD_RANGE; //!< 効果文字列: 射程 / dir
@@ -13,18 +14,18 @@ extern concptr KWD_RANDOM; //!< 効果文字列: ランダム / random
 
 extern const uint32_t fake_spell_flags[4];
 
-concptr info_string_dice(concptr str, DICE_NUMBER dice, DICE_SID sides, int base);
-concptr info_damage(DICE_NUMBER dice, DICE_SID sides, int base);
-concptr info_duration(int base, DICE_SID sides);
-concptr info_range(POSITION range);
-concptr info_heal(DICE_NUMBER dice, DICE_SID sides, int base);
-concptr info_delay(int base, DICE_SID sides);
-concptr info_multi_damage(int dam);
-concptr info_multi_damage_dice(DICE_NUMBER dice, DICE_SID sides);
-concptr info_power(int power);
-concptr info_power_dice(DICE_NUMBER dice, DICE_SID sides);
-concptr info_radius(POSITION rad);
-concptr info_weight(WEIGHT weight);
+std::string info_string_dice(concptr str, DICE_NUMBER dice, DICE_SID sides, int base);
+std::string info_damage(DICE_NUMBER dice, DICE_SID sides, int base);
+std::string info_duration(int base, DICE_SID sides);
+std::string info_range(POSITION range);
+std::string info_heal(DICE_NUMBER dice, DICE_SID sides, int base);
+std::string info_delay(int base, DICE_SID sides);
+std::string info_multi_damage(int dam);
+std::string info_multi_damage_dice(DICE_NUMBER dice, DICE_SID sides);
+std::string info_power(int power);
+std::string info_power_dice(DICE_NUMBER dice, DICE_SID sides);
+std::string info_radius(POSITION rad);
+std::string info_weight(WEIGHT weight);
 
 class PlayerType;
 void do_cmd_browse(PlayerType *player_ptr);

--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -102,7 +102,6 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
     static int cx_save = 0;
     static int cy_save = 0;
     autopick_type an_entry, *entry = &an_entry;
-    char buf[MAX_LINELEN];
     int i;
     int key = -1;
     static int32_t old_autosave_turn = 0L;
@@ -201,10 +200,10 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
     }
 
     screen_load();
-    strcpy(buf, pickpref_filename(player_ptr, tb->filename_mode));
+    const auto filename = pickpref_filename(player_ptr, tb->filename_mode);
 
     if (quit == APE_QUIT_AND_SAVE) {
-        write_text_lines(buf, tb->lines_list.data());
+        write_text_lines(filename.data(), tb->lines_list.data());
     }
 
     free_text_lines(tb->lines_list);
@@ -212,7 +211,7 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
     string_free(tb->last_destroyed);
     kill_yank_chain(tb);
 
-    process_autopick_file(player_ptr, buf);
+    process_autopick_file(player_ptr, filename.data());
     w_ptr->start_time = (uint32_t)time(nullptr);
     cx_save = tb->cx;
     cy_save = tb->cy;

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -333,14 +333,16 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
                         strcat(dummy,
                             format(_(" %-22.22s 充填:%2d/%2d%3d%%", " %-22.22s   (%2d/%2d) %3d%%"), baseitems_info[bi_id].name.data(),
                                 item.charge ? (item.charge - 1) / (EATER_ROD_CHARGE * baseitems_info[bi_id].pval) + 1 : 0,
-                                item.count, chance));
+                                item.count, chance)
+                                .data());
                         if (item.charge > baseitems_info[bi_id].pval * (item.count - 1) * EATER_ROD_CHARGE) {
                             col = TERM_RED;
                         }
                     } else {
                         strcat(dummy,
                             format(" %-22.22s    %2d/%2d %3d%%", baseitems_info[bi_id].name.data(), (int16_t)(item.charge / EATER_CHARGE),
-                                item.count, chance));
+                                item.count, chance)
+                                .data());
                         if (item.charge < EATER_CHARGE) {
                             col = TERM_RED;
                         }

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -95,7 +95,7 @@ static bool deal_damege_by_feat(PlayerType *player_ptr, grid_type *g_ptr, concpt
     if (resist_levitation) {
         msg_print(msg_levitation);
 
-        take_hit(player_ptr, DAMAGE_NOESCAPE, damage, format(_("%sの上に浮遊したダメージ", "flying over %s"), terrains_info[g_ptr->get_feat_mimic()].name.data()));
+        take_hit(player_ptr, DAMAGE_NOESCAPE, damage, format(_("%sの上に浮遊したダメージ", "flying over %s"), terrains_info[g_ptr->get_feat_mimic()].name.data()).data());
 
         if (additional_effect != nullptr) {
             additional_effect(player_ptr, damage);

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -574,7 +574,7 @@ static void dump_aux_home_museum(PlayerType *player_ptr, FILE *fff)
  * @brief チェックサム情報を出力 / Get check sum in string form
  * @return チェックサム情報の文字列
  */
-static concptr get_check_sum(void)
+static std::string get_check_sum(void)
 {
     return format("%02x%02x%02x%02x%02x%02x%02x%02x%02x", terrains_header.checksum, baseitems_header.checksum,
         artifacts_header.checksum, egos_header.checksum, monraces_header.checksum, dungeons_header.checksum,
@@ -611,5 +611,5 @@ void make_character_dump(PlayerType *player_ptr, FILE *fff)
     dump_aux_equipment_inventory(player_ptr, fff);
     dump_aux_home_museum(player_ptr, fff);
 
-    fprintf(fff, _("  [チェックサム: \"%s\"]\n\n", "  [Check Sum: \"%s\"]\n\n"), get_check_sum());
+    fprintf(fff, _("  [チェックサム: \"%s\"]\n\n", "  [Check Sum: \"%s\"]\n\n"), get_check_sum().data());
 }

--- a/src/io/uid-checker.cpp
+++ b/src/io/uid-checker.cpp
@@ -10,22 +10,22 @@ void safe_setuid_drop(void)
 #ifdef SAFE_SETUID_POSIX
     if (auto ret = setuid(getuid()); ret != 0) {
         auto msg = _("setuid(): 正しく許可が取れません！ エラーコード：%d", "setuid(): cannot set permissions correctly! Error code: %d");
-        quit(format(msg, ret));
+        quit_fmt(msg, ret);
     }
 
     if (auto ret = setgid(getgid()); ret != 0) {
         auto msg = _("setgid(): 正しく許可が取れません！ エラーコード：%d", "setgid(): cannot set permissions correctly! Error code: %d");
-        quit(format(msg, ret));
+        quit_fmt(msg, ret);
     }
 #else
     if (auto ret = setreuid(geteuid(), getuid()); ret != 0) {
         auto msg = _("setreuid(): 正しく許可が取れません！ エラーコード：%d", "setreuid(): cannot set permissions correctly! Error code: %d");
-        quit(format(msg, ret));
+        quit_fmt(msg, ret);
     }
 
     if (auto ret = setregid(getegid(), getgid()); ret != 0) {
         auto msg = _("setregid(): 正しく許可が取れません！ エラーコード：%d", "setregid(): cannot set permissions correctly! Error code: %d");
-        quit(format(msg, ret));
+        quit_fmt(msg, ret);
     }
 #endif
 #endif
@@ -41,23 +41,23 @@ void safe_setuid_grab(PlayerType *player_ptr)
 #ifdef SAFE_SETUID_POSIX
     if (auto ret = setuid(player_ptr->player_euid); ret != 0) {
         auto msg = _("setuid(): 正しく許可が取れません！ エラーコード：%d", "setuid(): cannot set permissions correctly! Error code: %d");
-        quit(format(msg, ret));
+        quit_fmt(msg, ret);
     }
 
     if (auto ret = setgid(player_ptr->player_egid); ret != 0) {
         auto msg = _("setgid(): 正しく許可が取れません！ エラーコード：%d", "setgid(): cannot set permissions correctly! Error code: %d");
-        quit(format(msg, ret));
+        quit_fmt(msg, ret);
     }
 #else
     (void)player_ptr;
     if (auto ret = setreuid(geteuid(), getuid()); ret != 0) {
         auto msg = _("setreuid(): 正しく許可が取れません！ エラーコード：%d", "setreuid(): cannot set permissions correctly! Error code: %d");
-        quit(format(msg, ret));
+        quit_fmt(msg, ret);
     }
 
     if (auto ret = setregid(getegid(), getgid()); ret != 0) {
         auto msg = _("setregid(): 正しく許可が取れません！ エラーコード：%d", "setregid(): cannot set permissions correctly! Error code: %d");
-        quit(format(msg, ret));
+        quit_fmt(msg, ret);
     }
 #endif
 #else

--- a/src/io/write-diary.cpp
+++ b/src/io/write-diary.cpp
@@ -315,12 +315,12 @@ errr exe_write_diary(PlayerType *player_ptr, int type, int num, concptr note)
         break;
     }
     case DIARY_STAIR: {
-        concptr to = inside_quest(q_idx) && (quest_type::is_fixed(q_idx) && !(q_idx == QuestId::MELKO))
-                         ? _("地上", "the surface")
-                     : !(player_ptr->current_floor_ptr->dun_level + num)
-                         ? _("地上", "the surface")
-                         : format(_("%d階", "level %d"), player_ptr->current_floor_ptr->dun_level + num);
-        fprintf(fff, _(" %2d:%02d %20s %sへ%s。\n", " %2d:%02d %20s %s %s.\n"), hour, min, note_level.data(), _(to, note), _(note, to));
+        auto to = inside_quest(q_idx) && (quest_type::is_fixed(q_idx) && !(q_idx == QuestId::MELKO))
+                      ? _("地上", "the surface")
+                  : !(player_ptr->current_floor_ptr->dun_level + num)
+                      ? _("地上", "the surface")
+                      : format(_("%d階", "level %d"), player_ptr->current_floor_ptr->dun_level + num);
+        fprintf(fff, _(" %2d:%02d %20s %sへ%s。\n", " %2d:%02d %20s %s %s.\n"), hour, min, note_level.data(), _(to.data(), note), _(note, to.data()));
         break;
     }
     case DIARY_RECALL: {
@@ -372,18 +372,18 @@ errr exe_write_diary(PlayerType *player_ptr, int type, int num, concptr note)
     }
     case DIARY_WIZ_TELE: {
         const auto &floor_ref = *player_ptr->current_floor_ptr;
-        concptr to = !floor_ref.is_in_dungeon()
-                         ? _("地上", "the surface")
-                         : format(_("%d階(%s)", "level %d of %s"), floor_ref.dun_level, dungeons_info[player_ptr->dungeon_idx].name.data());
-        fprintf(fff, _(" %2d:%02d %20s %sへとウィザード・テレポートで移動した。\n", " %2d:%02d %20s wizard-teleported to %s.\n"), hour, min, note_level.data(), to);
+        auto to = !floor_ref.is_in_dungeon()
+                      ? _("地上", "the surface")
+                      : format(_("%d階(%s)", "level %d of %s"), floor_ref.dun_level, dungeons_info[player_ptr->dungeon_idx].name.data());
+        fprintf(fff, _(" %2d:%02d %20s %sへとウィザード・テレポートで移動した。\n", " %2d:%02d %20s wizard-teleported to %s.\n"), hour, min, note_level.data(), to.data());
         break;
     }
     case DIARY_PAT_TELE: {
         const auto &floor_ref = *player_ptr->current_floor_ptr;
-        concptr to = !floor_ref.is_in_dungeon()
-                         ? _("地上", "the surface")
-                         : format(_("%d階(%s)", "level %d of %s"), floor_ref.dun_level, dungeons_info[player_ptr->dungeon_idx].name.data());
-        fprintf(fff, _(" %2d:%02d %20s %sへとパターンの力で移動した。\n", " %2d:%02d %20s used Pattern to teleport to %s.\n"), hour, min, note_level.data(), to);
+        auto to = !floor_ref.is_in_dungeon()
+                      ? _("地上", "the surface")
+                      : format(_("%d階(%s)", "level %d of %s"), floor_ref.dun_level, dungeons_info[player_ptr->dungeon_idx].name.data());
+        fprintf(fff, _(" %2d:%02d %20s %sへとパターンの力で移動した。\n", " %2d:%02d %20s used Pattern to teleport to %s.\n"), hour, min, note_level.data(), to.data());
         break;
     }
     case DIARY_LEVELUP: {

--- a/src/knowledge/knowledge-autopick.cpp
+++ b/src/knowledge/knowledge-autopick.cpp
@@ -60,9 +60,9 @@ void do_cmd_knowledge_autopick(PlayerType *player_ptr)
         }
 
         if (act & DO_DISPLAY) {
-            fprintf(fff, "%11s", format("[%s]", tmp));
+            fprintf(fff, "%11s", format("[%s]", tmp).data());
         } else {
-            fprintf(fff, "%11s", format("(%s)", tmp));
+            fprintf(fff, "%11s", format("(%s)", tmp).data());
         }
 
         tmp = autopick_line_from_entry(&item);

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -128,7 +128,7 @@ void do_cmd_knowledge_pets(PlayerType *player_ptr)
 
         t_friends++;
         monster_desc(player_ptr, pet_name, m_ptr, MD_ASSUME_VISIBLE | MD_INDEF_VISIBLE);
-        fprintf(fff, "%s (%s)\n", pet_name, look_mon_desc(m_ptr, 0x00));
+        fprintf(fff, "%s (%s)\n", pet_name, look_mon_desc(m_ptr, 0x00).data());
     }
 
     int show_upkeep = calculate_upkeep(player_ptr);

--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -1503,13 +1503,13 @@ errr init_gcu(int argc, char *argv[])
 
                 i++;
                 if (i >= argc) {
-                    quit(format("Missing size specifier for -%s", left ? "left" : "right"));
+                    quit_fmt("Missing size specifier for -%s", left ? "left" : "right");
                 }
 
                 arg = argv[i];
                 tmp = strchr(arg, 'x');
                 if (!tmp) {
-                    quit(format("Expected something like -%s 60x27,* for two %s hand terminals of 60 columns, the first 27 lines and the second whatever is left.", left ? "left" : "right", left ? "left" : "right"));
+                    quit_fmt("Expected something like -%s 60x27,* for two %s hand terminals of 60 columns, the first 27 lines and the second whatever is left.", left ? "left" : "right", left ? "left" : "right");
                 }
                 cx = atoi(arg);
                 remaining.cx -= cx;
@@ -1534,11 +1534,11 @@ errr init_gcu(int argc, char *argv[])
                         cy = remaining.y + remaining.cy - y;
                     }
                     if (next_term >= MAX_TERM_DATA) {
-                        quit(format("Too many terminals. Only %d are allowed.", MAX_TERM_DATA));
+                        quit_fmt("Too many terminals. Only %d are allowed.", MAX_TERM_DATA);
                     }
                     if (cy <= 0) {
-                        quit(format("Out of bounds in -%s: %d is too large (%d rows max for this strip)",
-                            left ? "left" : "right", cys[j], remaining.cy));
+                        quit_fmt("Out of bounds in -%s: %d is too large (%d rows max for this strip)",
+                            left ? "left" : "right", cys[j], remaining.cy);
                     }
                     data[next_term++].r = rect(x, y, cx, cy);
                     y += cy + spacer_cy;
@@ -1551,13 +1551,13 @@ errr init_gcu(int argc, char *argv[])
 
                 i++;
                 if (i >= argc) {
-                    quit(format("Missing size specifier for -%s", top ? "top" : "bottom"));
+                    quit_fmt("Missing size specifier for -%s", top ? "top" : "bottom");
                 }
 
                 arg = argv[i];
                 tmp = strchr(arg, 'x');
                 if (!tmp) {
-                    quit(format("Expected something like -%s *x7 for a single %s terminal of 7 lines using as many columns as are available.", top ? "top" : "bottom", top ? "top" : "bottom"));
+                    quit_fmt("Expected something like -%s *x7 for a single %s terminal of 7 lines using as many columns as are available.", top ? "top" : "bottom", top ? "top" : "bottom");
                 }
                 tmp++;
                 cy = atoi(tmp);
@@ -1584,11 +1584,11 @@ errr init_gcu(int argc, char *argv[])
                         cx = remaining.x + remaining.cx - x;
                     }
                     if (next_term >= MAX_TERM_DATA) {
-                        quit(format("Too many terminals. Only %d are allowed.", MAX_TERM_DATA));
+                        quit_fmt("Too many terminals. Only %d are allowed.", MAX_TERM_DATA);
                     }
                     if (cx <= 0) {
-                        quit(format("Out of bounds in -%s: %d is too large (%d cols max for this strip)",
-                            top ? "top" : "bottom", cxs[j], remaining.cx));
+                        quit_fmt("Out of bounds in -%s: %d is too large (%d cols max for this strip)",
+                            top ? "top" : "bottom", cxs[j], remaining.cx);
                     }
                     data[next_term++].r = rect(x, y, cx, cy);
                     x += cx + spacer_cx;

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -2193,8 +2193,6 @@ static errr term_data_init(term_data *td, int i)
 
     int wid, hgt, num;
 
-    char buf[80];
-
     concptr str;
 
     int val;

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -2209,8 +2209,7 @@ static errr term_data_init(term_data *td, int i)
     XWMHints *wh;
 #endif
 
-    sprintf(buf, "ANGBAND_X11_FONT_%d", i);
-    font = getenv(buf);
+    font = getenv(format("ANGBAND_X11_FONT_%d", i).data());
     if (!font) {
         font = getenv("ANGBAND_X11_FONT");
     }
@@ -2247,23 +2246,19 @@ static errr term_data_init(term_data *td, int i)
         }
     }
 
-    sprintf(buf, "ANGBAND_X11_AT_X_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_AT_X_%d", i).data());
     x = (str != nullptr) ? atoi(str) : -1;
 
-    sprintf(buf, "ANGBAND_X11_AT_Y_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_AT_Y_%d", i).data());
     y = (str != nullptr) ? atoi(str) : -1;
 
-    sprintf(buf, "ANGBAND_X11_COLS_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_COLS_%d", i).data());
     val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0) {
         cols = val;
     }
 
-    sprintf(buf, "ANGBAND_X11_ROWS_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_ROWS_%d", i).data());
     val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0) {
         rows = val;
@@ -2278,15 +2273,13 @@ static errr term_data_init(term_data *td, int i)
         }
     }
 
-    sprintf(buf, "ANGBAND_X11_IBOX_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_IBOX_%d", i).data());
     val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0) {
         ox = val;
     }
 
-    sprintf(buf, "ANGBAND_X11_IBOY_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_IBOY_%d", i).data());
     val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0) {
         oy = val;

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -97,7 +97,7 @@ static errr init_info(std::string_view filename, angband_header &head, InfoType 
 
     auto *fp = angband_fopen(buf, "r");
     if (!fp) {
-        quit(format(_("'%s'ファイルをオープンできません。", "Cannot open '%s' file."), filename));
+        quit_fmt(_("'%s'ファイルをオープンできません。", "Cannot open '%s' file."), filename);
     }
 
     constexpr auto info_is_vector = is_vector_v<InfoType>;
@@ -118,7 +118,7 @@ static errr init_info(std::string_view filename, angband_header &head, InfoType 
         msg_format(_("レコード %d は '%s' エラーがあります。", "Record %d contains a '%s' error."), error_idx, oops);
         msg_format(_("構文 '%s'。", "Parsing '%s'."), buf);
         msg_print(nullptr);
-        quit(format(_("'%s'ファイルにエラー", "Error in '%s' file."), filename));
+        quit_fmt(_("'%s'ファイルにエラー", "Error in '%s' file."), filename);
     }
 
     if constexpr (info_is_vector) {

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -291,8 +291,8 @@ bool monster_arena_comm(PlayerType *player_ptr)
         auto *r_ptr = &monraces_info[battle_mon_list[i]];
 
         sprintf(buf, _("%d) %-58s  %4ld.%02ld倍", "%d) %-58s  %4ld.%02ld"), i + 1,
-            _(format("%s%s", r_ptr->name.data(), r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? "もどき" : "      "),
-                format("%s%s", r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? "Fake " : "", r_ptr->name.data())),
+            _(format("%s%s", r_ptr->name.data(), r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? "もどき" : "      ").c_str(),
+                format("%s%s", r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? "Fake " : "", r_ptr->name.data()).c_str()),
             (long int)mon_odds[i] / 100, (long int)mon_odds[i] % 100);
         prt(buf, 5 + i, 1);
     }

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -203,14 +203,14 @@ static void describe_silly_melee(mam_type *mam_ptr)
         mam_ptr->act = silly_attacks2[randint0(MAX_SILLY_ATTACK)];
     }
 
-    strfmt(temp, mam_ptr->act, mam_ptr->t_name);
+    strnfmt(temp, sizeof(temp), mam_ptr->act, mam_ptr->t_name);
     msg_format("%^sは%s", mam_ptr->m_name, temp);
 #else
     if (mam_ptr->do_silly_attack) {
         mam_ptr->act = silly_attacks[randint0(MAX_SILLY_ATTACK)];
-        strfmt(temp, "%s %s.", mam_ptr->act, mam_ptr->t_name);
+        strnfmt(temp, sizeof(temp), "%s %s.", mam_ptr->act, mam_ptr->t_name);
     } else {
-        strfmt(temp, mam_ptr->act, mam_ptr->t_name);
+        strnfmt(temp, sizeof(temp), mam_ptr->act, mam_ptr->t_name);
     }
 
     msg_format("%^s %s", mam_ptr->m_name, temp);

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -370,7 +370,7 @@ concptr get_element_name(int realm_idx, int n)
  * @param spell_idx 呪文番号
  * @return 説明文
  */
-static concptr get_element_tip(PlayerType *player_ptr, int spell_idx)
+static std::string get_element_tip(PlayerType *player_ptr, int spell_idx)
 {
     auto realm = i2enum<ElementRealmType>(player_ptr->element);
     auto spell = i2enum<ElementSpells>(spell_idx);
@@ -979,7 +979,7 @@ void do_cmd_element_browse(PlayerType *player_ptr)
         term_erase(12, 18, 255);
         term_erase(12, 17, 255);
         term_erase(12, 16, 255);
-        shape_buffer(get_element_tip(player_ptr, n), 62, temp, sizeof(temp));
+        shape_buffer(get_element_tip(player_ptr, n).data(), 62, temp, sizeof(temp));
         for (int j = 0, line = 17; temp[j]; j += (1 + strlen(&temp[j]))) {
             prt(&temp[j], line, 15);
             line++;

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -815,7 +815,7 @@ bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_browse)
 
                     concptr s = get_element_name(player_ptr->element, elem);
                     sprintf(name, spell.name, s);
-                    strcat(desc, format("%-30s%2d %4d %3d%%%s", name, spell.min_lev, mana_cost, chance, comment));
+                    strcat(desc, format("%-30s%2d %4d %3d%%%s", name, spell.min_lev, mana_cost, chance, comment).c_str());
                     prt(desc, y + i + 1, x);
                 }
 

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -269,7 +269,8 @@ void MindPowerGetter::display_each_mind_chance()
 
         strcat(psi_desc,
             format("%-30s%2d %4d%s %3d%%%s", this->spell->name, this->spell->min_lev, mana_cost,
-                (((this->use_mind == MindKindType::MINDCRAFTER) && (this->index == 13)) ? _("～", "~ ") : "  "), chance, comment));
+                (((this->use_mind == MindKindType::MINDCRAFTER) && (this->index == 13)) ? _("～", "~ ") : "  "), chance, comment)
+                .c_str());
         prt(psi_desc, y + this->index + 1, x);
     }
 }

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -261,7 +261,7 @@ void monster_desc(PlayerType *player_ptr, char *desc, MonsterEntity *m_ptr, BIT_
     }
 
     if ((mode & MD_IGNORE_HALLU) && !m_ptr->is_original_ap()) {
-        strcat(desc, format("(%s)", monraces_info[m_ptr->r_idx].name.data()));
+        strcat(desc, format("(%s)", monraces_info[m_ptr->r_idx].name.data()).data());
     }
 
     /* Handle the Possessive as a special afterthought */

--- a/src/mspell/mspell-util.cpp
+++ b/src/mspell/mspell-util.cpp
@@ -10,14 +10,6 @@
 #include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
-mspell_cast_msg::mspell_cast_msg(concptr to_player_true, concptr to_mons_true, concptr to_player_false, concptr to_mons_false)
-    : to_player_true(to_player_true)
-    , to_mons_true(to_mons_true)
-    , to_player_false(to_player_false)
-    , to_mons_false(to_mons_false)
-{
-}
-
 mspell_cast_msg_blind::mspell_cast_msg_blind(concptr blind, concptr to_player, concptr to_mons)
     : blind(blind)
     , to_player(to_player)

--- a/src/mspell/mspell-util.h
+++ b/src/mspell/mspell-util.h
@@ -15,12 +15,19 @@ class FloorType;
 class PlayerType;
 
 struct mspell_cast_msg {
-    mspell_cast_msg(concptr to_player_true, concptr to_mons_true, concptr to_player_false, concptr to_mons_false);
+    template <typename T, typename U, typename V, typename W>
+    mspell_cast_msg(T &&to_player_true, U &&to_mons_true, V &&to_player_false, W &&to_mons_false)
+        : to_player_true(std::forward<T>(to_player_true))
+        , to_mons_true(std::forward<U>(to_mons_true))
+        , to_player_false(std::forward<V>(to_player_false))
+        , to_mons_false(std::forward<W>(to_mons_false))
+    {
+    }
     mspell_cast_msg() = default;
-    concptr to_player_true; /*!< msg_flagがTRUEかつプレイヤー対象*/
-    concptr to_mons_true; /*!< msg_flagがTRUEかつモンスター対象*/
-    concptr to_player_false; /*!< msg_flagがFALSEかつプレイヤー対象*/
-    concptr to_mons_false; /*!< msg_flagがFALSEかつモンスター対象*/
+    std::string to_player_true; /*!< msg_flagがTRUEかつプレイヤー対象*/
+    std::string to_mons_true; /*!< msg_flagがTRUEかつモンスター対象*/
+    std::string to_player_false; /*!< msg_flagがFALSEかつプレイヤー対象*/
+    std::string to_mons_false; /*!< msg_flagがFALSEかつモンスター対象*/
 };
 
 struct mspell_cast_msg_blind {

--- a/src/object-use/read/parchment-read-executor.cpp
+++ b/src/object-use/read/parchment-read-executor.cpp
@@ -33,7 +33,7 @@ bool ParchmentReadExecutor::read()
     screen_save();
     auto q = format("book-%d_jp.txt", this->o_ptr->bi_key.sval());
     describe_flavor(this->player_ptr, o_name, this->o_ptr, OD_NAME_ONLY);
-    (void)path_build(buf, sizeof(buf), ANGBAND_DIR_FILE, q);
+    (void)path_build(buf, sizeof(buf), ANGBAND_DIR_FILE, q.data());
     (void)show_file(this->player_ptr, true, buf, o_name, 0, 0);
     screen_load();
     return false;

--- a/src/player-info/alignment.cpp
+++ b/src/player-info/alignment.cpp
@@ -26,7 +26,7 @@ PlayerAlignment::PlayerAlignment(PlayerType *player_ptr)
  * @param with_value 徳の情報と一緒に表示する時だけtrue
  * @return アライメントの表記を返す。
  */
-concptr PlayerAlignment::get_alignment_description(bool with_value)
+std::string PlayerAlignment::get_alignment_description(bool with_value)
 {
     auto s = alignment_label();
     if (with_value || show_actual_value) {

--- a/src/player-info/alignment.h
+++ b/src/player-info/alignment.h
@@ -1,13 +1,14 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <string>
 
 class PlayerType;
 class PlayerAlignment {
 public:
     PlayerAlignment(PlayerType *player_ptr);
     virtual ~PlayerAlignment() = default;
-    concptr get_alignment_description(bool with_value = false);
+    std::string get_alignment_description(bool with_value = false);
     void update_alignment();
 
 private:

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -156,7 +156,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
     int nasty_chance = 6;
     int type;
     patron_reward effect;
-    concptr reward = nullptr;
+    std::string reward;
     GAME_TEXT o_name[MAX_NLEN];
 
     int count = 0;
@@ -588,8 +588,9 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             msg_format(_("「あー、あー、答えは %d/%d。質問は何？」", "'Uh... uh... the answer's %d/%d, what's the question?'"), type, effect);
         }
     }
-    if (reward) {
-        exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, format(_("パトロンの報酬で%s", "The patron rewarded you with %s."), reward));
+    if (!reward.empty()) {
+        const auto note = format(_("パトロンの報酬で%s", "The patron rewarded you with %s."), reward.data());
+        exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, note.data());
     }
 }
 

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -500,7 +500,7 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_fr
 
                 if (death_message[0] == '\0') {
 #ifdef JP
-                    strcpy(death_message, format("あなたは%sました。", android ? "壊れ" : "死に"));
+                    strcpy(death_message, format("あなたは%sました。", android ? "壊れ" : "死に").data());
 #else
                     strcpy(death_message, android ? "You are broken." : "You die.");
 #endif

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -176,7 +176,7 @@ static void show_tomb_detail(PlayerType *player_ptr)
     put_str(center_string(format("Killed on Level %d", player_ptr->current_floor_ptr->dun_level)), 14, 11);
 
     char buf[160];
-    shape_buffer(format("by %s.", player_ptr->died_from.data()), GRAVE_LINE_WIDTH + 1, buf, sizeof(buf));
+    shape_buffer(format("by %s.", player_ptr->died_from.data()).data(), GRAVE_LINE_WIDTH + 1, buf, sizeof(buf));
     put_str(center_string(buf), 15, 11);
     char *t = buf + strlen(buf) + 1;
     if (!*t) {

--- a/src/spell-kind/spells-genocide.cpp
+++ b/src/spell-kind/spells-genocide.cpp
@@ -103,7 +103,7 @@ bool genocide_aux(PlayerType *player_ptr, MONSTER_IDX m_idx, int power, bool pla
     }
 
     if (player_cast) {
-        take_hit(player_ptr, DAMAGE_GENO, randint1(dam_side), format(_("%^sの呪文を唱えた疲労", "the strain of casting %^s"), spell_name));
+        take_hit(player_ptr, DAMAGE_GENO, randint1(dam_side), format(_("%^sの呪文を唱えた疲労", "the strain of casting %^s"), spell_name).data());
     }
 
     move_cursor_relative(player_ptr->y, player_ptr->x);

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -307,7 +307,7 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
         }
 
         if (s_ptr->slevel >= 99) {
-            strcat(out_val, format("%-30s", _("(判読不能)", "(illegible)")));
+            strcat(out_val, format("%-30s", _("(判読不能)", "(illegible)")).c_str());
             c_prt(TERM_L_DARK, out_val, y + i + 1, x);
             continue;
         }
@@ -340,11 +340,12 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
 
         const auto spell_name = exe_spell(player_ptr, use_realm, spell, SpellProcessType::NAME);
         if (use_realm == REALM_HISSATSU) {
-            strcat(out_val, format("%-25s %2d %4d", spell_name->data(), s_ptr->slevel, need_mana));
+            strcat(out_val, format("%-25s %2d %4d", spell_name->data(), s_ptr->slevel, need_mana).c_str());
         } else {
             strcat(out_val,
                 format("%-25s%c%-4s %2d %4d %3d%% %s", spell_name->data(), (max ? '!' : ' '), ryakuji, s_ptr->slevel,
-                    need_mana, spell_chance(player_ptr, spell, use_realm), comment));
+                    need_mana, spell_chance(player_ptr, spell, use_realm), comment)
+                    .c_str());
         }
 
         c_prt(line_attr, out_val, y + i + 1, x);

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -51,7 +51,7 @@ static std::optional<PRICE> prompt_to_buy(PlayerType *player_ptr, ItemEntity *o_
     auto price_ask = price_item(player_ptr, o_ptr, ot_ptr->inflate, false, store_num);
 
     price_ask *= o_ptr->number;
-    concptr s = format(_("買値 $%ld で買いますか？", "Do you buy for $%ld? "), static_cast<long>(price_ask));
+    const auto s = format(_("買値 $%ld で買いますか？", "Do you buy for $%ld? "), static_cast<long>(price_ask));
     if (get_check_strict(player_ptr, s, CHECK_DEFAULT_Y)) {
         return price_ask;
     }

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -54,7 +54,7 @@ static std::optional<PRICE> prompt_to_sell(PlayerType *player_ptr, ItemEntity *o
 
     price_ask = std::min(price_ask, ot_ptr->max_cost);
     price_ask *= o_ptr->number;
-    concptr s = format(_("売値 $%ld で売りますか？", "Do you sell for $%ld? "), static_cast<long>(price_ask));
+    const auto s = format(_("売値 $%ld で売りますか？", "Do you sell for $%ld? "), static_cast<long>(price_ask));
     if (get_check_strict(player_ptr, s, CHECK_DEFAULT_Y)) {
         return price_ask;
     }

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -71,7 +71,7 @@ struct eg_type {
     OBJECT_IDX next_o_idx;
     FEAT_IDX feat;
     TerrainType *f_ptr;
-    concptr name;
+    std::string name;
 };
 
 static eg_type *initialize_eg_type(PlayerType *player_ptr, eg_type *eg_ptr, POSITION y, POSITION x, target_type mode, concptr info)
@@ -207,11 +207,12 @@ static void describe_grid_monster(PlayerType *player_ptr, eg_type *eg_ptr)
         }
 
         std::string acount = evaluate_monster_exp(player_ptr, eg_ptr->m_ptr);
+        const auto mon_desc = look_mon_desc(eg_ptr->m_ptr, 0x01);
 #ifdef JP
-        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "[%s]%s%s(%s)%s%s [r思 %s%s]", acount.data(), eg_ptr->s1, m_name, look_mon_desc(eg_ptr->m_ptr, 0x01), eg_ptr->s2, eg_ptr->s3,
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "[%s]%s%s(%s)%s%s [r思 %s%s]", acount.data(), eg_ptr->s1, m_name, mon_desc.data(), eg_ptr->s2, eg_ptr->s3,
             eg_ptr->x_info, eg_ptr->info);
 #else
-        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "[%s]%s%s%s%s(%s) [r, %s%s]", acount.data(), eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, m_name, look_mon_desc(eg_ptr->m_ptr, 0x01),
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "[%s]%s%s%s%s(%s) [r, %s%s]", acount.data(), eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, m_name, mon_desc.data(),
             eg_ptr->x_info, eg_ptr->info);
 #endif
         prt(eg_ptr->out_val, 0, 0);
@@ -458,7 +459,7 @@ static int16_t sweep_footing_items(PlayerType *player_ptr, eg_type *eg_ptr)
     return CONTINUOUS_DESCRIPTION;
 }
 
-static concptr decide_target_floor(PlayerType *player_ptr, eg_type *eg_ptr)
+static std::string decide_target_floor(PlayerType *player_ptr, eg_type *eg_ptr)
 {
     if (eg_ptr->f_ptr->flags.has(TerrainCharacteristics::QUEST_ENTER)) {
         QuestId old_quest = player_ptr->current_floor_ptr->quest_number;
@@ -501,9 +502,9 @@ static void describe_grid_monster_all(eg_type *eg_ptr)
 {
     if (!w_ptr->wizard) {
 #ifdef JP
-        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s[%s]", eg_ptr->s1, eg_ptr->name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s[%s]", eg_ptr->s1, eg_ptr->name.data(), eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
 #else
-        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, eg_ptr->name, eg_ptr->info);
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, eg_ptr->name.data(), eg_ptr->info);
 #endif
         return;
     }
@@ -516,11 +517,11 @@ static void describe_grid_monster_all(eg_type *eg_ptr)
     }
 
 #ifdef JP
-    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s[%s] %x %s %d %d %d (%d,%d) %d", eg_ptr->s1, eg_ptr->name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info,
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s[%s] %x %s %d %d %d (%d,%d) %d", eg_ptr->s1, eg_ptr->name.data(), eg_ptr->s2, eg_ptr->s3, eg_ptr->info,
         (uint)eg_ptr->g_ptr->info, f_idx_str.data(), eg_ptr->g_ptr->dists[FLOW_NORMAL], eg_ptr->g_ptr->costs[FLOW_NORMAL], eg_ptr->g_ptr->when, (int)eg_ptr->y,
         (int)eg_ptr->x, travel.cost[eg_ptr->y][eg_ptr->x]);
 #else
-    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s] %x %s %d %d %d (%d,%d)", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, eg_ptr->name, eg_ptr->info, eg_ptr->g_ptr->info,
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s] %x %s %d %d %d (%d,%d)", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, eg_ptr->name.data(), eg_ptr->info, eg_ptr->g_ptr->info,
         f_idx_str.data(), eg_ptr->g_ptr->dists[FLOW_NORMAL], eg_ptr->g_ptr->costs[FLOW_NORMAL], eg_ptr->g_ptr->when, (int)eg_ptr->y, (int)eg_ptr->x);
 #endif
 }

--- a/src/term/screen-processor.cpp
+++ b/src/term/screen-processor.cpp
@@ -135,7 +135,7 @@ void c_roff(TERM_COLOR a, std::string_view str)
         return;
     }
 
-    for (auto s = str.begin(); s != str.end(); s++) {
+    for (auto s = str.data(); *s != '\0'; ++s) {
         char ch;
 #ifdef JP
         int k_flag = iskanji(*s);

--- a/src/term/z-form.cpp
+++ b/src/term/z-form.cpp
@@ -654,19 +654,10 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
     return n;
 }
 
-/*
- * Do a vstrnfmt (see above) into a (growable) static buffer.
- * This buffer is usable for very short term formatting of results.
- */
-char *vformat(concptr fmt, va_list vp)
+std::string vformat(concptr fmt, va_list vp)
 {
     /* Initial allocation */
-    static std::vector<char> format_buf(1024);
-
-    /* Null format yields last result */
-    if (!fmt) {
-        return format_buf.data();
-    }
+    std::vector<char> format_buf(1024);
 
     /* Keep going until successful */
     while (true) {
@@ -684,8 +675,8 @@ char *vformat(concptr fmt, va_list vp)
         format_buf.resize(format_buf.size() * 2);
     }
 
-    /* Return the new buffer */
-    return format_buf.data();
+    /* Return the new string */
+    return std::string(format_buf.data());
 }
 
 /*
@@ -711,44 +702,20 @@ uint strnfmt(char *buf, uint max, concptr fmt, ...)
 }
 
 /*
- * Do a vstrnfmt (see above) into a buffer of unknown size.
- * Since the buffer size is unknown, the user better verify the args.
- */
-uint strfmt(char *buf, concptr fmt, ...)
-{
-    uint len;
-
-    va_list vp;
-
-    /* Begin the Varargs Stuff */
-    va_start(vp, fmt);
-
-    /* Build the string, assume 32K buffer */
-    len = vstrnfmt(buf, 32767, fmt, vp);
-
-    /* End the Varargs Stuff */
-    va_end(vp);
-
-    /* Return the number of bytes written */
-    return len;
-}
-
-/*
  * Do a vstrnfmt() into (see above) into a (growable) static buffer.
  * This buffer is usable for very short term formatting of results.
  * Note that the buffer is (technically) writable, but only up to
  * the length of the string contained inside it.
  */
-char *format(concptr fmt, ...)
+std::string format(concptr fmt, ...)
 {
-    char *res;
     va_list vp;
 
     /* Begin the Varargs Stuff */
     va_start(vp, fmt);
 
     /* Format the args */
-    res = vformat(fmt, vp);
+    auto res = vformat(fmt, vp);
 
     /* End the Varargs Stuff */
     va_end(vp);
@@ -762,20 +729,19 @@ char *format(concptr fmt, ...)
  */
 void plog_fmt(concptr fmt, ...)
 {
-    char *res;
     va_list vp;
 
     /* Begin the Varargs Stuff */
     va_start(vp, fmt);
 
     /* Format the args */
-    res = vformat(fmt, vp);
+    auto res = vformat(fmt, vp);
 
     /* End the Varargs Stuff */
     va_end(vp);
 
     /* Call plog */
-    plog(res);
+    plog(res.data());
 }
 
 /*
@@ -783,20 +749,19 @@ void plog_fmt(concptr fmt, ...)
  */
 void quit_fmt(concptr fmt, ...)
 {
-    char *res;
     va_list vp;
 
     /* Begin the Varargs Stuff */
     va_start(vp, fmt);
 
     /* Format */
-    res = vformat(fmt, vp);
+    auto res = vformat(fmt, vp);
 
     /* End the Varargs Stuff */
     va_end(vp);
 
     /* Call quit() */
-    quit(res);
+    quit(res.data());
 }
 
 /*
@@ -804,18 +769,17 @@ void quit_fmt(concptr fmt, ...)
  */
 void core_fmt(concptr fmt, ...)
 {
-    char *res;
     va_list vp;
 
     /* Begin the Varargs Stuff */
     va_start(vp, fmt);
 
     /* If requested, Do a virtual fprintf to stderr */
-    res = vformat(fmt, vp);
+    auto res = vformat(fmt, vp);
 
     /* End the Varargs Stuff */
     va_end(vp);
 
     /* Call core() */
-    core(res);
+    core(res.data());
 }

--- a/src/term/z-form.h
+++ b/src/term/z-form.h
@@ -12,6 +12,7 @@
 #define INCLUDED_Z_FORM_H
 
 #include "system/h-basic.h"
+#include <string>
 
 /*
  * This file provides functions very similar to "sprintf()", but which
@@ -32,14 +33,11 @@ extern uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp);
 /* Simple interface to "vstrnfmt()" */
 extern uint strnfmt(char *buf, uint max, concptr fmt, ...);
 
-/* Simple interface to "vstrnfmt()", assuming infinite length */
-extern uint strfmt(char *buf, concptr fmt, ...);
-
 /* Format arguments into a static resizing buffer */
-extern char *vformat(concptr fmt, va_list vp);
+extern std::string vformat(concptr fmt, va_list vp);
 
 /* Simple interface to "vformat()" */
-extern char *format(concptr fmt, ...);
+extern std::string format(concptr fmt, ...);
 
 /* Vararg interface to "plog()", using "format()" */
 extern void plog_fmt(concptr fmt, ...);

--- a/src/view/display-monster-status.cpp
+++ b/src/view/display-monster-status.cpp
@@ -11,7 +11,7 @@
 /*
  * Monster health description
  */
-concptr look_mon_desc(MonsterEntity *m_ptr, BIT_FLAGS mode)
+std::string look_mon_desc(MonsterEntity *m_ptr, BIT_FLAGS mode)
 {
     bool living = monster_living(m_ptr->ap_r_idx);
     int perc = m_ptr->maxhp > 0 ? 100L * m_ptr->hp / m_ptr->maxhp : 0;

--- a/src/view/display-monster-status.h
+++ b/src/view/display-monster-status.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <string>
 
 class MonsterEntity;
-concptr look_mon_desc(MonsterEntity *m_ptr, BIT_FLAGS mode);
+std::string look_mon_desc(MonsterEntity *m_ptr, BIT_FLAGS mode);

--- a/src/view/display-scores.cpp
+++ b/src/view/display-scores.cpp
@@ -133,7 +133,7 @@ void display_scores(int from, int to, int note, high_score *score)
                 class_info[pc].title, clev);
 #endif
             if (mlev > clev) {
-                strcat(out_val, format(_(" (最高%d)", " (Max %d)"), mlev));
+                strcat(out_val, format(_(" (最高%d)", " (Max %d)"), mlev).c_str());
             }
 
             c_put_str(attr, out_val, n * 4 + 2, 0);
@@ -167,7 +167,7 @@ void display_scores(int from, int to, int note, high_score *score)
             }
 
             if (mdun > cdun) {
-                strcat(out_val, format(" (Max %d)", mdun));
+                strcat(out_val, format(" (Max %d)", mdun).c_str());
             }
 #endif
             c_put_str(attr, out_val, n * 4 + 3, 0);

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -366,7 +366,7 @@ static void display_first_page(PlayerType *player_ptr, int xthb, int *damage, in
 
     display_player_one_line(ENTRY_SHOTS, format("%d.%02d", shots, shot_frac), TERM_L_BLUE);
 
-    concptr desc;
+    std::string desc;
     if ((damage[0] + damage[1]) == 0) {
         desc = "nil!";
     } else {

--- a/src/wizard/monster-info-spoiler.cpp
+++ b/src/wizard/monster-info-spoiler.cpp
@@ -235,7 +235,7 @@ SpoilerOutputResultType spoil_mon_info(concptr fname)
         sprintf(buf, "Exp:%ld\n", (long)(r_ptr->mexp));
         spoil_out(buf);
         output_monster_spoiler(r_idx, roff_func);
-        spoil_out(nullptr);
+        spoil_out({}, true);
     }
 
     return ferror(spoiler_file) || angband_fclose(spoiler_file) ? SpoilerOutputResultType::FILE_CLOSE_FAILED

--- a/src/wizard/spoiler-util.cpp
+++ b/src/wizard/spoiler-util.cpp
@@ -47,13 +47,14 @@ void spoiler_underline(concptr str)
  * @brief 文字列をファイルポインタに出力する /
  * Buffer text to the given file. (-SHAWN-)
  * This is basically c_roff() from mon-desc.c with a few changes.
- * @param str 文字列参照ポインタ
+ * @param sv 文字列
+ * @param flush_buffer trueならバッファの内容をフラッシュし、改行を書き込む。strは無視される。
  */
-void spoil_out(concptr str)
+void spoil_out(std::string_view sv, bool flush_buffer)
 {
     concptr r;
-    static char roff_buf[256];
-    static char roff_waiting_buf[256];
+    static char roff_buf[256]{};
+    static char roff_waiting_buf[256]{};
 
 #ifdef JP
     bool iskanji_flag = false;
@@ -62,7 +63,7 @@ void spoil_out(concptr str)
     static char *roff_p = roff_buf;
     static char *roff_s = nullptr;
     static bool waiting_output = false;
-    if (!str) {
+    if (flush_buffer) {
         if (waiting_output) {
             fputs(roff_waiting_buf, spoiler_file);
             waiting_output = false;
@@ -88,7 +89,7 @@ void spoil_out(concptr str)
         return;
     }
 
-    for (; *str; str++) {
+    for (auto str = sv.data(); *str != '\0'; ++str) {
 #ifdef JP
         char cbak;
         bool k_flag = iskanji((unsigned char)(*str));

--- a/src/wizard/spoiler-util.h
+++ b/src/wizard/spoiler-util.h
@@ -2,6 +2,7 @@
 
 #include "system/angband.h"
 #include "wizard/spoiler-table.h"
+#include <string_view>
 
 /* MAX_LINE_LEN specifies when a line should wrap. */
 #define MAX_LINE_LEN 75
@@ -53,4 +54,4 @@ extern FILE *spoiler_file;
 
 void spoiler_blanklines(int n);
 void spoiler_underline(concptr str);
-void spoil_out(concptr str);
+void spoil_out(std::string_view sv, bool flush_buffer = false);


### PR DESCRIPTION
既存の format 関数は、結果文字列を関数内部で保持している静的バッファ領域に格納しそれ
に対するポインタを返すという仕様のため、非常に注意深く使用する必要がある。
使いにくくて仕方がないので std::string オブジェクトを返すようにし、format 関数を 呼んだ側が確実に自由に結果文字列を扱えるようにする。