### PR TITLE
[Fix] 画面左下部の情報が正しく表示されない

### DIFF
--- a/src/core/window-redrawer.cpp
+++ b/src/core/window-redrawer.cpp
@@ -49,14 +49,17 @@ void redraw_window(void)
  */
 static void print_dungeon(PlayerType *player_ptr)
 {
-    c_put_str(TERM_WHITE, "             ", ROW_DUNGEON, COL_DUNGEON);
+    TERM_LEN width, height;
+    term_get_size(&width, &height);
+
+    c_put_str(TERM_WHITE, "             ", height + ROW_DUNGEON, COL_DUNGEON);
     concptr dungeon_name = map_name(player_ptr);
     TERM_LEN col = COL_DUNGEON + 6 - strlen(dungeon_name) / 2;
     if (col < 0) {
         col = 0;
     }
 
-    c_put_str(TERM_L_UMBER, format("%s", dungeon_name), ROW_DUNGEON, col);
+    c_put_str(TERM_L_UMBER, format("%s", dungeon_name), height + ROW_DUNGEON, col);
 }
 
 /*!

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -419,28 +419,18 @@ void print_health(PlayerType *player_ptr, bool riding)
         col = COL_INFO;
     }
 
-    const int max_height_riding = 3; // 騎乗時に描画する高さの最大範囲
-    const int max_height = 6; // 通常時に描画する高さの最大範囲
     const int max_width = 12; // 表示幅
 
-    // 表示範囲を一旦全部消す
-    int range = riding ? max_height_riding : max_height;
-    for (int y = row; y < row + range; y++) {
-        term_erase(col, y, max_width);
-    }
+    term_erase(col, row, max_width);
 
     if (!monster_idx.has_value()) {
         return;
     }
 
-    const int row_offset_name = 0; // 名前
-    const int row_offset_health = 1; // HP
-    const int row_offset_condition = 2; // 状態異常
-
     const auto &monster = player_ptr->current_floor_ptr->m_list[monster_idx.value()];
 
     if ((!monster.ml) || (player_ptr->effects()->hallucination()->is_hallucinated()) || monster.is_dead()) {
-        term_putstr(col, row + row_offset_health, max_width, TERM_WHITE, "[----------]");
+        term_putstr(col, row, max_width, TERM_WHITE, "[----------]");
         return;
     }
 
@@ -449,14 +439,9 @@ void print_health(PlayerType *player_ptr, bool riding)
     int len = (pct2 < 10) ? 1 : (pct2 < 90) ? (pct2 / 10 + 1)
                                             : 10;
     auto hit_point_bar_color = get_monster_hp_point_bar_color(monster);
-    const auto &ap_r_ref = monraces_info[monster.ap_r_idx];
 
-    // 名前
-    // 表示枠に収まらない場合は途中で切る
-    term_putstr(col, row + row_offset_name, max_width, TERM_WHITE, str_separate(ap_r_ref.name, max_width)[0].data());
-    // HPの割合
-    term_putstr(col, row + row_offset_health, max_width, TERM_WHITE, "[----------]");
-    term_putstr(col + 1, row + row_offset_health, len, hit_point_bar_color, "**********");
+    term_putstr(col, row, max_width, TERM_WHITE, "[----------]");
+    term_putstr(col + 1, row, len, hit_point_bar_color, "**********");
 
     // 騎乗中のモンスターの状態異常は表示しない
     if (riding) {
@@ -464,16 +449,23 @@ void print_health(PlayerType *player_ptr, bool riding)
     }
 
     int col_offset = 0;
-    int row_offset = 0;
+    int row_offset = 1;
+
+    TERM_LEN width, height;
+    term_get_size(&width, &height);
+    const auto extra_line_count = height - 24;
 
     // 一時的状態異常
     // MAX_WIDTHを超えたら次の行に移動する
     for (const auto &info : get_condition_layout_info(monster)) {
+        if (row_offset > extra_line_count) {
+            break;
+        }
         if (col_offset + info.label.length() - 1 > max_width) { // 改行が必要かどうかチェック。length() - 1してるのは\0の分を文字数から取り除くため
             col_offset = 0;
             row_offset++;
         }
-        term_putstr(col + col_offset, row + row_offset_condition + row_offset, max_width, info.color, info.label.data());
+        term_putstr(col + col_offset, row + row_offset, max_width, info.color, info.label);
         col_offset += info.label.length() + 1; // 文字数と空白の分だけoffsetを加算
     }
 }

--- a/src/window/main-window-row-column.h
+++ b/src/window/main-window-row-column.h
@@ -52,28 +52,28 @@
 #define ROW_CURSP 15
 #define COL_CURSP 0 /* "Cur SP xxxxx" */
 
-#define ROW_CUT 16
-#define COL_CUT 0 /* <cut> */
-
-#define ROW_STUN 17
-#define COL_STUN 0 /* <stun> */
-
-#define ROW_HUNGRY 18
-#define COL_HUNGRY 0 /* "Weak" / "Hungry" / "Full" / "Gorged" */
-
-#define ROW_STATE 19
-#define COL_STATE 7 /* <state> */
-
-#define ROW_RIDING_INFO 21
+#define ROW_RIDING_INFO 16
 #define COL_RIDING_INFO 0 /* "xxxxxxxxxxxx" */
 
-#define ROW_INFO 24
+#define ROW_INFO 17
 #define COL_INFO 0 /* "xxxxxxxxxxxx" */
 
-#define ROW_DAY 32
+#define ROW_CUT (-6)
+#define COL_CUT 0 /* <cut> */
+
+#define ROW_STUN (-5)
+#define COL_STUN 0 /* <stun> */
+
+#define ROW_HUNGRY (-4)
+#define COL_HUNGRY 0 /* "Weak" / "Hungry" / "Full" / "Gorged" */
+
+#define ROW_STATE (-4)
+#define COL_STATE 7 /* <state> */
+
+#define ROW_DAY (-3)
 #define COL_DAY 0 /* day */
 
-#define ROW_DUNGEON 33
+#define ROW_DUNGEON (-2)
 #define COL_DUNGEON 0 /* dungeon */
 
 #define ROW_SPEED (-1)

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -106,16 +106,20 @@ void WorldTurnProcessor::process_world()
  */
 void WorldTurnProcessor::print_time()
 {
+    TERM_LEN width, height;
+    term_get_size(&width, &height);
+    const auto row = height + ROW_DAY;
+
     int day;
-    c_put_str(TERM_WHITE, "             ", ROW_DAY, COL_DAY);
+    c_put_str(TERM_WHITE, "             ", row, COL_DAY);
     extract_day_hour_min(this->player_ptr, &day, &this->hour, &this->min);
     if (day < 1000) {
-        c_put_str(TERM_WHITE, format(_("%2d日目", "Day%3d"), day), ROW_DAY, COL_DAY);
+        c_put_str(TERM_WHITE, format(_("%2d日目", "Day%3d"), day), row, COL_DAY);
     } else {
-        c_put_str(TERM_WHITE, _("***日目", "Day***"), ROW_DAY, COL_DAY);
+        c_put_str(TERM_WHITE, _("***日目", "Day***"), row, COL_DAY);
     }
 
-    c_put_str(TERM_WHITE, format("%2d:%02d", this->hour, this->min), ROW_DAY, COL_DAY + 7);
+    c_put_str(TERM_WHITE, format("%2d:%02d", this->hour, this->min), row, COL_DAY + 7);
 }
 
 /*!


### PR DESCRIPTION
PR #2852 で追加されたモンスターのHP表示部に追加情報を表示する機能において、画面サイズ
を考慮していないため小さな画面では情報がすべて表示されない。
表示内容を一旦機能追加前を基準としたものに戻したうえで、プレイヤーの切り傷・朦朧・空腹
の状態やダンジョン名・経過日数はウィンドウの縦幅にあわせて下に移動させるようにし、空い
たスペースにモンスターの状態を表示するようにする。
なお、縦サイズが最小の24行の場合は空きスペースは無いためモンスターの状態表示はされない。