### PR TITLE
変愚「[Feature] 財宝に生成階層とレアリティを設定する #4652」のマージ 

### DIFF
--- a/lib/edit/BaseitemDefinitions.jsonc
+++ b/lib/edit/BaseitemDefinitions.jsonc
@@ -16328,7 +16328,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 3
+      "cost": 3,
+      "allocations": [
+        {
+          "depth": 1,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 481,
@@ -16347,7 +16353,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 4
+      "cost": 4,
+      "allocations": [
+        {
+          "depth": 2,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 482,
@@ -16366,7 +16378,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 5
+      "cost": 5,
+      "allocations": [
+        {
+          "depth": 4,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 483,
@@ -16385,7 +16403,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 6
+      "cost": 6,
+      "allocations": [
+        {
+          "depth": 6,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 484,
@@ -16404,7 +16428,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 7
+      "cost": 7,
+      "allocations": [
+        {
+          "depth": 8,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 485,
@@ -16423,7 +16453,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 8
+      "cost": 8,
+      "allocations": [
+        {
+          "depth": 10,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 486,
@@ -16442,7 +16478,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 9
+      "cost": 9,
+      "allocations": [
+        {
+          "depth": 12,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 487,
@@ -16461,7 +16503,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 10
+      "cost": 10,
+      "allocations": [
+        {
+          "depth": 14,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 488,
@@ -16480,7 +16528,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 12
+      "cost": 12,
+      "allocations": [
+        {
+          "depth": 16,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 489,
@@ -16499,7 +16553,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 14
+      "cost": 14,
+      "allocations": [
+        {
+          "depth": 18,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 490,
@@ -16518,7 +16578,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 16
+      "cost": 16,
+      "allocations": [
+        {
+          "depth": 20,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 491,
@@ -16537,7 +16603,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 18
+      "cost": 18,
+      "allocations": [
+        {
+          "depth": 22,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 492,
@@ -16556,7 +16628,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 20
+      "cost": 20,
+      "allocations": [
+        {
+          "depth": 24,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 493,
@@ -16575,7 +16653,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 24
+      "cost": 24,
+      "allocations": [
+        {
+          "depth": 26,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 494,
@@ -16594,7 +16678,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 28
+      "cost": 28,
+      "allocations": [
+        {
+          "depth": 28,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 495,
@@ -16613,7 +16703,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 32
+      "cost": 32,
+      "allocations": [
+        {
+          "depth": 30,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 496,
@@ -16632,7 +16728,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 40
+      "cost": 40,
+      "allocations": [
+        {
+          "depth": 32,
+          "rarity": 1
+        }
+      ]
     },
     {
       "id": 497,
@@ -16651,7 +16753,13 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 80
+      "cost": 80,
+      "allocations": [
+        {
+          "depth": 34,
+          "rarity": 1
+        }
+      ]
     },
     //##### Objects 498 and 499 are the "Morgoth Artifacts" #####
     //# These objects, like objects 500 to 511, are never created

--- a/src/object-enchant/item-apply-magic.h
+++ b/src/object-enchant/item-apply-magic.h
@@ -12,7 +12,8 @@ enum item_am_type : uint32_t {
     AM_CURSED = 0x00000010, /*!< Generate cursed/worthless items */
     AM_FORBID_CHEST = 0x00000020, /*!< 箱からさらに箱が出現することを抑止する */
     AM_NASTY = 0x00000040, /*!< 例のアレなアイテムだけ落とす */
-    AM_NO_NEVER_MOVE = 0x00000080 /*!< NEVER_MOVEアイテムは生成外 */
+    AM_NO_NEVER_MOVE = 0x00000080, /*!< NEVER_MOVEアイテムは生成外 */
+    AM_GOLD = 0x00000100, /*!< 財宝を生成する */
 };
 
 // @todo v3.0 正式リリース以降、上記enum をこちらに差し替える.

--- a/src/system/alloc-entries.cpp
+++ b/src/system/alloc-entries.cpp
@@ -142,6 +142,11 @@ bool BaseitemAllocationEntry::is_chest() const
     return this->get_bi_key().tval() == ItemKindType::CHEST;
 }
 
+bool BaseitemAllocationEntry::is_gold() const
+{
+    return this->get_bi_key().tval() == ItemKindType::GOLD;
+}
+
 int BaseitemAllocationEntry::get_baseitem_level() const
 {
     return this->get_baseitem().level;

--- a/src/system/alloc-entries.h
+++ b/src/system/alloc-entries.h
@@ -71,6 +71,7 @@ public:
     short prob2; /* Probability, pass 2 */
     bool is_same_bi_key(const BaseitemKey &bi_key) const;
     bool is_chest() const;
+    bool is_gold() const;
     int get_baseitem_level() const;
     bool order_level(const BaseitemAllocationEntry &other) const;
 

--- a/src/world/world-object.cpp
+++ b/src/world/world-object.cpp
@@ -87,7 +87,15 @@ OBJECT_IDX get_obj_index(const FloorType *floor_ptr, DEPTH level, BIT_FLAGS mode
             break;
         }
 
-        if ((mode & AM_FORBID_CHEST) && (entry.is_chest())) {
+        if (any_bits(mode, AM_FORBID_CHEST) && entry.is_chest()) {
+            continue;
+        }
+
+        if (any_bits(mode, AM_GOLD) && !entry.is_gold()) {
+            continue;
+        }
+
+        if (none_bits(mode, AM_GOLD) && entry.is_gold()) {
             continue;
         }
 


### PR DESCRIPTION
現在、財宝は独自処理にて生成されているため生成階層と重みづけに強い制約がある。
これを解消する準備として財宝の定義に生成階層とレアリティを追加する。

そのままだとアイテムドロップに財宝が混ざってしまうので財宝ドロップ時以外は生成されない処理も追加している。