### PR TITLE
変愚「[Fix] リピートコマンドで方向入力の値の妥当性をチェックする #4711」のマージ

### DIFF
--- a/src/target/target-getter.cpp
+++ b/src/target/target-getter.cpp
@@ -20,6 +20,13 @@
 #include "view/display-messages.h"
 #include <string>
 
+namespace {
+bool is_valid_dir(int dir)
+{
+    return (dir >= 0) && (dir < static_cast<int>(std::size(ddx)));
+}
+}
+
 /*
  * Get an "aiming direction" from the user.
  *
@@ -38,8 +45,8 @@ bool get_aim_dir(PlayerType *player_ptr, int *dp)
         dir = 5;
     }
 
-    short code;
-    if (repeat_pull(&code)) {
+    short code = 0;
+    if (repeat_pull(&code) && is_valid_dir(code)) {
         if (!(code == 5 && !target_okay(player_ptr))) {
             dir = code;
         }
@@ -130,8 +137,8 @@ bool get_aim_dir(PlayerType *player_ptr, int *dp)
 std::optional<int> get_direction(PlayerType *player_ptr)
 {
     auto dir = command_dir;
-    short code;
-    if (repeat_pull(&code)) {
+    short code = 0;
+    if (repeat_pull(&code) && is_valid_dir(code)) {
         dir = code;
     }
 
@@ -220,8 +227,8 @@ std::optional<int> get_direction_as_cdir(PlayerType *player_ptr)
 bool get_rep_dir(PlayerType *player_ptr, int *dp, bool under)
 {
     auto dir = command_dir;
-    short code;
-    if (repeat_pull(&code)) {
+    short code = 0;
+    if (repeat_pull(&code) && is_valid_dir(code)) {
         dir = code;
     }
 


### PR DESCRIPTION
リピートコマンドに方向入力が含まれるとき、方向の値の妥当性を調べず
そのまま方向として設定しているので、何らかの理由により値が異常だった
場合におかしな値となってしまい、クラッシュの原因となる可能性がある。
方向の値として正しい場合のみ設定するようにする。