### PR TITLE
(Monster)[Fix] STUPIDフラグの判定が正しくマージされきっていなかった不具合を修正。

### DIFF
--- a/src/mspell/mspell-selector.cpp
+++ b/src/mspell/mspell-selector.cpp
@@ -301,7 +301,7 @@ MonsterAbilityType choose_attack_spell(PlayerType *player_ptr, msa_type *msa_ptr
 
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[msa_ptr->m_idx];
     auto *r_ptr = &monraces_info[m_ptr->r_idx];
-    if (r_ptr->flags2 & RF2_STUPID) {
+    if (r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID)) {
         return rand_choice(msa_ptr->mspells);
     }
 


### PR DESCRIPTION
これによりネクサスクイルスルグやぶぶ漬けが無条件にテレポートアウェイを行動の選択肢に入れる余地がなかった。