### PR TITLE
変愚「[Fix] モルサンクに永久光源特性がついている #3717」のマージ

### DIFF
--- a/lib/edit/ArtifactDefinitions.txt
+++ b/lib/edit/ArtifactDefinitions.txt
@@ -4423,7 +4423,7 @@ I:23:4:1
 W:4:10:12:12000
 P:0:2d4:4:6:0
 F:STR | HIDE_TYPE
-F:BRAND_ACID | RES_ACID | ACTIVATE | SHOW_MODS | LITE | THROW | XTRA_H_RES
+F:BRAND_ACID | RES_ACID | ACTIVATE | SHOW_MODS | THROW | XTRA_H_RES
 U:ACID_BALL_AND_RESISTANCE
 D:$An acidic dagger finely balanced for deadly throws.
 D:「黒の牙」を意味する名を持つこの暗澹とした短剣は、


### PR DESCRIPTION
明らかにナルサンクからコピーしてFIREをACIDに変えただけでLITEを消し忘れた
ミスと思われるので永久光源特性を削除する修正する。