### PR TITLE
変愚「SMART/STUPID フラグの更新処理が無意味なものになっていたので修正した」のマージ

### DIFF
--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -231,11 +231,11 @@ static POSITION decide_updated_distance(PlayerType *player_ptr, um_type *um_ptr)
 
 static void update_smart_stupid_flags(MonsterRaceInfo *r_ptr)
 {
-    if (r_ptr->r_behavior_flags.has(MonsterBehaviorType::SMART)) {
+    if (r_ptr->behavior_flags.has(MonsterBehaviorType::SMART)) {
         r_ptr->r_behavior_flags.set(MonsterBehaviorType::SMART);
     }
 
-    if (r_ptr->r_behavior_flags.has(MonsterBehaviorType::STUPID)) {
+    if (r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID)) {
         r_ptr->r_behavior_flags.set(MonsterBehaviorType::STUPID);
     }
 }


### PR DESCRIPTION
update_smart_stupid_flags() は、「SMART/STUPID フラグがあるかないか知らないモンスター種族に対して思い出フラグを付与する処理」が正しい