### PR TITLE
変愚「[Chore] プリコンパイルヘッダを使用しないようにする #4313」のマージ

### DIFF
--- a/.github/workflows/create-cache-for-ccache.yml
+++ b/.github/workflows/create-cache-for-ccache.yml
@@ -26,6 +26,7 @@ jobs:
       runner: ubuntu-24.04
       cxx: g++-13
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
+      configure-opts: "--disable-pch"
       use-ccache: true
 
   gcc_english:
@@ -35,5 +36,6 @@ jobs:
       runner: ubuntu-24.04
       cxx: g++-13
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
-      configure-opts: "--disable-japanese"
+      configure-opts: "--disable-pch --disable-japanese"
+      distcheck: true
       use-ccache: true

--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -40,6 +40,7 @@ jobs:
       runner: ubuntu-24.04
       cxx: g++-13
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
+      configure-opts: "--disable-pch"
       use-ccache: true
 
   build_test_english:
@@ -49,5 +50,6 @@ jobs:
       runner: ubuntu-24.04
       cxx: g++-13
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
-      configure-opts: "--disable-japanese"
+      configure-opts: "--disable-pch --disable-japanese"
+      distcheck: true
       use-ccache: true


### PR DESCRIPTION
ヘッダのインクルード不足によるコンパイルエラーを検出するため、GCCによる
ビルドテストでプリコンパイルヘッダを使用しないようにする。