### PR TITLE
変愚「性別フラグをEnum class化した」のマージ 

### DIFF
--- a/Bakabakaband/Bakabakaband/Bakabakaband.vcxproj
+++ b/Bakabakaband/Bakabakaband/Bakabakaband.vcxproj
@@ -279,6 +279,7 @@
     <ClCompile Include="..\..\src\load\monster\monster-loader-factory.cpp" />
     <ClCompile Include="..\..\src\load\player-class-specific-data-loader.cpp" />
     <ClCompile Include="..\..\src\monster-race\race-brightness-mask.cpp" />
+    <ClCompile Include="..\..\src\monster-race\race-sex-const.cpp" />
     <ClCompile Include="..\..\src\monster\monster-pain-describer.cpp" />
     <ClCompile Include="..\..\src\object-enchant\enchanter-factory.cpp" />
     <ClCompile Include="..\..\src\mspell\mspell-attack\abstract-mspell.cpp" />
@@ -1927,6 +1928,7 @@
     <ClInclude Include="..\..\src\wizard\tval-descriptions-table.h" />
     <ClInclude Include="..\..\src\load\quest-loader.h" />
     <ClInclude Include="..\..\src\view\display-store.h" />
+    <ClInclude Include="..\..\src\monster-race\race-sex-const.h" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\system\angband.h" />

--- a/Bakabakaband/Bakabakaband/Bakabakaband.vcxproj.filters
+++ b/Bakabakaband/Bakabakaband/Bakabakaband.vcxproj.filters
@@ -2489,6 +2489,9 @@
     <ClCompile Include="..\..\src\mspell\mspell-attack\mspell-breath.cpp" />
     <ClCompile Include="..\..\src\mspell\mspell-attack\mspell-curse.cpp" />
     <ClCompile Include="..\..\src\mspell\mspell-attack\mspell-ball.cpp" />
+    <ClCompile Include="..\..\src\monster-race\race-sex-const.cpp">
+      <Filter>monster-race</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5384,6 +5387,9 @@
     <ClInclude Include="..\..\src\mspell\mspell-attack\mspell-breath.h" />
     <ClInclude Include="..\..\src\mspell\mspell-attack\mspell-curse.h" />
     <ClInclude Include="..\..\src\mspell\mspell-attack\mspell-ball.h" />
+    <ClInclude Include="..\..\src\monster-race\race-sex-const.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\wall.bmp" />

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -531,6 +531,7 @@ hengband_SOURCES = \
 	monster-race/race-kind-flags.h \
 	monster-race/race-population-flags.h \
 	monster-race/race-resistance-mask.cpp monster-race/race-resistance-mask.h \
+	monster-race/race-sex-const.cpp monster-race/race-sex-const.h \
 	monster-race/race-speak-flags.h \
 	monster-race/race-special-flags.h \
 	monster-race/race-visual-flags.h \

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -207,7 +207,7 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
 
     auto is_confused = effects->confusion()->is_confused();
     auto is_stunned = effects->stun()->is_stunned();
-    if (any_bits(r_ptr->flags1, RF1_FEMALE) && !(is_stunned || is_confused || is_hallucinated || !m_ptr->ml)) {
+    if (is_female(*r_ptr) && !(is_stunned || is_confused || is_hallucinated || !m_ptr->ml)) {
         // @todo 「特定の武器を装備している」旨のメソッドを別途作る
         constexpr auto zantetsu = FixedArtifactId::ZANTETSU;
         const auto is_main_hand_zantetsu = player_ptr->inventory_list[INVEN_MAIN_HAND].is_specific_artifact(zantetsu);

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -331,6 +331,17 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
         }
     } else if (tokens[0] == "M") {
         // M:monsterflags
+        if (tokens[1] == "X") {
+            if (tokens.size() < 3) {
+                return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+            }
+            uint32_t sex;
+            if (!info_grab_one_const(sex, r_info_sex, tokens[2])) {
+                return PARSE_ERROR_INVALID_FLAG;
+            }
+            d_ptr->mon_sex = static_cast<MonsterSex>(sex);
+            return 0;
+        }
         if (tokens.size() < 2) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -101,7 +101,6 @@ static bool grab_one_basic_monster_flag(dungeon_type *d_ptr, std::string_view wh
         return true;
     }
 
-    msg_format(_("未知のモンスター・フラグ '%s'。", "Unknown monster flag '%s'."), what.data());
     return false;
 }
 
@@ -348,7 +347,12 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
                 continue;
             }
 
-            if (!grab_one_basic_monster_flag(d_ptr, f)) {
+            if (grab_one_basic_monster_flag(d_ptr, f)) {
+                continue;
+            }
+
+            uint32_t sex;
+            if (!info_grab_one_const(sex, r_info_sex, f)) {
                 return PARSE_ERROR_INVALID_FLAG;
             }
         }

--- a/src/info-reader/race-info-tokens-table.cpp
+++ b/src/info-reader/race-info-tokens-table.cpp
@@ -1,4 +1,4 @@
-#include "info-reader/race-info-tokens-table.h"
+﻿#include "info-reader/race-info-tokens-table.h"
 #include "monster-attack/monster-attack-effect.h"
 #include "monster-attack/monster-attack-table.h"
 #include "monster-race/race-ability-flags.h"
@@ -7,6 +7,7 @@
 #include "monster-race/race-feature-flags.h"
 #include "monster-race/race-kind-flags.h"
 #include "monster-race/race-population-flags.h"
+#include "monster-race/race-sex-const.h"
 #include "monster-race/race-speak-flags.h"
 #include "monster-race/race-special-flags.h"
 #include "monster-race/race-visual-flags.h"
@@ -101,8 +102,6 @@ const std::unordered_map<std::string_view, RaceBlowEffectType> r_info_blow_effec
  */
 const std::unordered_map<std::string_view, race_flags1> r_info_flags1 = {
     { "QUESTOR", RF1_QUESTOR },
-    { "MALE", RF1_MALE },
-    { "FEMALE", RF1_FEMALE },
     { "FORCE_DEPTH", RF1_FORCE_DEPTH },
     { "FORCE_MAXHP", RF1_FORCE_MAXHP },
     { "FORCE_EXTRA", RF1_FORCE_EXTRA },
@@ -531,4 +530,10 @@ const std::unordered_map<std::string_view, MonsterBrightnessType> r_info_brightn
 
 const std::unordered_map<std::string_view, MonsterSpecialType> r_info_special_flags = {
     { "DIMINISH_MAX_DAMAGE", MonsterSpecialType::DIMINISH_MAX_DAMAGE },
+};
+
+const std::unordered_map<std::string_view, MonsterSex> r_info_sex = {
+    { "NONE", MonsterSex::NONE },
+    { "MALE", MonsterSex::MALE },
+    { "FEMALE", MonsterSex::FEMALE },
 };

--- a/src/info-reader/race-info-tokens-table.h
+++ b/src/info-reader/race-info-tokens-table.h
@@ -17,6 +17,7 @@
 #include "monster-race/race-flags9.h"
 #include "monster-race/race-kind-flags.h"
 #include "monster-race/race-population-flags.h"
+#include "monster-race/race-sex-const.h"
 #include "monster-race/race-speak-flags.h"
 #include "monster-race/race-special-flags.h"
 #include "monster-race/race-visual-flags.h"
@@ -48,3 +49,4 @@ extern const std::unordered_map<std::string_view, MonsterPopulationType> r_info_
 extern const std::unordered_map<std::string_view, MonsterSpeakType> r_info_speak_flags;
 extern const std::unordered_map<std::string_view, MonsterBrightnessType> r_info_brightness_flags;
 extern const std::unordered_map<std::string_view, MonsterSpecialType> r_info_special_flags;
+extern const std::unordered_map<std::string_view, MonsterSex> r_info_sex;

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -89,7 +89,6 @@ static bool grab_one_basic_flag(MonsterRaceInfo *r_ptr, std::string_view what)
         return true;
     }
 
-    msg_format(_("未知のモンスター・フラグ '%s'。", "Unknown monster flag '%s'."), what.data());
     return false;
 }
 
@@ -473,9 +472,18 @@ errr parse_monraces_info(std::string_view buf, angband_header *)
                 r_ptr->dead_spawns.push_back({ num, deno, r_idx, ds, dn });
                 continue;
             }
-            if (!grab_one_basic_flag(r_ptr, f)) {
+
+            if (grab_one_basic_flag(r_ptr, f)) {
+                continue;
+            }
+
+            uint32_t sex;
+            if (!info_grab_one_const(sex, r_info_sex, f)) {
                 return PARSE_ERROR_INVALID_FLAG;
             }
+
+            r_ptr->sex = static_cast<MonsterSex>(sex);
+
         }
 
     } else if (tokens[0] == "S") {

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -483,7 +483,6 @@ errr parse_monraces_info(std::string_view buf, angband_header *)
             }
 
             r_ptr->sex = static_cast<MonsterSex>(sex);
-
         }
 
     } else if (tokens[0] == "S") {
@@ -536,7 +535,6 @@ errr parse_monraces_info(std::string_view buf, angband_header *)
             return PARSE_ERROR_INVALID_FLAG;
         }
         r_ptr->sex = static_cast<MonsterSex>(sex);
-
     } else if (tokens[0] == "V") {
         // V:arena_odds
         if (tokens.size() < 2) {

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -519,6 +519,16 @@ errr parse_monraces_info(std::string_view buf, angband_header *)
         info_set_value(a_idx, tokens[1]);
         info_set_value(chance, tokens[2]);
         r_ptr->drop_artifacts.emplace_back(a_idx, chance);
+    } else if (tokens[0] == "X") {
+        if (tokens.size() < 2) {
+            return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+        }
+        uint32_t sex;
+        if (!info_grab_one_const(sex, r_info_sex, tokens[1])) {
+            return PARSE_ERROR_INVALID_FLAG;
+        }
+        r_ptr->sex = static_cast<MonsterSex>(sex);
+
     } else if (tokens[0] == "V") {
         // V:arena_odds
         if (tokens.size() < 2) {

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -125,11 +125,11 @@ std::optional<std::string> get_random_line(concptr file_name, int entry)
         }
 
         if (buf[2] == 'M') {
-            if (monraces_info[i2enum<MonsterRaceId>(entry)].flags1 & RF1_MALE) {
+            if (is_male(monraces_info[i2enum<MonsterRaceId>(entry)])) {
                 break;
             }
         } else if (buf[2] == 'F') {
-            if (monraces_info[i2enum<MonsterRaceId>(entry)].flags1 & RF1_FEMALE) {
+            if (is_female(monraces_info[i2enum<MonsterRaceId>(entry)])) {
                 break;
             }
         } else if (sscanf(&(buf[2]), "%d", &test) != EOF) {

--- a/src/lore/monster-lore.cpp
+++ b/src/lore/monster-lore.cpp
@@ -14,6 +14,7 @@
 #include "monster-race/race-flags2.h"
 #include "monster-race/race-flags3.h"
 #include "monster-race/race-indice-types.h"
+#include "monster-race/race-sex-const.h"
 #include "player-ability/player-ability-types.h"
 #include "system/angband.h"
 #include "system/monster-race-info.h"
@@ -28,13 +29,11 @@
 static void set_msex_flags(lore_type *lore_ptr)
 {
     lore_ptr->msex = MSEX_NONE;
-    if (lore_ptr->r_ptr->flags1 & RF1_FEMALE) {
-        lore_ptr->msex = MSEX_FEMALE;
-        return;
-    }
-
-    if (lore_ptr->r_ptr->flags1 & RF1_MALE) {
+    if (is_male(*(lore_ptr->r_ptr))) {
         lore_ptr->msex = MSEX_MALE;
+    }
+    if (is_female(*(lore_ptr->r_ptr))) {
+        lore_ptr->msex = MSEX_FEMALE;
     }
 }
 
@@ -46,14 +45,6 @@ static void set_flags1(lore_type *lore_ptr)
 
     if (lore_ptr->r_ptr->flags1 & RF1_QUESTOR) {
         lore_ptr->flags1 |= (RF1_QUESTOR);
-    }
-
-    if (lore_ptr->r_ptr->flags1 & RF1_MALE) {
-        lore_ptr->flags1 |= (RF1_MALE);
-    }
-
-    if (lore_ptr->r_ptr->flags1 & RF1_FEMALE) {
-        lore_ptr->flags1 |= (RF1_FEMALE);
     }
 
     if (lore_ptr->r_ptr->flags1 & RF1_FRIENDS) {

--- a/src/mind/monk-attack.cpp
+++ b/src/mind/monk-attack.cpp
@@ -142,7 +142,7 @@ static int process_monk_additional_effect(player_attack_type *pa_ptr, int *stun_
     int special_effect = 0;
     auto *r_ptr = &pa_ptr->m_ptr->get_monrace();
     if (pa_ptr->ma_ptr->effect == MA_KNEE) {
-        if (r_ptr->flags1 & RF1_MALE) {
+        if (is_male(*r_ptr)) {
             msg_format(_("%sに金的膝蹴りをくらわした！", "You hit %s in the groin with your knee!"), pa_ptr->m_name);
             sound(SOUND_PAIN);
             special_effect = MA_KNEE;

--- a/src/monster-race/race-sex-const.cpp
+++ b/src/monster-race/race-sex-const.cpp
@@ -1,0 +1,42 @@
+#include "monster-race/race-sex-const.h"
+#include "system/monster-race-info.h"
+
+/*!
+ * @brief 性別が男性を含むか否かを判定
+ * @param 性別の変数
+ * @return 男性を含むか否か
+ */
+bool is_male(const MonsterSex sex)
+{
+    return sex == MonsterSex::MALE;
+}
+
+/*!
+ * @brief 性別が男性を含むか否かを判定
+ * @param 判定するモンスターの参照
+ * @return 男性を含むか否か
+ */
+bool is_male(const MonsterRaceInfo &monrace)
+{
+    return is_male(monrace.sex);
+}
+
+/*!
+ * @brief 性別が女性を含むか否かを判定
+ * @param 性別の変数
+ * @return 女性を含むか否か
+ */
+bool is_female(const MonsterSex sex)
+{
+    return sex == MonsterSex::FEMALE;
+}
+
+/*!
+ *@brief 性別が女性を含むか否かを判定
+ * @param 判定するモンスターの参照
+ *@return 女性を含むか否か
+ */
+bool is_female(const MonsterRaceInfo &monrace)
+{
+    return is_female(monrace.sex);
+}

--- a/src/monster-race/race-sex-const.h
+++ b/src/monster-race/race-sex-const.h
@@ -1,0 +1,14 @@
+#pragma once
+
+class MonsterRaceInfo;
+
+enum class MonsterSex {
+    NONE = 0,
+    MALE = 1,
+    FEMALE = 2,
+};
+
+bool is_male(const MonsterSex sex);
+bool is_male(const MonsterRaceInfo &monrace);
+bool is_female(const MonsterSex sex);
+bool is_female(const MonsterRaceInfo &monrace);

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -3,6 +3,7 @@
 #include "locale/english.h"
 #include "monster-race/monster-race.h"
 #include "monster-race/race-flags1.h"
+#include "monster-race/race-sex-const.h"
 #include "monster/monster-description-types.h"
 #include "monster/monster-flag-types.h"
 #include "monster/monster-info.h"
@@ -27,15 +28,12 @@ static int get_monster_pronoun_kind(const MonsterRaceInfo &monrace, const bool p
     if (!pron) {
         return 0x00;
     }
-
-    if (any_bits(monrace.flags1, RF1_FEMALE)) {
+    if (monrace.sex == MonsterSex::FEMALE) {
         return 0x20;
     }
-
-    if (any_bits(monrace.flags1, RF1_MALE)) {
+    if (monrace.sex == MonsterSex::MALE) {
         return 0x10;
     }
-
     return 0x00;
 }
 
@@ -116,11 +114,11 @@ static std::optional<std::string> get_monster_self_pronoun(const MonsterEntity &
         return std::nullopt;
     }
 
-    if (any_bits(monrace.flags1, RF1_FEMALE)) {
+    if (monrace.sex == MonsterSex::FEMALE) {
         return _("彼女自身", "herself");
     }
 
-    if (any_bits(monrace.flags1, RF1_MALE)) {
+    if (monrace.sex == MonsterSex::MALE) {
         return _("彼自身", "himself");
     }
 

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -141,6 +141,8 @@ static bool restrict_monster_to_dungeon(const FloorType *floor_ptr, MonsterRaceI
             is_possible_monster_and(r_ptr->population_flags, d_ptr->mon_population_flags),
             is_possible_monster_and(r_ptr->speak_flags, d_ptr->mon_speak_flags),
             is_possible_monster_and(r_ptr->brightness_flags, d_ptr->mon_brightness_flags),
+            is_male(d_ptr->mon_sex) ? is_male(r_ptr->sex) : true,
+            is_female(d_ptr->mon_sex) ? is_female(r_ptr->sex) : true,
         };
 
         auto result = std::all_of(is_possible.begin(), is_possible.end(), [](const auto &v) { return v; });
@@ -167,6 +169,8 @@ static bool restrict_monster_to_dungeon(const FloorType *floor_ptr, MonsterRaceI
             is_possible_monster_or(r_ptr->population_flags, d_ptr->mon_population_flags),
             is_possible_monster_or(r_ptr->speak_flags, d_ptr->mon_speak_flags),
             is_possible_monster_or(r_ptr->brightness_flags, d_ptr->mon_brightness_flags),
+            is_male(d_ptr->mon_sex) ? is_male(r_ptr->sex) : true,
+            is_female(d_ptr->mon_sex) ? is_female(r_ptr->sex) : true,
         };
 
         auto result = std::any_of(is_possible.begin(), is_possible.end(), [](const auto &v) { return v; });

--- a/src/system/dungeon-info.h
+++ b/src/system/dungeon-info.h
@@ -53,6 +53,7 @@ constexpr auto DUNGEON_FEAT_PROB_NUM = 3;
 
 enum class FixedArtifactId : short;
 enum class MonsterRaceId : int16_t;
+enum class MonsterSex;
 
 struct feat_prob {
     FEAT_IDX feat{}; /* Feature tile */
@@ -107,6 +108,7 @@ struct dungeon_type {
     EnumClassFlagGroup<MonsterSpeakType> mon_speak_flags;
     EnumClassFlagGroup<MonsterBrightnessType> mon_brightness_flags;
     EnumClassFlagGroup<MonsterSpecialType> mon_special_flags;
+    MonsterSex mon_sex{};
 
     std::vector<char> r_chars; /* Monster symbols allowed */
     short final_object{}; /* The object you'll find at the bottom */
@@ -128,7 +130,7 @@ struct dungeon_type {
     bool has_river_flag() const;
 };
 
-extern std::vector<DEPTH> max_dlv;
+extern std::vector<int> max_dlv;
 extern std::vector<dungeon_type> dungeons_info;
 
 class PlayerType;

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -12,6 +12,7 @@
 #include "monster-race/race-flags-resistance.h"
 #include "monster-race/race-kind-flags.h"
 #include "monster-race/race-population-flags.h"
+#include "monster-race/race-sex-const.h"
 #include "monster-race/race-speak-flags.h"
 #include "monster-race/race-special-flags.h"
 #include "monster-race/race-visual-flags.h"
@@ -78,6 +79,7 @@ public:
     byte speed{}; //!< 加速(110で+0) / Speed (normally 110)
     EXP mexp{}; //!< 殺害時基本経験値 / Exp value for kill
     RARITY freq_spell{}; //!< 魔法＆特殊能力仕様頻度(1/n) /  Spell frequency
+    MonsterSex sex{}; //!< 性別 / Sex
     BIT_FLAGS flags1{}; //!< Flags 1 (general)
     BIT_FLAGS flags2{}; //!< Flags 2 (abilities)
     BIT_FLAGS flags3{}; //!< Flags 3 (race/resist)

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -223,9 +223,9 @@ static void describe_monster_person(GridExamination *ge_ptr)
 {
     const auto &monrace = ge_ptr->m_ptr->get_appearance_monrace();
     ge_ptr->s1 = _("それは", "It is ");
-    if (monrace.flags1 & RF1_FEMALE) {
+    if (monrace.sex == MonsterSex::FEMALE) {
         ge_ptr->s1 = _("彼女は", "She is ");
-    } else if (monrace.flags1 & RF1_MALE) {
+    } else if (monrace.sex == MonsterSex::MALE) {
         ge_ptr->s1 = _("彼は", "He is ");
     }
 


### PR DESCRIPTION
データ置換が絶望的にめんどいのでMonsterDefinitionのMALE/FEMALEは`X:`でなく依然`F:`を参照させる。