### PR TITLE
変愚「[Fix] WindowsのシステムロケールがUTF-8の時クラッシュする #4425」のマージ

### DIFF
--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -2,6 +2,9 @@
 #include "locale/japanese.h"
 #include "system/angband-exceptions.h"
 #include "util/string-processor.h"
+#ifdef WINDOWS
+#include "main-win/main-win-utils.h"
+#endif
 #include <sstream>
 #include <string>
 
@@ -167,7 +170,13 @@ std::filesystem::path path_build(const std::filesystem::path &path, std::string_
     }
 
     auto parsed_path = path_parse(path);
+#ifdef WINDOWS
+    // システムロケールがUTF-8の場合、appendによるUTF-16への変換時に
+    // Shift-JISをUTF-8とみなしてしまい変換に失敗するので、自前でUTF-16に変換してからappendする
+    const auto &path_ret = parsed_path.append(to_wchar(file.data()).wc_str());
+#else
     const auto &path_ret = parsed_path.append(file);
+#endif
     constexpr auto max_path_length = 1024;
     const auto path_str = path_ret.string();
     if (path_str.length() > max_path_length) {


### PR DESCRIPTION
Windows環境において、std::filesystem::path::appendはstd::string_viewを 受け取ると、その文字コードはシステムロケールに一致すると想定し、システム
ロケールからWindows内部処理の文字コードであるUTF-16に変換する。
変愚蛮怒の内部文字コードはSJIS固定であるため、システムロケールがUTF-8の
環境ではSJISをUTF-8とみなしてUTF-16へ変換しようとしてしまい、変換失敗の
例外が発生しクラッシュする。
対策として、Windows環境では自前でSJIS→UTF-16の変換を行い、UTF-16の
文字列を渡すようにする。