### PR TITLE
変愚「[Refactor] ItemEntityのコピーコンストラクタとコピー代入演算子を隠蔽 #4693」のマージ

### DIFF
--- a/src/action/weapon-shield.cpp
+++ b/src/action/weapon-shield.cpp
@@ -39,7 +39,7 @@ void verify_equip_slot(PlayerType *player_ptr, INVENTORY_IDX i_idx)
         }
 
         auto &item_main_hand = player_ptr->inventory_list[INVEN_MAIN_HAND];
-        item_main_hand = item_sub_hand;
+        item_main_hand = item_sub_hand.clone();
         inven_item_increase(player_ptr, INVEN_SUB_HAND, -item_sub_hand.number);
         inven_item_optimize(player_ptr, INVEN_SUB_HAND);
         if (item_main_hand.allow_two_hands_wielding() && can_two_hands_wielding(player_ptr)) {
@@ -73,7 +73,7 @@ void verify_equip_slot(PlayerType *player_ptr, INVENTORY_IDX i_idx)
     }
 
     auto &item_sub_hand = player_ptr->inventory_list[INVEN_SUB_HAND];
-    item_sub_hand = item_main_hand;
+    item_sub_hand = item_main_hand.clone();
     inven_item_increase(player_ptr, INVEN_MAIN_HAND, -item_main_hand.number);
     inven_item_optimize(player_ptr, INVEN_MAIN_HAND);
     msg_format(_("%sを持ち替えた。", "You shifted %s to your other hand."), item_name.data());

--- a/src/autopick/autopick-destroyer.cpp
+++ b/src/autopick/autopick-destroyer.cpp
@@ -155,7 +155,7 @@ void auto_destroy_item(PlayerType *player_ptr, ItemEntity *o_ptr, int autopick_i
         return;
     }
 
-    autopick_last_destroyed_object = *o_ptr;
+    autopick_last_destroyed_object = o_ptr->clone();
     o_ptr->marked.set(OmType::AUTODESTROY);
     RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::AUTO_DESTRUCTION);
 }

--- a/src/cmd-item/cmd-destroy.cpp
+++ b/src/cmd-item/cmd-destroy.cpp
@@ -190,7 +190,7 @@ static void process_destroy_magic_book(PlayerType *player_ptr, const ItemEntity 
 
 static void exe_destroy_item(PlayerType *player_ptr, ItemEntity &destroying_item, short i_idx, int amount)
 {
-    ItemEntity destroyed_item = destroying_item;
+    auto destroyed_item = destroying_item.clone();
     destroyed_item.number = amount;
     const auto item_name = describe_flavor(player_ptr, destroyed_item, 0);
     msg_format(_("%sを壊した。", "You destroy %s."), item_name.data());

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -510,7 +510,7 @@ static bool exe_eat_charge_of_magic_device(PlayerType *player_ptr, ItemEntity *o
 
     /* XXX Hack -- unstack if necessary */
     if (is_staff && (i_idx >= 0) && (o_ptr->number > 1)) {
-        ItemEntity item = *o_ptr;
+        auto item = o_ptr->clone();
         item.number = 1;
 
         /* Restore the charges */

--- a/src/core/object-compressor.cpp
+++ b/src/core/object-compressor.cpp
@@ -10,6 +10,7 @@
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
 #include <algorithm>
+#include <utility>
 
 /*!
  * @brief グローバルオブジェクト配列の要素番号i1のオブジェクトを要素番号i2に移動する /
@@ -23,15 +24,12 @@ static void compact_objects_aux(FloorType *floor_ptr, OBJECT_IDX i1, OBJECT_IDX 
         return;
     }
 
-    auto *o_ptr = &floor_ptr->o_list[i1];
-
     // モンスター所為アイテムリストもしくは床上アイテムリストの要素番号i1をi2に書き換える
     auto &list = get_o_idx_list_contains(floor_ptr, i1);
     std::replace(list.begin(), list.end(), i1, i2);
 
-    // 要素番号i1のオブジェクトを要素番号i2に移動
-    floor_ptr->o_list[i2] = floor_ptr->o_list[i1];
-    o_ptr->wipe();
+    // 要素番号i1のオブジェクトを要素番号i2に移動し、i1はクリアする
+    floor_ptr->o_list[i2] = std::exchange(floor_ptr->o_list[i1], {});
 }
 
 /*!

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -374,7 +374,9 @@ void wipe_generate_random_floor_flags(FloorType *floor_ptr)
 void clear_cave(PlayerType *player_ptr)
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    std::fill_n(floor_ptr->o_list.begin(), floor_ptr->o_max, ItemEntity{});
+    for (auto &item : floor_ptr->o_list) {
+        item.wipe();
+    }
     floor_ptr->o_max = 1;
     floor_ptr->o_cnt = 0;
 

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -106,9 +106,9 @@ bool make_object(PlayerType *player_ptr, ItemEntity *j_ptr, BIT_FLAGS mode, std:
     const auto prob = any_bits(mode, AM_GOOD) ? 10 : 1000;
     const auto base = get_base_floor(floor, mode, rq_mon_level);
     if (one_in_(prob)) {
-        const auto fa_opt = floor.try_make_instant_artifact();
+        auto fa_opt = floor.try_make_instant_artifact();
         if (fa_opt) {
-            *j_ptr = *fa_opt;
+            *j_ptr = std::move(*fa_opt);
             apply();
             return true;
         }

--- a/src/grid/object-placer.cpp
+++ b/src/grid/object-placer.cpp
@@ -33,14 +33,14 @@ void place_gold(PlayerType *player_ptr, POSITION y, POSITION x)
         return;
     }
 
-    const auto item = floor.make_gold();
+    auto item = floor.make_gold();
     const auto o_idx = o_pop(&floor);
     if (o_idx == 0) {
         return;
     }
 
     auto &item_pop = floor.o_list[o_idx];
-    item_pop = item;
+    item_pop = std::move(item);
     item_pop.iy = y;
     item_pop.ix = x;
     grid.o_idx_list.add(&floor, o_idx);

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -117,12 +117,12 @@ void inven_item_optimize(PlayerType *player_ptr, INVENTORY_IDX i_idx)
     }
 
     player_ptr->inven_cnt--;
-    int i;
-    for (i = i_idx; i < INVEN_PACK; i++) {
-        player_ptr->inventory_list[i] = player_ptr->inventory_list[i + 1];
-    }
 
-    (&player_ptr->inventory_list[i])->wipe();
+    auto first = &player_ptr->inventory_list[i_idx];
+    auto last = &player_ptr->inventory_list[INVEN_PACK];
+    std::rotate(first, first + 1, last + 1);
+    last->wipe();
+
     static constexpr auto flags = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::SPELL,
@@ -152,7 +152,7 @@ void drop_from_inventory(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NUMBE
         o_ptr = &player_ptr->inventory_list[i_idx];
     }
 
-    ItemEntity item = *o_ptr;
+    auto item = o_ptr->clone();
     distribute_charges(o_ptr, &item, amt);
 
     item.number = amt;
@@ -199,12 +199,10 @@ void combine_pack(PlayerType *player_ptr)
                     flag = true;
                     item2.absorb(item1);
                     player_ptr->inven_cnt--;
-                    int k;
-                    for (k = i; k < INVEN_PACK; k++) {
-                        player_ptr->inventory_list[k] = player_ptr->inventory_list[k + 1];
-                    }
-
-                    (&player_ptr->inventory_list[k])->wipe();
+                    auto first = &player_ptr->inventory_list[i];
+                    auto last = &player_ptr->inventory_list[INVEN_PACK];
+                    std::rotate(first, first + 1, last + 1);
+                    last->wipe();
                 } else {
                     int old_num = item1.number;
                     int remain = item2.number + item1.number - max_num;
@@ -387,7 +385,7 @@ INVENTORY_IDX inven_takeoff(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NU
         amt = item_inventory.number;
     }
 
-    ItemEntity item = item_inventory;
+    auto item = item_inventory.clone();
     item.number = amt;
     const auto item_name = describe_flavor(player_ptr, item, 0);
     std::string act;

--- a/src/load/store-loader.cpp
+++ b/src/load/store-loader.cpp
@@ -53,7 +53,7 @@ static void home_carry_load(PlayerType *player_ptr, store_type *store_ptr, ItemE
     std::rotate(first + slot, last, last + 1);
 
     store_ptr->stock_num++;
-    *store_ptr->stock[slot] = *o_ptr;
+    *store_ptr->stock[slot] = o_ptr->clone();
     chg_virtue(player_ptr, Virtue::SACRIFICE, -1);
 }
 
@@ -96,7 +96,7 @@ static void rd_store(PlayerType *player_ptr, int town_number_initial, StoreSaleT
             home_carry_load(player_ptr, &store, &item);
         } else {
             int k = store.stock_num++;
-            *store.stock[k] = item;
+            *store.stock[k] = std::move(item);
         }
     }
 }

--- a/src/object-use/quaff/quaff-execution.cpp
+++ b/src/object-use/quaff/quaff-execution.cpp
@@ -125,8 +125,7 @@ bool ObjectQuaffEntity::can_quaff()
 
 ItemEntity ObjectQuaffEntity::copy_object(const INVENTORY_IDX i_idx)
 {
-    auto *tmp_o_ptr = ref_item(this->player_ptr, i_idx);
-    ItemEntity o_val = *tmp_o_ptr;
+    auto o_val = ref_item(this->player_ptr, i_idx)->clone();
     o_val.number = 1;
     return o_val;
 }

--- a/src/perception/object-perception.cpp
+++ b/src/perception/object-perception.cpp
@@ -37,8 +37,6 @@ void object_aware(PlayerType *player_ptr, const ItemEntity &item)
     }
 
     // playrecordに識別したアイテムを記録
-    ItemEntity item_record = item;
-    item_record.number = 1;
-    const auto item_name = describe_flavor(player_ptr, item_record, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, item, OD_NAME_ONLY | OD_OMIT_PREFIX);
     exe_write_diary(*player_ptr->current_floor_ptr, DiaryKind::FOUND, 0, item_name);
 }

--- a/src/smith/object-smith.cpp
+++ b/src/smith/object-smith.cpp
@@ -349,7 +349,7 @@ Smith::DrainEssenceResult Smith::drain_essence(ItemEntity *o_ptr)
     const auto is_fixed_or_random_artifact = o_ptr->is_fixed_or_random_artifact();
 
     // アイテムをエッセンス抽出後の状態にする
-    const ItemEntity old_o = *o_ptr;
+    const ItemEntity old_o = o_ptr->clone();
     o_ptr->generate(o_ptr->bi_id);
     o_ptr->iy = old_o.iy;
     o_ptr->ix = old_o.ix;

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -583,7 +583,7 @@ bool cosmic_cast_off(PlayerType *player_ptr, ItemEntity **o_ptr_ptr)
         return false;
     }
 
-    ItemEntity item = *o_ptr;
+    auto item = o_ptr->clone();
     inven_item_increase(player_ptr, slot, (0 - o_ptr->number));
     inven_item_optimize(player_ptr, slot);
 

--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -173,7 +173,7 @@ void do_cmd_store(PlayerType *player_ptr)
                 leave_store = true;
             } else {
                 msg_print(_("ザックからアイテムがあふれてしまった！", "Your pack overflows!"));
-                ItemEntity item = item_inventory;
+                auto item = item_inventory.clone();
                 const auto item_name = describe_flavor(player_ptr, item, 0);
                 msg_format(_("%sが落ちた。(%c)", "You drop %s (%c)."), item_name.data(), index_to_label(i_idx));
                 vary_item(player_ptr, i_idx, -255);

--- a/src/store/home.cpp
+++ b/src/store/home.cpp
@@ -77,7 +77,7 @@ int home_carry(PlayerType *player_ptr, ItemEntity *o_ptr, StoreSaleType store_nu
     std::rotate(first + slot, last, last + 1);
 
     st_ptr->stock_num++;
-    *st_ptr->stock[slot] = *o_ptr;
+    *st_ptr->stock[slot] = o_ptr->clone();
     chg_virtue(player_ptr, Virtue::SACRIFICE, -1);
     (void)combine_and_reorder_home(player_ptr, store_num);
     return slot;

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -183,7 +183,7 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
     const short item_num = *item_num_opt + store_top;
     auto &item_store = *st_ptr->stock[item_num];
     auto amt = 1;
-    ItemEntity item = item_store;
+    auto item = item_store.clone();
 
     /*
      * If a rod or wand, allocate total maximum timeouts or charges
@@ -208,7 +208,7 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
         }
     }
 
-    item = item_store;
+    item = item_store.clone();
 
     /*
      * If a rod or wand, allocate total maximum timeouts or charges

--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -186,6 +186,6 @@ int store_carry(ItemEntity *o_ptr)
     std::rotate(first + slot, last, last + 1);
 
     st_ptr->stock_num++;
-    *st_ptr->stock[slot] = *o_ptr;
+    *st_ptr->stock[slot] = o_ptr->clone();
     return slot;
 }

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -38,6 +38,9 @@ public:
     ItemEntity();
     ItemEntity(short bi_id);
     ItemEntity(const BaseitemKey &bi_key);
+    ItemEntity(ItemEntity &&) = default;
+    ItemEntity &operator=(ItemEntity &&) = default;
+
     short bi_id{}; /*!< ベースアイテムID (0は、不具合調査用の無効アイテム または 何も装備していない箇所のアイテム であることを示す) */
     POSITION iy{}; /*!< Y-position on map, or zero */
     POSITION ix{}; /*!< X-position on map, or zero */
@@ -176,6 +179,9 @@ public:
     void absorb(ItemEntity &other);
 
 private:
+    ItemEntity(const ItemEntity &) = default;
+    ItemEntity &operator=(const ItemEntity &) = default;
+
     int get_baseitem_price() const;
     int calc_figurine_value() const;
     int calc_capture_value() const;

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -40,6 +40,8 @@ public:
     ItemEntity(const BaseitemKey &bi_key);
     ItemEntity(ItemEntity &&) = default;
     ItemEntity &operator=(ItemEntity &&) = default;
+    ItemEntity(const ItemEntity &) = default;
+    ItemEntity &operator=(const ItemEntity &) = default;
 
     short bi_id{}; /*!< ベースアイテムID (0は、不具合調査用の無効アイテム または 何も装備していない箇所のアイテム であることを示す) */
     POSITION iy{}; /*!< Y-position on map, or zero */
@@ -179,9 +181,6 @@ public:
     void absorb(ItemEntity &other);
 
 private:
-    ItemEntity(const ItemEntity &) = default;
-    ItemEntity &operator=(const ItemEntity &) = default;
-
     int get_baseitem_price() const;
     int calc_figurine_value() const;
     int calc_capture_value() const;

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -602,7 +602,7 @@ static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
         return;
     }
 
-    ItemEntity item = *o_ptr;
+    auto item = o_ptr->clone();
     auto changed = false;
     constexpr auto prompt = "[a]ccept, [w]orthless, [c]ursed, [n]ormal, [g]ood, [e]xcellent, [s]pecial? ";
     while (true) {
@@ -628,9 +628,9 @@ static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
             item.fa_id = FixedArtifactId::NONE;
         }
 
-        const auto applied_item = wiz_apply_magic_to_item(player_ptr, *command, o_ptr->bi_id);
+        auto applied_item = wiz_apply_magic_to_item(player_ptr, *command, o_ptr->bi_id);
         if (applied_item) {
-            item = *applied_item;
+            item = std::move(*applied_item);
         }
 
         item.iy = o_ptr->iy;
@@ -642,7 +642,7 @@ static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
         return;
     }
 
-    *o_ptr = item;
+    *o_ptr = std::move(item);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
         StatusRecalculatingFlag::BONUS,


### PR DESCRIPTION
ItemEntityクラスのコピーコンストラクタとコピー代入演算子を隠蔽し、
オブジェクトのコピーが必要なところでは明示的に ItemEntity::clone() を
呼ぶようにする。
そもそもコピーする必要がない箇所については std::move() でムーブする
ことで対応し効率化を図る。