### PR TITLE
変愚「[Fix] スナイパーの技の説明がおかしい (英語版)」のマージ

### DIFF
--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -77,7 +77,7 @@ static concptr const snipe_tips[MAX_SNIPE_POWERS] = {
     "Shoot an arrow able to shatter rocks.",
     "Deals extra damage of ice.",
     "Shoot an arrow that pushes away the target.",
-    "Shoot an arrow that does not always stop at the first target on its path."
+    "Shoot an arrow that does not always stop at the first target on its path.",
     "Deals more damage to good monsters.",
     "Deals more damage to evil monsters.",
     "Shoot an arrow that explodes when it hits a monster.",


### PR DESCRIPTION
スナイパーの技の説明のリストでカンマを付け忘れているため文字列リテラルが連結してしまい、
一つ分足りなくなってしまっている。正しくカンマを付けて修正する。