### PR TITLE
変愚「[Refactor] info_get_const #3708」のマージ

### DIFF
--- a/src/util/flag-group.h
+++ b/src/util/flag-group.h
@@ -654,17 +654,16 @@ public:
      * @brief 文字列からフラグへのマップを指定した検索キーで検索し、
      *        見つかった場合はフラグ集合に該当するフラグをセットする
      *
-     * @tparam Map std::map<string_view, FlagType> もしくは std::unordered_map<string_view, FlagType>
      * @param fg フラグをセットするフラグ集合
      * @param dict 文字列からフラグへのマップ
      * @param what マップの検索キー
      * @return 検索キーでフラグが見つかり、フラグをセットした場合 true
      *         見つからなかった場合 false
      */
-    template <typename Map>
-    static bool grab_one_flag(FlagGroup<FlagType, MAX> &fg, const Map &dict, std::string_view what)
+    template <typename Key, DictIndexedBy<Key> Dict>
+    static bool grab_one_flag(FlagGroup<FlagType, MAX> &fg, const Dict &dict, Key &&what)
     {
-        auto val = info_get_const<FlagType>(dict, what);
+        auto val = info_get_const(dict, std::forward<Key>(what));
         if (val) {
             fg.set(*val);
             return true;


### PR DESCRIPTION
info_get_constに渡す辞書オブジェクトのコンセプトを定義し、info_get_const とそれに関連する関数テンプレートの呼び出しにおいて任意の型のキーを持つ
std::mapやstd::unordered_mapオブジェクトを辞書として引数に渡せるように
する。