### PR TITLE
変愚「[Fix] 魔法領域なしの職業のセーブデータで起動するとクラッシュ #4394」のマージ

### DIFF
--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -144,7 +144,11 @@ void load_prev_data(PlayerType *player_ptr, bool swap)
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
         player_ptr->element = previous_char.realm1;
     } else {
-        pr.set(i2enum<RealmType>(previous_char.realm1), i2enum<RealmType>(previous_char.realm2));
+        const auto realm1 = i2enum<RealmType>(previous_char.realm1);
+        const auto realm2 = i2enum<RealmType>(previous_char.realm2);
+        if (realm1 != RealmType::NONE) {
+            pr.set(realm1, realm2);
+        }
     }
 
     player_ptr->age = previous_char.age;

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -45,12 +45,15 @@ static void rd_realms(PlayerType *player_ptr)
         return;
     }
 
-    const auto realm1 = rd_byte();
+    const auto realm1 = i2enum<RealmType>(rd_byte());
     auto realm2 = rd_byte();
+    if (realm1 == RealmType::NONE) {
+        return;
+    }
     if (realm2 == 255) { // 何のため？
         realm2 = 0;
     }
-    pr.set(i2enum<RealmType>(realm1), i2enum<RealmType>(realm2));
+    pr.set(realm1, i2enum<RealmType>(realm2));
 }
 
 /*!


### PR DESCRIPTION
魔法領域なしの時にもPlayerRealm::setで領域をセットしているので、領域の
チェックで例外が発生してしまう。
魔法領域なしの時はPlayerRealm::setを呼ばずに終了するように修正する。