### PR TITLE
変愚「[Fix] prefファイルのパースで空白があると正しく判定されない #4343」のマージ

### DIFF
--- a/src/info-reader/fixed-map-parser.cpp
+++ b/src/info-reader/fixed-map-parser.cpp
@@ -64,7 +64,7 @@ static std::string parse_fixed_map_expression(PlayerType *player_ptr, char **sp,
             v = "0";
             while (*s && (f != b2)) {
                 t = parse_fixed_map_expression(player_ptr, &s, &f);
-                if (t != "0") {
+                if (!t.empty() && t != "0") {
                     v = "1";
                 }
             }
@@ -72,7 +72,7 @@ static std::string parse_fixed_map_expression(PlayerType *player_ptr, char **sp,
             v = "1";
             while (*s && (f != b2)) {
                 t = parse_fixed_map_expression(player_ptr, &s, &f);
-                if (t == "0") {
+                if (!t.empty() && t == "0") {
                     v = "0";
                 }
             }
@@ -80,7 +80,7 @@ static std::string parse_fixed_map_expression(PlayerType *player_ptr, char **sp,
             v = "1";
             while (*s && (f != b2)) {
                 t = parse_fixed_map_expression(player_ptr, &s, &f);
-                if (t == "1") {
+                if (!t.empty() && t == "1") {
                     v = "0";
                 }
             }

--- a/src/io/pref-file-expressor.cpp
+++ b/src/io/pref-file-expressor.cpp
@@ -53,7 +53,7 @@ std::string process_pref_file_expr(PlayerType *player_ptr, char **sp, char *fp)
             v = "0";
             while (*s && (f != b2)) {
                 t = process_pref_file_expr(player_ptr, &s, &f);
-                if (t != "0") {
+                if (!t.empty() && t != "0") {
                     v = "1";
                 }
             }
@@ -61,7 +61,7 @@ std::string process_pref_file_expr(PlayerType *player_ptr, char **sp, char *fp)
             v = "1";
             while (*s && (f != b2)) {
                 t = process_pref_file_expr(player_ptr, &s, &f);
-                if (t == "0") {
+                if (!t.empty() && t == "0") {
                     v = "0";
                 }
             }
@@ -69,7 +69,7 @@ std::string process_pref_file_expr(PlayerType *player_ptr, char **sp, char *fp)
             v = "1";
             while (*s && (f != b2)) {
                 t = process_pref_file_expr(player_ptr, &s, &f);
-                if (t == "1") {
+                if (!t.empty() && t == "1") {
                     v = "0";
                 }
             }


### PR DESCRIPTION
188eb7e および 2c32946 で条件式から空文字列の判定を省略してしまった
ため、空白がある時に正しく処理されなくなっている。
元通り空文字列の判定を行うようにする。