### PR TITLE
変愚「[Fix] GitHub Actionsによる自動生成スポイラーページの公開に失敗する」のマージ

### DIFF
--- a/.github/workflows/publish-spoiler-page.yml
+++ b/.github/workflows/publish-spoiler-page.yml
@@ -25,7 +25,7 @@ jobs:
         run: ./bootstrap
 
       - name: Configuration for Japanese version
-        run: ./configure --disable-worldscore
+        run: ./configure --disable-net
         env:
           CFLAGS: "-pipe"
 
@@ -33,16 +33,16 @@ jobs:
         run: make -j$(nproc)
 
       - name: Output spoilers
-        run: src/hengband --output-spoilers
+        run: src/bakabakaband --output-spoilers
 
       - name: Convert encoding to UTF-8
-        run: nkf -w --in-place ~/.angband/Hengband/*.txt
+        run: nkf -w --in-place ~/.angband/Bakabakaband/*.txt
 
       - name: Upload spoilers
         uses: actions/upload-artifact@v2
         with:
           name: spoiler-files
-          path: ~/.angband/Hengband/*.txt
+          path: ~/.angband/Bakabakaband/*.txt
 
 
   publish:
@@ -50,7 +50,7 @@ jobs:
     needs: create_spoilers
     runs-on: ubuntu-20.04
     env:
-      GITHUB_PAGES_REPOSITORY: hengband/spoiler
+      GITHUB_PAGES_REPOSITORY: bakabakaband/spoiler
     steps:
       - uses: actions/checkout@v3
         with:
@@ -72,5 +72,5 @@ jobs:
           publish_dir: ./docs
           external_repository: ${{ env.GITHUB_PAGES_REPOSITORY }}
           enable_jekyll: true
-          user_name: hengband
-          user_email: hengband@users.noreply.github.com
+          user_name: bakabakaband
+          user_email: sikabane-works@users.noreply.github.com


### PR DESCRIPTION
ネット機能の実装により --disable-worldscore だけでは libcurl が依然とし て必要になったため、--disable-net を指定するようにして libcurl のインス
トールをしなくてもコンパイルできるように修正する。