### PR TITLE
変愚「[Refactor] Windows版の効果音再生処理 #4440」のマージ

### DIFF
--- a/src/main-win/wav-reader.cpp
+++ b/src/main-win/wav-reader.cpp
@@ -53,9 +53,9 @@ bool wav_reader::open(const std::filesystem::path &path)
         return false;
     }
 
-    this->buffer.reset(new BYTE[data_chunk.cksize]);
+    this->buffer.resize(data_chunk.cksize);
     read_size = this->data_chunk.cksize;
-    readed_size = ::mmioRead(this->hmmio, (HPSTR)this->buffer.get(), read_size);
+    readed_size = ::mmioRead(this->hmmio, reinterpret_cast<HPSTR>(this->buffer.data()), read_size);
     if (readed_size != read_size) {
         return false;
     }
@@ -63,13 +63,14 @@ bool wav_reader::open(const std::filesystem::path &path)
     return true;
 }
 
-BYTE *wav_reader::read_data()
+std::vector<uint8_t> wav_reader::retrieve_data()
 {
-    return this->buffer.release();
+    return std::move(this->buffer);
 }
 
 void wav_reader::close()
 {
+    this->buffer.clear();
     if (this->hmmio != NULL) {
         ::mmioClose(this->hmmio, 0);
         this->hmmio = NULL;

--- a/src/main-win/wav-reader.h
+++ b/src/main-win/wav-reader.h
@@ -35,19 +35,17 @@ public:
      * @retval false 処理エラー
      */
     bool open(const std::filesystem::path &path);
+
     /*!
      * PCMデータ取得
-     * @details 呼び出し元でdelete[]すること
+     *
      * @return PCMデータ
      */
-    BYTE *read_data();
-    const WAVEFORMATEX *get_waveformat()
+    std::vector<uint8_t> retrieve_data();
+
+    const WAVEFORMATEX *get_waveformat() const
     {
         return &waveformatex;
-    }
-    const MMCKINFO *get_data_chunk()
-    {
-        return &data_chunk;
     }
     void close();
 
@@ -57,5 +55,5 @@ protected:
     MMCKINFO fmt_chunk{};
     WAVEFORMATEX waveformatex{};
     MMCKINFO data_chunk{};
-    std::unique_ptr<BYTE[]> buffer;
+    std::vector<uint8_t> buffer;
 };


### PR DESCRIPTION
現状のWindows版の効果音再生処理は生ポインタとnew/deleteを伴う古臭い
コードとなっているので、Modern C++によりリファクタリングを行う。