### PR TITLE
変愚「[Fix] 不足しているSTLヘッダのinclude文を追加 #4246」のマージ

### DIFF
--- a/src/market/building-monster.cpp
+++ b/src/market/building-monster.cpp
@@ -14,6 +14,7 @@
 #include "util/string-processor.h"
 #include "view/display-lore.h"
 #include "view/display-messages.h"
+#include <algorithm>
 
 /*!
  * @brief 施設でモンスターの情報を知るメインルーチン / research_mon -KMW-

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -30,7 +30,6 @@
 #include "util/enum-converter.h"
 #include "util/string-processor.h"
 #include <algorithm>
-#include <iostream>
 #include <sstream>
 #include <vector>
 


### PR DESCRIPTION
GCC 13においてプリコンパイルヘッダの指定無しの時にSTLヘッダのinclude
不足によりコンパイルエラーとなるファイルがあるので、必要なヘッダの
include文を追加する。