### PR TITLE
変愚「[Fix] object_is_quest_target()の判定修正」のマージ

### DIFF
--- a/src/object-hook/hook-quest.cpp
+++ b/src/object-hook/hook-quest.cpp
@@ -53,7 +53,7 @@ bool object_is_quest_target(QuestId quest_idx, const ItemEntity *o_ptr)
     }
 
     const auto &quest = QuestList::get_instance()[quest_idx];
-    if (quest.has_reward()) {
+    if (!quest.has_reward()) {
         return false;
     }
 


### PR DESCRIPTION
fix #3960
クエスト対象アイテムの存在判定が反転している。