### PR TITLE
[Fix] （デバッグ）セーブ時にクラッシュ

### DIFF
--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -315,6 +315,11 @@ bool save_player(PlayerType *player_ptr, SaveType type)
     auto savefile_new = ss_new.str();
     safe_setuid_grab();
     fd_kill(savefile_new);
+    if (type == SaveType::DEBUG) {
+        const auto debug_save_dir = std::filesystem::path(debug_savefile).remove_filename();
+        std::error_code ec;
+        std::filesystem::create_directory(debug_save_dir, ec);
+    }
     safe_setuid_drop();
     update_playtime();
     bool result = false;

--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -351,11 +351,9 @@ errr angband_fputs(FILE *fff, concptr buf, ulong n)
 void fd_kill(const std::filesystem::path &path)
 {
     const auto &parsed_path = path_parse(path);
-    if (!std::filesystem::exists(parsed_path)) {
-        return;
-    }
 
-    std::filesystem::remove(parsed_path);
+    std::error_code ec;
+    std::filesystem::remove(parsed_path, ec);
 }
 
 /*!
@@ -366,17 +364,10 @@ void fd_kill(const std::filesystem::path &path)
 void fd_move(const std::filesystem::path &path_from, const std::filesystem::path &path_to)
 {
     const auto &abs_path_from = path_parse(path_from);
-    if (!std::filesystem::exists(abs_path_from)) {
-        return;
-    }
-
     const auto &abs_path_to = path_parse(path_to);
-    const auto directory = std::filesystem::path(abs_path_to).remove_filename();
-    if (!std::filesystem::exists(directory)) {
-        std::filesystem::create_directory(directory);
-    }
 
-    std::filesystem::rename(abs_path_from, abs_path_to);
+    std::error_code ec;
+    std::filesystem::rename(abs_path_from, abs_path_to, ec);
 }
 
 /*!


### PR DESCRIPTION
ゲームを普通にプレイしていると頻繁にクラッシュするという報告があり、検証
の結果（デバッグ）セーブ時に std::filesystem のファイル操作関数のエラー
により例外が発生している可能性が高いことがわかった。
多分に環境に依存するファイルシステムのエラーを完全に想定することは不可能
なので、例外ではなくエラーコードを受け取るようにするオーバーロードを使用
して例外を投げないようにする。
エラーコードによるエラーの処理は行っていないが、std::filesystem 以降前も
rename や remove 関数の戻り値はチェックしておらずそれで不具合も起きていな
かったので、ひとまず実用上の問題はないかと思われる。