### PR TITLE
変愚「[Fix] 不要になったLLVMのAPTリポジトリを削除」のマージ

### DIFF
--- a/.github/scripts/check-format.sh
+++ b/.github/scripts/check-format.sh
@@ -1,22 +1,5 @@
 #!/bin/sh
 
-# InsertBraces オプションに対応するため、clang-format-15 をインストールする
-# そのため LLVM が用意している APT リポジトリを追加する
-# 将来的に GitHub Actions の Ubuntu runner が 22.04 になれば Ubuntu の APT リポジトリからインストールできるかもしれない
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | sudo apt-key add - >/dev/null 2>&1
-
-cat <<EOF | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
-deb http://apt.llvm.org/focal/ llvm-toolchain-focal main
-deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal main
-# 13
-deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main
-deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main
-# 14
-deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main
-deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main
-
-EOF
-
 sudo apt-get update >/dev/null
 sudo apt-get install clang-format-15 >/dev/null
 


### PR DESCRIPTION
Ubuntu 22.04本家のAPTリポジトリにclang-format-15が追加されたので、LLVMの APTリポジトリを追加するコードをソースコード整形チェック用スクリプトから
削除する。