### PR TITLE
変愚「[Refactor] bool型を直接足し算でカウントするのをやめる #4348」のマージ

### DIFF
--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -157,7 +157,7 @@ static MonsterSpellResult spell_RF6_SPECIAL_ROLENTO(PlayerType *player_ptr, POSI
     }
 
     for (k = 0; k < num; k++) {
-        count += summon_named_creature(player_ptr, m_idx, y, x, MonsterRaceId::GRENADE, mode);
+        count += summon_named_creature(player_ptr, m_idx, y, x, MonsterRaceId::GRENADE, mode) ? 1 : 0;
     }
     if (player_ptr->effects()->blindness().is_blind() && count) {
         msg_print(_("多くのものが間近にばらまかれる音がする。", "You hear many things scattered nearby."));

--- a/src/mspell/mspell-summon.cpp
+++ b/src/mspell/mspell-summon.cpp
@@ -76,7 +76,7 @@ static MONSTER_NUMBER summon_Kin(PlayerType *player_ptr, POSITION y, POSITION x,
 {
     int count = 0;
     for (int k = 0; k < 4; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_KIN, PM_ALLOW_GROUP);
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_KIN, PM_ALLOW_GROUP) ? 1 : 0;
     }
 
     return count;
@@ -277,7 +277,7 @@ MonsterSpellResult spell_RF6_S_CYBER(PlayerType *player_ptr, POSITION y, POSITIO
 
     int count = 0;
     if (m_ptr->is_friendly() && mon_to_mon) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_CYBER, (PM_ALLOW_GROUP));
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_CYBER, (PM_ALLOW_GROUP)) ? 1 : 0;
     } else {
         count += summon_cyber(player_ptr, m_idx, y, x);
     }
@@ -325,11 +325,11 @@ MonsterSpellResult spell_RF6_S_MONSTER(PlayerType *player_ptr, POSITION y, POSIT
     int count = 0;
     for (int k = 0; k < 1; k++) {
         if (mon_to_player) {
-            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
+            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
         }
 
         if (mon_to_mon) {
-            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_NONE, (monster_u_mode(floor_ptr, m_idx)));
+            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_NONE, (monster_u_mode(floor_ptr, m_idx))) ? 1 : 0;
         }
     }
 
@@ -376,11 +376,11 @@ MonsterSpellResult spell_RF6_S_MONSTERS(PlayerType *player_ptr, POSITION y, POSI
     int count = 0;
     for (auto k = 0; k < S_NUM_6; k++) {
         if (mon_to_player) {
-            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
+            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
         }
 
         if (mon_to_mon) {
-            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_NONE, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx)));
+            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_NONE, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx))) ? 1 : 0;
         }
     }
 
@@ -426,7 +426,7 @@ MonsterSpellResult spell_RF6_S_ANT(PlayerType *player_ptr, POSITION y, POSITION 
 
     int count = 0;
     for (auto k = 0; k < S_NUM_6; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ANT, PM_ALLOW_GROUP);
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ANT, PM_ALLOW_GROUP) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count && mon_to_player) {
@@ -471,7 +471,7 @@ MonsterSpellResult spell_RF6_S_SPIDER(PlayerType *player_ptr, POSITION y, POSITI
 
     int count = 0;
     for (auto k = 0; k < S_NUM_6; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_SPIDER, PM_ALLOW_GROUP);
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_SPIDER, PM_ALLOW_GROUP) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count && mon_to_player) {
@@ -516,7 +516,7 @@ MonsterSpellResult spell_RF6_S_HOUND(PlayerType *player_ptr, POSITION y, POSITIO
 
     int count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HOUND, PM_ALLOW_GROUP);
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HOUND, PM_ALLOW_GROUP) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count && mon_to_player) {
@@ -561,7 +561,7 @@ MonsterSpellResult spell_RF6_S_HYDRA(PlayerType *player_ptr, POSITION y, POSITIO
 
     int count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HYDRA, PM_ALLOW_GROUP);
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HYDRA, PM_ALLOW_GROUP) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count && mon_to_player) {
@@ -612,7 +612,7 @@ MonsterSpellResult spell_RF6_S_ANGEL(PlayerType *player_ptr, POSITION y, POSITIO
 
     int count = 0;
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ANGEL, PM_ALLOW_GROUP);
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ANGEL, PM_ALLOW_GROUP) ? 1 : 0;
     }
 
     const auto is_blind = player_ptr->effects()->blindness().is_blind();
@@ -664,7 +664,7 @@ MonsterSpellResult spell_RF6_S_DEMON(PlayerType *player_ptr, POSITION y, POSITIO
 
     int count = 0;
     for (int k = 0; k < 1; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DEMON, PM_ALLOW_GROUP);
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DEMON, PM_ALLOW_GROUP) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count) {
@@ -709,7 +709,7 @@ MonsterSpellResult spell_RF6_S_UNDEAD(PlayerType *player_ptr, POSITION y, POSITI
 
     int count = 0;
     for (int k = 0; k < 1; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_UNDEAD, PM_ALLOW_GROUP);
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_UNDEAD, PM_ALLOW_GROUP) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count) {
@@ -754,11 +754,11 @@ MonsterSpellResult spell_RF6_S_DRAGON(PlayerType *player_ptr, POSITION y, POSITI
 
     int count = 0;
     if (mon_to_player) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DRAGON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DRAGON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
     }
 
     if (mon_to_mon) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DRAGON, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx)));
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DRAGON, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx))) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count) {
@@ -810,11 +810,11 @@ MonsterSpellResult spell_RF6_S_HI_UNDEAD(PlayerType *player_ptr, POSITION y, POS
 
         for (auto k = 0; k < S_NUM_6; k++) {
             if (mon_to_player) {
-                count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HI_UNDEAD, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
+                count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HI_UNDEAD, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
             }
 
             if (mon_to_mon) {
-                count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HI_UNDEAD, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx)));
+                count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HI_UNDEAD, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx))) ? 1 : 0;
             }
         }
     }
@@ -863,11 +863,11 @@ MonsterSpellResult spell_RF6_S_HI_DRAGON(PlayerType *player_ptr, POSITION y, POS
     int count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {
         if (mon_to_player) {
-            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HI_DRAGON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
+            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HI_DRAGON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
         }
 
         if (mon_to_mon) {
-            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HI_DRAGON, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx)));
+            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HI_DRAGON, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx))) ? 1 : 0;
         }
     }
 
@@ -914,7 +914,7 @@ MonsterSpellResult spell_RF6_S_AMBERITES(PlayerType *player_ptr, POSITION y, POS
 
     int count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_AMBERITES, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_AMBERITES, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count && mon_to_player) {
@@ -962,7 +962,7 @@ MonsterSpellResult spell_RF6_S_UNIQUE(PlayerType *player_ptr, POSITION y, POSITI
     bool uniques_are_summoned = false;
     int count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_UNIQUE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_UNIQUE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
     }
 
     if (count) {
@@ -977,7 +977,7 @@ MonsterSpellResult spell_RF6_S_UNIQUE(PlayerType *player_ptr, POSITION y, POSITI
     }
 
     for (auto k = count; k < S_NUM_4; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, non_unique_type, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, non_unique_type, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count && mon_to_player) {
@@ -1024,7 +1024,7 @@ MonsterSpellResult spell_RF6_S_DEAD_UNIQUE(PlayerType *player_ptr, POSITION y, P
 
     auto count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DEAD_UNIQUE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_CLONE));
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DEAD_UNIQUE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_CLONE)) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count && mon_to_player) {

--- a/src/mspell/specified-summon.cpp
+++ b/src/mspell/specified-summon.cpp
@@ -30,7 +30,7 @@ MONSTER_NUMBER summon_EAGLE(PlayerType *player_ptr, POSITION y, POSITION x, int 
     int count = 0;
     int num = 4 + randint1(3);
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_EAGLES, PM_ALLOW_GROUP | PM_ALLOW_UNIQUE);
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_EAGLES, PM_ALLOW_GROUP | PM_ALLOW_UNIQUE) ? 1 : 0;
     }
 
     return count;
@@ -50,7 +50,7 @@ MONSTER_NUMBER summon_EDGE(PlayerType *player_ptr, POSITION y, POSITION x, int r
     int count = 0;
     int num = 2 + randint1(1 + rlev / 20);
     for (int k = 0; k < num; k++) {
-        count += summon_named_creature(player_ptr, m_idx, y, x, MonsterRaceId::EDGE, PM_NONE);
+        count += summon_named_creature(player_ptr, m_idx, y, x, MonsterRaceId::EDGE, PM_NONE) ? 1 : 0;
     }
 
     return count;
@@ -88,7 +88,7 @@ MONSTER_NUMBER summon_guardian(PlayerType *player_ptr, POSITION y, POSITION x, i
 
     int count = 0;
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_GUARDIANS, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_GUARDIANS, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
     }
 
     return count;
@@ -107,7 +107,7 @@ MONSTER_NUMBER summon_LOCKE_CLONE(PlayerType *player_ptr, POSITION y, POSITION x
     int count = 0;
     int num = randint1(3);
     for (int k = 0; k < num; k++) {
-        count += summon_named_creature(player_ptr, m_idx, y, x, MonsterRaceId::LOCKE_CLONE, PM_NONE);
+        count += summon_named_creature(player_ptr, m_idx, y, x, MonsterRaceId::LOCKE_CLONE, PM_NONE) ? 1 : 0;
     }
 
     return count;
@@ -127,7 +127,7 @@ MONSTER_NUMBER summon_LOUSE(PlayerType *player_ptr, POSITION y, POSITION x, int 
     int count = 0;
     int num = 2 + randint1(3);
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_LOUSE, PM_ALLOW_GROUP);
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_LOUSE, PM_ALLOW_GROUP) ? 1 : 0;
     }
 
     return count;
@@ -138,7 +138,7 @@ MONSTER_NUMBER summon_MOAI(PlayerType *player_ptr, POSITION y, POSITION x, int r
     int count = 0;
     int num = 3 + randint1(3);
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_SMALL_MOAI, PM_NONE);
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_SMALL_MOAI, PM_NONE) ? 1 : 0;
     }
 
     return count;
@@ -154,7 +154,7 @@ MONSTER_NUMBER summon_DEMON_SLAYER(PlayerType *player_ptr, POSITION y, POSITION 
 
     auto count = 0;
     for (auto k = 0; k < MAX_NAZGUL_NUM; k++) {
-        count += summon_named_creature(player_ptr, m_idx, y, x, MonsterRaceId::DESLAYER_MEMBER, PM_NONE);
+        count += summon_named_creature(player_ptr, m_idx, y, x, MonsterRaceId::DESLAYER_MEMBER, PM_NONE) ? 1 : 0;
     }
 
     if (count == 0) {
@@ -234,7 +234,7 @@ MONSTER_NUMBER summon_APOCRYPHA(PlayerType *player_ptr, POSITION y, POSITION x, 
     int num = 4 + randint1(4);
     summon_type followers = one_in_(2) ? SUMMON_APOCRYPHA_FOLLOWERS : SUMMON_APOCRYPHA_DRAGONS;
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, 200, followers, PM_ALLOW_UNIQUE);
+        count += summon_specific(player_ptr, m_idx, y, x, 200, followers, PM_ALLOW_UNIQUE) ? 1 : 0;
     }
 
     return count;
@@ -245,7 +245,7 @@ MONSTER_NUMBER summon_HIGHEST_DRAGON(PlayerType *player_ptr, POSITION y, POSITIO
     int count = 0;
     int num = 4 + randint1(4);
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, 100, SUMMON_APOCRYPHA_DRAGONS, PM_ALLOW_UNIQUE);
+        count += summon_specific(player_ptr, m_idx, y, x, 100, SUMMON_APOCRYPHA_DRAGONS, PM_ALLOW_UNIQUE) ? 1 : 0;
     }
 
     return count;
@@ -256,7 +256,7 @@ MONSTER_NUMBER summon_PYRAMID(PlayerType *player_ptr, POSITION y, POSITION x, in
     int count = 0;
     int num = 2 + randint1(3);
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_PYRAMID, PM_NONE);
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_PYRAMID, PM_NONE) ? 1 : 0;
     }
 
     return count;
@@ -267,7 +267,7 @@ MONSTER_NUMBER summon_EYE_PHORN(PlayerType *player_ptr, POSITION y, POSITION x, 
     int count = 0;
     int num = 2 + randint1(1 + rlev / 20);
     for (int k = 0; k < num; k++) {
-        count += summon_named_creature(player_ptr, m_idx, y, x, MonsterRaceId::EYE_PHORN, PM_NONE);
+        count += summon_named_creature(player_ptr, m_idx, y, x, MonsterRaceId::EYE_PHORN, PM_NONE) ? 1 : 0;
     }
 
     return count;
@@ -278,7 +278,7 @@ MONSTER_NUMBER summon_VESPOID(PlayerType *player_ptr, POSITION y, POSITION x, in
     int count = 0;
     int num = 2 + randint1(3);
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_VESPOID, PM_NONE);
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_VESPOID, PM_NONE) ? 1 : 0;
     }
 
     return count;
@@ -289,7 +289,7 @@ MONSTER_NUMBER summon_THUNDERS(PlayerType *player_ptr, POSITION y, POSITION x, i
     auto count = (MONSTER_NUMBER)0;
     auto num = 11;
     for (auto k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ANTI_TIGERS, PM_NONE);
+        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ANTI_TIGERS, PM_NONE) ? 1 : 0;
     }
 
     return count;
@@ -311,7 +311,7 @@ MONSTER_NUMBER summon_YENDER_WIZARD(PlayerType *player_ptr, POSITION y, POSITION
         return 0;
     }
 
-    auto count = (MONSTER_NUMBER)summon_named_creature(player_ptr, m_idx, y, x, MonsterRaceId::YENDOR_WIZARD_2, PM_NONE);
+    auto count = summon_named_creature(player_ptr, m_idx, y, x, MonsterRaceId::YENDOR_WIZARD_2, PM_NONE) ? 1 : 0;
     if (count == 0) {
         msg_print(_("どこからか声が聞こえる…「三重苦は負わぬ。。。」", "Heard a voice from somewhere... 'I will deny the triple suffering...'"));
         return 0;
@@ -326,7 +326,7 @@ MONSTER_NUMBER summon_PLASMA(PlayerType *player_ptr, POSITION y, POSITION x, int
     auto count = 0;
     auto num = 2 + randint1(1 + rlev / 20);
     for (auto k = 0; k < num; k++) {
-        count += summon_named_creature(player_ptr, m_idx, y, x, MonsterRaceId::PLASMA_VORTEX, PM_NONE);
+        count += summon_named_creature(player_ptr, m_idx, y, x, MonsterRaceId::PLASMA_VORTEX, PM_NONE) ? 1 : 0;
     }
 
     msg_print(_("プーラーズーマーッ！！", "P--la--s--ma--!!"));
@@ -346,7 +346,7 @@ MONSTER_NUMBER summon_LAFFEY_II(PlayerType *player_ptr, const Pos2D &position, M
     auto count = 0;
     constexpr auto summon_num = 2;
     for (auto k = 0; k < summon_num; k++) {
-        count += summon_named_creature(player_ptr, m_idx, position.y, position.x, MonsterRaceId::BUNBUN_STRIKERS, PM_NONE);
+        count += summon_named_creature(player_ptr, m_idx, position.y, position.x, MonsterRaceId::BUNBUN_STRIKERS, PM_NONE) ? 1 : 0;
     }
     return count;
 }

--- a/src/spell-kind/blood-curse.cpp
+++ b/src/spell-kind/blood-curse.cpp
@@ -104,8 +104,8 @@ void blood_curse_to_enemy(PlayerType *player_ptr, MONSTER_IDX m_idx)
                 mode |= (PM_NO_PET | PM_FORCE_FRIENDLY);
             }
 
-            count += summon_specific(player_ptr, (pet ? -1 : 0), player_ptr->y, player_ptr->x,
-                (pet ? player_ptr->lev * 2 / 3 + randint1(player_ptr->lev / 2) : player_ptr->current_floor_ptr->dun_level), SUMMON_NONE, mode);
+            const auto level = pet ? player_ptr->lev * 2 / 3 + randint1(player_ptr->lev / 2) : player_ptr->current_floor_ptr->dun_level;
+            count += summon_specific(player_ptr, (pet ? -1 : 0), player_ptr->y, player_ptr->x, level, SUMMON_NONE, mode) ? 1 : 0;
             if (!one_in_(6)) {
                 break;
             }

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -175,8 +175,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
         case 8:
         case 9:
         case 18:
-            (*count) += summon_specific(
-                player_ptr, 0, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+            (*count) += summon_specific(player_ptr, 0, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET)) ? 1 : 0;
             if (!one_in_(6)) {
                 break;
             }

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -281,7 +281,7 @@ int summon_cyber(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITI
 
     int count = 0;
     for (int i = 0; i < max_cyber; i++) {
-        count += summon_specific(player_ptr, src_idx, y, x, 100, SUMMON_CYBER, mode);
+        count += summon_specific(player_ptr, src_idx, y, x, 100, SUMMON_CYBER, mode) ? 1 : 0;
     }
 
     return count;
@@ -373,71 +373,71 @@ int activate_hi_summon(PlayerType *player_ptr, POSITION y, POSITION x, bool can_
         switch (randint1(25) + (dungeon_level / 20)) {
         case 1:
         case 2:
-            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_ANT, mode);
+            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_ANT, mode) ? 1 : 0;
             break;
         case 3:
         case 4:
-            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_SPIDER, mode);
+            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_SPIDER, mode) ? 1 : 0;
             break;
         case 5:
         case 6:
-            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_HOUND, mode);
+            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_HOUND, mode) ? 1 : 0;
             break;
         case 7:
         case 8:
-            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_HYDRA, mode);
+            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_HYDRA, mode) ? 1 : 0;
             break;
         case 9:
         case 10:
-            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_ANGEL, mode);
+            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_ANGEL, mode) ? 1 : 0;
             break;
         case 11:
         case 12:
-            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_UNDEAD, mode);
+            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_UNDEAD, mode) ? 1 : 0;
             break;
         case 13:
         case 14:
-            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_DRAGON, mode);
+            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_DRAGON, mode) ? 1 : 0;
             break;
         case 15:
         case 16:
-            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_DEMON, mode);
+            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_DEMON, mode) ? 1 : 0;
             break;
         case 17:
             if (can_pet) {
                 break;
             }
-            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_AMBERITES, (mode | PM_ALLOW_UNIQUE));
+            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_AMBERITES, (mode | PM_ALLOW_UNIQUE)) ? 1 : 0;
             break;
         case 18:
         case 19:
             if (can_pet) {
                 break;
             }
-            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_UNIQUE, (mode | PM_ALLOW_UNIQUE));
+            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_UNIQUE, (mode | PM_ALLOW_UNIQUE)) ? 1 : 0;
             break;
         case 20:
         case 21:
             if (!can_pet) {
                 mode |= PM_ALLOW_UNIQUE;
             }
-            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_HI_UNDEAD, mode);
+            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_HI_UNDEAD, mode) ? 1 : 0;
             break;
         case 22:
         case 23:
             if (!can_pet) {
                 mode |= PM_ALLOW_UNIQUE;
             }
-            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_HI_DRAGON, mode);
+            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, summon_lev, SUMMON_HI_DRAGON, mode) ? 1 : 0;
             break;
         case 24:
-            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, 100, SUMMON_CYBER, mode);
+            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, 100, SUMMON_CYBER, mode) ? 1 : 0;
             break;
         default:
             if (!can_pet) {
                 mode |= PM_ALLOW_UNIQUE;
             }
-            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, pet ? summon_lev : (((summon_lev * 3) / 2) + 5), SUMMON_NONE, mode);
+            count += summon_specific(player_ptr, (pet ? -1 : 0), y, x, pet ? summon_lev : (((summon_lev * 3) / 2) + 5), SUMMON_NONE, mode) ? 1 : 0;
         }
     }
 


### PR DESCRIPTION
関数がtrueを返した回数を、戻り値をそのまま足し算することによりカウント
しているが、true == 1, false == 0 となる事を前提とするのはCの言語仕様
への依存が強いので、三項演算子を用いてtrueなら1、falseなら0を明示的に
足すようにする。