### PR TITLE
[Fix] ダンプの名前の位置が右にずれる

### DIFF
--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -39,6 +39,7 @@
 #include "system/monster-entity.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
+#include "term/gameterm.h"
 #include "term/z-form.h"
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
@@ -608,7 +609,7 @@ static std::string get_check_sum(void)
  */
 void make_character_dump(PlayerType *player_ptr, FILE *fff)
 {
-    TermOffsetSetter tos(0, 0);
+    TermCenteredOffsetSetter tos(MAIN_TERM_MIN_COLS, std::nullopt);
 
     fprintf(fff, _("  [%s キャラクタ情報]\n\n", "  [%s Character Dump]\n\n"), get_version().data());
 


### PR DESCRIPTION
※馬鹿馬鹿上ではマージ手順のミスかまだ直っていない。恐らくマージし忘れの個所が原因

33209e24c4b2cefa5086f878bd63a1ca2be297d0 で名前の中央表示を実装したが、 中央表示時に表示画面の幅が計算されておりその分右にずれてしまう。
そもそもダンプの作成時は横幅80で計算していいはずなので、
make_character_dump()冒頭のermCenteredOffsetSetterをそのように設定する。