### PR TITLE
変愚「[Fix] 巻物でアーティファクトを生成した時に徳が変化しない事がある」のマージ

### DIFF
--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -404,8 +404,6 @@ static std::string name_unnatural_random_artifact(PlayerType *player_ptr, ItemEn
         }
     }
 
-    chg_virtue(player_ptr, V_INDIVIDUALISM, 2);
-    chg_virtue(player_ptr, V_ENCHANT, 5);
     return std::string(_("《", "'")).append(new_name).append(_("》", "'"));
 }
 
@@ -476,5 +474,11 @@ bool become_random_artifact(PlayerType *player_ptr, ItemEntity *o_ptr, bool a_sc
     }
 
     generate_unnatural_random_artifact(player_ptr, o_ptr, a_scroll, power_level, max_powers, total_flags);
+
+    if (a_scroll) {
+        chg_virtue(player_ptr, V_INDIVIDUALISM, 2);
+        chg_virtue(player_ptr, V_ENCHANT, 5);
+    }
+
     return true;
 }


### PR DESCRIPTION
アーティファクト生成の巻物でランダムアーティファクトを生成した時、「秘」と「個」の徳が
上昇するようになっているが、名付けをキャンセルしてランダムな名前を付けた時にこれらの徳
があがらなくなっている。
常に上昇するよう修正する。