### PR TITLE
変愚「[Refactor] summon_specificのシグニチャ #4416」のマージ

### DIFF
--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -186,7 +186,7 @@ bool exe_mutation_power(PlayerType *player_ptr, PlayerMutationType power)
         return alchemy(player_ptr);
     case PlayerMutationType::GROW_MOLD:
         for (DIRECTION i = 0; i < 8; i++) {
-            summon_specific(player_ptr, -1, player_ptr->y, player_ptr->x, lvl, SUMMON_MOLD, PM_FORCE_PET);
+            summon_specific(player_ptr, player_ptr->y, player_ptr->x, lvl, SUMMON_MOLD, PM_FORCE_PET);
         }
 
         return true;

--- a/src/blue-magic/blue-magic-summon.cpp
+++ b/src/blue-magic/blue-magic-summon.cpp
@@ -32,7 +32,7 @@ bool cast_blue_summon_cyber(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
     msg_print(_("サイバーデーモンを召喚した！", "You summon a Cyberdemon!"));
     for (int k = 0; k < 1; k++) {
-        if (summon_specific(player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_CYBER, bmc_ptr->p_mode)) {
+        if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_CYBER, bmc_ptr->p_mode)) {
             if (!bmc_ptr->pet) {
                 msg_print(_("召喚されたサイバーデーモンは怒っている！", "The summoned Cyberdemon is angry!"));
             }
@@ -48,7 +48,7 @@ bool cast_blue_summon_monster(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
     msg_print(_("仲間を召喚した。", "You summon help."));
     for (int k = 0; k < 1; k++) {
-        if (summon_specific(player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_NONE, bmc_ptr->p_mode)) {
+        if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_NONE, bmc_ptr->p_mode)) {
             if (!bmc_ptr->pet) {
                 msg_print(_("召喚されたモンスターは怒っている！", "The summoned monster is angry!"));
             }
@@ -64,7 +64,7 @@ bool cast_blue_summon_monsters(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
     msg_print(_("モンスターを召喚した！", "You summon monsters!"));
     for (int k = 0; k < bmc_ptr->plev / 15 + 2; k++) {
-        if (summon_specific(player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_NONE, (bmc_ptr->p_mode | bmc_ptr->u_mode))) {
+        if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_NONE, (bmc_ptr->p_mode | bmc_ptr->u_mode))) {
             if (!bmc_ptr->pet) {
                 msg_print(_("召喚されたモンスターは怒っている！", "The summoned monsters are angry!"));
             }
@@ -80,7 +80,7 @@ bool cast_blue_summon_ant(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
     msg_print(_("アリを召喚した。", "You summon ants."));
     if (summon_specific(
-            player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_ANT, (PM_ALLOW_GROUP | bmc_ptr->p_mode))) {
+            player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_ANT, (PM_ALLOW_GROUP | bmc_ptr->p_mode))) {
         if (!bmc_ptr->pet) {
             msg_print(_("召喚されたアリは怒っている！", "The summoned ants are angry!"));
         }
@@ -95,7 +95,7 @@ bool cast_blue_summon_spider(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
     msg_print(_("蜘蛛を召喚した。", "You summon spiders."));
     if (summon_specific(
-            player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_SPIDER, (PM_ALLOW_GROUP | bmc_ptr->p_mode))) {
+            player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_SPIDER, (PM_ALLOW_GROUP | bmc_ptr->p_mode))) {
         if (!bmc_ptr->pet) {
             msg_print(_("召喚された蜘蛛は怒っている！", "The summoned spiders are angry!"));
         }
@@ -110,7 +110,7 @@ bool cast_blue_summon_hound(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
     msg_print(_("ハウンドを召喚した。", "You summon hounds."));
     if (summon_specific(
-            player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_HOUND, (PM_ALLOW_GROUP | bmc_ptr->p_mode))) {
+            player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_HOUND, (PM_ALLOW_GROUP | bmc_ptr->p_mode))) {
         if (!bmc_ptr->pet) {
             msg_print(_("召喚されたハウンドは怒っている！", "The summoned hounds are angry!"));
         }
@@ -125,7 +125,7 @@ bool cast_blue_summon_hydra(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
     msg_print(_("ヒドラを召喚した。", "You summon a hydras."));
     if (summon_specific(
-            player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_HYDRA, (bmc_ptr->g_mode | bmc_ptr->p_mode))) {
+            player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_HYDRA, (bmc_ptr->g_mode | bmc_ptr->p_mode))) {
         if (!bmc_ptr->pet) {
             msg_print(_("召喚されたヒドラは怒っている！", "The summoned hydras are angry!"));
         }
@@ -140,7 +140,7 @@ bool cast_blue_summon_angel(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
     msg_print(_("天使を召喚した！", "You summon an angel!"));
     if (summon_specific(
-            player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_ANGEL, (bmc_ptr->g_mode | bmc_ptr->p_mode))) {
+            player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_ANGEL, (bmc_ptr->g_mode | bmc_ptr->p_mode))) {
         if (!bmc_ptr->pet) {
             msg_print(_("召喚された天使は怒っている！", "The summoned angel is angry!"));
         }
@@ -155,7 +155,7 @@ bool cast_blue_summon_demon(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
     msg_print(_("混沌の宮廷から悪魔を召喚した！", "You summon a demon from the Courts of Chaos!"));
     if (summon_specific(
-            player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_DEMON, (bmc_ptr->g_mode | bmc_ptr->p_mode))) {
+            player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_DEMON, (bmc_ptr->g_mode | bmc_ptr->p_mode))) {
         if (!bmc_ptr->pet) {
             msg_print(_("召喚されたデーモンは怒っている！", "The summoned demon is angry!"));
         }
@@ -170,7 +170,7 @@ bool cast_blue_summon_undead(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
     msg_print(_("アンデッドの強敵を召喚した！", "You summon an undead adversary!"));
     if (summon_specific(
-            player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_UNDEAD, (bmc_ptr->g_mode | bmc_ptr->p_mode))) {
+            player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_UNDEAD, (bmc_ptr->g_mode | bmc_ptr->p_mode))) {
         if (!bmc_ptr->pet) {
             msg_print(_("召喚されたアンデッドは怒っている！", "The summoned undead is angry!"));
         }
@@ -185,7 +185,7 @@ bool cast_blue_summon_dragon(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
     msg_print(_("ドラゴンを召喚した！", "You summon a dragon!"));
     if (summon_specific(
-            player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_DRAGON, (bmc_ptr->g_mode | bmc_ptr->p_mode))) {
+            player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_DRAGON, (bmc_ptr->g_mode | bmc_ptr->p_mode))) {
         if (!bmc_ptr->pet) {
             msg_print(_("召喚されたドラゴンは怒っている！", "The summoned dragon is angry!"));
         }
@@ -199,7 +199,7 @@ bool cast_blue_summon_dragon(PlayerType *player_ptr, bmc_type *bmc_ptr)
 bool cast_blue_summon_high_undead(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
     msg_print(_("強力なアンデッドを召喚した！", "You summon a greater undead!"));
-    if (summon_specific(player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_HI_UNDEAD,
+    if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_HI_UNDEAD,
             (bmc_ptr->g_mode | bmc_ptr->p_mode | bmc_ptr->u_mode))) {
         if (!bmc_ptr->pet) {
             msg_print(_("召喚された上級アンデッドは怒っている！", "The summoned greater undead is angry!"));
@@ -214,7 +214,7 @@ bool cast_blue_summon_high_undead(PlayerType *player_ptr, bmc_type *bmc_ptr)
 bool cast_blue_summon_high_dragon(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
     msg_print(_("古代ドラゴンを召喚した！", "You summon an ancient dragon!"));
-    if (summon_specific(player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_HI_DRAGON,
+    if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_HI_DRAGON,
             (bmc_ptr->g_mode | bmc_ptr->p_mode | bmc_ptr->u_mode))) {
         if (!bmc_ptr->pet) {
             msg_print(_("召喚された古代ドラゴンは怒っている！", "The summoned ancient dragon is angry!"));
@@ -229,7 +229,7 @@ bool cast_blue_summon_high_dragon(PlayerType *player_ptr, bmc_type *bmc_ptr)
 bool cast_blue_summon_amberite(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
     msg_print(_("アンバーの王族を召喚した！", "You summon a Lord of Amber!"));
-    if (summon_specific(player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_AMBERITES,
+    if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_AMBERITES,
             (bmc_ptr->g_mode | bmc_ptr->p_mode | bmc_ptr->u_mode))) {
         if (!bmc_ptr->pet) {
             msg_print(_("召喚されたアンバーの王族は怒っている！", "The summoned Lord of Amber is angry!"));
@@ -246,7 +246,7 @@ bool cast_blue_summon_unique(PlayerType *player_ptr, bmc_type *bmc_ptr)
     int count = 0;
     msg_print(_("特別な強敵を召喚した！", "You summon a special opponent!"));
     for (int k = 0; k < 1; k++) {
-        if (summon_specific(player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_UNIQUE,
+        if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_UNIQUE,
                 (bmc_ptr->g_mode | bmc_ptr->p_mode | PM_ALLOW_UNIQUE))) {
             count++;
             if (!bmc_ptr->pet) {
@@ -256,7 +256,7 @@ bool cast_blue_summon_unique(PlayerType *player_ptr, bmc_type *bmc_ptr)
     }
 
     for (int k = count; k < 1; k++) {
-        if (summon_specific(player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_HI_UNDEAD,
+        if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_HI_UNDEAD,
                 (bmc_ptr->g_mode | bmc_ptr->p_mode | PM_ALLOW_UNIQUE))) {
             count++;
             if (!bmc_ptr->pet) {
@@ -277,7 +277,7 @@ bool cast_blue_summon_dead_unique(PlayerType *player_ptr, bmc_type *bmc_ptr)
     BIT_FLAGS mode = bmc_ptr->g_mode | bmc_ptr->p_mode | PM_ALLOW_UNIQUE | PM_CLONE;
 
     msg_print(_("特別な強敵を蘇らせた！", "You summon a special dead opponent!"));
-    if (summon_specific(player_ptr, (bmc_ptr->pet ? -1 : 0), player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_DEAD_UNIQUE, mode)) {
+    if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, bmc_ptr->summon_lev, SUMMON_DEAD_UNIQUE, mode)) {
         if (!bmc_ptr->pet) {
             msg_print(_("蘇生されたユニーク・モンスターは怒っている！", "The summoned special dead opponent is angry!"));
         }

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -1050,7 +1050,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
             max_cyber = 4;
         }
         for (k = 0; k < max_cyber; k++) {
-            summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_CYBER, mode);
+            summon_specific(player_ptr, target_row, target_col, plev, SUMMON_CYBER, mode);
         }
         break;
     }
@@ -1061,7 +1061,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         }
         msg_print(_("仲間を召喚した。", "You summon help."));
         for (k = 0; k < 1; k++) {
-            summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_NONE, (mode | u_mode));
+            summon_specific(player_ptr, target_row, target_col, plev, SUMMON_NONE, (mode | u_mode));
         }
         break;
     }
@@ -1072,7 +1072,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         }
         msg_print(_("モンスターを召喚した！", "You summon monsters!"));
         for (k = 0; k < 6; k++) {
-            summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_NONE, (mode | u_mode));
+            summon_specific(player_ptr, target_row, target_col, plev, SUMMON_NONE, (mode | u_mode));
         }
         break;
     }
@@ -1083,7 +1083,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         }
         msg_print(_("アリを召喚した。", "You summon ants."));
         for (k = 0; k < 6; k++) {
-            summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_ANT, mode);
+            summon_specific(player_ptr, target_row, target_col, plev, SUMMON_ANT, mode);
         }
         break;
     }
@@ -1094,7 +1094,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         }
         msg_print(_("蜘蛛を召喚した。", "You summon spiders."));
         for (k = 0; k < 6; k++) {
-            summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_SPIDER, mode);
+            summon_specific(player_ptr, target_row, target_col, plev, SUMMON_SPIDER, mode);
         }
         break;
     }
@@ -1105,7 +1105,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         }
         msg_print(_("ハウンドを召喚した。", "You summon hounds."));
         for (k = 0; k < 4; k++) {
-            summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_HOUND, mode);
+            summon_specific(player_ptr, target_row, target_col, plev, SUMMON_HOUND, mode);
         }
         break;
     }
@@ -1116,7 +1116,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         }
         msg_print(_("ヒドラを召喚した。", "You summon hydras."));
         for (k = 0; k < 4; k++) {
-            summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_HYDRA, mode);
+            summon_specific(player_ptr, target_row, target_col, plev, SUMMON_HYDRA, mode);
         }
         break;
     }
@@ -1127,7 +1127,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         }
         msg_print(_("天使を召喚した！", "You summon an angel!"));
         for (k = 0; k < 1; k++) {
-            summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_ANGEL, mode);
+            summon_specific(player_ptr, target_row, target_col, plev, SUMMON_ANGEL, mode);
         }
         break;
     }
@@ -1138,7 +1138,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         }
         msg_print(_("混沌の宮廷から悪魔を召喚した！", "You summon a demon from the Courts of Chaos!"));
         for (k = 0; k < 1; k++) {
-            summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_DEMON, (mode | u_mode));
+            summon_specific(player_ptr, target_row, target_col, plev, SUMMON_DEMON, (mode | u_mode));
         }
         break;
     }
@@ -1149,7 +1149,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         }
         msg_print(_("アンデッドの強敵を召喚した！", "You summon an undead adversary!"));
         for (k = 0; k < 1; k++) {
-            summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_UNDEAD, (mode | u_mode));
+            summon_specific(player_ptr, target_row, target_col, plev, SUMMON_UNDEAD, (mode | u_mode));
         }
         break;
     }
@@ -1160,7 +1160,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         }
         msg_print(_("ドラゴンを召喚した！", "You summon a dragon!"));
         for (k = 0; k < 1; k++) {
-            summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_DRAGON, (mode | u_mode));
+            summon_specific(player_ptr, target_row, target_col, plev, SUMMON_DRAGON, (mode | u_mode));
         }
         break;
     }
@@ -1171,7 +1171,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         }
         msg_print(_("強力なアンデッドを召喚した！", "You summon greater undead!"));
         for (k = 0; k < 6; k++) {
-            summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_HI_UNDEAD, (mode | u_mode));
+            summon_specific(player_ptr, target_row, target_col, plev, SUMMON_HI_UNDEAD, (mode | u_mode));
         }
         break;
     }
@@ -1182,7 +1182,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         }
         msg_print(_("古代ドラゴンを召喚した！", "You summon ancient dragons!"));
         for (k = 0; k < 4; k++) {
-            summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_HI_DRAGON, (mode | u_mode));
+            summon_specific(player_ptr, target_row, target_col, plev, SUMMON_HI_DRAGON, (mode | u_mode));
         }
         break;
     }
@@ -1193,7 +1193,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         }
         msg_print(_("アンバーの王族を召喚した！", "You summon Lords of Amber!"));
         for (k = 0; k < 4; k++) {
-            summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_AMBERITES, (mode | PM_ALLOW_UNIQUE));
+            summon_specific(player_ptr, target_row, target_col, plev, SUMMON_AMBERITES, (mode | PM_ALLOW_UNIQUE));
         }
         break;
     }
@@ -1204,12 +1204,12 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         }
         msg_print(_("特別な強敵を召喚した！", "You summon special opponents!"));
         for (k = 0; k < 4; k++) {
-            if (summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_UNIQUE, (mode | PM_ALLOW_UNIQUE))) {
+            if (summon_specific(player_ptr, target_row, target_col, plev, SUMMON_UNIQUE, (mode | PM_ALLOW_UNIQUE))) {
                 count++;
             }
         }
         for (k = count; k < 4; k++) {
-            summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_HI_UNDEAD, (mode | u_mode));
+            summon_specific(player_ptr, target_row, target_col, plev, SUMMON_HI_UNDEAD, (mode | u_mode));
         }
         break;
     }
@@ -1220,7 +1220,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         }
         msg_print(_("特別な強敵を蘇生した！", "You summon special dead opponents!"));
         for (auto k = 0; k < 4; k++) {
-            if (summon_specific(player_ptr, -1, target_row, target_col, plev, SUMMON_DEAD_UNIQUE, (mode | PM_ALLOW_UNIQUE | PM_CLONE))) {
+            if (summon_specific(player_ptr, target_row, target_col, plev, SUMMON_DEAD_UNIQUE, (mode | PM_ALLOW_UNIQUE | PM_CLONE))) {
                 count++;
             }
         }

--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -93,7 +93,7 @@ int staff_effect(PlayerType *player_ptr, int sval, bool *use_charge, bool powerf
     case SV_STAFF_SUMMONING: {
         const int times = randint1(powerful ? 8 : 4);
         for (k = 0; k < times; k++) {
-            if (summon_specific(player_ptr, 0, player_ptr->y, player_ptr->x, player_ptr->current_floor_ptr->dun_level, SUMMON_NONE,
+            if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, player_ptr->current_floor_ptr->dun_level, SUMMON_NONE,
                     (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET))) {
                 ident = true;
             }

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -452,7 +452,7 @@ void hit_trap(PlayerType *player_ptr, bool break_trap)
         msg_print(_("何かがピカッと光った！", "There is a flash of shimmering light!"));
         const auto num = 2 + randint1(3);
         for (auto i = 0; i < num; i++) {
-            (void)summon_specific(player_ptr, 0, p_pos.y, p_pos.x, player_ptr->current_floor_ptr->dun_level, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+            (void)summon_specific(player_ptr, p_pos.y, p_pos.x, player_ptr->current_floor_ptr->dun_level, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
         }
 
         if (player_ptr->current_floor_ptr->dun_level > randint1(100)) {
@@ -597,11 +597,11 @@ void hit_trap(PlayerType *player_ptr, bool break_trap)
                     continue;
                 }
 
-                if (auto m_idx = summon_specific(player_ptr, 0, y1, x1, lev, SUMMON_ARMAGE_EVIL, (PM_NO_PET))) {
+                if (auto m_idx = summon_specific(player_ptr, y1, x1, lev, SUMMON_ARMAGE_EVIL, (PM_NO_PET))) {
                     evil_idx = *m_idx;
                 }
 
-                if (auto m_idx = summon_specific(player_ptr, 0, y1, x1, lev, SUMMON_ARMAGE_GOOD, (PM_NO_PET))) {
+                if (auto m_idx = summon_specific(player_ptr, y1, x1, lev, SUMMON_ARMAGE_GOOD, (PM_NO_PET))) {
                     good_idx = *m_idx;
                 }
 
@@ -629,7 +629,7 @@ void hit_trap(PlayerType *player_ptr, bool break_trap)
         /* Summon Piranhas */
         const auto num = 1 + player_ptr->current_floor_ptr->dun_level / 20;
         for (auto i = 0; i < num; i++) {
-            (void)summon_specific(player_ptr, 0, p_pos.y, p_pos.x, player_ptr->current_floor_ptr->dun_level, SUMMON_PIRANHAS, (PM_ALLOW_GROUP | PM_NO_PET));
+            (void)summon_specific(player_ptr, p_pos.y, p_pos.x, player_ptr->current_floor_ptr->dun_level, SUMMON_PIRANHAS, (PM_ALLOW_GROUP | PM_NO_PET));
         }
         break;
     }

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -336,7 +336,7 @@ static void curse_call_monster(PlayerType *player_ptr)
     const int obj_desc_type = OD_OMIT_PREFIX | OD_NAME_ONLY;
     auto *floor_ptr = player_ptr->current_floor_ptr;
     if (player_ptr->cursed.has(CurseTraitType::CALL_ANIMAL) && one_in_(2500)) {
-        if (summon_specific(player_ptr, 0, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_ANIMAL, call_type)) {
+        if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_ANIMAL, call_type)) {
             const auto item_name = describe_flavor(player_ptr, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_ANIMAL), obj_desc_type);
             msg_format(_("%sが動物を引き寄せた！", "Your %s has attracted an animal!"), item_name.data());
             disturb(player_ptr, false, true);
@@ -344,7 +344,7 @@ static void curse_call_monster(PlayerType *player_ptr)
     }
 
     if (player_ptr->cursed.has(CurseTraitType::CALL_DEMON) && one_in_(1111)) {
-        if (summon_specific(player_ptr, 0, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_DEMON, call_type)) {
+        if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_DEMON, call_type)) {
             const auto item_name = describe_flavor(player_ptr, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_DEMON), obj_desc_type);
             msg_format(_("%sが悪魔を引き寄せた！", "Your %s has attracted a demon!"), item_name.data());
             disturb(player_ptr, false, true);
@@ -352,7 +352,7 @@ static void curse_call_monster(PlayerType *player_ptr)
     }
 
     if (player_ptr->cursed.has(CurseTraitType::CALL_DRAGON) && one_in_(800)) {
-        if (summon_specific(player_ptr, 0, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_DRAGON, call_type)) {
+        if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_DRAGON, call_type)) {
             const auto item_name = describe_flavor(player_ptr, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_DRAGON), obj_desc_type);
             msg_format(_("%sがドラゴンを引き寄せた！", "Your %s has attracted a dragon!"), item_name.data());
             disturb(player_ptr, false, true);
@@ -360,7 +360,7 @@ static void curse_call_monster(PlayerType *player_ptr)
     }
 
     if (player_ptr->cursed.has(CurseTraitType::CALL_UNDEAD) && one_in_(1111)) {
-        if (summon_specific(player_ptr, 0, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_UNDEAD, call_type)) {
+        if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_UNDEAD, call_type)) {
             const auto item_name = describe_flavor(player_ptr, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_UNDEAD), obj_desc_type);
             msg_format(_("%sが死霊を引き寄せた！", "Your %s has attracted an undead!"), item_name.data());
             disturb(player_ptr, false, true);

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -345,7 +345,7 @@ bool cast_force_spell(PlayerType *player_ptr, MindForceTrainerType spell)
     case MindForceTrainerType::SUMMON_GHOST: {
         bool success = false;
         for (int i = 0; i < 1 + boost / 100; i++) {
-            if (summon_specific(player_ptr, -1, player_ptr->y, player_ptr->x, plev, SUMMON_PHANTOM, PM_FORCE_PET)) {
+            if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, plev, SUMMON_PHANTOM, PM_FORCE_PET)) {
                 success = true;
             }
         }

--- a/src/monster-floor/monster-generator.cpp
+++ b/src/monster-floor/monster-generator.cpp
@@ -435,7 +435,7 @@ bool alloc_horde(PlayerType *player_ptr, POSITION y, POSITION x, summon_specific
     POSITION cx = x;
     for (auto attempts = randint1(10) + 5; attempts > 0; attempts--) {
         scatter(player_ptr, &cy, &cx, y, x, 5, PROJECT_NONE);
-        (void)(*summon_specific)(player_ptr, m_idx, cy, cx, floor.dun_level + 5, SUMMON_KIN, PM_ALLOW_GROUP);
+        (void)(*summon_specific)(player_ptr, cy, cx, floor.dun_level + 5, SUMMON_KIN, PM_ALLOW_GROUP, m_idx);
         y = cy;
         x = cx;
     }

--- a/src/monster-floor/monster-generator.h
+++ b/src/monster-floor/monster-generator.h
@@ -6,7 +6,7 @@
 enum summon_type : int;
 enum class MonsterRaceId : int16_t;
 class PlayerType;
-using summon_specific_pf = std::optional<MONSTER_IDX>(PlayerType *, MONSTER_IDX, POSITION, POSITION, DEPTH, summon_type, BIT_FLAGS);
+using summon_specific_pf = std::optional<MONSTER_IDX>(PlayerType *, POSITION, POSITION, DEPTH, summon_type, BIT_FLAGS, std::optional<MONSTER_IDX>);
 
 bool mon_scatter(PlayerType *player_ptr, MonsterRaceId r_idx, POSITION *yp, POSITION *xp, POSITION y, POSITION x, POSITION max_dist);
 std::optional<MONSTER_IDX> multiply_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, MonsterRaceId r_idx, bool clone, BIT_FLAGS mode);

--- a/src/monster-floor/monster-summon.h
+++ b/src/monster-floor/monster-summon.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include "system/angband.h"
+#include <optional>
 
 enum summon_type : int;
 enum class MonsterRaceId : int16_t;
 class PlayerType;
-std::optional<MONSTER_IDX> summon_specific(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode);
+std::optional<MONSTER_IDX> summon_specific(PlayerType *player_ptr, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
 std::optional<MONSTER_IDX> summon_named_creature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION oy, POSITION ox, MonsterRaceId r_idx, BIT_FLAGS mode);

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -83,7 +83,6 @@ static void summon_self(PlayerType *player_ptr, MonsterDeath *md_ptr, summon_typ
     POSITION wy = md_ptr->md_y;
     POSITION wx = md_ptr->md_x;
     int attempts = 100;
-    bool pet = md_ptr->m_ptr->is_pet();
     do {
         scatter(player_ptr, &wy, &wx, md_ptr->md_y, md_ptr->md_x, radius, PROJECT_NONE);
     } while (!(in_bounds(floor_ptr, wy, wx) && is_cave_empty_bold2(player_ptr, wy, wx)) && --attempts);
@@ -93,7 +92,7 @@ static void summon_self(PlayerType *player_ptr, MonsterDeath *md_ptr, summon_typ
     }
 
     BIT_FLAGS mode = dead_mode(md_ptr);
-    if (summon_specific(player_ptr, (pet ? -1 : md_ptr->m_idx), wy, wx, 100, type, mode) && player_can_see_bold(player_ptr, wy, wx)) {
+    if (summon_specific(player_ptr, wy, wx, 100, type, mode) && player_can_see_bold(player_ptr, wy, wx)) {
         msg_print(message);
     }
 }
@@ -109,9 +108,8 @@ static void on_dead_pink_horror(PlayerType *player_ptr, MonsterDeath *md_ptr)
     for (int i = 0; i < blue_horrors; i++) {
         POSITION wy = md_ptr->md_y;
         POSITION wx = md_ptr->md_x;
-        bool pet = md_ptr->m_ptr->is_pet();
         BIT_FLAGS mode = dead_mode(md_ptr);
-        if (summon_specific(player_ptr, (pet ? -1 : md_ptr->m_idx), wy, wx, 100, SUMMON_BLUE_HORROR, mode) && player_can_see_bold(player_ptr, wy, wx)) {
+        if (summon_specific(player_ptr, wy, wx, 100, SUMMON_BLUE_HORROR, mode) && player_can_see_bold(player_ptr, wy, wx)) {
             notice = true;
         }
     }

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -472,7 +472,7 @@ void process_special(PlayerType *player_ptr, MONSTER_IDX m_idx)
     BIT_FLAGS p_mode = m_ptr->is_pet() ? PM_FORCE_PET : PM_NONE;
 
     for (int k = 0; k < A_MAX; k++) {
-        if (auto summoned_m_idx = summon_specific(player_ptr, m_idx, m_ptr->fy, m_ptr->fx, rlev, SUMMON_MOLD, (PM_ALLOW_GROUP | p_mode))) {
+        if (auto summoned_m_idx = summon_specific(player_ptr, m_ptr->fy, m_ptr->fx, rlev, SUMMON_MOLD, (PM_ALLOW_GROUP | p_mode), m_idx)) {
             if (player_ptr->current_floor_ptr->m_list[*summoned_m_idx].ml) {
                 count++;
             }

--- a/src/mspell/mspell-summon.cpp
+++ b/src/mspell/mspell-summon.cpp
@@ -76,7 +76,7 @@ static MONSTER_NUMBER summon_Kin(PlayerType *player_ptr, POSITION y, POSITION x,
 {
     int count = 0;
     for (int k = 0; k < 4; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_KIN, PM_ALLOW_GROUP) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_KIN, PM_ALLOW_GROUP, m_idx) ? 1 : 0;
     }
 
     return count;
@@ -95,7 +95,7 @@ static MONSTER_NUMBER summon_Alliance(PlayerType *player_ptr, POSITION y, POSITI
 {
     int count = 0;
     for (int k = 0; k < 4; k++) {
-        if (summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ALLIANCE, PM_ALLOW_GROUP)) {
+        if (summon_specific(player_ptr, y, x, rlev, SUMMON_ALLIANCE, PM_ALLOW_GROUP)) {
             count++;
         };
     }
@@ -279,9 +279,9 @@ MonsterSpellResult spell_RF6_S_CYBER(PlayerType *player_ptr, POSITION y, POSITIO
 
     int count = 0;
     if (m_ptr->is_friendly() && mon_to_mon) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_CYBER, (PM_ALLOW_GROUP)) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_CYBER, (PM_ALLOW_GROUP), m_idx) ? 1 : 0;
     } else {
-        count += summon_cyber(player_ptr, m_idx, y, x);
+        count += summon_cyber(player_ptr, y, x, m_idx);
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count && mon_to_player) {
@@ -327,11 +327,11 @@ MonsterSpellResult spell_RF6_S_MONSTER(PlayerType *player_ptr, POSITION y, POSIT
     int count = 0;
     for (int k = 0; k < 1; k++) {
         if (mon_to_player) {
-            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
+            count += summon_specific(player_ptr, y, x, rlev, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE), m_idx) ? 1 : 0;
         }
 
         if (mon_to_mon) {
-            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_NONE, (monster_u_mode(floor_ptr, m_idx))) ? 1 : 0;
+            count += summon_specific(player_ptr, y, x, rlev, SUMMON_NONE, (monster_u_mode(floor_ptr, m_idx)), m_idx) ? 1 : 0;
         }
     }
 
@@ -378,11 +378,11 @@ MonsterSpellResult spell_RF6_S_MONSTERS(PlayerType *player_ptr, POSITION y, POSI
     int count = 0;
     for (auto k = 0; k < S_NUM_6; k++) {
         if (mon_to_player) {
-            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
+            count += summon_specific(player_ptr, y, x, rlev, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE), m_idx) ? 1 : 0;
         }
 
         if (mon_to_mon) {
-            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_NONE, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx))) ? 1 : 0;
+            count += summon_specific(player_ptr, y, x, rlev, SUMMON_NONE, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx)), m_idx) ? 1 : 0;
         }
     }
 
@@ -428,7 +428,7 @@ MonsterSpellResult spell_RF6_S_ANT(PlayerType *player_ptr, POSITION y, POSITION 
 
     int count = 0;
     for (auto k = 0; k < S_NUM_6; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ANT, PM_ALLOW_GROUP) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_ANT, PM_ALLOW_GROUP, m_idx) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count && mon_to_player) {
@@ -473,7 +473,7 @@ MonsterSpellResult spell_RF6_S_SPIDER(PlayerType *player_ptr, POSITION y, POSITI
 
     int count = 0;
     for (auto k = 0; k < S_NUM_6; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_SPIDER, PM_ALLOW_GROUP) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_SPIDER, PM_ALLOW_GROUP, m_idx) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count && mon_to_player) {
@@ -518,7 +518,7 @@ MonsterSpellResult spell_RF6_S_HOUND(PlayerType *player_ptr, POSITION y, POSITIO
 
     int count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HOUND, PM_ALLOW_GROUP) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_HOUND, PM_ALLOW_GROUP, m_idx) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count && mon_to_player) {
@@ -563,7 +563,7 @@ MonsterSpellResult spell_RF6_S_HYDRA(PlayerType *player_ptr, POSITION y, POSITIO
 
     int count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HYDRA, PM_ALLOW_GROUP) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_HYDRA, PM_ALLOW_GROUP, m_idx) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count && mon_to_player) {
@@ -614,7 +614,7 @@ MonsterSpellResult spell_RF6_S_ANGEL(PlayerType *player_ptr, POSITION y, POSITIO
 
     int count = 0;
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ANGEL, PM_ALLOW_GROUP) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_ANGEL, PM_ALLOW_GROUP, m_idx) ? 1 : 0;
     }
 
     const auto is_blind = player_ptr->effects()->blindness().is_blind();
@@ -666,7 +666,7 @@ MonsterSpellResult spell_RF6_S_DEMON(PlayerType *player_ptr, POSITION y, POSITIO
 
     int count = 0;
     for (int k = 0; k < 1; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DEMON, PM_ALLOW_GROUP) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_DEMON, PM_ALLOW_GROUP, m_idx) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count) {
@@ -711,7 +711,7 @@ MonsterSpellResult spell_RF6_S_UNDEAD(PlayerType *player_ptr, POSITION y, POSITI
 
     int count = 0;
     for (int k = 0; k < 1; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_UNDEAD, PM_ALLOW_GROUP) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_UNDEAD, PM_ALLOW_GROUP, m_idx) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count) {
@@ -756,11 +756,11 @@ MonsterSpellResult spell_RF6_S_DRAGON(PlayerType *player_ptr, POSITION y, POSITI
 
     int count = 0;
     if (mon_to_player) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DRAGON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_DRAGON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE), m_idx) ? 1 : 0;
     }
 
     if (mon_to_mon) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DRAGON, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx))) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_DRAGON, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx)), m_idx) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count) {
@@ -812,11 +812,11 @@ MonsterSpellResult spell_RF6_S_HI_UNDEAD(PlayerType *player_ptr, POSITION y, POS
 
         for (auto k = 0; k < S_NUM_6; k++) {
             if (mon_to_player) {
-                count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HI_UNDEAD, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
+                count += summon_specific(player_ptr, y, x, rlev, SUMMON_HI_UNDEAD, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE), m_idx) ? 1 : 0;
             }
 
             if (mon_to_mon) {
-                count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HI_UNDEAD, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx))) ? 1 : 0;
+                count += summon_specific(player_ptr, y, x, rlev, SUMMON_HI_UNDEAD, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx)), m_idx) ? 1 : 0;
             }
         }
     }
@@ -865,11 +865,11 @@ MonsterSpellResult spell_RF6_S_HI_DRAGON(PlayerType *player_ptr, POSITION y, POS
     int count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {
         if (mon_to_player) {
-            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HI_DRAGON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
+            count += summon_specific(player_ptr, y, x, rlev, SUMMON_HI_DRAGON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE), m_idx) ? 1 : 0;
         }
 
         if (mon_to_mon) {
-            count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HI_DRAGON, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx))) ? 1 : 0;
+            count += summon_specific(player_ptr, y, x, rlev, SUMMON_HI_DRAGON, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx)), m_idx) ? 1 : 0;
         }
     }
 
@@ -916,7 +916,7 @@ MonsterSpellResult spell_RF6_S_AMBERITES(PlayerType *player_ptr, POSITION y, POS
 
     int count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_AMBERITES, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_AMBERITES, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE), m_idx) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count && mon_to_player) {
@@ -964,7 +964,7 @@ MonsterSpellResult spell_RF6_S_UNIQUE(PlayerType *player_ptr, POSITION y, POSITI
     bool uniques_are_summoned = false;
     int count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_UNIQUE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_UNIQUE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE), m_idx) ? 1 : 0;
     }
 
     if (count) {
@@ -979,7 +979,7 @@ MonsterSpellResult spell_RF6_S_UNIQUE(PlayerType *player_ptr, POSITION y, POSITI
     }
 
     for (auto k = count; k < S_NUM_4; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, non_unique_type, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, non_unique_type, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE), m_idx) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count && mon_to_player) {
@@ -1026,7 +1026,7 @@ MonsterSpellResult spell_RF6_S_DEAD_UNIQUE(PlayerType *player_ptr, POSITION y, P
 
     auto count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DEAD_UNIQUE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_CLONE)) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_DEAD_UNIQUE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_CLONE), m_idx) ? 1 : 0;
     }
 
     if (player_ptr->effects()->blindness().is_blind() && count && mon_to_player) {

--- a/src/mspell/mspell-summon.cpp
+++ b/src/mspell/mspell-summon.cpp
@@ -95,9 +95,7 @@ static MONSTER_NUMBER summon_Alliance(PlayerType *player_ptr, POSITION y, POSITI
 {
     int count = 0;
     for (int k = 0; k < 4; k++) {
-        if (summon_specific(player_ptr, y, x, rlev, SUMMON_ALLIANCE, PM_ALLOW_GROUP)) {
-            count++;
-        };
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx) ? 1 : 0;
     }
 
     return count;

--- a/src/mspell/specified-summon.cpp
+++ b/src/mspell/specified-summon.cpp
@@ -30,7 +30,7 @@ MONSTER_NUMBER summon_EAGLE(PlayerType *player_ptr, POSITION y, POSITION x, int 
     int count = 0;
     int num = 4 + randint1(3);
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_EAGLES, PM_ALLOW_GROUP | PM_ALLOW_UNIQUE) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_EAGLES, PM_ALLOW_GROUP | PM_ALLOW_UNIQUE, m_idx) ? 1 : 0;
     }
 
     return count;
@@ -88,7 +88,7 @@ MONSTER_NUMBER summon_guardian(PlayerType *player_ptr, POSITION y, POSITION x, i
 
     int count = 0;
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_GUARDIANS, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE)) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_GUARDIANS, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE), m_idx) ? 1 : 0;
     }
 
     return count;
@@ -127,7 +127,7 @@ MONSTER_NUMBER summon_LOUSE(PlayerType *player_ptr, POSITION y, POSITION x, int 
     int count = 0;
     int num = 2 + randint1(3);
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_LOUSE, PM_ALLOW_GROUP) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_LOUSE, PM_ALLOW_GROUP, m_idx) ? 1 : 0;
     }
 
     return count;
@@ -138,7 +138,7 @@ MONSTER_NUMBER summon_MOAI(PlayerType *player_ptr, POSITION y, POSITION x, int r
     int count = 0;
     int num = 3 + randint1(3);
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_SMALL_MOAI, PM_NONE) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_SMALL_MOAI, PM_NONE, m_idx) ? 1 : 0;
     }
 
     return count;
@@ -234,7 +234,7 @@ MONSTER_NUMBER summon_APOCRYPHA(PlayerType *player_ptr, POSITION y, POSITION x, 
     int num = 4 + randint1(4);
     summon_type followers = one_in_(2) ? SUMMON_APOCRYPHA_FOLLOWERS : SUMMON_APOCRYPHA_DRAGONS;
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, 200, followers, PM_ALLOW_UNIQUE) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, 200, followers, PM_ALLOW_UNIQUE, m_idx) ? 1 : 0;
     }
 
     return count;
@@ -245,7 +245,7 @@ MONSTER_NUMBER summon_HIGHEST_DRAGON(PlayerType *player_ptr, POSITION y, POSITIO
     int count = 0;
     int num = 4 + randint1(4);
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, 100, SUMMON_APOCRYPHA_DRAGONS, PM_ALLOW_UNIQUE) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, 100, SUMMON_APOCRYPHA_DRAGONS, PM_ALLOW_UNIQUE, m_idx) ? 1 : 0;
     }
 
     return count;
@@ -256,7 +256,7 @@ MONSTER_NUMBER summon_PYRAMID(PlayerType *player_ptr, POSITION y, POSITION x, in
     int count = 0;
     int num = 2 + randint1(3);
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_PYRAMID, PM_NONE) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_PYRAMID, PM_NONE, m_idx) ? 1 : 0;
     }
 
     return count;
@@ -278,7 +278,7 @@ MONSTER_NUMBER summon_VESPOID(PlayerType *player_ptr, POSITION y, POSITION x, in
     int count = 0;
     int num = 2 + randint1(3);
     for (int k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_VESPOID, PM_NONE) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_VESPOID, PM_NONE, m_idx) ? 1 : 0;
     }
 
     return count;
@@ -289,7 +289,7 @@ MONSTER_NUMBER summon_THUNDERS(PlayerType *player_ptr, POSITION y, POSITION x, i
     auto count = (MONSTER_NUMBER)0;
     auto num = 11;
     for (auto k = 0; k < num; k++) {
-        count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ANTI_TIGERS, PM_NONE) ? 1 : 0;
+        count += summon_specific(player_ptr, y, x, rlev, SUMMON_ANTI_TIGERS, PM_NONE, m_idx) ? 1 : 0;
     }
 
     return count;

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -125,7 +125,7 @@ static int get_hack_dir(PlayerType *player_ptr)
 void process_world_aux_sudden_attack(PlayerType *player_ptr)
 {
     if (randint1(10000) == 1919) {
-        summon_specific(player_ptr, 0, player_ptr->y, player_ptr->x, player_ptr->current_floor_ptr->dun_level, SUMMON_TURBAN_KID, PM_AMBUSH);
+        summon_specific(player_ptr, player_ptr->y, player_ptr->x, player_ptr->current_floor_ptr->dun_level, SUMMON_TURBAN_KID, PM_AMBUSH);
     }
 
     if (randint1(100) == 36) {
@@ -257,7 +257,7 @@ void process_world_aux_mutation(PlayerType *player_ptr)
             mode |= (PM_ALLOW_UNIQUE | PM_NO_PET);
         }
 
-        if (summon_specific(player_ptr, (pet ? -1 : 0), player_ptr->y, player_ptr->x, player_ptr->current_floor_ptr->dun_level, SUMMON_DEMON, mode)) {
+        if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, player_ptr->current_floor_ptr->dun_level, SUMMON_DEMON, mode)) {
             msg_print(_("あなたはデーモンを引き寄せた！", "You have attracted a demon!"));
             disturb(player_ptr, false, true);
         }
@@ -327,7 +327,7 @@ void process_world_aux_mutation(PlayerType *player_ptr)
             mode |= (PM_ALLOW_UNIQUE | PM_NO_PET);
         }
 
-        if (summon_specific(player_ptr, (pet ? -1 : 0), player_ptr->y, player_ptr->x, player_ptr->current_floor_ptr->dun_level, SUMMON_ANIMAL, mode)) {
+        if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, player_ptr->current_floor_ptr->dun_level, SUMMON_ANIMAL, mode)) {
             msg_print(_("動物を引き寄せた！", "You have attracted an animal!"));
             disturb(player_ptr, false, true);
         }
@@ -414,7 +414,7 @@ void process_world_aux_mutation(PlayerType *player_ptr)
             mode |= (PM_ALLOW_UNIQUE | PM_NO_PET);
         }
 
-        if (summon_specific(player_ptr, (pet ? -1 : 0), player_ptr->y, player_ptr->x, player_ptr->current_floor_ptr->dun_level, SUMMON_DRAGON, mode)) {
+        if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, player_ptr->current_floor_ptr->dun_level, SUMMON_DRAGON, mode)) {
             msg_print(_("ドラゴンを引き寄せた！", "You have attracted a dragon!"));
             disturb(player_ptr, false, true);
         }

--- a/src/object-activation/activation-switcher.cpp
+++ b/src/object-activation/activation-switcher.cpp
@@ -164,11 +164,11 @@ bool switch_activation(PlayerType *player_ptr, ItemEntity **o_ptr_ptr, const Ran
     case RandomArtActType::CHARM_OTHERS:
         return activate_charm_others(player_ptr);
     case RandomArtActType::SUMMON_ANIMAL:
-        (void)summon_specific(player_ptr, -1, player_ptr->y, player_ptr->x, player_ptr->lev, SUMMON_ANIMAL_RANGER, PM_ALLOW_GROUP | PM_FORCE_PET);
+        (void)summon_specific(player_ptr, player_ptr->y, player_ptr->x, player_ptr->lev, SUMMON_ANIMAL_RANGER, PM_ALLOW_GROUP | PM_FORCE_PET);
         return true;
     case RandomArtActType::SUMMON_PHANTOM:
         msg_print(_("幻霊を召喚した。", "You summon a phantasmal servant."));
-        (void)summon_specific(player_ptr, -1, player_ptr->y, player_ptr->x, player_ptr->current_floor_ptr->dun_level, SUMMON_PHANTOM, PM_ALLOW_GROUP | PM_FORCE_PET);
+        (void)summon_specific(player_ptr, player_ptr->y, player_ptr->x, player_ptr->current_floor_ptr->dun_level, SUMMON_PHANTOM, PM_ALLOW_GROUP | PM_FORCE_PET);
         return true;
     case RandomArtActType::SUMMON_ELEMENTAL:
         return cast_summon_elemental(player_ptr, (player_ptr->lev * 3) / 2);
@@ -181,7 +181,7 @@ bool switch_activation(PlayerType *player_ptr, ItemEntity **o_ptr_ptr, const Ran
         return cast_summon_hound(player_ptr, (player_ptr->lev * 3) / 2);
     case RandomArtActType::SUMMON_DAWN:
         msg_print(_("暁の師団を召喚した。", "You summon the Legion of the Dawn."));
-        (void)summon_specific(player_ptr, -1, player_ptr->y, player_ptr->x, player_ptr->current_floor_ptr->dun_level, SUMMON_DAWN, PM_ALLOW_GROUP | PM_FORCE_PET);
+        (void)summon_specific(player_ptr, player_ptr->y, player_ptr->x, player_ptr->current_floor_ptr->dun_level, SUMMON_DAWN, PM_ALLOW_GROUP | PM_FORCE_PET);
         return true;
     case RandomArtActType::SUMMON_OCTOPUS:
         return cast_summon_octopus(player_ptr);

--- a/src/object-use/read/scroll-read-executor.cpp
+++ b/src/object-use/read/scroll-read-executor.cpp
@@ -102,7 +102,7 @@ bool ScrollReadExecutor::read()
     }
     case SV_SCROLL_SUMMON_MONSTER:
         for (auto k = 0; k < randint1(3); k++) {
-            if (summon_specific(this->player_ptr, 0, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_NONE,
+            if (summon_specific(this->player_ptr, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_NONE,
                     PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET)) {
                 this->ident = true;
             }
@@ -111,7 +111,7 @@ bool ScrollReadExecutor::read()
         break;
     case SV_SCROLL_SUMMON_UNDEAD:
         for (auto k = 0; k < randint1(3); k++) {
-            if (summon_specific(this->player_ptr, 0, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_UNDEAD,
+            if (summon_specific(this->player_ptr, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_UNDEAD,
                     PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET)) {
                 this->ident = true;
             }
@@ -120,7 +120,7 @@ bool ScrollReadExecutor::read()
         break;
     case SV_SCROLL_SUMMON_PET:
         if (summon_specific(
-                this->player_ptr, -1, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_NONE, PM_ALLOW_GROUP | PM_FORCE_PET)) {
+                this->player_ptr, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_NONE, PM_ALLOW_GROUP | PM_FORCE_PET)) {
             this->ident = true;
         }
 
@@ -438,7 +438,7 @@ bool ScrollReadExecutor::read()
     }
     case SV_SCROLL_POWERFUL_EYE_SENIOR: {
         for (int k = 0; k < 20; k++) {
-            summon_specific(player_ptr, -1, player_ptr->y, player_ptr->x, 50, SUMMON_POWERFUL_EYE_SENIOR, 0);
+            summon_specific(player_ptr, player_ptr->y, player_ptr->x, 50, SUMMON_POWERFUL_EYE_SENIOR, 0);
         }
         ident = true;
         break;

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -260,7 +260,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「我が下僕たちよ、かの傲慢なる者を倒すべし！」", "'My pets, destroy the arrogant mortal!'"));
             for (int i = 0, summon_num = randint1(5) + 1; i < summon_num; i++) {
-                (void)summon_specific(this->player_ptr, 0, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_NONE,
+                (void)summon_specific(this->player_ptr, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_NONE,
                     (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
             }
 
@@ -478,7 +478,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             break;
         case REW_SER_DEMO:
             msg_format(_("%sは褒美として悪魔の使いをよこした！", "%s rewards you with a demonic servant!"), this->name.data());
-            if (!summon_specific(this->player_ptr, -1, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_DEMON, PM_FORCE_PET)) {
+            if (!summon_specific(this->player_ptr, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_DEMON, PM_FORCE_PET)) {
                 msg_print(_("何も現れなかった...", "Nobody ever turns up..."));
             } else {
                 reward = _("悪魔がペットになった。", "a demonic servant");
@@ -487,7 +487,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             break;
         case REW_SER_MONS:
             msg_format(_("%sは褒美として使いをよこした！", "%s rewards you with a servant!"), this->name.data());
-            if (!summon_specific(this->player_ptr, -1, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_NONE, PM_FORCE_PET)) {
+            if (!summon_specific(this->player_ptr, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_NONE, PM_FORCE_PET)) {
                 msg_print(_("何も現れなかった...", "Nobody ever turns up..."));
             } else {
                 reward = _("モンスターがペットになった。", "a servant");
@@ -496,7 +496,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             break;
         case REW_SER_UNDE:
             msg_format(_("%sは褒美としてアンデッドの使いをよこした。", "%s rewards you with an undead servant!"), this->name.data());
-            if (!summon_specific(this->player_ptr, -1, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_UNDEAD, PM_FORCE_PET)) {
+            if (!summon_specific(this->player_ptr, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_UNDEAD, PM_FORCE_PET)) {
                 msg_print(_("何も現れなかった...", "Nobody ever turns up..."));
             } else {
                 reward = _("アンデッドがペットになった。", "an undead servant");

--- a/src/realm/realm-arcane.cpp
+++ b/src/realm/realm-arcane.cpp
@@ -341,7 +341,7 @@ std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spe
 
     case 25: {
         if (cast) {
-            if (!summon_specific(player_ptr, -1, player_ptr->y, player_ptr->x, plev, SUMMON_ELEMENTAL, (PM_ALLOW_GROUP | PM_FORCE_PET))) {
+            if (!summon_specific(player_ptr, player_ptr->y, player_ptr->x, plev, SUMMON_ELEMENTAL, (PM_ALLOW_GROUP | PM_FORCE_PET))) {
                 msg_print(_("エレメンタルは現れなかった。", "No elementals arrive."));
             }
         }

--- a/src/realm/realm-craft.cpp
+++ b/src/realm/realm-craft.cpp
@@ -294,7 +294,7 @@ std::optional<std::string> do_craft_spell(PlayerType *player_ptr, SPELL_IDX spel
 
     case 22: {
         if (cast) {
-            if (summon_specific(player_ptr, -1, player_ptr->y, player_ptr->x, plev, SUMMON_GOLEM, PM_FORCE_PET)) {
+            if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, plev, SUMMON_GOLEM, PM_FORCE_PET)) {
                 msg_print(_("ゴーレムを作った。", "You make a golem."));
             } else {
                 msg_print(_("うまくゴーレムを作れなかった。", "You couldn't make a golem."));

--- a/src/realm/realm-crusade.cpp
+++ b/src/realm/realm-crusade.cpp
@@ -350,7 +350,7 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
                 flg |= PM_ALLOW_GROUP;
             }
 
-            if (summon_specific(player_ptr, (pet ? -1 : 0), player_ptr->y, player_ptr->x, (plev * 3) / 2, SUMMON_ANGEL, flg)) {
+            if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, (plev * 3) / 2, SUMMON_ANGEL, flg)) {
                 if (pet) {
                     msg_print(_("「ご用でございますか、ご主人様」", "'What is thy bidding... Master?'"));
                 } else {
@@ -471,7 +471,7 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
                     continue;
                 }
 
-                summon_specific(player_ptr, -1, my, mx, plev, SUMMON_KNIGHTS, PM_ALLOW_GROUP | PM_FORCE_PET | PM_HASTE);
+                summon_specific(player_ptr, my, mx, plev, SUMMON_KNIGHTS, PM_ALLOW_GROUP | PM_FORCE_PET | PM_HASTE);
             }
 
             set_hero(player_ptr, randint1(base) + base, false);

--- a/src/realm/realm-demon.cpp
+++ b/src/realm/realm-demon.cpp
@@ -118,7 +118,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
 
     case 5: {
         if (cast) {
-            if (!summon_specific(player_ptr, -1, player_ptr->y, player_ptr->x, (plev * 3) / 2, SUMMON_MANES, (PM_ALLOW_GROUP | PM_FORCE_PET))) {
+            if (!summon_specific(player_ptr, player_ptr->y, player_ptr->x, (plev * 3) / 2, SUMMON_MANES, (PM_ALLOW_GROUP | PM_FORCE_PET))) {
                 msg_print(_("古代の死霊は現れなかった。", "No Manes arrive."));
             }
         }

--- a/src/realm/realm-nature.cpp
+++ b/src/realm/realm-nature.cpp
@@ -269,7 +269,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
 
     case 14: {
         if (cast) {
-            if (!(summon_specific(player_ptr, -1, player_ptr->y, player_ptr->x, plev, SUMMON_ANIMAL_RANGER, (PM_ALLOW_GROUP | PM_FORCE_PET)))) {
+            if (!(summon_specific(player_ptr, player_ptr->y, player_ptr->x, plev, SUMMON_ANIMAL_RANGER, (PM_ALLOW_GROUP | PM_FORCE_PET)))) {
                 msg_print(_("動物は現れなかった。", "No animals arrive."));
             }
             break;

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -180,7 +180,7 @@ void Chest::fire_trap(const Pos2D &pos, short item_idx)
             if (randint1(100) < this->player_ptr->current_floor_ptr->dun_level) {
                 activate_hi_summon(this->player_ptr, this->player_ptr->y, this->player_ptr->x, false);
             } else {
-                (void)summon_specific(this->player_ptr, 0, pos.y, pos.x, mon_level, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+                (void)summon_specific(this->player_ptr, pos.y, pos.x, mon_level, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
             }
         }
     }
@@ -189,7 +189,7 @@ void Chest::fire_trap(const Pos2D &pos, short item_idx)
     if (trap.has(ChestTrapType::E_SUMMON)) {
         msg_print(_("宝を守るためにエレメンタルが現れた！", "Elemental beings appear to protect their treasures!"));
         for (auto i = 0; i < randint1(3) + 5; i++) {
-            (void)summon_specific(this->player_ptr, 0, pos.y, pos.x, mon_level, SUMMON_ELEMENTAL, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+            (void)summon_specific(this->player_ptr, pos.y, pos.x, mon_level, SUMMON_ELEMENTAL, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
         }
     }
 
@@ -202,7 +202,7 @@ void Chest::fire_trap(const Pos2D &pos, short item_idx)
         }
 
         for (auto i = 0; i < randint1(5) + o_ptr->pval / 5; i++) {
-            (void)summon_specific(this->player_ptr, 0, pos.y, pos.x, mon_level, SUMMON_BIRD, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+            (void)summon_specific(this->player_ptr, pos.y, pos.x, mon_level, SUMMON_BIRD, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
         }
     }
 
@@ -213,7 +213,7 @@ void Chest::fire_trap(const Pos2D &pos, short item_idx)
             msg_print(_("炎と硫黄の雲の中に悪魔が姿を現した！", "Demons materialize in clouds of fire and brimstone!"));
             for (auto i = 0; i < randint1(3) + 2; i++) {
                 (void)fire_meteor(this->player_ptr, -1, AttributeType::FIRE, pos.y, pos.x, 10, 5);
-                (void)summon_specific(this->player_ptr, 0, pos.y, pos.x, mon_level, SUMMON_DEMON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+                (void)summon_specific(this->player_ptr, pos.y, pos.x, mon_level, SUMMON_DEMON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
             }
         }
 
@@ -221,7 +221,7 @@ void Chest::fire_trap(const Pos2D &pos, short item_idx)
         else if (one_in_(3)) {
             msg_print(_("暗闇にドラゴンの影がぼんやりと現れた！", "Draconic forms loom out of the darkness!"));
             for (auto i = 0; i < randint1(3) + 2; i++) {
-                (void)summon_specific(this->player_ptr, 0, pos.y, pos.x, mon_level, SUMMON_DRAGON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+                (void)summon_specific(this->player_ptr, pos.y, pos.x, mon_level, SUMMON_DRAGON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
             }
         }
 
@@ -229,7 +229,7 @@ void Chest::fire_trap(const Pos2D &pos, short item_idx)
         else if (one_in_(2)) {
             msg_print(_("奇妙な姿の怪物が襲って来た！", "Creatures strange and twisted assault you!"));
             for (auto i = 0; i < randint1(5) + 3; i++) {
-                (void)summon_specific(this->player_ptr, 0, pos.y, pos.x, mon_level, SUMMON_HYBRID, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+                (void)summon_specific(this->player_ptr, pos.y, pos.x, mon_level, SUMMON_HYBRID, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
             }
         }
 
@@ -237,7 +237,7 @@ void Chest::fire_trap(const Pos2D &pos, short item_idx)
         else {
             msg_print(_("渦巻が合体し、破裂した！", "Vortices coalesce and wreak destruction!"));
             for (auto i = 0; i < randint1(3) + 2; i++) {
-                (void)summon_specific(this->player_ptr, 0, pos.y, pos.x, mon_level, SUMMON_VORTEX, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+                (void)summon_specific(this->player_ptr, pos.y, pos.x, mon_level, SUMMON_VORTEX, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
             }
         }
     }

--- a/src/spell-kind/blood-curse.cpp
+++ b/src/spell-kind/blood-curse.cpp
@@ -105,7 +105,7 @@ void blood_curse_to_enemy(PlayerType *player_ptr, MONSTER_IDX m_idx)
             }
 
             const auto level = pet ? player_ptr->lev * 2 / 3 + randint1(player_ptr->lev / 2) : player_ptr->current_floor_ptr->dun_level;
-            count += summon_specific(player_ptr, (pet ? -1 : 0), player_ptr->y, player_ptr->x, level, SUMMON_NONE, mode) ? 1 : 0;
+            count += summon_specific(player_ptr, player_ptr->y, player_ptr->x, level, SUMMON_NONE, mode) ? 1 : 0;
             if (!one_in_(6)) {
                 break;
             }

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -175,7 +175,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
         case 8:
         case 9:
         case 18:
-            (*count) += summon_specific(player_ptr, 0, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET)) ? 1 : 0;
+            (*count) += summon_specific(player_ptr, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET)) ? 1 : 0;
             if (!one_in_(6)) {
                 break;
             }
@@ -226,7 +226,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
             [[fallthrough]];
         case 25:
             if ((floor_ptr->dun_level > 65) && !stop_ty) {
-                (*count) += summon_cyber(player_ptr, -1, player_ptr->y, player_ptr->x);
+                (*count) += summon_cyber(player_ptr, player_ptr->y, player_ptr->x);
                 stop_ty = true;
                 break;
             }
@@ -334,7 +334,7 @@ void wild_magic(PlayerType *player_ptr, int spell)
     case 35:
         for (int counter = 0; counter < 8; counter++) {
             (void)summon_specific(
-                player_ptr, 0, player_ptr->y, player_ptr->x, (floor_ptr->dun_level * 3) / 2, i2enum<summon_type>(type), (PM_ALLOW_GROUP | PM_NO_PET));
+                player_ptr, player_ptr->y, player_ptr->x, (floor_ptr->dun_level * 3) / 2, i2enum<summon_type>(type), (PM_ALLOW_GROUP | PM_NO_PET));
         }
 
         break;
@@ -343,7 +343,7 @@ void wild_magic(PlayerType *player_ptr, int spell)
         activate_hi_summon(player_ptr, player_ptr->y, player_ptr->x, false);
         break;
     case 38:
-        (void)summon_cyber(player_ptr, -1, player_ptr->y, player_ptr->x);
+        (void)summon_cyber(player_ptr, player_ptr->y, player_ptr->x);
         break;
     default: {
         int count = 0;

--- a/src/spell-realm/spells-trump.cpp
+++ b/src/spell-realm/spells-trump.cpp
@@ -76,7 +76,7 @@ void cast_shuffle(PlayerType *player_ptr)
 
     if (die < 14) {
         msg_print(_("なんてこった！《悪魔》だ！", "Oh no! It's the Devil!"));
-        summon_specific(player_ptr, 0, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_DEMON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+        summon_specific(player_ptr, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_DEMON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
         return;
     }
 

--- a/src/spell/spells-summon.h
+++ b/src/spell/spells-summon.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "system/angband.h"
+#include <optional>
 
 enum summon_type : int;
 
@@ -15,6 +16,6 @@ bool cast_summon_octopus(PlayerType *player_ptr);
 bool cast_summon_greater_demon(PlayerType *player_ptr);
 bool summon_kin_player(PlayerType *player_ptr, DEPTH level, POSITION y, POSITION x, BIT_FLAGS mode);
 void mitokohmon(PlayerType *player_ptr);
-int summon_cyber(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x);
+int summon_cyber(PlayerType *player_ptr, POSITION y, POSITION x, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
 int activate_hi_summon(PlayerType *player_ptr, POSITION y, POSITION x, bool can_pet);
 void cast_invoke_spirits(PlayerType *player_ptr, DIRECTION dir);

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -219,7 +219,7 @@ void wiz_summon_random_monster(PlayerType *player_ptr, int num)
     const auto y = player_ptr->y;
     const auto x = player_ptr->x;
     for (auto i = 0; i < num; i++) {
-        if (!summon_specific(player_ptr, 0, y, x, level, SUMMON_NONE, flags)) {
+        if (!summon_specific(player_ptr, y, x, level, SUMMON_NONE, flags)) {
             msg_print_wizard(player_ptr, 1, "Monster isn't summoned correctly...");
             return;
         }


### PR DESCRIPTION
summon_specificの引数src_idxは、モンスターによる召喚であれば召喚主の
モンスターID、そうでなければ0、もしくはプレイヤーのペットとして召喚する
場合は-1とややこしい事になっているので、これを改善する。
まず、ペットとして召喚するかどうかはmodeにPM_FORCE_PETフラグがあるかでも
判別可能なので、ペットとして召喚するなら-1を渡すという仕様は廃止する。
また、引数を std::optional とし、モンスターによる召喚であればこれまで
通り召喚主のモンスターID、そうでなければ std::nullopt を渡すようにする。