### PR TITLE
[Fix] 装備変更時に店のアイテム表示内容が更新されない

### DIFF
--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -152,6 +152,8 @@ void do_cmd_store(PlayerType *player_ptr)
         prt(_("コマンド:", "You may: "), 20 + xtra_stock, 0);
         InputKeyRequestor(player_ptr, true).request_command();
         store_process_command(player_ptr, store_num);
+
+        const auto should_redraw_store_inventory = rfu.has(StatusRecalculatingFlag::BONUS);
         w_ptr->character_icky_depth = 1;
         handle_stuff(player_ptr);
         if (player_ptr->inventory_list[INVEN_PACK].bi_id) {
@@ -188,7 +190,7 @@ void do_cmd_store(PlayerType *player_ptr)
             }
         }
 
-        if (rfu.has(StatusRecalculatingFlag::BONUS)) {
+        if (should_redraw_store_inventory) {
             display_store_inventory(player_ptr, store_num);
         }
 


### PR DESCRIPTION
b790502db5a8a6b26a7439fee5f4d06ec117659f で店のアイテム表示内容の更新が 必要かどうかのフラグを削除してStatusRedrawingFlag::BONUSを見るようにした
が、このフラグはhandle_stuffが呼ばれると落とされるため、元のコードのよう
に別途フラグとして保持しておく必要があった。