### PR TITLE
変愚「Initialize all of a buffer in counts_seek(). …」のマージ

### DIFF
--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -218,7 +218,7 @@ errr get_rnd_line_jonly(concptr file_name, int entry, char *output, int count)
  */
 static errr counts_seek(PlayerType *player_ptr, int fd, uint32_t where, bool flag)
 {
-    char temp1[128], temp2[128];
+    char temp1[128]{}, temp2[128]{};
     auto short_pclass = enum2i(player_ptr->pclass);
 #ifdef SAVEFILE_USE_UID
     (void)sprintf(temp1, "%d.%s.%d%d%d", player_ptr->player_uid, savefile_base, short_pclass, player_ptr->ppersonality, player_ptr->age);


### PR DESCRIPTION
….com/hengband/hengband/issues/2983 .  Initialize all of temp2 as well to silence bogus Visual Studio 2022 warning.