### PR TITLE
[Refactor] #3547 鉄獄100Fがムーンサイド状態になっていた不具合を修正した

### DIFF
--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -155,7 +155,7 @@ static void accept_winner_message(PlayerType *player_ptr)
             continue;
         }
 
-        if (!input_check_strict(player_ptr, _("よろしいですか？", "Are you sure? "), UserCheck::NO_HISTORY)) {
+        if (input_check_strict(player_ptr, _("よろしいですか？", "Are you sure? "), UserCheck::NO_HISTORY)) {
             break;
         }
     }


### PR DESCRIPTION
勝利メッセージ確定のyes/no が反転していた