### PR TITLE
変愚「[Refactor] アイテムがランダムアーティファクトかどうかの判定にメソッドを使用する」のマージ

### DIFF
--- a/src/core/object-compressor.cpp
+++ b/src/core/object-compressor.cpp
@@ -91,7 +91,7 @@ void compact_objects(PlayerType *player_ptr, int size)
             }
 
             int chance = 90;
-            if ((o_ptr->is_fixed_artifact() || o_ptr->art_name) && (cnt < 1000)) {
+            if (o_ptr->is_artifact() && (cnt < 1000)) {
                 chance = 100;
             }
 

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -71,7 +71,7 @@ static std::string describe_artifact_mark_ja(const ItemEntity &item, const descr
 
     if (item.is_fixed_artifact()) {
         return "★";
-    } else if (item.art_name) {
+    } else if (item.is_random_artifact()) {
         return "☆";
     }
 
@@ -95,7 +95,7 @@ static std::string describe_unique_name_before_body_ja(const ItemEntity &item, c
         return "";
     }
 
-    if (item.art_name) {
+    if (item.is_random_artifact()) {
         concptr temp = quark_str(item.art_name);
 
         /* '『' から始まらない伝説のアイテムの名前は最初に付加する */
@@ -128,7 +128,7 @@ static std::string describe_unique_name_before_body_ja(const ItemEntity &item, c
 
 static std::optional<std::string> describe_random_artifact_name_after_body_ja(const ItemEntity &item)
 {
-    if (item.art_name == 0) {
+    if (!item.is_random_artifact()) {
         return std::nullopt;
     }
 
@@ -290,7 +290,7 @@ static std::string describe_unique_name_after_body_en(const ItemEntity &item, co
 
     std::stringstream ss;
 
-    if (item.art_name) {
+    if (item.is_random_artifact()) {
         ss << ' ' << quark_str(item.art_name);
         return ss.str();
     }

--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -369,7 +369,7 @@ void build_streamer(PlayerType *player_ptr, FEAT_IDX feat, int chance)
                             describe_flavor(player_ptr, o_name, o_ptr, (OD_NAME_ONLY | OD_STORE));
                             msg_format(_("伝説のアイテム (%s) はストリーマーにより削除された。", "Artifact (%s) was deleted by streamer."), o_name);
                         }
-                    } else if (cheat_peek && o_ptr->art_name) {
+                    } else if (cheat_peek && o_ptr->is_random_artifact()) {
                         msg_print(_("ランダム・アーティファクトの1つはストリーマーにより削除された。", "One of the random artifacts was deleted by streamer."));
                     }
                 }

--- a/src/io-dump/random-art-info-dumper.cpp
+++ b/src/io-dump/random-art-info-dumper.cpp
@@ -55,7 +55,7 @@ static void spoiler_print_randart(ItemEntity *o_ptr, obj_desc_list *art_ptr)
 static void spoil_random_artifact_aux(PlayerType *player_ptr, ItemEntity *o_ptr, ItemKindType tval)
 {
     obj_desc_list artifact;
-    if (!o_ptr->is_known() || !o_ptr->art_name || (o_ptr->bi_key.tval() != tval)) {
+    if (!o_ptr->is_known() || !o_ptr->is_random_artifact() || (o_ptr->bi_key.tval() != tval)) {
         return;
     }
 

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -534,7 +534,7 @@ static void on_dead_random_artifact(PlayerType *player_ptr, monster_death_type *
             continue;
         }
 
-        if (q_ptr->art_name > 0) {
+        if (q_ptr->is_random_artifact()) {
             break;
         }
 

--- a/src/object-enchant/weapon/melee-weapon-enchanter.cpp
+++ b/src/object-enchant/weapon/melee-weapon-enchanter.cpp
@@ -46,7 +46,7 @@ void MeleeWeaponEnchanter::strengthen()
     }
 
     this->give_ego_index();
-    if (this->o_ptr->art_name > 0) {
+    if (this->o_ptr->is_random_artifact()) {
         return;
     }
 

--- a/src/object/object-value-calc.cpp
+++ b/src/object/object-value-calc.cpp
@@ -540,7 +540,7 @@ PRICE flag_cost(const ItemEntity *o_ptr, int plusses)
     }
 
     /* Also, give some extra for activatable powers... */
-    if (o_ptr->art_name && (o_ptr->art_flags.has(TR_ACTIVATE))) {
+    if (o_ptr->is_random_artifact() && o_ptr->art_flags.has(TR_ACTIVATE)) {
         auto act_ptr = find_activation_info(o_ptr);
         if (act_ptr.has_value()) {
             total += act_ptr.value()->value;

--- a/src/racial/racial-android.cpp
+++ b/src/racial/racial-android.cpp
@@ -89,7 +89,7 @@ void calc_android_exp(PlayerType *player_ptr)
             level += std::min(20, fixed_artifact.rarity / (fixed_artifact.gen_flags.has(ItemGenerationTraitType::INSTA_ART) ? 10 : 3));
         } else if (o_ptr->is_ego()) {
             level += std::max(3, (egos_info[o_ptr->ego_idx].rating - 5) / 2);
-        } else if (o_ptr->art_name) {
+        } else if (o_ptr->is_random_artifact()) {
             int32_t total_flags = flag_cost(o_ptr, o_ptr->pval);
             int fake_level;
 

--- a/src/save/item-writer.cpp
+++ b/src/save/item-writer.cpp
@@ -110,7 +110,7 @@ static void write_item_flags(ItemEntity *o_ptr, BIT_FLAGS *flags)
         set_bits(*flags, SaveDataItemFlagType::INSCRIPTION);
     }
 
-    if (o_ptr->art_name) {
+    if (o_ptr->is_random_artifact()) {
         set_bits(*flags, SaveDataItemFlagType::ART_NAME);
     }
 

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -359,7 +359,7 @@ bool destroy_area(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION r, 
                             describe_flavor(player_ptr, o_name, o_ptr, (OD_NAME_ONLY | OD_STORE));
                             msg_format(_("伝説のアイテム (%s) は生成中に*破壊*された。", "Artifact (%s) was *destroyed* during generation."), o_name);
                         }
-                    } else if (in_generate && cheat_peek && o_ptr->art_name) {
+                    } else if (in_generate && cheat_peek && o_ptr->is_random_artifact()) {
                         msg_print(
                             _("ランダム・アーティファクトの1つは生成中に*破壊*された。", "One of the random artifacts was *destroyed* during generation."));
                     }

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -86,7 +86,7 @@ bool identify_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     if (record_fix_art && !old_known && o_ptr->is_fixed_artifact()) {
         exe_write_diary(player_ptr, DIARY_ART, 0, o_name);
     }
-    if (record_rand_art && !old_known && o_ptr->art_name) {
+    if (record_rand_art && !old_known && o_ptr->is_random_artifact()) {
         exe_write_diary(player_ptr, DIARY_ART, 0, o_name);
     }
 

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -292,7 +292,7 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
     player_ptr->plus_incident(INCIDENT::STORE_BUY, 1);
 
     describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
-    if (record_rand_art && o_ptr->art_name) {
+    if (record_rand_art && o_ptr->is_random_artifact()) {
         exe_write_diary(player_ptr, DIARY_ART, 0, o_name);
     }
 

--- a/src/store/service-checker.cpp
+++ b/src/store/service-checker.cpp
@@ -447,7 +447,7 @@ void mass_produce(ItemEntity *o_ptr, StoreSaleType store_num)
     const auto cost = o_ptr->get_price();
     int size = switch_mass_production(*o_ptr, cost, store_num);
     auto discount = decide_discount_rate(cost);
-    if (o_ptr->art_name) {
+    if (o_ptr->is_random_artifact()) {
         discount = 0;
     }
 

--- a/src/util/object-sort.cpp
+++ b/src/util/object-sort.cpp
@@ -20,7 +20,7 @@ static int get_item_sort_rank(const ItemEntity &item)
         return 3;
     }
 
-    if (item.art_name) {
+    if (item.is_random_artifact()) {
         return 2;
     }
 

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -1063,9 +1063,9 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
                 do {
                     o_ptr->prep(bi_id);
                     ItemMagicApplier(player_ptr, o_ptr, baseitem.level, AM_SPECIAL | AM_NO_FIXED_ART).execute();
-                } while (!o_ptr->art_name || o_ptr->is_ego() || o_ptr->is_cursed());
+                } while (!o_ptr->is_random_artifact() || o_ptr->is_ego() || o_ptr->is_cursed());
 
-                if (o_ptr->art_name) {
+                if (o_ptr->is_random_artifact()) {
                     drop_near(player_ptr, o_ptr, -1, player_ptr->y, player_ptr->x);
                 }
             } else {
@@ -1087,7 +1087,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
                     for (i = 0; i < max_roll; i++) {
                         o_ptr->prep(bi_id);
                         ItemMagicApplier(player_ptr, o_ptr, baseitem.level, AM_GREAT | AM_NO_FIXED_ART).execute();
-                        if (o_ptr->art_name) {
+                        if (o_ptr->is_random_artifact()) {
                             continue;
                         }
 


### PR DESCRIPTION
現状、アイテムがランダムアーティファクトかどうかの判定は art_name が 0 かどうか
(art_name は名称が登録された quark_str のインデクスを持つ) で判断しており、それを ラップするメソッド ItemEntity::is_random_artifact が用意されているがこれが正しく 使用されていない箇所が多数あるので、すべてこのメソッドを使用するように変更する。