### PR TITLE
変愚「Include <string> to avoid compiler error on MacOS/clang when not …」のマージ

### DIFF
--- a/src/view/display-util.cpp
+++ b/src/view/display-util.cpp
@@ -1,5 +1,6 @@
 ﻿#include "view/display-util.h"
 #include "term/term-color-types.h"
+#include <string>
 #include <vector>
 
 namespace {


### PR DESCRIPTION
…g precompiled headers.  Resolves https://github.com/hengband/hengband/issues/2963 .