### PR TITLE
変愚「[Fix] 忍者にふさわしくない武器の攻撃回数ペナルティが機能していない」のマージ

### DIFF
--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1599,6 +1599,10 @@ static int16_t calc_num_blow(PlayerType *player_ptr, int i)
                 num_blow = 1;
             }
 
+            if (has_not_ninja_weapon(player_ptr, i)) {
+                num_blow /= 2;
+            }
+
             if (num_blow < 1) {
                 num_blow = 1;
             }
@@ -1667,13 +1671,6 @@ static int16_t calc_num_blow(PlayerType *player_ptr, int i)
         }
 
         num_blow += 1 + player_ptr->extra_blows[0];
-    }
-
-    if (has_not_ninja_weapon(player_ptr, i)) {
-        num_blow /= 2;
-        if (num_blow < 1) {
-            num_blow = 1;
-        }
     }
 
     return num_blow;


### PR DESCRIPTION
攻撃回数の計算処理を行う calc_num_blow 関数で、忍者の攻撃回数ペナルティの計算を行う
処理の位置が不適切なため発生する。
適切な位置に移動して修正する。