### PR TITLE
変愚「[Refactor] place_monster_one/place_monster_specificのシグニチャ #4458」のマージ

### DIFF
--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -330,7 +330,7 @@ static void init_riding_pet(PlayerType *player_ptr, bool new_game)
 
     MonsterRaceId pet_r_idx = pc.equals(PlayerClassType::CAVALRY) ? MonsterRaceId::HORSE : MonsterRaceId::YASE_HORSE;
     auto *r_ptr = &monraces_info[pet_r_idx];
-    auto m_idx = place_specific_monster(player_ptr, 0, player_ptr->y, player_ptr->x - 1, pet_r_idx, (PM_FORCE_PET | PM_NO_KAGE));
+    auto m_idx = place_specific_monster(player_ptr, player_ptr->y, player_ptr->x - 1, pet_r_idx, (PM_FORCE_PET | PM_NO_KAGE));
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[*m_idx];
     m_ptr->mspeed = r_ptr->speed;
     m_ptr->maxhp = r_ptr->hit_dice.floored_expected_value();

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -77,7 +77,7 @@ static void process_fishing(PlayerType *player_ptr)
         msg_print(nullptr);
         if (MonraceList::is_valid(r_idx) && one_in_(2)) {
             const auto pos = player_ptr->get_neighbor(player_ptr->fishing_dir);
-            if (auto m_idx = place_specific_monster(player_ptr, 0, pos.y, pos.x, r_idx, PM_NO_KAGE)) {
+            if (auto m_idx = place_specific_monster(player_ptr, pos.y, pos.x, r_idx, PM_NO_KAGE)) {
                 const auto m_name = monster_desc(player_ptr, &floor_ptr->m_list[*m_idx], 0);
                 msg_print(_(format("%sが釣れた！", m_name.data()), "You have a good catch!"));
                 success = true;

--- a/src/dungeon/quest-monster-placer.cpp
+++ b/src/dungeon/quest-monster-placer.cpp
@@ -74,7 +74,7 @@ bool place_quest_monsters(PlayerType *player_ptr)
                     return false;
                 }
 
-                if (place_specific_monster(player_ptr, 0, pos.y, pos.x, quest.r_idx, mode)) {
+                if (place_specific_monster(player_ptr, pos.y, pos.x, quest.r_idx, mode)) {
                     break;
                 }
 

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -139,7 +139,7 @@ static void parse_qtw_D(PlayerType *player_ptr, qtwg_type *qtwg_ptr, char *s)
                 r_ref.max_num = r_ref.mob_num;
             }
 
-            const auto m_idx = place_specific_monster(player_ptr, 0, *qtwg_ptr->y, *qtwg_ptr->x, r_idx, (PM_ALLOW_SLEEP | PM_NO_KAGE));
+            const auto m_idx = place_specific_monster(player_ptr, *qtwg_ptr->y, *qtwg_ptr->x, r_idx, (PM_ALLOW_SLEEP | PM_NO_KAGE));
             if (clone && m_idx) {
                 floor_ptr->m_list[*m_idx].mflag2.set(MonsterConstantFlagType::CLONED);
                 r_ref.cur_num = old_cur_num;

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -153,7 +153,7 @@ static void generate_challenge_arena(PlayerType *player_ptr)
     player_place(player_ptr, y, x);
     auto &entries = ArenaEntryList::get_instance();
     const auto &monrace = entries.get_monrace();
-    if (place_specific_monster(player_ptr, 0, player_ptr->y + 5, player_ptr->x, monrace.idx, PM_NO_KAGE | PM_NO_PET)) {
+    if (place_specific_monster(player_ptr, player_ptr->y + 5, player_ptr->x, monrace.idx, PM_NO_KAGE | PM_NO_PET)) {
         return;
     }
 
@@ -252,7 +252,7 @@ static void generate_gambling_arena(PlayerType *player_ptr)
     build_battle(player_ptr, &y, &x);
     player_place(player_ptr, y, x);
     for (MONSTER_IDX i = 0; i < 4; i++) {
-        const auto m_idx = place_specific_monster(player_ptr, 0, player_ptr->y + 8 + (i / 2) * 4, player_ptr->x - 2 + (i % 2) * 4, battle_mon_list[i], (PM_NO_KAGE | PM_NO_PET));
+        const auto m_idx = place_specific_monster(player_ptr, player_ptr->y + 8 + (i / 2) * 4, player_ptr->x - 2 + (i % 2) * 4, battle_mon_list[i], (PM_NO_KAGE | PM_NO_PET));
         if (m_idx) {
             floor_ptr->m_list[*m_idx].set_friendly();
         }

--- a/src/monster-floor/monster-generator.h
+++ b/src/monster-floor/monster-generator.h
@@ -10,7 +10,7 @@ using summon_specific_pf = std::optional<MONSTER_IDX>(PlayerType *, POSITION, PO
 
 bool mon_scatter(PlayerType *player_ptr, MonsterRaceId r_idx, POSITION *yp, POSITION *xp, POSITION y, POSITION x, POSITION max_dist);
 std::optional<MONSTER_IDX> multiply_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, MonsterRaceId r_idx, bool clone, BIT_FLAGS mode);
-std::optional<MONSTER_IDX> place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
+std::optional<MONSTER_IDX> place_specific_monster(PlayerType *player_ptr, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
 std::optional<MONSTER_IDX> place_random_monster(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FLAGS mode);
 bool alloc_horde(PlayerType *player_ptr, POSITION y, POSITION x, summon_specific_pf summon_specific);
 bool alloc_guardian(PlayerType *player_ptr, bool def_val);

--- a/src/monster-floor/monster-summon.cpp
+++ b/src/monster-floor/monster-summon.cpp
@@ -140,7 +140,7 @@ std::optional<MONSTER_IDX> summon_specific(PlayerType *player_ptr, POSITION y1, 
         mode |= PM_NO_KAGE;
     }
 
-    auto summoned_m_idx = place_specific_monster(player_ptr, summoner_m_idx.value_or(0), y, x, r_idx, mode, summoner_m_idx);
+    auto summoned_m_idx = place_specific_monster(player_ptr, y, x, r_idx, mode, summoner_m_idx);
     if (!summoned_m_idx) {
         return std::nullopt;
     }
@@ -187,5 +187,6 @@ std::optional<MONSTER_IDX> summon_named_creature(PlayerType *player_ptr, MONSTER
         return false;
     }
 
-    return place_specific_monster(player_ptr, src_idx, y, x, r_idx, (mode | PM_NO_KAGE));
+    const auto summon_who = is_monster(src_idx) ? std::make_optional(src_idx) : std::nullopt;
+    return place_specific_monster(player_ptr, y, x, r_idx, (mode | PM_NO_KAGE), summon_who);
 }

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -48,16 +48,6 @@
 #include "world/world.h"
 #include <time.h>
 
-static bool is_friendly_idx(PlayerType *player_ptr, MONSTER_IDX m_idx)
-{
-    if (m_idx == 0) {
-        return false;
-    }
-
-    const auto &m_ref = player_ptr->current_floor_ptr->m_list[m_idx];
-    return m_ref.is_friendly();
-}
-
 /*!
  * @brief たぬきの変身対象となるモンスターかどうか判定する / Hook for Tanuki
  * @param r_idx モンスター種族ID
@@ -254,7 +244,6 @@ static void warn_unique_generation(PlayerType *player_ptr, MonsterRaceId r_idx)
 /*!
  * @brief モンスターを一体生成する / Attempt to place a monster of the given race at the given location.
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param src_idx 召喚を行ったモンスターID
  * @param y 生成位置y座標
  * @param x 生成位置x座標
  * @param r_idx 生成モンスター種族
@@ -262,7 +251,7 @@ static void warn_unique_generation(PlayerType *player_ptr, MonsterRaceId r_idx)
  * @param summoner_m_idx モンスターの召喚による場合、召喚主のモンスターID
  * @return 生成に成功したらモンスターID、失敗したらstd::nullopt
  */
-std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx)
+std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     auto *g_ptr = &floor.grid_array[y][x];
@@ -314,14 +303,16 @@ std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, MONSTER_IDX
     }
 
     const auto &new_monrace = m_ptr->get_monrace();
+    const auto is_summoned = summoner_m_idx.has_value();
+    const MonsterEntity &summoner = floor.m_list[summoner_m_idx.value_or(0)];
 
     auto same_appearance_as_parent = m_ptr->mflag2.has_not(MonsterConstantFlagType::CHAMELEON);
     same_appearance_as_parent &= any_bits(mode, PM_MULTIPLY);
-    same_appearance_as_parent &= is_monster(src_idx) && !floor.m_list[src_idx].is_original_ap();
+    same_appearance_as_parent &= is_summoned && !summoner.is_original_ap();
 
     if (same_appearance_as_parent) {
-        m_ptr->ap_r_idx = floor.m_list[src_idx].ap_r_idx;
-        if (floor.m_list[src_idx].mflag2.has(MonsterConstantFlagType::KAGE)) {
+        m_ptr->ap_r_idx = summoner.ap_r_idx;
+        if (summoner.mflag2.has(MonsterConstantFlagType::KAGE)) {
             m_ptr->mflag2.set(MonsterConstantFlagType::KAGE);
         }
     }
@@ -338,9 +329,9 @@ std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, MONSTER_IDX
         m_ptr->mflag2.set(MonsterConstantFlagType::LARGE);
     }
 
-    if (m_ptr->mflag2.has_not(MonsterConstantFlagType::CHAMELEON) && is_monster(src_idx) && new_monrace.kind_flags.has_none_of(alignment_mask)) {
-        m_ptr->sub_align = floor.m_list[src_idx].sub_align;
-    } else if (m_ptr->mflag2.has(MonsterConstantFlagType::CHAMELEON) && new_monrace.kind_flags.has(MonsterKindType::UNIQUE) && !is_monster(src_idx)) {
+    if (m_ptr->mflag2.has_not(MonsterConstantFlagType::CHAMELEON) && is_summoned && new_monrace.kind_flags.has_none_of(alignment_mask)) {
+        m_ptr->sub_align = summoner.sub_align;
+    } else if (m_ptr->mflag2.has(MonsterConstantFlagType::CHAMELEON) && new_monrace.kind_flags.has(MonsterKindType::UNIQUE) && !is_summoned) {
         m_ptr->sub_align = SUB_ALIGN_NEUTRAL;
     } else {
         m_ptr->sub_align = SUB_ALIGN_NEUTRAL;
@@ -365,9 +356,9 @@ std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, MONSTER_IDX
     m_ptr->nickname.clear();
     m_ptr->exp = 0;
 
-    if (is_monster(src_idx) && floor.m_list[src_idx].is_pet()) {
+    if (is_summoned && summoner.is_pet()) {
         set_bits(mode, PM_FORCE_PET);
-        m_ptr->parent_m_idx = src_idx;
+        m_ptr->parent_m_idx = *summoner_m_idx;
     } else {
         m_ptr->parent_m_idx = 0;
     }
@@ -383,8 +374,13 @@ std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, MONSTER_IDX
     m_ptr->ml = false;
     if (any_bits(mode, PM_FORCE_PET)) {
         set_pet(player_ptr, m_ptr);
-    } else if ((is_player(src_idx) && new_monrace.behavior_flags.has(MonsterBehaviorType::FRIENDLY)) || is_friendly_idx(player_ptr, src_idx) || any_bits(mode, PM_FORCE_FRIENDLY)) {
-        if (!monster_has_hostile_align(player_ptr, nullptr, 0, -1, &new_monrace) && !player_ptr->current_floor_ptr->inside_arena) {
+    } else {
+        auto should_be_friendly = !is_summoned && new_monrace.behavior_flags.has(MonsterBehaviorType::FRIENDLY);
+        should_be_friendly |= is_summoned && summoner.is_friendly();
+        should_be_friendly |= any_bits(mode, PM_FORCE_FRIENDLY);
+        auto force_hostile = monster_has_hostile_align(player_ptr, nullptr, 0, -1, &new_monrace);
+        force_hostile |= player_ptr->current_floor_ptr->inside_arena;
+        if (should_be_friendly && !force_hostile) {
             m_ptr->set_friendly();
         }
     }

--- a/src/monster-floor/one-monster-placer.h
+++ b/src/monster-floor/one-monster-placer.h
@@ -5,4 +5,4 @@
 
 enum class MonsterRaceId : int16_t;
 class PlayerType;
-std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
+std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);

--- a/src/room/rooms-nest.cpp
+++ b/src/room/rooms-nest.cpp
@@ -120,7 +120,7 @@ void place_monsters_in_nest(PlayerType *player_ptr, const Pos2D &center, std::ar
 {
     Rect2D(center, Vector2D(2, 9)).each_area([player_ptr, &nest_mon_info_list](const Pos2D &pos) {
         auto &nest_mon_info = rand_choice(nest_mon_info_list);
-        (void)place_specific_monster(player_ptr, 0, pos.y, pos.x, nest_mon_info.monrace_id, 0L);
+        (void)place_specific_monster(player_ptr, pos.y, pos.x, nest_mon_info.monrace_id, 0L);
         nest_mon_info.used = true;
     });
 }

--- a/src/room/rooms-pit.cpp
+++ b/src/room/rooms-pit.cpp
@@ -248,49 +248,49 @@ bool build_type6(PlayerType *player_ptr, dun_data_type *dd_ptr)
 
     /* Top and bottom rows */
     for (auto x = center.x - 9; x <= center.x + 9; x++) {
-        place_specific_monster(player_ptr, 0, center.y - 2, x, (*whats)[0], PM_NO_KAGE);
-        place_specific_monster(player_ptr, 0, center.y + 2, x, (*whats)[0], PM_NO_KAGE);
+        place_specific_monster(player_ptr, center.y - 2, x, (*whats)[0], PM_NO_KAGE);
+        place_specific_monster(player_ptr, center.y + 2, x, (*whats)[0], PM_NO_KAGE);
     }
 
     /* Middle columns */
     for (auto y = center.y - 1; y <= center.y + 1; y++) {
-        place_specific_monster(player_ptr, 0, y, center.x - 9, (*whats)[0], PM_NO_KAGE);
-        place_specific_monster(player_ptr, 0, y, center.x + 9, (*whats)[0], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x - 9, (*whats)[0], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x + 9, (*whats)[0], PM_NO_KAGE);
 
-        place_specific_monster(player_ptr, 0, y, center.x - 8, (*whats)[1], PM_NO_KAGE);
-        place_specific_monster(player_ptr, 0, y, center.x + 8, (*whats)[1], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x - 8, (*whats)[1], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x + 8, (*whats)[1], PM_NO_KAGE);
 
-        place_specific_monster(player_ptr, 0, y, center.x - 7, (*whats)[1], PM_NO_KAGE);
-        place_specific_monster(player_ptr, 0, y, center.x + 7, (*whats)[1], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x - 7, (*whats)[1], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x + 7, (*whats)[1], PM_NO_KAGE);
 
-        place_specific_monster(player_ptr, 0, y, center.x - 6, (*whats)[2], PM_NO_KAGE);
-        place_specific_monster(player_ptr, 0, y, center.x + 6, (*whats)[2], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x - 6, (*whats)[2], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x + 6, (*whats)[2], PM_NO_KAGE);
 
-        place_specific_monster(player_ptr, 0, y, center.x - 5, (*whats)[2], PM_NO_KAGE);
-        place_specific_monster(player_ptr, 0, y, center.x + 5, (*whats)[2], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x - 5, (*whats)[2], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x + 5, (*whats)[2], PM_NO_KAGE);
 
-        place_specific_monster(player_ptr, 0, y, center.x - 4, (*whats)[3], PM_NO_KAGE);
-        place_specific_monster(player_ptr, 0, y, center.x + 4, (*whats)[3], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x - 4, (*whats)[3], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x + 4, (*whats)[3], PM_NO_KAGE);
 
-        place_specific_monster(player_ptr, 0, y, center.x - 3, (*whats)[3], PM_NO_KAGE);
-        place_specific_monster(player_ptr, 0, y, center.x + 3, (*whats)[3], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x - 3, (*whats)[3], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x + 3, (*whats)[3], PM_NO_KAGE);
 
-        place_specific_monster(player_ptr, 0, y, center.x - 2, (*whats)[4], PM_NO_KAGE);
-        place_specific_monster(player_ptr, 0, y, center.x + 2, (*whats)[4], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x - 2, (*whats)[4], PM_NO_KAGE);
+        place_specific_monster(player_ptr, y, center.x + 2, (*whats)[4], PM_NO_KAGE);
     }
 
     /* Above/Below the center monster */
     for (auto x = center.x - 1; x <= center.x + 1; x++) {
-        place_specific_monster(player_ptr, 0, center.y + 1, x, (*whats)[5], PM_NO_KAGE);
-        place_specific_monster(player_ptr, 0, center.y - 1, x, (*whats)[5], PM_NO_KAGE);
+        place_specific_monster(player_ptr, center.y + 1, x, (*whats)[5], PM_NO_KAGE);
+        place_specific_monster(player_ptr, center.y - 1, x, (*whats)[5], PM_NO_KAGE);
     }
 
     /* Next to the center monster */
-    place_specific_monster(player_ptr, 0, center.y, center.x + 1, (*whats)[6], PM_NO_KAGE);
-    place_specific_monster(player_ptr, 0, center.y, center.x - 1, (*whats)[6], PM_NO_KAGE);
+    place_specific_monster(player_ptr, center.y, center.x + 1, (*whats)[6], PM_NO_KAGE);
+    place_specific_monster(player_ptr, center.y, center.x - 1, (*whats)[6], PM_NO_KAGE);
 
     /* Center monster */
-    place_specific_monster(player_ptr, 0, center.y, center.x, (*whats)[7], PM_NO_KAGE);
+    place_specific_monster(player_ptr, center.y, center.x, (*whats)[7], PM_NO_KAGE);
 
     return true;
 }
@@ -498,7 +498,7 @@ bool build_type13(PlayerType *player_ptr, dun_data_type *dd_ptr)
     const Pos2DVec vec(yval, xval);
     for (const auto &trapped_monster : place_table_trapped_pit) {
         const auto trapped_pos = trapped_monster.pos + vec;
-        place_specific_monster(player_ptr, 0, trapped_pos.y, trapped_pos.x, (*whats)[trapped_monster.strength], PM_NO_KAGE);
+        place_specific_monster(player_ptr, trapped_pos.y, trapped_pos.x, (*whats)[trapped_monster.strength], PM_NO_KAGE);
     }
 
     return true;

--- a/src/room/rooms-special.cpp
+++ b/src/room/rooms-special.cpp
@@ -111,7 +111,7 @@ bool build_type15(PlayerType *player_ptr, dun_data_type *dd_ptr)
             const auto y = yval + 2 * ddy_ddd[dir1];
             const auto x = xval + 2 * ddx_ddd[dir1];
             if (MonraceList::is_valid(monrace_id)) {
-                place_specific_monster(player_ptr, 0, y, x, monrace_id, PM_ALLOW_SLEEP);
+                place_specific_monster(player_ptr, y, x, monrace_id, PM_ALLOW_SLEEP);
             }
 
             /* Walls around the breather */
@@ -153,7 +153,7 @@ bool build_type15(PlayerType *player_ptr, dun_data_type *dd_ptr)
 
         const auto monrace_id = get_mon_num(player_ptr, 0, floor.dun_level, 0);
         if (MonraceList::is_valid(monrace_id)) {
-            place_specific_monster(player_ptr, 0, yval, xval, monrace_id, 0L);
+            place_specific_monster(player_ptr, yval, xval, monrace_id, 0L);
         }
 
         /* Walls around the breather */
@@ -202,7 +202,7 @@ bool build_type15(PlayerType *player_ptr, dun_data_type *dd_ptr)
             const auto y = yval + ddy_ddd[dir1];
             const auto x = xval + ddx_ddd[dir1];
             if (MonraceList::is_valid(monrace_id)) {
-                place_specific_monster(player_ptr, 0, y, x, monrace_id, 0L);
+                place_specific_monster(player_ptr, y, x, monrace_id, 0L);
             }
         }
 

--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -357,7 +357,7 @@ void build_vault(vault_type *v_ptr, PlayerType *player_ptr, POSITION yval, POSIT
                 set_cave_feat(floor_ptr, y, x, v_ptr->feature_list[*t]);
                 set_cave_feat_mimic(floor_ptr, y, x, v_ptr->feature_ap_list[*t]);
                 if (v_ptr->place_monster_list.count(*t) != 0) {
-                    place_monster_one(player_ptr, 0, y, x, v_ptr->place_monster_list[*t], 0);
+                    place_monster_one(player_ptr, y, x, v_ptr->place_monster_list[*t], 0);
                 }
                 continue;
             }

--- a/src/specific-object/monster-ball.cpp
+++ b/src/specific-object/monster-ball.cpp
@@ -100,7 +100,7 @@ static bool release_monster(PlayerType *player_ptr, ItemEntity &item, DIRECTION 
         return false;
     }
 
-    const auto m_idx = place_specific_monster(player_ptr, 0, pos.y, pos.x, monrace.idx, PM_FORCE_PET | PM_NO_KAGE);
+    const auto m_idx = place_specific_monster(player_ptr, pos.y, pos.x, monrace.idx, PM_FORCE_PET | PM_NO_KAGE);
     if (!m_idx) {
         return false;
     }

--- a/src/spell-kind/spells-polymorph.cpp
+++ b/src/spell-kind/spells-polymorph.cpp
@@ -115,7 +115,7 @@ bool polymorph_monster(PlayerType *player_ptr, POSITION y, POSITION x)
     m_ptr->hold_o_idx_list.clear();
     delete_monster_idx(player_ptr, g_ptr->m_idx);
     bool polymorphed = false;
-    auto m_idx = place_specific_monster(player_ptr, 0, y, x, new_r_idx, mode);
+    auto m_idx = place_specific_monster(player_ptr, y, x, new_r_idx, mode);
     if (m_idx) {
         auto &monster = floor_ptr->m_list[*m_idx];
         monster.nickname = back_m.nickname;
@@ -123,7 +123,7 @@ bool polymorph_monster(PlayerType *player_ptr, POSITION y, POSITION x)
         monster.hold_o_idx_list = back_m.hold_o_idx_list;
         polymorphed = true;
     } else {
-        m_idx = place_specific_monster(player_ptr, 0, y, x, old_r_idx, (mode | PM_NO_KAGE | PM_IGNORE_TERRAIN));
+        m_idx = place_specific_monster(player_ptr, y, x, old_r_idx, (mode | PM_NO_KAGE | PM_IGNORE_TERRAIN));
         if (m_idx) {
             floor_ptr->m_list[*m_idx] = back_m;
             mproc_init(floor_ptr);


### PR DESCRIPTION
関数 place_monster_one と place_monster_specific の引数 src_idx と summoner_m_idx はどちらも召喚主のモンスターIDを渡す引数として使用して
おり、役割が被っているので summoner_m_idx に統合する。