### PR TITLE
変愚「[Fix] 魔法の笛とモンスター・ボールが発動できない #4143」のマージ

### DIFF
--- a/lib/edit/BaseitemDefinitions.jsonc
+++ b/lib/edit/BaseitemDefinitions.jsonc
@@ -12123,7 +12123,8 @@
       "hit_bonus": 0,
       "damage_bonus": 0,
       "ac_bonus": 0,
-      "allocations": [{ "depth": 15, "rarity": 4 }]
+      "allocations": [{ "depth": 15, "rarity": 4 }],
+      "activate": "CAPTURE_MONSTER"
     },
     {
       "id": 594,
@@ -13266,7 +13267,8 @@
       "level": 15,
       "weight": 3,
       "cost": 1000,
-      "allocations": [{ "depth": 15, "rarity": 2 }]
+      "allocations": [{ "depth": 15, "rarity": 2 }],
+      "activate": "WHISTLE"
     },
     {
       "id": 652,

--- a/schema/ArtifactDefinitions.schema.json
+++ b/schema/ArtifactDefinitions.schema.json
@@ -272,7 +272,9 @@
                             "DETECT_TREASURE",
                             "HERO_BLESS",
                             "CREATE_AMMO",
-                            "DISPEL_MAGIC"
+                            "DISPEL_MAGIC",
+                            "WHISTLE",
+                            "CAPTURE_MONSTER"
                         ]
                     },
                     "flags": {

--- a/schema/BaseitemDefinitions.schema.json
+++ b/schema/BaseitemDefinitions.schema.json
@@ -310,7 +310,9 @@
                             "DETECT_TREASURE",
                             "HERO_BLESS",
                             "CREATE_AMMO",
-                            "DISPEL_MAGIC"
+                            "DISPEL_MAGIC",
+                            "WHISTLE",
+                            "CAPTURE_MONSTER"
                         ]
                     },
                     "flags": {

--- a/src/artifact/random-art-effects.h
+++ b/src/artifact/random-art-effects.h
@@ -143,6 +143,9 @@ enum class RandomArtActType : short {
     DISPEL_MAGIC = 144,
     DESTRUCTION = 145,
     /* 143 - 245 unused */
+    /* 143 - 243 unused */
+    WHISTLE = 244,
+    CAPTURE_MONSTER = 245,
     FALLING_STAR = 246,
     STRAIN_HASTE = 247,
     TELEPORT_LEVEL = 248,

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -454,3 +454,34 @@ bool activate_dispel_magic(PlayerType *player_ptr)
     dispel_monster_status(player_ptr, m_idx);
     return true;
 }
+
+bool activate_whistle(PlayerType *player_ptr, const ItemEntity &item)
+{
+    if (item.bi_key.tval() != ItemKindType::WHISTLE) {
+        return false;
+    }
+
+    if (music_singing_any(player_ptr)) {
+        stop_singing(player_ptr);
+    }
+
+    if (SpellHex(player_ptr).is_spelling_any()) {
+        (void)SpellHex(player_ptr).stop_all_spells();
+    }
+
+    const auto &floor = *player_ptr->current_floor_ptr;
+    std::vector<short> pet_index;
+    for (short pet_indice = floor.m_max - 1; pet_indice >= 1; pet_indice--) {
+        const auto &monster = floor.m_list[pet_indice];
+        if (monster.is_pet() && (player_ptr->riding != pet_indice)) {
+            pet_index.push_back(pet_indice);
+        }
+    }
+
+    std::stable_sort(pet_index.begin(), pet_index.end(), [&floor](auto x, auto y) { return floor.order_pet_whistle(x, y); });
+    for (auto pet_indice : pet_index) {
+        teleport_monster_to(player_ptr, pet_indice, player_ptr->y, player_ptr->x, 100, TELEPORT_PASSIVE);
+    }
+
+    return true;
+}

--- a/src/object-activation/activation-others.h
+++ b/src/object-activation/activation-others.h
@@ -46,3 +46,4 @@ bool activate_detect_treasure(PlayerType *player_ptr);
 bool activate_create_ammo(PlayerType *player_ptr);
 bool activate_dispel_magic(PlayerType *player_ptr);
 bool activate_huge_stinking_storm(PlayerType *player_ptr);
+bool activate_whistle(PlayerType *player_ptr, const ItemEntity &item);

--- a/src/object-activation/activation-switcher.cpp
+++ b/src/object-activation/activation-switcher.cpp
@@ -21,6 +21,7 @@
 #include "specific-object/blade-turner.h"
 #include "specific-object/bloody-moon.h"
 #include "specific-object/death-crimson.h"
+#include "specific-object/monster-ball.h"
 #include "specific-object/muramasa.h"
 #include "specific-object/ring-of-power.h"
 #include "specific-object/stone-of-lore.h"
@@ -388,6 +389,10 @@ bool switch_activation(PlayerType *player_ptr, ItemEntity **o_ptr_ptr, const Ran
         return destroy_area(player_ptr, player_ptr->y, player_ptr->x, (13) + randint0(5), false);
     case RandomArtActType::HUGE_STINKING_STORM:
         return activate_huge_stinking_storm(player_ptr);
+    case RandomArtActType::WHISTLE:
+        return activate_whistle(player_ptr, *o_ptr);
+    case RandomArtActType::CAPTURE_MONSTER:
+        return exe_monster_capture(player_ptr, *o_ptr);
     default:
         msg_format(_("Unknown activation effect: %d.", "Unknown activation effect: %d."), enum2i(index));
         return false;

--- a/src/object-enchant/activation-info-table.cpp
+++ b/src/object-enchant/activation-info-table.cpp
@@ -155,6 +155,8 @@ const std::vector<ActivationType> activation_info = {
     { "DISPEL_MAGIC", RandomArtActType::DISPEL_MAGIC, 10, 10000, 50, 50, _("魔力消去", "Dispel Magic") },
     { "DESTRUCTION", RandomArtActType::DESTRUCTION, 10, 30000, 50, 50, _("*破壊*", "*Destruction*") },
     { "HUGE_STINKING_STORM", RandomArtActType::HUGE_STINKING_STORM, 40, 25000, 200, 200, _("超巨大悪臭嵐", "huge stinking storm") },
+    { "WHISTLE", RandomArtActType::WHISTLE, 0, 0, 100, 100, _("ペット呼び寄せ", "call pet") },
+    { "CAPTURE_MONSTER", RandomArtActType::CAPTURE_MONSTER, 0, 0, 0, 0, _("モンスターを捕える、又は解放する。", "captures or releases a monster.") },
 };
 
 std::optional<std::string> ActivationType::build_timeout_description() const

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -523,22 +523,6 @@ bool BaseitemKey::should_refuse_enchant() const
     return *this == BaseitemKey(ItemKindType::SWORD, SV_POISON_NEEDLE);
 }
 
-/*!
- * @brief ベースアイテムが発動効果を持つ時、その記述を生成する
- * @return 発動効果
- */
-std::string BaseitemKey::explain_activation() const
-{
-    switch (this->type_value) {
-    case ItemKindType::WHISTLE:
-        return _("ペット呼び寄せ : 100+d100ターン毎", "call pet every 100+d100 turns");
-    case ItemKindType::CAPTURE:
-        return _("モンスターを捕える、又は解放する。", "captures or releases a monster.");
-    default:
-        return _("何も起きない", "Nothing");
-    }
-}
-
 bool BaseitemKey::is_convertible() const
 {
     auto is_convertible = this->is(ItemKindType::JUNK) || this->is(ItemKindType::SKELETON);

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -79,7 +79,6 @@ public:
     bool is_armour() const;
     bool is_cross_bow() const;
     bool should_refuse_enchant() const;
-    std::string explain_activation() const;
     bool is_convertible() const;
     bool is_fuel() const;
     bool is_lance() const;

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -903,7 +903,7 @@ std::string ItemEntity::explain_activation() const
         return this->build_activation_description();
     }
 
-    return this->bi_key.explain_activation();
+    return _("何も起きない", "Nothing");
 }
 
 std::string ItemEntity::build_timeout_description(const ActivationType &act) const


### PR DESCRIPTION
BaseitemDefinitionsをjson化した時に、元のtxt形式のデータでACTIVATE フラグだけ持って発動内容がセットされていない魔法の笛と
モンスター・ボールが発動できなくなっていた。
この2つだけ例外的にItemKindTypeによる判定を行っているというのが
そもそもあまりよろしくないので、発動種別としてWHISTLEとCAPTURE_MONSTERを
追加し、この2つのアイテムにそれぞれセットする。