### PR TITLE
変愚「[Fix] 確認メッセージのカーソルが変な場所に表示される #3985」のマージ

### DIFF
--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -291,7 +291,7 @@ bool input_check_strict(PlayerType *player_ptr, std::string_view prompt, EnumCla
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     if (auto_more) {
         rfu.set_flag(SubWindowRedrawingFlag::MESSAGE);
-        handle_stuff(player_ptr);
+        window_stuff(player_ptr);
         num_more = 0;
     }
 
@@ -301,7 +301,7 @@ bool input_check_strict(PlayerType *player_ptr, std::string_view prompt, EnumCla
     if (mode.has_not(UserCheck::NO_HISTORY) && player_ptr->playing) {
         message_add(buf);
         rfu.set_flag(SubWindowRedrawingFlag::MESSAGE);
-        handle_stuff(player_ptr);
+        window_stuff(player_ptr);
     }
 
     bool flag = false;


### PR DESCRIPTION
確認メッセージをサブウィンドウにも表示する目的でサブウィンドウの更新だけすべきところで
不要にすべての更新を行う handle_stuff() を呼んでおり、メインウィンドウの再描画まで
行われてしまうことによりカーソルの位置がおかしくなってしまっている。
window_stuff() を呼ぶように修正してサブウィンドウの更新のみが行われるようにする。