### PR TITLE
変愚「攻撃方法"CRUSH" の誤訳を修正 #4481」のマージ

### DIFF
--- a/src/lore/combat-types-setter.cpp
+++ b/src/lore/combat-types-setter.cpp
@@ -46,7 +46,7 @@ void set_monster_blow_method(lore_type *lore_ptr, int m)
         lore_ptr->pc = TERM_L_WHITE;
         break;
     case RaceBlowMethodType::CRUSH:
-        lore_ptr->p = _("体当たりする", "crush");
+        lore_ptr->p = _("締めつける", "crush");
         lore_ptr->pc = TERM_L_WHITE;
         break;
     case RaceBlowMethodType::ENGULF:


### PR DESCRIPTION
"CRUSH"は「握り潰す、潰す」などの意味があるが、蛇系のモンスターも同様の攻撃方法を持っているため「締めつける」が妥当と判断 なお参考として「体当たり」と訳せる発音の近い単語に「衝突」を意味する"CRASH"という単語がある