### PR TITLE
変愚「[Fix] CIで使用するコンパイラのバージョンをアップデート」のマージ

### DIFF
--- a/.github/workflows/build-with-autotools.yml
+++ b/.github/workflows/build-with-autotools.yml
@@ -18,14 +18,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
 
       - if: ${{ inputs.use-ccache }}
-        uses: hendrikmuhs/ccache-action@v1
+        uses: hendrikmuhs/ccache-action@v1.2
 
       - name: Configuring ccache to use precompiled headers
         if: ${{ inputs.use-ccache }}
@@ -42,7 +42,6 @@ jobs:
             libncursesw5-dev \
             libcurl4-openssl-dev \
             nkf \
-            clang-11 \
 
       - name: Generate configure
         run: ./bootstrap

--- a/.github/workflows/create-cache-for-ccache.yml
+++ b/.github/workflows/create-cache-for-ccache.yml
@@ -13,7 +13,7 @@ jobs:
     name: Japanese version with clang (without using pre-compiled headers)
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      cxx: clang++-11
+      cxx: clang++-14
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -Wno-unused-const-variable -Wno-invalid-source-encoding"
       configure-opts: "--disable-pch"
       use-ccache: true
@@ -23,7 +23,7 @@ jobs:
     needs: clang_without_pch_japanese
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      cxx: g++
+      cxx: g++-11
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
       use-ccache: true
 
@@ -32,7 +32,7 @@ jobs:
     needs: gcc_japanese
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      cxx: g++
+      cxx: g++-11
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
       configure-opts: "--disable-japanese"
       use-ccache: true

--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -27,7 +27,7 @@ jobs:
     needs: [check_bom, check_format]
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      cxx: clang++-11
+      cxx: clang++-14
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -Wno-unused-const-variable -Wno-invalid-source-encoding"
       configure-opts: "--disable-pch"
       use-ccache: true
@@ -37,7 +37,7 @@ jobs:
     needs: build_test_clang_without_pch
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      cxx: g++
+      cxx: g++-11
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
       use-ccache: true
 
@@ -46,7 +46,7 @@ jobs:
     needs: build_test_japanese
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      cxx: g++
+      cxx: g++-11
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
       configure-opts: "--disable-japanese"
       use-ccache: true


### PR DESCRIPTION
C++20に備えるため、gccのバージョンを11、clangのバージョンを14にする。
また runner をこれらのコンパイラ・ツールチェインがデフォルトでインストールされている
Ubuntu-22.04 にする。
さらに Node.js 12 のサポート終了にともない、 ccache-action のバージョンを 1 から 1.2 にする。