### PR TITLE
変愚「FileDisplaery のコンストラクタにplayer_name を追加し、display() メソッドの引数を減らした #4071」のマージ

### DIFF
--- a/src/autopick/autopick-editor-command.cpp
+++ b/src/autopick/autopick-editor-command.cpp
@@ -65,7 +65,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         break;
     }
     case EC_HELP: {
-        FileDisplayer().display(player_ptr->name, true, _("jeditor.txt", "editor.txt"), 0, 0);
+        FileDisplayer(player_ptr->name).display(true, _("jeditor.txt", "editor.txt"), 0, 0);
         tb->dirty_flags |= DIRTY_SCREEN;
         break;
     }

--- a/src/birth/birth-util.cpp
+++ b/src/birth/birth-util.cpp
@@ -22,7 +22,7 @@ void birth_quit(void)
 void show_help(PlayerType *player_ptr, concptr helpfile)
 {
     screen_save();
-    FileDisplayer().display(player_ptr->name, true, helpfile, 0, 0);
+    FileDisplayer(player_ptr->name).display(true, helpfile, 0, 0);
     screen_load();
 }
 

--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -86,7 +86,7 @@ bool reinit_wilderness = false;
 static void town_history(PlayerType *player_ptr)
 {
     screen_save();
-    FileDisplayer().display(player_ptr->name, true, _("jbldg.txt", "bldg.txt"), 0, 0);
+    FileDisplayer(player_ptr->name).display(true, _("jbldg.txt", "bldg.txt"), 0, 0);
     screen_load();
 }
 

--- a/src/cmd-io/cmd-diary.cpp
+++ b/src/cmd-io/cmd-diary.cpp
@@ -37,7 +37,7 @@ static void display_diary(PlayerType *player_ptr)
     std::stringstream ss;
     ss << _("playrecord-", "playrec-") << savefile_base << ".txt";
     const auto &path = path_build(ANGBAND_DIR_USER, ss.str());
-    FileDisplayer().display(player_ptr->name, false, path.string(), -1, 0, diary_title);
+    FileDisplayer(player_ptr->name).display(false, path.string(), -1, 0, diary_title);
 }
 
 /*!

--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -157,7 +157,7 @@ static void do_cmd_options_autosave(PlayerType *player_ptr, concptr info)
         }
 
         case '?': {
-            FileDisplayer().display(player_ptr->name, true, _("joption.txt#Autosave", "option.txt#Autosave"), 0, 0);
+            FileDisplayer(player_ptr->name).display(true, _("joption.txt#Autosave", "option.txt#Autosave"), 0, 0);
             term_clear();
             break;
         }
@@ -298,7 +298,7 @@ static void do_cmd_options_win(PlayerType *player_ptr)
             set_window_flag(x, y);
             break;
         case '?':
-            FileDisplayer().display(player_ptr->name, true, _("joption.txt#Window", "option.txt#Window"), 0, 0);
+            FileDisplayer(player_ptr->name).display(true, _("joption.txt#Window", "option.txt#Window"), 0, 0);
             term_clear();
             break;
         default:
@@ -400,7 +400,7 @@ static void do_cmd_options_cheat(PlayerType *player_ptr, concptr info)
             k = (k + 1) % n;
             break;
         case '?':
-            FileDisplayer().display(player_ptr->name, true, std::string(_("joption.txt#", "option.txt#")).append(cheat_info[k].o_text), 0, 0);
+            FileDisplayer(player_ptr->name).display(true, std::string(_("joption.txt#", "option.txt#")).append(cheat_info[k].o_text), 0, 0);
             term_clear();
             break;
         default:
@@ -595,7 +595,7 @@ void do_cmd_options(PlayerType *player_ptr)
                 if (k == ESCAPE) {
                     break;
                 } else if (k == '?') {
-                    FileDisplayer().display(player_ptr->name, true, _("joption.txt#Hitpoint", "option.txt#Hitpoint"), 0, 0);
+                    FileDisplayer(player_ptr->name).display(true, _("joption.txt#Hitpoint", "option.txt#Hitpoint"), 0, 0);
                     term_clear();
                 } else if (isdigit(k)) {
                     hitpoint_warn = D2I(k);
@@ -617,7 +617,7 @@ void do_cmd_options(PlayerType *player_ptr)
                 if (k == ESCAPE) {
                     break;
                 } else if (k == '?') {
-                    FileDisplayer().display(player_ptr->name, true, _("joption.txt#Manapoint", "option.txt#Manapoint"), 0, 0);
+                    FileDisplayer(player_ptr->name).display(true, _("joption.txt#Manapoint", "option.txt#Manapoint"), 0, 0);
                     term_clear();
                 } else if (isdigit(k)) {
                     mana_warn = D2I(k);
@@ -629,7 +629,7 @@ void do_cmd_options(PlayerType *player_ptr)
             break;
         }
         case '?':
-            FileDisplayer().display(player_ptr->name, true, _("joption.txt", "option.txt"), 0, 0);
+            FileDisplayer(player_ptr->name).display(true, _("joption.txt", "option.txt"), 0, 0);
             term_clear();
             break;
         default: {
@@ -750,7 +750,7 @@ void do_cmd_options_aux(PlayerType *player_ptr, game_option_types page, concptr 
             break;
         }
         case '?': {
-            FileDisplayer().display(player_ptr->name, true, std::string(_("joption.txt#", "option.txt#")).append(option_info[opt[k]].o_text), 0, 0);
+            FileDisplayer(player_ptr->name).display(true, std::string(_("joption.txt#", "option.txt#")).append(option_info[opt[k]].o_text), 0, 0);
             term_clear();
             break;
         }

--- a/src/cmd-io/cmd-help.cpp
+++ b/src/cmd-io/cmd-help.cpp
@@ -12,6 +12,6 @@
 void do_cmd_help(PlayerType *player_ptr)
 {
     screen_save();
-    FileDisplayer().display(player_ptr->name, true, _("jhelp.hlp", "help.hlp"), 0, 0);
+    FileDisplayer(player_ptr->name).display(true, _("jhelp.hlp", "help.hlp"), 0, 0);
     screen_load();
 }

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -134,7 +134,7 @@ static void show_file_aux_line(std::string_view str, int cy, std::string_view sh
  * </pre>
  * @todo 表示とそれ以外を分割する
  */
-void FileDisplayer::display(std::string_view player_name, bool show_version, std::string_view name_with_tag, int initial_line, uint32_t mode, std::string_view what)
+void FileDisplayer::display(bool show_version, std::string_view name_with_tag, int initial_line, uint32_t mode, std::string_view what)
 {
     TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, std::nullopt);
 
@@ -328,7 +328,7 @@ void FileDisplayer::display(std::string_view player_name, bool show_version, std
         switch (skey) {
         case '?':
             if (name != _("jhelpinfo.txt", "helpinfo.txt")) {
-                this->display(player_name, true, _("jhelpinfo.txt", "helpinfo.txt"), 0, mode);
+                this->display(true, _("jhelpinfo.txt", "helpinfo.txt"), 0, mode);
             }
 
             break;
@@ -404,7 +404,7 @@ void FileDisplayer::display(std::string_view player_name, bool show_version, std
                 break;
             }
 
-            this->display(player_name, true, *ask_result, 0, mode);
+            this->display(true, *ask_result, 0, mode);
             if (this->is_terminated) {
                 skey = 'q';
             }
@@ -467,7 +467,7 @@ void FileDisplayer::display(std::string_view player_name, bool show_version, std
 
             if ((key > -1) && hook[key][0]) {
                 /* Recurse on that file */
-                this->display(player_name, true, hook[key], 0, mode);
+                this->display(true, hook[key], 0, mode);
                 if (this->is_terminated) {
                     skey = 'q';
                 }
@@ -491,7 +491,7 @@ void FileDisplayer::display(std::string_view player_name, bool show_version, std
                 break;
             }
 
-            fprintf(ffp, "%s: %s\n", player_name.data(), !what.empty() ? what.data() : caption_str.data());
+            fprintf(ffp, "%s: %s\n", this->player_name.data(), !what.empty() ? what.data() : caption_str.data());
             char buff[1024]{};
             while (!angband_fgets(fff, buff, sizeof(buff))) {
                 angband_fputs(ffp, buff, 80);

--- a/src/core/show-file.h
+++ b/src/core/show-file.h
@@ -1,16 +1,21 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <string_view>
 
 class FileDisplayer {
 public:
-    FileDisplayer() = default;
+    FileDisplayer(std::string_view player_name)
+        : player_name(player_name)
+    {
+    }
 
-    void display(std::string_view player_name, bool show_version, std::string_view name_with_tag, int initial_line, uint32_t mode, std::string_view what = "");
+    void display(bool show_version, std::string_view name_with_tag, int initial_line, uint32_t mode, std::string_view what = "");
 
 private:
     bool is_terminated = false;
+    std::string player_name;
 };
 
 void str_tolower(char *str);

--- a/src/knowledge/knowledge-alliance.cpp
+++ b/src/knowledge/knowledge-alliance.cpp
@@ -73,6 +73,6 @@ void do_cmd_knowledge_alliance(PlayerType *player_ptr, bool detail)
     }
 
     angband_fclose(fff);
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("各アライアンス情報", "Information of all alliances"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("各アライアンス情報", "Information of all alliances"));
     fd_kill(file_name);
 }

--- a/src/knowledge/knowledge-autopick.cpp
+++ b/src/knowledge/knowledge-autopick.cpp
@@ -73,6 +73,6 @@ void do_cmd_knowledge_autopick(PlayerType *player_ptr)
 
     angband_fclose(fff);
 
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("自動拾い/破壊 設定リスト", "Auto-picker/Destroyer"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("自動拾い/破壊 設定リスト", "Auto-picker/Destroyer"));
     fd_kill(file_name);
 }

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -67,7 +67,7 @@ void do_cmd_knowledge_weapon_exp(PlayerType *player_ptr)
     }
 
     angband_fclose(fff);
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("武器の経験値", "Weapon Proficiency"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("武器の経験値", "Weapon Proficiency"));
     fd_kill(file_name);
 }
 
@@ -159,7 +159,7 @@ void do_cmd_knowledge_spell_exp(PlayerType *player_ptr)
     }
 
     angband_fclose(fff);
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("魔法の経験値", "Spell Proficiency"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("魔法の経験値", "Spell Proficiency"));
     fd_kill(file_name);
 }
 
@@ -196,6 +196,6 @@ void do_cmd_knowledge_skill_exp(PlayerType *player_ptr)
     }
 
     angband_fclose(fff);
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("技能の経験値", "Miscellaneous Proficiency"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("技能の経験値", "Miscellaneous Proficiency"));
     fd_kill(file_name);
 }

--- a/src/knowledge/knowledge-features.cpp
+++ b/src/knowledge/knowledge-features.cpp
@@ -391,6 +391,6 @@ void do_cmd_knowledge_dungeon(PlayerType *player_ptr)
     }
 
     angband_fclose(fff);
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("今までに入ったダンジョン", "Dungeon"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("今までに入ったダンジョン", "Dungeon"));
     fd_kill(file_name);
 }

--- a/src/knowledge/knowledge-incident.cpp
+++ b/src/knowledge/knowledge-incident.cpp
@@ -72,6 +72,6 @@ void do_cmd_knowledge_incident(PlayerType *player_ptr)
     }
     angband_fclose(fff);
 
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("これまでの出来事", "Incidents"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("これまでの出来事", "Incidents"));
     fd_kill(file_name);
 }

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -293,6 +293,6 @@ void do_cmd_knowledge_inventory(PlayerType *player_ptr)
     }
 
     angband_fclose(fff);
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("*鑑定*済み武器/防具の耐性リスト", "Resistances of *identified* equipment"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("*鑑定*済み武器/防具の耐性リスト", "Resistances of *identified* equipment"));
     fd_kill(file_name);
 }

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -111,7 +111,7 @@ void do_cmd_knowledge_artifacts(PlayerType *player_ptr)
     }
 
     angband_fclose(fff);
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("既知の伝説のアイテム", "Artifacts Seen"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("既知の伝説のアイテム", "Artifacts Seen"));
     fd_kill(file_name);
 }
 

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -135,7 +135,7 @@ void do_cmd_knowledge_pets(PlayerType *player_ptr)
     fprintf(fff, _(" 維持コスト: %d%% MP\n", "   Upkeep: %d%% mana.\n"), show_upkeep);
 
     angband_fclose(fff);
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("現在のペット", "Current Pets"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("現在のペット", "Current Pets"));
     fd_kill(file_name);
 }
 
@@ -238,7 +238,7 @@ void do_cmd_knowledge_kill_count(PlayerType *player_ptr)
 #endif
 
     angband_fclose(fff);
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("倒した敵の数", "Kill Count"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("倒した敵の数", "Kill Count"));
     fd_kill(file_name);
 }
 
@@ -501,6 +501,6 @@ void do_cmd_knowledge_bounty(PlayerType *player_ptr)
     }
 
     angband_fclose(fff);
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("賞金首の一覧", "Wanted monsters"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("賞金首の一覧", "Wanted monsters"));
     fd_kill(file_name);
 }

--- a/src/knowledge/knowledge-mutations.cpp
+++ b/src/knowledge/knowledge-mutations.cpp
@@ -25,6 +25,6 @@ void do_cmd_knowledge_mutations(PlayerType *player_ptr)
     dump_mutations(player_ptr, fff);
     angband_fclose(fff);
 
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("突然変異", "Mutations"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("突然変異", "Mutations"));
     fd_kill(file_name);
 }

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -331,6 +331,6 @@ void do_cmd_knowledge_quests(PlayerType *player_ptr)
     }
 
     angband_fclose(fff);
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("クエスト達成状況", "Quest status"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("クエスト達成状況", "Quest status"));
     fd_kill(file_name);
 }

--- a/src/knowledge/knowledge-self.cpp
+++ b/src/knowledge/knowledge-self.cpp
@@ -44,7 +44,7 @@ void do_cmd_knowledge_virtues(PlayerType *player_ptr)
     fprintf(fff, _("現在の属性 : %s\n\n", "Your alignment : %s\n\n"), alg.data());
     dump_virtues(player_ptr, fff);
     angband_fclose(fff);
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("八つの徳", "Virtues"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("八つの徳", "Virtues"));
     fd_kill(file_name);
 }
 
@@ -176,7 +176,7 @@ void do_cmd_knowledge_stat(PlayerType *player_ptr)
     dump_winner_classes(fff);
     angband_fclose(fff);
 
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, _("自分に関する情報", "HP-rate & Max stat"));
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, _("自分に関する情報", "HP-rate & Max stat"));
     fd_kill(file_name);
 }
 
@@ -198,7 +198,7 @@ void do_cmd_knowledge_home(PlayerType *player_ptr)
     const auto &store = towns_info[1].stores[StoreSaleType::HOME];
     if (store.stock_num == 0) {
         angband_fclose(fff);
-        FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, home_inventory);
+        FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, home_inventory);
         fd_kill(file_name);
         return;
     }
@@ -234,6 +234,6 @@ void do_cmd_knowledge_home(PlayerType *player_ptr)
 
     fprintf(fff, "\n\n");
     angband_fclose(fff);
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, home_inventory);
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, home_inventory);
     fd_kill(file_name);
 }

--- a/src/knowledge/knowledge-uniques.cpp
+++ b/src/knowledge/knowledge-uniques.cpp
@@ -162,6 +162,6 @@ void do_cmd_knowledge_uniques(PlayerType *player_ptr, bool is_alive)
     display_uniques(unique_list_ptr, fff);
     angband_fclose(fff);
     concptr title_desc = unique_list_ptr->is_alive ? _("まだ生きているユニーク・モンスター", "Alive Uniques") : _("もう撃破したユニーク・モンスター", "Dead Uniques");
-    FileDisplayer().display(player_ptr->name, true, file_name, 0, 0, title_desc);
+    FileDisplayer(player_ptr->name).display(true, file_name, 0, 0, title_desc);
     fd_kill(file_name);
 }

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -178,7 +178,7 @@ bool arena_comm(PlayerType *player_ptr, int cmd)
         return false;
     case BACT_ARENA_RULES:
         screen_save();
-        FileDisplayer().display(player_ptr->name, true, _("arena_j.txt", "arena.txt"), 0, 0);
+        FileDisplayer(player_ptr->name).display(true, _("arena_j.txt", "arena.txt"), 0, 0);
         screen_load();
         return false;
     default:

--- a/src/market/play-gamble.cpp
+++ b/src/market/play-gamble.cpp
@@ -21,7 +21,7 @@ void gamble_comm(PlayerType *player_ptr, int cmd)
 {
     screen_save();
     if (cmd == BACT_GAMBLE_RULES) {
-        FileDisplayer().display(player_ptr->name, true, _("jgambling.txt", "gambling.txt"), 0, 0);
+        FileDisplayer(player_ptr->name).display(true, _("jgambling.txt", "gambling.txt"), 0, 0);
         screen_load();
         return;
     }

--- a/src/object-use/read/parchment-read-executor.cpp
+++ b/src/object-use/read/parchment-read-executor.cpp
@@ -38,7 +38,7 @@ bool ParchmentReadExecutor::read()
     auto path = path_build(ANGBAND_DIR_FILE, "books");
     path.append(ss.str());
     const auto &filename = path.string();
-    FileDisplayer().display(this->player_ptr->name, true, filename, 0, 0, item_name);
+    FileDisplayer(this->player_ptr->name).display(true, filename, 0, 0, item_name);
     screen_load();
     return false;
 }


### PR DESCRIPTION
…減らした

プレイヤー名は当該メソッドの中で値の変更がなく、再帰呼び出しする度に同じ引数を入れる必要がないと判断した