### PR TITLE
変愚「[Fix] 店舗内でデバッグセーブを実行している」のマージ

### DIFF
--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -76,7 +76,7 @@ void InputKeyRequestor::request_command()
 void InputKeyRequestor::input_command()
 {
     while (true) {
-        if (!macro_running() && !command_new && auto_debug_save && (!inkey_next || *inkey_next == '\0')) {
+        if (!this->shopping && !macro_running() && !command_new && auto_debug_save && (!inkey_next || *inkey_next == '\0')) {
             save_player(this->player_ptr, SaveType::DEBUG);
         }
 


### PR DESCRIPTION
通常店舗内ではセーブはできないが、auto_debug_save オプションが ON のとき店舗内に 居るにも関わらずセーブが実行されている。
デバッグ用セーブファイルとはいえ、通常では想定されていないタイミングでのセーブ実行であ
るためおかしな動作の原因となる事も考えられるため、店舗内ではセーブが実行されないように
修正する。