### PR TITLE
変愚「[Fix] 空の名前が設定できてしまう #4420」のマージ

### DIFF
--- a/src/player/process-name.cpp
+++ b/src/player/process-name.cpp
@@ -138,11 +138,8 @@ void get_name(PlayerType *player_ptr)
     const auto copy_size = sizeof(player_ptr->name);
     constexpr auto prompt = _("キャラクターの名前を入力して下さい: ", "Enter a name for your character: ");
     const auto name = input_string(prompt, max_name_size, initial_name);
-    if (name.has_value()) {
-        if (!name->empty()) {
-            angband_strcpy(player_ptr->name, *name, copy_size);
-        }
-
+    if (name && !name->empty()) {
+        angband_strcpy(player_ptr->name, *name, copy_size);
         return;
     }
 


### PR DESCRIPTION
初期設定の名前が空（新規キャラメイク時）で、入力した名前も空の場合には
「PLAYER」という名前に設定し空の名前にならないようにする仕様だったが、
b6d6401 で空の名前が設定できるようになってしまっている。
以前の通り空の名前を入力した場合は「PLAYER」を設定するように修正する。