### PR TITLE
変愚「[Refactor] rd_string()のシグニチャを変更する #4070」のマージ

### DIFF
--- a/src/load/birth-loader.cpp
+++ b/src/load/birth-loader.cpp
@@ -42,7 +42,9 @@ void load_quick_start(void)
     }
 
     for (int i = 0; i < 4; i++) {
-        rd_string(previous_char.history[i], sizeof(previous_char.history[i]));
+        const auto history = rd_string();
+        const auto len = history.copy(previous_char.history[i], sizeof(previous_char.history[i]) - 1);
+        previous_char.history[i][len] = '\0';
     }
 
     strip_bytes(1);

--- a/src/load/dummy-loader.cpp
+++ b/src/load/dummy-loader.cpp
@@ -50,8 +50,7 @@ void rd_dummy_monsters()
  */
 void rd_ghost(void)
 {
-    char buf[64];
-    rd_string(buf, sizeof(buf));
+    (void)rd_string();
     strip_bytes(60);
 }
 

--- a/src/load/info-loader.cpp
+++ b/src/load/info-loader.cpp
@@ -90,9 +90,7 @@ void rd_messages(void)
     auto num = rd_u32b();
     int message_max = (int)num;
     for (int i = 0; i < message_max; i++) {
-        char buf[128];
-        rd_string(buf, sizeof(buf));
-        message_add(buf);
+        message_add(rd_string());
     }
 }
 

--- a/src/load/load-util.cpp
+++ b/src/load/load-util.cpp
@@ -110,40 +110,38 @@ int32_t rd_s32b()
 }
 
 /*!
- * @brief ロードファイルポインタから文字列を読み込んでポインタに渡す / Hack -- read a string
- * @param str 読み込みポインタ
- * @param max 最大読み取りバイト数
+ * @brief ロードファイルポインタから文字列を読み込む
  */
-void rd_string(char *str, int max)
+std::string rd_string()
 {
-    for (int i = 0; true; i++) {
-        auto tmp8u = rd_byte();
-        if (i < max) {
-            str[i] = tmp8u;
-        }
+    std::string str;
+    str.reserve(1024);
 
-        if (!tmp8u) {
+    while (true) {
+        const auto ch = static_cast<char>(rd_byte());
+        if (ch == '\0') {
             break;
         }
+
+        str.push_back(ch);
     }
 
-    str[max - 1] = '\0';
 #ifdef JP
     switch (kanji_code) {
 #ifdef SJIS
     case 2:
-        euc2sjis(str);
+        euc2sjis(str.data());
         break;
 #endif
 
 #ifdef EUC
     case 3:
-        sjis2euc(str);
+        sjis2euc(str.data());
         break;
 #endif
 
     case 0: {
-        byte code = codeconv(str);
+        const auto code = codeconv(str.data());
 
         /* 漢字コードが判明したら、それを記録 */
         if (code) {
@@ -156,18 +154,9 @@ void rd_string(char *str, int max)
         break;
     }
 #endif
-}
 
-/*!
- * @brief ロードファイルポインタから文字列を読み込んで std::string オブジェクトに格納する
- * @param str std::string オブジェクトへの参照
- * @param max 最大読み取りバイト数
- */
-void rd_string(std::string &str, int max)
-{
-    std::vector<char> buf(max);
-    rd_string(buf.data(), max);
-    str = buf.data();
+    str.shrink_to_fit();
+    return str;
 }
 
 /*!

--- a/src/load/load-util.h
+++ b/src/load/load-util.h
@@ -22,8 +22,7 @@ uint16_t rd_u16b();
 int16_t rd_s16b();
 uint32_t rd_u32b();
 int32_t rd_s32b();
-void rd_string(char *str, int max);
-void rd_string(std::string &str, int max);
+std::string rd_string();
 void strip_bytes(int n);
 bool loading_savefile_version_is_older_than(uint32_t version);
 

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -230,7 +230,8 @@ static errr exe_reading_savefile(PlayerType *player_ptr)
     player_ptr->pet_extra_flags = rd_u16b();
 
     std::vector<char> buf(SCREEN_BUF_MAX_SIZE);
-    rd_string(buf.data(), SCREEN_BUF_MAX_SIZE);
+    const auto dump_str = rd_string();
+    dump_str.copy(buf.data(), SCREEN_BUF_MAX_SIZE - 1);
     if (buf[0]) {
         screen_dump = string_make(buf.data());
     }

--- a/src/load/old/item-loader-savefile50.cpp
+++ b/src/load/old/item-loader-savefile50.cpp
@@ -157,17 +157,13 @@ void ItemLoader50::rd_item(ItemEntity *o_ptr)
     }
 
     if (any_bits(flags, SaveDataItemFlagType::INSCRIPTION)) {
-        char buf[128];
-        rd_string(buf, sizeof(buf));
-        o_ptr->inscription.emplace(buf);
+        o_ptr->inscription = rd_string();
     } else {
         o_ptr->inscription.reset();
     }
 
     if (any_bits(flags, SaveDataItemFlagType::ART_NAME)) {
-        char buf[128];
-        rd_string(buf, sizeof(buf));
-        o_ptr->randart_name.emplace(buf);
+        o_ptr->randart_name = rd_string();
     } else {
         o_ptr->randart_name.reset();
     }

--- a/src/load/old/monster-loader-savefile50.cpp
+++ b/src/load/old/monster-loader-savefile50.cpp
@@ -89,9 +89,7 @@ void MonsterLoader50::rd_monster(MonsterEntity *m_ptr_)
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::NICKNAME)) {
-        char buf[128];
-        rd_string(buf, sizeof(buf));
-        this->m_ptr->nickname = buf;
+        this->m_ptr->nickname = rd_string();
     } else {
         this->m_ptr->nickname.clear();
     }

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -60,16 +60,18 @@ static void rd_realms(PlayerType *player_ptr)
  */
 void rd_base_info(PlayerType *player_ptr)
 {
-    rd_string(player_ptr->name, sizeof(player_ptr->name));
-    rd_string(player_ptr->died_from, 1024);
-    char buf[1024];
-    rd_string(buf, sizeof buf);
-    player_ptr->last_message = buf;
+    const auto player_name = rd_string();
+    const auto player_name_len = player_name.copy(player_ptr->name, sizeof(player_ptr->name) - 1);
+    player_ptr->name[player_name_len] = '\0';
+    player_ptr->died_from = rd_string();
+    player_ptr->last_message = rd_string();
 
     load_quick_start();
     const int max_history_lines = 4;
     for (int i = 0; i < max_history_lines; i++) {
-        rd_string(player_ptr->history[i], sizeof(player_ptr->history[i]));
+        const auto history = rd_string();
+        const auto history_len = history.copy(player_ptr->history[i], sizeof(player_ptr->history[i]) - 1);
+        player_ptr->history[i][history_len] = '\0';
     }
 
     player_ptr->prace = i2enum<PlayerRaceType>(rd_byte());


### PR DESCRIPTION
rd_string()のシグネチャを、読み込み最大数バイト数を指定しchar型のバッファもしくは
std::stringに格納する形から、読み込みバイト数無制限でstd::stringを返す形に変更する。 これにより、マルチバイト文字の途中で読み込み最大バイト数に達した場合にマルチバイト
文字の一部が残る問題も解決する。