### PR TITLE
変愚「[Fix] モンスターの思い出に撃破数が表示されない #4662」のマージ

### DIFF
--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -192,12 +192,11 @@ void display_kill_numbers(lore_type *lore_ptr)
     }
 
     const auto kill_unique_description = lore_ptr->build_kill_unique_description();
-    if (!kill_unique_description) {
+    if (kill_unique_description) {
+        for (const auto &[text, color] : *kill_unique_description) {
+            hook_c_roff(color, text);
+        }
         return;
-    }
-
-    for (const auto &[text, color] : *kill_unique_description) {
-        hook_c_roff(color, text);
     }
 
     if (lore_ptr->r_ptr->r_deaths == 0) {


### PR DESCRIPTION
resolve #4661
リファクタ時のエンバグと思われる。