### PR TITLE
変愚「[Refactor] グローバル変数 hack_m_idx_ii を削除する #4354」のマージ

### DIFF
--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -331,8 +331,8 @@ static void init_riding_pet(PlayerType *player_ptr, bool new_game)
 
     MonsterRaceId pet_r_idx = pc.equals(PlayerClassType::CAVALRY) ? MonsterRaceId::HORSE : MonsterRaceId::YASE_HORSE;
     auto *r_ptr = &monraces_info[pet_r_idx];
-    place_specific_monster(player_ptr, 0, player_ptr->y, player_ptr->x - 1, pet_r_idx, (PM_FORCE_PET | PM_NO_KAGE));
-    auto *m_ptr = &player_ptr->current_floor_ptr->m_list[hack_m_idx_ii];
+    auto m_idx = place_specific_monster(player_ptr, 0, player_ptr->y, player_ptr->x - 1, pet_r_idx, (PM_FORCE_PET | PM_NO_KAGE));
+    auto *m_ptr = &player_ptr->current_floor_ptr->m_list[*m_idx];
     m_ptr->mspeed = r_ptr->speed;
     m_ptr->maxhp = r_ptr->hit_dice.floored_expected_value();
     m_ptr->max_maxhp = m_ptr->maxhp;

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -77,8 +77,8 @@ static void process_fishing(PlayerType *player_ptr)
         msg_print(nullptr);
         if (MonraceList::is_valid(r_idx) && one_in_(2)) {
             const auto pos = player_ptr->get_neighbor(player_ptr->fishing_dir);
-            if (place_specific_monster(player_ptr, 0, pos.y, pos.x, r_idx, PM_NO_KAGE)) {
-                const auto m_name = monster_desc(player_ptr, &floor_ptr->m_list[floor_ptr->get_grid(pos).m_idx], 0);
+            if (auto m_idx = place_specific_monster(player_ptr, 0, pos.y, pos.x, r_idx, PM_NO_KAGE)) {
+                const auto m_name = monster_desc(player_ptr, &floor_ptr->m_list[*m_idx], 0);
                 msg_print(_(format("%sが釣れた！", m_name.data()), "You have a good catch!"));
                 success = true;
             }

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -139,9 +139,9 @@ static void parse_qtw_D(PlayerType *player_ptr, qtwg_type *qtwg_ptr, char *s)
                 r_ref.max_num = r_ref.mob_num;
             }
 
-            place_specific_monster(player_ptr, 0, *qtwg_ptr->y, *qtwg_ptr->x, r_idx, (PM_ALLOW_SLEEP | PM_NO_KAGE));
-            if (clone) {
-                floor_ptr->m_list[hack_m_idx_ii].mflag2.set(MonsterConstantFlagType::CLONED);
+            const auto m_idx = place_specific_monster(player_ptr, 0, *qtwg_ptr->y, *qtwg_ptr->x, r_idx, (PM_ALLOW_SLEEP | PM_NO_KAGE));
+            if (clone && m_idx) {
+                floor_ptr->m_list[*m_idx].mflag2.set(MonsterConstantFlagType::CLONED);
                 r_ref.cur_num = old_cur_num;
                 r_ref.mob_num = old_mob_num;
                 r_ref.max_num = old_max_num;

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -252,8 +252,10 @@ static void generate_gambling_arena(PlayerType *player_ptr)
     build_battle(player_ptr, &y, &x);
     player_place(player_ptr, y, x);
     for (MONSTER_IDX i = 0; i < 4; i++) {
-        place_specific_monster(player_ptr, 0, player_ptr->y + 8 + (i / 2) * 4, player_ptr->x - 2 + (i % 2) * 4, battle_mon_list[i], (PM_NO_KAGE | PM_NO_PET));
-        set_friendly(&floor_ptr->m_list[floor_ptr->grid_array[player_ptr->y + 8 + (i / 2) * 4][player_ptr->x - 2 + (i % 2) * 4].m_idx]);
+        const auto m_idx = place_specific_monster(player_ptr, 0, player_ptr->y + 8 + (i / 2) * 4, player_ptr->x - 2 + (i % 2) * 4, battle_mon_list[i], (PM_NO_KAGE | PM_NO_PET));
+        if (m_idx) {
+            set_friendly(&floor_ptr->m_list[*m_idx]);
+        }
     }
 
     for (MONSTER_IDX i = 1; i < floor_ptr->m_max; i++) {

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -597,12 +597,12 @@ void hit_trap(PlayerType *player_ptr, bool break_trap)
                     continue;
                 }
 
-                if (summon_specific(player_ptr, 0, y1, x1, lev, SUMMON_ARMAGE_EVIL, (PM_NO_PET))) {
-                    evil_idx = hack_m_idx_ii;
+                if (auto m_idx = summon_specific(player_ptr, 0, y1, x1, lev, SUMMON_ARMAGE_EVIL, (PM_NO_PET))) {
+                    evil_idx = *m_idx;
                 }
 
-                if (summon_specific(player_ptr, 0, y1, x1, lev, SUMMON_ARMAGE_GOOD, (PM_NO_PET))) {
-                    good_idx = hack_m_idx_ii;
+                if (auto m_idx = summon_specific(player_ptr, 0, y1, x1, lev, SUMMON_ARMAGE_GOOD, (PM_NO_PET))) {
+                    good_idx = *m_idx;
                 }
 
                 /* Let them fight each other */

--- a/src/monster-floor/monster-generator.cpp
+++ b/src/monster-floor/monster-generator.cpp
@@ -121,32 +121,33 @@ bool mon_scatter(PlayerType *player_ptr, MonsterRaceId r_idx, POSITION *yp, POSI
  * @param r_idx 増殖させたいモンスターID
  * @param clone クローン・モンスター処理ならばtrue
  * @param mode 生成オプション
- * @return 生成できたらtrueを返す
+ * @return 生成に成功したらモンスターID、失敗したらstd::nullopt
  * @details
  * Note that "reproduction" REQUIRES empty space.
  */
-bool multiply_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, MonsterRaceId r_idx, bool clone, BIT_FLAGS mode)
+std::optional<MONSTER_IDX> multiply_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, MonsterRaceId r_idx, bool clone, BIT_FLAGS mode)
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
     auto *m_ptr = &floor_ptr->m_list[m_idx];
     POSITION y, x;
-    if (!mon_scatter(player_ptr, r_idx, &y, &x, m_ptr->fy, m_ptr->fx, 1)) {
-        return false;
+    if (!mon_scatter(player_ptr, m_ptr->r_idx, &y, &x, m_ptr->fy, m_ptr->fx, 1)) {
+        return std::nullopt;
     }
 
     if (m_ptr->mflag2.has(MonsterConstantFlagType::NOPET)) {
         mode |= PM_NO_PET;
     }
 
-    if (!place_specific_monster(player_ptr, m_idx, y, x, r_idx, (mode | PM_NO_KAGE | PM_MULTIPLY))) {
-        return false;
+    const auto multiplied_m_idx = place_specific_monster(player_ptr, m_idx, y, x, r_idx, (mode | PM_NO_KAGE | PM_MULTIPLY));
+    if (!multiplied_m_idx) {
+        return std::nullopt;
     }
 
     if (clone || m_ptr->mflag2.has(MonsterConstantFlagType::CLONED)) {
-        floor_ptr->m_list[hack_m_idx_ii].mflag2.set({ MonsterConstantFlagType::CLONED, MonsterConstantFlagType::NOPET });
+        floor_ptr->m_list[*multiplied_m_idx].mflag2.set({ MonsterConstantFlagType::CLONED, MonsterConstantFlagType::NOPET });
     }
 
-    return true;
+    return multiplied_m_idx;
 }
 
 /*!
@@ -273,10 +274,10 @@ static bool place_monster_can_escort(PlayerType *player_ptr, MonsterRaceId monra
  * @param r_idx 生成するモンスターの種族ID
  * @param mode 生成オプション
  * @param summoner_m_idx モンスターの召喚による場合、召喚主のモンスターID
- * @return 生成に成功したらtrue
+ * @return 生成に成功したらモンスターID、失敗したらstd::nullopt
  * @details 護衛も一緒に生成する
  */
-bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx)
+std::optional<MONSTER_IDX> place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx)
 {
     auto *r_ptr = &monraces_info[r_idx];
 
@@ -284,14 +285,13 @@ bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITIO
         mode |= PM_KAGE;
     }
 
-    if (!place_monster_one(player_ptr, src_idx, y, x, r_idx, mode, summoner_m_idx)) {
-        return false;
+    const auto m_idx = place_monster_one(player_ptr, src_idx, y, x, r_idx, mode, summoner_m_idx);
+    if (!m_idx) {
+        return std::nullopt;
     }
     if (!(mode & PM_ALLOW_GROUP)) {
-        return true;
+        return m_idx;
     }
-
-    const auto place_monster_m_idx = hack_m_idx_ii;
 
     /* Reinforcement */
     for (const auto &[reinforce_monrace_id, num_dice] : r_ptr->reinforces) {
@@ -305,7 +305,7 @@ bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITIO
             const POSITION scatter_max = 40;
             for (d = scatter_min; d <= scatter_max; d++) {
                 scatter(player_ptr, &ny, &nx, y, x, d, PROJECT_NONE);
-                if (place_monster_one(player_ptr, place_monster_m_idx, ny, nx, reinforce_monrace_id, mode, summoner_m_idx)) {
+                if (place_monster_one(player_ptr, *m_idx, ny, nx, reinforce_monrace_id, mode, summoner_m_idx)) {
                     break;
                 }
             }
@@ -320,7 +320,7 @@ bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITIO
     }
 
     if (r_ptr->misc_flags.has_not(MonsterMiscType::ESCORT)) {
-        return true;
+        return m_idx;
     }
 
     for (int i = 0; i < 32; i++) {
@@ -330,7 +330,7 @@ bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITIO
             continue;
         }
 
-        auto hook = [place_monster_monrace_id = r_idx, place_monster_m_idx](PlayerType *player_ptr, MonsterRaceId escort_monrace_id) {
+        auto hook = [place_monster_monrace_id = r_idx, place_monster_m_idx = *m_idx](PlayerType *player_ptr, MonsterRaceId escort_monrace_id) {
             return place_monster_can_escort(player_ptr, escort_monrace_id, place_monster_monrace_id, place_monster_m_idx);
         };
         get_mon_num_prep(player_ptr, std::move(hook), get_monster_hook2(player_ptr, ny, nx));
@@ -339,13 +339,13 @@ bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITIO
             break;
         }
 
-        (void)place_monster_one(player_ptr, place_monster_m_idx, ny, nx, monrace_id, mode, summoner_m_idx);
+        (void)place_monster_one(player_ptr, *m_idx, ny, nx, monrace_id, mode, summoner_m_idx);
         if (monraces_info[monrace_id].misc_flags.has(MonsterMiscType::HAS_FRIENDS) || r_ptr->misc_flags.has(MonsterMiscType::MORE_ESCORT)) {
-            (void)place_monster_group(player_ptr, place_monster_m_idx, ny, nx, monrace_id, mode, summoner_m_idx);
+            (void)place_monster_group(player_ptr, *m_idx, ny, nx, monrace_id, mode, summoner_m_idx);
         }
     }
 
-    return true;
+    return m_idx;
 }
 /*!
  * @brief フロア相当のモンスターを1体生成する
@@ -353,9 +353,9 @@ bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITIO
  * @param y 生成地点y座標
  * @param x 生成地点x座標
  * @param mode 生成オプション
- * @return 生成に成功したらtrue
+ * @return 生成に成功したらモンスターID、失敗したらstd::nullopt
  */
-bool place_random_monster(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FLAGS mode)
+std::optional<MONSTER_IDX> place_random_monster(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FLAGS mode)
 {
     get_mon_num_prep(player_ptr, get_monster_hook(player_ptr), get_monster_hook2(player_ptr, y, x));
     const auto &floor = *player_ptr->current_floor_ptr;
@@ -364,7 +364,7 @@ bool place_random_monster(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FL
         monrace_id = get_mon_num(player_ptr, 0, floor.monster_level, PM_NONE);
     } while ((mode & PM_NO_QUEST) && monraces_info[monrace_id].misc_flags.has(MonsterMiscType::NO_QUEST));
     if (!MonraceList::is_valid(monrace_id)) {
-        return false;
+        return std::nullopt;
     }
 
     auto try_become_jural = one_in_(5) || !floor.is_in_underground();

--- a/src/monster-floor/monster-generator.h
+++ b/src/monster-floor/monster-generator.h
@@ -6,12 +6,12 @@
 enum summon_type : int;
 enum class MonsterRaceId : int16_t;
 class PlayerType;
-typedef bool (*summon_specific_pf)(PlayerType *, MONSTER_IDX, POSITION, POSITION, DEPTH, summon_type, BIT_FLAGS);
+using summon_specific_pf = std::optional<MONSTER_IDX>(PlayerType *, MONSTER_IDX, POSITION, POSITION, DEPTH, summon_type, BIT_FLAGS);
 
 bool mon_scatter(PlayerType *player_ptr, MonsterRaceId r_idx, POSITION *yp, POSITION *xp, POSITION y, POSITION x, POSITION max_dist);
-bool multiply_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, MonsterRaceId r_idx, bool clone, BIT_FLAGS mode);
-bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
-bool place_random_monster(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FLAGS mode);
+std::optional<MONSTER_IDX> multiply_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, MonsterRaceId r_idx, bool clone, BIT_FLAGS mode);
+std::optional<MONSTER_IDX> place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
+std::optional<MONSTER_IDX> place_random_monster(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FLAGS mode);
 bool alloc_horde(PlayerType *player_ptr, POSITION y, POSITION x, summon_specific_pf summon_specific);
 bool alloc_guardian(PlayerType *player_ptr, bool def_val);
 bool alloc_monster(PlayerType *player_ptr, int min_dis, BIT_FLAGS mode, summon_specific_pf summon_specific, int max_dis = 65535);

--- a/src/monster-floor/monster-summon.h
+++ b/src/monster-floor/monster-summon.h
@@ -5,5 +5,5 @@
 enum summon_type : int;
 enum class MonsterRaceId : int16_t;
 class PlayerType;
-bool summon_specific(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode);
-bool summon_named_creature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION oy, POSITION ox, MonsterRaceId r_idx, BIT_FLAGS mode);
+std::optional<MONSTER_IDX> summon_specific(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode);
+std::optional<MONSTER_IDX> summon_named_creature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION oy, POSITION ox, MonsterRaceId r_idx, BIT_FLAGS mode);

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -260,24 +260,24 @@ static void warn_unique_generation(PlayerType *player_ptr, MonsterRaceId r_idx)
  * @param r_idx 生成モンスター種族
  * @param mode 生成オプション
  * @param summoner_m_idx モンスターの召喚による場合、召喚主のモンスターID
- * @return 成功したらtrue
+ * @return 生成に成功したらモンスターID、失敗したらstd::nullopt
  */
-bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx)
+std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     auto *g_ptr = &floor.grid_array[y][x];
     auto *r_ptr = &MonraceList::get_instance().get_monrace(r_idx);
     const auto &world = AngbandWorld::get_instance();
     if (world.is_wild_mode() || !in_bounds(&floor, y, x) || !MonraceList::is_valid(r_idx)) {
-        return false;
+        return std::nullopt;
     }
 
     if (none_bits(mode, PM_IGNORE_TERRAIN) && (pattern_tile(&floor, y, x) || !monster_can_enter(player_ptr, y, x, r_ptr, 0))) {
-        return false;
+        return std::nullopt;
     }
 
     if (!check_unique_placeable(floor, r_idx, mode) || !check_quest_placeable(floor, r_idx) || !check_procection_rune(player_ptr, r_idx, y, x)) {
-        return false;
+        return std::nullopt;
     }
 
     msg_format_wizard(player_ptr, CHEAT_MONSTER, _("%s(Lv%d)を生成しました。", "%s(Lv%d) was generated."), r_ptr->name.data(), r_ptr->level);
@@ -286,9 +286,8 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, 
     }
 
     g_ptr->m_idx = m_pop(&floor);
-    hack_m_idx_ii = g_ptr->m_idx;
     if (!g_ptr->has_monster()) {
-        return false;
+        return std::nullopt;
     }
 
     MonsterEntity *m_ptr;
@@ -477,5 +476,5 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, 
 
     activate_explosive_rune(player_ptr, Pos2D(y, x), *r_ptr);
 
-    return true;
+    return m_ptr->is_valid() ? std::make_optional(g_ptr->m_idx) : std::nullopt;
 }

--- a/src/monster-floor/one-monster-placer.h
+++ b/src/monster-floor/one-monster-placer.h
@@ -5,4 +5,4 @@
 
 enum class MonsterRaceId : int16_t;
 class PlayerType;
-bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
+std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -470,8 +470,8 @@ void process_special(PlayerType *player_ptr, MONSTER_IDX m_idx)
     BIT_FLAGS p_mode = m_ptr->is_pet() ? PM_FORCE_PET : PM_NONE;
 
     for (int k = 0; k < A_MAX; k++) {
-        if (summon_specific(player_ptr, m_idx, m_ptr->fy, m_ptr->fx, rlev, SUMMON_MOLD, (PM_ALLOW_GROUP | p_mode))) {
-            if (player_ptr->current_floor_ptr->m_list[hack_m_idx_ii].ml) {
+        if (auto summoned_m_idx = summon_specific(player_ptr, m_idx, m_ptr->fy, m_ptr->fx, rlev, SUMMON_MOLD, (PM_ALLOW_GROUP | p_mode))) {
+            if (player_ptr->current_floor_ptr->m_list[*summoned_m_idx].ml) {
                 count++;
             }
         }
@@ -517,8 +517,8 @@ bool decide_monster_multiplication(PlayerType *player_ptr, MONSTER_IDX m_idx, PO
 
     constexpr auto chance_reproduction = 8;
     if ((k < 5) && (!k || !randint0(k * chance_reproduction))) {
-        if (multiply_monster(player_ptr, m_idx, m_ptr->r_idx, false, (m_ptr->is_pet() ? PM_FORCE_PET : 0))) {
-            if (player_ptr->current_floor_ptr->m_list[hack_m_idx_ii].ml && is_original_ap_and_seen(player_ptr, m_ptr)) {
+        if (auto multiplied_m_idx = multiply_monster(player_ptr, m_idx, r_ptr->idx, false, (m_ptr->is_pet() ? PM_FORCE_PET : 0))) {
+            if (player_ptr->current_floor_ptr->m_list[*multiplied_m_idx].ml && is_original_ap_and_seen(player_ptr, m_ptr)) {
                 r_ptr->r_misc_flags.set(MonsterMiscType::MULTIPLY);
             }
             return true;
@@ -629,7 +629,8 @@ bool process_monster_spawn_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, PO
         auto idx = std::get<2>(spawn_info);
         if (randint1(deno) <= num) {
             if (multiply_monster(player_ptr, m_idx, idx, false, (m_ptr->is_pet() ? PM_FORCE_PET : 0))) {
-                if (player_ptr->current_floor_ptr->m_list[hack_m_idx_ii].ml && is_original_ap_and_seen(player_ptr, m_ptr)) {
+                auto &monster = player_ptr->current_floor_ptr->m_list[m_idx];
+                if (monster.ml && is_original_ap_and_seen(player_ptr, m_ptr)) {
                     r_ptr->misc_flags.set(MonsterMiscType::MULTIPLY);
                 }
                 return true;

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -31,7 +31,6 @@ enum dungeon_mode_type {
 };
 
 MONSTER_IDX hack_m_idx = 0; /* Hack -- see "process_monsters()" */
-MONSTER_IDX hack_m_idx_ii = 0;
 
 /**
  * @brief モンスターがダンジョンに出現できる条件を満たしているかのフラグ判定関数(AND)

--- a/src/monster/monster-util.h
+++ b/src/monster/monster-util.h
@@ -9,7 +9,6 @@ class PlayerType;
 using monsterrace_hook_type = std::function<bool(PlayerType *, MonsterRaceId)>;
 
 extern MONSTER_IDX hack_m_idx;
-extern MONSTER_IDX hack_m_idx_ii;
 enum summon_type : int;
 
 monsterrace_hook_type get_monster_hook(PlayerType *player_ptr);

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -66,9 +66,13 @@ static MonsterSpellResult spell_RF6_SPECIAL_UNIFICATION(PlayerType *player_ptr, 
 
         delete_monster_idx(player_ptr, floor_ptr->grid_array[m_ptr->fy][m_ptr->fx].m_idx);
         for (const auto separate : it_unified->second) {
-            summon_named_creature(player_ptr, 0, dummy_y, dummy_x, separate, MD_NONE);
-            floor_ptr->m_list[hack_m_idx_ii].hp = separated_hp;
-            floor_ptr->m_list[hack_m_idx_ii].maxhp = separated_maxhp;
+            auto summoned_m_idx = summon_named_creature(player_ptr, 0, dummy_y, dummy_x, separate, MD_NONE);
+            if (!summoned_m_idx) {
+                continue;
+            }
+
+            floor_ptr->m_list[*summoned_m_idx].hp = separated_hp;
+            floor_ptr->m_list[*summoned_m_idx].maxhp = separated_maxhp;
         }
 
         const auto &m_name = monraces.get_monrace(it_unified->first).name;
@@ -103,9 +107,10 @@ static MonsterSpellResult spell_RF6_SPECIAL_UNIFICATION(PlayerType *player_ptr, 
             delete_monster_idx(player_ptr, k);
         }
 
-        summon_named_creature(player_ptr, 0, dummy_y, dummy_x, unified_unique, MD_NONE);
-        floor_ptr->m_list[hack_m_idx_ii].hp = unified_hp;
-        floor_ptr->m_list[hack_m_idx_ii].maxhp = unified_maxhp;
+        if (auto summoned_m_idx = summon_named_creature(player_ptr, 0, dummy_y, dummy_x, unified_unique, MD_NONE)) {
+            floor_ptr->m_list[*summoned_m_idx].hp = unified_hp;
+            floor_ptr->m_list[*summoned_m_idx].maxhp = unified_maxhp;
+        }
         std::vector<std::string> m_names;
         for (const auto &separate : separates) {
             const auto &monrace = monraces.get_monrace(separate);

--- a/src/mspell/mspell-summon.cpp
+++ b/src/mspell/mspell-summon.cpp
@@ -95,7 +95,9 @@ static MONSTER_NUMBER summon_Alliance(PlayerType *player_ptr, POSITION y, POSITI
 {
     int count = 0;
     for (int k = 0; k < 4; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ALLIANCE, PM_ALLOW_GROUP);
+        if (summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ALLIANCE, PM_ALLOW_GROUP)) {
+            count++;
+        };
     }
 
     return count;

--- a/src/specific-object/monster-ball.cpp
+++ b/src/specific-object/monster-ball.cpp
@@ -100,11 +100,12 @@ static bool release_monster(PlayerType *player_ptr, ItemEntity &item, DIRECTION 
         return false;
     }
 
-    if (!place_specific_monster(player_ptr, 0, pos.y, pos.x, monrace.idx, PM_FORCE_PET | PM_NO_KAGE)) {
+    const auto m_idx = place_specific_monster(player_ptr, 0, pos.y, pos.x, monrace.idx, PM_FORCE_PET | PM_NO_KAGE);
+    if (!m_idx) {
         return false;
     }
 
-    auto &monster = player_ptr->current_floor_ptr->m_list[hack_m_idx_ii];
+    auto &monster = player_ptr->current_floor_ptr->m_list[*m_idx];
     if (item.captured_monster_speed > 0) {
         monster.mspeed = item.captured_monster_speed;
     }

--- a/src/spell-kind/spells-polymorph.cpp
+++ b/src/spell-kind/spells-polymorph.cpp
@@ -115,14 +115,17 @@ bool polymorph_monster(PlayerType *player_ptr, POSITION y, POSITION x)
     m_ptr->hold_o_idx_list.clear();
     delete_monster_idx(player_ptr, g_ptr->m_idx);
     bool polymorphed = false;
-    if (place_specific_monster(player_ptr, 0, y, x, new_r_idx, mode)) {
-        floor_ptr->m_list[hack_m_idx_ii].nickname = back_m.nickname;
-        floor_ptr->m_list[hack_m_idx_ii].parent_m_idx = back_m.parent_m_idx;
-        floor_ptr->m_list[hack_m_idx_ii].hold_o_idx_list = back_m.hold_o_idx_list;
+    auto m_idx = place_specific_monster(player_ptr, 0, y, x, new_r_idx, mode);
+    if (m_idx) {
+        auto &monster = floor_ptr->m_list[*m_idx];
+        monster.nickname = back_m.nickname;
+        monster.parent_m_idx = back_m.parent_m_idx;
+        monster.hold_o_idx_list = back_m.hold_o_idx_list;
         polymorphed = true;
     } else {
-        if (place_specific_monster(player_ptr, 0, y, x, old_r_idx, (mode | PM_NO_KAGE | PM_IGNORE_TERRAIN))) {
-            floor_ptr->m_list[hack_m_idx_ii] = back_m;
+        m_idx = place_specific_monster(player_ptr, 0, y, x, old_r_idx, (mode | PM_NO_KAGE | PM_IGNORE_TERRAIN));
+        if (m_idx) {
+            floor_ptr->m_list[*m_idx] = back_m;
             mproc_init(floor_ptr);
         } else {
             preserve_hold_objects = false;
@@ -132,7 +135,7 @@ bool polymorph_monster(PlayerType *player_ptr, POSITION y, POSITION x)
     if (preserve_hold_objects) {
         for (const auto this_o_idx : back_m.hold_o_idx_list) {
             auto *o_ptr = &floor_ptr->o_list[this_o_idx];
-            o_ptr->held_m_idx = hack_m_idx_ii;
+            o_ptr->held_m_idx = *m_idx;
         }
     } else {
         for (auto it = back_m.hold_o_idx_list.begin(); it != back_m.hold_o_idx_list.end();) {
@@ -142,10 +145,10 @@ bool polymorph_monster(PlayerType *player_ptr, POSITION y, POSITION x)
     }
 
     if (targeted) {
-        target_who = hack_m_idx_ii;
+        target_who = m_idx.value_or(0);
     }
     if (health_tracked) {
-        health_track(player_ptr, hack_m_idx_ii);
+        health_track(player_ptr, m_idx.value_or(0));
     }
     return polymorphed;
 }

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -251,7 +251,7 @@ bool summon_kin_player(PlayerType *player_ptr, DEPTH level, POSITION y, POSITION
     if (!pet) {
         mode |= PM_NO_PET;
     }
-    return summon_specific(player_ptr, (pet ? -1 : 0), y, x, level, SUMMON_KIN, mode);
+    return summon_specific(player_ptr, (pet ? -1 : 0), y, x, level, SUMMON_KIN, mode).has_value();
 }
 
 /*!


### PR DESCRIPTION
グローバル変数 hack_m_idx_ii はモンスターの生成を行う関数によって生成
されたモンスターに、関数呼び出し直後にアクセスする用途で使用されている。
しかし、モンスター生成関数は集団生成などが発生すると内部でネストして
呼び出されることがあり、その中でさらに hack_m_idx_ii が上書きされて
しまう可能性があるため、hack_m_idx_ii が本当に想定している対象の
モンスターを指しているのか疑問が残る。
hack_m_idx_ii の使用箇所に関連するモンスター生成関数の戻り値を単純な
生成に成功したかを示すboolの代わりに成功した場合に生成したモンスターの
IDを std::optional<MONSTER_IDX> で返すようにし、それを使用して
モンスターにアクセスするように変更し、hack_m_idx_ii は削除する。