### PR TITLE
変愚「[Refactor] choose_chameleon_polymorph() からupdate_monster() とlite_spot() の呼び出しを削除 #4452」のマージ

### DIFF
--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -22,7 +22,6 @@
 #include "monster-floor/monster-summon.h"
 #include "monster-floor/place-monster-types.h"
 #include "monster-race/monster-kind-mask.h"
-#include "monster-race/race-brightness-mask.h"
 #include "monster-race/race-indice-types.h"
 #include "monster/monster-describer.h"
 #include "monster/monster-info.h"
@@ -328,17 +327,8 @@ void choose_chameleon_polymorph(PlayerType *player_ptr, MONSTER_IDX m_idx, const
         return;
     }
 
-    const auto &monrace = MonraceList::get_instance().get_monrace(*new_monrace_id);
-
     monster.r_idx = *new_monrace_id;
     monster.ap_r_idx = *new_monrace_id;
-    update_monster(player_ptr, m_idx, false);
-    lite_spot(player_ptr, monster.fy, monster.fx);
-
-    const auto &new_monrace = monster.get_monrace();
-    if (new_monrace.brightness_flags.has_any_of(ld_mask) || monrace.brightness_flags.has_any_of(ld_mask)) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
-    }
 }
 
 /*!

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -22,6 +22,7 @@
 #include "game-option/birth-options.h"
 #include "game-option/play-record-options.h"
 #include "grid/feature.h"
+#include "grid/grid.h"
 #include "io/write-diary.h"
 #include "melee/melee-postprocess.h"
 #include "melee/melee-spell.h"
@@ -33,6 +34,7 @@
 #include "monster-floor/monster-summon.h"
 #include "monster-floor/place-monster-types.h"
 #include "monster-floor/quantum-effect.h"
+#include "monster-race/race-brightness-mask.h"
 #include "monster-race/race-flags-resistance.h"
 #include "monster-race/race-indice-types.h"
 #include "monster/monster-damage.h"
@@ -136,9 +138,18 @@ void process_monster(PlayerType *player_ptr, MONSTER_IDX m_idx)
 
         const auto old_m_name = monster_desc(player_ptr, m_ptr, 0);
 
+        const auto &monrace = m_ptr->get_monrace();
+
         choose_chameleon_polymorph(player_ptr, m_idx, floor.get_grid(Pos2D(m_ptr->fy, m_ptr->fx)));
 
+        update_monster(player_ptr, m_idx, false);
+        lite_spot(player_ptr, m_ptr->fy, m_ptr->fx);
+
         const auto &new_monrace = m_ptr->get_monrace();
+
+        if (new_monrace.brightness_flags.has_any_of(ld_mask) || monrace.brightness_flags.has_any_of(ld_mask)) {
+            RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
+        }
 
         if (m_idx == player_ptr->riding) {
             msg_format(_("突然%sが変身した。", "Suddenly, %s transforms!"), old_m_name.data());


### PR DESCRIPTION
…() の呼び出し及び明かり更新フラグ立てを削除

これらはフロアに滞在中の変身処理に因むものと思われるため