### PR TITLE
変愚「[Implement] レベル不明のモンスターが動いたら行動を中止するオプションの追加 #4457」のマージ

### DIFF
--- a/src/game-option/disturbance-options.cpp
+++ b/src/game-option/disturbance-options.cpp
@@ -8,6 +8,7 @@ bool flush_failure; /* Flush input on various failures */
 bool flush_disturb; /* Flush input whenever disturbed */
 bool disturb_move; /* Disturb whenever any monster moves */
 bool disturb_high; /* Disturb whenever high-level monster moves */
+bool disturb_unknown; /* Disturb whenever unknown-level monster moves */
 bool disturb_near; /* Disturb whenever viewable monster moves */
 bool disturb_pets; /* Disturb when visible pets move */
 bool disturb_panel; /* Disturb whenever map panel changes */

--- a/src/game-option/disturbance-options.h
+++ b/src/game-option/disturbance-options.h
@@ -10,6 +10,7 @@ extern bool flush_failure; /* Flush input on various failures */
 extern bool flush_disturb; /* Flush input whenever disturbed */
 extern bool disturb_move; /* Disturb whenever any monster moves */
 extern bool disturb_high; /* Disturb whenever high-level monster moves */
+extern bool disturb_unknown; /* Disturb whenever unknown-level monster moves */
 extern bool disturb_near; /* Disturb whenever viewable monster moves */
 extern bool disturb_pets; /* Disturb when visible pets move */
 extern bool disturb_panel; /* Disturb whenever map panel changes */

--- a/src/game-option/option-types-table.cpp
+++ b/src/game-option/option-types-table.cpp
@@ -180,8 +180,11 @@ const std::vector<option_type> option_info = {
 
     { &disturb_move, false, OPT_PAGE_DISTURBANCE, 0, 20, "disturb_move", _("どこのモンスターが動いても行動を中止する", "Disturb whenever any monster moves") },
 
-    { &disturb_high, false, OPT_PAGE_DISTURBANCE, 1, 3, "disturb_high",
+    { &disturb_high, true, OPT_PAGE_DISTURBANCE, 1, 3, "disturb_high",
         _("レベルの高いモンスターが動いたら行動を中止する", "Disturb whenever high-level monster moves") },
+
+    { &disturb_unknown, true, OPT_PAGE_DISTURBANCE, 0, 26, "disturb_unknown",
+        _("レベル不明のモンスターが動いたら行動を中止する", "Disturb whenever unknown-level monster moves") },
 
     { &disturb_near, true, OPT_PAGE_DISTURBANCE, 0, 21, "disturb_near",
         _("視界内のモンスターが動いたら行動を中止する", "Disturb whenever viewable monster moves") },

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -474,7 +474,8 @@ bool process_monster_movement(PlayerType *player_ptr, turn_flags *turn_flags_ptr
         const auto is_projectable = projectable(player_ptr, player_ptr->y, player_ptr->x, monster.fy, monster.fx);
         const auto can_see = disturb_near && monster.mflag.has(MonsterTemporaryFlagType::VIEW) && is_projectable;
         const auto is_high_level = disturb_high && (ap_r_ref.r_tkills > 0) && (ap_r_ref.level >= player_ptr->lev);
-        if (monster.ml && (disturb_move || can_see || is_high_level)) {
+        const auto is_unknown_level = disturb_unknown && (ap_r_ref.r_tkills == 0);
+        if (monster.ml && (disturb_move || can_see || is_high_level || is_unknown_level)) {
             if (monster.is_hostile()) {
                 disturb(player_ptr, false, true);
             }


### PR DESCRIPTION
行動中止オプションを拡張し、未知のモンスターに対して警戒できるように修正する。
単発の修正のためIssueなし。