### PR TITLE
変愚「[Refactor] #3275 jverb関数のシグネチャ改善」のマージ

### DIFF
--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -316,9 +316,6 @@ static int get_spell(PlayerType *player_ptr, SPELL_IDX *sn, concptr prompt, OBJE
     char out_val[160];
     concptr p;
     COMMAND_CODE code;
-#ifdef JP
-    char jverb_buf[128];
-#endif
     int menu_line = (use_menu ? 1 : 0);
 
     /* Get the spell, if available */
@@ -384,8 +381,8 @@ static int get_spell(PlayerType *player_ptr, SPELL_IDX *sn, concptr prompt, OBJE
 
     /* Build a prompt (accept all spells) */
 #ifdef JP
-    jverb(prompt, jverb_buf, JVERB_AND);
-    (void)strnfmt(out_val, 78, "(%s^:%c-%c, '*'で一覧, ESCで中断) どの%sを%s^ますか? ", p, I2A(0), I2A(num - 1), p, jverb_buf);
+    const auto verb = conjugate_jverb(prompt, JVerbConjugationType::AND);
+    (void)strnfmt(out_val, 78, "(%s^:%c-%c, '*'で一覧, ESCで中断) どの%sを%s^ますか? ", p, I2A(0), I2A(num - 1), p, verb.data());
 #else
     (void)strnfmt(out_val, 78, "(%s^s %c-%c, *=List, ESC=exit) %s^ which %s? ", p, I2A(0), I2A(num - 1), prompt, p);
 #endif

--- a/src/locale/japanese.h
+++ b/src/locale/japanese.h
@@ -6,10 +6,12 @@
 
 #ifdef JP
 
-constexpr int JVERB_AND = 1;
-constexpr int JVERB_TO = 2;
-constexpr int JVERB_OR = 3;
-void jverb(concptr in, char *out, int flag);
+enum class JVerbConjugationType {
+    AND = 0,
+    TO = 1,
+    OR = 2,
+};
+std::string conjugate_jverb(std::string_view in, JVerbConjugationType type);
 
 std::string sindarin_to_kana(std::string_view sindarin);
 bool is_kinsoku(std::string_view ch);

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -26,9 +26,7 @@ enum monster_sex {
 
 class MonsterRaceInfo;
 struct lore_type {
-#ifdef JP
-    char jverb_buf[64];
-#else
+#ifndef JP
     bool sin;
 #endif
     bool nightmare;

--- a/src/view/display-lore-attacks.cpp
+++ b/src/view/display-lore-attacks.cpp
@@ -35,23 +35,22 @@ static void display_monster_blow_jp(lore_type *lore_ptr, int attack_numbers, int
 
     /* XXしてYYし/XXしてYYする/XXし/XXする */
     if (lore_ptr->q != nullptr) {
-        jverb(lore_ptr->p, lore_ptr->jverb_buf, JVERB_TO);
+        const auto verb = conjugate_jverb(lore_ptr->p, JVerbConjugationType::TO);
+        hook_c_roff(lore_ptr->pc, verb);
     } else if (attack_numbers != lore_ptr->count - 1) {
-        jverb(lore_ptr->p, lore_ptr->jverb_buf, JVERB_AND);
+        const auto verb = conjugate_jverb(lore_ptr->p, JVerbConjugationType::AND);
+        hook_c_roff(lore_ptr->pc, verb);
     } else {
-        strcpy(lore_ptr->jverb_buf, lore_ptr->p);
+        hook_c_roff(lore_ptr->pc, lore_ptr->p);
     }
-
-    hook_c_roff(lore_ptr->pc, lore_ptr->jverb_buf);
 
     if (lore_ptr->q) {
         if (attack_numbers != lore_ptr->count - 1) {
-            jverb(lore_ptr->q, lore_ptr->jverb_buf, JVERB_AND);
+            const auto verb = conjugate_jverb(lore_ptr->q, JVerbConjugationType::AND);
+            hook_c_roff(lore_ptr->qc, verb);
         } else {
-            strcpy(lore_ptr->jverb_buf, lore_ptr->q);
+            hook_c_roff(lore_ptr->qc, lore_ptr->q);
         }
-
-        hook_c_roff(lore_ptr->qc, lore_ptr->jverb_buf);
     }
 
     if (attack_numbers != lore_ptr->count - 1) {

--- a/src/view/display-lore-status.cpp
+++ b/src/view/display-lore-status.cpp
@@ -102,8 +102,8 @@ void display_monster_abilities(lore_type *lore_ptr)
     for (int n = 0; n < lore_ptr->vn; n++) {
 #ifdef JP
         if (n != lore_ptr->vn - 1) {
-            jverb(lore_ptr->vp[n], lore_ptr->jverb_buf, JVERB_AND);
-            hook_c_roff(lore_ptr->color[n], lore_ptr->jverb_buf);
+            const auto verb = conjugate_jverb(lore_ptr->vp[n], JVerbConjugationType::AND);
+            hook_c_roff(lore_ptr->color[n], verb);
             hooked_roff("、");
         } else {
             hook_c_roff(lore_ptr->color[n], lore_ptr->vp[n]);

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -753,8 +753,8 @@ void display_monster_sometimes(lore_type *lore_ptr)
     for (int n = 0; n < lore_ptr->vn; n++) {
 #ifdef JP
         if (n != lore_ptr->vn - 1) {
-            jverb(lore_ptr->vp[n], lore_ptr->jverb_buf, JVERB_OR);
-            hook_c_roff(lore_ptr->color[n], lore_ptr->jverb_buf);
+            const auto verb = conjugate_jverb(lore_ptr->vp[n], JVerbConjugationType::OR);
+            hook_c_roff(lore_ptr->color[n], verb);
             hook_c_roff(lore_ptr->color[n], "り");
             hooked_roff("、");
         } else {


### PR DESCRIPTION
既存のシグネチャは入力文字列としてconst char*を受け取る、引数に出力用バッ
ファを指定する、int型引数で処理内容をスイッチする、関数名から処理内容が
わからない、とツッコミが追いつかない状況なのでよりよい形に変更する。