### PR TITLE
[Fix] 名前の長いアイテムを博物館に寄贈しようとするとクラッシュする

### DIFF
--- a/src/term/z-term.cpp
+++ b/src/term/z-term.cpp
@@ -570,9 +570,7 @@ static void term_queue_chars(TERM_LEN x, TERM_LEN y, int n, TERM_COLOR a, std::s
      * (条件追加：タイルの1文字目でない事を確かめるように。)
      */
     {
-        int w, h;
-        term_get_size(&w, &h);
-        if (x != w && !(scr_aa[x] & AF_TILE1) && (scr_aa[x] & AF_KANJI2)) {
+        if ((x < game_term->wid) && !(scr_aa[x] & AF_TILE1) && (scr_aa[x] & AF_KANJI2)) {
             scr_cc[x] = ' ';
             scr_aa[x] &= AF_KANJIC;
             if (x1 < 0) {


### PR DESCRIPTION
名前の長いアイテムを博物館に寄贈しようとすると、ゲーム画面の右端まで確認
メッセージが到達するが、この時ゲーム画面の実際の横幅ではなく中央寄せした
時の幅で境界をチェックしているので配列外アクセスが発生している。
正しくゲーム画面の幅を得るように修正する。