### PR TITLE
[Fix] モンスターを視認していないのに損傷具合が分かってしまう

### DIFF
--- a/src/view/display-monster-status.cpp
+++ b/src/view/display-monster-status.cpp
@@ -17,7 +17,9 @@ std::string look_mon_desc(MonsterEntity *m_ptr, BIT_FLAGS mode)
     auto perc = m_ptr->maxhp > 0 ? 100L * m_ptr->hp / m_ptr->maxhp : 0;
 
     concptr desc;
-    if (m_ptr->hp >= m_ptr->maxhp) {
+    if (!m_ptr->ml) {
+        desc = _("損傷具合不明", "damage unknown");
+    } else if (m_ptr->hp >= m_ptr->maxhp) {
         desc = living ? _("無傷", "unhurt") : _("無ダメージ", "undamaged");
     } else if (perc >= 60) {
         desc = living ? _("軽傷", "somewhat wounded") : _("小ダメージ", "somewhat damaged");


### PR DESCRIPTION
視認していないモンスターに対してlook_mon_desc()が呼ばれた場合、視認して
いないにもかかわらず損傷具合が分かってしまう。
現状、現在の知識コマンドからペット一覧を表示した時が該当する。
視認していない場合は「損傷具合不明」と表示するよう変更する。