### PR TITLE
変愚「[Fix] #3137 キャラメイク時職業の能力修正値情報が更新されない」のマージ

### DIFF
--- a/src/birth/birth-select-class.cpp
+++ b/src/birth/birth-select-class.cpp
@@ -134,9 +134,9 @@ static bool select_class(PlayerType *player_ptr, concptr sym, int *k)
     auto cs = player_ptr->pclass;
     auto os = PlayerClassType::MAX;
     int int_os = enum2i(os);
-    int int_cs = enum2i(cs);
     auto cur = birth_class_label(int_os, sym);
     while (true) {
+        int int_cs = enum2i(cs);
         cur = display_class_stat(int_cs, &int_os, cur, sym);
         if (*k >= 0) {
             break;


### PR DESCRIPTION
変数 int_cs の定義位置がまずく、ループ毎に能力修正値情報が更新されなく
なっている。適切な位置に移動する。