### PR TITLE
変愚「[Fix] 持ち物が一杯で装備を外したときの挙動 #4691」のマージ

### DIFF
--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -246,14 +246,18 @@ void reorder_pack(PlayerType *player_ptr)
         return object_sort_comp(player_ptr, item1, item2);
     };
 
+    const auto sort_count = std::min(enum2i(INVEN_PACK), player_ptr->inven_cnt);
+
     auto first = &player_ptr->inventory_list[0];
-    auto last = &player_ptr->inventory_list[player_ptr->inven_cnt];
+    auto last = &player_ptr->inventory_list[sort_count];
 
     if (std::is_sorted(first, last, comp)) {
         return;
     }
 
     std::stable_sort(first, last, comp);
+    RedrawingFlagsUpdater::get_instance().set_flag(SubWindowRedrawingFlag::INVENTORY);
+
     msg_print(_("ザックの中のアイテムを並べ直した。", "You reorder some items in your pack."));
 }
 


### PR DESCRIPTION
PR #4687 から、装備を外したとき持ち物が一杯だと外した装備でなく持ち物の
一番下のアイテムがあふれて地面に落ちるようになってしまっている。
player_ptr->inventory_list[INVEN_PACK] は装備を外したときに持ちきれない アイテムを一時的に保持しておく場所であり、この場所もまとめてソートされる
ように変更してしまっていたために生じた不具合。
この場所は除外してソートするように修正する。
また、サブウィンドウの持ち物一覧を更新するフラグを立てる処理が消えて
しまっていたので、それもあわせて復活する。