### PR TITLE
変愚「フラグ"PREVENT_SUDDEN_MAGIC"の廃止 #4248」のマージ

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -69,7 +69,7 @@
       "AURA_ABYSS"
 
       "NEVER_BLOW", "NEVER_MOVE", "OPEN_DOOR", "BASH_DOOR", "MOVE_BODY", "KILL_BODY", "TAKE_ITEM", "KILL_ITEM",
-      "RAND_25", "RAND_50", "STUPID", "SMART", "FRIENDLY", "PREVENT_SUDDEN_MAGIC"
+      "RAND_25", "RAND_50", "STUPID", "SMART", "FRIENDLY",
       "CHAR_CLEAR", "SHAPECHANGER", "ATTR_CLEAR", "ATTR_MULTI", "ATTR_SEMIRAND", "ATTR_ANY"
       "UNIQUE", "HUMAN", "QUANTUM", "ORC", "TROLL", "GIANT", "DRAGON", "DEMON", "UNDEAD", "EVIL",
       "ANIMAL", "AMBERITE", "GOOD", "NONLIVING", "ANGEL"
@@ -2012,7 +2012,6 @@
       "rarity": 1,
       "exp": 3,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "NEVER_BLOW",
         "STUPID",
@@ -2285,7 +2284,6 @@
       "flags": [
         "HAS_LITE_1",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "GOOD",
         "WILD_ALL",
         "DROP_SKELETON",
@@ -2341,7 +2339,6 @@
       "flags": [
         "HAS_LITE_1",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "WILD_ALL",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -4061,7 +4058,6 @@
       "flags": [
         "HAS_LITE_1",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_SKELETON",
         "DROP_CORPSE",
         "DROP_60",
@@ -4538,7 +4534,6 @@
       "flags": [
         "HAS_LITE_2",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "DROP_60",
         "WILD_ALL",
@@ -4740,7 +4735,6 @@
         "GOOD",
         "HAS_LITE_1",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_60",
         "WILD_ALL",
         "DROP_SKELETON",
@@ -5313,7 +5307,6 @@
         "GOOD",
         "HAS_LITE_2",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "WILD_ALL",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -5655,7 +5648,6 @@
       "flags": [
         "HAS_LITE_1",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "WILD_ALL",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -5946,7 +5938,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_90",
         "OPEN_DOOR",
         "BASH_DOOR",
@@ -6721,7 +6712,6 @@
         "EVIL",
         "SPEAK_ALL",
         "HAS_LITE_2",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HUMAN",
         "ONLY_ITEM",
@@ -6786,7 +6776,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SPEAK_ALL",
         "HUMAN",
@@ -7011,7 +7000,6 @@
       "flags": [
         "HAS_LITE_2",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "DROP_60",
         "DROP_SKELETON",
@@ -7058,7 +7046,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_25",
         "SELF_LITE_1",
         "ANIMAL",
@@ -7258,7 +7245,6 @@
         "WILD_ALL",
         "DROP_SKELETON",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "HAS_LITE_2",
         "HUMAN",
         "FRIENDS",
@@ -7844,7 +7830,6 @@
       "flags": [
         "BASH_DOOR",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "UNIQUE",
         "DROP_CORPSE",
         "ANIMAL",
@@ -7979,7 +7964,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_90",
         "WILD_WOOD",
         "WILD_SWAMP",
@@ -8048,7 +8032,6 @@
       ],
       "flags": [
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_CORPSE",
         "ONLY_GOLD",
         "DROP_60",
@@ -8113,7 +8096,6 @@
       ],
       "flags": [
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "DROP_CORPSE",
         "ONLY_GOLD",
@@ -8178,7 +8160,6 @@
       ],
       "flags": [
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_GOLD",
         "DROP_60",
         "DROP_1D2",
@@ -8243,7 +8224,6 @@
       ],
       "flags": [
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "DROP_CORPSE",
         "ONLY_GOLD",
@@ -8308,7 +8288,6 @@
       ],
       "flags": [
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "DROP_CORPSE",
         "ONLY_GOLD",
@@ -8879,7 +8858,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_1D2",
         "DROP_SKELETON",
@@ -8989,7 +8967,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ESCORT",
         "ESCORTS",
@@ -9681,7 +9658,6 @@
       ],
       "flags": [
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "DROP_CORPSE",
         "DROP_60",
@@ -10246,7 +10222,6 @@
       "flags": [
         "ATTR_MULTI",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_GOLD",
         "DROP_60",
         "DROP_1D2",
@@ -10373,7 +10348,6 @@
         "UNIQUE",
         "DROP_CORPSE",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "RES_WATE",
         "IM_POIS",
         "IM_ACID",
@@ -10943,7 +10917,6 @@
       "flags": [
         "WILD_SWAMP",
         "WILD_WASTE",
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_90",
         "HAS_LITE_2",
         "OPEN_DOOR",
@@ -11303,7 +11276,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_60",
         "HAS_LITE_2",
         "OPEN_DOOR",
@@ -11368,7 +11340,6 @@
       "flags": [
         "GOOD",
         "HAS_LITE_2",
-        "PREVENT_SUDDEN_MAGIC",
         "HUMAN",
         "DROP_1D2",
         "SMART",
@@ -11428,7 +11399,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_1D2",
         "SMART",
@@ -11701,7 +11671,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_25",
         "DROP_60",
         "DROP_90",
@@ -11874,7 +11843,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "BASH_DOOR",
         "DROP_SKELETON",
         "EVIL",
@@ -12033,7 +12001,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ESCORT",
         "ESCORTS",
@@ -12200,7 +12167,6 @@
       ],
       "flags": [
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_1D2",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -12272,7 +12238,6 @@
         "WILD_WOOD",
         "HAS_LITE_2",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_1D2",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -12728,7 +12693,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "WILD_WASTE",
         "RAND_50",
         "CAN_FLY",
@@ -12836,7 +12800,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_50",
         "MULTIPLY",
         "OPEN_DOOR",
@@ -13610,7 +13573,6 @@
       "rarity": 2,
       "exp": 10,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "NEVER_BLOW",
         "FRIENDS",
@@ -13792,7 +13754,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_GOLD",
         "DROP_60",
         "DROP_CORPSE",
@@ -13850,7 +13811,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "SELF_LITE_1",
         "SELF_LITE_2",
@@ -13896,7 +13856,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "BASH_DOOR",
         "HURT_LITE",
@@ -14357,7 +14316,6 @@
       ],
       "flags": [
         "HAS_LITE_1",
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "DROP_60",
         "OPEN_DOOR",
@@ -14697,7 +14655,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_50",
         "RAND_25",
         "WILD_SWAMP",
@@ -15076,7 +15033,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "RAND_25",
         "ONLY_ITEM",
@@ -15138,7 +15094,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RIDING",
         "ONLY_GOLD",
         "DROP_1D2",
@@ -15197,7 +15152,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "RAND_25",
         "ONLY_ITEM",
@@ -15315,7 +15269,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "COLD_BLOOD",
         "EMPTY_MIND",
@@ -15359,7 +15312,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "SELF_LITE_2",
         "EMPTY_MIND",
@@ -15403,7 +15355,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "SELF_LITE_2",
         "EMPTY_MIND",
@@ -15455,7 +15406,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "WILD_SHORE",
         "WILD_SWAMP",
         "ONLY_GOLD",
@@ -15773,7 +15723,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "SELF_LITE_2",
         "FRIENDS",
         "BASH_DOOR",
@@ -15829,7 +15778,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "HURT_FIRE",
         "BASH_DOOR",
@@ -15884,7 +15832,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "SELF_LITE_2",
         "FRIENDS",
         "BASH_DOOR",
@@ -15940,7 +15887,6 @@
       ],
       "flags": [
         "ATTR_SEMIRAND",
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "EMPTY_MIND",
         "COLD_BLOOD",
@@ -16000,7 +15946,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "EMPTY_MIND",
         "COLD_BLOOD",
@@ -16494,7 +16439,6 @@
       "rarity": 1,
       "exp": 70,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_BLOW",
         "RAND_50",
         "RAND_25",
@@ -16589,7 +16533,6 @@
       "rarity": 2,
       "exp": 68,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_BLOW",
         "RAND_50",
         "RAND_25",
@@ -16734,7 +16677,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_50",
         "RAND_25",
         "WILD_MOUNTAIN",
@@ -17255,7 +17197,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_GOLD",
         "DROP_60",
         "DROP_90",
@@ -17433,7 +17374,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "BASH_DOOR",
         "HURT_ROCK",
@@ -17493,7 +17433,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "CAN_FLY",
         "BASH_DOOR",
@@ -17607,7 +17546,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "BASH_DOOR",
         "CAN_SWIM",
@@ -17667,7 +17605,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "DROP_CORPSE",
         "BASH_DOOR",
@@ -17712,7 +17649,6 @@
       "rarity": 1,
       "exp": 250,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "NEVER_BLOW",
         "EMPTY_MIND",
@@ -18020,7 +17956,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_2D2",
         "DROP_SKELETON",
@@ -18190,7 +18125,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_50",
         "SELF_LITE_1",
         "BASH_DOOR",
@@ -18251,7 +18185,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "EMPTY_MIND",
         "COLD_BLOOD",
@@ -18317,7 +18250,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "EMPTY_MIND",
         "COLD_BLOOD",
@@ -18369,7 +18301,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_50",
         "CAN_FLY",
         "WILD_VOLCANO",
@@ -18426,7 +18357,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_50",
         "WILD_SHORE",
         "EMPTY_MIND",
@@ -18554,7 +18484,6 @@
         "RAND_50",
         "EVIL",
         "DEMON",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "OPEN_DOOR",
         "BASH_DOOR",
@@ -18606,7 +18535,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_50",
         "AURA_COLD",
         "COLD_BLOOD",
@@ -18661,7 +18589,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_50",
         "CAN_FLY",
         "SELF_LITE_2",
@@ -19074,7 +19001,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "EMPTY_MIND",
         "COLD_BLOOD",
         "BASH_DOOR",
@@ -19140,7 +19066,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RES_TELE",
         "EMPTY_MIND",
         "COLD_BLOOD",
@@ -19544,7 +19469,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_1D2",
         "DROP_SKELETON",
@@ -19662,7 +19586,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_50",
         "SELF_LITE_1",
         "BASH_DOOR",
@@ -19824,7 +19747,6 @@
         "SPEAK_ALL",
         "DROP_SKELETON",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HUMAN",
         "DROP_90",
@@ -19889,7 +19811,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_25",
         "DROP_60",
         "DROP_90",
@@ -19969,7 +19890,6 @@
         "SPEAK_ALL",
         "DROP_SKELETON",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_1D2",
         "DROP_GOOD",
@@ -20047,7 +19967,6 @@
         "SPEAK_ALL",
         "DROP_SKELETON",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_1D2",
         "DROP_GOOD",
@@ -20227,7 +20146,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "AQUATIC",
         "RES_WATE",
         "ANIMAL"
@@ -20283,7 +20201,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_GOLD",
         "DROP_4D2",
         "WILD_SWAMP",
@@ -20424,7 +20341,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "OPEN_DOOR",
         "BASH_DOOR",
         "MOVE_BODY",
@@ -20591,7 +20507,6 @@
         "SPEAK_ALL",
         "DROP_SKELETON",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HAS_LITE_1",
         "HUMAN",
@@ -20972,7 +20887,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "EMPTY_MIND",
         "COLD_BLOOD",
         "BASH_DOOR",
@@ -21102,7 +21016,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_1D2",
         "DROP_SKELETON",
@@ -21276,7 +21189,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_90",
         "DROP_SKELETON",
@@ -21996,7 +21908,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_1D2",
         "COLD_BLOOD",
         "OPEN_DOOR",
@@ -22073,7 +21984,6 @@
       ],
       "flags": [
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "NO_FEAR",
         "SELF_LITE_1",
         "ONLY_ITEM",
@@ -22226,7 +22136,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_SKELETON",
         "DROP_CORPSE",
         "DROP_2D2",
@@ -22298,7 +22207,6 @@
         "IM_POIS",
         "IM_COLD",
         "RES_CHAO",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "COLD_BLOOD",
@@ -22560,7 +22468,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "BASH_DOOR",
         "IM_FIRE",
         "IM_POIS",
@@ -22628,7 +22535,6 @@
       ],
       "flags": [
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "NO_FEAR",
         "NEVER_MOVE",
         "ONLY_GOLD",
@@ -22761,7 +22667,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "BASH_DOOR",
         "ANIMAL",
@@ -22822,7 +22727,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RES_NEXU",
         "FRIENDS",
         "BASH_DOOR",
@@ -22883,7 +22787,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_1D2",
         "WILD_MOUNTAIN",
         "OPEN_DOOR",
@@ -23017,7 +22920,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "COLD_BLOOD",
         "DROP_60",
         "DROP_1D2",
@@ -23094,7 +22996,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "BASH_DOOR",
         "CAN_FLY",
         "DROP_CORPSE",
@@ -23205,7 +23106,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "SELF_LITE_1",
         "EMPTY_MIND",
         "COLD_BLOOD",
@@ -23274,7 +23174,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "ONLY_ITEM",
         "DROP_90",
@@ -23515,7 +23414,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_GOLD",
         "DROP_1D2",
         "DROP_4D2",
@@ -23598,7 +23496,6 @@
         "NO_SLEEP",
         "FORCE_MAXHP",
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "RES_CHAO"
       ],
       "skill": {
@@ -23665,7 +23562,6 @@
       ],
       "flags": [
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_1D2",
         "OPEN_DOOR",
         "BASH_DOOR",
@@ -23724,7 +23620,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "AQUATIC",
         "GOOD",
         "ANIMAL",
@@ -23785,7 +23680,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_1D2",
         "TAKE_ITEM",
         "WILD_SHORE",
@@ -23847,7 +23741,6 @@
       "flags": [
         "HAS_LITE_2",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_1D2",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -24019,7 +23912,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "COLD_BLOOD",
         "EMPTY_MIND",
         "KILL_WALL",
@@ -24086,7 +23978,6 @@
       "flags": [
         "HAS_LITE_2",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_1D2",
         "DROP_SKELETON",
@@ -24147,7 +24038,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "ONLY_ITEM",
@@ -24217,7 +24107,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "KILL_BODY",
         "KILL_ITEM",
@@ -24550,7 +24439,6 @@
       ],
       "flags": [
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "NO_FEAR",
         "GOOD",
         "ONLY_ITEM",
@@ -24627,7 +24515,6 @@
       ],
       "flags": [
         "ATTR_SEMIRAND",
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "EMPTY_MIND",
         "COLD_BLOOD",
@@ -24689,7 +24576,6 @@
       "flags": [
         "ATTR_MULTI",
         "ATTR_ANY",
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "MULTIPLY",
         "EMPTY_MIND",
@@ -24755,7 +24641,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "WILD_MOUNTAIN",
         "WILD_WOOD",
@@ -24825,7 +24710,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "WILD_MOUNTAIN",
         "WILD_WASTE",
@@ -24894,7 +24778,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "WILD_MOUNTAIN",
         "WILD_SWAMP",
@@ -24963,7 +24846,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "WILD_MOUNTAIN",
         "DROP_60",
@@ -25453,7 +25335,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_25",
         "ONLY_ITEM",
         "DROP_1D2",
@@ -25525,7 +25406,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SELF_DARK_1",
         "ONLY_ITEM",
@@ -25590,7 +25470,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "BASH_DOOR",
         "CAN_FLY",
@@ -25742,7 +25621,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ANIMAL",
         "MOVE_BODY",
         "WILD_WOOD",
@@ -25809,7 +25687,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_1D2",
         "TAKE_ITEM",
         "BASH_DOOR",
@@ -25870,7 +25747,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_25",
         "DROP_60",
         "DROP_1D2",
@@ -25990,7 +25866,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_90",
         "DROP_CORPSE",
@@ -26037,7 +25912,6 @@
       "rarity": 1,
       "exp": 300,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "NEVER_BLOW",
         "STUPID",
@@ -26105,7 +25979,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ESCORT",
         "ESCORTS",
@@ -26255,7 +26128,6 @@
         "DROP_1D2",
         "FORCE_MAXHP",
         "ESCORT",
-        "PREVENT_SUDDEN_MAGIC",
         "EVIL",
         "UNDEAD",
         "IM_POIS",
@@ -26417,7 +26289,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "STUPID",
         "EMPTY_MIND",
@@ -26474,7 +26345,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_1D2",
         "WILD_MOUNTAIN",
@@ -26551,7 +26421,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "STUPID",
         "EMPTY_MIND",
         "CAN_FLY",
@@ -26685,7 +26554,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_1D2",
         "TAKE_ITEM",
         "DROP_CORPSE",
@@ -27216,7 +27084,6 @@
       ],
       "flags": [
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "EVIL",
         "HAS_LITE_1",
@@ -27293,7 +27160,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "DROP_60",
         "COLD_BLOOD",
@@ -27430,7 +27296,6 @@
         "ATTR_MULTI",
         "ATTR_ANY",
         "CAN_FLY",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -27502,7 +27367,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "GOOD",
         "ONLY_ITEM",
@@ -27577,7 +27441,6 @@
       "flags": [
         "ATTR_MULTI",
         "ATTR_ANY",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -27654,7 +27517,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -27849,7 +27711,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_25",
         "ONLY_ITEM",
         "DROP_90",
@@ -27927,7 +27788,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_25",
         "ONLY_ITEM",
         "DROP_90",
@@ -28069,7 +27929,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_25",
         "SELF_LITE_1",
         "EMPTY_MIND",
@@ -28146,7 +28005,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_FEAR",
         "GOOD",
@@ -28226,7 +28084,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_25",
         "EMPTY_MIND",
         "COLD_BLOOD",
@@ -28295,7 +28152,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "BASH_DOOR",
         "ATTR_MULTI",
@@ -28608,7 +28464,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_1D2",
         "SMART",
@@ -28670,7 +28525,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "STUPID",
         "EMPTY_MIND",
         "CAN_FLY",
@@ -28729,7 +28583,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_4D2",
         "COLD_BLOOD",
@@ -28808,7 +28661,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_4D2",
         "CAN_FLY",
@@ -28890,7 +28742,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_FEAR",
         "EVIL",
@@ -29075,7 +28926,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "EMPTY_MIND",
         "COLD_BLOOD",
         "NONLIVING",
@@ -29141,7 +28991,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_25",
         "EMPTY_MIND",
         "COLD_BLOOD",
@@ -29212,7 +29061,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "ONLY_ITEM",
@@ -29455,7 +29303,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "UNIQUE",
         "REFLECTING",
@@ -29575,7 +29422,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_25",
         "ONLY_ITEM",
         "DROP_90",
@@ -29652,7 +29498,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_25",
         "ONLY_ITEM",
         "DROP_60",
@@ -29828,7 +29673,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "EMPTY_MIND",
         "KILL_ITEM",
         "KILL_BODY",
@@ -30015,7 +29859,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "BASH_DOOR",
         "ANIMAL",
@@ -30150,7 +29993,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "BASH_DOOR",
         "ANIMAL",
@@ -30211,7 +30053,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "BASH_DOOR",
         "ANIMAL",
@@ -30330,7 +30171,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "EMPTY_MIND",
         "COLD_BLOOD",
         "WILD_SHORE",
@@ -30403,7 +30243,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "WILD_SWAMP",
         "DROP_60",
@@ -30568,7 +30407,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_2D2",
         "DROP_CORPSE",
@@ -30821,7 +30659,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_1D2",
         "INVISIBLE",
@@ -30888,7 +30725,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_60",
         "DROP_90",
@@ -30951,7 +30787,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "REGENERATE",
         "DROP_60",
@@ -31023,7 +30858,6 @@
       ],
       "flags": [
         "ATTR_MULTI",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "DROP_1D2",
@@ -31082,7 +30916,6 @@
         "NEVER_MOVE",
         "NEVER_BLOW",
         "NONLIVING",
-        "PREVENT_SUDDEN_MAGIC",
         "EVIL",
         "COLD_BLOOD",
         "EMPTY_MIND",
@@ -31224,7 +31057,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_60",
@@ -31291,7 +31123,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_60",
@@ -31362,7 +31193,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_60",
@@ -31432,7 +31262,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "WILD_MOUNTAIN",
         "DROP_1D2",
@@ -31499,7 +31328,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_60",
@@ -31678,7 +31506,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "TAKE_ITEM",
         "OPEN_DOOR",
         "BASH_DOOR",
@@ -31783,7 +31610,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "PASS_WALL",
         "INVISIBLE",
         "IM_POIS",
@@ -31857,7 +31683,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "OPEN_DOOR",
         "BASH_DOOR",
         "NONLIVING",
@@ -31924,7 +31749,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "EMPTY_MIND",
         "COLD_BLOOD",
         "AURA_COLD",
@@ -31992,7 +31816,6 @@
       ],
       "flags": [
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_1D2",
@@ -32068,7 +31891,6 @@
       ],
       "flags": [
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "UNIQUE",
         "NO_STUN",
         "NO_CONF",
@@ -32181,7 +32003,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -32428,7 +32249,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_1D2",
         "SMART",
@@ -32498,7 +32318,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "WEIRD_MIND",
         "BASH_DOOR",
@@ -32692,7 +32511,6 @@
         "UNIQUE",
         "GOOD",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ESCORT",
         "ESCORTS",
@@ -32760,7 +32578,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RAND_50",
         "SELF_LITE_1",
@@ -32879,7 +32696,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "EMPTY_MIND",
         "AURA_FIRE",
         "WILD_VOLCANO",
@@ -33054,7 +32870,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_50",
         "RAND_25",
         "RES_NEXU",
@@ -33108,7 +32923,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "SELF_LITE_1",
         "RAND_50",
         "RAND_25",
@@ -33179,7 +32993,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "WILD_MOUNTAIN",
         "WILD_VOLCANO",
@@ -33250,7 +33063,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "WILD_MOUNTAIN",
         "DROP_1D2",
@@ -33318,7 +33130,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "RIDING",
@@ -33393,7 +33204,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_CORPSE",
@@ -33464,7 +33274,6 @@
       ],
       "flags": [
         "ATTR_MULTI",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_3D2",
@@ -33539,7 +33348,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_60",
@@ -33637,7 +33445,6 @@
         "IM_POIS",
         "RES_WATE",
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_CONF",
         "NO_SLEEP"
@@ -33718,7 +33525,6 @@
         "IM_POIS",
         "RES_WATE",
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_CONF",
         "NO_SLEEP"
@@ -33785,7 +33591,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "RES_NETH",
@@ -33863,7 +33668,6 @@
         "SPEAK_ALL",
         "HAS_LITE_2",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -33925,7 +33729,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_50",
         "RAND_25",
         "EMPTY_MIND",
@@ -33974,7 +33777,6 @@
         "ATTR_MULTI",
         "SELF_LITE_1",
         "SELF_LITE_2",
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_BLOW",
         "RAND_50",
         "RAND_25",
@@ -34043,7 +33845,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SELF_LITE_1",
         "DROP_3D2",
@@ -34112,7 +33913,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "DROP_3D2",
@@ -34187,7 +33987,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RES_TELE",
         "CAN_FLY",
         "BASH_DOOR",
@@ -34261,7 +34060,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_90",
@@ -34340,7 +34138,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "NO_FEAR",
@@ -34427,7 +34224,6 @@
       "flags": [
         "UNIQUE",
         "SELF_LITE_2",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RAND_25",
         "EMPTY_MIND",
@@ -34500,7 +34296,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -34571,7 +34366,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_60",
@@ -34712,7 +34506,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "UNIQUE",
         "CAN_SWIM",
         "FORCE_MAXHP",
@@ -34789,7 +34582,6 @@
       ],
       "flags": [
         "UNDEAD",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "RES_TELE",
@@ -34867,7 +34659,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -34944,7 +34735,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RAND_25",
         "CAN_FLY",
@@ -35030,7 +34820,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "WILD_SHORE",
         "WILD_SWAMP",
         "ONLY_GOLD",
@@ -35113,7 +34902,6 @@
         "ONLY_ITEM",
         "DROP_GOOD",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RAND_25",
         "DROP_CORPSE",
@@ -35194,7 +34982,6 @@
         "ATTR_MULTI",
         "SPEAK_ALL",
         "ATTR_ANY",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "SELF_LITE_2",
@@ -35279,7 +35066,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_3D2",
         "DROP_4D2",
@@ -35351,7 +35137,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "DROP_3D2",
@@ -35695,7 +35480,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_60",
@@ -35775,7 +35559,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_3D2",
@@ -35838,7 +35621,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_50",
         "RAND_25",
         "RES_CHAO",
@@ -35903,7 +35685,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ATTR_MULTI",
         "ATTR_ANY",
         "MULTIPLY",
@@ -36007,7 +35788,6 @@
         "REGENERATE",
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "ONLY_ITEM",
@@ -36284,7 +36064,6 @@
       "rarity": 1,
       "exp": 1500,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NEVER_MOVE",
         "NEVER_BLOW",
@@ -36357,7 +36136,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_2D2",
         "DROP_4D2",
@@ -36430,7 +36208,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "WILD_SHORE",
         "WILD_SWAMP",
         "ONLY_GOLD",
@@ -36496,7 +36273,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -36565,7 +36341,6 @@
       ],
       "flags": [
         "HAS_LITE_2",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -36648,7 +36423,6 @@
       ],
       "flags": [
         "HAS_LITE_2",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -36897,7 +36671,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_SWIM",
         "ONLY_ITEM",
@@ -36978,7 +36751,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SELF_DARK_1",
         "ONLY_ITEM",
@@ -37054,7 +36826,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "DROP_3D2",
@@ -37127,7 +36898,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "DROP_3D2",
@@ -37197,7 +36967,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "REFLECTING",
         "DROP_CORPSE",
@@ -37270,7 +37039,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -37334,7 +37102,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "FRIENDS",
         "ONLY_ITEM",
@@ -37398,7 +37165,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_90",
@@ -37471,7 +37237,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_SWIM",
         "IM_FIRE",
@@ -37550,7 +37315,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -37631,7 +37395,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_2D2",
         "DROP_3D2",
@@ -37781,7 +37544,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "SELF_LITE_1",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_4D2",
@@ -37872,7 +37634,6 @@
         "NO_STUN",
         "NO_SLEEP",
         "NO_CONF",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ELDRITCH_HORROR",
         "ESCORT",
@@ -37937,7 +37698,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_4D2",
@@ -38018,7 +37778,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -38104,7 +37863,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "RES_TELE",
@@ -38180,7 +37938,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "FRIENDS",
         "ONLY_ITEM",
@@ -38258,7 +38015,6 @@
         "AMBERITE",
         "DROP_SKELETON",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HAS_LITE_2",
         "HUMAN",
@@ -38336,7 +38092,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "SELF_LITE_2",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -38425,7 +38180,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ELDRITCH_HORROR",
         "NONLIVING",
@@ -38500,7 +38254,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ELDRITCH_HORROR",
         "ONLY_ITEM",
@@ -38577,7 +38330,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_TELE",
         "CAN_FLY",
@@ -38650,7 +38402,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "ONLY_ITEM",
         "DROP_1D2",
@@ -38722,7 +38473,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "REFLECTING",
         "COLD_BLOOD",
@@ -38813,7 +38563,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_25",
         "FRIENDS",
         "CAN_FLY",
@@ -38962,7 +38711,6 @@
         "EVIL",
         "UNIQUE",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -39122,7 +38870,6 @@
         "ATTR_MULTI",
         "UNDEAD",
         "EVIL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "IM_FIRE",
@@ -39314,7 +39061,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_4D2",
@@ -39398,7 +39144,6 @@
       "flags": [
         "ATTR_MULTI",
         "SELF_LITE_2",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_CORPSE",
@@ -39481,7 +39226,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -39557,7 +39301,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ELDRITCH_HORROR",
         "ONLY_ITEM",
@@ -39626,7 +39369,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RAND_25",
         "QUANTUM",
@@ -39713,7 +39455,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "EMPTY_MIND",
         "COLD_BLOOD",
@@ -39861,7 +39602,6 @@
         "SPEAK_ALL",
         "EVIL",
         "DEMON",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NEVER_MOVE",
         "ELDRITCH_HORROR",
@@ -39937,7 +39677,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ELDRITCH_HORROR",
         "PASS_WALL",
         "FORCE_MAXHP",
@@ -40028,7 +39767,6 @@
         "IM_COLD",
         "AURA_COLD",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_4D2",
@@ -40098,7 +39836,6 @@
         "RES_TIME",
         "ELDRITCH_HORROR",
         "RES_NETH",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -40187,7 +39924,6 @@
         "CAN_SWIM",
         "RES_DARK",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "HURT_LITE",
         "POWERFUL",
         "ELDRITCH_HORROR",
@@ -40248,7 +39984,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_4D2",
@@ -40335,7 +40070,6 @@
         "UNIQUE",
         "AURA_ELEC",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SELF_LITE_1",
         "RAND_25",
@@ -40412,7 +40146,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "WILD_SHORE",
         "WILD_SWAMP",
         "ONLY_GOLD",
@@ -40482,7 +40215,6 @@
       "flags": [
         "HAS_LITE_2",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -40561,7 +40293,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RAND_25",
         "ONLY_ITEM",
@@ -40644,7 +40375,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_TELE",
         "EMPTY_MIND",
@@ -40722,7 +40452,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_3D2",
@@ -40848,7 +40577,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "ONLY_ITEM",
@@ -40936,7 +40664,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RAND_25",
         "CAN_SWIM",
@@ -41102,7 +40829,6 @@
         "REFLECTING",
         "CAN_FLY",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SPEAK_ALL",
         "SELF_LITE_2",
@@ -41184,7 +40910,6 @@
         "IM_FIRE",
         "RES_NETH",
         "RES_CHAO",
-        "PREVENT_SUDDEN_MAGIC",
         "UNIQUE",
         "FORCE_MAXHP",
         "CAN_FLY",
@@ -41383,7 +41108,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -41467,7 +41191,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -41540,7 +41263,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -41622,7 +41344,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_TELE",
         "AQUATIC",
@@ -41691,7 +41412,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "EVIL",
         "UNDEAD",
@@ -41764,7 +41484,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ELDRITCH_HORROR",
         "NEVER_MOVE",
         "REGENERATE",
@@ -41846,7 +41565,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ELDRITCH_HORROR",
         "PASS_WALL",
         "UNIQUE",
@@ -41944,7 +41662,6 @@
       ],
       "flags": [
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "FRIENDLY",
         "HURT_FIRE",
@@ -42007,7 +41724,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HURT_ROCK",
         "ONLY_GOLD",
@@ -42069,7 +41785,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_CORPSE",
@@ -42143,7 +41858,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "CAN_SWIM",
         "EVIL",
@@ -42210,7 +41924,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SPEAK_ALL",
         "DROP_CORPSE",
@@ -42293,7 +42006,6 @@
         "DROP_CORPSE",
         "SPEAK_ALL",
         "HURT_FIRE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_4D2",
@@ -42355,7 +42067,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "UNIQUE",
         "EVIL",
@@ -42432,7 +42143,6 @@
         "UNIQUE",
         "CAN_SWIM",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SELF_LITE_2",
         "ONLY_ITEM",
@@ -42509,7 +42219,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_SWIM",
         "ANIMAL",
@@ -42582,7 +42291,6 @@
       "flags": [
         "UNIQUE",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -42651,7 +42359,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "COLD_BLOOD",
         "EMPTY_MIND",
         "PASS_WALL",
@@ -42719,7 +42426,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "AURA_FIRE",
         "NONLIVING",
@@ -42803,7 +42509,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "AURA_FIRE",
         "CAN_FLY",
@@ -42883,7 +42588,6 @@
       "flags": [
         "EVIL",
         "DEMON",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -42964,7 +42668,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -43052,7 +42755,6 @@
         "DROP_CORPSE",
         "EVIL",
         "IM_FIRE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP"
       ],
       "skill": {
@@ -43109,7 +42811,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "SELF_DARK_1",
         "FRIENDS",
         "RES_NETH",
@@ -43173,7 +42874,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "OPEN_DOOR",
         "BASH_DOOR",
@@ -43236,7 +42936,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "RES_PLAS",
         "SELF_LITE_2",
@@ -43279,7 +42978,6 @@
       "rarity": 1,
       "exp": 3000,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NEVER_MOVE",
         "NEVER_BLOW",
@@ -43350,7 +43048,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "AURA_ELEC",
         "CAN_FLY",
@@ -43424,7 +43121,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_1D2",
@@ -43499,7 +43195,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_1D2",
@@ -43572,7 +43267,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "IM_FIRE",
@@ -43654,7 +43348,6 @@
         "SPEAK_ALL",
         "DROP_SKELETON",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HUMAN",
         "ONLY_ITEM",
@@ -43737,7 +43430,6 @@
         "REFLECTING",
         "DROP_SKELETON",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "HAS_LITE_1",
@@ -43830,7 +43522,6 @@
         "SPEAK_ALL",
         "ESCORT",
         "REGENERATE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ELDRITCH_HORROR",
         "ONLY_ITEM",
@@ -43918,7 +43609,6 @@
         "SPEAK_ALL",
         "ATTR_MULTI",
         "ATTR_ANY",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ELDRITCH_HORROR",
         "ONLY_ITEM",
@@ -44009,7 +43699,6 @@
         "EVIL",
         "NONLIVING",
         "CAN_SWIM",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -44092,7 +43781,6 @@
       "flags": [
         "EVIL",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_SKELETON",
         "ONLY_ITEM",
@@ -44173,7 +43861,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_3D2",
@@ -44262,7 +43949,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "RES_NETH",
         "RES_TIME",
@@ -44334,7 +44020,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "AQUATIC",
         "WILD_OCEAN",
@@ -44419,7 +44104,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "AURA_COLD",
@@ -44497,7 +44181,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "RES_TELE",
@@ -44595,7 +44278,6 @@
         "AURA_FIRE",
         "SELF_LITE_1",
         "SELF_LITE_2",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "RES_LITE",
@@ -44673,7 +44355,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "SMART",
         "KILL_WALL",
         "CAN_SWIM",
@@ -44757,7 +44438,6 @@
         "DROP_GOOD",
         "MOVE_BODY",
         "NONLIVING",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -44848,7 +44528,6 @@
         "DROP_GOOD",
         "NONLIVING",
         "CAN_SWIM",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -44998,7 +44677,6 @@
         "to": 749
       },
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NEVER_MOVE",
         "NEVER_BLOW",
@@ -45077,7 +44755,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NEVER_MOVE",
         "RES_TELE",
@@ -45150,7 +44827,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NEVER_MOVE",
         "RES_TELE",
@@ -45210,7 +44886,6 @@
       "flags": [
         "ATTR_MULTI",
         "ATTR_ANY",
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_BLOW",
         "RAND_50",
         "RAND_25",
@@ -45281,7 +44956,6 @@
       "flags": [
         "ATTR_MULTI",
         "ATTR_ANY",
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "RAND_50",
         "RAND_25",
@@ -45397,7 +45071,6 @@
         "CAN_FLY",
         "RES_NETH",
         "RIDING",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "ONLY_ITEM",
@@ -45477,7 +45150,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "DROP_CORPSE",
@@ -45560,7 +45232,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "SPEAK_ALL",
@@ -45650,7 +45321,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_CORPSE",
@@ -45739,7 +45409,6 @@
         "CAN_SWIM",
         "EVIL",
         "UNDEAD",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "SPEAK_ALL",
@@ -45831,7 +45500,6 @@
         "REGENERATE",
         "CAN_FLY",
         "NONLIVING",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_4D2",
@@ -45875,7 +45543,6 @@
       "rarity": 3,
       "exp": 5500,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NEVER_MOVE",
         "NEVER_BLOW",
@@ -45948,7 +45615,6 @@
       "flags": [
         "UNIQUE",
         "ELDRITCH_HORROR",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SPEAK_ALL",
         "SMART",
@@ -46044,7 +45710,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "UNIQUE",
         "SPEAK_ALL",
@@ -46128,7 +45793,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "FRIENDLY",
         "ONLY_ITEM",
@@ -46222,7 +45886,6 @@
         "DROP_CORPSE",
         "HAS_LITE_2",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SHAPECHANGER",
         "SPEAK_ALL",
@@ -46325,7 +45988,6 @@
         "GOOD",
         "AURA_FIRE",
         "REFLECTING",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -46425,7 +46087,6 @@
         "RES_NETH",
         "NO_FEAR",
         "GOOD",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "REFLECTING",
@@ -46522,7 +46183,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -46601,7 +46261,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -46680,7 +46339,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_4D2",
         "DROP_GOOD",
@@ -46768,7 +46426,6 @@
         "SPEAK_ALL",
         "NO_FEAR",
         "GOOD",
-        "PREVENT_SUDDEN_MAGIC",
         "SMART",
         "AURA_ELEC",
         "REFLECTING",
@@ -46868,7 +46525,6 @@
         "SPEAK_ALL",
         "HAS_LITE_2",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "DROP_CORPSE",
@@ -46958,7 +46614,6 @@
         "FRIENDLY",
         "HAS_LITE_2",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "REFLECTING",
         "RES_TELE",
@@ -47064,7 +46719,6 @@
         "FRIENDLY",
         "HAS_LITE_2",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "REFLECTING",
         "RES_TELE",
@@ -47175,7 +46829,6 @@
         "AMBERITE",
         "ATTR_ANY",
         "RES_TELE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -47279,7 +46932,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SELF_DARK_2",
         "ONLY_ITEM",
@@ -47365,7 +47017,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "AQUATIC",
         "WILD_OCEAN",
@@ -47450,7 +47101,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "RES_TELE",
@@ -47550,7 +47200,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ESCORT",
         "ESCORTS",
@@ -47624,7 +47273,6 @@
       "flags": [
         "ATTR_MULTI",
         "EVIL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_TELE",
         "ONLY_ITEM",
@@ -47693,7 +47341,6 @@
       "flags": [
         "ATTR_MULTI",
         "ATTR_ANY",
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "BASH_DOOR",
         "ANIMAL",
@@ -47760,7 +47407,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "SPEAK_ALL",
@@ -47853,7 +47499,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RES_TELE",
         "HAS_DARK_1",
         "COLD_BLOOD",
@@ -47931,7 +47576,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "AQUATIC",
         "WILD_OCEAN",
@@ -48011,7 +47655,6 @@
       "flags": [
         "ATTR_MULTI",
         "ATTR_ANY",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_CHAO",
         "RES_DISE",
@@ -48088,7 +47731,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "GOOD",
         "DROP_CORPSE",
@@ -48168,7 +47810,6 @@
         "ATTR_MULTI",
         "ATTR_ANY",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -48249,7 +47890,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_TELE",
         "ONLY_ITEM",
@@ -48332,7 +47972,6 @@
         "RES_CHAO",
         "RES_INER",
         "CAN_FLY",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "EVIL",
         "SMART",
@@ -48427,7 +48066,6 @@
         "RES_WATE",
         "CAN_SWIM",
         "REGENERATE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "EVIL",
         "SMART",
@@ -48512,7 +48150,6 @@
         "RES_TELE",
         "DROP_CORPSE",
         "HAS_LITE_2",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_CONF",
         "NO_SLEEP",
@@ -48602,7 +48239,6 @@
       "flags": [
         "ATTR_MULTI",
         "CAN_FLY",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "AURA_ELEC",
         "AURA_FIRE",
@@ -48698,7 +48334,6 @@
         "DROP_SKELETON",
         "HAS_LITE_2",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_CONF",
         "NO_SLEEP",
@@ -48794,7 +48429,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SPEAK_ALL",
         "CAN_FLY",
@@ -48880,7 +48514,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "AURA_ELEC",
         "AURA_COLD",
@@ -48966,7 +48599,6 @@
         "RES_TELE",
         "DROP_SKELETON",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_CONF",
         "NO_SLEEP",
@@ -49073,7 +48705,6 @@
         "UNIQUE",
         "CAN_FLY",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ESCORT",
         "RIDING",
@@ -49171,7 +48802,6 @@
         "AURA_FIRE",
         "AURA_ELEC",
         "AURA_COLD",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -49266,7 +48896,6 @@
         "SPEAK_ALL",
         "AURA_FIRE",
         "AURA_ELEC",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -49349,7 +48978,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "CAN_SWIM",
@@ -49450,7 +49078,6 @@
         "BASH_DOOR",
         "DROP_CORPSE",
         "DROP_SKELETON",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_CONF",
         "NO_SLEEP",
@@ -49519,7 +49146,6 @@
       "rarity": 3,
       "exp": 12000,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NEVER_MOVE",
         "NEVER_BLOW",
@@ -49569,7 +49195,6 @@
       "rarity": 3,
       "exp": 10500,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NEVER_MOVE",
         "NEVER_BLOW",
@@ -49617,7 +49242,6 @@
       "rarity": 3,
       "exp": 10500,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NEVER_MOVE",
         "NEVER_BLOW",
@@ -49780,7 +49404,6 @@
         "DROP_SKELETON",
         "SPEAK_ALL",
         "RES_TELE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ESCORT",
         "POWERFUL",
@@ -49875,7 +49498,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "RES_TELE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "SMART",
@@ -49959,7 +49581,6 @@
         "SPEAK_ALL",
         "RES_TELE",
         "ELDRITCH_HORROR",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_1D2",
         "DROP_2D2",
@@ -50038,7 +49659,6 @@
         "DROP_SKELETON",
         "DROP_CORPSE",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_CONF",
         "NO_SLEEP",
@@ -50118,7 +49738,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "SELF_DARK_1",
@@ -50207,7 +49826,6 @@
         "SPEAK_ALL",
         "ELDRITCH_HORROR",
         "RES_TELE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_4D2",
@@ -50294,7 +49912,6 @@
         "SPEAK_ALL",
         "ELDRITCH_HORROR",
         "RES_TELE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_4D2",
@@ -50377,7 +49994,6 @@
       "flags": [
         "ATTR_MULTI",
         "ATTR_ANY",
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "FRIENDS",
         "BASH_DOOR",
@@ -50473,7 +50089,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_CONF",
         "NO_SLEEP",
@@ -50565,7 +50180,6 @@
         "BASH_DOOR",
         "DROP_CORPSE",
         "DROP_SKELETON",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_CONF",
         "NO_SLEEP",
@@ -50672,7 +50286,6 @@
         "ELDRITCH_HORROR",
         "OPEN_DOOR",
         "BASH_DOOR",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_CONF",
         "NO_SLEEP",
@@ -50749,7 +50362,6 @@
         "KILL_ITEM",
         "KILL_BODY",
         "NO_FEAR",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "MULTIPLY",
         "CAN_FLY",
@@ -50849,7 +50461,6 @@
         "RES_TELE",
         "IM_POIS",
         "IM_FIRE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NONLIVING"
       ],
@@ -50914,7 +50525,6 @@
         "SPEAK_ALL",
         "POWERFUL",
         "RES_TELE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "ONLY_ITEM",
@@ -51003,7 +50613,6 @@
         "DROP_CORPSE",
         "DROP_SKELETON",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "HAS_LITE_2",
@@ -51091,7 +50700,6 @@
         "RES_TELE",
         "HAS_LITE_2",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "DROP_CORPSE",
@@ -51199,7 +50807,6 @@
         "BASH_DOOR",
         "DROP_CORPSE",
         "DROP_SKELETON",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_CONF",
         "NO_SLEEP",
@@ -51294,7 +50901,6 @@
         "UNIQUE",
         "DROP_CORPSE",
         "RES_TELE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NEVER_MOVE",
         "NEVER_BLOW",
@@ -51345,7 +50951,6 @@
         "SPEAK_ALL",
         "DROP_CORPSE",
         "RES_TELE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NEVER_MOVE",
         "NEVER_BLOW",
@@ -51440,7 +51045,6 @@
         "IM_FIRE",
         "CAN_FLY",
         "RES_PLAS",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NONLIVING",
         "SELF_LITE_2",
@@ -51527,7 +51131,6 @@
         "BASH_DOOR",
         "DROP_CORPSE",
         "DROP_SKELETON",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_CONF",
         "NO_SLEEP",
@@ -51616,7 +51219,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "RES_TELE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "ONLY_ITEM",
@@ -51711,7 +51313,6 @@
         "RES_TELE",
         "ELDRITCH_HORROR",
         "CAN_FLY",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "SELF_DARK_1",
@@ -51802,7 +51403,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -51888,7 +51488,6 @@
         "ESCORT",
         "ELDRITCH_HORROR",
         "RES_TELE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "AURA_COLD",
@@ -51975,7 +51574,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "RAND_25",
@@ -52044,7 +51642,6 @@
         "SPEAK_ALL",
         "DROP_SKELETON",
         "RES_TELE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -52135,7 +51732,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "CAN_FLY",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "OPEN_DOOR",
         "BASH_DOOR",
@@ -52227,7 +51823,6 @@
         "CAN_SWIM",
         "DROP_CORPSE",
         "RIDING",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_PLAS",
         "RES_DISE",
@@ -52316,7 +51911,6 @@
         "UNIQUE",
         "NEVER_MOVE",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "IM_ACID",
         "IM_POIS",
         "IM_COLD",
@@ -52407,7 +52001,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_TELE",
         "RES_NETH",
@@ -52498,7 +52091,6 @@
       "flags": [
         "UNIQUE",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_TELE",
         "RES_NETH",
@@ -52609,7 +52201,6 @@
         "DROP_2D2",
         "DROP_90",
         "ONLY_ITEM",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "EVIL",
         "DEMON",
@@ -52698,7 +52289,6 @@
       "flags": [
         "UNIQUE",
         "SELF_LITE_2",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_TELE",
         "RES_NETH",
@@ -52797,7 +52387,6 @@
         "UNIQUE",
         "RIDING",
         "ATTR_MULTI",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "ONLY_ITEM",
@@ -52873,7 +52462,6 @@
         "SELF_LITE_1",
         "SELF_LITE_2",
         "AURA_FIRE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ESCORT",
         "ESCORTS",
@@ -52959,7 +52547,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ESCORT",
         "ESCORTS",
@@ -53044,7 +52631,6 @@
         "UNIQUE",
         "NEVER_MOVE",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "IM_ACID",
         "IM_POIS",
         "IM_COLD",
@@ -53152,7 +52738,6 @@
         "RES_TELE",
         "IM_POIS",
         "IM_FIRE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NONLIVING",
         "IM_COLD",
@@ -53234,7 +52819,6 @@
         "UNIQUE",
         "IM_POIS",
         "IM_FIRE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NONLIVING"
       ],
@@ -53297,7 +52881,6 @@
         "DROP_SKELETON",
         "SPEAK_ALL",
         "RES_TELE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ESCORT",
         "ONLY_ITEM",
@@ -53394,7 +52977,6 @@
         "RES_TIME",
         "RES_TELE",
         "PASS_WALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "AURA_ELEC",
         "AURA_FIRE",
@@ -53492,7 +53074,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_4D2",
@@ -53565,7 +53146,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "REFLECTING",
         "AURA_FIRE",
@@ -53699,7 +53279,6 @@
         "AURA_ELEC",
         "RES_TELE",
         "ATTR_MULTI",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "PASS_WALL",
         "ATTR_ANY",
@@ -53788,7 +53367,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "PASS_WALL",
         "ONLY_ITEM",
@@ -53963,7 +53541,6 @@
         "ELDRITCH_HORROR",
         "RES_TELE",
         "NONLIVING",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "PASS_WALL",
         "DEMON",
@@ -54073,7 +53650,6 @@
         "UNIQUE",
         "ELDRITCH_HORROR",
         "RES_TELE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DEMON",
         "AURA_FIRE",
@@ -54170,7 +53746,6 @@
         "AURA_FIRE",
         "ANIMAL",
         "EVIL",
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_CORPSE",
         "ONLY_ITEM",
         "DROP_3D2",
@@ -54240,7 +53815,6 @@
       "flags": [
         "UNIQUE",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "AQUATIC",
         "WILD_OCEAN",
         "MOVE_BODY",
@@ -54320,7 +53894,6 @@
         "NONLIVING",
         "NO_FEAR",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "REFLECTING",
         "MOVE_BODY",
         "KILL_WALL",
@@ -54405,7 +53978,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "CAN_FLY",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ESCORT",
         "ESCORTS",
@@ -54503,7 +54075,6 @@
         "DEMON",
         "ELDRITCH_HORROR",
         "NONLIVING",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ESCORT",
         "ESCORTS",
@@ -54617,7 +54188,6 @@
         "SPEAK_ALL",
         "REFLECTING",
         "HAS_LITE_2",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HUMAN",
         "ONLY_ITEM",
@@ -54731,7 +54301,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "REFLECTING",
         "AURA_COLD",
@@ -54865,7 +54434,6 @@
         "ATTR_MULTI",
         "AMBERITE",
         "RES_TELE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "FORCE_DEPTH",
         "HUMAN",
@@ -54999,7 +54567,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "FORCE_DEPTH",
         "SELF_DARK_1",
@@ -55095,7 +54662,6 @@
         "SPEAK_ALL",
         "ATTR_MULTI",
         "ATTR_ANY",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "FORCE_DEPTH",
         "SELF_LITE_1",
@@ -55271,7 +54837,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "ONLY_ITEM",
         "DROP_90",
@@ -55564,7 +55129,6 @@
       "flags": [
         "CHAR_CLEAR",
         "ATTR_CLEAR",
-        "PREVENT_SUDDEN_MAGIC",
         "SMART",
         "INVISIBLE",
         "COLD_BLOOD",
@@ -55747,7 +55311,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_1D2",
         "DROP_2D2",
@@ -55825,7 +55388,6 @@
       "flags": [
         "UNIQUE",
         "ATTR_MULTI",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "ANIMAL",
@@ -55919,7 +55481,6 @@
         "UNIQUE",
         "HAS_LITE_2",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "SPEAK_ALL",
@@ -56021,7 +55582,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SELF_DARK_2",
         "DROP_2D2",
@@ -56099,7 +55659,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "REGENERATE",
@@ -56271,7 +55830,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "SPEAK_ALL",
@@ -56413,7 +55971,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_1D2",
@@ -56507,7 +56064,6 @@
       "flags": [
         "UNIQUE",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "FRIENDLY",
         "ONLY_ITEM",
@@ -56596,7 +56152,6 @@
       "flags": [
         "UNIQUE",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SPEAK_ALL",
         "ONLY_ITEM",
@@ -56692,7 +56247,6 @@
         "UNDEAD",
         "ONLY_ONE",
         "NO_INSTANTLY_DEATH",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "FORCE_DEPTH",
         "REFLECTING",
@@ -56896,7 +56450,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_90",
@@ -56979,7 +56532,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "SELF_LITE_1",
         "OPEN_DOOR",
@@ -57149,7 +56701,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_90",
@@ -57225,7 +56776,6 @@
       "flags": [
         "UNIQUE",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HUMAN",
         "ONLY_ITEM",
@@ -57552,7 +57102,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_1D2",
         "SMART",
@@ -57608,7 +57157,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_50",
         "EMPTY_MIND",
         "BASH_DOOR",
@@ -58619,7 +58167,6 @@
         "GOOD",
         "DROP_CORPSE",
         "DROP_SKELETON",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HUMAN",
         "ONLY_ITEM",
@@ -58693,7 +58240,6 @@
         "GOOD",
         "DROP_CORPSE",
         "DROP_SKELETON",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HUMAN",
         "ONLY_ITEM",
@@ -58767,7 +58313,6 @@
         "GOOD",
         "DROP_CORPSE",
         "DROP_SKELETON",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HUMAN",
         "ONLY_ITEM",
@@ -58951,7 +58496,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ESCORT",
         "CAN_FLY",
@@ -59025,7 +58569,6 @@
         "STUPID",
         "EMPTY_MIND",
         "REFLECTING",
-        "PREVENT_SUDDEN_MAGIC",
         "SPEAK_ALL",
         "BASH_DOOR",
         "EVIL",
@@ -59354,7 +58897,6 @@
         "UNIQUE",
         "DROP_SKELETON",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HAS_LITE_2",
         "HUMAN",
@@ -59432,7 +58974,6 @@
         "UNIQUE",
         "DROP_SKELETON",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_1D2",
         "DROP_2D2",
@@ -59500,7 +59041,6 @@
       "flags": [
         "DROP_SKELETON",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ATTR_MULTI",
         "RAND_25",
@@ -59743,7 +59283,6 @@
       ],
       "flags": [
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -59826,7 +59365,6 @@
       "flags": [
         "UNIQUE",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HUMAN",
         "ONLY_ITEM",
@@ -59918,7 +59456,6 @@
       "flags": [
         "UNIQUE",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HUMAN",
         "ONLY_ITEM",
@@ -60011,7 +59548,6 @@
       "flags": [
         "UNIQUE",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HUMAN",
         "ONLY_ITEM",
@@ -60103,7 +59639,6 @@
       "flags": [
         "UNIQUE",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HUMAN",
         "ONLY_ITEM",
@@ -60186,7 +59721,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_4D2",
@@ -60266,7 +59800,6 @@
         "DROP_CORPSE",
         "DROP_SKELETON",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_CONF",
         "NO_SLEEP",
@@ -60342,7 +59875,6 @@
         "NONLIVING",
         "NO_FEAR",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "KILL_BODY",
         "IM_FIRE",
         "IM_POIS",
@@ -60402,7 +59934,6 @@
       ],
       "flags": [
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_1D2",
         "OPEN_DOOR",
         "BASH_DOOR",
@@ -60466,7 +59997,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "ONLY_ITEM",
@@ -60553,7 +60083,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SELF_LITE_1",
         "ONLY_ITEM",
@@ -60693,7 +60222,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "GOOD",
         "SELF_LITE_2",
@@ -60782,7 +60310,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "GOOD",
         "SELF_LITE_2",
@@ -60923,7 +60450,6 @@
         "UNIQUE",
         "FORCE_MAXHP",
         "EVIL",
-        "PREVENT_SUDDEN_MAGIC",
         "SPEAK_ALL",
         "DEMON",
         "ONLY_ITEM",
@@ -61003,7 +60529,6 @@
       "flags": [
         "UNIQUE",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "SPEAK_ALL",
         "DEMON",
         "ONLY_ITEM",
@@ -61202,7 +60727,6 @@
         "FORCE_MAXHP",
         "EVIL",
         "GOOD",
-        "PREVENT_SUDDEN_MAGIC",
         "SPEAK_ALL",
         "ONLY_ITEM",
         "DROP_3D2",
@@ -61283,7 +60807,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_CORPSE",
         "RAND_50",
         "ANIMAL"
@@ -61388,7 +60911,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "OPEN_DOOR",
         "BASH_DOOR",
@@ -61494,7 +61016,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_1D2",
         "SMART",
         "DROP_CORPSE",
@@ -61940,7 +61461,6 @@
         "BASH_DOOR",
         "DROP_CORPSE",
         "DROP_SKELETON",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "MOVE_BODY",
         "TAKE_ITEM",
@@ -62030,7 +61550,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "EMPTY_MIND",
         "COLD_BLOOD",
@@ -62094,7 +61613,6 @@
         "UNIQUE",
         "DROP_SKELETON",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HAS_LITE_2",
         "HUMAN",
@@ -62171,7 +61689,6 @@
         "DROP_SKELETON",
         "DROP_CORPSE",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HAS_LITE_2",
         "DROP_2D2",
@@ -62237,7 +61754,6 @@
         "UNIQUE",
         "DROP_CORPSE",
         "FRIENDLY",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_TELE",
         "ONLY_ITEM",
@@ -62317,7 +61833,6 @@
       "flags": [
         "UNIQUE",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_TELE",
         "ONLY_ITEM",
@@ -62397,7 +61912,6 @@
       "flags": [
         "UNIQUE",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_TELE",
         "ONLY_ITEM",
@@ -62479,7 +61993,6 @@
         "UNIQUE",
         "DROP_CORPSE",
         "FRIENDLY",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_TELE",
         "ONLY_ITEM",
@@ -62560,7 +62073,6 @@
       "flags": [
         "UNIQUE",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_TELE",
         "AURA_FIRE",
@@ -62858,7 +62370,6 @@
       "flags": [
         "UNIQUE",
         "SPEAK_ALL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "MOVE_BODY",
         "DROP_CORPSE",
@@ -62934,7 +62445,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -63011,7 +62521,6 @@
       ],
       "flags": [
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "UNIQUE",
         "SPEAK_ALL",
@@ -63151,7 +62660,6 @@
       ],
       "flags": [
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "NO_FEAR",
         "FRIENDLY",
         "ANIMAL",
@@ -63395,7 +62903,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_CORPSE",
         "ANIMAL",
         "BASH_DOOR",
@@ -63506,7 +63013,6 @@
       ],
       "flags": [
         "EVIL",
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_1D2",
         "ANIMAL",
         "SMART",
@@ -63574,7 +63080,6 @@
         "DROP_3D2",
         "ANIMAL",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "REGENERATE",
         "IM_FIRE",
         "IM_COLD",
@@ -63650,7 +63155,6 @@
         "NONLIVING",
         "AURA_FIRE",
         "SELF_LITE_2",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_1D2",
@@ -63741,7 +63245,6 @@
         "MOVE_BODY",
         "NONLIVING",
         "AURA_ELEC",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_1D2",
@@ -63939,7 +63442,6 @@
         "SPEAK_ALL",
         "DROP_CORPSE",
         "WILD_WOOD",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RAND_25",
         "GOOD",
@@ -64178,7 +63680,6 @@
         "DROP_CORPSE",
         "DROP_SKELETON",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "SPEAK_ALL",
         "ONLY_ITEM",
         "DROP_1D2",
@@ -64413,7 +63914,6 @@
         "UNIQUE",
         "CAN_FLY",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ESCORT",
         "ONLY_ITEM",
@@ -64662,7 +64162,6 @@
         "DROP_SKELETON",
         "DROP_CORPSE",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HAS_LITE_1",
         "DROP_1D2",
@@ -64741,7 +64240,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "HAS_LITE_2",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "DROP_CORPSE",
@@ -64923,7 +64421,6 @@
         "DROP_CORPSE",
         "DROP_SKELETON",
         "HAS_LITE_2",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_1D2",
@@ -64986,7 +64483,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_4D2",
@@ -65056,7 +64552,6 @@
       ],
       "flags": [
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "ONLY_ONE",
         "NO_INSTANTLY_DEATH",
@@ -65116,7 +64611,6 @@
       ],
       "flags": [
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "ONLY_ONE",
         "NO_INSTANTLY_DEATH",
@@ -65366,7 +64860,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "REFLECTING",
         "EMPTY_MIND",
@@ -65515,7 +65008,6 @@
         "BASH_DOOR",
         "DROP_CORPSE",
         "DROP_SKELETON",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_CONF",
         "NO_SLEEP",
@@ -65766,7 +65258,6 @@
         "RES_TELE",
         "DROP_SKELETON",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "KILL_WALL",
         "HUMAN",
@@ -65943,7 +65434,6 @@
       "flags": [
         "UNIQUE",
         "SMART",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_GOLD",
         "DROP_3D2",
@@ -66027,7 +65517,6 @@
       ],
       "flags": [
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_4D2",
@@ -66348,7 +65837,6 @@
         "NONLIVING",
         "NO_FEAR",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "REFLECTING",
         "MOVE_BODY",
         "KILL_WALL",
@@ -66420,7 +65908,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_SWIM",
         "ELDRITCH_HORROR",
@@ -66500,7 +65987,6 @@
       "flags": [
         "UNIQUE",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "KILL_WALL",
         "ONLY_ITEM",
@@ -67000,7 +66486,6 @@
         "DROP_CORPSE",
         "AQUATIC",
         "ANIMAL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -67068,7 +66553,6 @@
         "RES_NETH",
         "AURA_COLD",
         "EVIL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -67177,7 +66661,6 @@
       "rarity": 6,
       "exp": 5000,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_BLOW",
         "RAND_50",
         "RAND_25",
@@ -67384,7 +66867,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "DROP_4D2",
@@ -67452,7 +66934,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "DROP_3D2",
@@ -67522,7 +67003,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_GOOD",
@@ -67593,7 +67073,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "MOVE_BODY",
         "ONLY_ITEM",
@@ -67672,7 +67151,6 @@
       ],
       "flags": [
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "NO_FEAR",
         "EVIL",
         "ONLY_ITEM",
@@ -67856,7 +67334,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_90",
         "WILD_ALL",
         "HUMAN",
@@ -67922,7 +67399,6 @@
       ],
       "flags": [
         "ONLY_ITEM",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_4D2",
         "SMART",
@@ -68050,7 +67526,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_60",
@@ -68239,7 +67714,6 @@
         "NO_SLEEP",
         "FORCE_MAXHP",
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "RES_CHAO"
       ],
       "skill": {
@@ -68431,7 +67905,6 @@
       ],
       "flags": [
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -68576,7 +68049,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_90",
@@ -69557,7 +69029,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SPEAK_ALL",
         "HUMAN",
@@ -70165,7 +69636,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "RES_CHAO",
@@ -70259,7 +69729,6 @@
       "rarity": 6,
       "exp": 5000,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "WEIRD_MIND",
         "BASH_DOOR",
@@ -70504,7 +69973,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_60",
@@ -70573,7 +70041,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "WILD_MOUNTAIN",
         "DROP_1D2",
@@ -70639,7 +70106,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "DROP_3D2",
@@ -70792,7 +70258,6 @@
         "DROP_1D2",
         "DROP_SKELETON",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "OPEN_DOOR",
         "WILD_WASTE",
         "WILD_SWAMP",
@@ -70839,7 +70304,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_4D2",
@@ -71189,7 +70653,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "KILL_BODY",
         "DROP_2D2",
@@ -71258,7 +70721,6 @@
         "UNIQUE",
         "DROP_CORPSE",
         "HAS_LITE_1",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HUMAN",
         "DEMON",
@@ -72996,7 +72458,6 @@
         "DROP_4D2",
         "DROP_CORPSE",
         "DROP_SKELETON",
-        "PREVENT_SUDDEN_MAGIC",
         "SMART",
         "REFLECTING",
         "INVISIBLE",
@@ -73152,7 +72613,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_25",
         "COLD_BLOOD",
         "CAN_FLY",
@@ -73248,7 +72708,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "AURA_FIRE",
         "WILD_VOLCANO",
         "KILL_ITEM",
@@ -73340,7 +72799,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "RAND_25",
         "SELF_LITE_2",
         "CAN_FLY",
@@ -73431,7 +72889,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "POWERFUL",
         "COLD_BLOOD",
         "AURA_COLD",
@@ -73530,7 +72987,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "POWERFUL",
         "COLD_BLOOD",
         "WILD_SHORE",
@@ -74278,7 +73734,6 @@
         "IM_ELEC",
         "RES_PLAS",
         "RES_GRAV",
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_60",
         "DROP_1D2",
         "ONLY_GOLD",
@@ -74325,7 +73780,6 @@
         "RES_GRAV",
         "RES_TELE",
         "FRIENDS",
-        "PREVENT_SUDDEN_MAGIC",
         "DROP_90",
         "NONLIVING",
         "NO_CONF",
@@ -74823,7 +74277,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -74950,7 +74403,6 @@
         "CAN_FLY",
         "DROP_SKELETON",
         "DROP_CORPSE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "KILL_WALL",
         "DEMON",
@@ -75309,7 +74761,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "RES_TELE",
@@ -75398,7 +74849,6 @@
         "GOOD",
         "DROP_CORPSE",
         "DROP_SKELETON",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_4D2",
@@ -75473,7 +74923,6 @@
         "GOOD",
         "DROP_CORPSE",
         "DROP_SKELETON",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_GOOD",
@@ -75545,7 +74994,6 @@
         "DROP_CORPSE",
         "DROP_SKELETON",
         "HAS_LITE_2",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_1D2",
@@ -75606,7 +75054,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "REFLECTING",
         "COLD_BLOOD",
@@ -75687,7 +75134,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "REFLECTING",
         "COLD_BLOOD",
@@ -75775,7 +75221,6 @@
         "DROP_SKELETON",
         "SMART",
         "HAS_DARK_1",
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_GOOD",
         "DROP_2D2",
@@ -75849,7 +75294,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_90",
@@ -75926,7 +75370,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_TELE",
         "HAS_DARK_1",
@@ -76006,7 +75449,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "RES_TELE",
         "CAN_FLY",
@@ -76072,7 +75514,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_2D2",
         "TAKE_ITEM",
@@ -76137,7 +75578,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -76210,7 +75650,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -76283,7 +75722,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -76360,7 +75798,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "AURA_ELEC",
         "CAN_FLY",
@@ -76435,7 +75872,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "AURA_ELEC",
         "CAN_FLY",
@@ -76515,7 +75951,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_CORPSE",
@@ -76591,7 +76026,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "DROP_CORPSE",
@@ -76672,7 +76106,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "AURA_COLD",
@@ -76747,7 +76180,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "AURA_COLD",
@@ -76825,7 +76257,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -76898,7 +76329,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -76975,7 +76405,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "AURA_ELEC",
         "AURA_FIRE",
@@ -77066,7 +76495,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "AURA_ELEC",
         "AURA_FIRE",
@@ -77241,7 +76669,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "REFLECTING",
         "DROP_CORPSE",
@@ -77318,7 +76745,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_CORPSE",
         "DROP_2D2",
@@ -79853,7 +79279,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -79932,7 +79357,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "CAN_FLY",
         "ONLY_ITEM",
@@ -80142,7 +79566,6 @@
         "RAND_25",
         "SMART",
         "REFLECTING",
-        "PREVENT_SUDDEN_MAGIC",
         "SPEAK_ALL",
         "REGENERATE",
         "AURA_ELEC",
@@ -80233,7 +79656,6 @@
       "flags": [
         "SMART",
         "FRIENDS",
-        "PREVENT_SUDDEN_MAGIC",
         "AURA_ELEC",
         "IM_POIS",
         "RES_SOUN",
@@ -80378,7 +79800,6 @@
         "DROP_CORPSE",
         "DROP_SKELETON",
         "ANIMAL",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NO_CONF",
         "NO_SLEEP",
@@ -80444,7 +79865,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "DROP_CORPSE",
@@ -80625,7 +80045,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ANIMAL",
         "IM_ACID",
         "IM_ELEC",
@@ -80683,7 +80102,6 @@
         "UNIQUE",
         "ANIMAL",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "RAND_25",
         "ONLY_ITEM",
@@ -80759,7 +80177,6 @@
         "UNIQUE",
         "SPEAK_ALL",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "SHAPECHANGER",
         "ATTR_MULTI",
         "ATTR_ANY",
@@ -81128,7 +80545,6 @@
         "UNIQUE",
         "DROP_CORPSE",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "NONLIVING",
         "SPEAK_ALL",
         "POWERFUL",
@@ -81187,7 +80603,6 @@
       "rarity": 2,
       "exp": 3000,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NEVER_MOVE",
         "NEVER_BLOW",
@@ -81232,7 +80647,6 @@
       "rarity": 3,
       "exp": 10500,
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "NEVER_MOVE",
         "NEVER_BLOW",
@@ -81294,7 +80708,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "ANIMAL",
         "REGENERATE",
         "OPEN_DOOR",
@@ -81855,7 +81268,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "REFLECTING",
         "INVISIBLE",
@@ -81940,7 +81352,6 @@
         "ONLY_ITEM",
         "DROP_GOOD",
         "DROP_1D2",
-        "PREVENT_SUDDEN_MAGIC",
         "IM_COLD",
         "IM_POIS",
         "RES_WATE",
@@ -82120,7 +81531,6 @@
       ],
       "flags": [
         "QUANTUM",
-        "PREVENT_SUDDEN_MAGIC",
         "FRIENDS",
         "DROP_90",
         "TAKE_ITEM",
@@ -82183,7 +81593,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "STUPID",
         "WEIRD_MIND",
@@ -82565,7 +81974,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "WEIRD_MIND",
         "DROP_2D2",
@@ -82641,7 +82049,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SPEAK_ALL",
         "HUMAN",
@@ -82723,7 +82130,6 @@
         "STUPID",
         "POWERFUL",
         "NONLIVING",
-        "PREVENT_SUDDEN_MAGIC",
         "EVIL",
         "DROP_4D2",
         "DROP_3D2",
@@ -82808,7 +82214,6 @@
         "DROP_CORPSE",
         "DROP_SKELETON",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "HAS_LITE_2",
@@ -82891,7 +82296,6 @@
         "DROP_CORPSE",
         "DROP_SKELETON",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "HAS_LITE_2",
@@ -82973,7 +82377,6 @@
         "DROP_CORPSE",
         "DROP_SKELETON",
         "HUMAN",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "HAS_LITE_2",
@@ -83115,7 +82518,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "DROP_1D2",
         "NONLIVING",
@@ -83227,7 +82629,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "SPEAK_ALL",
@@ -83278,7 +82679,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "SPEAK_ALL",
@@ -83349,7 +82749,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "SPEAK_ALL",
@@ -83415,7 +82814,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "UNIQUE",
         "FORCE_MAXHP",
@@ -83491,7 +82889,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "UNIQUE",
         "FORCE_MAXHP",
         "RAND_25",
@@ -85098,7 +84495,6 @@
       ],
       "flags": [
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "ANIMAL",
         "POWERFUL",
         "REGENERATE",
@@ -85170,7 +84566,6 @@
       ],
       "flags": [
         "UNIQUE",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "ONLY_GOLD",
         "AURA_FIRE",
@@ -85243,7 +84638,6 @@
       "flags": [
         "UNIQUE",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_60",
         "DROP_3D2",
@@ -85330,7 +84724,6 @@
       "flags": [
         "UNIQUE",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_3D2",
         "DROP_4D2",
@@ -85422,7 +84815,6 @@
       "flags": [
         "UNIQUE",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "REGENERATE",
         "ONLY_ITEM",
         "DROP_2D2",
@@ -85700,7 +85092,6 @@
         "FORCE_MAXHP",
         "RAND_25",
         "RAND_50",
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_BLOW",
         "DROP_60",
         "DROP_90",
@@ -85762,7 +85153,6 @@
         "REFLECTING",
         "ESCORT",
         "ESCORTS",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "HUMAN",
         "DROP_CORPSE",
@@ -86302,7 +85692,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "EMPTY_MIND",
         "COLD_BLOOD",
@@ -86369,7 +85758,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "EMPTY_MIND",
         "COLD_BLOOD",
@@ -86436,7 +85824,6 @@
         }
       ],
       "flags": [
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_MOVE",
         "EMPTY_MIND",
         "COLD_BLOOD",
@@ -86508,7 +85895,6 @@
         "DROP_4D2",
         "DROP_2D2",
         "DROP_GREAT",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "OPEN_DOOR",
@@ -86589,7 +85975,6 @@
         "DROP_4D2",
         "DROP_2D2",
         "DROP_GREAT",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "OPEN_DOOR",
@@ -86669,7 +86054,6 @@
         "DROP_4D2",
         "DROP_2D2",
         "DROP_GREAT",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "OPEN_DOOR",
@@ -86746,7 +86130,6 @@
       "flags": [
         "UNIQUE",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "CAN_FLY",
         "BASH_DOOR",
         "EVIL",
@@ -86900,7 +86283,6 @@
       "flags": [
         "UNIQUE",
         "FORCE_MAXHP",
-        "PREVENT_SUDDEN_MAGIC",
         "ONLY_ITEM",
         "DROP_1D2",
         "DROP_4D2",
@@ -87193,7 +86575,6 @@
       "flags": [
         "ATTR_MULTI",
         "ATTR_ANY",
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_BLOW",
         "RAND_50",
         "RAND_25",
@@ -87242,7 +86623,6 @@
       "flags": [
         "ATTR_MULTI",
         "ATTR_ANY",
-        "PREVENT_SUDDEN_MAGIC",
         "NEVER_BLOW",
         "RAND_50",
         "RAND_25",
@@ -87319,7 +86699,6 @@
         "DROP_2D2",
         "DROP_4D2",
         "DROP_GREAT",
-        "PREVENT_SUDDEN_MAGIC",
         "FORCE_MAXHP",
         "SMART",
         "OPEN_DOOR",

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -423,7 +423,6 @@
                                 "STUPID",
                                 "SMART",
                                 "FRIENDLY",
-                                "PREVENT_SUDDEN_MAGIC",
                                 "CHAR_CLEAR",
                                 "SHAPECHANGER",
                                 "ATTR_CLEAR",

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -120,7 +120,7 @@ static MonsterRaceInfo &set_pet_params(PlayerType *player_ptr, const int current
     m_ptr->hold_o_idx_list.clear();
     m_ptr->target_y = 0;
     auto &r_ref = m_ptr->get_real_monrace();
-    if (r_ref.behavior_flags.has(MonsterBehaviorType::PREVENT_SUDDEN_MAGIC) && !ironman_nightmare) {
+    if (!ironman_nightmare) {
         m_ptr->mflag.set(MonsterTemporaryFlagType::PREVENT_MAGIC);
     }
 

--- a/src/info-reader/race-info-tokens-table.cpp
+++ b/src/info-reader/race-info-tokens-table.cpp
@@ -357,7 +357,6 @@ const std::unordered_map<std::string_view, MonsterBehaviorType> r_info_behavior_
     { "STUPID", MonsterBehaviorType::STUPID },
     { "SMART", MonsterBehaviorType::SMART },
     { "FRIENDLY", MonsterBehaviorType::FRIENDLY },
-    { "PREVENT_SUDDEN_MAGIC", MonsterBehaviorType::PREVENT_SUDDEN_MAGIC },
 };
 
 const std::unordered_map<std::string_view, MonsterVisualType> r_info_visual_flags = {

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -425,7 +425,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, 
         m_ptr->energy_need = ENERGY_NEED() - (int16_t)randint0(100) * 2;
     }
 
-    if (r_ptr->behavior_flags.has(MonsterBehaviorType::PREVENT_SUDDEN_MAGIC) && !ironman_nightmare) {
+    if (!ironman_nightmare) {
         m_ptr->mflag.set(MonsterTemporaryFlagType::PREVENT_MAGIC);
     }
 

--- a/src/monster-race/race-behavior-flags.h
+++ b/src/monster-race/race-behavior-flags.h
@@ -14,6 +14,5 @@ enum class MonsterBehaviorType {
     STUPID = 10,
     SMART = 11,
     FRIENDLY = 12,
-    PREVENT_SUDDEN_MAGIC = 13,
     MAX,
 };


### PR DESCRIPTION
resolve #4241
召喚即魔法行動を抑制するフラグだが、終盤の強力なモンスターほぼ全てに配られているためフラグとして存在する意味がない。 新規モンスター実装の際つけ忘れるなど良いことがないため、フラグを廃止して全てのモンスターに対して召喚即魔法を抑制する。(悪夢モード時を除く)