### PR TITLE
変愚「[Fix] スポイラーの出力にドロップアイテムの質が表示されない」のマージ

### DIFF
--- a/src/lore/lore-calculator.cpp
+++ b/src/lore/lore-calculator.cpp
@@ -141,7 +141,7 @@ void set_damage(PlayerType *player_ptr, lore_type *lore_ptr, MonsterAbilityType 
     strnfmt(tmp, tmpsz, msg, std::string("(").append(dice_to_string(base_damage, dice_num, dice_side, dice_mult, dice_div)).append(")").data());
 }
 
-void set_drop_flags(lore_type *lore_ptr)
+void set_flags_for_full_knowledge(lore_type *lore_ptr)
 {
     if (!lore_ptr->know_everything) {
         return;
@@ -165,4 +165,5 @@ void set_drop_flags(lore_type *lore_ptr)
     lore_ptr->behavior_flags = lore_ptr->r_ptr->behavior_flags;
     lore_ptr->resistance_flags = lore_ptr->r_ptr->resistance_flags;
     lore_ptr->feature_flags = lore_ptr->r_ptr->feature_flags;
+    lore_ptr->drop_flags = lore_ptr->r_ptr->drop_flags;
 }

--- a/src/lore/lore-calculator.h
+++ b/src/lore/lore-calculator.h
@@ -12,4 +12,4 @@ std::string dice_to_string(int base_damage, int dice_num, int dice_side, int dic
 bool know_armour(MonsterRaceId r_idx, const bool know_everything);
 bool know_damage(MonsterRaceId r_idx, int i);
 void set_damage(PlayerType *player_ptr, lore_type *lore_ptr, MonsterAbilityType ms_type, concptr msg);
-void set_drop_flags(lore_type *lore_ptr);
+void set_flags_for_full_knowledge(lore_type *lore_ptr);

--- a/src/lore/monster-lore.cpp
+++ b/src/lore/monster-lore.cpp
@@ -248,7 +248,7 @@ void process_monster_lore(PlayerType *player_ptr, MonsterRaceId r_idx, monster_l
         lore_ptr->know_everything = true;
     }
 
-    set_drop_flags(lore_ptr);
+    set_flags_for_full_knowledge(lore_ptr);
     set_msex_flags(lore_ptr);
     set_flags1(lore_ptr);
     set_race_flags(lore_ptr);


### PR DESCRIPTION
モンスターの完全な情報が分かるとき（cheat_knowがONのとき・スポイラー出力時など）に、
ドロップ情報のフラグを思い出の状態を考慮しない状態に更新していないのが原因。
ドロップ情報のフラグを正しく更新するようにする。
また、この処理を行っている set_drop_flags() は名称が関数の処理の実態に全く合ってい ないので、set_flags_for_full_knowledge() に変更する。