### PR TITLE
変愚「[Refactor] self_info_type #4016」のマージ

### DIFF
--- a/src/player-info/base-status-info.cpp
+++ b/src/player-info/base-status-info.cpp
@@ -19,72 +19,72 @@ void set_equipment_influence(PlayerType *player_ptr, self_info_type *self_ptr)
     }
 
     if (self_ptr->flags.has(TR_STR)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの腕力は装備によって影響を受けている。", "Your strength is affected by your equipment.");
+        self_ptr->info_list.emplace_back(_("あなたの腕力は装備によって影響を受けている。", "Your strength is affected by your equipment."));
     }
 
     if (self_ptr->flags.has(TR_INT)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの知能は装備によって影響を受けている。", "Your intelligence is affected by your equipment.");
+        self_ptr->info_list.emplace_back(_("あなたの知能は装備によって影響を受けている。", "Your intelligence is affected by your equipment."));
     }
 
     if (self_ptr->flags.has(TR_WIS)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの賢さは装備によって影響を受けている。", "Your wisdom is affected by your equipment.");
+        self_ptr->info_list.emplace_back(_("あなたの賢さは装備によって影響を受けている。", "Your wisdom is affected by your equipment."));
     }
 
     if (self_ptr->flags.has(TR_DEX)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの器用さは装備によって影響を受けている。", "Your dexterity is affected by your equipment.");
+        self_ptr->info_list.emplace_back(_("あなたの器用さは装備によって影響を受けている。", "Your dexterity is affected by your equipment."));
     }
 
     if (self_ptr->flags.has(TR_CON)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの耐久力は装備によって影響を受けている。", "Your constitution is affected by your equipment.");
+        self_ptr->info_list.emplace_back(_("あなたの耐久力は装備によって影響を受けている。", "Your constitution is affected by your equipment."));
     }
 
     if (self_ptr->flags.has(TR_CHR)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの魅力は装備によって影響を受けている。", "Your charisma is affected by your equipment.");
+        self_ptr->info_list.emplace_back(_("あなたの魅力は装備によって影響を受けている。", "Your charisma is affected by your equipment."));
     }
 
     if (self_ptr->flags.has(TR_STEALTH)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの隠密行動能力は装備によって影響を受けている。", "Your stealth is affected by your equipment.");
+        self_ptr->info_list.emplace_back(_("あなたの隠密行動能力は装備によって影響を受けている。", "Your stealth is affected by your equipment."));
     }
 
     if (self_ptr->flags.has(TR_SEARCH)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの探索能力は装備によって影響を受けている。", "Your searching ability is affected by your equipment.");
+        self_ptr->info_list.emplace_back(_("あなたの探索能力は装備によって影響を受けている。", "Your searching ability is affected by your equipment."));
     }
 
     if (self_ptr->flags.has(TR_INFRA)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの赤外線視力は装備によって影響を受けている。", "Your infravision is affected by your equipment.");
+        self_ptr->info_list.emplace_back(_("あなたの赤外線視力は装備によって影響を受けている。", "Your infravision is affected by your equipment."));
     }
 
     if (self_ptr->flags.has(TR_TUNNEL)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの採掘能力は装備によって影響を受けている。", "Your digging ability is affected by your equipment.");
+        self_ptr->info_list.emplace_back(_("あなたの採掘能力は装備によって影響を受けている。", "Your digging ability is affected by your equipment."));
     }
 
     if (self_ptr->flags.has(TR_SPEED)) {
-        self_ptr->info[self_ptr->line++] = _("あなたのスピードは装備によって影響を受けている。", "Your speed is affected by your equipment.");
+        self_ptr->info_list.emplace_back(_("あなたのスピードは装備によって影響を受けている。", "Your speed is affected by your equipment."));
     }
 
     if (self_ptr->flags.has(TR_BLOWS)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの攻撃速度は装備によって影響を受けている。", "Your attack speed is affected by your equipment.");
+        self_ptr->info_list.emplace_back(_("あなたの攻撃速度は装備によって影響を受けている。", "Your attack speed is affected by your equipment."));
     }
 }
 
 void set_status_sustain_info(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     if (has_sustain_str(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの腕力は維持されている。", "Your strength is sustained.");
+        self_ptr->info_list.emplace_back(_("あなたの腕力は維持されている。", "Your strength is sustained."));
     }
     if (has_sustain_int(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの知能は維持されている。", "Your intelligence is sustained.");
+        self_ptr->info_list.emplace_back(_("あなたの知能は維持されている。", "Your intelligence is sustained."));
     }
     if (has_sustain_wis(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの賢さは維持されている。", "Your wisdom is sustained.");
+        self_ptr->info_list.emplace_back(_("あなたの賢さは維持されている。", "Your wisdom is sustained."));
     }
     if (has_sustain_con(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの耐久力は維持されている。", "Your constitution is sustained.");
+        self_ptr->info_list.emplace_back(_("あなたの耐久力は維持されている。", "Your constitution is sustained."));
     }
     if (has_sustain_dex(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの器用さは維持されている。", "Your dexterity is sustained.");
+        self_ptr->info_list.emplace_back(_("あなたの器用さは維持されている。", "Your dexterity is sustained."));
     }
     if (has_sustain_chr(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの魅力は維持されている。", "Your charisma is sustained.");
+        self_ptr->info_list.emplace_back(_("あなたの魅力は維持されている。", "Your charisma is sustained."));
     }
 }

--- a/src/player-info/body-improvement-info.cpp
+++ b/src/player-info/body-improvement-info.cpp
@@ -8,31 +8,31 @@
 void set_body_improvement_info_1(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     if (is_blessed(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは高潔さを感じている。", "You feel rightous.");
+        self_ptr->info_list.emplace_back(_("あなたは高潔さを感じている。", "You feel rightous."));
     }
 
     if (is_hero(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはヒーロー気分だ。", "You feel heroic.");
+        self_ptr->info_list.emplace_back(_("あなたはヒーロー気分だ。", "You feel heroic."));
     }
 
     if (is_shero(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは戦闘狂だ。", "You are in a battle rage.");
+        self_ptr->info_list.emplace_back(_("あなたは戦闘狂だ。", "You are in a battle rage."));
     }
 
     if (player_ptr->protevil) {
-        self_ptr->info[self_ptr->line++] = _("あなたは邪悪なる存在から守られている。", "You are protected from evil.");
+        self_ptr->info_list.emplace_back(_("あなたは邪悪なる存在から守られている。", "You are protected from evil."));
     }
 
     if (player_ptr->shield) {
-        self_ptr->info[self_ptr->line++] = _("あなたは神秘のシールドで守られている。", "You are protected by a mystic shield.");
+        self_ptr->info_list.emplace_back(_("あなたは神秘のシールドで守られている。", "You are protected by a mystic shield."));
     }
 
     if (is_invuln(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは現在傷つかない。", "You are temporarily invulnerable.");
+        self_ptr->info_list.emplace_back(_("あなたは現在傷つかない。", "You are temporarily invulnerable."));
     }
 
     if (player_ptr->wraith_form) {
-        self_ptr->info[self_ptr->line++] = _("あなたは一時的に幽体化している。", "You are temporarily incorporeal.");
+        self_ptr->info_list.emplace_back(_("あなたは一時的に幽体化している。", "You are temporarily incorporeal."));
     }
 }
 
@@ -40,39 +40,39 @@ void set_body_improvement_info_1(PlayerType *player_ptr, self_info_type *self_pt
 void set_body_improvement_info_2(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     if (player_ptr->new_spells) {
-        self_ptr->info[self_ptr->line++] = _("あなたは呪文や祈りを学ぶことができる。", "You can learn some spells/prayers.");
+        self_ptr->info_list.emplace_back(_("あなたは呪文や祈りを学ぶことができる。", "You can learn some spells/prayers."));
     }
 
     if (player_ptr->word_recall) {
-        self_ptr->info[self_ptr->line++] = _("あなたはすぐに帰還するだろう。", "You will soon be recalled.");
+        self_ptr->info_list.emplace_back(_("あなたはすぐに帰還するだろう。", "You will soon be recalled."));
     }
 
     if (player_ptr->alter_reality) {
-        self_ptr->info[self_ptr->line++] = _("あなたはすぐにこの世界を離れるだろう。", "You will soon be altered.");
+        self_ptr->info_list.emplace_back(_("あなたはすぐにこの世界を離れるだろう。", "You will soon be altered."));
     }
 
     if (player_ptr->see_infra) {
-        self_ptr->info[self_ptr->line++] = _("あなたの瞳は赤外線に敏感である。", "Your eyes are sensitive to infrared light.");
+        self_ptr->info_list.emplace_back(_("あなたの瞳は赤外線に敏感である。", "Your eyes are sensitive to infrared light."));
     }
 
     if (player_ptr->see_inv) {
-        self_ptr->info[self_ptr->line++] = _("あなたは透明なモンスターを見ることができる。", "You can see invisible creatures.");
+        self_ptr->info_list.emplace_back(_("あなたは透明なモンスターを見ることができる。", "You can see invisible creatures."));
     }
 
     if (player_ptr->levitation) {
-        self_ptr->info[self_ptr->line++] = _("あなたは飛ぶことができる。", "You can fly.");
+        self_ptr->info_list.emplace_back(_("あなたは飛ぶことができる。", "You can fly."));
     }
 
     if (player_ptr->free_act) {
-        self_ptr->info[self_ptr->line++] = _("あなたは麻痺知らずの効果を持っている。", "You have free action.");
+        self_ptr->info_list.emplace_back(_("あなたは麻痺知らずの効果を持っている。", "You have free action."));
     }
 
     if (player_ptr->regenerate) {
-        self_ptr->info[self_ptr->line++] = _("あなたは素早く体力を回復する。", "You regenerate quickly.");
+        self_ptr->info_list.emplace_back(_("あなたは素早く体力を回復する。", "You regenerate quickly."));
     }
 
     if (player_ptr->slow_digest) {
-        self_ptr->info[self_ptr->line++] = _("あなたは食欲が少ない。", "Your appetite is small.");
+        self_ptr->info_list.emplace_back(_("あなたは食欲が少ない。", "Your appetite is small."));
     }
 }
 
@@ -80,75 +80,75 @@ void set_body_improvement_info_2(PlayerType *player_ptr, self_info_type *self_pt
 void set_body_improvement_info_3(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     if (player_ptr->hold_exp) {
-        self_ptr->info[self_ptr->line++] = _("あなたは自己の経験値をしっかりと維持する。", "You have a firm hold on your experience.");
+        self_ptr->info_list.emplace_back(_("あなたは自己の経験値をしっかりと維持する。", "You have a firm hold on your experience."));
     }
 
     if (has_reflect(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは矢の呪文を反射する。", "You reflect bolt spells.");
+        self_ptr->info_list.emplace_back(_("あなたは矢の呪文を反射する。", "You reflect bolt spells."));
     }
 
     if (has_resist_curse(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはより強く呪いに抵抗できる。", "You can resist curses powerfully.");
+        self_ptr->info_list.emplace_back(_("あなたはより強く呪いに抵抗できる。", "You can resist curses powerfully."));
     }
 
     if (has_sh_fire(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは炎のオーラに包まれている。", "You are surrounded with a fiery aura.");
+        self_ptr->info_list.emplace_back(_("あなたは炎のオーラに包まれている。", "You are surrounded with a fiery aura."));
     }
 
     if (get_player_flags(player_ptr, TR_SELF_FIRE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは身を焼く炎に包まれている。", "You are being damaged with fire.");
+        self_ptr->info_list.emplace_back(_("あなたは身を焼く炎に包まれている。", "You are being damaged with fire."));
     }
 
     if (has_sh_elec(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは電気のオーラに包まれている。", "You are surrounded with an electricity aura.");
+        self_ptr->info_list.emplace_back(_("あなたは電気のオーラに包まれている。", "You are surrounded with an electricity aura."));
     }
 
     if (get_player_flags(player_ptr, TR_SELF_ELEC)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは身を焦がす電撃に包まれている。", "You are being damaged with electricity.");
+        self_ptr->info_list.emplace_back(_("あなたは身を焦がす電撃に包まれている。", "You are being damaged with electricity."));
     }
 
     if (has_sh_cold(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは冷気のオーラに包まれている。", "You are surrounded with an aura of coldness.");
+        self_ptr->info_list.emplace_back(_("あなたは冷気のオーラに包まれている。", "You are surrounded with an aura of coldness."));
     }
 
     if (get_player_flags(player_ptr, TR_SELF_COLD)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは身も凍る冷気に包まれている。", "You are being damaged with coldness.");
+        self_ptr->info_list.emplace_back(_("あなたは身も凍る冷気に包まれている。", "You are being damaged with coldness."));
     }
 
     if (player_ptr->tim_sh_holy) {
-        self_ptr->info[self_ptr->line++] = _("あなたは聖なるオーラに包まれている。", "You are surrounded with a holy aura.");
+        self_ptr->info_list.emplace_back(_("あなたは聖なるオーラに包まれている。", "You are surrounded with a holy aura."));
     }
 
     if (player_ptr->tim_sh_touki) {
-        self_ptr->info[self_ptr->line++] = _("あなたは闘気のオーラに包まれている。", "You are surrounded with an energy aura.");
+        self_ptr->info_list.emplace_back(_("あなたは闘気のオーラに包まれている。", "You are surrounded with an energy aura."));
     }
 
     if (player_ptr->anti_magic) {
-        self_ptr->info[self_ptr->line++] = _("あなたは反魔法シールドに包まれている。", "You are surrounded by an anti-magic shell.");
+        self_ptr->info_list.emplace_back(_("あなたは反魔法シールドに包まれている。", "You are surrounded by an anti-magic shell."));
     }
 
     if (player_ptr->anti_tele) {
-        self_ptr->info[self_ptr->line++] = _("あなたはテレポートできない。", "You cannot teleport.");
+        self_ptr->info_list.emplace_back(_("あなたはテレポートできない。", "You cannot teleport."));
     }
 
     if (player_ptr->lite) {
-        self_ptr->info[self_ptr->line++] = _("あなたの身体は光っている。", "You are carrying a permanent light.");
+        self_ptr->info_list.emplace_back(_("あなたの身体は光っている。", "You are carrying a permanent light."));
     }
 
     if (player_ptr->warning) {
-        self_ptr->info[self_ptr->line++] = _("あなたは行動の前に危険を察知することができる。", "You will be warned before dangerous actions.");
+        self_ptr->info_list.emplace_back(_("あなたは行動の前に危険を察知することができる。", "You will be warned before dangerous actions."));
     }
 
     if (player_ptr->dec_mana) {
-        self_ptr->info[self_ptr->line++] = _("あなたは少ない消費魔力で魔法を唱えることができる。", "You can cast spells with fewer mana points.");
+        self_ptr->info_list.emplace_back(_("あなたは少ない消費魔力で魔法を唱えることができる。", "You can cast spells with fewer mana points."));
     }
 
     if (player_ptr->easy_spell) {
-        self_ptr->info[self_ptr->line++] = _("あなたは低い失敗率で魔法を唱えることができる。", "Your magic fails less often.");
+        self_ptr->info_list.emplace_back(_("あなたは低い失敗率で魔法を唱えることができる。", "Your magic fails less often."));
     }
 
     if (player_ptr->mighty_throw) {
-        self_ptr->info[self_ptr->line++] = _("あなたは強く物を投げる。", "You can throw objects powerfully.");
+        self_ptr->info_list.emplace_back(_("あなたは強く物を投げる。", "You can throw objects powerfully."));
     }
 }
 
@@ -156,14 +156,14 @@ void set_body_improvement_info_3(PlayerType *player_ptr, self_info_type *self_pt
 void set_body_improvement_info_4(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     if (has_resist_fear(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは全く恐怖を感じない。", "You are completely fearless.");
+        self_ptr->info_list.emplace_back(_("あなたは全く恐怖を感じない。", "You are completely fearless."));
     }
 
     if (has_resist_blind(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの目は盲目への耐性を持っている。", "Your eyes are resistant to blindness.");
+        self_ptr->info_list.emplace_back(_("あなたの目は盲目への耐性を持っている。", "Your eyes are resistant to blindness."));
     }
 
     if (has_resist_time(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは時間逆転への耐性を持っている。", "You are resistant to time.");
+        self_ptr->info_list.emplace_back(_("あなたは時間逆転への耐性を持っている。", "You are resistant to time."));
     }
 }

--- a/src/player-info/class-ability-info.cpp
+++ b/src/player-info/class-ability-info.cpp
@@ -9,7 +9,7 @@ void set_class_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
     switch (player_ptr->pclass) {
     case PlayerClassType::WARRIOR:
         if (player_ptr->lev > 39) {
-            self_ptr->info[self_ptr->line++] = _("あなたはランダムな方向に対して数回攻撃することができる。(75 HP)", "You can attack some random directions simultaneously (cost 75).");
+            self_ptr->info_list.emplace_back(_("あなたはランダムな方向に対して数回攻撃することができる。(75 HP)", "You can attack some random directions simultaneously (cost 75)."));
         }
 
         break;
@@ -21,70 +21,70 @@ void set_class_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
     case PlayerClassType::MAGE:
     case PlayerClassType::SORCERER:
         if (player_ptr->lev > 24) {
-            self_ptr->info[self_ptr->line++] = _("あなたはアイテムの魔力を吸収することができる。(1 MP)", "You can absorb charges from an item (cost 1).");
+            self_ptr->info_list.emplace_back(_("あなたはアイテムの魔力を吸収することができる。(1 MP)", "You can absorb charges from an item (cost 1)."));
         }
 
         break;
     case PlayerClassType::PRIEST:
         if (is_good_realm(player_ptr->realm1)) {
             if (player_ptr->lev > 34) {
-                self_ptr->info[self_ptr->line++] = _("あなたは武器を祝福することができる。(70 MP)", "You can bless a weapon (cost 70).");
+                self_ptr->info_list.emplace_back(_("あなたは武器を祝福することができる。(70 MP)", "You can bless a weapon (cost 70)."));
             }
 
             break;
         }
 
         if (player_ptr->lev > 41) {
-            self_ptr->info[self_ptr->line++] = _("あなたは周りのすべてのモンスターを攻撃することができる。(40 MP)", "You can damage all monsters in sight (cost 40).");
+            self_ptr->info_list.emplace_back(_("あなたは周りのすべてのモンスターを攻撃することができる。(40 MP)", "You can damage all monsters in sight (cost 40)."));
         }
 
         break;
     case PlayerClassType::ROGUE:
         if (player_ptr->lev > 7) {
-            self_ptr->info[self_ptr->line++] = _("あなたは攻撃して即座に逃げることができる。(12 MP)", "You can hit a monster and teleport away simultaneously (cost 12).");
+            self_ptr->info_list.emplace_back(_("あなたは攻撃して即座に逃げることができる。(12 MP)", "You can hit a monster and teleport away simultaneously (cost 12)."));
         }
 
         break;
     case PlayerClassType::RANGER:
         if (player_ptr->lev > 14) {
-            self_ptr->info[self_ptr->line++] = _("あなたは怪物を調査することができる。(20 MP)", "You can probe monsters (cost 20).");
+            self_ptr->info_list.emplace_back(_("あなたは怪物を調査することができる。(20 MP)", "You can probe monsters (cost 20)."));
         }
 
         break;
     case PlayerClassType::PALADIN:
         if (is_good_realm(player_ptr->realm1)) {
             if (player_ptr->lev > 29) {
-                self_ptr->info[self_ptr->line++] = _("あなたは聖なる槍を放つことができる。(30 MP)", "You can fire a holy spear (cost 30).");
+                self_ptr->info_list.emplace_back(_("あなたは聖なる槍を放つことができる。(30 MP)", "You can fire a holy spear (cost 30)."));
             }
 
             break;
         }
 
         if (player_ptr->lev > 29) {
-            self_ptr->info[self_ptr->line++] = _("あなたは生命力を減少させる槍を放つことができる。(30 MP)", "You can fire a spear which drains vitality (cost 30).");
+            self_ptr->info_list.emplace_back(_("あなたは生命力を減少させる槍を放つことができる。(30 MP)", "You can fire a spear which drains vitality (cost 30)."));
         }
 
         break;
     case PlayerClassType::WARRIOR_MAGE:
         if (player_ptr->lev > 24) {
-            self_ptr->info[self_ptr->line++] = _("あなたはＨＰをＭＰに変換することができる。(消費なし)", "You can convert HP to SP (cost 0).");
-            self_ptr->info[self_ptr->line++] = _("あなたはＭＰをＨＰに変換することができる。(消費なし)", "You can convert SP to HP (cost 0).");
+            self_ptr->info_list.emplace_back(_("あなたはＨＰをＭＰに変換することができる。(消費なし)", "You can convert HP to SP (cost 0)."));
+            self_ptr->info_list.emplace_back(_("あなたはＭＰをＨＰに変換することができる。(消費なし)", "You can convert SP to HP (cost 0)."));
         }
 
         break;
     case PlayerClassType::CHAOS_WARRIOR:
         if (player_ptr->lev > 39) {
-            self_ptr->info[self_ptr->line++] = _("あなたは周囲に怪物を惑わす光を発生させることができる。(50 MP)", "You can radiate light which confuses nearby monsters (cost 50).");
+            self_ptr->info_list.emplace_back(_("あなたは周囲に怪物を惑わす光を発生させることができる。(50 MP)", "You can radiate light which confuses nearby monsters (cost 50)."));
         }
 
         break;
     case PlayerClassType::MONK:
         if (player_ptr->lev > 24) {
-            self_ptr->info[self_ptr->line++] = _("あなたは構えることができる。(消費なし)", "You can assume a special stance (cost 0).");
+            self_ptr->info_list.emplace_back(_("あなたは構えることができる。(消費なし)", "You can assume a special stance (cost 0)."));
         }
 
         if (player_ptr->lev > 29) {
-            self_ptr->info[self_ptr->line++] = _("あなたは通常の2倍の攻撃を行うことができる。(30 MP)", "You can perform two attacks at the same time (cost 30).");
+            self_ptr->info_list.emplace_back(_("あなたは通常の2倍の攻撃を行うことができる。(30 MP)", "You can perform two attacks at the same time (cost 30)."));
         }
 
         break;
@@ -92,86 +92,86 @@ void set_class_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
     case PlayerClassType::FORCETRAINER:
     case PlayerClassType::ELEMENTALIST:
         if (player_ptr->lev > 14) {
-            self_ptr->info[self_ptr->line++] = _("あなたは精神を集中してＭＰを回復させることができる。(消費なし)", "You can concentrate to regenerate your mana (cost 0).");
+            self_ptr->info_list.emplace_back(_("あなたは精神を集中してＭＰを回復させることができる。(消費なし)", "You can concentrate to regenerate your mana (cost 0)."));
         }
 
         break;
     case PlayerClassType::TOURIST:
-        self_ptr->info[self_ptr->line++] = _("あなたは写真を撮影することができる。(消費なし)", "You can take a photograph (cost 0).");
+        self_ptr->info_list.emplace_back(_("あなたは写真を撮影することができる。(消費なし)", "You can take a photograph (cost 0)."));
 
         if (player_ptr->lev > 24) {
-            self_ptr->info[self_ptr->line++] = _("あなたはアイテムを完全に鑑定することができる。(20 MP)", "You can *identify* items (cost 20).");
+            self_ptr->info_list.emplace_back(_("あなたはアイテムを完全に鑑定することができる。(20 MP)", "You can *identify* items (cost 20)."));
         }
 
         break;
     case PlayerClassType::IMITATOR:
         if (player_ptr->lev > 29) {
-            self_ptr->info[self_ptr->line++] = _("あなたは怪物の特殊攻撃をダメージ2倍でまねることができる。(100 MP)",
-                "You can imitate monster's special attacks with double damage (cost 100).");
+            self_ptr->info_list.emplace_back(_("あなたは怪物の特殊攻撃をダメージ2倍でまねることができる。(100 MP)",
+                "You can imitate monster's special attacks with double damage (cost 100)."));
         }
 
         break;
     case PlayerClassType::BEASTMASTER:
-        self_ptr->info[self_ptr->line++] = _("あなたは1体の生命のあるモンスターを支配することができる。((レベル+3)/4 MP)", "You can dominate a monster (cost (level+3)/4).");
+        self_ptr->info_list.emplace_back(_("あなたは1体の生命のあるモンスターを支配することができる。((レベル+3)/4 MP)", "You can dominate a monster (cost (level+3)/4)."));
 
         if (player_ptr->lev > 29) {
-            self_ptr->info[self_ptr->line++] = _("あなたは視界内の生命のあるモンスターを支配することができる。((レベル+20)/2 MP)",
-                "You can dominate living monsters in sight (cost (level+20)/2).");
+            self_ptr->info_list.emplace_back(_("あなたは視界内の生命のあるモンスターを支配することができる。((レベル+20)/2 MP)",
+                "You can dominate living monsters in sight (cost (level+20)/2)."));
         }
 
         break;
     case PlayerClassType::MAGIC_EATER:
-        self_ptr->info[self_ptr->line++] = _("あなたは杖/魔法棒/ロッドの魔力を自分のものにすることができる。(消費なし)", "You can absorb a staff, wand or rod itself (cost 0).");
+        self_ptr->info_list.emplace_back(_("あなたは杖/魔法棒/ロッドの魔力を自分のものにすることができる。(消費なし)", "You can absorb a staff, wand or rod itself (cost 0)."));
 
         if (player_ptr->lev > 9) {
-            self_ptr->info[self_ptr->line++] = _("あなたは杖/魔法棒/ロッドの魔力を強力に発動することができる。(10+(レベル-10)/2 HP)",
-                "You can powerfully activate a staff, wand or rod (cost 10+(level-10)/2).");
+            self_ptr->info_list.emplace_back(_("あなたは杖/魔法棒/ロッドの魔力を強力に発動することができる。(10+(レベル-10)/2 HP)",
+                "You can powerfully activate a staff, wand or rod (cost 10+(level-10)/2)."));
         }
 
         break;
     case PlayerClassType::RED_MAGE:
         if (player_ptr->lev > 47) {
-            self_ptr->info[self_ptr->line++] = _("あなたは1ターンに2回魔法を唱えることができる。(20 MP)", "You can cast two spells simultaneously (cost 20).");
+            self_ptr->info_list.emplace_back(_("あなたは1ターンに2回魔法を唱えることができる。(20 MP)", "You can cast two spells simultaneously (cost 20)."));
         }
 
         break;
     case PlayerClassType::SAMURAI:
-        self_ptr->info[self_ptr->line++] = _("あなたは精神を集中して気合いを溜めることができる。(消費なし)", "You can concentrate to regenerate your mana (cost 0).");
+        self_ptr->info_list.emplace_back(_("あなたは精神を集中して気合いを溜めることができる。(消費なし)", "You can concentrate to regenerate your mana (cost 0)."));
 
         if (player_ptr->lev > 24) {
-            self_ptr->info[self_ptr->line++] = _("あなたは特殊な型で構えることができる。(消費なし)", "You can assume a special stance (cost 0).");
+            self_ptr->info_list.emplace_back(_("あなたは特殊な型で構えることができる。(消費なし)", "You can assume a special stance (cost 0)."));
         }
 
         break;
     case PlayerClassType::BLUE_MAGE:
-        self_ptr->info[self_ptr->line++] = _("あなたは相手に使われた魔法を学ぶことができる。(消費なし)", "You can study spells which your enemy casts on you (cost 0).");
+        self_ptr->info_list.emplace_back(_("あなたは相手に使われた魔法を学ぶことができる。(消費なし)", "You can study spells which your enemy casts on you (cost 0)."));
         break;
     case PlayerClassType::CAVALRY:
         if (player_ptr->lev > 9) {
-            self_ptr->info[self_ptr->line++] = _("あなたはモンスターに乗って無理矢理ペットにすることができる。(消費なし)",
-                "You can ride on a hostile monster to forcibly turn it into a pet  (cost 0).");
+            self_ptr->info_list.emplace_back(_("あなたはモンスターに乗って無理矢理ペットにすることができる。(消費なし)",
+                "You can ride on a hostile monster to forcibly turn it into a pet  (cost 0)."));
         }
 
         break;
     case PlayerClassType::BERSERKER:
         if (player_ptr->lev > 9) {
-            self_ptr->info[self_ptr->line++] = _("あなたは街とダンジョンの間を行き来することができる。(10 HP)", "You can travel between town and the depths (cost 10).");
+            self_ptr->info_list.emplace_back(_("あなたは街とダンジョンの間を行き来することができる。(10 HP)", "You can travel between town and the depths (cost 10)."));
         }
 
         break;
     case PlayerClassType::SMITH:
         if (player_ptr->lev > 4) {
-            self_ptr->info[self_ptr->line++] = _("あなたは武器や防具を鑑定することができる。(15 HP)", "You can identify weapons or armours (cost 15).");
+            self_ptr->info_list.emplace_back(_("あなたは武器や防具を鑑定することができる。(15 HP)", "You can identify weapons or armours (cost 15)."));
         }
 
         break;
     case PlayerClassType::MIRROR_MASTER:
-        self_ptr->info[self_ptr->line++] = _("あなたは鏡を作り出すことができる。(2 MP)", "You can create a Mirror (cost 2).");
-        self_ptr->info[self_ptr->line++] = _("あなたは鏡を割ることができる。(消費なし)", "You can break distant Mirrors (cost 0).");
+        self_ptr->info_list.emplace_back(_("あなたは鏡を作り出すことができる。(2 MP)", "You can create a Mirror (cost 2)."));
+        self_ptr->info_list.emplace_back(_("あなたは鏡を割ることができる。(消費なし)", "You can break distant Mirrors (cost 0)."));
         break;
     case PlayerClassType::NINJA:
         if (player_ptr->lev > 19) {
-            self_ptr->info[self_ptr->line++] = _("あなたは素早く移動することができる。(消費なし)", "You can walk extremely fast (cost 0).");
+            self_ptr->info_list.emplace_back(_("あなたは素早く移動することができる。(消費なし)", "You can walk extremely fast (cost 0)."));
         }
 
         break;

--- a/src/player-info/mutation-info.cpp
+++ b/src/player-info/mutation-info.cpp
@@ -13,352 +13,352 @@ void set_mutation_info(PlayerType *player_ptr, self_info_type *self_ptr)
     }
 
     if (player_ptr->muta.has(PlayerMutationType::SPIT_ACID)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは酸を吹きかけることができる。(ダメージ レベルX1)", "You can spit acid (dam lvl).");
+        self_ptr->info_list.emplace_back(_("あなたは酸を吹きかけることができる。(ダメージ レベルX1)", "You can spit acid (dam lvl)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::BR_FIRE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは炎のブレスを吐くことができる。(ダメージ レベルX2)", "You can breathe fire (dam lvl * 2).");
+        self_ptr->info_list.emplace_back(_("あなたは炎のブレスを吐くことができる。(ダメージ レベルX2)", "You can breathe fire (dam lvl * 2)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::HYPN_GAZE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの睨みは催眠効果をもつ。", "Your gaze is hypnotic.");
+        self_ptr->info_list.emplace_back(_("あなたの睨みは催眠効果をもつ。", "Your gaze is hypnotic."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::TELEKINES)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは念動力をもっている。", "You are telekinetic.");
+        self_ptr->info_list.emplace_back(_("あなたは念動力をもっている。", "You are telekinetic."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::VTELEPORT)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは自分の意思でテレポートできる。", "You can teleport at will.");
+        self_ptr->info_list.emplace_back(_("あなたは自分の意思でテレポートできる。", "You can teleport at will."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::MIND_BLST)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは精神攻撃を行える。(ダメージ 3～12d3)", "You can Mind Blast your enemies (3 to 12d3 dam).");
+        self_ptr->info_list.emplace_back(_("あなたは精神攻撃を行える。(ダメージ 3～12d3)", "You can Mind Blast your enemies (3 to 12d3 dam)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::RADIATION)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは自分の意思で強い放射線を発生することができる。(ダメージ レベルX2)", "You can emit hard radiation at will (dam lvl * 2).");
+        self_ptr->info_list.emplace_back(_("あなたは自分の意思で強い放射線を発生することができる。(ダメージ レベルX2)", "You can emit hard radiation at will (dam lvl * 2)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::VAMPIRISM)) {
-        self_ptr->info[self_ptr->line++] = _(
-            "あなたは吸血鬼のように敵から生命力を吸収することができる。(ダメージ レベルX2)", "Like a vampire, you can drain life from a foe (dam lvl * 2).");
+        self_ptr->info_list.emplace_back(_(
+            "あなたは吸血鬼のように敵から生命力を吸収することができる。(ダメージ レベルX2)", "Like a vampire, you can drain life from a foe (dam lvl * 2)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::SMELL_MET)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは近くにある貴金属をかぎ分けることができる。", "You can smell nearby precious metal.");
+        self_ptr->info_list.emplace_back(_("あなたは近くにある貴金属をかぎ分けることができる。", "You can smell nearby precious metal."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::SMELL_MON)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは近くのモンスターの存在をかぎ分けることができる。", "You can smell nearby monsters.");
+        self_ptr->info_list.emplace_back(_("あなたは近くのモンスターの存在をかぎ分けることができる。", "You can smell nearby monsters."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::BLINK)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは短い距離をテレポートできる。", "You can teleport yourself short distances.");
+        self_ptr->info_list.emplace_back(_("あなたは短い距離をテレポートできる。", "You can teleport yourself short distances."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::EAT_ROCK)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは硬い岩を食べることができる。", "You can consume solid rock.");
+        self_ptr->info_list.emplace_back(_("あなたは硬い岩を食べることができる。", "You can consume solid rock."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::SWAP_POS)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは他の者と場所を入れ替わることができる。", "You can switch locations with another being.");
+        self_ptr->info_list.emplace_back(_("あなたは他の者と場所を入れ替わることができる。", "You can switch locations with another being."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::SHRIEK)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは身の毛もよだつ叫び声を発することができる。(ダメージ レベルX2)", "You can emit a horrible shriek (dam 2 * lvl).");
+        self_ptr->info_list.emplace_back(_("あなたは身の毛もよだつ叫び声を発することができる。(ダメージ レベルX2)", "You can emit a horrible shriek (dam 2 * lvl)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::ILLUMINE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは明るい光を放つことができる。", "You can emit bright light.");
+        self_ptr->info_list.emplace_back(_("あなたは明るい光を放つことができる。", "You can emit bright light."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::DET_CURSE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは邪悪な魔法の危険を感じとることができる。", "You can feel the danger of evil magic.");
+        self_ptr->info_list.emplace_back(_("あなたは邪悪な魔法の危険を感じとることができる。", "You can feel the danger of evil magic."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::BERSERK)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは自分の意思で狂乱戦闘状態になることができる。", "You can drive yourself into a berserk frenzy.");
+        self_ptr->info_list.emplace_back(_("あなたは自分の意思で狂乱戦闘状態になることができる。", "You can drive yourself into a berserk frenzy."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::POLYMORPH)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは自分の意志で変化できる。", "You can polymorph yourself at will.");
+        self_ptr->info_list.emplace_back(_("あなたは自分の意志で変化できる。", "You can polymorph yourself at will."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::MIDAS_TCH)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは通常アイテムを金に変えることができる。", "You can turn ordinary items to gold.");
+        self_ptr->info_list.emplace_back(_("あなたは通常アイテムを金に変えることができる。", "You can turn ordinary items to gold."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::GROW_MOLD)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは周囲にキノコを生やすことができる。", "You can cause mold to grow near you.");
+        self_ptr->info_list.emplace_back(_("あなたは周囲にキノコを生やすことができる。", "You can cause mold to grow near you."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::RESIST)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは元素の攻撃に対して身を硬くすることができる。", "You can harden yourself to the ravages of the elements.");
+        self_ptr->info_list.emplace_back(_("あなたは元素の攻撃に対して身を硬くすることができる。", "You can harden yourself to the ravages of the elements."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::EARTHQUAKE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは周囲のダンジョンを崩壊させることができる。", "You can bring down the dungeon around your ears.");
+        self_ptr->info_list.emplace_back(_("あなたは周囲のダンジョンを崩壊させることができる。", "You can bring down the dungeon around your ears."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::EAT_MAGIC)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは魔法のエネルギーを自分の物として使用できる。", "You can consume magic energy for your own use.");
+        self_ptr->info_list.emplace_back(_("あなたは魔法のエネルギーを自分の物として使用できる。", "You can consume magic energy for your own use."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::WEIGH_MAG)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは自分に影響を与える魔法の力を感じることができる。", "You can feel the strength of the magics affecting you.");
+        self_ptr->info_list.emplace_back(_("あなたは自分に影響を与える魔法の力を感じることができる。", "You can feel the strength of the magics affecting you."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::STERILITY)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは集団的生殖不能を起こすことができる。", "You can cause mass impotence.");
+        self_ptr->info_list.emplace_back(_("あなたは集団的生殖不能を起こすことができる。", "You can cause mass impotence."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::HIT_AND_AWAY)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは攻撃した後身を守るため逃げることができる。", "You can run for your life after hitting something.");
+        self_ptr->info_list.emplace_back(_("あなたは攻撃した後身を守るため逃げることができる。", "You can run for your life after hitting something."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::DAZZLE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは混乱と盲目を引き起こす放射能を発生することができる。 ", "You can emit confusing, blinding radiation.");
+        self_ptr->info_list.emplace_back(_("あなたは混乱と盲目を引き起こす放射能を発生することができる。 ", "You can emit confusing, blinding radiation."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::LASER_EYE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは目からレーザー光線を発することができる。(ダメージ レベルX2)", "Your eyes can fire laser beams (dam 2 * lvl).");
+        self_ptr->info_list.emplace_back(_("あなたは目からレーザー光線を発することができる。(ダメージ レベルX2)", "Your eyes can fire laser beams (dam 2 * lvl)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::RECALL)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは街とダンジョンの間を行き来することができる。", "You can travel between town and the depths.");
+        self_ptr->info_list.emplace_back(_("あなたは街とダンジョンの間を行き来することができる。", "You can travel between town and the depths."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::BANISH)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは邪悪なモンスターを地獄に落とすことができる。", "You can send evil creatures directly to Hell.");
+        self_ptr->info_list.emplace_back(_("あなたは邪悪なモンスターを地獄に落とすことができる。", "You can send evil creatures directly to Hell."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::COLD_TOUCH)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは敵を触って凍らせることができる。(ダメージ レベルX3)", "You can freeze things with a touch (dam 3 * lvl).");
+        self_ptr->info_list.emplace_back(_("あなたは敵を触って凍らせることができる。(ダメージ レベルX3)", "You can freeze things with a touch (dam 3 * lvl)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::LAUNCHER)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはアイテムを力強く投げることができる。", "You can hurl objects with great force.");
+        self_ptr->info_list.emplace_back(_("あなたはアイテムを力強く投げることができる。", "You can hurl objects with great force."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::BERS_RAGE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは狂戦士化の発作を起こす。", "You are subject to berserker fits.");
+        self_ptr->info_list.emplace_back(_("あなたは狂戦士化の発作を起こす。", "You are subject to berserker fits."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::COWARDICE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは時々臆病になる。", "You are subject to cowardice.");
+        self_ptr->info_list.emplace_back(_("あなたは時々臆病になる。", "You are subject to cowardice."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::RTELEPORT)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはランダムにテレポートする。", "You may randomly teleport.");
+        self_ptr->info_list.emplace_back(_("あなたはランダムにテレポートする。", "You may randomly teleport."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::ALCOHOL)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの体はアルコールを分泌する。", "Your body produces alcohol.");
+        self_ptr->info_list.emplace_back(_("あなたの体はアルコールを分泌する。", "Your body produces alcohol."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::HALLU)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは幻覚を引き起こす精神錯乱に侵されている。", "You have a hallucinatory insanity.");
+        self_ptr->info_list.emplace_back(_("あなたは幻覚を引き起こす精神錯乱に侵されている。", "You have a hallucinatory insanity."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::FLATULENT)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは制御できない強烈な屁をこく。", "You are subject to uncontrollable flatulence.");
+        self_ptr->info_list.emplace_back(_("あなたは制御できない強烈な屁をこく。", "You are subject to uncontrollable flatulence."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::PROD_MANA)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは制御不能な魔法のエネルギーを発している。", "You produce magical energy uncontrollably.");
+        self_ptr->info_list.emplace_back(_("あなたは制御不能な魔法のエネルギーを発している。", "You produce magical energy uncontrollably."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::ATT_DEMON)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはデーモンを引きつける。", "You attract demons.");
+        self_ptr->info_list.emplace_back(_("あなたはデーモンを引きつける。", "You attract demons."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::SCOR_TAIL)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはサソリの尻尾が生えている。(毒、ダメージ 3d7)", "You have a scorpion tail (poison, 3d7).");
+        self_ptr->info_list.emplace_back(_("あなたはサソリの尻尾が生えている。(毒、ダメージ 3d7)", "You have a scorpion tail (poison, 3d7)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::HORNS)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは角が生えている。(ダメージ 2d6)", "You have horns (dam. 2d6).");
+        self_ptr->info_list.emplace_back(_("あなたは角が生えている。(ダメージ 2d6)", "You have horns (dam. 2d6)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::BEAK)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはクチバシが生えている。(ダメージ 2d4)", "You have a beak (dam. 2d4).");
+        self_ptr->info_list.emplace_back(_("あなたはクチバシが生えている。(ダメージ 2d4)", "You have a beak (dam. 2d4)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::SPEED_FLUX)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはランダムに早く動いたり遅く動いたりする。", "You move faster or slower randomly.");
+        self_ptr->info_list.emplace_back(_("あなたはランダムに早く動いたり遅く動いたりする。", "You move faster or slower randomly."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::BANISH_ALL)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは時々近くのモンスターを消滅させる。", "You sometimes cause nearby creatures to vanish.");
+        self_ptr->info_list.emplace_back(_("あなたは時々近くのモンスターを消滅させる。", "You sometimes cause nearby creatures to vanish."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::EAT_LIGHT)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは時々周囲の光を吸収して栄養にする。", "You sometimes feed off of the light around you.");
+        self_ptr->info_list.emplace_back(_("あなたは時々周囲の光を吸収して栄養にする。", "You sometimes feed off of the light around you."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::TRUNK)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは象のような鼻を持っている。(ダメージ 1d4)", "You have an elephantine trunk (dam 1d4).");
+        self_ptr->info_list.emplace_back(_("あなたは象のような鼻を持っている。(ダメージ 1d4)", "You have an elephantine trunk (dam 1d4)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::ATT_ANIMAL)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは動物を引きつける。", "You attract animals.");
+        self_ptr->info_list.emplace_back(_("あなたは動物を引きつける。", "You attract animals."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::TENTACLES)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは邪悪な触手を持っている。(ダメージ 2d5)", "You have evil looking tentacles (dam 2d5).");
+        self_ptr->info_list.emplace_back(_("あなたは邪悪な触手を持っている。(ダメージ 2d5)", "You have evil looking tentacles (dam 2d5)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::RAW_CHAOS)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはしばしば純カオスに包まれる。", "You occasionally are surrounded with raw chaos.");
+        self_ptr->info_list.emplace_back(_("あなたはしばしば純カオスに包まれる。", "You occasionally are surrounded with raw chaos."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::NORMALITY)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは変異していたが、回復してきている。", "You may be mutated, but you're recovering.");
+        self_ptr->info_list.emplace_back(_("あなたは変異していたが、回復してきている。", "You may be mutated, but you're recovering."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::WRAITH)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの肉体は幽体化したり実体化したりする。", "You fade in and out of physical reality.");
+        self_ptr->info_list.emplace_back(_("あなたの肉体は幽体化したり実体化したりする。", "You fade in and out of physical reality."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::POLY_WOUND)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの健康はカオスの力に影響を受ける。", "Your health is subject to chaotic forces.");
+        self_ptr->info_list.emplace_back(_("あなたの健康はカオスの力に影響を受ける。", "Your health is subject to chaotic forces."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::WASTING)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは衰弱する恐ろしい病気にかかっている。", "You have a horrible wasting disease.");
+        self_ptr->info_list.emplace_back(_("あなたは衰弱する恐ろしい病気にかかっている。", "You have a horrible wasting disease."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::ATT_DRAGON)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはドラゴンを引きつける。", "You attract dragons.");
+        self_ptr->info_list.emplace_back(_("あなたはドラゴンを引きつける。", "You attract dragons."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::WEIRD_MIND)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの精神はランダムに拡大したり縮小したりしている。", "Your mind randomly expands and contracts.");
+        self_ptr->info_list.emplace_back(_("あなたの精神はランダムに拡大したり縮小したりしている。", "Your mind randomly expands and contracts."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::NAUSEA)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの胃は非常に落ち着きがない。", "You have a seriously upset stomach.");
+        self_ptr->info_list.emplace_back(_("あなたの胃は非常に落ち着きがない。", "You have a seriously upset stomach."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::CHAOS_GIFT)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはカオスの守護悪魔から褒美をうけとる。", "Chaos deities give you gifts.");
+        self_ptr->info_list.emplace_back(_("あなたはカオスの守護悪魔から褒美をうけとる。", "Chaos deities give you gifts."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::WALK_SHAD)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはしばしば他の「影」に迷い込む。", "You occasionally stumble into other shadows.");
+        self_ptr->info_list.emplace_back(_("あなたはしばしば他の「影」に迷い込む。", "You occasionally stumble into other shadows."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::WARNING)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは敵に関する警告を感じる。", "You receive warnings about your foes.");
+        self_ptr->info_list.emplace_back(_("あなたは敵に関する警告を感じる。", "You receive warnings about your foes."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::INVULN)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは時々負け知らずな気分になる。", "You occasionally feel invincible.");
+        self_ptr->info_list.emplace_back(_("あなたは時々負け知らずな気分になる。", "You occasionally feel invincible."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::SP_TO_HP)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは時々血が筋肉にどっと流れる。", "Your blood sometimes rushes to your muscles.");
+        self_ptr->info_list.emplace_back(_("あなたは時々血が筋肉にどっと流れる。", "Your blood sometimes rushes to your muscles."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::HP_TO_SP)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは時々頭に血がどっと流れる。", "Your blood sometimes rushes to your head.");
+        self_ptr->info_list.emplace_back(_("あなたは時々頭に血がどっと流れる。", "Your blood sometimes rushes to your head."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::DISARM)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはよくつまづいて物を落とす。", "You occasionally stumble and drop things.");
+        self_ptr->info_list.emplace_back(_("あなたはよくつまづいて物を落とす。", "You occasionally stumble and drop things."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::HYPER_STR)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは超人的に強い。(腕力+4)", "You are superhumanly strong (+4 STR).");
+        self_ptr->info_list.emplace_back(_("あなたは超人的に強い。(腕力+4)", "You are superhumanly strong (+4 STR)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::PUNY)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは虚弱だ。(腕力-4)", "You are puny (-4 STR).");
+        self_ptr->info_list.emplace_back(_("あなたは虚弱だ。(腕力-4)", "You are puny (-4 STR)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::HYPER_INT)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの脳は生体コンピュータだ。(知能＆賢さ+4)", "Your brain is a living computer (+4 INT/WIS).");
+        self_ptr->info_list.emplace_back(_("あなたの脳は生体コンピュータだ。(知能＆賢さ+4)", "Your brain is a living computer (+4 INT/WIS)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::MORONIC)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは精神薄弱だ。(知能＆賢さ-4)", "You are moronic (-4 INT/WIS).");
+        self_ptr->info_list.emplace_back(_("あなたは精神薄弱だ。(知能＆賢さ-4)", "You are moronic (-4 INT/WIS)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::RESILIENT)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは非常にタフだ。(耐久+4)", "You are very resilient (+4 CON).");
+        self_ptr->info_list.emplace_back(_("あなたは非常にタフだ。(耐久+4)", "You are very resilient (+4 CON)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::XTRA_FAT)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは極端に太っている。(耐久+2,スピード-2)", "You are extremely fat (+2 CON, -2 speed).");
+        self_ptr->info_list.emplace_back(_("あなたは極端に太っている。(耐久+2,スピード-2)", "You are extremely fat (+2 CON, -2 speed)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::ALBINO)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはアルビノだ。(耐久-4)", "You are an albino (-4 CON).");
+        self_ptr->info_list.emplace_back(_("あなたはアルビノだ。(耐久-4)", "You are an albino (-4 CON)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::FLESH_ROT)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの肉体は腐敗している。(耐久-2,魅力-1)", "Your flesh is rotting (-2 CON, -1 CHR).");
+        self_ptr->info_list.emplace_back(_("あなたの肉体は腐敗している。(耐久-2,魅力-1)", "Your flesh is rotting (-2 CON, -1 CHR)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::SILLY_VOI)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの声は間抜けなキーキー声だ。(魅力-4)", "Your voice is a silly squeak (-4 CHR).");
+        self_ptr->info_list.emplace_back(_("あなたの声は間抜けなキーキー声だ。(魅力-4)", "Your voice is a silly squeak (-4 CHR)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::BLANK_FAC)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはのっぺらぼうだ。(魅力-1)", "Your face is featureless (-1 CHR).");
+        self_ptr->info_list.emplace_back(_("あなたはのっぺらぼうだ。(魅力-1)", "Your face is featureless (-1 CHR)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::ILL_NORM)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは幻影に覆われている。", "Your appearance is masked with illusion.");
+        self_ptr->info_list.emplace_back(_("あなたは幻影に覆われている。", "Your appearance is masked with illusion."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::XTRA_EYES)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは余分に二つの目を持っている。(探索+15)", "You have an extra pair of eyes (+15 search).");
+        self_ptr->info_list.emplace_back(_("あなたは余分に二つの目を持っている。(探索+15)", "You have an extra pair of eyes (+15 search)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::MAGIC_RES)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは魔法への耐性をもっている。", "You are resistant to magic.");
+        self_ptr->info_list.emplace_back(_("あなたは魔法への耐性をもっている。", "You are resistant to magic."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::XTRA_NOIS)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは変な音を発している。(隠密-3)", "You make a lot of strange noise (-3 stealth).");
+        self_ptr->info_list.emplace_back(_("あなたは変な音を発している。(隠密-3)", "You make a lot of strange noise (-3 stealth)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::INFRAVIS)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは素晴らしい赤外線視力を持っている。(+3)", "You have remarkable infravision (+3).");
+        self_ptr->info_list.emplace_back(_("あなたは素晴らしい赤外線視力を持っている。(+3)", "You have remarkable infravision (+3)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::XTRA_LEGS)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは余分に二本の足が生えている。(加速+3)", "You have an extra pair of legs (+3 speed).");
+        self_ptr->info_list.emplace_back(_("あなたは余分に二本の足が生えている。(加速+3)", "You have an extra pair of legs (+3 speed)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::SHORT_LEG)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの足は短い突起だ。(加速-3)", "Your legs are short stubs (-3 speed).");
+        self_ptr->info_list.emplace_back(_("あなたの足は短い突起だ。(加速-3)", "Your legs are short stubs (-3 speed)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::ELEC_TOUC)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの血管には電流が流れている。", "Electricity is running through your veins.");
+        self_ptr->info_list.emplace_back(_("あなたの血管には電流が流れている。", "Electricity is running through your veins."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::FIRE_BODY)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの体は炎につつまれている。", "Your body is enveloped in flames.");
+        self_ptr->info_list.emplace_back(_("あなたの体は炎につつまれている。", "Your body is enveloped in flames."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::WART_SKIN)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの肌はイボに被われている。(魅力-2, AC+5)", "Your skin is covered with warts (-2 CHR, +5 AC).");
+        self_ptr->info_list.emplace_back(_("あなたの肌はイボに被われている。(魅力-2, AC+5)", "Your skin is covered with warts (-2 CHR, +5 AC)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::SCALES)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの肌は鱗になっている。(魅力-1, AC+10)", "Your skin has turned into scales (-1 CHR, +10 AC).");
+        self_ptr->info_list.emplace_back(_("あなたの肌は鱗になっている。(魅力-1, AC+10)", "Your skin has turned into scales (-1 CHR, +10 AC)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::IRON_SKIN)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの肌は鉄でできている。(器用-1, AC+25)", "Your skin is made of steel (-1 DEX, +25 AC).");
+        self_ptr->info_list.emplace_back(_("あなたの肌は鉄でできている。(器用-1, AC+25)", "Your skin is made of steel (-1 DEX, +25 AC)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::WINGS)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは羽を持っている。", "You have wings.");
+        self_ptr->info_list.emplace_back(_("あなたは羽を持っている。", "You have wings."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::FEARLESS)) {
@@ -374,34 +374,34 @@ void set_mutation_info(PlayerType *player_ptr, self_info_type *self_ptr)
     }
 
     if (player_ptr->muta.has(PlayerMutationType::LIMBER)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの体は非常にしなやかだ。(器用+3)", "Your body is very limber (+3 DEX).");
+        self_ptr->info_list.emplace_back(_("あなたの体は非常にしなやかだ。(器用+3)", "Your body is very limber (+3 DEX)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::ARTHRITIS)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはいつも関節に痛みを感じている。(器用-3)", "Your joints ache constantly (-3 DEX).");
+        self_ptr->info_list.emplace_back(_("あなたはいつも関節に痛みを感じている。(器用-3)", "Your joints ache constantly (-3 DEX)."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::VULN_ELEM)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは元素の攻撃に弱い。", "You are susceptible to damage from the elements.");
+        self_ptr->info_list.emplace_back(_("あなたは元素の攻撃に弱い。", "You are susceptible to damage from the elements."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::MOTION)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの動作は正確で力強い。(隠密+1)", "Your movements are precise and forceful (+1 STL).");
+        self_ptr->info_list.emplace_back(_("あなたの動作は正確で力強い。(隠密+1)", "Your movements are precise and forceful (+1 STL)."));
     }
 
     if (has_good_luck(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは白いオーラにつつまれている。", "There is a white aura surrounding you.");
+        self_ptr->info_list.emplace_back(_("あなたは白いオーラにつつまれている。", "There is a white aura surrounding you."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::BAD_LUCK)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは黒いオーラにつつまれている。", "There is a black aura surrounding you.");
+        self_ptr->info_list.emplace_back(_("あなたは黒いオーラにつつまれている。", "There is a black aura surrounding you."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::DEFECATION)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは脱糞を制御できない。", "You are subject to uncontrollable defecation.");
+        self_ptr->info_list.emplace_back(_("あなたは脱糞を制御できない。", "You are subject to uncontrollable defecation."));
     }
 
     if (player_ptr->muta.has(PlayerMutationType::ZEERO_VIRUS)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはゼEROウイルスに感染している。", "You've been infected with the ZEERO virus.");
+        self_ptr->info_list.emplace_back(_("あなたはゼEROウイルスに感染している。", "You've been infected with the ZEERO virus."));
     }
 }

--- a/src/player-info/race-ability-info.cpp
+++ b/src/player-info/race-ability-info.cpp
@@ -15,205 +15,212 @@ void set_race_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
     switch (player_ptr->prace) {
     case PlayerRaceType::DWARF:
         if (player_ptr->lev >= 5) {
-            self_ptr->info[self_ptr->line++] = _("あなたは罠とドアと階段を感知できる。(5 MP)", "You can find traps, doors and stairs (cost 5).");
+            self_ptr->info_list.emplace_back(_("あなたは罠とドアと階段を感知できる。(5 MP)", "You can find traps, doors and stairs (cost 5)."));
         }
 
         break;
     case PlayerRaceType::NIBELUNG:
         if (player_ptr->lev >= 10) {
-            self_ptr->info[self_ptr->line++] = _("あなたは罠とドアと階段を感知できる。(5 MP)", "You can find traps, doors and stairs (cost 5).");
+            self_ptr->info_list.emplace_back(_("あなたは罠とドアと階段を感知できる。(5 MP)", "You can find traps, doors and stairs (cost 5)."));
         }
 
         break;
     case PlayerRaceType::HOBBIT:
         if (player_ptr->lev >= 15) {
-            self_ptr->info[self_ptr->line++] = _("あなたは食料を生成できる。(10 MP)", "You can produce food (cost 10).");
+            self_ptr->info_list.emplace_back(_("あなたは食料を生成できる。(10 MP)", "You can produce food (cost 10)."));
         }
 
         break;
     case PlayerRaceType::GNOME:
         if (player_ptr->lev >= 5) {
-            self_ptr->info[self_ptr->line++] = _("あなたは範囲 10 以内にテレポートできる。(5 MP)", "You can teleport, range 10 (cost 5).");
+            self_ptr->info_list.emplace_back(_("あなたは範囲 10 以内にテレポートできる。(5 MP)", "You can teleport, range 10 (cost 5)."));
         }
 
         break;
     case PlayerRaceType::HALF_ORC:
         if (player_ptr->lev >= 3) {
-            self_ptr->info[self_ptr->line++] = _("あなたは恐怖を除去できる。(5 MP)", "You can remove fear (cost 5).");
+            self_ptr->info_list.emplace_back(_("あなたは恐怖を除去できる。(5 MP)", "You can remove fear (cost 5)."));
         }
 
         break;
     case PlayerRaceType::HALF_TROLL:
         if (player_ptr->lev >= 10) {
-            self_ptr->info[self_ptr->line++] = _("あなたは狂暴化することができる。(12 MP) ", "You can enter a berserk fury (cost 12).");
+            self_ptr->info_list.emplace_back(_("あなたは狂暴化することができる。(12 MP) ", "You can enter a berserk fury (cost 12)."));
         }
 
         break;
     case PlayerRaceType::AMBERITE:
         if (player_ptr->lev >= 30) {
-            self_ptr->info[self_ptr->line++] = _("あなたはシャドウシフトすることができる。(50 MP)", "You can Shift Shadows (cost 50).");
+            self_ptr->info_list.emplace_back(_("あなたはシャドウシフトすることができる。(50 MP)", "You can Shift Shadows (cost 50)."));
         }
 
         if (player_ptr->lev >= 40) {
-            self_ptr->info[self_ptr->line++] = _("あなたは「パターン」を心に描いて歩くことができる。(75 MP)", "You can mentally Walk the Pattern (cost 75).");
+            self_ptr->info_list.emplace_back(_("あなたは「パターン」を心に描いて歩くことができる。(75 MP)", "You can mentally Walk the Pattern (cost 75)."));
         }
 
         break;
     case PlayerRaceType::BARBARIAN:
         if (player_ptr->lev >= 8) {
-            self_ptr->info[self_ptr->line++] = _("あなたは狂暴化することができる。(10 MP) ", "You can enter a berserk fury (cost 10).");
+            self_ptr->info_list.emplace_back(_("あなたは狂暴化することができる。(10 MP) ", "You can enter a berserk fury (cost 10)."));
         }
 
         break;
     case PlayerRaceType::HALF_OGRE:
         if (player_ptr->lev >= 25) {
-            self_ptr->info[self_ptr->line++] = _("あなたは爆発のルーンを仕掛けることができる。(35 MP)", "You can set an Explosive Rune (cost 35).");
+            self_ptr->info_list.emplace_back(_("あなたは爆発のルーンを仕掛けることができる。(35 MP)", "You can set an Explosive Rune (cost 35)."));
         }
 
         break;
     case PlayerRaceType::HALF_GIANT:
         if (player_ptr->lev >= 20) {
-            self_ptr->info[self_ptr->line++] = _("あなたは石の壁を壊すことができる。(10 MP)", "You can break stone walls (cost 10).");
+            self_ptr->info_list.emplace_back(_("あなたは石の壁を壊すことができる。(10 MP)", "You can break stone walls (cost 10)."));
         }
 
         break;
     case PlayerRaceType::HALF_TITAN:
         if (player_ptr->lev >= 15) {
-            self_ptr->info[self_ptr->line++] = _("あなたはモンスターをスキャンすることができる。(10 MP)", "You can probe monsters (cost 10).");
+            self_ptr->info_list.emplace_back(_("あなたはモンスターをスキャンすることができる。(10 MP)", "You can probe monsters (cost 10)."));
         }
 
         break;
     case PlayerRaceType::CYCLOPS:
         if (player_ptr->lev >= 20) {
-            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの岩石を投げることができる。(15 MP)", "You can throw a boulder, dam. %d (cost 15)."),
-                (3 * player_ptr->lev) / 2);
-            self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
+            constexpr auto fmt = _("あなたは %d ダメージの岩石を投げることができる。(15 MP)", "You can throw a boulder, dam. %d (cost 15).");
+            const auto dam = (3 * player_ptr->lev) / 2;
+            self_ptr->info_list.push_back(format(fmt, dam));
         }
 
         break;
     case PlayerRaceType::YEEK:
         if (player_ptr->lev >= 15) {
-            self_ptr->info[self_ptr->line++] = _("あなたは恐怖を呼び起こす叫び声を発することができる。(15 MP)", "You can make a terrifying scream (cost 15).");
+            self_ptr->info_list.emplace_back(_("あなたは恐怖を呼び起こす叫び声を発することができる。(15 MP)", "You can make a terrifying scream (cost 15)."));
         }
 
         break;
     case PlayerRaceType::KLACKON:
         if (player_ptr->lev >= 9) {
-            strnfmt(
-                self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの酸を吹きかけることができる。(9 MP)", "You can spit acid, dam. %d (cost 9)."), player_ptr->lev);
-            self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
+            constexpr auto fmt = _("あなたは %d ダメージの酸を吹きかけることができる。(9 MP)", "You can spit acid, dam. %d (cost 9).");
+            const auto dam = player_ptr->lev;
+            self_ptr->info_list.push_back(format(fmt, dam));
         }
 
         break;
     case PlayerRaceType::KOBOLD:
         if (player_ptr->lev >= 12) {
-            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの毒矢を投げることができる。(8 MP)", "You can throw a dart of poison, dam. %d (cost 8)."),
-                player_ptr->lev);
-            self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
+            constexpr auto fmt = _("あなたは %d ダメージの毒矢を投げることができる。(8 MP)", "You can throw a dart of poison, dam. %d (cost 8).");
+            const auto dam = player_ptr->lev;
+            self_ptr->info_list.push_back(format(fmt, dam));
         }
 
         break;
     case PlayerRaceType::DARK_ELF:
         if (player_ptr->lev >= 2) {
-            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのマジック・ミサイルの呪文を使える。(2 MP)", "You can cast a Magic Missile, dam %d (cost 2)."),
-                (3 + ((player_ptr->lev - 1) / 5)));
-            self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
+            constexpr auto fmt = _("あなたは %d ダメージのマジック・ミサイルの呪文を使える。(2 MP)", "You can cast a Magic Missile, dam %d (cost 2).");
+            const auto dam = 3 + ((player_ptr->lev - 1) / 5);
+            self_ptr->info_list.push_back(format(fmt, dam));
         }
 
         break;
-    case PlayerRaceType::DRACONIAN:
-        strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのブレスを吐くことができる。(%d MP)", "You can breathe, dam. %d (cost %d)."), 2 * player_ptr->lev,
-            player_ptr->lev);
-        self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
+    case PlayerRaceType::DRACONIAN: {
+        constexpr auto fmt = _("あなたは %d ダメージのブレスを吐くことができる。(%d MP)", "You can breathe, dam. %d (cost %d).");
+        const auto dam = 2 * player_ptr->lev;
+        const auto cost = player_ptr->lev;
+        self_ptr->info_list.push_back(format(fmt, dam, cost));
         break;
+    }
     case PlayerRaceType::MIND_FLAYER:
         if (player_ptr->lev >= 15) {
-            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの精神攻撃をすることができる。(12 MP)", "You can mind blast your enemies, dam %d (cost 12)."),
-                player_ptr->lev);
+            constexpr auto fmt = _("あなたは %d ダメージの精神攻撃をすることができる。(12 MP)", "You can mind blast your enemies, dam %d (cost 12).");
+            const auto dam = player_ptr->lev;
+            self_ptr->info_list.push_back(format(fmt, dam));
         }
 
-        self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         break;
     case PlayerRaceType::IMP:
         if (player_ptr->lev >= 30) {
-            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのファイア・ボールの呪文を使える。(15 MP)", "You can cast a Fire Ball, dam. %d (cost 15)."),
-                player_ptr->lev);
-            self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
+            constexpr auto fmt = _("あなたは %d ダメージのファイア・ボールの呪文を使える。(15 MP)", "You can cast a Fire Ball, dam. %d (cost 15).");
+            const auto dam = player_ptr->lev;
+            self_ptr->info_list.push_back(format(fmt, dam));
             break;
         }
 
         if (player_ptr->lev >= 9) {
-            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのファイア・ボルトの呪文を使える。(15 MP)", "You can cast a Fire Bolt, dam. %d (cost 15)."),
-                player_ptr->lev);
-            self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
+            constexpr auto fmt = _("あなたは %d ダメージのファイア・ボルトの呪文を使える。(15 MP)", "You can cast a Fire Bolt, dam. %d (cost 15).");
+            const auto dam = player_ptr->lev;
+            self_ptr->info_list.push_back(format(fmt, dam));
         }
 
         break;
     case PlayerRaceType::GOLEM:
         if (player_ptr->lev >= 20) {
-            self_ptr->info[self_ptr->line++] = _("あなたは d20+30 ターンの間肌を石に変化させられる。(15 MP)", "You can turn your skin to stone, dur d20+30 (cost 15).");
+            self_ptr->info_list.emplace_back(_("あなたは d20+30 ターンの間肌を石に変化させられる。(15 MP)", "You can turn your skin to stone, dur d20+30 (cost 15)."));
         }
 
         break;
     case PlayerRaceType::ZOMBIE:
     case PlayerRaceType::SKELETON:
         if (player_ptr->lev >= 30) {
-            self_ptr->info[self_ptr->line++] = _("あなたは失った経験値を回復することができる。(30 MP)", "You can restore lost experience (cost 30).");
+            self_ptr->info_list.emplace_back(_("あなたは失った経験値を回復することができる。(30 MP)", "You can restore lost experience (cost 30)."));
         }
 
         break;
     case PlayerRaceType::VAMPIRE:
-        if (player_ptr->lev < 2) {
-            break;
+        if (player_ptr->lev >= 2) {
+            constexpr auto fmt = _("あなたは敵から %d HP の生命力を吸収できる。(%d MP)", "You can steal life from a foe, dam. %d (cost %d).");
+            const auto dam = player_ptr->lev * 2;
+            const auto cost = 1 + (player_ptr->lev / 3);
+            self_ptr->info_list.push_back(format(fmt, dam, cost));
         }
 
-        strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは敵から %d HP の生命力を吸収できる。(%d MP)", "You can steal life from a foe, dam. %d (cost %d)."),
-            player_ptr->lev * 2, 1 + (player_ptr->lev / 3));
-        self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         break;
     case PlayerRaceType::SPECTRE:
         if (player_ptr->lev >= 4) {
-            self_ptr->info[self_ptr->line++] = _("あなたは泣き叫んで敵を恐怖させることができる。(6 MP)", "You can wail to terrify your enemies (cost 6).");
+            self_ptr->info_list.emplace_back(_("あなたは泣き叫んで敵を恐怖させることができる。(6 MP)", "You can wail to terrify your enemies (cost 6)."));
         }
 
         break;
     case PlayerRaceType::SPRITE:
         if (player_ptr->lev >= 12) {
-            self_ptr->info[self_ptr->line++] = _("あなたは敵を眠らせる魔法の粉を投げることができる。(12 MP)", "You can throw magical dust which induces sleep (cost 12).");
+            self_ptr->info_list.emplace_back(_("あなたは敵を眠らせる魔法の粉を投げることができる。(12 MP)", "You can throw magical dust which induces sleep (cost 12)."));
         }
 
         break;
-    case PlayerRaceType::BALROG:
-        strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの地獄か火炎のブレスを吐くことができる。(%d MP)", "You can breathe nether, dam. %d (cost %d)."),
-            3 * player_ptr->lev, 10 + player_ptr->lev / 3);
-        self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
+    case PlayerRaceType::BALROG: {
+        constexpr auto fmt = _("あなたは %d ダメージの地獄か火炎のブレスを吐くことができる。(%d MP)", "You can breathe nether, dam. %d (cost %d).");
+        const auto dam = 3 * player_ptr->lev;
+        const auto cost = 10 + player_ptr->lev / 3;
+        self_ptr->info_list.push_back(format(fmt, dam, cost));
         break;
+    }
     case PlayerRaceType::KUTAR:
         if (player_ptr->lev >= 20) {
-            self_ptr->info[self_ptr->line++] = _("あなたは d20+30 ターンの間横に伸びることができる。(15 MP)", "You can expand horizontally, dur d20+30 (cost 15).");
+            self_ptr->info_list.emplace_back(_("あなたは d20+30 ターンの間横に伸びることができる。(15 MP)", "You can expand horizontally, dur d20+30 (cost 15)."));
         }
 
         break;
     case PlayerRaceType::ANDROID:
         if (player_ptr->lev < 10) {
-            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのレイガンを撃つことができる。(7 MP)", "You can fire a ray gun with damage %d (cost 7)."),
-                (player_ptr->lev + 1) / 2);
+            constexpr auto fmt = _("あなたは %d ダメージのレイガンを撃つことができる。(7 MP)", "You can fire a ray gun with damage %d (cost 7).");
+            const auto dam = (player_ptr->lev + 1) / 2;
+            self_ptr->info_list.push_back(format(fmt, dam));
         } else if (player_ptr->lev < 25) {
-            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのブラスターを撃つことができる。(13 MP)", "You can fire a blaster with damage %d (cost 13)."),
-                player_ptr->lev);
+            constexpr auto fmt = _("あなたは %d ダメージのブラスターを撃つことができる。(13 MP)", "You can fire a blaster with damage %d (cost 13).");
+            const auto dam = player_ptr->lev;
+            self_ptr->info_list.push_back(format(fmt, dam));
         } else if (player_ptr->lev < 35) {
-            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのバズーカを撃つことができる。(26 MP)", "You can fire a bazooka with damage %d (cost 26)."),
-                player_ptr->lev * 2);
+            constexpr auto fmt = _("あなたは %d ダメージのバズーカを撃つことができる。(26 MP)", "You can fire a bazooka with damage %d (cost 26).");
+            const auto dam = player_ptr->lev * 2;
+            self_ptr->info_list.push_back(format(fmt, dam));
         } else if (player_ptr->lev < 45) {
-            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf),
-                _("あなたは %d ダメージのビームキャノンを撃つことができる。(40 MP)", "You can fire a beam cannon with damage %d (cost 40)."),
-                player_ptr->lev * 2);
+            constexpr auto fmt = _("あなたは %d ダメージのビームキャノンを撃つことができる。(40 MP)", "You can fire a beam cannon with damage %d (cost 40).");
+            const auto dam = player_ptr->lev * 2;
+            self_ptr->info_list.push_back(format(fmt, dam));
         } else {
-            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのロケットを撃つことができる。(60 MP)", "You can fire a rocket with damage %d (cost 60)."),
-                player_ptr->lev * 5);
+            constexpr auto fmt = _("あなたは %d ダメージのロケットを撃つことができる。(60 MP)", "You can fire a rocket with damage %d (cost 60).");
+            const auto dam = player_ptr->lev * 5;
+            self_ptr->info_list.push_back(format(fmt, dam));
         }
 
-        self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         break;
     default:
         break;

--- a/src/player-info/resistance-info.cpp
+++ b/src/player-info/resistance-info.cpp
@@ -11,103 +11,103 @@ void set_element_resistance_info(PlayerType *player_ptr, self_info_type *self_pt
     const auto race_tr_flags = PlayerRace(player_ptr).tr_flags();
 
     if (has_immune_acid(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは酸に対する完全なる免疫を持っている。", "You are completely immune to acid.");
+        self_ptr->info_list.emplace_back(_("あなたは酸に対する完全なる免疫を持っている。", "You are completely immune to acid."));
     } else if (has_resist_acid(player_ptr) && is_oppose_acid(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは酸への強力な耐性を持っている。", "You resist acid exceptionally well.");
+        self_ptr->info_list.emplace_back(_("あなたは酸への強力な耐性を持っている。", "You resist acid exceptionally well."));
     } else if (has_resist_acid(player_ptr) || is_oppose_acid(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは酸への耐性を持っている。", "You are resistant to acid.");
+        self_ptr->info_list.emplace_back(_("あなたは酸への耐性を持っている。", "You are resistant to acid."));
     }
 
     if (race_tr_flags.has(TR_VUL_ACID) && !has_immune_acid(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは酸に弱い。", "You are susceptible to damage from acid.");
+        self_ptr->info_list.emplace_back(_("あなたは酸に弱い。", "You are susceptible to damage from acid."));
     }
 
     if (has_immune_elec(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは電撃に対する完全なる免疫を持っている。", "You are completely immune to lightning.");
+        self_ptr->info_list.emplace_back(_("あなたは電撃に対する完全なる免疫を持っている。", "You are completely immune to lightning."));
     } else if (has_resist_elec(player_ptr) && is_oppose_elec(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは電撃への強力な耐性を持っている。", "You resist lightning exceptionally well.");
+        self_ptr->info_list.emplace_back(_("あなたは電撃への強力な耐性を持っている。", "You resist lightning exceptionally well."));
     } else if (has_resist_elec(player_ptr) || is_oppose_elec(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは電撃への耐性を持っている。", "You are resistant to lightning.");
+        self_ptr->info_list.emplace_back(_("あなたは電撃への耐性を持っている。", "You are resistant to lightning."));
     }
 
     if (race_tr_flags.has(TR_VUL_ELEC) && !has_immune_elec(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは電撃に弱い。", "You are susceptible to damage from lightning.");
+        self_ptr->info_list.emplace_back(_("あなたは電撃に弱い。", "You are susceptible to damage from lightning."));
     }
 
     if (has_immune_fire(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは火に対する完全なる免疫を持っている。", "You are completely immune to fire.");
+        self_ptr->info_list.emplace_back(_("あなたは火に対する完全なる免疫を持っている。", "You are completely immune to fire."));
     } else if (has_resist_fire(player_ptr) && is_oppose_fire(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは火への強力な耐性を持っている。", "You resist fire exceptionally well.");
+        self_ptr->info_list.emplace_back(_("あなたは火への強力な耐性を持っている。", "You resist fire exceptionally well."));
     } else if (has_resist_fire(player_ptr) || is_oppose_fire(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは火への耐性を持っている。", "You are resistant to fire.");
+        self_ptr->info_list.emplace_back(_("あなたは火への耐性を持っている。", "You are resistant to fire."));
     }
 
     if (race_tr_flags.has(TR_VUL_FIRE) && !has_immune_fire(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは火に弱い。", "You are susceptible to damage from fire.");
+        self_ptr->info_list.emplace_back(_("あなたは火に弱い。", "You are susceptible to damage from fire."));
     }
 
     if (has_immune_cold(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは冷気に対する完全なる免疫を持っている。", "You are completely immune to cold.");
+        self_ptr->info_list.emplace_back(_("あなたは冷気に対する完全なる免疫を持っている。", "You are completely immune to cold."));
     } else if (has_resist_cold(player_ptr) && is_oppose_cold(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは冷気への強力な耐性を持っている。", "You resist cold exceptionally well.");
+        self_ptr->info_list.emplace_back(_("あなたは冷気への強力な耐性を持っている。", "You resist cold exceptionally well."));
     } else if (has_resist_cold(player_ptr) || is_oppose_cold(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは冷気への耐性を持っている。", "You are resistant to cold.");
+        self_ptr->info_list.emplace_back(_("あなたは冷気への耐性を持っている。", "You are resistant to cold."));
     }
 
     if (race_tr_flags.has(TR_VUL_COLD) && !has_immune_cold(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは冷気に弱い。", "You are susceptible to damage from cold.");
+        self_ptr->info_list.emplace_back(_("あなたは冷気に弱い。", "You are susceptible to damage from cold."));
     }
 
     if (has_resist_pois(player_ptr) && is_oppose_pois(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは毒への強力な耐性を持っている。", "You resist poison exceptionally well.");
+        self_ptr->info_list.emplace_back(_("あなたは毒への強力な耐性を持っている。", "You resist poison exceptionally well."));
     } else if (has_resist_pois(player_ptr) || is_oppose_pois(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは毒への耐性を持っている。", "You are resistant to poison.");
+        self_ptr->info_list.emplace_back(_("あなたは毒への耐性を持っている。", "You are resistant to poison."));
     }
 }
 
 void set_high_resistance_info(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     if (has_resist_lite(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは閃光への耐性を持っている。", "You are resistant to bright light.");
+        self_ptr->info_list.emplace_back(_("あなたは閃光への耐性を持っている。", "You are resistant to bright light."));
     }
 
     if (has_vuln_lite(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは閃光に弱い。", "You are susceptible to damage from bright light.");
+        self_ptr->info_list.emplace_back(_("あなたは閃光に弱い。", "You are susceptible to damage from bright light."));
     }
 
     if (has_immune_dark(player_ptr) || player_ptr->wraith_form) {
-        self_ptr->info[self_ptr->line++] = _("あなたは暗黒に対する完全なる免疫を持っている。", "You are completely immune to darkness.");
+        self_ptr->info_list.emplace_back(_("あなたは暗黒に対する完全なる免疫を持っている。", "You are completely immune to darkness."));
     } else if (has_resist_dark(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは暗黒への耐性を持っている。", "You are resistant to darkness.");
+        self_ptr->info_list.emplace_back(_("あなたは暗黒への耐性を持っている。", "You are resistant to darkness."));
     }
 
     if (has_resist_conf(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは混乱への耐性を持っている。", "You are resistant to confusion.");
+        self_ptr->info_list.emplace_back(_("あなたは混乱への耐性を持っている。", "You are resistant to confusion."));
     }
 
     if (has_resist_sound(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは音波の衝撃への耐性を持っている。", "You are resistant to sonic attacks.");
+        self_ptr->info_list.emplace_back(_("あなたは音波の衝撃への耐性を持っている。", "You are resistant to sonic attacks."));
     }
 
     if (has_resist_disen(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは劣化への耐性を持っている。", "You are resistant to disenchantment.");
+        self_ptr->info_list.emplace_back(_("あなたは劣化への耐性を持っている。", "You are resistant to disenchantment."));
     }
 
     if (has_resist_chaos(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはカオスの力への耐性を持っている。", "You are resistant to chaos.");
+        self_ptr->info_list.emplace_back(_("あなたはカオスの力への耐性を持っている。", "You are resistant to chaos."));
     }
 
     if (has_resist_shard(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは破片の攻撃への耐性を持っている。", "You are resistant to blasts of shards.");
+        self_ptr->info_list.emplace_back(_("あなたは破片の攻撃への耐性を持っている。", "You are resistant to blasts of shards."));
     }
 
     if (has_resist_nexus(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは因果混乱の攻撃への耐性を持っている。", "You are resistant to nexus attacks.");
+        self_ptr->info_list.emplace_back(_("あなたは因果混乱の攻撃への耐性を持っている。", "You are resistant to nexus attacks."));
     }
 
     if (PlayerRace(player_ptr).equals(PlayerRaceType::SPECTRE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは地獄の力を吸収できる。", "You can drain nether forces.");
+        self_ptr->info_list.emplace_back(_("あなたは地獄の力を吸収できる。", "You can drain nether forces."));
     } else if (has_resist_neth(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは地獄の力への耐性を持っている。", "You are resistant to nether forces.");
+        self_ptr->info_list.emplace_back(_("あなたは地獄の力への耐性を持っている。", "You are resistant to nether forces."));
     }
 }

--- a/src/player-info/self-info-util.h
+++ b/src/player-info/self-info-util.h
@@ -1,14 +1,11 @@
 #pragma once
 
 #include "system/item-entity.h"
+#include <string>
+#include <vector>
 
 struct self_info_type {
     self_info_type() = default;
-    int line = 0;
-    char v_string[8][128]{};
-    char s_string[6][128]{};
     TrFlags flags{};
-    char plev_buf[80]{};
-    char buf[2][80]{};
-    const char *info[220]{};
+    std::vector<std::string> info_list{};
 };

--- a/src/player-info/self-info.cpp
+++ b/src/player-info/self-info.cpp
@@ -44,188 +44,188 @@ static void set_bad_status_info(PlayerType *player_ptr, self_info_type *self_ptr
 {
     auto effects = player_ptr->effects();
     if (effects->blindness()->is_blind()) {
-        self_ptr->info[self_ptr->line++] = _("あなたは目が見えない。", "You cannot see.");
+        self_ptr->info_list.emplace_back(_("あなたは目が見えない。", "You cannot see."));
     }
 
     if (effects->confusion()->is_confused()) {
-        self_ptr->info[self_ptr->line++] = _("あなたは混乱している。", "You are confused.");
+        self_ptr->info_list.emplace_back(_("あなたは混乱している。", "You are confused."));
     }
 
     if (effects->fear()->is_fearful()) {
-        self_ptr->info[self_ptr->line++] = _("あなたは恐怖に侵されている。", "You are terrified.");
+        self_ptr->info_list.emplace_back(_("あなたは恐怖に侵されている。", "You are terrified."));
     }
 
     if (effects->cut()->is_cut()) {
-        self_ptr->info[self_ptr->line++] = _("あなたは出血している。", "You are bleeding.");
+        self_ptr->info_list.emplace_back(_("あなたは出血している。", "You are bleeding."));
     }
 
     if (effects->stun()->is_stunned()) {
-        self_ptr->info[self_ptr->line++] = _("あなたはもうろうとしている。", "You are stunned.");
+        self_ptr->info_list.emplace_back(_("あなたはもうろうとしている。", "You are stunned."));
     }
 
     if (effects->poison()->is_poisoned()) {
-        self_ptr->info[self_ptr->line++] = _("あなたは毒に侵されている。", "You are poisoned.");
+        self_ptr->info_list.emplace_back(_("あなたは毒に侵されている。", "You are poisoned."));
     }
 
     if (effects->hallucination()->is_hallucinated()) {
-        self_ptr->info[self_ptr->line++] = _("あなたは幻覚を見ている。", "You are hallucinating.");
+        self_ptr->info_list.emplace_back(_("あなたは幻覚を見ている。", "You are hallucinating."));
     }
 }
 
 static void set_curse_info(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     if (player_ptr->cursed.has(CurseTraitType::TY_CURSE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは邪悪な怨念に包まれている。", "You carry an ancient foul curse.");
+        self_ptr->info_list.emplace_back(_("あなたは邪悪な怨念に包まれている。", "You carry an ancient foul curse."));
     }
 
     if (has_aggravate(player_ptr)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはモンスターを怒らせている。", "You aggravate monsters.");
+        self_ptr->info_list.emplace_back(_("あなたはモンスターを怒らせている。", "You aggravate monsters."));
     }
 
     if (player_ptr->cursed.has(CurseTraitType::DRAIN_EXP)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは経験値を吸われている。", "You occasionally lose experience for no reason.");
+        self_ptr->info_list.emplace_back(_("あなたは経験値を吸われている。", "You occasionally lose experience for no reason."));
     }
 
     if (player_ptr->cursed.has(CurseTraitType::SLOW_REGEN)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの回復力は非常に遅い。", "You regenerate slowly.");
+        self_ptr->info_list.emplace_back(_("あなたの回復力は非常に遅い。", "You regenerate slowly."));
     }
 
     if (player_ptr->cursed.has(CurseTraitType::ADD_L_CURSE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの弱い呪いは増える。", "Your weak curses multiply.");
+        self_ptr->info_list.emplace_back(_("あなたの弱い呪いは増える。", "Your weak curses multiply."));
     } /* 暫定的 -- henkma */
 
     if (player_ptr->cursed.has(CurseTraitType::ADD_H_CURSE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの強い呪いは増える。", "Your heavy curses multiply.");
+        self_ptr->info_list.emplace_back(_("あなたの強い呪いは増える。", "Your heavy curses multiply."));
     } /* 暫定的 -- henkma */
 
     if (player_ptr->cursed.has(CurseTraitType::CALL_ANIMAL)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは動物に狙われている。", "You attract animals.");
+        self_ptr->info_list.emplace_back(_("あなたは動物に狙われている。", "You attract animals."));
     }
 
     if (player_ptr->cursed.has(CurseTraitType::CALL_DEMON)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは悪魔に狙われている。", "You attract demons.");
+        self_ptr->info_list.emplace_back(_("あなたは悪魔に狙われている。", "You attract demons."));
     }
 
     if (player_ptr->cursed.has(CurseTraitType::CALL_DRAGON)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはドラゴンに狙われている。", "You attract dragons.");
+        self_ptr->info_list.emplace_back(_("あなたはドラゴンに狙われている。", "You attract dragons."));
     }
 
     if (player_ptr->cursed.has(CurseTraitType::COWARDICE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは時々臆病になる。", "You are subject to cowardice.");
+        self_ptr->info_list.emplace_back(_("あなたは時々臆病になる。", "You are subject to cowardice."));
     }
 
     if (player_ptr->cursed.has(CurseTraitType::BERS_RAGE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは狂戦士化の発作を起こす。", "You are subject to berserker fits.");
+        self_ptr->info_list.emplace_back(_("あなたは狂戦士化の発作を起こす。", "You are subject to berserker fits."));
     }
 
     if (player_ptr->cursed.has(CurseTraitType::TELEPORT)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの位置はひじょうに不安定だ。", "Your position is very uncertain.");
+        self_ptr->info_list.emplace_back(_("あなたの位置はひじょうに不安定だ。", "Your position is very uncertain."));
     }
 
     if (player_ptr->cursed.has(CurseTraitType::LOW_MELEE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は攻撃を外しやすい。", "Your weapon causes you to miss blows.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は攻撃を外しやすい。", "Your weapon causes you to miss blows."));
     }
 
     if (player_ptr->cursed.has(CurseTraitType::LOW_AC)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは攻撃を受けやすい。", "You are subject to be hit.");
+        self_ptr->info_list.emplace_back(_("あなたは攻撃を受けやすい。", "You are subject to be hit."));
     }
 
     if (player_ptr->cursed.has(CurseTraitType::HARD_SPELL)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは魔法を失敗しやすい。", "Your spells fail more frequently.");
+        self_ptr->info_list.emplace_back(_("あなたは魔法を失敗しやすい。", "Your spells fail more frequently."));
     }
 
     if (player_ptr->cursed.has(CurseTraitType::FAST_DIGEST)) {
-        self_ptr->info[self_ptr->line++] = _("あなたはすぐお腹がへる。", "You have a good appetite.");
+        self_ptr->info_list.emplace_back(_("あなたはすぐお腹がへる。", "You have a good appetite."));
     }
 
     if (player_ptr->cursed.has(CurseTraitType::DRAIN_HP)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは体力を吸われている。", "You occasionally lose hit points for no reason.");
+        self_ptr->info_list.emplace_back(_("あなたは体力を吸われている。", "You occasionally lose hit points for no reason."));
     }
 
     if (player_ptr->cursed.has(CurseTraitType::DRAIN_MANA)) {
-        self_ptr->info[self_ptr->line++] = _("あなたは魔力を吸われている。", "You occasionally lose spell points for no reason.");
+        self_ptr->info_list.emplace_back(_("あなたは魔力を吸われている。", "You occasionally lose spell points for no reason."));
     }
 }
 
 static void set_special_attack_info(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     if (player_ptr->special_attack & ATTACK_CONFUSE) {
-        self_ptr->info[self_ptr->line++] = _("あなたの手は赤く輝いている。", "Your hands are glowing dull red.");
+        self_ptr->info_list.emplace_back(_("あなたの手は赤く輝いている。", "Your hands are glowing dull red."));
     }
 
     if (player_ptr->special_attack & ATTACK_FIRE) {
-        self_ptr->info[self_ptr->line++] = _("あなたの手は火炎に覆われている。", "You can strike the enemy with flame.");
+        self_ptr->info_list.emplace_back(_("あなたの手は火炎に覆われている。", "You can strike the enemy with flame."));
     }
 
     if (player_ptr->special_attack & ATTACK_COLD) {
-        self_ptr->info[self_ptr->line++] = _("あなたの手は冷気に覆われている。", "You can strike the enemy with cold.");
+        self_ptr->info_list.emplace_back(_("あなたの手は冷気に覆われている。", "You can strike the enemy with cold."));
     }
 
     if (player_ptr->special_attack & ATTACK_ACID) {
-        self_ptr->info[self_ptr->line++] = _("あなたの手は酸に覆われている。", "You can strike the enemy with acid.");
+        self_ptr->info_list.emplace_back(_("あなたの手は酸に覆われている。", "You can strike the enemy with acid."));
     }
 
     if (player_ptr->special_attack & ATTACK_ELEC) {
-        self_ptr->info[self_ptr->line++] = _("あなたの手は電撃に覆われている。", "You can strike the enemy with electoric shock.");
+        self_ptr->info_list.emplace_back(_("あなたの手は電撃に覆われている。", "You can strike the enemy with electoric shock."));
     }
 
     if (player_ptr->special_attack & ATTACK_POIS) {
-        self_ptr->info[self_ptr->line++] = _("あなたの手は毒に覆われている。", "You can strike the enemy with poison.");
+        self_ptr->info_list.emplace_back(_("あなたの手は毒に覆われている。", "You can strike the enemy with poison."));
     }
 }
 
 static void set_esp_info(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     if (player_ptr->telepathy) {
-        self_ptr->info[self_ptr->line++] = _("あなたはテレパシー能力を持っている。", "You have ESP.");
+        self_ptr->info_list.emplace_back(_("あなたはテレパシー能力を持っている。", "You have ESP."));
     }
 
     if (player_ptr->esp_animal) {
-        self_ptr->info[self_ptr->line++] = _("あなたは自然界の生物の存在を感じる能力を持っている。", "You sense natural creatures.");
+        self_ptr->info_list.emplace_back(_("あなたは自然界の生物の存在を感じる能力を持っている。", "You sense natural creatures."));
     }
 
     if (player_ptr->esp_undead) {
-        self_ptr->info[self_ptr->line++] = _("あなたはアンデッドの存在を感じる能力を持っている。", "You sense undead.");
+        self_ptr->info_list.emplace_back(_("あなたはアンデッドの存在を感じる能力を持っている。", "You sense undead."));
     }
 
     if (player_ptr->esp_demon) {
-        self_ptr->info[self_ptr->line++] = _("あなたは悪魔の存在を感じる能力を持っている。", "You sense demons.");
+        self_ptr->info_list.emplace_back(_("あなたは悪魔の存在を感じる能力を持っている。", "You sense demons."));
     }
 
     if (player_ptr->esp_orc) {
-        self_ptr->info[self_ptr->line++] = _("あなたはオークの存在を感じる能力を持っている。", "You sense orcs.");
+        self_ptr->info_list.emplace_back(_("あなたはオークの存在を感じる能力を持っている。", "You sense orcs."));
     }
 
     if (player_ptr->esp_troll) {
-        self_ptr->info[self_ptr->line++] = _("あなたはトロルの存在を感じる能力を持っている。", "You sense trolls.");
+        self_ptr->info_list.emplace_back(_("あなたはトロルの存在を感じる能力を持っている。", "You sense trolls."));
     }
 
     if (player_ptr->esp_giant) {
-        self_ptr->info[self_ptr->line++] = _("あなたは巨人の存在を感じる能力を持っている。", "You sense giants.");
+        self_ptr->info_list.emplace_back(_("あなたは巨人の存在を感じる能力を持っている。", "You sense giants."));
     }
 
     if (player_ptr->esp_dragon) {
-        self_ptr->info[self_ptr->line++] = _("あなたはドラゴンの存在を感じる能力を持っている。", "You sense dragons.");
+        self_ptr->info_list.emplace_back(_("あなたはドラゴンの存在を感じる能力を持っている。", "You sense dragons."));
     }
 
     if (player_ptr->esp_human) {
-        self_ptr->info[self_ptr->line++] = _("あなたは人間の存在を感じる能力を持っている。", "You sense humans.");
+        self_ptr->info_list.emplace_back(_("あなたは人間の存在を感じる能力を持っている。", "You sense humans."));
     }
 
     if (player_ptr->esp_evil) {
-        self_ptr->info[self_ptr->line++] = _("あなたは邪悪な生き物の存在を感じる能力を持っている。", "You sense evil creatures.");
+        self_ptr->info_list.emplace_back(_("あなたは邪悪な生き物の存在を感じる能力を持っている。", "You sense evil creatures."));
     }
 
     if (player_ptr->esp_good) {
-        self_ptr->info[self_ptr->line++] = _("あなたは善良な生き物の存在を感じる能力を持っている。", "You sense good creatures.");
+        self_ptr->info_list.emplace_back(_("あなたは善良な生き物の存在を感じる能力を持っている。", "You sense good creatures."));
     }
 
     if (player_ptr->esp_nonliving) {
-        self_ptr->info[self_ptr->line++] = _("あなたは活動する無生物体の存在を感じる能力を持っている。", "You sense non-living creatures.");
+        self_ptr->info_list.emplace_back(_("あなたは活動する無生物体の存在を感じる能力を持っている。", "You sense non-living creatures."));
     }
 
     if (player_ptr->esp_unique) {
-        self_ptr->info[self_ptr->line++] = _("あなたは特別な強敵の存在を感じる能力を持っている。", "You sense unique monsters.");
+        self_ptr->info_list.emplace_back(_("あなたは特別な強敵の存在を感じる能力を持っている。", "You sense unique monsters."));
     }
 }
 
@@ -255,7 +255,7 @@ void self_knowledge(PlayerType *player_ptr)
     chg_virtue(player_ptr, Virtue::ENLIGHTEN, 1);
     display_max_base_status(player_ptr, self_ptr);
     display_virtue(player_ptr, self_ptr);
-    self_ptr->info[self_ptr->line++] = "";
+    self_ptr->info_list.emplace_back("");
     if (player_ptr->mimic_form != MimicKindType::NONE) {
         display_mimic_race_ability(player_ptr, self_ptr);
     } else {
@@ -270,7 +270,7 @@ void self_knowledge(PlayerType *player_ptr)
     set_special_attack_info(player_ptr, self_ptr);
     switch (player_ptr->action) {
     case ACTION_SEARCH:
-        self_ptr->info[self_ptr->line++] = _("あなたはひじょうに注意深く周囲を見渡している。", "You are looking around very carefully.");
+        self_ptr->info_list.emplace_back(_("あなたはひじょうに注意深く周囲を見渡している。", "You are looking around very carefully."));
         break;
     }
 

--- a/src/player-info/weapon-effect-info.cpp
+++ b/src/player-info/weapon-effect-info.cpp
@@ -8,117 +8,117 @@
 static void set_weapon_bless_info(self_info_type *self_ptr)
 {
     if (self_ptr->flags.has(TR_BLESSED)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は神の祝福を受けている。", "Your weapon has been blessed by the gods.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は神の祝福を受けている。", "Your weapon has been blessed by the gods."));
     }
 
     if (self_ptr->flags.has(TR_CHAOTIC)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器はログルスの徴の属性をもつ。", "Your weapon is branded with the Sign of Logrus.");
+        self_ptr->info_list.emplace_back(_("あなたの武器はログルスの徴の属性をもつ。", "Your weapon is branded with the Sign of Logrus."));
     }
 
     if (self_ptr->flags.has(TR_BRAND_MAGIC)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は魔術的効果を発動することがある。", "Your weapon is branded with magical power.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は魔術的効果を発動することがある。", "Your weapon is branded with magical power."));
     }
 
     if (self_ptr->flags.has(TR_EARTHQUAKE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は打撃で地震を発生することができる。", "The impact of your weapon can cause earthquakes.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は打撃で地震を発生することができる。", "The impact of your weapon can cause earthquakes."));
     }
 
     if (self_ptr->flags.has(TR_VORPAL)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は非常に鋭い。", "Your weapon is very sharp.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は非常に鋭い。", "Your weapon is very sharp."));
     }
 
     if (self_ptr->flags.has(TR_IMPACT)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は強力な一撃を放てる。", "Your weapon hits your foes strongly.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は強力な一撃を放てる。", "Your weapon hits your foes strongly."));
     }
 
     if (self_ptr->flags.has(TR_VAMPIRIC)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は敵から生命力を吸収する。", "Your weapon drains life from your foes.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は敵から生命力を吸収する。", "Your weapon drains life from your foes."));
     }
 }
 
 static void set_brand_attack_info(self_info_type *self_ptr)
 {
     if (self_ptr->flags.has(TR_BRAND_ACID)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は敵を溶かす。", "Your weapon melts your foes.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は敵を溶かす。", "Your weapon melts your foes."));
     }
 
     if (self_ptr->flags.has(TR_BRAND_ELEC)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は敵を感電させる。", "Your weapon shocks your foes.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は敵を感電させる。", "Your weapon shocks your foes."));
     }
 
     if (self_ptr->flags.has(TR_BRAND_FIRE)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は敵を燃やす。", "Your weapon burns your foes.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は敵を燃やす。", "Your weapon burns your foes."));
     }
 
     if (self_ptr->flags.has(TR_BRAND_COLD)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は敵を凍らせる。", "Your weapon freezes your foes.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は敵を凍らせる。", "Your weapon freezes your foes."));
     }
 
     if (self_ptr->flags.has(TR_BRAND_POIS)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は敵を毒で侵す。", "Your weapon poisons your foes.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は敵を毒で侵す。", "Your weapon poisons your foes."));
     }
 }
 
 static void set_slay_info(self_info_type *self_ptr)
 {
     if (self_ptr->flags.has(TR_KILL_ANIMAL)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は動物の天敵である。", "Your weapon is a great bane of animals.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は動物の天敵である。", "Your weapon is a great bane of animals."));
     } else if (self_ptr->flags.has(TR_SLAY_ANIMAL)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は動物に対して強い力を発揮する。", "Your weapon strikes at animals with extra force.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は動物に対して強い力を発揮する。", "Your weapon strikes at animals with extra force."));
     }
 
     if (self_ptr->flags.has(TR_KILL_EVIL)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は邪悪なる存在の天敵である。", "Your weapon is a great bane of evil.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は邪悪なる存在の天敵である。", "Your weapon is a great bane of evil."));
     } else if (self_ptr->flags.has(TR_SLAY_EVIL)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は邪悪なる存在に対して強い力を発揮する。", "Your weapon strikes at evil with extra force.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は邪悪なる存在に対して強い力を発揮する。", "Your weapon strikes at evil with extra force."));
     }
 
     if (self_ptr->flags.has(TR_KILL_GOOD)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は善良なる存在の天敵である。", "Your weapon is a great bane of good.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は善良なる存在の天敵である。", "Your weapon is a great bane of good."));
     } else if (self_ptr->flags.has(TR_SLAY_GOOD)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は善良なる存在に対して強い力を発揮する。", "Your weapon strikes at good with extra force.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は善良なる存在に対して強い力を発揮する。", "Your weapon strikes at good with extra force."));
     }
 
     if (self_ptr->flags.has(TR_KILL_HUMAN)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は人間の天敵である。", "Your weapon is a great bane of humans.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は人間の天敵である。", "Your weapon is a great bane of humans."));
     } else if (self_ptr->flags.has(TR_SLAY_HUMAN)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は人間に対して特に強い力を発揮する。", "Your weapon is especially deadly against humans.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は人間に対して特に強い力を発揮する。", "Your weapon is especially deadly against humans."));
     }
 
     if (self_ptr->flags.has(TR_KILL_UNDEAD)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器はアンデッドの天敵である。", "Your weapon is a great bane of undead.");
+        self_ptr->info_list.emplace_back(_("あなたの武器はアンデッドの天敵である。", "Your weapon is a great bane of undead."));
     } else if (self_ptr->flags.has(TR_SLAY_UNDEAD)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器はアンデッドに対して神聖なる力を発揮する。", "Your weapon strikes at undead with holy wrath.");
+        self_ptr->info_list.emplace_back(_("あなたの武器はアンデッドに対して神聖なる力を発揮する。", "Your weapon strikes at undead with holy wrath."));
     }
 
     if (self_ptr->flags.has(TR_KILL_DEMON)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器はデーモンの天敵である。", "Your weapon is a great bane of demons.");
+        self_ptr->info_list.emplace_back(_("あなたの武器はデーモンの天敵である。", "Your weapon is a great bane of demons."));
     } else if (self_ptr->flags.has(TR_SLAY_DEMON)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器はデーモンに対して神聖なる力を発揮する。", "Your weapon strikes at demons with holy wrath.");
+        self_ptr->info_list.emplace_back(_("あなたの武器はデーモンに対して神聖なる力を発揮する。", "Your weapon strikes at demons with holy wrath."));
     }
 
     if (self_ptr->flags.has(TR_KILL_ORC)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器はオークの天敵である。", "Your weapon is a great bane of orcs.");
+        self_ptr->info_list.emplace_back(_("あなたの武器はオークの天敵である。", "Your weapon is a great bane of orcs."));
     } else if (self_ptr->flags.has(TR_SLAY_ORC)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器はオークに対して特に強い力を発揮する。", "Your weapon is especially deadly against orcs.");
+        self_ptr->info_list.emplace_back(_("あなたの武器はオークに対して特に強い力を発揮する。", "Your weapon is especially deadly against orcs."));
     }
 
     if (self_ptr->flags.has(TR_KILL_TROLL)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器はトロルの天敵である。", "Your weapon is a great bane of trolls.");
+        self_ptr->info_list.emplace_back(_("あなたの武器はトロルの天敵である。", "Your weapon is a great bane of trolls."));
     } else if (self_ptr->flags.has(TR_SLAY_TROLL)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器はトロルに対して特に強い力を発揮する。", "Your weapon is especially deadly against trolls.");
+        self_ptr->info_list.emplace_back(_("あなたの武器はトロルに対して特に強い力を発揮する。", "Your weapon is especially deadly against trolls."));
     }
 
     if (self_ptr->flags.has(TR_KILL_GIANT)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は巨人の天敵である。", "Your weapon is a great bane of giants.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は巨人の天敵である。", "Your weapon is a great bane of giants."));
     } else if (self_ptr->flags.has(TR_SLAY_GIANT)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は巨人に対して特に強い力を発揮する。", "Your weapon is especially deadly against giants.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は巨人に対して特に強い力を発揮する。", "Your weapon is especially deadly against giants."));
     }
 
     if (self_ptr->flags.has(TR_KILL_DRAGON)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器はドラゴンの天敵である。", "Your weapon is a great bane of dragons.");
+        self_ptr->info_list.emplace_back(_("あなたの武器はドラゴンの天敵である。", "Your weapon is a great bane of dragons."));
     } else if (self_ptr->flags.has(TR_SLAY_DRAGON)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器はドラゴンに対して特に強い力を発揮する。", "Your weapon is especially deadly against dragons.");
+        self_ptr->info_list.emplace_back(_("あなたの武器はドラゴンに対して特に強い力を発揮する。", "Your weapon is especially deadly against dragons."));
     }
 }
 
@@ -133,10 +133,10 @@ void set_weapon_effect_info(PlayerType *player_ptr, self_info_type *self_ptr)
     set_brand_attack_info(self_ptr);
     set_slay_info(self_ptr);
     if (self_ptr->flags.has(TR_FORCE_WEAPON)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器はMPを使って攻撃する。", "Your weapon causes great damage using your MP.");
+        self_ptr->info_list.emplace_back(_("あなたの武器はMPを使って攻撃する。", "Your weapon causes great damage using your MP."));
     }
 
     if (self_ptr->flags.has(TR_THROW)) {
-        self_ptr->info[self_ptr->line++] = _("あなたの武器は投げやすい。", "Your weapon can be thrown well.");
+        self_ptr->info_list.emplace_back(_("あなたの武器は投げやすい。", "Your weapon can be thrown well."));
     }
 }

--- a/src/view/display-self-info.cpp
+++ b/src/view/display-self-info.cpp
@@ -16,32 +16,26 @@
 void display_life_rating(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     player_ptr->knowledge |= KNOW_STAT | KNOW_HPRATE;
-    strcpy(self_ptr->plev_buf, "");
-    int percent = (int)(((long)player_ptr->player_hp[PY_MAX_LEVEL - 1] * 200L) / (2 * player_ptr->hitdie + ((PY_MAX_LEVEL - 1 + 3) * (player_ptr->hitdie + 1))));
-    sprintf(self_ptr->plev_buf, _("現在の体力ランク : %d/100", "Your current Life Rating is %d/100."), percent);
-    strcpy(self_ptr->buf[0], self_ptr->plev_buf);
-    self_ptr->info[self_ptr->line++] = self_ptr->buf[0];
-    self_ptr->info[self_ptr->line++] = "";
+    const int percent = (int)(((long)player_ptr->player_hp[PY_MAX_LEVEL - 1] * 200L) / (2 * player_ptr->hitdie + ((PY_MAX_LEVEL - 1 + 3) * (player_ptr->hitdie + 1))));
+    self_ptr->info_list.push_back(format(_("現在の体力ランク : %d/100", "Your current Life Rating is %d/100."), percent));
+    self_ptr->info_list.emplace_back("");
 }
 
 void display_max_base_status(PlayerType *player_ptr, self_info_type *self_ptr)
 {
-    self_ptr->info[self_ptr->line++] = _("能力の最大値", "Limits of maximum stats");
+    self_ptr->info_list.emplace_back(_("能力の最大値", "Limits of maximum stats"));
     for (int v_nr = 0; v_nr < A_MAX; v_nr++) {
-        char stat_desc[80];
-        sprintf(stat_desc, "%s 18/%d", stat_names[v_nr], player_ptr->stat_max_max[v_nr] - 18);
-        strcpy(self_ptr->s_string[v_nr], stat_desc);
-        self_ptr->info[self_ptr->line++] = self_ptr->s_string[v_nr];
+        auto stat = format("%s 18/%d", stat_names[v_nr], player_ptr->stat_max_max[v_nr] - 18);
+        self_ptr->info_list.push_back(std::move(stat));
     }
 }
 
 void display_virtue(PlayerType *player_ptr, self_info_type *self_ptr)
 {
-    self_ptr->info[self_ptr->line++] = "";
-    std::string alg = PlayerAlignment(player_ptr).get_alignment_description(true);
-    strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("現在の属性 : %s", "Your alignment : %s"), alg.data());
-    angband_strcpy(self_ptr->buf[1], self_ptr->plev_buf, sizeof(self_ptr->buf[1]));
-    self_ptr->info[self_ptr->line++] = self_ptr->buf[1];
+    self_ptr->info_list.emplace_back("");
+    const std::string alg = PlayerAlignment(player_ptr).get_alignment_description(true);
+    self_ptr->info_list.push_back(format(_("現在の属性 : %s", "Your alignment : %s"), alg.data()));
+
     for (int v_nr = 0; v_nr < 8; v_nr++) {
         const auto vir_name = virtue_names.at(player_ptr->vir_types[v_nr]).data();
         std::string vir_desc;
@@ -74,8 +68,7 @@ void display_virtue(PlayerType *player_ptr, self_info_type *self_ptr)
             vir_desc = format(_("[%s]の具現者 (%d)", "You are the living embodiment of %s (%d)."), vir_name, tester);
         }
 
-        angband_strcpy(self_ptr->v_string[v_nr], vir_desc, sizeof(self_ptr->v_string[v_nr]));
-        self_ptr->info[self_ptr->line++] = self_ptr->v_string[v_nr];
+        self_ptr->info_list.push_back(std::move(vir_desc));
     }
 }
 
@@ -85,20 +78,22 @@ void display_mimic_race_ability(PlayerType *player_ptr, self_info_type *self_ptr
     case MimicKindType::NONE:
         return;
     case MimicKindType::DEMON:
-    case MimicKindType::DEMON_LORD:
-        sprintf(self_ptr->plev_buf, _("あなたは %d ダメージの地獄か火炎のブレスを吐くことができる。(%d MP)", "You can breathe nether, dam. %d (cost %d)."),
-            3 * player_ptr->lev, 10 + player_ptr->lev / 3);
-
-        self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
+    case MimicKindType::DEMON_LORD: {
+        constexpr auto fmt = _("あなたは %d ダメージの地獄か火炎のブレスを吐くことができる。(%d MP)", "You can breathe nether, dam. %d (cost %d).");
+        const auto dam = 3 * player_ptr->lev;
+        const auto cost = 10 + player_ptr->lev / 3;
+        self_ptr->info_list.push_back(format(fmt, dam, cost));
         return;
+    }
     case MimicKindType::VAMPIRE:
-        if (player_ptr->lev <= 1) {
-            break;
+        if (player_ptr->lev >= 2) {
+            constexpr auto fmt = _("あなたは敵から %d-%d HP の生命力を吸収できる。(%d MP)", "You can steal life from a foe, dam. %d-%d (cost %d).");
+            const auto lev = player_ptr->lev;
+            const auto min_dam = lev + std::max(1, lev / 10);
+            const auto max_dam = lev + lev * std::max(1, lev / 10);
+            const auto cost = 1 + lev / 3;
+            self_ptr->info_list.push_back(format(fmt, min_dam, max_dam, cost));
         }
-        sprintf(self_ptr->plev_buf, _("あなたは敵から %d-%d HP の生命力を吸収できる。(%d MP)", "You can steal life from a foe, dam. %d-%d (cost %d)."),
-            player_ptr->lev + std::max(1, player_ptr->lev / 10), player_ptr->lev + player_ptr->lev * std::max(1, player_ptr->lev / 10),
-            1 + (player_ptr->lev / 3));
-        self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         return;
     }
 }
@@ -112,11 +107,11 @@ void display_self_info(self_info_type *self_ptr)
 
     prt(_("        あなたの状態:", "     Your Attributes:"), 1, 15);
     int k = 2;
-    for (int j = 0; j < self_ptr->line; j++) {
-        prt(self_ptr->info[j], k++, 15);
+    for (auto j = 0; j < std::ssize(self_ptr->info_list); j++) {
+        prt(self_ptr->info_list[j], k++, 15);
 
         /* Every 20 entries (lines 2 to 21), start over */
-        if ((k != 22) || (j + 1 >= self_ptr->line)) {
+        if ((k != 22) || (j + 1 >= std::ssize(self_ptr->info_list))) {
             continue;
         }
 


### PR DESCRIPTION
自己分析の情報を `const char*` の配列ではなく、 `std::vector<std::string>` で 所持するようにする。