### PR TITLE
変愚「[Fix] SIGKILL にシグナルハンドラを設定している」のマージ

### DIFF
--- a/src/io/signal-handlers.cpp
+++ b/src/io/signal-handlers.cpp
@@ -216,10 +216,6 @@ void signals_init(void)
     (void)signal(SIGIOT, handle_signal_abort);
 #endif
 
-#ifdef SIGKILL
-    (void)signal(SIGKILL, handle_signal_abort);
-#endif
-
 #ifdef SIGBUS
     (void)signal(SIGBUS, handle_signal_abort);
 #endif


### PR DESCRIPTION
SIGKILL はいかなる手段を用いても捕捉不可能なシグナルであり、シグナルハンドラを設定する
事自体間違いなので削除する。