### PR TITLE
[Refactor] *鑑定*時のサブウィンドウ更新処理

### DIFF
--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -180,14 +180,7 @@ bool identify_fully(PlayerType *player_ptr, bool only_equip)
 
     o_ptr->ident |= (IDENT_FULL_KNOWN);
 
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
-    };
-    rfu.reset_flags(flags_srf);
-    handle_stuff(player_ptr);
-    rfu.set_flags(flags_srf);
+    window_stuff(player_ptr);
 
     const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
     if (item >= INVEN_MAIN_HAND) {

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -237,8 +237,6 @@ void wiz_identify_full_inventory(PlayerType *player_ptr)
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,
     };
-    rfu.reset_flags(flags_srf);
-    handle_stuff(player_ptr);
     rfu.set_flags(flags_srf);
     set_bits(player_ptr->window_flags, PW_INVENTORY | PW_EQUIPMENT);
 }


### PR DESCRIPTION
*鑑定*時にサブウィンドウの更新を行う時に持ち物の並べ替えとまとめ直しが
発生しないように一時的にフラグを落としてhandle_stuffを呼ぶというトンデモ
な処理が行われている。単にwindow_stuffを呼べばよいだけなのでそのように
変更する。
また、デバッグコマンドのインベントリ全鑑定についてはサブウィンドウの更新
は不要なので持ち物の並べ替えとまとめ直しのフラグを立てるのみでよいと判断
した。