### PR TITLE
変愚「[Fix] エラーレポートの文字化け #4424」のマージ

### DIFF
--- a/src/main-win/main-win-exception.cpp
+++ b/src/main-win/main-win-exception.cpp
@@ -1,4 +1,5 @@
 #include "main-win/main-win-exception.h"
+#include "locale/japanese.h"
 #include "main-win/main-win-utils.h"
 #include "net/report-error.h"
 #include <sstream>
@@ -15,7 +16,13 @@ void handle_unexpected_exception(const std::exception &e)
 {
     constexpr auto caption = _(L"予期しないエラー！", L"Unexpected error!");
 
-    const std::string msg = e.what();
+    std::string msg = e.what();
+#ifdef JP
+    // 例外メッセージがUTF-8の場合一旦SJISに変換する(SJISの場合はそのまま)
+    const auto msg_len = guess_convert_to_system_encoding(msg.data(), msg.size());
+    msg.erase(msg_len);
+#endif
+
     const auto first_line = msg.substr(0, msg.find('\n'));
 
 #if !defined(DISABLE_NET)


### PR DESCRIPTION
システムロケールがUTF-8のWindows環境において、STLが出力する日本語の例外
メッセージの文字コードはUTF-8となる。しかし、エラーレポートのコードでは
文字コードはSJISであることを想定しており、UTF-8をSJISとみなして文字
コードの変換を行ってしまうため文字化けが発生する。
guess_convert_to_system_encoding 関数を通すことでメッセージを一旦SJISに 統一することで、システムロケールがSJISでもUTF-8でも正しく動作するように
する。