### PR TITLE
変愚「[Fix] MonraceDefinitions.shcema.jsoncの修正 #4456」のマージ

### DIFF
--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -62,7 +62,7 @@
                             "character": {
                                 "type": "string",
                                 "description": "表示される文字",
-                                "pattern": "[a-zA-Z!\/.!?#$%&()@,|*'`<>+{}=~\\[\\]]|\\\\"
+                                "pattern": "[a-zA-Z0-9!\/.!?#$%&()@,|*'`<>+{}=~\\[\\]]|\\\\"
                             },
                             "color": {
                                 "type": "string",
@@ -508,7 +508,8 @@
                                 "QUESTOR",
                                 "EMPTY_MIND",
                                 "WEIRD_MIND",
-                                "DIMINISH_MAX_DAMAGE"
+                                "DIMINISH_MAX_DAMAGE",
+                                "BUNBUN_STRIKER"
                             ]
                         }
                     },


### PR DESCRIPTION
MonraceDefinitions.jsoncに使用するシンボルとフラグを拡張した際にschemaを変更していないため現在validation checkに失敗している。
 #4410 からのシンボルに0-9を使用する、#3941 からフラグBUNBUN_STRIKERの追加に対応してschemaを修正する。
単発の修正のためIssueはなし。