### PR TITLE
変愚「[Refactor] モンスター種族のシンボル文字による判定 #4245」のマージ 

### DIFF
--- a/src/autopick/autopick-destroyer.cpp
+++ b/src/autopick/autopick-destroyer.cpp
@@ -48,7 +48,7 @@ static bool is_leave_special_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     const auto &bi_key = o_ptr->bi_key;
     const auto tval = bi_key.tval();
     if (PlayerRace(player_ptr).equals(PlayerRaceType::BALROG)) {
-        if (o_ptr->is_corpse() && angband_strchr("pht", o_ptr->get_monrace().symbol_definition.character)) {
+        if (o_ptr->is_corpse() && o_ptr->get_monrace().symbol_char_is_any_of("pht")) {
             return false;
         }
     } else if (pc.equals(PlayerClassType::ARCHER)) {

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -444,7 +444,7 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, co
     }
 
     if (tval == ItemKindType::CORPSE) {
-        if (angband_strchr("pht", o_ptr->get_monrace().symbol_definition.character)) {
+        if (o_ptr->get_monrace().symbol_char_is_any_of("pht")) {
             entry->add(FLG_HUMAN);
         }
     }

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -305,7 +305,7 @@ bool is_autopick_match(PlayerType *player_ptr, const ItemEntity *o_ptr, const au
 
     if (entry.has(FLG_HUMAN) && o_ptr->has_monrace()) {
         const auto &monrace = o_ptr->get_monrace();
-        if ((tval != ItemKindType::CORPSE || !angband_strchr("pht", monrace.symbol_definition.character))) {
+        if (tval != ItemKindType::CORPSE || !monrace.symbol_char_is_any_of("pht")) {
             return false;
         }
     }

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -623,8 +623,8 @@ void exe_eat_food(PlayerType *player_ptr, INVENTORY_IDX i_idx)
     auto food_type = PlayerRace(player_ptr).food();
 
     /* Balrogs change humanoid corpses to energy */
-    if (food_type == PlayerRaceFoodType::CORPSE && o_ptr->is_corpse()) {
-        if (angband_strchr("pht", o_ptr->get_monrace().symbol_definition.character) != nullptr) {
+    if (food_type == PlayerRaceFoodType::CORPSE) {
+        if (o_ptr->is_corpse() && o_ptr->get_monrace().symbol_char_is_any_of("pht")) {
             const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
             msg_format(_("%sは燃え上り灰になった。精力を吸収した気がする。", "%s^ is burnt to ashes.  You absorb its vitality!"), item_name.data());
             (void)set_food(player_ptr, PY_FOOD_MAX - 1);

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -201,7 +201,7 @@ void do_cmd_knowledge_kill_count(PlayerType *player_ptr)
         }
 
 #ifdef JP
-        const auto number_of_kills = angband_strchr("pt", monrace.symbol_definition.character) ? "人" : "体";
+        const auto number_of_kills = monrace.symbol_char_is_any_of("pt") ? "人" : "体";
         fprintf(fff, "     %3d %sの %s\n", this_monster, number_of_kills, monrace.name.data());
 #else
         if (this_monster < 2) {

--- a/src/melee/melee-spell-flags-checker.cpp
+++ b/src/melee/melee-spell-flags-checker.cpp
@@ -256,7 +256,7 @@ static void check_melee_spell_special(PlayerType *player_ptr, melee_spell_type *
         return;
     }
 
-    if (ms_ptr->r_ptr->symbol_definition.character == 'B') {
+    if (ms_ptr->r_ptr->symbol_char_is_any_of("B")) {
         if ((player_ptr->pet_extra_flags & (PF_ATTACK_SPELL | PF_TELEPORT)) != (PF_ATTACK_SPELL | PF_TELEPORT)) {
             ms_ptr->ability_flags.reset(MonsterAbilityType::SPECIAL);
         }
@@ -380,7 +380,7 @@ bool check_melee_spell_set(PlayerType *player_ptr, melee_spell_type *ms_ptr)
         ms_ptr->ability_flags.reset(MonsterAbilityType::BR_LITE);
     }
 
-    if (ms_ptr->ability_flags.has(MonsterAbilityType::SPECIAL) && (ms_ptr->m_ptr->r_idx != MonsterRaceId::ROLENTO) && (ms_ptr->r_ptr->symbol_definition.character != 'B')) {
+    if (ms_ptr->ability_flags.has(MonsterAbilityType::SPECIAL) && (ms_ptr->m_ptr->r_idx != MonsterRaceId::ROLENTO) && !ms_ptr->r_ptr->symbol_char_is_any_of("B")) {
         ms_ptr->ability_flags.reset(MonsterAbilityType::SPECIAL);
     }
 

--- a/src/mind/monk-attack.cpp
+++ b/src/mind/monk-attack.cpp
@@ -147,7 +147,7 @@ static int process_monk_additional_effect(player_attack_type *pa_ptr, int *stun_
     }
 
     else if (pa_ptr->ma_ptr->effect == MA_SLOW) {
-        if (!(r_ptr->behavior_flags.has(MonsterBehaviorType::NEVER_MOVE) || angband_strchr("~#{}.UjmeEv$,DdsbBFIJQSXclnw!=?", r_ptr->symbol_definition.character))) {
+        if (!(r_ptr->behavior_flags.has(MonsterBehaviorType::NEVER_MOVE) || r_ptr->symbol_char_is_any_of("~#{}.UjmeEv$,DdsbBFIJQSXclnw!=?"))) {
             msg_format(_("%sの足首に関節蹴りをくらわした！", "You kick %s in the ankle."), pa_ptr->m_name);
             special_effect = MA_SLOW;
         } else {

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -292,7 +292,7 @@ static int decide_drop_numbers(PlayerType player, MonsterDeath *md_ptr, const bo
         drop_numbers = 0;
     }
 
-    if (!drop_item && (md_ptr->r_ptr->symbol_definition.character != '$')) {
+    if (!drop_item && !md_ptr->r_ptr->symbol_char_is_any_of("$")) {
         drop_numbers = 0;
     }
 

--- a/src/monster-floor/monster-generator.cpp
+++ b/src/monster-floor/monster-generator.cpp
@@ -379,7 +379,7 @@ bool place_random_monster(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FL
 
     auto try_become_jural = one_in_(5) || !floor.is_in_underground();
     try_become_jural &= monraces_info[monrace_id].kind_flags.has_not(MonsterKindType::UNIQUE);
-    try_become_jural &= angband_strchr("hkoptuyAHLOPTUVY", monraces_info[monrace_id].symbol_definition.character) != nullptr;
+    try_become_jural &= monraces_info[monrace_id].symbol_char_is_any_of("hkoptuyAHLOPTUVY");
     if (try_become_jural) {
         mode |= PM_JURAL;
     }

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -396,11 +396,7 @@ bool vault_aux_jelly(PlayerType *player_ptr, MonsterRaceId r_idx)
         return false;
     }
 
-    if (!angband_strchr("ijm,", monrace.symbol_definition.character)) {
-        return false;
-    }
-
-    return true;
+    return monrace.symbol_char_is_any_of("ijm,");
 }
 
 /*!
@@ -480,7 +476,7 @@ bool vault_aux_chapel_g(PlayerType *player_ptr, MonsterRaceId r_idx)
         return false;
     }
 
-    if (monrace.symbol_definition.character == 'A') {
+    if (monrace.symbol_char_is_any_of("A")) {
         return true;
     }
 
@@ -500,11 +496,7 @@ bool vault_aux_kennel(PlayerType *player_ptr, MonsterRaceId r_idx)
         return false;
     }
 
-    if (!angband_strchr("CZ", r_ptr->symbol_definition.character)) {
-        return false;
-    }
-
-    return true;
+    return r_ptr->symbol_char_is_any_of("CZ");
 }
 
 /*!
@@ -520,11 +512,7 @@ bool vault_aux_mimic(PlayerType *player_ptr, MonsterRaceId r_idx)
         return false;
     }
 
-    if (!angband_strchr("!$&(/=?[\\|][`~>+", r_ptr->symbol_definition.character)) {
-        return false;
-    }
-
-    return true;
+    return r_ptr->symbol_char_is_any_of("!$&(/=?[\\|][`~>+");
 }
 
 /*!
@@ -881,11 +869,7 @@ bool monster_hook_human(PlayerType *player_ptr, MonsterRaceId r_idx)
         return false;
     }
 
-    if (angband_strchr("pht", monrace.symbol_definition.character)) {
-        return true;
-    }
-
-    return false;
+    return monrace.symbol_char_is_any_of("pht");
 }
 
 /*!

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -277,7 +277,7 @@ MonsterSpellResult spell_RF6_SPECIAL(PlayerType *player_ptr, POSITION y, POSITIO
     case MonsterRaceId::ROLENTO:
         return spell_RF6_SPECIAL_ROLENTO(player_ptr, y, x, m_idx, t_idx, target_type);
     default:
-        if (monrace.symbol_definition.character == 'B') {
+        if (monrace.symbol_char_is_any_of("B")) {
             return spell_RF6_SPECIAL_B(player_ptr, y, x, m_idx, t_idx, target_type);
         }
 

--- a/src/mspell/summon-checker.cpp
+++ b/src/mspell/summon-checker.cpp
@@ -22,15 +22,15 @@ bool check_summon_specific(PlayerType *player_ptr, MonsterRaceId summoner_idx, M
     const auto &smonrace = monraces_info[summoner_idx];
     switch (type) {
     case SUMMON_ANT:
-        return monrace.symbol_definition.character == 'a';
+        return monrace.symbol_char_is_any_of("a");
     case SUMMON_SPIDER:
-        return monrace.symbol_definition.character == 'S';
+        return monrace.symbol_char_is_any_of("S");
     case SUMMON_HOUND:
-        return (monrace.symbol_definition.character == 'C') || (monrace.symbol_definition.character == 'Z');
+        return monrace.symbol_char_is_any_of("CZ");
     case SUMMON_HYDRA:
-        return monrace.symbol_definition.character == 'M';
+        return monrace.symbol_char_is_any_of("M");
     case SUMMON_ANGEL:
-        return (monrace.symbol_definition.character == 'A') && ((monrace.kind_flags.has(MonsterKindType::EVIL)) || (monrace.kind_flags.has(MonsterKindType::GOOD)));
+        return monrace.symbol_char_is_any_of("A") && (monrace.kind_flags.has(MonsterKindType::EVIL) || monrace.kind_flags.has(MonsterKindType::GOOD));
     case SUMMON_DEMON:
         return monrace.kind_flags.has(MonsterKindType::DEMON);
     case SUMMON_UNDEAD:
@@ -38,29 +38,29 @@ bool check_summon_specific(PlayerType *player_ptr, MonsterRaceId summoner_idx, M
     case SUMMON_DRAGON:
         return monrace.kind_flags.has(MonsterKindType::DRAGON);
     case SUMMON_HI_UNDEAD:
-        return (monrace.symbol_definition.character == 'L') || (monrace.symbol_definition.character == 'V') || (monrace.symbol_definition.character == 'W');
+        return monrace.symbol_char_is_any_of("LVW");
     case SUMMON_HI_DRAGON:
-        return monrace.symbol_definition.character == 'D';
+        return monrace.symbol_char_is_any_of("D");
     case SUMMON_HI_DEMON:
-        return ((monrace.symbol_definition.character == 'U') || (monrace.symbol_definition.character == 'H') || (monrace.symbol_definition.character == 'B')) && (monrace.kind_flags.has(MonsterKindType::DEMON));
+        return monrace.symbol_char_is_any_of("UHB") && monrace.kind_flags.has(MonsterKindType::DEMON);
     case SUMMON_AMBERITES:
         return monrace.kind_flags.has(MonsterKindType::AMBERITE);
     case SUMMON_UNIQUE:
         return monrace.kind_flags.has(MonsterKindType::UNIQUE);
     case SUMMON_MOLD:
-        return monrace.symbol_definition.character == 'm';
+        return monrace.symbol_char_is_any_of("m");
     case SUMMON_BAT:
-        return monrace.symbol_definition.character == 'b';
+        return monrace.symbol_char_is_any_of("b");
     case SUMMON_QUYLTHULG:
-        return monrace.symbol_definition.character == 'Q';
+        return monrace.symbol_char_is_any_of("Q");
     case SUMMON_COIN_MIMIC:
-        return monrace.symbol_definition.character == '$';
+        return monrace.symbol_char_is_any_of("$");
     case SUMMON_MIMIC:
-        return (monrace.symbol_definition.character == '!') || (monrace.symbol_definition.character == '?') || (monrace.symbol_definition.character == '=') || (monrace.symbol_definition.character == '$') || (monrace.symbol_definition.character == '|');
+        return monrace.symbol_char_is_any_of("!?=$|");
     case SUMMON_GOLEM:
-        return (monrace.symbol_definition.character == 'g');
+        return monrace.symbol_char_is_any_of("g");
     case SUMMON_CYBER:
-        return (monrace.symbol_definition.character == 'U') && monrace.ability_flags.has(MonsterAbilityType::ROCKET);
+        return monrace.symbol_char_is_any_of("U") && monrace.ability_flags.has(MonsterAbilityType::ROCKET);
     case SUMMON_KIN: {
         const auto summon_kin_type = MonraceList::is_valid(summoner_idx) ? monraces_info[summoner_idx].symbol_definition.character : PlayerRace(player_ptr).get_summon_symbol();
         return (monrace.symbol_definition.character == summon_kin_type) && (r_idx != MonsterRaceId::HAGURE);
@@ -71,7 +71,7 @@ bool check_summon_specific(PlayerType *player_ptr, MonsterRaceId summoner_idx, M
         return monrace.kind_flags.has(MonsterKindType::ANIMAL);
     case SUMMON_ANIMAL_RANGER: {
         auto is_match = monrace.kind_flags.has(MonsterKindType::ANIMAL);
-        is_match &= angband_strchr("abcflqrwBCHIJKMRS", monrace.symbol_definition.character) != nullptr;
+        is_match &= monrace.symbol_char_is_any_of("abcflqrwBCHIJKMRS");
         is_match &= monrace.kind_flags.has_not(MonsterKindType::DRAGON);
         is_match &= monrace.kind_flags.has_not(MonsterKindType::EVIL);
         is_match &= monrace.kind_flags.has_not(MonsterKindType::UNDEAD);
@@ -83,7 +83,7 @@ bool check_summon_specific(PlayerType *player_ptr, MonsterRaceId summoner_idx, M
     case SUMMON_SMALL_MOAI:
         return r_idx == MonsterRaceId::SMALL_MOAI;
     case SUMMON_PYRAMID:
-        return one_in_(16) ? monrace.symbol_definition.character == 'z' : r_idx == MonsterRaceId::SCARAB;
+        return one_in_(16) ? monrace.symbol_char_is_any_of("z") : r_idx == MonsterRaceId::SCARAB;
     case SUMMON_PHANTOM:
         return (r_idx == MonsterRaceId::PHANTOM_B) || (r_idx == MonsterRaceId::PHANTOM_W);
     case SUMMON_BLUE_HORROR:
@@ -93,15 +93,15 @@ bool check_summon_specific(PlayerType *player_ptr, MonsterRaceId summoner_idx, M
     case SUMMON_LIVING:
         return monrace.has_living_flag();
     case SUMMON_HI_DRAGON_LIVING:
-        return (monrace.symbol_definition.character == 'D') && monrace.has_living_flag();
+        return monrace.symbol_char_is_any_of("D") && monrace.has_living_flag();
     case SUMMON_ELEMENTAL:
-        return monrace.symbol_definition.character == 'E';
+        return monrace.symbol_char_is_any_of("E");
     case SUMMON_VORTEX:
-        return monrace.symbol_definition.character == 'v';
+        return monrace.symbol_char_is_any_of("v");
     case SUMMON_HYBRID:
-        return monrace.symbol_definition.character == 'H';
+        return monrace.symbol_char_is_any_of("H");
     case SUMMON_BIRD:
-        return monrace.symbol_definition.character == 'B';
+        return monrace.symbol_char_is_any_of("B");
     case SUMMON_KAMIKAZE:
         return monrace.is_explodable();
     case SUMMON_KAMIKAZE_LIVING: {
@@ -122,7 +122,7 @@ bool check_summon_specific(PlayerType *player_ptr, MonsterRaceId summoner_idx, M
         return is_match;
     }
     case SUMMON_EAGLES: {
-        auto is_match = monrace.symbol_definition.character == 'B';
+        auto is_match = monrace.symbol_char_is_any_of("B");
         is_match &= monrace.wilderness_flags.has(MonsterWildernessType::WILD_MOUNTAIN);
         is_match &= monrace.wilderness_flags.has(MonsterWildernessType::WILD_ONLY);
         return is_match;
@@ -130,19 +130,19 @@ bool check_summon_specific(PlayerType *player_ptr, MonsterRaceId summoner_idx, M
     case SUMMON_PIRANHAS:
         return r_idx == MonsterRaceId::PIRANHA;
     case SUMMON_ARMAGE_GOOD:
-        return (monrace.symbol_definition.character == 'A') && (monrace.kind_flags.has(MonsterKindType::GOOD));
+        return monrace.symbol_char_is_any_of("A") && monrace.kind_flags.has(MonsterKindType::GOOD);
     case SUMMON_ARMAGE_EVIL:
-        return (monrace.kind_flags.has(MonsterKindType::DEMON)) || ((monrace.symbol_definition.character == 'A') && (monrace.kind_flags.has(MonsterKindType::EVIL)));
+        return monrace.kind_flags.has(MonsterKindType::DEMON) || (monrace.symbol_char_is_any_of("A") && monrace.kind_flags.has(MonsterKindType::EVIL));
     case SUMMON_APOCRYPHA_FOLLOWERS:
         return (r_idx == MonsterRaceId::FOLLOWER_WARRIOR) || (r_idx == MonsterRaceId::FOLLOWER_MAGE);
     case SUMMON_APOCRYPHA_DRAGONS:
-        return (monrace.symbol_definition.character == 'D') && (monrace.level >= 60) && (r_idx != MonsterRaceId::WYRM_COLOURS) && (r_idx != MonsterRaceId::ALDUIN);
+        return monrace.symbol_char_is_any_of("D") && (monrace.level >= 60) && (r_idx != MonsterRaceId::WYRM_COLOURS) && (r_idx != MonsterRaceId::ALDUIN);
     case SUMMON_VESPOID:
         return r_idx == MonsterRaceId::VESPOID;
     case SUMMON_ANTI_TIGERS: {
-        auto is_match = one_in_(32) ? (monrace.symbol_definition.character == 'P') : false;
-        is_match |= one_in_(48) ? (monrace.symbol_definition.character == 'd') : false;
-        is_match |= one_in_(16) ? (monrace.symbol_definition.character == 'l') : false;
+        auto is_match = one_in_(32) ? monrace.symbol_char_is_any_of("P") : false;
+        is_match |= one_in_(48) ? monrace.symbol_char_is_any_of("d") : false;
+        is_match |= one_in_(16) ? monrace.symbol_char_is_any_of("l") : false;
         is_match |= (r_idx == MonsterRaceId::STAR_VAMPIRE) || (r_idx == MonsterRaceId::SWALLOW) || (r_idx == MonsterRaceId::HAWK);
         is_match |= (r_idx == MonsterRaceId::LION) || (r_idx == MonsterRaceId::BUFFALO) || (r_idx == MonsterRaceId::FIGHTER) || (r_idx == MonsterRaceId::GOLDEN_EAGLE);
         is_match |= (r_idx == MonsterRaceId::SHALLOW_PUDDLE) || (r_idx == MonsterRaceId::DEEP_PUDDLE) || (r_idx == MonsterRaceId::SKY_WHALE);

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -542,7 +542,7 @@ void exe_player_attack_to_monster(PlayerType *player_ptr, POSITION y, POSITION x
     player_attack_type tmp_attack(*player_ptr->current_floor_ptr, y, x, hand, mode, fear, mdeath);
     auto pa_ptr = &tmp_attack;
 
-    const auto is_human = (pa_ptr->r_ptr->symbol_definition.character == 'p');
+    const auto is_human = pa_ptr->r_ptr->symbol_char_is_any_of("p");
     const auto is_lowlevel = (pa_ptr->r_ptr->level < (player_ptr->lev - 15));
 
     attack_classify(player_ptr, pa_ptr);
@@ -554,8 +554,8 @@ void exe_player_attack_to_monster(PlayerType *player_ptr, POSITION y, POSITION x
 
     int chance = calc_attack_quality(player_ptr, pa_ptr);
     auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
-    const auto is_zantetsu_nullified = (o_ptr->is_specific_artifact(FixedArtifactId::ZANTETSU) && (pa_ptr->r_ptr->symbol_definition.character == 'j'));
-    const auto is_ej_nullified = (o_ptr->is_specific_artifact(FixedArtifactId::EXCALIBUR_J) && (pa_ptr->r_ptr->symbol_definition.character == 'S'));
+    const auto is_zantetsu_nullified = o_ptr->is_specific_artifact(FixedArtifactId::ZANTETSU) && pa_ptr->r_ptr->symbol_char_is_any_of("j");
+    const auto is_ej_nullified = o_ptr->is_specific_artifact(FixedArtifactId::EXCALIBUR_J) && pa_ptr->r_ptr->symbol_char_is_any_of("S");
     calc_num_blow(player_ptr, pa_ptr);
 
     /* Attack once for each legal blow */

--- a/src/store/service-checker.cpp
+++ b/src/store/service-checker.cpp
@@ -104,7 +104,7 @@ static bool check_store_temple(const ItemEntity &item)
         if (monrace.kind_flags.has_not(MonsterKindType::EVIL)) {
             auto can_sell = monrace.kind_flags.has(MonsterKindType::GOOD);
             can_sell |= monrace.kind_flags.has(MonsterKindType::ANIMAL);
-            can_sell |= angband_strchr("?!", monrace.symbol_definition.character) != nullptr;
+            can_sell |= monrace.symbol_char_is_any_of("?!");
             if (can_sell) {
                 return true;
             }

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -474,7 +474,7 @@ bool ItemEntity::is_offerable() const
         return false;
     }
 
-    return angband_strchr("pht", this->get_monrace().symbol_definition.character) != nullptr;
+    return this->get_monrace().symbol_char_is_any_of("pht");
 }
 
 /*!

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -126,8 +126,7 @@ bool MonsterEntity::is_mimicry() const
     }
 
     const auto &monrace = this->get_appearance_monrace();
-    const auto mimic_symbols = "/|\\()[]=$,.!?&`#%<>+~";
-    if (angband_strchr(mimic_symbols, monrace.symbol_definition.character) == nullptr) {
+    if (monrace.symbol_char_is_any_of(R"(/|\()[]="$,.!?&`#%<>+~)")) {
         return false;
     }
 

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -60,6 +60,17 @@ bool MonsterRaceInfo::is_explodable() const
 }
 
 /*!
+ * @brief モンスターのシンボル文字が指定された文字列に含まれるかどうかを返す
+ * @param candidate_chars シンボル文字の集合の文字列。"pht" のように複数の文字を指定可能。
+ * @return モンスターのシンボル文字が candidate_chars に含まれるならばtrue
+ * @note ASCIIのみ対応。マルチバイト文字が指定された場合の動作は未定義。
+ */
+bool MonsterRaceInfo::symbol_char_is_any_of(std::string_view candidate_chars) const
+{
+    return candidate_chars.find(this->symbol_definition.character) != std::string_view::npos;
+}
+
+/*!
  * @brief モンスターを撃破した際の述語メッセージを返す
  * @return 撃破されたモンスターの述語
  */

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -24,6 +24,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <vector>
 
@@ -157,6 +158,7 @@ public:
     bool is_valid() const;
     bool has_living_flag() const;
     bool is_explodable() const;
+    bool symbol_char_is_any_of(std::string_view symbol_characters) const;
     std::string get_died_message() const;
     std::optional<bool> order_pet(const MonsterRaceInfo &other) const;
     void kill_unique();


### PR DESCRIPTION
MonsterRaceInfo::symbol_char_is_any_of() を実装し、モンスター種族の シンボル文字による判定を行っている箇所をこのメソッドで置き換える。