### PR TITLE
変愚「トラップ付の箱を開けた時、箱が破損する処理と中のアイテムを取り出す処理が競合してクラッシュする不具合を解消した #3749」のマージ

### DIFF
--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -58,6 +58,10 @@ void Chest::chest_death(bool scatter, POSITION y, POSITION x, OBJECT_IDX o_idx)
     BIT_FLAGS mode = AM_GOOD | AM_FORBID_CHEST;
     auto *floor_ptr = this->player_ptr->current_floor_ptr;
     auto *o_ptr = &floor_ptr->o_list[o_idx];
+    if (!o_ptr->is_valid()) {
+        msg_print(_("箱は既に壊れてしまっている…", "The chest was broken and you couldn't open it..."));
+        return;
+    }
 
     /* Small chests often hold "gold" */
     const auto sval = o_ptr->bi_key.sval().value();


### PR DESCRIPTION
箱は破損しているので中のアイテムは取り出せないものとする