### PR TITLE
変愚「monraces_info からMonsterRaceInfo を取得している箇所をMonraceList に差し替えた その1 #4221」のマージ

### DIFF
--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -162,8 +162,8 @@ void init_dungeon_quests(PlayerType *player_ptr)
         auto &quest = quests.get_quest(quest_id);
         quest.status = QuestStatusType::TAKEN;
         determine_random_questor(player_ptr, quest);
-        auto &quest_monrace = monraces_info[quest.r_idx];
-        quest_monrace.misc_flags.set(MonsterMiscType::QUESTOR);
+        auto &monrace = quest.get_bounty();
+        monrace.misc_flags.set(MonsterMiscType::QUESTOR);
         quest.max_num = 1;
     }
 

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -117,8 +117,8 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
 
     disturb(player_ptr, true, true);
     const auto quest_id = floor.get_quest_id();
-    const auto &quests = QuestList::get_instance();
-    auto &monrace_questor = monraces_info[quests.get_quest(quest_id).r_idx];
+    auto &quests = QuestList::get_instance();
+    auto &monrace_questor = quests.get_quest(quest_id).get_bounty();
     if (inside_quest(quest_id)) {
         monrace_questor.misc_flags.set(MonsterMiscType::QUESTOR);
     }

--- a/src/dungeon/quest-monster-placer.cpp
+++ b/src/dungeon/quest-monster-placer.cpp
@@ -32,8 +32,8 @@ bool place_quest_monsters(PlayerType *player_ptr)
             continue;
         }
 
-        auto &monrace = monraces_info[quest.r_idx];
-        if (monrace.kind_flags.has(MonsterKindType::UNIQUE) && (monrace.cur_num >= monrace.mob_num)) {
+        const auto &monrace = quest.get_bounty();
+        if (monrace.kind_flags.has(MonsterKindType::UNIQUE) && (monrace.cur_num >= monrace.max_num)) {
             continue;
         }
 

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -123,52 +123,52 @@ const QuestType &QuestList::get_quest(QuestId id) const
     return this->quests.at(id);
 }
 
-QuestList::iterator QuestList::begin()
+std::map<QuestId, QuestType>::iterator QuestList::begin()
 {
     return this->quests.begin();
 }
 
-QuestList::const_iterator QuestList::begin() const
+std::map<QuestId, QuestType>::const_iterator QuestList::begin() const
 {
     return this->quests.cbegin();
 }
 
-QuestList::iterator QuestList::end()
+std::map<QuestId, QuestType>::iterator QuestList::end()
 {
     return this->quests.end();
 }
 
-QuestList::const_iterator QuestList::end() const
+std::map<QuestId, QuestType>::const_iterator QuestList::end() const
 {
     return this->quests.cend();
 }
 
-QuestList::reverse_iterator QuestList::rbegin()
+std::map<QuestId, QuestType>::reverse_iterator QuestList::rbegin()
 {
     return this->quests.rbegin();
 }
 
-QuestList::const_reverse_iterator QuestList::rbegin() const
+std::map<QuestId, QuestType>::const_reverse_iterator QuestList::rbegin() const
 {
     return this->quests.crbegin();
 }
 
-QuestList::reverse_iterator QuestList::rend()
+std::map<QuestId, QuestType>::reverse_iterator QuestList::rend()
 {
     return this->quests.rend();
 }
 
-QuestList::const_reverse_iterator QuestList::rend() const
+std::map<QuestId, QuestType>::const_reverse_iterator QuestList::rend() const
 {
     return this->quests.crend();
 }
 
-QuestList::iterator QuestList::find(QuestId id)
+std::map<QuestId, QuestType>::iterator QuestList::find(QuestId id)
 {
     return this->quests.find(id);
 }
 
-QuestList::const_iterator QuestList::find(QuestId id) const
+std::map<QuestId, QuestType>::const_iterator QuestList::find(QuestId id) const
 {
     return this->quests.find(id);
 }

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -78,6 +78,15 @@ ArtifactType &QuestType::get_reward() const
  * @brief 討伐対象モンスターを返す. いなければプレイヤー (無効値の意)
  * @return 討伐対象モンスター
  */
+MonsterRaceInfo &QuestType::get_bounty()
+{
+    return MonraceList::get_instance().get_monrace(this->r_idx);
+}
+
+/*!
+ * @brief 討伐対象モンスターを返す. いなければプレイヤー (無効値の意)
+ * @return 討伐対象モンスター
+ */
 const MonsterRaceInfo &QuestType::get_bounty() const
 {
     return MonraceList::get_instance().get_monrace(this->r_idx);
@@ -325,7 +334,7 @@ void quest_discovery(QuestId quest_id)
 {
     auto &quests = QuestList::get_instance();
     auto &quest = quests.get_quest(quest_id);
-    const auto &monrace = monraces_info[quest.r_idx];
+    const auto &monrace = quest.get_bounty();
     if (!inside_quest(quest_id)) {
         return;
     }
@@ -385,7 +394,7 @@ void leave_quest_check(PlayerType *player_ptr)
         quest.get_reward().gen_flags.reset(ItemGenerationTraitType::QUESTITEM);
         break;
     case QuestKindType::RANDOM:
-        monraces_info[quest.r_idx].misc_flags.reset(MonsterMiscType::QUESTOR);
+        quest.get_bounty().misc_flags.reset(MonsterMiscType::QUESTOR);
         FloorChangeModesStore::get_instace()->set(FloorChangeMode::NO_RETURN);
         break;
     default:

--- a/src/dungeon/quest.h
+++ b/src/dungeon/quest.h
@@ -127,6 +127,7 @@ public:
     static bool is_fixed(QuestId quest_idx);
     bool has_reward() const;
     ArtifactType &get_reward() const;
+    MonsterRaceInfo &get_bounty();
     const MonsterRaceInfo &get_bounty() const;
 };
 

--- a/src/dungeon/quest.h
+++ b/src/dungeon/quest.h
@@ -132,10 +132,6 @@ public:
 
 class QuestList final {
 public:
-    using iterator = std::map<QuestId, QuestType>::iterator;
-    using reverse_iterator = std::map<QuestId, QuestType>::reverse_iterator;
-    using const_iterator = std::map<QuestId, QuestType>::const_iterator;
-    using const_reverse_iterator = std::map<QuestId, QuestType>::const_reverse_iterator;
     QuestList(const QuestList &) = delete;
     QuestList(QuestList &&) = delete;
     QuestList &operator=(const QuestList &) = delete;
@@ -145,16 +141,16 @@ public:
     void initialize();
     QuestType &get_quest(QuestId id);
     const QuestType &get_quest(QuestId id) const;
-    iterator begin();
-    const_iterator begin() const;
-    iterator end();
-    const_iterator end() const;
-    reverse_iterator rbegin();
-    const_reverse_iterator rbegin() const;
-    reverse_iterator rend();
-    const_reverse_iterator rend() const;
-    iterator find(QuestId id);
-    const_iterator find(QuestId id) const;
+    std::map<QuestId, QuestType>::iterator begin();
+    std::map<QuestId, QuestType>::const_iterator begin() const;
+    std::map<QuestId, QuestType>::iterator end();
+    std::map<QuestId, QuestType>::const_iterator end() const;
+    std::map<QuestId, QuestType>::reverse_iterator rbegin();
+    std::map<QuestId, QuestType>::const_reverse_iterator rbegin() const;
+    std::map<QuestId, QuestType>::reverse_iterator rend();
+    std::map<QuestId, QuestType>::const_reverse_iterator rend() const;
+    std::map<QuestId, QuestType>::iterator find(QuestId id);
+    std::map<QuestId, QuestType>::const_iterator find(QuestId id) const;
     size_t size() const;
     std::vector<QuestId> get_sorted_quest_ids() const;
 

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -223,9 +223,9 @@ static bool parse_qtw_QQ(QuestType *q_ptr, char **zz, int num)
         q_ptr->flags = atoi(zz[10]);
     }
 
-    auto &r_ref = monraces_info[q_ptr->r_idx];
-    if (r_ref.kind_flags.has(MonsterKindType::UNIQUE)) {
-        r_ref.misc_flags.set(MonsterMiscType::QUESTOR);
+    auto &monrace = q_ptr->get_bounty();
+    if (monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
+        monrace.misc_flags.set(MonsterMiscType::QUESTOR);
     }
 
     if (fa_id == FixedArtifactId::NONE) {

--- a/src/floor/object-allocator.cpp
+++ b/src/floor/object-allocator.cpp
@@ -94,8 +94,8 @@ bool alloc_stairs(PlayerType *player_ptr, FEAT_IDX feat, int num, int walls)
         auto quest_id = floor.get_quest_id();
         const auto &quests = QuestList::get_instance();
         if (floor.dun_level > 1 && inside_quest(quest_id)) {
-            const auto &monrace = monraces_info[quests.get_quest(quest_id).r_idx];
-            if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) || (monrace.mob_num > 0)) {
+            const auto &monrace = quests.get_quest(quest_id).get_bounty();
+            if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) || (monrace.max_num > 0)) {
                 return true;
             }
         }

--- a/src/io/write-diary.cpp
+++ b/src/io/write-diary.cpp
@@ -217,12 +217,12 @@ int exe_write_diary_quest(PlayerType *player_ptr, DiaryKind dk, QuestId quest_id
     }
     case DiaryKind::RAND_QUEST_C: {
         constexpr auto fmt = _(" %2d:%02d %20s ランダムクエスト(%s)を達成した。\n", " %2d:%02d %20s completed random quest '%s'\n");
-        fprintf(fff, fmt, hour, min, note_level.data(), monraces_info[quest.r_idx].name.data());
+        fprintf(fff, fmt, hour, min, note_level.data(), quest.get_bounty().name.data());
         break;
     }
     case DiaryKind::RAND_QUEST_F: {
         constexpr auto fmt = _(" %2d:%02d %20s ランダムクエスト(%s)から逃げ出した。\n", " %2d:%02d %20s ran away from quest '%s'.\n");
-        fprintf(fff, fmt, hour, min, note_level.data(), monraces_info[quest.r_idx].name.data());
+        fprintf(fff, fmt, hour, min, note_level.data(), quest.get_bounty().name.data());
         break;
     }
     case DiaryKind::TO_QUEST: {

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -83,7 +83,7 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
             if (quest.status == QuestStatusType::TAKEN || quest.status == QuestStatusType::STAGE_COMPLETED) {
                 switch (quest.type) {
                 case QuestKindType::KILL_LEVEL: {
-                    const auto &monrace = monraces_info[quest.r_idx];
+                    const auto &monrace = quest.get_bounty();
                     if (quest.max_num > 1) {
 #ifdef JP
                         note = format(" - %d 体の%sを倒す。(あと %d 体)", (int)quest.max_num, monrace.name.data(), (int)(quest.max_num - quest.cur_num));
@@ -151,7 +151,7 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
             continue;
         }
 
-        const auto &monrace = monraces_info[quest.r_idx];
+        const auto &monrace = quest.get_bounty();
         if (quest.max_num <= 1) {
             constexpr auto mes = _("  %s (%d 階) - %sを倒す。\n", "  %s (Dungeon level: %d)\n  Kill %s.\n");
             rand_tmp_str = format(mes, quest.name.data(), (int)quest.level, monrace.name.data());
@@ -210,7 +210,7 @@ static bool do_cmd_knowledge_quests_aux(PlayerType *player_ptr, FILE *fff, Quest
         return true;
     }
 
-    auto name = str_separate(monraces_info[quest.r_idx].name, 35);
+    const auto name = str_separate(quest.get_bounty().name, 35);
     if (quest.complev == 0) {
         constexpr auto mes = _("  %-35s (%3d階)            -   不戦勝 - %s\n", "  %-35s (Dungeon level: %3d) - Unearned - %s\n");
         fprintf(fff, mes, name.front().data(), (int)quest.level, playtime_str.data());
@@ -286,7 +286,7 @@ static void do_cmd_knowledge_quests_wiz_random(FILE *fff)
         if ((quest.type == QuestKindType::RANDOM) && (quest.status == QuestStatusType::TAKEN)) {
             total++;
             constexpr auto mes = _("  %s (%d階, %s)\n", "  %s (%d, %s)\n");
-            fprintf(fff, mes, quest.name.data(), (int)quest.level, monraces_info[quest.r_idx].name.data());
+            fprintf(fff, mes, quest.name.data(), (int)quest.level, quest.get_bounty().name.data());
         }
     }
 

--- a/src/load/dungeon-loader.cpp
+++ b/src/load/dungeon-loader.cpp
@@ -124,9 +124,9 @@ static errr rd_dungeon(PlayerType *player_ptr)
 errr restore_dungeon(PlayerType *player_ptr)
 {
     if (player_ptr->is_dead) {
-        const auto &quests = QuestList::get_instance();
+        auto &quests = QuestList::get_instance();
         for (const auto quest_id : EnumRange(QuestId::RANDOM_QUEST1, QuestId::RANDOM_QUEST10)) {
-            monraces_info[quests.get_quest(quest_id).r_idx].misc_flags.reset(MonsterMiscType::QUESTOR);
+            quests.get_quest(quest_id).get_bounty().misc_flags.reset(MonsterMiscType::QUESTOR);
         }
 
         return 0;

--- a/src/load/quest-loader.cpp
+++ b/src/load/quest-loader.cpp
@@ -114,7 +114,7 @@ void analyze_quests(PlayerType *player_ptr, const uint16_t max_quests_load, cons
         quest.dungeon = rd_byte();
 
         if (quest.status == QuestStatusType::TAKEN || quest.status == QuestStatusType::UNTAKEN) {
-            auto &monrace = monraces_info[quest.r_idx];
+            auto &monrace = quest.get_bounty();
             if (monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
                 monrace.misc_flags.set(MonsterMiscType::QUESTOR);
             }

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -44,7 +44,7 @@ void check_random_quest_auto_failure(PlayerType *player_ptr)
         quest.complev = (byte)player_ptr->lev;
         w_ptr->update_playtime();
         quest.comptime = w_ptr->play_time;
-        monraces_info[quest.r_idx].misc_flags.reset(MonsterMiscType::QUESTOR);
+        quest.get_bounty().misc_flags.reset(MonsterMiscType::QUESTOR);
     }
 }
 


### PR DESCRIPTION
廃止クエストの表示消しは馬鹿馬鹿では再度採用する可能性があるためオミット。