### PR TITLE
[Refactor] ItemEntity::copy_from を clone で置き換える

### DIFF
--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -56,14 +56,14 @@ void wield_all(PlayerType *player_ptr)
         if (slot == INVEN_LITE) {
             continue;
         }
-        if (player_ptr->inventory_list[slot].is_valid()) {
+
+        auto &wield_slot_item = player_ptr->inventory_list[slot];
+        if (wield_slot_item.is_valid()) {
             continue;
         }
 
-        ItemEntity *i_ptr;
-        i_ptr = &ObjectType_body;
-        i_ptr->copy_from(o_ptr);
-        i_ptr->number = 1;
+        wield_slot_item = o_ptr->clone();
+        wield_slot_item.number = 1;
 
         if (i_idx >= 0) {
             inven_item_increase(player_ptr, i_idx, -1);
@@ -73,8 +73,6 @@ void wield_all(PlayerType *player_ptr)
             floor_item_optimize(player_ptr, 0 - i_idx);
         }
 
-        o_ptr = &player_ptr->inventory_list[slot];
-        o_ptr->copy_from(i_ptr);
         player_ptr->equip_cnt++;
     }
 }

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -460,8 +460,6 @@ static MULTIPLY calc_shot_damage_with_slay(
 void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SPELL_IDX snipe_type)
 {
     POSITION y, x, ny, nx, ty, tx, prev_y, prev_x;
-    ItemEntity forge;
-    ItemEntity *q_ptr;
     ItemEntity *o_ptr;
 
     AttributeFlags attribute_flags{};
@@ -599,11 +597,10 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
         /* Start at the player */
         y = player_ptr->y;
         x = player_ptr->x;
-        q_ptr = &forge;
-        q_ptr->copy_from(o_ptr);
+        auto fire_item = o_ptr->clone();
 
         /* Single object */
-        q_ptr->number = 1;
+        fire_item.number = 1;
 
         vary_item(player_ptr, i_idx, -1);
 
@@ -673,7 +670,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
 
             /* The player can see the (on screen) missile */
             if (panel_contains(ny, nx) && player_can_see_bold(player_ptr, ny, nx)) {
-                const auto symbol = q_ptr->get_symbol();
+                const auto symbol = fire_item.get_symbol();
 
                 /* Draw, Hilite, Fresh, Pause, Erase */
                 if (delay_factor > 0) {
@@ -796,10 +793,10 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
                         }
                     } else {
 
-                        attribute_flags = shot_attribute(player_ptr, j_ptr, q_ptr, snipe_type);
+                        attribute_flags = shot_attribute(player_ptr, j_ptr, &fire_item, snipe_type);
                         /* Apply special damage */
-                        tdam = calc_shot_damage_with_slay(player_ptr, j_ptr, q_ptr, tdam, m_ptr, snipe_type);
-                        tdam = critical_shot(player_ptr, q_ptr->weight, q_ptr->to_h, j_ptr->to_h, tdam);
+                        tdam = calc_shot_damage_with_slay(player_ptr, j_ptr, &fire_item, tdam, m_ptr, snipe_type);
+                        tdam = critical_shot(player_ptr, fire_item.weight, fire_item.to_h, j_ptr->to_h, tdam);
 
                         /* No negative damage */
                         if (tdam < 0) {
@@ -840,7 +837,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
                     else {
                         const auto m_name = monster_desc(player_ptr, m_ptr, 0);
                         /* STICK TO */
-                        if (q_ptr->is_fixed_artifact() && (sniper_concent == 0)) {
+                        if (fire_item.is_fixed_artifact() && (sniper_concent == 0)) {
                             stick_to = true;
                             msg_format(_("%sは%sに突き刺さった！", "%s^ is stuck in %s!"), item_name.data(), m_name.data());
                         }
@@ -934,7 +931,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
         }
 
         /* Chance of breakage (during attacks) */
-        auto j = (hit_body ? breakage_chance(player_ptr, q_ptr, PlayerClass(player_ptr).equals(PlayerClassType::ARCHER), snipe_type) : 0);
+        auto j = (hit_body ? breakage_chance(player_ptr, &fire_item, PlayerClass(player_ptr).equals(PlayerClassType::ARCHER), snipe_type) : 0);
 
         if (stick_to) {
             MONSTER_IDX m_idx = floor_ptr->grid_array[y][x].m_idx;
@@ -943,32 +940,31 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
 
             if (!o_idx) {
                 msg_format(_("%sはどこかへ行った。", "The %s went somewhere."), item_name.data());
-                if (q_ptr->is_fixed_artifact()) {
+                if (fire_item.is_fixed_artifact()) {
                     ArtifactList::get_instance().get_artifact(j_ptr->fa_id).is_generated = false;
                 }
                 return;
             }
 
-            o_ptr = &floor_ptr->o_list[o_idx];
-            o_ptr->copy_from(q_ptr);
-
             /* Forget mark */
-            o_ptr->marked.reset(OmType::TOUCHED);
+            fire_item.marked.reset(OmType::TOUCHED);
 
             /* Forget location */
-            o_ptr->iy = o_ptr->ix = 0;
+            fire_item.iy = fire_item.ix = 0;
 
             /* Memorize monster */
-            o_ptr->held_m_idx = m_idx;
+            fire_item.held_m_idx = m_idx;
+
+            floor_ptr->o_list[o_idx] = std::move(fire_item);
 
             /* Carry object */
             m_ptr->hold_o_idx_list.add(floor_ptr, o_idx);
         } else if (cave_has_flag_bold(floor_ptr, y, x, TerrainCharacteristics::PROJECT)) {
             /* Drop (or break) near that location */
-            (void)drop_near(player_ptr, q_ptr, j, y, x);
+            (void)drop_near(player_ptr, &fire_item, j, y, x);
         } else {
             /* Drop (or break) near that location */
-            (void)drop_near(player_ptr, q_ptr, j, prev_y, prev_x);
+            (void)drop_near(player_ptr, &fire_item, j, prev_y, prev_x);
         }
 
         /* Sniper - Repeat shooting when double shots */

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -57,20 +57,19 @@ qtwg_type *initialize_quest_generator_type(qtwg_type *qtwg_ptr, int ymin, int xm
  * @brief フロアの所定のマスにオブジェクトを配置する
  * Place the object j_ptr to a grid
  * @param floor_ptr 現在フロアへの参照ポインタ
- * @param j_ptr オブジェクト構造体の参照ポインタ
+ * @param item アイテムの参照
  * @param y 配置先Y座標
  * @param x 配置先X座標
  * @return エラーコード
  */
-static void drop_here(FloorType *floor_ptr, ItemEntity *j_ptr, POSITION y, POSITION x)
+static void drop_here(FloorType *floor_ptr, ItemEntity &&item, POSITION y, POSITION x)
 {
     OBJECT_IDX o_idx = o_pop(floor_ptr);
-    ItemEntity *o_ptr;
-    o_ptr = &floor_ptr->o_list[o_idx];
-    o_ptr->copy_from(j_ptr);
-    o_ptr->iy = y;
-    o_ptr->ix = x;
-    o_ptr->held_m_idx = 0;
+    auto &dropped_item = floor_ptr->o_list[o_idx];
+    dropped_item = std::move(item);
+    dropped_item.iy = y;
+    dropped_item.ix = x;
+    dropped_item.held_m_idx = 0;
     auto *g_ptr = &floor_ptr->grid_array[y][x];
     g_ptr->o_idx_list.add(floor_ptr, o_idx);
 }
@@ -87,7 +86,7 @@ static void generate_artifact(PlayerType *player_ptr, qtwg_type *qtwg_ptr, const
     }
 
     ItemEntity item({ ItemKindType::SCROLL, SV_SCROLL_ACQUIREMENT });
-    drop_here(player_ptr->current_floor_ptr, &item, *qtwg_ptr->y, *qtwg_ptr->x);
+    drop_here(player_ptr->current_floor_ptr, std::move(item), *qtwg_ptr->y, *qtwg_ptr->x);
 }
 
 /**
@@ -185,7 +184,7 @@ static void parse_qtw_D(PlayerType *player_ptr, qtwg_type *qtwg_ptr, char *s)
             }
 
             ItemMagicApplier(player_ptr, &item, floor.base_level, AM_NO_FIXED_ART | AM_GOOD).execute();
-            drop_here(&floor, &item, *qtwg_ptr->y, *qtwg_ptr->x);
+            drop_here(&floor, std::move(item), *qtwg_ptr->y, *qtwg_ptr->x);
         }
 
         generate_artifact(player_ptr, qtwg_ptr, letter[idx].artifact);

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -511,7 +511,7 @@ OBJECT_IDX drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, PERCENTAGE chanc
     }
 
     if (!done) {
-        (&floor_ptr->o_list[o_idx])->copy_from(j_ptr);
+        floor_ptr->o_list[o_idx] = j_ptr->clone();
         j_ptr = &floor_ptr->o_list[o_idx];
         j_ptr->iy = by;
         j_ptr->ix = bx;

--- a/src/grid/object-placer.cpp
+++ b/src/grid/object-placer.cpp
@@ -66,33 +66,23 @@ void place_object(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FLAGS mode
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
     auto *g_ptr = &floor_ptr->grid_array[y][x];
-    ItemEntity forge;
-    ItemEntity *q_ptr;
     if (!in_bounds(floor_ptr, y, x) || !cave_drop_bold(floor_ptr, y, x) || !g_ptr->o_idx_list.empty()) {
-        return;
-    }
-
-    q_ptr = &forge;
-    q_ptr->wipe();
-    if (!make_object(player_ptr, q_ptr, mode)) {
         return;
     }
 
     OBJECT_IDX o_idx = o_pop(floor_ptr);
     if (o_idx == 0) {
-        if (q_ptr->is_fixed_artifact()) {
-            q_ptr->get_fixed_artifact().is_generated = false;
-        }
-
         return;
     }
 
-    ItemEntity *o_ptr;
-    o_ptr = &floor_ptr->o_list[o_idx];
-    o_ptr->copy_from(q_ptr);
+    auto &item = floor_ptr->o_list[o_idx];
+    item.wipe();
+    if (!make_object(player_ptr, &item, mode)) {
+        return;
+    }
 
-    o_ptr->iy = y;
-    o_ptr->ix = x;
+    item.iy = y;
+    item.ix = x;
     g_ptr->o_idx_list.add(floor_ptr, o_idx);
 
     note_spot(player_ptr, y, x);

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -17,6 +17,7 @@
 #include "util/object-sort.h"
 #include "view/display-messages.h"
 #include "view/object-describer.h"
+#include <algorithm>
 
 void vary_item(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NUMBER num)
 {
@@ -241,46 +242,19 @@ void combine_pack(PlayerType *player_ptr)
  */
 void reorder_pack(PlayerType *player_ptr)
 {
-    int i, j, k;
-    ItemEntity forge;
-    ItemEntity *q_ptr;
-    ItemEntity *o_ptr;
-    bool flag = false;
+    const auto comp = [player_ptr](const auto &item1, const auto &item2) {
+        return object_sort_comp(player_ptr, item1, item2);
+    };
 
-    for (i = 0; i < INVEN_PACK; i++) {
-        if ((i == INVEN_PACK) && (player_ptr->inven_cnt == INVEN_PACK)) {
-            break;
-        }
+    auto first = &player_ptr->inventory_list[0];
+    auto last = &player_ptr->inventory_list[player_ptr->inven_cnt];
 
-        o_ptr = &player_ptr->inventory_list[i];
-        if (!o_ptr->is_valid()) {
-            continue;
-        }
-
-        for (j = 0; j < INVEN_PACK; j++) {
-            if (object_sort_comp(player_ptr, *o_ptr, player_ptr->inventory_list[j])) {
-                break;
-            }
-        }
-
-        if (j >= i) {
-            continue;
-        }
-
-        flag = true;
-        q_ptr = &forge;
-        q_ptr->copy_from(&player_ptr->inventory_list[i]);
-        for (k = i; k > j; k--) {
-            (&player_ptr->inventory_list[k])->copy_from(&player_ptr->inventory_list[k - 1]);
-        }
-
-        (&player_ptr->inventory_list[j])->copy_from(q_ptr);
-        RedrawingFlagsUpdater::get_instance().set_flag(SubWindowRedrawingFlag::INVENTORY);
+    if (std::is_sorted(first, last, comp)) {
+        return;
     }
 
-    if (flag) {
-        msg_print(_("ザックの中のアイテムを並べ直した。", "You reorder some items in your pack."));
-    }
+    std::stable_sort(first, last, comp);
+    msg_print(_("ザックの中のアイテムを並べ直した。", "You reorder some items in your pack."));
 }
 
 /*!
@@ -291,7 +265,7 @@ void reorder_pack(PlayerType *player_ptr)
  */
 int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
-    INVENTORY_IDX i, j, k;
+    INVENTORY_IDX i, j;
     INVENTORY_IDX n = -1;
 
     ItemEntity *j_ptr;
@@ -335,14 +309,10 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
         }
 
         i = j;
-        for (k = n; k >= i; k--) {
-            (&player_ptr->inventory_list[k + 1])->copy_from(&player_ptr->inventory_list[k]);
-        }
-
-        (&player_ptr->inventory_list[i])->wipe();
+        std::rotate(&player_ptr->inventory_list[i], &player_ptr->inventory_list[n + 1], &player_ptr->inventory_list[n + 2]);
     }
 
-    (&player_ptr->inventory_list[i])->copy_from(o_ptr);
+    player_ptr->inventory_list[i] = o_ptr->clone();
     j_ptr = &player_ptr->inventory_list[i];
     j_ptr->held_m_idx = 0;
     j_ptr->iy = j_ptr->ix = 0;

--- a/src/load/inventory-loader.cpp
+++ b/src/load/inventory-loader.cpp
@@ -44,7 +44,7 @@ static errr rd_inventory(PlayerType *player_ptr)
 
         if (n >= INVEN_MAIN_HAND) {
             item.marked.set(OmType::TOUCHED);
-            player_ptr->inventory_list[n].copy_from(&item);
+            player_ptr->inventory_list[n] = std::move(item);
             player_ptr->equip_cnt++;
             continue;
         }
@@ -56,7 +56,7 @@ static errr rd_inventory(PlayerType *player_ptr)
 
         n = slot++;
         item.marked.set(OmType::TOUCHED);
-        player_ptr->inventory_list[n].copy_from(&item);
+        player_ptr->inventory_list[n] = std::move(item);
         player_ptr->inven_cnt++;
     }
 

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -298,7 +298,6 @@ static void list_weapon(PlayerType *player_ptr, const ItemEntity &item, TERM_LEN
 PRICE compare_weapons(PlayerType *player_ptr, PRICE bcost)
 {
     ItemEntity *o_ptr[2]{};
-    ItemEntity orig_weapon;
     TERM_LEN row = 2;
     TERM_LEN wid = 38, mgn = 2;
     auto &world = AngbandWorld::get_instance();
@@ -310,7 +309,7 @@ PRICE compare_weapons(PlayerType *player_ptr, PRICE bcost)
     screen_save();
     clear_bldg(0, 22);
     auto *i_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND];
-    (&orig_weapon)->copy_from(i_ptr);
+    auto orig_weapon = i_ptr->clone();
 
     constexpr auto first_q = _("第一の武器は？", "What is your first weapon? ");
     constexpr auto first_s = _("比べるものがありません。", "You have nothing to compare.");
@@ -332,7 +331,7 @@ PRICE compare_weapons(PlayerType *player_ptr, PRICE bcost)
         for (int i = 0; i < n; i++) {
             int col = (wid * i + mgn);
             if (o_ptr[i] != i_ptr) {
-                i_ptr->copy_from(o_ptr[i]);
+                *i_ptr = o_ptr[i]->clone();
             }
 
             rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -340,7 +339,7 @@ PRICE compare_weapons(PlayerType *player_ptr, PRICE bcost)
 
             list_weapon(player_ptr, *o_ptr[i], row, col);
             compare_weapon_aux(player_ptr, o_ptr[i], col, row + 8);
-            i_ptr->copy_from(&orig_weapon);
+            *i_ptr = orig_weapon.clone();
         }
 
         rfu.set_flag(StatusRecalculatingFlag::BONUS);

--- a/src/mind/mind-mage.cpp
+++ b/src/mind/mind-mage.cpp
@@ -67,15 +67,12 @@ bool eat_magic(PlayerType *player_ptr, int power)
                 o_ptr->pval--;
 
                 if ((tval == ItemKindType::STAFF) && (i_idx >= 0) && (o_ptr->number > 1)) {
-                    ItemEntity forge;
-                    ItemEntity *q_ptr;
-                    q_ptr = &forge;
-                    q_ptr->copy_from(o_ptr);
+                    auto eat_item = o_ptr->clone();
 
-                    q_ptr->number = 1;
+                    eat_item.number = 1;
                     o_ptr->pval++;
                     o_ptr->number--;
-                    i_idx = store_item_to_inventory(player_ptr, q_ptr);
+                    i_idx = store_item_to_inventory(player_ptr, &eat_item);
 
                     msg_print(_("杖をまとめなおした。", "You unstack your staff."));
                 }

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -115,16 +115,16 @@ static void move_item_to_monster(PlayerType *player_ptr, MonsterAttackPlayer *mo
         return;
     }
 
-    auto *j_ptr = &player_ptr->current_floor_ptr->o_list[o_idx];
-    j_ptr->copy_from(monap_ptr->o_ptr);
-    j_ptr->number = 1;
+    auto &item = player_ptr->current_floor_ptr->o_list[o_idx];
+    item = monap_ptr->o_ptr->clone();
+    item.number = 1;
     if (monap_ptr->o_ptr->is_wand_rod()) {
-        j_ptr->pval = monap_ptr->o_ptr->pval / monap_ptr->o_ptr->number;
-        monap_ptr->o_ptr->pval -= j_ptr->pval;
+        item.pval = monap_ptr->o_ptr->pval / monap_ptr->o_ptr->number;
+        monap_ptr->o_ptr->pval -= item.pval;
     }
 
-    j_ptr->marked.clear().set(OmType::TOUCHED);
-    j_ptr->held_m_idx = monap_ptr->m_idx;
+    item.marked.clear().set(OmType::TOUCHED);
+    item.held_m_idx = monap_ptr->m_idx;
     monap_ptr->m_ptr->hold_o_idx_list.add(player_ptr->current_floor_ptr, o_idx);
 }
 

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -215,16 +215,11 @@ void update_object_by_monster_movement(PlayerType *player_ptr, turn_flags *turn_
 void monster_drop_carried_objects(PlayerType *player_ptr, MonsterEntity *m_ptr)
 {
     for (auto it = m_ptr->hold_o_idx_list.begin(); it != m_ptr->hold_o_idx_list.end();) {
-        ItemEntity forge;
-        ItemEntity *o_ptr;
-        ItemEntity *q_ptr;
         const OBJECT_IDX this_o_idx = *it++;
-        o_ptr = &player_ptr->current_floor_ptr->o_list[this_o_idx];
-        q_ptr = &forge;
-        q_ptr->copy_from(o_ptr);
-        q_ptr->held_m_idx = 0;
+        auto drop_item = player_ptr->current_floor_ptr->o_list[this_o_idx].clone();
+        drop_item.held_m_idx = 0;
         delete_object_idx(player_ptr, this_o_idx);
-        (void)drop_near(player_ptr, q_ptr, -1, m_ptr->fy, m_ptr->fx);
+        (void)drop_near(player_ptr, &drop_item, -1, m_ptr->fy, m_ptr->fx);
     }
 
     m_ptr->hold_o_idx_list.clear();

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -102,7 +102,7 @@ bool ObjectThrowEntity::check_can_throw()
 
 void ObjectThrowEntity::calc_throw_range()
 {
-    this->q_ptr->copy_from(this->o_ptr);
+    *this->q_ptr = this->o_ptr->clone();
     this->obj_flags = this->q_ptr->get_flags();
     torch_flags(this->q_ptr, this->obj_flags);
     distribute_charges(this->o_ptr, this->q_ptr, 1);
@@ -304,7 +304,7 @@ void ObjectThrowEntity::process_boomerang_back()
         }
 
         this->o_ptr = &player_ptr->inventory_list[this->i_idx];
-        this->o_ptr->copy_from(this->q_ptr);
+        *this->o_ptr = this->q_ptr->clone();
         this->player_ptr->equip_cnt++;
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         static constexpr auto flags = {

--- a/src/object-use/use-execution.cpp
+++ b/src/object-use/use-execution.cpp
@@ -136,13 +136,11 @@ void ObjectUseEntity::execute()
 
     o_ptr->pval--;
     if ((this->i_idx >= 0) && (o_ptr->number > 1)) {
-        ItemEntity forge;
-        auto *q_ptr = &forge;
-        q_ptr->copy_from(o_ptr);
-        q_ptr->number = 1;
+        auto used_item = o_ptr->clone();
+        used_item.number = 1;
         o_ptr->pval++;
         o_ptr->number--;
-        this->i_idx = store_item_to_inventory(this->player_ptr, q_ptr);
+        this->i_idx = store_item_to_inventory(this->player_ptr, &used_item);
         msg_print(_("杖をまとめなおした。", "You unstack your staff."));
     }
 

--- a/src/racial/racial-android.cpp
+++ b/src/racial/racial-android.cpp
@@ -65,8 +65,6 @@ void calc_android_exp(PlayerType *player_ptr)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         auto *o_ptr = &player_ptr->inventory_list[i];
-        ItemEntity forge;
-        auto *q_ptr = &forge;
         uint32_t value, exp;
         DEPTH level = std::max(o_ptr->get_baseitem_level() - 8, 1);
 
@@ -76,11 +74,6 @@ void calc_android_exp(PlayerType *player_ptr)
         if (!o_ptr->is_valid()) {
             continue;
         }
-
-        q_ptr->wipe();
-        q_ptr->copy_from(o_ptr);
-        q_ptr->discount = 0;
-        q_ptr->curse_flags.clear();
 
         if (o_ptr->is_fixed_artifact()) {
             const auto &artifact = o_ptr->get_fixed_artifact();
@@ -113,7 +106,12 @@ void calc_android_exp(PlayerType *player_ptr)
             level = std::max(level, (level + std::max(fake_level - 8, 5)) / 2 + 3);
         }
 
-        value = object_value_real(q_ptr);
+        // 装備品の割引や呪いはアンドロイドの経験値計算に影響しない
+        auto item = o_ptr->clone();
+        item.discount = 0;
+        item.curse_flags.clear();
+
+        value = object_value_real(&item);
         if (value <= 0) {
             continue;
         }

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -110,32 +110,30 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
         }
     }
 
-    ItemEntity forge;
-    auto *q_ptr = &forge;
-    q_ptr->copy_from(o_ptr);
-    q_ptr->number = amt;
+    auto selling_item = o_ptr->clone();
+    selling_item.number = amt;
 
     if (o_ptr->is_wand_rod()) {
-        q_ptr->pval = o_ptr->pval * amt / o_ptr->number;
+        selling_item.pval = o_ptr->pval * amt / o_ptr->number;
     }
 
     if ((store_num != StoreSaleType::HOME) && (store_num != StoreSaleType::MUSEUM)) {
-        q_ptr->inscription.reset();
-        q_ptr->feeling = FEEL_NONE;
+        selling_item.inscription.reset();
+        selling_item.feeling = FEEL_NONE;
     }
 
-    if (!store_check_num(q_ptr, store_num)) {
+    if (!store_check_num(&selling_item, store_num)) {
         msg_print(s_full);
         return;
     }
 
     bool placed = false;
     if ((store_num != StoreSaleType::HOME) && (store_num != StoreSaleType::MUSEUM)) {
-        const auto item_name = describe_flavor(player_ptr, *q_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, selling_item, 0);
         msg_format(_("%s(%c)を売却する。", "Selling %s (%c)."), item_name.data(), index_to_label(i_idx));
         msg_print(nullptr);
 
-        auto res = prompt_to_sell(player_ptr, q_ptr, store_num);
+        auto res = prompt_to_sell(player_ptr, &selling_item, store_num);
         placed = res.has_value();
         if (placed) {
             const auto price = res.value();
@@ -153,20 +151,19 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
 
             player_ptr->au += price;
             store_prt_gold(player_ptr);
-            const auto dummy = q_ptr->calc_price() * q_ptr->number;
+            const auto dummy = selling_item.calc_price() * selling_item.number;
 
             identify_item(player_ptr, o_ptr);
-            q_ptr = &forge;
-            q_ptr->copy_from(o_ptr);
-            q_ptr->number = amt;
-            q_ptr->ident |= IDENT_STORE;
+            auto sold_item = o_ptr->clone();
+            sold_item.number = amt;
+            sold_item.ident |= IDENT_STORE;
 
             if (o_ptr->is_wand_rod()) {
-                q_ptr->pval = o_ptr->pval * amt / o_ptr->number;
+                sold_item.pval = o_ptr->pval * amt / o_ptr->number;
             }
 
-            const auto value = q_ptr->calc_price() * q_ptr->number;
-            const auto sold_item_name = describe_flavor(player_ptr, *q_ptr, 0);
+            const auto value = sold_item.calc_price() * sold_item.number;
+            const auto sold_item_name = describe_flavor(player_ptr, sold_item, 0);
             msg_format(_("%sを $%dで売却しました。", "You sold %s for %d gold."), sold_item_name.data(), price);
 
             if (record_sell) {
@@ -179,8 +176,8 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
                 purchase_analyze(player_ptr, price, value, dummy);
             }
 
-            distribute_charges(o_ptr, q_ptr, amt);
-            q_ptr->timeout = 0;
+            distribute_charges(o_ptr, &sold_item, amt);
+            sold_item.timeout = 0;
             inven_item_increase(player_ptr, i_idx, -amt);
             inven_item_describe(player_ptr, i_idx);
             if (o_ptr->number > 0) {
@@ -188,15 +185,15 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
             }
 
             inven_item_optimize(player_ptr, i_idx);
-            int item_pos = store_carry(q_ptr);
+            int item_pos = store_carry(&sold_item);
             if (item_pos >= 0) {
                 store_top = (item_pos / store_bottom) * store_bottom;
                 display_store_inventory(player_ptr, store_num);
             }
         }
     } else if (store_num == StoreSaleType::MUSEUM) {
-        const auto museum_item_name = describe_flavor(player_ptr, *q_ptr, OD_NAME_ONLY);
-        if (-1 == store_check_num(q_ptr, store_num)) {
+        const auto museum_item_name = describe_flavor(player_ptr, selling_item, OD_NAME_ONLY);
+        if (-1 == store_check_num(&selling_item, store_num)) {
             msg_print(_("それと同じ品物は既に博物館にあるようです。", "The Museum already has one of those items."));
         } else {
             msg_print(_("博物館に寄贈したものは取り出すことができません！！", "You cannot take back items which have been donated to the Museum!!"));
@@ -206,27 +203,27 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
             return;
         }
 
-        identify_item(player_ptr, q_ptr);
-        q_ptr->ident |= IDENT_FULL_KNOWN;
+        identify_item(player_ptr, &selling_item);
+        selling_item.ident |= IDENT_FULL_KNOWN;
 
-        distribute_charges(o_ptr, q_ptr, amt);
+        distribute_charges(o_ptr, &selling_item, amt);
         msg_format(_("%sを置いた。(%c)", "You drop %s (%c)."), museum_item_name.data(), index_to_label(i_idx));
         placed = true;
 
         vary_item(player_ptr, i_idx, -amt);
 
-        int item_pos = home_carry(player_ptr, q_ptr, store_num);
+        int item_pos = home_carry(player_ptr, &selling_item, store_num);
         if (item_pos >= 0) {
             store_top = (item_pos / store_bottom) * store_bottom;
             display_store_inventory(player_ptr, store_num);
         }
     } else {
-        distribute_charges(o_ptr, q_ptr, amt);
-        const auto item_name = describe_flavor(player_ptr, *q_ptr, 0);
+        distribute_charges(o_ptr, &selling_item, amt);
+        const auto item_name = describe_flavor(player_ptr, selling_item, 0);
         msg_format(_("%sを置いた。(%c)", "You drop %s (%c)."), item_name.data(), index_to_label(i_idx));
         placed = true;
         vary_item(player_ptr, i_idx, -amt);
-        int item_pos = home_carry(player_ptr, q_ptr, store_num);
+        int item_pos = home_carry(player_ptr, &selling_item, store_num);
         if (item_pos >= 0) {
             store_top = (item_pos / store_bottom) * store_bottom;
             display_store_inventory(player_ptr, store_num);

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -67,11 +67,11 @@ void ItemEntity::wipe()
 
 /*!
  * @brief アイテムを複製する
- * @param j_ptr 複製元アイテムへの参照ポインタ
+ * @return 複製したアイテム
  */
-void ItemEntity::copy_from(const ItemEntity *j_ptr)
+ItemEntity ItemEntity::clone() const
 {
-    *this = *j_ptr;
+    return *this;
 }
 
 void ItemEntity::generate(const BaseitemKey &new_bi_key)

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -81,7 +81,7 @@ public:
     RandomArtifactBias artifact_bias{}; /*!< ランダムアーティファクト生成時のバイアスID */
 
     void wipe();
-    void copy_from(const ItemEntity *j_ptr);
+    ItemEntity clone() const;
     void generate(const BaseitemKey &new_bi_key);
     void generate(short new_bi_id);
     bool is(ItemKindType tval) const;

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -744,13 +744,11 @@ void wiz_modify_item(PlayerType *player_ptr)
 
     screen_save();
 
-    ItemEntity forge;
-    auto *q_ptr = &forge;
-    q_ptr->copy_from(o_ptr);
+    auto modified_item = o_ptr->clone();
     auto changed = false;
     constexpr auto prompt = "[a]ccept [s]tatistics [r]eroll [t]weak [q]uantity? ";
     while (true) {
-        wiz_display_item(player_ptr, q_ptr);
+        wiz_display_item(player_ptr, &modified_item);
         const auto command = input_command(prompt);
         if (!command.has_value()) {
             changed = false;
@@ -763,19 +761,19 @@ void wiz_modify_item(PlayerType *player_ptr)
         }
 
         if (command == 's' || command == 'S') {
-            wiz_statistics(player_ptr, q_ptr);
+            wiz_statistics(player_ptr, &modified_item);
         }
 
         if (command == 'r' || command == 'R') {
-            wiz_reroll_item(player_ptr, q_ptr);
+            wiz_reroll_item(player_ptr, &modified_item);
         }
 
         if (command == 't' || command == 'T') {
-            wiz_tweak_item(player_ptr, q_ptr);
+            wiz_tweak_item(player_ptr, &modified_item);
         }
 
         if (command == 'q' || command == 'Q') {
-            wiz_quantity_item(q_ptr);
+            wiz_quantity_item(&modified_item);
         }
     }
 
@@ -783,7 +781,7 @@ void wiz_modify_item(PlayerType *player_ptr)
     if (changed) {
         msg_print("Changes accepted.");
 
-        o_ptr->copy_from(q_ptr);
+        *o_ptr = std::move(modified_item);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         static constexpr auto flags_srf = {
             StatusRecalculatingFlag::BONUS,


### PR DESCRIPTION
自身を複製したオブジェクトを返す ItemEntity::clone() を実装し、これまで
アイテムの複製処理で ItemEntity::copy_from() を使用していた箇所を
置き換える。
また、そもそも複製が不要な箇所についてはstd::moveやSTL経由でのムーブ
セマンティクスによる処理に変更する。