### PR TITLE
変愚「[Refactor] player_magic::spell_xtraを解体する #4256」のマージ

### DIFF
--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -70,8 +70,6 @@
 #include "view/display-util.h"
 #include <string_view>
 
-static const int extra_magic_gain_exp = 4;
-
 concptr KWD_DAM = _("損傷:", "dam ");
 concptr KWD_RANGE = _("射程:", "rng ");
 concptr KWD_DURATION = _("期間:", "dur ");
@@ -1298,7 +1296,7 @@ bool do_cmd_cast(PlayerType *player_ptr)
             }
             break;
         }
-        if (any_bits(mp_ptr->spell_xtra, extra_magic_gain_exp)) {
+        if (mp_ptr->is_spell_trainable) {
             PlayerSkill(player_ptr).gain_spell_skill_exp(realm, spell);
         }
     }

--- a/src/info-reader/magic-reader.cpp
+++ b/src/info-reader/magic-reader.cpp
@@ -80,7 +80,12 @@ errr parse_class_magics_info(std::string_view buf, angband_header *)
 
         m_ptr->spell_stat = stat->second;
 
-        info_set_value(m_ptr->spell_xtra, tokens[3], 16);
+        uint extra_flag;
+        info_set_value(extra_flag, tokens[3], 16);
+        m_ptr->has_glove_mp_penalty = any_bits(extra_flag, 1);
+        m_ptr->has_magic_fail_rate_cap = any_bits(extra_flag, 2);
+        m_ptr->is_spell_trainable = any_bits(extra_flag, 4);
+
         info_set_value(m_ptr->spell_type, tokens[4]);
         info_set_value(m_ptr->spell_first, tokens[5]);
         info_set_value(m_ptr->spell_weight, tokens[6]);

--- a/src/player-info/class-info.h
+++ b/src/player-info/class-info.h
@@ -22,7 +22,9 @@
 
 struct player_magic {
     ItemKindType spell_book{}; /* Tval of spell books (if any) */
-    BIT_FLAGS8 spell_xtra{}; /* Something for later */
+    bool has_glove_mp_penalty{}; /* 籠手装備によるMP減少 */
+    bool has_magic_fail_rate_cap{}; /* 魔法失率の5%キャップ */
+    bool is_spell_trainable{}; /* 魔法熟練度 */
 
     int spell_stat{}; /* Stat for spells (if any)  */
     int spell_type{}; /* Spell type (mage/priest) */

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -111,8 +111,6 @@
 #include "view/display-messages.h"
 #include "world/world.h"
 
-static const int extra_magic_glove_reduce_mana = 1;
-
 static bool is_martial_arts_mode(PlayerType *player_ptr);
 
 static ACTION_SKILL_POWER calc_disarming(PlayerType *player_ptr);
@@ -826,7 +824,7 @@ static void update_max_mana(PlayerType *player_ptr)
         }
     }
 
-    if (any_bits(mp_ptr->spell_xtra, extra_magic_glove_reduce_mana)) {
+    if (mp_ptr->has_glove_mp_penalty) {
         player_ptr->cumber_glove = false;
         const auto *o_ptr = &player_ptr->inventory_list[INVEN_ARMS];
         const auto flags = o_ptr->get_flags();

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -21,9 +21,6 @@
 #include "view/display-messages.h"
 #include "world/world.h"
 
-// 5%
-static const int extra_min_magic_fail_rate = 2;
-
 /*!
  * @brief 呪文の消費MPを返す /
  * Modify mana consumption rate using spell exp and dec_mana
@@ -152,7 +149,7 @@ PERCENTAGE spell_chance(PlayerType *player_ptr, SPELL_IDX spell, int16_t use_rea
     }
 
     PERCENTAGE minfail = adj_mag_fail[player_ptr->stat_index[mp_ptr->spell_stat]];
-    if (any_bits(mp_ptr->spell_xtra, extra_min_magic_fail_rate)) {
+    if (mp_ptr->has_magic_fail_rate_cap) {
         if (minfail < 5) {
             minfail = 5;
         }

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -199,9 +199,12 @@ static SpoilerOutputResultType spoil_player_spell()
             }
         }
 
-        constexpr auto mes = "BookType:%s Stat:%s Xtra:%x Type:%d Weight:%d\n";
+        constexpr auto mes = "BookType:%s Stat:%s %s%s%sType:%d Weight:%d\n";
         const auto &spell = wiz_spell_stat[magic_ptr->spell_stat];
-        spoil_out(format(mes, book_name.data(), spell.data(), magic_ptr->spell_xtra, magic_ptr->spell_type, magic_ptr->spell_weight));
+        auto trainable = magic_ptr->is_spell_trainable ? "Trainable " : "";
+        auto glove = magic_ptr->has_glove_mp_penalty ? "GlovePenalty " : "";
+        auto failcap = magic_ptr->has_magic_fail_rate_cap ? "5%FailCap " : "";
+        spoil_out(format(mes, book_name.data(), spell.data(), glove, failcap, trainable, magic_ptr->spell_type, magic_ptr->spell_weight));
         if (magic_ptr->spell_book == ItemKindType::NONE) {
             spoil_out(_("呪文なし\n\n", "No spells.\n\n"));
             continue;


### PR DESCRIPTION
spell_xtraは3フラグの集合体だが、わかりにくいので解体する。
設定ファイル側はjson化するときに対応するので今回はそのままとする。