### PR TITLE
変愚「[Refactor] plural_aux() のシグニチャの改善」のマージ

### DIFF
--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -314,25 +314,24 @@ void quest_discovery(QuestId q_idx)
         return;
     }
 
-    GAME_TEXT name[MAX_NLEN];
-    strcpy(name, (r_ptr->name.data()));
+#ifdef JP
+    const auto &name = r_ptr->name;
+#else
+    const auto &name = (q_num != 1) ? pluralize(r_ptr->name) : r_ptr->name;
+#endif
 
     msg_print(find_quest_list[rand_range(0, 4)]);
     msg_print(nullptr);
 
     if (q_num != 1) {
-#ifdef JP
-#else
-        plural_aux(name);
-#endif
-        msg_format(_("注意しろ！この階は%d体の%sによって守られている！", "Be warned, this level is guarded by %d %s!"), q_num, name);
+        msg_format(_("注意しろ！この階は%d体の%sによって守られている！", "Be warned, this level is guarded by %d %s!"), q_num, name.data());
         return;
     }
 
     bool is_random_quest_skipped = r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
     is_random_quest_skipped &= r_ptr->mob_num == 0;
     if (!is_random_quest_skipped) {
-        msg_format(_("注意せよ！この階は%sによって守られている！", "Beware, this level is protected by %s!"), name);
+        msg_format(_("注意せよ！この階は%sによって守られている！", "Beware, this level is protected by %s!"), name.data());
         return;
     }
 

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -223,10 +223,8 @@ void do_cmd_knowledge_kill_count(PlayerType *player_ptr)
                 fprintf(fff, "     1 %s\n", r_ptr->name.data());
             }
         } else {
-            char ToPlural[80];
-            strcpy(ToPlural, r_ptr->name.data());
-            plural_aux(ToPlural);
-            fprintf(fff, "     %d %s\n", this_monster, ToPlural);
+            const auto name = pluralize(r_ptr->name);
+            fprintf(fff, "     %d %s\n", this_monster, name.data());
         }
 #endif
         total += this_monster;

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -93,8 +93,7 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
 #ifdef JP
                         note = format(" - %d 体の%sを倒す。(あと %d 体)", (int)quest.max_num, monrace.name.data(), (int)(quest.max_num - quest.cur_num));
 #else
-                        auto monster_name(monrace.name);
-                        plural_aux(monster_name.data());
+                        const auto monster_name = pluralize(monrace.name);
                         note = format(" - kill %d %s, have killed %d.", (int)quest.max_num, monster_name.data(), (int)quest.cur_num);
 #endif
                     } else {
@@ -171,8 +170,7 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
         rand_tmp_str = format("  %s (%d 階) - %d 体の%sを倒す。(あと %d 体)\n", quest.name.data(), (int)quest.level, (int)quest.max_num, monrace.name.data(),
             (int)(quest.max_num - quest.cur_num));
 #else
-        auto monster_name(monrace.name);
-        plural_aux(monster_name.data());
+        const auto monster_name = pluralize(monrace.name);
         rand_tmp_str = format("  %s (Dungeon level: %d)\n  Kill %d %s, have killed %d.\n", quest.name.data(), (int)quest.level, (int)quest.max_num,
             monster_name.data(), (int)quest.cur_num);
 #endif

--- a/src/locale/english.h
+++ b/src/locale/english.h
@@ -1,4 +1,9 @@
 #pragma once
 
-void plural_aux(char *Name);
+#include <string>
+#include <string_view>
+
+#ifndef JP
+std::string pluralize(std::string_view name);
 bool is_a_vowel(int ch);
+#endif

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -474,10 +474,7 @@ bool probing(PlayerType *player_ptr)
 #ifdef JP
             msg_format("%sについてさらに詳しくなった気がする。", monrace.name.data());
 #else
-            std::string nm = monrace.name;
-            /* Leave room for making it plural. */
-            nm.resize(monrace.name.length() + 16);
-            plural_aux(nm.data());
+            const auto nm = pluralize(monrace.name);
             msg_format("You now know more about %s.", nm.data());
 #endif
             msg_print(nullptr);

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -684,13 +684,9 @@ static void display_monster_escort_contents(lore_type *lore_ptr)
 #ifdef JP
         hooked_roff(format("、 %dd%d 体の%s", dd, ds, rf_ptr->name.data()));
 #else
-        auto plural = (dd * ds > 1);
-        GAME_TEXT name[MAX_NLEN];
-        strcpy(name, rf_ptr->name.data());
-        if (plural) {
-            plural_aux(name);
-        }
-        hooked_roff(format("%s%dd%d %s", prefix, dd, ds, name));
+        const auto plural = (dd * ds > 1);
+        const auto &name = plural ? pluralize(rf_ptr->name) : rf_ptr->name;
+        hooked_roff(format("%s%dd%d %s", prefix, dd, ds, name.data()));
 #endif
     }
 


### PR DESCRIPTION
plural_aux() は英語版のみで使用される、名詞の複数形変化を処理する関数。
引数で与えられた文字列バッファを直接変更するインターフェスから、引数で与えられた
文字列を複数形にした新規の std::string オブジェクトを返すインターフェースへ変更する。