### PR TITLE
変愚「[Fix] Apple Clang で日本語版がコンパイルできない」のマージ

### DIFF
--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -116,7 +116,7 @@ static int show_killing_monster(PlayerType *player_ptr)
 
         if (lines[0].length() + lines[1].length() - start_pos <= GRAVE_LINE_WIDTH) {
             const auto name = lines[0].substr(start_pos).append(lines[1]);
-            std::string_view title(lines[0].begin(), lines[0].begin() + start_pos);
+            std::string_view title(lines[0].data(), start_pos);
             show_tomb_line(title, GRAVE_KILLER_NAME_ROW);
             show_tomb_line(name, GRAVE_KILLER_NAME_ROW + 1);
             return 1;


### PR DESCRIPTION
std::string_view のイテレータのペアを引数に取るコンストラクタのオーバーロードがまだ Apple Clang でサポートされていないためコンパイルエラーになる。
サポートされている、文字列の先頭文字へのポインタと文字列の長さを取るオーバーロードに変
更する。（そもそもこちらのほうが素直だし最初からこちらにするべきだった）