### PR TITLE
変愚「[Fix] #4209 モンスター撃破時に経験値が入らない不具合を修正した」のマージ

### DIFF
--- a/src/monster/monster-damage.h
+++ b/src/monster/monster-damage.h
@@ -27,7 +27,7 @@ private:
     AttributeFlags attribute_flags{};
     void get_exp_from_mon(const MonsterEntity &monster, int exp_dam);
     bool genocide_chaos_patron();
-    bool process_dead_exp_virtue(std::string_view note, const MonsterEntity &monster);
+    bool process_dead_exp_virtue(std::string_view note, const MonsterEntity &exp_mon);
     void death_special_flag_monster();
     void death_unique_monster(MonsterRaceId r_idx);
     void increase_kill_numbers();


### PR DESCRIPTION
3.0.1.14Hotfix内容