### PR TITLE
変愚「[Fix] アイテム破壊時に自動破壊登録すると自動拾いファイルがリセットされる 」のマージ

### DIFF
--- a/src/autopick/autopick-reader-writer.h
+++ b/src/autopick/autopick-reader-writer.h
@@ -1,12 +1,14 @@
 #pragma once
 
 #include "system/angband.h"
+#include <filesystem>
 #include <string>
 #include <string_view>
 #include <vector>
 
 class PlayerType;
 void autopick_load_pref(PlayerType *player_ptr, bool disp_mes);
+std::filesystem::path search_pickpref_path(PlayerType *player_ptr);
 std::vector<concptr> read_pickpref_text_lines(PlayerType *player_ptr, int *filename_mode_p);
 bool write_text_lines(std::string_view filename, const std::vector<concptr> &lines);
 std::string pickpref_filename(PlayerType *player_ptr, int filename_mode);

--- a/src/autopick/autopick-registry.cpp
+++ b/src/autopick/autopick-registry.cpp
@@ -28,13 +28,11 @@ static const char autoregister_header[] = "?:$AUTOREGISTER";
  */
 static bool clear_auto_register(PlayerType *player_ptr)
 {
-    auto path_pref = path_build(ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_WITH_PNAME));
-    auto *pref_fff = angband_fopen(path_pref, FileOpenMode::READ);
-    if (!pref_fff) {
-        path_pref = path_build(ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_DEFAULT));
-        pref_fff = angband_fopen(path_pref, FileOpenMode::READ);
+    const auto path_pref = search_pickpref_path(player_ptr);
+    if (path_pref.empty()) {
+        return true;
     }
-
+    auto *pref_fff = angband_fopen(path_pref, FileOpenMode::READ);
     if (!pref_fff) {
         return true;
     }
@@ -138,12 +136,8 @@ bool autopick_autoregister(PlayerType *player_ptr, ItemEntity *o_ptr)
         }
     }
 
-    const auto path_pref = path_build(ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_WITH_PNAME));
-    auto *pref_fff = angband_fopen(path_pref, FileOpenMode::READ);
-    if (!pref_fff) {
-        path_build(ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_DEFAULT));
-        pref_fff = angband_fopen(path_pref, FileOpenMode::READ);
-    }
+    const auto path_pref = search_pickpref_path(player_ptr);
+    auto *pref_fff = !path_pref.empty() ? angband_fopen(path_pref, FileOpenMode::READ) : nullptr;
 
     if (pref_fff) {
         while (true) {


### PR DESCRIPTION
自動破壊登録時に自動拾いファイルをpicktype-プレイヤー名.prf、picktype.prf
の順に探しているが、後者のみ存在する場合後者のパスを変数に再代入するのを
忘れているため前者のファイルに対して自動破壊を登録してしまう。
その結果自動破壊のみが登録されたpicktype-プレイヤー名.prfが新しく作られ
てしまう。
他にも上述の順序で自動拾いファイルを決定している場所があるので、この際
自動拾いファイルを決定する処理を search_pickpref_path() に関数化し、
それを使用するようにすることで修正とする。