### PR TITLE
[Fix] 英語版に日本語のメッセージが含まれる

### DIFF
--- a/src/action/racial-execution.cpp
+++ b/src/action/racial-execution.cpp
@@ -71,7 +71,7 @@ PERCENTAGE racial_chance(PlayerType *player_ptr, rpi_type *rpi_ptr)
 
     auto special_easy = PlayerClass(player_ptr).equals(PlayerClassType::IMITATOR);
     special_easy &= player_ptr->inventory_list[INVEN_NECK].is_specific_artifact(FixedArtifactId::GOGO_PENDANT);
-    special_easy &= rpi_ptr->racial_name.compare("倍返し") == 0;
+    special_easy &= rpi_ptr->racial_name == _("倍返し", "Double Revenge");
     if (special_easy) {
         difficulty -= 12;
     }

--- a/src/artifact/random-art-characteristics.cpp
+++ b/src/artifact/random-art-characteristics.cpp
@@ -189,7 +189,8 @@ static int calc_arm_avgdamage(PlayerType *player_ptr, ItemEntity *o_ptr)
     }
 
     dam = dam + o_ptr->to_d;
-    msg_format_wizard(player_ptr, CHEAT_OBJECT, "素:%d> 対邪:%d> 理力:%d> 切:%d> 最終:%d", base, s_evil, forced, vorpal, dam);
+    constexpr auto fmt = _("素:%d> 対邪:%d> 理力:%d> 切:%d> 最終:%d", "Normal:%d> Evil:%d> Force:%d> Vorpal:%d> Total:%d");
+    msg_format_wizard(player_ptr, CHEAT_OBJECT, fmt, base, s_evil, forced, vorpal, dam);
     return dam;
 }
 

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -301,7 +301,7 @@ void determine_daily_bounty(PlayerType *player_ptr, bool conv_old)
         r_ptr = &monraces_info[w_ptr->today_mon];
 
         if (cheat_hear) {
-            msg_format("日替わり候補: %s ", r_ptr->name.data());
+            msg_format(_("日替わり候補: %s ", "Today's candidate: %s "), r_ptr->name.data());
         }
 
         if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -175,7 +175,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
             const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
             auto f = object_flags(o_ptr);
 
-            if (!get_check(format(_("本当に %s を呪いますか？", "Do you curse %s, really？"), item_name.data()))) {
+            if (!get_check(format(_("本当に %s を呪いますか？", "Do you curse %s, really?"), item_name.data()))) {
                 return "";
             }
 

--- a/src/room/rooms-pit-nest.cpp
+++ b/src/room/rooms-pit-nest.cpp
@@ -404,7 +404,8 @@ bool build_type5(PlayerType *player_ptr, dun_data_type *dd_ptr)
                 }
             }
 
-            msg_format_wizard(player_ptr, CHEAT_DUNGEON, "Nest構成モンスターNo.%d:%s", i, monraces_info[nest_mon_info[i].r_idx].name.data());
+            constexpr auto fmt = _("Nest構成モンスターNo.%d: %s", "Nest monster No.%d: %s");
+            msg_format_wizard(player_ptr, CHEAT_DUNGEON, fmt, i, monraces_info[nest_mon_info[i].r_idx].name.data());
         }
     }
 

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -160,7 +160,7 @@ void wiz_restore_monster_max_num(MonsterRaceId r_idx)
     }
 
     if (n == 0) {
-        msg_print("出現数に制限がないモンスターです。");
+        msg_print(_("出現数に制限がないモンスターです。", "This monster can appear any time."));
         msg_print(nullptr);
         return;
     }

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -191,7 +191,7 @@ static SpoilerOutputResultType spoil_player_spell(concptr fname)
         spoil_out(format("[[Class: %s]]\n", class_ptr->title));
 
         auto magic_ptr = &class_magics_info[c];
-        std::string book_name = "なし";
+        std::string book_name = _("なし", "None");
         if (magic_ptr->spell_book != ItemKindType::NONE) {
             ItemEntity book;
             auto o_ptr = &book;


### PR DESCRIPTION
英語版Windowsの環境でコンパイルしたところ、警告C4566が出力されたことで
意図せず日本語のメッセージが英語版にそのまま適用されている箇所が発見され
た。英語のメッセージに修正する。