### PR TITLE
変愚「[Chore] clangでのccache用のキャッシュ生成にlibc++を使用する」のマージ

### DIFF
--- a/.github/workflows/create-cache-for-ccache.yml
+++ b/.github/workflows/create-cache-for-ccache.yml
@@ -14,7 +14,7 @@ jobs:
     uses: ./.github/workflows/build-with-autotools.yml
     with:
       cxx: clang++-14
-      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -Wno-unused-const-variable -Wno-invalid-source-encoding"
+      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -Wno-unused-const-variable -Wno-invalid-source-encoding -stdlib=libc++"
       configure-opts: "--disable-pch"
       use-ccache: true
 


### PR DESCRIPTION
PR #3689 にて clang++-14 と libstdc++ の組み合わせでのコンパイルエラーに 対処したが、その時にccache用のキャッシュ生成のWorkflowに同じ修正を行う
ことを忘れていた。