### PR TITLE
変愚「[Fix] 属性への免疫を唱えた時のメッセージ」のマージ

### DIFF
--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -141,19 +141,19 @@ bool set_ele_immune(PlayerType *player_ptr, uint32_t immune_type, TIME_EFFECT v)
         player_ptr->ele_immune = v;
         std::string element;
         switch (immune_type) {
-        case ATTACK_ACID:
+        case DEFENSE_ACID:
             element = _("酸", "acid!");
             break;
-        case ATTACK_ELEC:
+        case DEFENSE_ELEC:
             element = _("電撃", "electricity!");
             break;
-        case ATTACK_FIRE:
+        case DEFENSE_FIRE:
             element = _("火炎", "fire!");
             break;
-        case ATTACK_COLD:
+        case DEFENSE_COLD:
             element = _("冷気", "cold!");
             break;
-        case ATTACK_POIS:
+        case DEFENSE_POIS:
             element = _("毒", "poison!");
             break;
         default: // @todo 本来はruntime_error を飛ばすべきだが、既存コードと同じように動くことを優先した.


### PR DESCRIPTION
リファクタリング時に誤ってDEFENSE_*だったものをATTACK_*にしてしまって
いたのが原因。正しくDEFENSE_*に戻す。