### PR TITLE
変愚「[Fix] システムロケールがUTF-8の時設定フォルダを開くのに失敗する #4434」のマージ

### DIFF
--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -1911,7 +1911,7 @@ static void process_menus(PlayerType *player_ptr, WORD wCmd)
     }
     case IDM_OPTIONS_OPEN_MUSIC_DIR: {
         const auto path = path_build(ANGBAND_DIR_XTRA_MUSIC, "music.cfg");
-        open_dir_in_explorer(path.string());
+        open_dir_in_explorer(path);
         break;
     }
     case IDM_OPTIONS_SOUND: {
@@ -1934,7 +1934,7 @@ static void process_menus(PlayerType *player_ptr, WORD wCmd)
     }
     case IDM_OPTIONS_OPEN_SOUND_DIR: {
         const auto path = path_build(ANGBAND_DIR_XTRA_SOUND, "sound.cfg");
-        open_dir_in_explorer(path.string());
+        open_dir_in_explorer(path);
         break;
     }
     case IDM_OPTIONS_NO_BG: {

--- a/src/main-win/main-win-utils.cpp
+++ b/src/main-win/main-win-utils.cpp
@@ -56,13 +56,13 @@ void save_screen_as_html(HWND hWnd)
 
 /*!
  * @brief 対象ファイルを選択した状態でエクスプローラーを開く
- * @param filename 対象ファイル
+ * @param path 対象ファイルのパス
  */
-void open_dir_in_explorer(std::string_view filename)
+void open_dir_in_explorer(const std::filesystem::path &path)
 {
-    std::stringstream ss;
-    ss << "/select," << filename;
-    ShellExecuteW(NULL, NULL, L"explorer.exe", to_wchar(ss.str().data()).wc_str(), NULL, SW_SHOWNORMAL);
+    std::wstringstream ss;
+    ss << L"/select," << path.wstring();
+    ShellExecuteW(NULL, NULL, L"explorer.exe", ss.str().data(), NULL, SW_SHOWNORMAL);
 }
 
 /*!

--- a/src/main-win/main-win-utils.h
+++ b/src/main-win/main-win-utils.h
@@ -84,5 +84,5 @@ protected:
 
 bool is_already_running(void);
 void save_screen_as_html(HWND hWnd);
-void open_dir_in_explorer(std::string_view filename);
+void open_dir_in_explorer(const std::filesystem::path &path);
 std::optional<std::filesystem::path> get_open_filename(OPENFILENAMEW *ofn, const std::filesystem::path &path_dir, const std::filesystem::path &path_file, DWORD max_name_size);


### PR DESCRIPTION
WindowsのシステムロケールがUTF-8の時、パスに日本語を含む場合にBGMや
効果音の設定フォルダを開く処理でUTF-16への文字コードの変換に失敗するため、
正しく設定フォルダを開くことができない。
std::filesystem::path::wstring で直接UTF-16のパス文字列を取得する ようにし、文字コードの変換を行わないようにする。