### PR TITLE
変愚「[Chore] upload-artifactのバージョンをv4に更新 #4705」のマージ

### DIFF
--- a/.github/workflows/publish-spoiler-page.yml
+++ b/.github/workflows/publish-spoiler-page.yml
@@ -39,7 +39,7 @@ jobs:
         run: nkf -w --in-place ~/.angband/Bakabakaband/*.txt
 
       - name: Upload spoilers
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: spoiler-files
           path: ~/.angband/Bakabakaband/*.txt


### PR DESCRIPTION
upload-artifactのバージョンv2がdeprecatedとなり、自動生成スポイラーの
Workflowがエラー終了するようになったので、v4にアップデートする。