### PR TITLE
[Fix] 自動拾いエディタの配列範囲外アクセス

### DIFF
--- a/src/autopick/autopick-editor-command.cpp
+++ b/src/autopick/autopick-editor-command.cpp
@@ -128,13 +128,14 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         }
         break;
     case EC_RIGHT: {
+        const int len = strlen(tb->lines_list[tb->cy]);
 #ifdef JP
-        if (iskanji(tb->lines_list[tb->cy][tb->cx])) {
+        if ((tb->cx + 1 < len) && iskanji(tb->lines_list[tb->cy][tb->cx])) {
             tb->cx++;
         }
 #endif
         tb->cx++;
-        int len = strlen(tb->lines_list[tb->cy]);
+
         if (len < tb->cx) {
             tb->cx = len;
             if (!tb->lines_list[tb->cy + 1]) {


### PR DESCRIPTION
カーソルを右に移動させる処理で、2バイト文字かどうかの判定を現在の行の長
さをチェックせずに行っているため配列範囲外アクセスが発生している。
カーソル位置が現在の行の長さに収まらない時は2バイト文字かどうかの判定は
行わないようにする。