### PR TITLE
[Fix] クリーピングモンスターの速度と感知範囲の再設定

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -1195,9 +1195,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BLINK"
-        ]
+        "list": ["BLINK"]
       },
       "flavor": {
         "ja": "それはそこにいるのだろうか？いないのだろうか？",
@@ -1331,13 +1329,7 @@
           "damage_dice": "1d5"
         }
       ],
-      "flags": [
-        "RAND_50",
-        "RAND_25",
-        "CAN_SWIM",
-        "EMPTY_MIND",
-        "DROP_CORPSE"
-      ],
+      "flags": ["RAND_50", "RAND_25", "CAN_SWIM", "EMPTY_MIND", "DROP_CORPSE"],
       "flavor": {
         "ja": "それはドロドロしてベトベトした小さなモンスターだ。",
         "en": "It is a smallish, slimy, icky creature."
@@ -1645,13 +1637,7 @@
           "effect": "PARALYZE"
         }
       ],
-      "flags": [
-        "NEVER_MOVE",
-        "CAN_FLY",
-        "DROP_CORPSE",
-        "HURT_LITE",
-        "NO_FEAR"
-      ],
+      "flags": ["NEVER_MOVE", "CAN_FLY", "DROP_CORPSE", "HURT_LITE", "NO_FEAR"],
       "flavor": {
         "ja": "地面から数十センチ上に浮かんでいる体を持たない目玉だ。",
         "en": "A disembodied eye, floating a few feet above the ground."
@@ -1687,12 +1673,7 @@
           "damage_dice": "1d3"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "CAN_SWIM",
-        "WILD_MOUNTAIN",
-        "DROP_CORPSE"
-      ],
+      "flags": ["ANIMAL", "CAN_SWIM", "WILD_MOUNTAIN", "DROP_CORPSE"],
       "flavor": {
         "ja": "それは小さなトカゲで硬い皮を持っている。",
         "en": "It is a small lizard with a hardened hide."
@@ -1855,13 +1836,7 @@
           "damage_dice": "1d3"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "CAN_FLY",
-        "WILD_WOOD",
-        "WILD_SWAMP",
-        "DROP_CORPSE"
-      ],
+      "flags": ["ANIMAL", "CAN_FLY", "WILD_WOOD", "WILD_SWAMP", "DROP_CORPSE"],
       "flavor": {
         "ja": "動きの素早い厄介者だ。",
         "en": "A fast-moving pest."
@@ -1975,11 +1950,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "TPORT",
-          "BLINK",
-          "TELE_AWAY"
-        ]
+        "list": ["TPORT", "BLINK", "TELE_AWAY"]
       },
       "artifacts": [
         {
@@ -2025,9 +1996,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "SHRIEK"
-        ]
+        "list": ["SHRIEK"]
       },
       "flavor": {
         "ja": "うーん！それはとてもおいしそうに見える。",
@@ -2294,11 +2263,7 @@
       ],
       "skill": {
         "probability": "1_IN_12",
-        "list": [
-          "HEAL",
-          "SCARE",
-          "CAUSE_1"
-        ]
+        "list": ["HEAL", "SCARE", "CAUSE_1"]
       },
       "flavor": {
         "ja": "彼は自分の法衣のすそを踏んづけてはつまづいている。",
@@ -2348,12 +2313,7 @@
       ],
       "skill": {
         "probability": "1_IN_12",
-        "list": [
-          "BLINK",
-          "BLIND",
-          "CONF",
-          "MISSILE"
-        ]
+        "list": ["BLINK", "BLIND", "CONF", "MISSILE"]
       },
       "flavor": {
         "ja": "彼はさっと呪文を唱えるだけ唱えては逃げようとする。",
@@ -3244,9 +3204,7 @@
       ],
       "skill": {
         "probability": "1_IN_15",
-        "list": [
-          "BLINK"
-        ]
+        "list": ["BLINK"]
       },
       "flavor": {
         "ja": "それは恐ろしげな幽霊のような姿をしている。",
@@ -3296,9 +3254,7 @@
       ],
       "skill": {
         "probability": "1_IN_15",
-        "list": [
-          "DRAIN_MANA"
-        ]
+        "list": ["DRAIN_MANA"]
       },
       "flavor": {
         "ja": "それは黄色い肉のような物質の塊だ。",
@@ -3467,13 +3423,7 @@
           "damage_dice": "13d1"
         }
       ],
-      "flags": [
-        "FRIENDS",
-        "AQUATIC",
-        "ANIMAL",
-        "WILD_ALL",
-        "RES_WATE"
-      ],
+      "flags": ["FRIENDS", "AQUATIC", "ANIMAL", "WILD_ALL", "RES_WATE"],
       "flavor": {
         "ja": "この血に飢えた魚はあなたの血の匂いを遠くから嗅ぎ分ける。",
         "en": "Bloodthirsty fish who can smell your blood from a great distance."
@@ -3616,9 +3566,7 @@
       ],
       "skill": {
         "probability": "1_IN_15",
-        "list": [
-          "DRAIN_MANA"
-        ]
+        "list": ["DRAIN_MANA"]
       },
       "flavor": {
         "ja": "それは銀色の肉のような物質の塊で、付近の光を全て吸い取る。",
@@ -3931,9 +3879,7 @@
       ],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "DRAIN_MANA"
-        ]
+        "list": ["DRAIN_MANA"]
       },
       "flavor": {
         "ja": "エネルギーを放出してパチパチと輝いている、体を持たない目玉だ。",
@@ -4009,11 +3955,7 @@
           "damage_dice": "1d10"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "CAN_SWIM",
-        "DROP_CORPSE"
-      ],
+      "flags": ["ANIMAL", "CAN_SWIM", "DROP_CORPSE"],
       "flavor": {
         "ja": "硬い皮を持ったトカゲで噛む力が強い。",
         "en": "It is an armoured lizard with a powerful bite."
@@ -4067,9 +4009,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "MISSILE"
-        ],
+        "list": ["MISSILE"],
         "shoot": "2d7"
       },
       "flavor": {
@@ -4205,11 +4145,7 @@
           "damage_dice": "1d6"
         }
       ],
-      "flags": [
-        "RAND_25",
-        "MULTIPLY",
-        "ANIMAL"
-      ],
+      "flags": ["RAND_25", "MULTIPLY", "ANIMAL"],
       "flavor": {
         "ja": "それは非常に凶暴な齧歯類の生物だ。",
         "en": "It is a very vicious rodent."
@@ -4298,12 +4234,7 @@
           "damage_dice": "7d1"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "AQUATIC",
-        "WILD_ALL",
-        "RES_WATE"
-      ],
+      "flags": ["ANIMAL", "AQUATIC", "WILD_ALL", "RES_WATE"],
       "flavor": {
         "ja": "それは剣のような\"鉤鼻\"を持った魚だ。",
         "en": "An animal with a swordlike \"beak\"."
@@ -4545,12 +4476,7 @@
       ],
       "skill": {
         "probability": "1_IN_12",
-        "list": [
-          "BLINK",
-          "BLIND",
-          "CONF",
-          "MISSILE"
-        ]
+        "list": ["BLINK", "BLIND", "CONF", "MISSILE"]
       },
       "flavor": {
         "ja": "彼らはみな、さっと呪文を唱えるだけ唱えては逃げようとする。",
@@ -4641,13 +4567,7 @@
           "damage_dice": "4d1"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "AQUATIC",
-        "WEIRD_MIND",
-        "RAND_25",
-        "RES_WATE"
-      ],
+      "flags": ["ANIMAL", "AQUATIC", "WEIRD_MIND", "RAND_25", "RES_WATE"],
       "flavor": {
         "ja": "げぇ！それはあなたの血を欲しているだけの嫌な奴だ！",
         "en": "Yech! The disgusting thing only wants your blood!"
@@ -4685,12 +4605,7 @@
           "damage_dice": "2d7"
         }
       ],
-      "flags": [
-        "AQUATIC",
-        "ANIMAL",
-        "WILD_ALL",
-        "RES_WATE"
-      ],
+      "flags": ["AQUATIC", "ANIMAL", "WILD_ALL", "RES_WATE"],
       "flavor": {
         "ja": "それはきわどく鋭い歯を持った肉食の魚だ。",
         "en": "A predatory fish with razor-sharp teeth."
@@ -4745,10 +4660,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "SCARE",
-          "CAUSE_1"
-        ]
+        "list": ["SCARE", "CAUSE_1"]
       },
       "flavor": {
         "ja": "深い信仰心と巧みな戦闘技術を持った冒険者だ。彼はあなたを悪の使いとみなしているようだ。",
@@ -4790,13 +4702,7 @@
           "effect": "FLAVOR"
         }
       ],
-      "flags": [
-        "EVIL",
-        "OPEN_DOOR",
-        "BASH_DOOR",
-        "DROP_90",
-        "DROP_SKELETON"
-      ],
+      "flags": ["EVIL", "OPEN_DOOR", "BASH_DOOR", "DROP_90", "DROP_SKELETON"],
       "flavor": {
         "ja": "よだれを垂らしている昆虫型のエイリアンで、気持ち悪い習性を持っている。",
         "en": "Drooling, insectoid aliens with disgusting habits."
@@ -5012,12 +4918,7 @@
           "damage_dice": "1d8"
         }
       ],
-      "flags": [
-        "RAND_50",
-        "CAN_SWIM",
-        "DROP_CORPSE",
-        "EMPTY_MIND"
-      ],
+      "flags": ["RAND_50", "CAN_SWIM", "DROP_CORPSE", "EMPTY_MIND"],
       "flavor": {
         "ja": "それはドロドロしてベトベトして不潔な小さいモンスターだ。",
         "en": "It is a smallish, slimy, icky, nasty creature."
@@ -5060,9 +4961,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "DRAIN_MANA"
-        ]
+        "list": ["DRAIN_MANA"]
       },
       "flavor": {
         "ja": "魔力を放出して火花をあげている、体を持たない目玉だ。",
@@ -5318,11 +5217,7 @@
       ],
       "skill": {
         "probability": "1_IN_12",
-        "list": [
-          "HEAL",
-          "SCARE",
-          "CAUSE_1"
-        ]
+        "list": ["HEAL", "SCARE", "CAUSE_1"]
       },
       "flavor": {
         "ja": "彼は自分の法衣のすそを踏んづけてはつまづくかもしれないが、仲間が彼を助けている。",
@@ -5594,16 +5489,10 @@
           "damage_dice": "3d2"
         }
       ],
-      "flags": [
-        "EVIL",
-        "ANIMAL",
-        "DROP_CORPSE"
-      ],
+      "flags": ["EVIL", "ANIMAL", "DROP_CORPSE"],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "SCARE"
-        ]
+        "list": ["SCARE"]
       },
       "flavor": {
         "ja": "遠目に見ると普通のネズミのようだが、頭部は邪悪な人間の顔である。足先も人間の手のようになっており、非常に強くて鋭い牙を持っている。死んだ信者を怪物に変え、死後も仕えさせようとして創造されたものと思われる。彼らは不老であり、自然死ということはない。（ラヴクラフト「魔女屋敷で見た夢」）",
@@ -5854,9 +5743,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_ACID"
-        ]
+        "list": ["BR_ACID"]
       },
       "flavor": {
         "ja": "それはゆっくりとあなたに近づいてくる。途中にあるものを全て食べながら...",
@@ -5951,11 +5838,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "CONF",
-          "DARKNESS",
-          "MISSILE"
-        ]
+        "list": ["CONF", "DARKNESS", "MISSILE"]
       },
       "flavor": {
         "ja": "漆黒の肌と白い髪の毛を持ったエルフで、その大きな目は邪悪に歪んでいる。",
@@ -6062,10 +5945,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "CAUSE_1",
-          "S_UNDEAD"
-        ]
+        "list": ["CAUSE_1", "S_UNDEAD"]
       },
       "flavor": {
         "ja": "黒装束に身を包んだ恐ろしげな骸骨の姿だ。（ロバート・ブロック「窖に潜むもの」）",
@@ -6286,18 +6166,10 @@
           "damage_dice": "2d7"
         }
       ],
-      "flags": [
-        "NEVER_MOVE",
-        "CAN_FLY",
-        "DROP_CORPSE",
-        "HURT_LITE",
-        "NO_FEAR"
-      ],
+      "flags": ["NEVER_MOVE", "CAN_FLY", "DROP_CORPSE", "HURT_LITE", "NO_FEAR"],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "DRAIN_MANA"
-        ]
+        "list": ["DRAIN_MANA"]
       },
       "flavor": {
         "ja": "体を持たない、血走っていて忌まわしい目玉だ。",
@@ -6501,10 +6373,7 @@
       ],
       "skill": {
         "probability": "1_IN_15",
-        "list": [
-          "TPORT",
-          "DRAIN_MANA"
-        ]
+        "list": ["TPORT", "DRAIN_MANA"]
       },
       "flavor": {
         "ja": "それはほとんど実体を持っていない。",
@@ -6546,12 +6415,7 @@
           "damage_dice": "1d8"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "CAN_SWIM",
-        "WILD_ALL",
-        "DROP_CORPSE"
-      ],
+      "flags": ["ANIMAL", "CAN_SWIM", "WILD_ALL", "DROP_CORPSE"],
       "flavor": {
         "ja": "それは硬い皮と強力な顎を持った黒いトカゲだ。",
         "en": "It is a black lizard with overlapping scales and a powerful jaw."
@@ -6727,13 +6591,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "HEAL",
-          "SLOW",
-          "TRAPS",
-          "BO_COLD",
-          "BA_POIS"
-        ]
+        "list": ["HEAL", "SLOW", "TRAPS", "BO_COLD", "BA_POIS"]
       },
       "flavor": {
         "ja": "彼はサルマンのためにスパイをしている。彼はこの世の全てに不満を抱いている不運な奴で、何のモラルもない歪んだ性質をしている。「また足許には賢人めいた青白い顔に瞼の重たくかぶさる目をした、しなびた男が一人、階段に腰を下ろしていました…彼は薄気味悪い笑い声を立てながら、ちらと重い瞼を上げ、悪意のある目をじっと旅人たちに注ぎました。」（J.R.R.トールキン、瀬田貞二・田中明子訳 新版指輪物語） ",
@@ -6794,10 +6652,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "HEAL",
-          "TRAPS"
-        ],
+        "list": ["HEAL", "TRAPS"],
         "shoot": "3d6"
       },
       "artifacts": [
@@ -7011,9 +6866,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "MISSILE"
-        ],
+        "list": ["MISSILE"],
         "shoot": "2d7"
       },
       "flavor": {
@@ -7057,9 +6910,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BR_FIRE"
-        ]
+        "list": ["BR_FIRE"]
       },
       "flavor": {
         "ja": "黒と黄色のまだらの大きなトカゲだ。逃げた方がいいぞ！",
@@ -7256,10 +7107,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "SCARE",
-          "CAUSE_1"
-        ]
+        "list": ["SCARE", "CAUSE_1"]
       },
       "flavor": {
         "ja": "深い信仰心と巧みな戦闘技術を持った冒険者で、戦友と共に悪に挑む。",
@@ -7446,13 +7294,7 @@
           "damage_dice": "1d5"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "NO_FEAR",
-        "CAN_FLY",
-        "WILD_WOOD",
-        "DROP_CORPSE"
-      ],
+      "flags": ["ANIMAL", "NO_FEAR", "CAN_FLY", "WILD_WOOD", "DROP_CORPSE"],
       "flavor": {
         "ja": "それは恐れる事なしに狩る事を訓練された鷹だ。",
         "en": "Trained to hunt and kill without fear."
@@ -7640,18 +7482,10 @@
           "damage_dice": "2d5"
         }
       ],
-      "flags": [
-        "RAND_50",
-        "EMPTY_MIND",
-        "CAN_SWIM",
-        "DROP_CORPSE",
-        "IM_POIS"
-      ],
+      "flags": ["RAND_50", "EMPTY_MIND", "CAN_SWIM", "DROP_CORPSE", "IM_POIS"],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "DRAIN_MANA"
-        ]
+        "list": ["DRAIN_MANA"]
       },
       "flavor": {
         "ja": "それはドロドロしてベトベトした奇妙なモンスターだ。",
@@ -7684,12 +7518,7 @@
           "damage_dice": "1d5"
         }
       ],
-      "flags": [
-        "RAND_25",
-        "MULTIPLY",
-        "ANIMAL",
-        "IM_POIS"
-      ],
+      "flags": ["RAND_25", "MULTIPLY", "ANIMAL", "IM_POIS"],
       "flavor": {
         "ja": "尋常ではない大きさの齧歯類の生物だ。",
         "en": "It is a rodent of unusual size."
@@ -7877,13 +7706,7 @@
           "damage_dice": "1d7"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "AQUATIC",
-        "IM_POIS",
-        "RES_WATE",
-        "WILD_ALL"
-      ],
+      "flags": ["ANIMAL", "AQUATIC", "IM_POIS", "RES_WATE", "WILD_ALL"],
       "flavor": {
         "ja": "奇妙な水棲生物で、その触手は致命的な毒を持つ。",
         "en": "A strange water creature, whose touch can be deadly."
@@ -7981,11 +7804,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BLINK",
-          "CAUSE_1",
-          "MISSILE"
-        ]
+        "list": ["BLINK", "CAUSE_1", "MISSILE"]
       },
       "flavor": {
         "ja": "荒々しい身振りをする、獣の皮を身にまとったオークだ。",
@@ -8047,9 +7866,7 @@
       ],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "BR_ELEC"
-        ]
+        "list": ["BR_ELEC"]
       },
       "flavor": {
         "ja": "このドラゴンは生まれたばかりなので、まだそれほど凶暴ではない。その目は光に慣れておらず、鱗は薄い青色をしてる。",
@@ -8111,9 +7928,7 @@
       ],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "BR_COLD"
-        ]
+        "list": ["BR_COLD"]
       },
       "flavor": {
         "ja": "このドラゴンは生まれたばかりなので、まだそれほど凶暴ではない。その目は光に慣れておらず、鱗は薄い白色をしている。",
@@ -8175,9 +7990,7 @@
       ],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "BR_POIS"
-        ]
+        "list": ["BR_POIS"]
       },
       "flavor": {
         "ja": "このドラゴンは生まれたばかりなので、まだそれほど凶暴ではない。その目は光に慣れておらず、鱗は病的な緑色をしている。",
@@ -8239,9 +8052,7 @@
       ],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "BR_ACID"
-        ]
+        "list": ["BR_ACID"]
       },
       "flavor": {
         "ja": "このドラゴンは生まれたばかりなので、まだそれほど凶暴ではない。その目は光に慣れておらず、鱗は鈍い黒色をしている。",
@@ -8303,9 +8114,7 @@
       ],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "BR_FIRE"
-        ]
+        "list": ["BR_FIRE"]
       },
       "flavor": {
         "ja": "このドラゴンは生まれたばかりなので、まだそれほど凶暴ではない。その目は光に慣れておらず、鱗は薄い赤色をしている。",
@@ -8347,13 +8156,7 @@
           "damage_dice": "1d4"
         }
       ],
-      "flags": [
-        "WEIRD_MIND",
-        "BASH_DOOR",
-        "WILD_ALL",
-        "DROP_CORPSE",
-        "ANIMAL"
-      ],
+      "flags": ["WEIRD_MIND", "BASH_DOOR", "WILD_ALL", "DROP_CORPSE", "ANIMAL"],
       "flavor": {
         "ja": "それは大きくて強力な顎を持っている。",
         "en": "It is large and has venomous mandibles."
@@ -8660,13 +8463,7 @@
           "damage_dice": "1d4"
         }
       ],
-      "flags": [
-        "WEIRD_MIND",
-        "FRIENDS",
-        "CAN_FLY",
-        "WILD_ALL",
-        "ANIMAL"
-      ],
+      "flags": ["WEIRD_MIND", "FRIENDS", "CAN_FLY", "WILD_ALL", "ANIMAL"],
       "flavor": {
         "ja": "それは毒を持っている上に攻撃的だ。",
         "en": "It is poisonous and aggressive."
@@ -8760,13 +8557,7 @@
           "damage_dice": "2d6"
         }
       ],
-      "flags": [
-        "WEIRD_MIND",
-        "BASH_DOOR",
-        "CAN_FLY",
-        "ANIMAL",
-        "IM_POIS"
-      ],
+      "flags": ["WEIRD_MIND", "BASH_DOOR", "CAN_FLY", "ANIMAL", "IM_POIS"],
       "flavor": {
         "ja": "それはゆっくりと冒険者の方に向かってくる。",
         "en": "It is moving slowly towards you."
@@ -8873,13 +8664,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BLIND",
-          "CONF",
-          "MISSILE",
-          "DARKNESS",
-          "BA_POIS"
-        ]
+        "list": ["BLIND", "CONF", "MISSILE", "DARKNESS", "BA_POIS"]
       },
       "flavor": {
         "ja": "黒い服を全身にまとったダークエルフで、呪文を唱えてくる。",
@@ -8984,14 +8769,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "HEAL",
-          "BLINK",
-          "TELE_TO",
-          "SLOW",
-          "CONF",
-          "S_MONSTER"
-        ]
+        "list": ["HEAL", "BLINK", "TELE_TO", "SLOW", "CONF", "S_MONSTER"]
       },
       "flavor": {
         "ja": "彼は父親にそっくりだ！彼は強力な呪文を知っているが、幸運にも彼はイークである。",
@@ -9047,10 +8825,7 @@
       ],
       "skill": {
         "probability": "1_IN_12",
-        "list": [
-          "CAUSE_1",
-          "SCARE"
-        ]
+        "list": ["CAUSE_1", "SCARE"]
       },
       "flavor": {
         "ja": "「グラーキ」の刺によって作られたアンデッドモンスター。元は人間だったため、従者になって間も無いうちは何とか人間に見えるが、時間が経つと腐敗してくる。ほとんどがグラーキの一部となっており、グラーキの記憶の全てを受け継いでいる。ギクシャクした動きをしており、グラーキの命令に従って行動するが、ある程度は独自の意志を持つようだ。６０年以上この半死の状態でいた者は、強い日の光に曝されると、「緑の崩壊」を起こす。「...死人の手だった！　血の気のまったくない、骸骨のような手。指の先には、信じられないほど長くてヒビ割れた爪がついていた」(Ｊ・ラムジー・キャンベル、「湖の住人」『クトゥルフ・コンパニオン』サプリメント編、ホビージャパン、p.11)",
@@ -9105,9 +8880,7 @@
       ],
       "skill": {
         "probability": "1_IN_12",
-        "list": [
-          "MISSILE"
-        ]
+        "list": ["MISSILE"]
       },
       "flavor": {
         "ja": "鎧を身にまとったダークエルフで、常に剣をかまえている。",
@@ -9404,13 +9177,7 @@
           "damage_dice": "1d10"
         }
       ],
-      "flags": [
-        "EVIL",
-        "ANIMAL",
-        "OPEN_DOOR",
-        "BASH_DOOR",
-        "DROP_CORPSE"
-      ],
+      "flags": ["EVIL", "ANIMAL", "OPEN_DOOR", "BASH_DOOR", "DROP_CORPSE"],
       "flavor": {
         "ja": "奇怪な熊型のモンスターで、フクロウの爪と顔を持っている。",
         "en": "A bizarre bear-creature with the claws and the face of an owl."
@@ -9609,9 +9376,7 @@
       ],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "DRAIN_MANA"
-        ]
+        "list": ["DRAIN_MANA"]
       },
       "flavor": {
         "ja": "それはダンジョンの床に生えている奇妙な輝くカビだ。",
@@ -9670,12 +9435,7 @@
       ],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "CONF",
-          "SCARE",
-          "BR_LITE",
-          "BR_DARK"
-        ]
+        "list": ["CONF", "SCARE", "BR_LITE", "BR_DARK"]
       },
       "flavor": {
         "ja": "暗い洞窟に生息するドラゴンの小型の近隣種だ。",
@@ -9720,12 +9480,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BLINK",
-          "TELE_TO",
-          "TELE_AWAY",
-          "TPORT"
-        ]
+        "list": ["BLINK", "TELE_TO", "TELE_AWAY", "TPORT"]
       },
       "flavor": {
         "ja": "それは動きの素早いデーモンで、瞬時に消えたり現れたりする。このテレポートの技術はデーモンの中でも秀でている。",
@@ -10158,20 +9913,10 @@
           "damage_dice": "1d3"
         }
       ],
-      "flags": [
-        "DROP_60",
-        "EVIL",
-        "SHAPECHANGER",
-        "ATTR_MULTI",
-        "ATTR_ANY"
-      ],
+      "flags": ["DROP_60", "EVIL", "SHAPECHANGER", "ATTR_MULTI", "ATTR_ANY"],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BO_FIRE",
-          "BO_COLD",
-          "CONF"
-        ]
+        "list": ["BO_FIRE", "BO_COLD", "CONF"]
       },
       "flavor": {
         "ja": "概ね人間の形をしているが絶えず姿を変化させている。",
@@ -10242,13 +9987,7 @@
       ],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "BR_ACID",
-          "BR_FIRE",
-          "BR_COLD",
-          "BR_ELEC",
-          "BR_POIS"
-        ]
+        "list": ["BR_ACID", "BR_FIRE", "BR_COLD", "BR_ELEC", "BR_POIS"]
       },
       "flavor": {
         "ja": "このドラゴンは生まれたばかりなので、まだそれほど凶暴ではない。その目は光に慣れておらず、鱗は微かな色に輝いている。",
@@ -10287,17 +10026,10 @@
           "damage_dice": "7d1"
         }
       ],
-      "flags": [
-        "BASH_DOOR",
-        "WILD_MOUNTAIN",
-        "DROP_CORPSE",
-        "ANIMAL"
-      ],
+      "flags": ["BASH_DOOR", "WILD_MOUNTAIN", "DROP_CORPSE", "ANIMAL"],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BLINK"
-        ]
+        "list": ["BLINK"]
       },
       "flavor": {
         "ja": "その剃刀のように鋭い前歯以外は可愛く見える。それは不気味にうなってあなたの喉に跳びかかる！",
@@ -10360,9 +10092,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "TELE_TO"
-        ]
+        "list": ["TELE_TO"]
       },
       "flavor": {
         "ja": "「それは、年を経て、劫をへた大木でした。とほうもなく大きな木のようで、ぶざまに張った枝は、まるで指の長い手をたくさんつけて、差し伸ばされた腕のように伸びていましたし、こぶだらけのねじ曲がった幹は、大きな割れ目をいくつも開けて、大枝が動くたびに、かすかにきしむような音をたてました。」（J.R.R.トールキン、瀬田貞二・田中明子訳 新版指輪物語） ",
@@ -10662,9 +10392,7 @@
       ],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "DRAIN_MANA"
-        ]
+        "list": ["DRAIN_MANA"]
       },
       "flavor": {
         "ja": "それは脈打って光を放つ肉のような物質の塊だ。",
@@ -10930,13 +10658,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BLINK",
-          "CAUSE_1",
-          "MISSILE",
-          "CONF",
-          "SCARE"
-        ]
+        "list": ["BLINK", "CAUSE_1", "MISSILE", "CONF", "SCARE"]
       },
       "flavor": {
         "ja": "スケイヴン族のシャーマンは、ワープストーンという混沌の力によって邪悪にされた謎の石から力を得ている。",
@@ -10983,19 +10705,10 @@
           "damage_dice": "1d6"
         }
       ],
-      "flags": [
-        "CAN_FLY",
-        "IM_POIS",
-        "WILD_WOOD",
-        "DROP_CORPSE",
-        "EVIL"
-      ],
+      "flags": ["CAN_FLY", "IM_POIS", "WILD_WOOD", "DROP_CORPSE", "EVIL"],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "HOLD",
-          "CONF"
-        ]
+        "list": ["HOLD", "CONF"]
       },
       "flavor": {
         "ja": "宙に浮かぶ眼でいくつかの小さな眼柄に囲まれている。その睨みは催眠効果を持つ。",
@@ -11088,14 +10801,7 @@
           "damage_dice": "2d5"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "EVIL",
-        "AQUATIC",
-        "IM_POIS",
-        "RES_WATE",
-        "WILD_ALL"
-      ],
+      "flags": ["ANIMAL", "EVIL", "AQUATIC", "IM_POIS", "RES_WATE", "WILD_ALL"],
       "flavor": {
         "ja": "深海に棲む悪魔のエイだ。",
         "en": "A devil ray of the depths."
@@ -11127,12 +10833,7 @@
           "damage_dice": "6d6"
         }
       ],
-      "flags": [
-        "RAND_50",
-        "FRIENDS",
-        "BASH_DOOR",
-        "ANIMAL"
-      ],
+      "flags": ["RAND_50", "FRIENDS", "BASH_DOOR", "ANIMAL"],
       "flavor": {
         "ja": "この可哀想な動物には爆発物が取り付けられていて、目標を発見して爆破するように訓練されている。",
         "en": "An explosive charge has been attached to this poor animal, who has been trained to search for its target and detonate."
@@ -11239,13 +10940,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "HEAL",
-          "BLIND",
-          "DARKNESS",
-          "CONF",
-          "CAUSE_2"
-        ]
+        "list": ["HEAL", "BLIND", "DARKNESS", "CONF", "CAUSE_2"]
       },
       "flavor": {
         "ja": "「自在に伸縮する大きな灰白色のぬるぬるしたものであり、もっぱらの姿と言えば――よく変化するものの――いかさま蟇めいたものだったが、もっとも目はなく、短いピンク色の触角が集まって震える妙なしろものが、太くて短い鼻らしきものの先端についていた」(Ｈ・Ｐ・ラヴクラフト、大瀧啓裕訳「未知なるカダスを夢に求めて」『ラヴクラフト全集６』、創元推理文庫、p.193)",
@@ -11290,14 +10985,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLINK",
-          "TPORT",
-          "BLIND",
-          "SLOW",
-          "BA_POIS",
-          "S_MONSTER"
-        ]
+        "list": ["BLINK", "TPORT", "BLIND", "SLOW", "BA_POIS", "S_MONSTER"]
       },
       "flavor": {
         "ja": "何らかの力を放射する人間型のモンスターだ。",
@@ -11353,12 +11041,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "HEAL",
-          "SCARE",
-          "CAUSE_2",
-          "S_MONSTER"
-        ]
+        "list": ["HEAL", "SCARE", "CAUSE_2", "S_MONSTER"]
       },
       "flavor": {
         "ja": "自分の信じる神に身を捧げる、ローブをまとった人間だ。",
@@ -11415,14 +11098,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "HEAL",
-          "BLIND",
-          "CONF",
-          "CAUSE_2",
-          "DARKNESS",
-          "MISSILE"
-        ]
+        "list": ["HEAL", "BLIND", "CONF", "CAUSE_2", "DARKNESS", "MISSILE"]
       },
       "flavor": {
         "ja": "黒い服を全身にまとったダークエルフで、呪いの言葉をつぶやき、冒険者を地獄へたたき落とそうと待ちかまえている。",
@@ -11690,10 +11366,7 @@
       ],
       "skill": {
         "probability": "1_IN_15",
-        "list": [
-          "TPORT",
-          "SCARE"
-        ]
+        "list": ["TPORT", "SCARE"]
       },
       "flavor": {
         "ja": "恐ろしげに唸る幽霊だ。",
@@ -11740,12 +11413,7 @@
           "damage_dice": "2d4"
         }
       ],
-      "flags": [
-        "WEIRD_MIND",
-        "BASH_DOOR",
-        "ANIMAL",
-        "DROP_SKELETON"
-      ],
+      "flags": ["WEIRD_MIND", "BASH_DOOR", "ANIMAL", "DROP_SKELETON"],
       "flavor": {
         "ja": "それは頑丈な顎と尖った尻尾を持った、防御力の高い巨大なムカデだ。",
         "en": "It is a vast armoured centipede with massive mandibles and a spiked tail."
@@ -11845,20 +11513,10 @@
           "damage_dice": "1d6"
         }
       ],
-      "flags": [
-        "BASH_DOOR",
-        "DROP_SKELETON",
-        "EVIL",
-        "IM_POIS"
-      ],
+      "flags": ["BASH_DOOR", "DROP_SKELETON", "EVIL", "IM_POIS"],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "CONF",
-          "CAUSE_1",
-          "DARKNESS",
-          "MISSILE"
-        ],
+        "list": ["CONF", "CAUSE_1", "DARKNESS", "MISSILE"],
         "shoot": "3d6"
       },
       "flavor": {
@@ -11953,13 +11611,7 @@
           "damage_dice": "3d4"
         }
       ],
-      "flags": [
-        "WEIRD_MIND",
-        "BASH_DOOR",
-        "CAN_FLY",
-        "DROP_CORPSE",
-        "ANIMAL"
-      ],
+      "flags": ["WEIRD_MIND", "BASH_DOOR", "CAN_FLY", "DROP_CORPSE", "ANIMAL"],
       "flavor": {
         "ja": "それは頑丈な甲羅を持った凶暴な昆虫だ。",
         "en": "It is a vicious insect with a tough carapace."
@@ -12022,14 +11674,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "HEAL",
-          "BLINK",
-          "TPORT",
-          "BLIND",
-          "SLOW",
-          "S_KIN"
-        ]
+        "list": ["HEAL", "BLINK", "TPORT", "BLIND", "SLOW", "S_KIN"]
       },
       "flavor": {
         "ja": "偉大なイークで魔法を得意としているが、やっぱりイークだ。",
@@ -12093,10 +11738,10 @@
         "character": "$",
         "color": "Light Blue"
       },
-      "speed": 0,
-      "hit_point": "20d8",
-      "vision": 5,
-      "armor_class": 50,
+      "speed": 10,
+      "hit_point": "40d12",
+      "vision": 15,
+      "armor_class": 90,
       "alertness": 10,
       "level": 13,
       "rarity": 4,
@@ -12314,10 +11959,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "CONF",
-          "SCARE"
-        ]
+        "list": ["CONF", "SCARE"]
       },
       "flavor": {
         "ja": "<ティーンチ>の下僕の、叫ぶ醜い小型の悪魔だ。",
@@ -12615,11 +12257,7 @@
           "damage_dice": "6d3"
         }
       ],
-      "flags": [
-        "AQUATIC",
-        "WILD_ALL",
-        "RES_WATE"
-      ],
+      "flags": ["AQUATIC", "WILD_ALL", "RES_WATE"],
       "flavor": {
         "ja": "洗練された、しかも好戦的な海のエルフの種族だ。",
         "en": "A race of fair yet belligerent sea elves."
@@ -12660,11 +12298,7 @@
           "damage_dice": "1d10"
         }
       ],
-      "flags": [
-        "OPEN_DOOR",
-        "DROP_SKELETON",
-        "DROP_CORPSE"
-      ],
+      "flags": ["OPEN_DOOR", "DROP_SKELETON", "DROP_CORPSE"],
       "flavor": {
         "ja": "この奇妙な生物は小型のティラノサウルスのように見える。瞳のない青い目と鋭いくちばしを持っていて、そのくちばしはあなたの目を狙って飛びかかる！",
         "en": "This strange creature looks like a miniature tyrannosaurus. It has empty, pale eyes and a sharp beak, which it aims at your eyes as it jumps at you!"
@@ -12707,9 +12341,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_COLD"
-        ]
+        "list": ["BR_COLD"]
       },
       "flavor": {
         "ja": "それは冷気を振りまく大きなトンボだ。",
@@ -12815,11 +12447,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE"
-        ]
+        "list": ["BLIND", "CONF", "SCARE"]
       },
       "flavor": {
         "ja": "原始的な知能を持ったネバネバした奇妙な生物だ。しかしその知能とは邪悪なずる賢さでしかない。それは常に食料に飢えていて、冒険者をとてもおいしそうに見つめている。",
@@ -12865,11 +12493,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SCARE",
-          "CONF",
-          "BR_LITE"
-        ]
+        "list": ["SCARE", "CONF", "BR_LITE"]
       },
       "flavor": {
         "ja": "脈動するたくさんの肉と目と口の混沌とした塊だ。",
@@ -12907,13 +12531,7 @@
           "damage_dice": "1d5"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "NO_FEAR",
-        "FRIENDS",
-        "DROP_SKELETON",
-        "DROP_CORPSE"
-      ],
+      "flags": ["ANIMAL", "NO_FEAR", "FRIENDS", "DROP_SKELETON", "DROP_CORPSE"],
       "flavor": {
         "ja": "よく訓練された番犬で、死ぬまで従順だ。",
         "en": "Well-trained watchdogs, obedient to death."
@@ -13113,9 +12731,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLINK"
-        ]
+        "list": ["BLINK"]
       },
       "flavor": {
         "ja": "陽気な小人だ。",
@@ -13152,13 +12768,7 @@
           "damage_dice": "1d2"
         }
       ],
-      "flags": [
-        "RAND_50",
-        "CAN_FLY",
-        "WEIRD_MIND",
-        "MULTIPLY",
-        "ANIMAL"
-      ],
+      "flags": ["RAND_50", "CAN_FLY", "WEIRD_MIND", "MULTIPLY", "ANIMAL"],
       "flavor": {
         "ja": "それを見るだけで体がむずがゆくなってくる。",
         "en": "It makes you itch just looking at it."
@@ -13376,12 +12986,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BO_ACID",
-          "S_MONSTER",
-          "SCARE",
-          "DRAIN_MANA"
-        ]
+        "list": ["BO_ACID", "S_MONSTER", "SCARE", "DRAIN_MANA"]
       },
       "flavor": {
         "ja": "魔法使いを好んで食べるゴリラ形の謎の守護者だ。「大きくて丸々と太った姿が僕の道を塞いでいた。コウモリの耳をした紫色のブッダのようだった。近づくにつれその詳細がはっきりしてきた---突き出た牙、目蓋がないように見える黄色い目、大きな手と足には赤くて長い爪があった。それはトンネルの真ん中に座って立ち上がろうとはしなかった。衣服は着ていなかったが、膨らんだ腹を膝の上に乗せていて、性別は分からなかった。」（ロジャー・ゼラズニイ, アンバー７「アンバーの血」）",
@@ -13489,13 +13094,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "HOLD",
-          "CONF",
-          "BO_COLD",
-          "HEAL",
-          "DARKNESS"
-        ]
+        "list": ["HOLD", "CONF", "BO_COLD", "HEAL", "DARKNESS"]
       },
       "flavor": {
         "ja": "女性の上半身を持った大きなヘビのような姿をしている。他のナーガほど強くないが、魔法に秀でている。",
@@ -13590,12 +13189,7 @@
       ],
       "skill": {
         "probability": "1_IN_1",
-        "list": [
-          "BLINK",
-          "SLOW",
-          "SCARE",
-          "DARKNESS"
-        ]
+        "list": ["BLINK", "SLOW", "SCARE", "DARKNESS"]
       },
       "flavor": {
         "ja": "うーん！それはとてもおいしそうに見える。それは奇妙な光に輝いているようだ。",
@@ -13653,12 +13247,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "SCARE",
-          "S_ANT",
-          "CAUSE_2",
-          "SLOW"
-        ]
+        "list": ["SCARE", "S_ANT", "CAUSE_2", "SLOW"]
       },
       "flavor": {
         "ja": "<ナーグル>の腐れ病という名で知られる不治の病によって死んだ不運な人間で、腐乱した悪魔のゾンビになってしまっている。目は一つだけで、一本の青白い角が額に生えている。",
@@ -13768,13 +13357,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BLINK",
-          "CAUSE_2",
-          "BO_COLD",
-          "BA_POIS",
-          "S_KIN"
-        ]
+        "list": ["BLINK", "CAUSE_2", "BO_COLD", "BA_POIS", "S_KIN"]
       },
       "flavor": {
         "ja": "赤い目を輝かせる大きなネズミだ。ワーラットは汚物と病気の中にいるのを好む忌むべき生物だ。",
@@ -13824,9 +13407,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_LITE"
-        ]
+        "list": ["BR_LITE"]
       },
       "flavor": {
         "ja": "光を発する犬型の生物で、その光は離れた所からでも冒険者の目を傷つける。",
@@ -13859,18 +13440,10 @@
           "damage_dice": "1d6"
         }
       ],
-      "flags": [
-        "FRIENDS",
-        "BASH_DOOR",
-        "HURT_LITE",
-        "ANIMAL",
-        "RES_DARK"
-      ],
+      "flags": ["FRIENDS", "BASH_DOOR", "HURT_LITE", "ANIMAL", "RES_DARK"],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_DARK"
-        ]
+        "list": ["BR_DARK"]
       },
       "flavor": {
         "ja": "巨大な犬の形をした空気の穴だ。どんな光もその姿を照らし出すことはできない。",
@@ -13973,11 +13546,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "CONF",
-          "S_MONSTER",
-          "S_DEMON"
-        ]
+        "list": ["CONF", "S_MONSTER", "S_DEMON"]
       },
       "flavor": {
         "ja": "「それはピンクがかった 1.5m 程度の大きさの甲殻類の体をしていて、異常な数の背びれのような膜状の羽と、関節のあるいくつかの足が生えている。頭があるべき場所には渦巻き状の楕円体があり、多数の短い触角で覆われている...」",
@@ -14329,12 +13898,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLINK",
-          "DARKNESS",
-          "BO_COLD",
-          "S_MONSTER"
-        ]
+        "list": ["BLINK", "DARKNESS", "BO_COLD", "S_MONSTER"]
       },
       "flavor": {
         "ja": "背の低いメイジだ。",
@@ -14377,13 +13941,7 @@
           "damage_dice": "1d6"
         }
       ],
-      "flags": [
-        "ATTR_CLEAR",
-        "FRIENDS",
-        "INVISIBLE",
-        "BASH_DOOR",
-        "ANIMAL"
-      ],
+      "flags": ["ATTR_CLEAR", "FRIENDS", "INVISIBLE", "BASH_DOOR", "ANIMAL"],
       "flavor": {
         "ja": "完全に半透明の犬だ。",
         "en": "A completely translucent hound."
@@ -14670,9 +14228,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_POIS"
-        ]
+        "list": ["BR_POIS"]
       },
       "flavor": {
         "ja": "不快な匂いを発する巨大なトンボだ。",
@@ -14926,12 +14482,7 @@
           "damage_dice": "4d4"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "AQUATIC",
-        "WILD_ALL",
-        "RES_WATE"
-      ],
+      "flags": ["ANIMAL", "AQUATIC", "WILD_ALL", "RES_WATE"],
       "flavor": {
         "ja": "奇妙な頭をした飢えた鮫だ。",
         "en": "A hungry shark with a strange head."
@@ -15110,10 +14661,7 @@
       ],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "SCARE",
-          "CONF"
-        ]
+        "list": ["SCARE", "CONF"]
       },
       "flavor": {
         "ja": "そのなぞなぞに答えられなかったらあなたは食べられてしまうだろう。",
@@ -15425,9 +14973,7 @@
       ],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "SCARE"
-        ]
+        "list": ["SCARE"]
       },
       "flavor": {
         "ja": "二つの首を持った奇妙な雑種の爬虫類で、蓄えた財宝を守っている。",
@@ -15464,12 +15010,7 @@
           "damage_dice": "5d2"
         }
       ],
-      "flags": [
-        "CAN_SWIM",
-        "OPEN_DOOR",
-        "BASH_DOOR",
-        "WILD_SWAMP"
-      ],
+      "flags": ["CAN_SWIM", "OPEN_DOOR", "BASH_DOOR", "WILD_SWAMP"],
       "flavor": {
         "ja": "昔は人間だったが、今は苔のように緑だ。事故にあって火ダルマになり沼に飛び込んだ科学者が、苔や藻と融合して生まれた。",
         "en": "A creature that was once human, but is now as green as moss."
@@ -15736,9 +15277,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_FIRE"
-        ]
+        "list": ["BR_FIRE"]
       },
       "flavor": {
         "ja": "火炎がその足下から立ちのぼり、その舌はまるで炎の剣のようだ。この生物が発散する熱気を浴びると、まるで溶鉱炉に投げ込まれたかのような感じがする。",
@@ -15781,18 +15320,10 @@
           "damage_dice": "1d6"
         }
       ],
-      "flags": [
-        "FRIENDS",
-        "HURT_FIRE",
-        "BASH_DOOR",
-        "ANIMAL",
-        "IM_COLD"
-      ],
+      "flags": ["FRIENDS", "HURT_FIRE", "BASH_DOOR", "ANIMAL", "IM_COLD"],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_COLD"
-        ]
+        "list": ["BR_COLD"]
       },
       "flavor": {
         "ja": "人間ほどの大きさのある犬で、角張った氷でできているような生物だ。体からは冷気が放射され、吐く息すらも凍ってしまう。",
@@ -15835,18 +15366,10 @@
           "damage_dice": "2d3"
         }
       ],
-      "flags": [
-        "SELF_LITE_2",
-        "FRIENDS",
-        "BASH_DOOR",
-        "ANIMAL",
-        "IM_ELEC"
-      ],
+      "flags": ["SELF_LITE_2", "FRIENDS", "BASH_DOOR", "ANIMAL", "IM_ELEC"],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_ELEC"
-        ]
+        "list": ["BR_ELEC"]
       },
       "flavor": {
         "ja": "セントエルモの炎のような幽玄な後光がこの犬を包み込んでいる。辺りに満ちたエネルギーが冒険者の周りに立ちのぼり、火花が指を突き刺す。",
@@ -15900,13 +15423,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "CAUSE_2",
-          "BO_COLD"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "CAUSE_2", "BO_COLD"]
       },
       "flavor": {
         "ja": "放置されたアイテムに化けている奇妙な生物で、愚かな冒険者がその毒のある爪の射程距離に入るのを待ちかまえている。",
@@ -15959,13 +15476,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "CAUSE_2",
-          "BO_COLD"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "CAUSE_2", "BO_COLD"]
       },
       "flavor": {
         "ja": "ドアに化けている奇妙な生物で愚かな冒険者がその毒のある爪の射程に入るのを待ち構えている。",
@@ -16009,10 +15520,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLINK",
-          "TELE_TO"
-        ]
+        "list": ["BLINK", "TELE_TO"]
       },
       "flavor": {
         "ja": "犬科に属する奇妙な魔法の生物だ。その姿は点滅していて、目の前から瞬時に消え失せたりする。",
@@ -16247,9 +15755,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "SHRIEK"
-        ]
+        "list": ["SHRIEK"]
       },
       "flavor": {
         "ja": "悪臭を振りまいて付近のものを目覚めさせながら這いずり回る、腐った植物の塊だ。",
@@ -16293,12 +15799,7 @@
           "damage_dice": "3d5"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "AQUATIC",
-        "WILD_ALL",
-        "RES_WATE"
-      ],
+      "flags": ["ANIMAL", "AQUATIC", "WILD_ALL", "RES_WATE"],
       "flavor": {
         "ja": "素早く動く深海のハンターだ。この怪物が動く時、水棲生物全てが恐怖する！",
         "en": "Fast moving hunter of the depths, when this creature moves, everybody in water is in danger!"
@@ -16350,12 +15851,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "MISSILE",
-          "BO_FIRE",
-          "CONF",
-          "TPORT"
-        ]
+        "list": ["MISSILE", "BO_FIRE", "CONF", "TPORT"]
       },
       "flavor": {
         "ja": "カオスに歪められた、本当に忌まわしい存在で、何種類かの生物の混ざった姿だ。",
@@ -16409,14 +15905,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "SCARE",
-          "S_DEMON",
-          "CAUSE_2",
-          "CONF",
-          "BO_FIRE",
-          "BO_COLD"
-        ]
+        "list": ["SCARE", "S_DEMON", "CAUSE_2", "CONF", "BO_FIRE", "BO_COLD"]
       },
       "flavor": {
         "ja": "下級の女性型悪魔で、概ね人間型をしているが、手の代わりに蟹のようなハサミがある。かなりきわどいボロ皮のビキニを着ていて、素早く動き、致命的な呪文を唱えてくる。",
@@ -16456,9 +15945,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BR_CONF"
-        ]
+        "list": ["BR_CONF"]
       },
       "flavor": {
         "ja": "青銅の光沢を持った巨大なトンボで、その単調な羽音は人に眠気を催させる。",
@@ -16549,9 +16036,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BR_ACID"
-        ]
+        "list": ["BR_ACID"]
       },
       "flavor": {
         "ja": "鳥ほどの大きさがあるトンボで、腐食性の酸を滴らせている。",
@@ -16693,9 +16178,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BR_SOUN"
-        ]
+        "list": ["BR_SOUN"]
       },
       "flavor": {
         "ja": "激しくはばたく長い羽を持ち、光沢のある体をした昆虫だ。やかましい羽音を部屋中に響かせている。",
@@ -16843,24 +16326,10 @@
           "damage_dice": "2d7"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "EVIL",
-        "AQUATIC",
-        "IM_POIS",
-        "RES_WATE",
-        "WILD_ALL"
-      ],
+      "flags": ["ANIMAL", "EVIL", "AQUATIC", "IM_POIS", "RES_WATE", "WILD_ALL"],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "TELE_TO",
-          "HEAL",
-          "SCARE",
-          "CAUSE_2",
-          "BLIND",
-          "S_MONSTER"
-        ]
+        "list": ["TELE_TO", "HEAL", "SCARE", "CAUSE_2", "BLIND", "S_MONSTER"]
       },
       "flavor": {
         "ja": "深海に棲む悪魔のエイで、僧侶の呪文を使う。",
@@ -16929,10 +16398,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BLINK",
-          "TELE_TO"
-        ]
+        "list": ["BLINK", "TELE_TO"]
       },
       "flavor": {
         "ja": "非常に強い、半ば意識を持った樹で、人間の形をした生物に敵意を抱くようになっている。もとはエントだったといわれている。",
@@ -17051,10 +16517,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BLINK",
-          "TELE_TO"
-        ]
+        "list": ["BLINK", "TELE_TO"]
       },
       "flavor": {
         "ja": "一カ所に見定めることのできない蜘蛛だ。姿を一瞬見たかと思うと、次の瞬間には消え失せていて、はっきりと姿を捉えることができない。",
@@ -17271,9 +16734,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "SPECIAL"
-        ]
+        "list": ["SPECIAL"]
       },
       "flavor": {
         "ja": "マンウェに遣わされた偉大な大鷲は人の言葉を話し、マイアールと同じ魂を持っていると言われる。この大鷲はその一族の一員である。",
@@ -17377,18 +16838,10 @@
           "damage_dice": "3d3"
         }
       ],
-      "flags": [
-        "FRIENDS",
-        "BASH_DOOR",
-        "HURT_ROCK",
-        "ANIMAL",
-        "RES_SHAR"
-      ],
+      "flags": ["FRIENDS", "BASH_DOOR", "HURT_ROCK", "ANIMAL", "RES_SHAR"],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_SHAR"
-        ]
+        "list": ["BR_SHAR"]
       },
       "flavor": {
         "ja": "水晶のような美しい姿をしているが、一目見ればこのハウンドが危険な存在であることは明らかだ。それが近づいてくると、冒険者の体は興奮でゾクゾクとしてくる。",
@@ -17436,18 +16889,10 @@
           "damage_dice": "3d3"
         }
       ],
-      "flags": [
-        "FRIENDS",
-        "CAN_FLY",
-        "BASH_DOOR",
-        "ANIMAL",
-        "IM_POIS"
-      ],
+      "flags": ["FRIENDS", "CAN_FLY", "BASH_DOOR", "ANIMAL", "IM_POIS"],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_POIS"
-        ]
+        "list": ["BR_POIS"]
       },
       "flavor": {
         "ja": "渦巻く蒸気を体にまといながら、まるで空気の上を歩くかのように、宙を浮いて近づいてくる野獣だ。有害なガスが冒険者の喉を刺激する。",
@@ -17559,9 +17004,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_ACID"
-        ]
+        "list": ["BR_ACID"]
       },
       "flavor": {
         "ja": "しめった足跡を残しながらダンジョンを徘徊する犬だ。その毛皮からは刺激的な酸の匂いが立ち昇っている。",
@@ -17618,9 +17061,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_FIRE"
-        ]
+        "list": ["BR_FIRE"]
       },
       "flavor": {
         "ja": "ライオンとドラゴンと山羊が混じったような奇妙な生物だ。非常に変わった外見をしていて、近寄りがたい雰囲気がある。",
@@ -17664,10 +17105,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLINK",
-          "S_MONSTER"
-        ]
+        "list": ["BLINK", "S_MONSTER"]
       },
       "flavor": {
         "ja": "それは脈打つ奇妙な肉の塊だ。",
@@ -18138,9 +17576,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BR_ELEC"
-        ]
+        "list": ["BR_ELEC"]
       },
       "flavor": {
         "ja": "それは鋭い尻尾を持った青く輝くコウモリだ。",
@@ -18198,14 +17634,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "CAUSE_2",
-          "BO_FIRE",
-          "S_MONSTER"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "CAUSE_2", "BO_FIRE", "S_MONSTER"]
       },
       "flavor": {
         "ja": "放置されたアイテムに化けている奇妙な生物で、愚かな冒険者がその毒のある爪の射程距離に入るのを待ちかまえている。",
@@ -18263,14 +17692,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "CAUSE_2",
-          "BA_POIS",
-          "S_MONSTER"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "CAUSE_2", "BA_POIS", "S_MONSTER"]
       },
       "flavor": {
         "ja": "放置された箱に化けている奇妙な生物で愚かな冒険者がその毒のある爪の射程に入るのを待ち構えている。",
@@ -18324,9 +17746,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_FIRE"
-        ]
+        "list": ["BR_FIRE"]
       },
       "flavor": {
         "ja": "グルグルと回って燃えさかる火炎の渦巻きだ。",
@@ -18376,9 +17796,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_ACID"
-        ]
+        "list": ["BR_ACID"]
       },
       "flavor": {
         "ja": "回転する腐食性の水の渦巻きだ。",
@@ -18501,10 +17919,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BA_FIRE",
-          "ANIM_DEAD"
-        ]
+        "list": ["BA_FIRE", "ANIM_DEAD"]
       },
       "flavor": {
         "ja": "青白い死体のような下級悪魔で、非常に素早く動き回り、そこらじゅうに悪を生み出す。",
@@ -18556,9 +17971,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_COLD"
-        ]
+        "list": ["BR_COLD"]
       },
       "flavor": {
         "ja": "回転する冷気の渦巻きだ。",
@@ -18609,9 +18022,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_ELEC"
-        ]
+        "list": ["BR_ELEC"]
       },
       "flavor": {
         "ja": "光を放つ空気の竜巻で、その周りには火花が閃光を発している。",
@@ -18661,9 +18072,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "BR_POIS"
-        ]
+        "list": ["BR_POIS"]
       },
       "flavor": {
         "ja": "その丸っこい魚は水中で最も強い毒を持つ奴だ。",
@@ -18815,12 +18224,7 @@
           "damage_dice": "8d3"
         }
       ],
-      "flags": [
-        "AQUATIC",
-        "WILD_OCEAN",
-        "RES_WATE",
-        "ANIMAL"
-      ],
+      "flags": ["AQUATIC", "WILD_OCEAN", "RES_WATE", "ANIMAL"],
       "flavor": {
         "ja": "それはとても美しいと同時に危険な獣だ。",
         "en": "An almost beautiful, deadly beast."
@@ -18878,12 +18282,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BA_POIS",
-          "S_MONSTER",
-          "SCARE",
-          "HOLD"
-        ]
+        "list": ["BA_POIS", "S_MONSTER", "SCARE", "HOLD"]
       },
       "flavor": {
         "ja": "「蛇人間たちはしなやかに動き、哺乳類に進化する以前の器官でもって直立したが、まだらで無毛の体は驚くほどしなやかだった。蛇人間たちがあちこちを歩きまわっているあいだ、呪文を唱えるようなしゅうしゅういう音がたえまなくつづいていた」(クラーク・アシュトン・スミス、池田勝子訳「七つの呪い」『クトゥルー４』、青心社文庫、p.128)",
@@ -19019,9 +18418,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SLOW"
-        ]
+        "list": ["SLOW"]
       },
       "flavor": {
         "ja": "それは堂々たる金属の巨像で、大きな足音を響かせて近づいてくる。",
@@ -19199,9 +18596,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BO_ELEC"
-        ]
+        "list": ["BO_ELEC"]
       },
       "flavor": {
         "ja": "緑色の法衣を身にまとった、拳法に熟練した修行僧だ。",
@@ -19254,9 +18649,7 @@
       ],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "DRAIN_MANA"
-        ]
+        "list": ["DRAIN_MANA"]
       },
       "flavor": {
         "ja": "それは奇妙に動く泥のようなものだ。",
@@ -19487,12 +18880,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "CONF",
-          "MISSILE",
-          "DARKNESS",
-          "BO_MANA"
-        ]
+        "list": ["CONF", "MISSILE", "DARKNESS", "BO_MANA"]
       },
       "flavor": {
         "ja": "ダークエルフのメイジでその呪文は恐ろしく破壊的な力を秘めている。",
@@ -19600,9 +18988,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BR_FIRE"
-        ]
+        "list": ["BR_FIRE"]
       },
       "flavor": {
         "ja": "鋭い尻尾を持ったコウモリで、体の周りには火炎が渦巻いている。",
@@ -19766,10 +19152,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "SLOW",
-          "FORGET"
-        ]
+        "list": ["SLOW", "FORGET"]
       },
       "flavor": {
         "ja": "西方国の人間を忌み嫌っている黒きヌメノール人だ。",
@@ -19834,10 +19217,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "SCARE",
-          "DRAIN_MANA"
-        ]
+        "list": ["SCARE", "DRAIN_MANA"]
       },
       "flavor": {
         "ja": "それは人間のような姿をした幽霊だ。",
@@ -19910,11 +19290,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "HEAL",
-          "HASTE",
-          "BO_FIRE"
-        ]
+        "list": ["HEAL", "HASTE", "BO_FIRE"]
       },
       "flavor": {
         "ja": "この小さな闇のドワーフは彼の兄アルベリヒに負けないくらい金に貪欲だ。",
@@ -19987,11 +19363,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "HEAL",
-          "HASTE",
-          "BO_FIRE"
-        ]
+        "list": ["HEAL", "HASTE", "BO_FIRE"]
       },
       "artifacts": [
         {
@@ -20054,10 +19426,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "SPECIAL",
-          "S_KIN"
-        ]
+        "list": ["SPECIAL", "S_KIN"]
       },
       "flavor": {
         "ja": "マンウェに遣わされた偉大な大鷲は人の言葉を話し、マイアールと同じ魂を持っていると言われる。メネルドールは一族の中でグワイヒアとその弟ランドローバルに継いで速く、疾翼と呼ばれる。",
@@ -20149,11 +19518,7 @@
           "damage_dice": "3d6"
         }
       ],
-      "flags": [
-        "AQUATIC",
-        "RES_WATE",
-        "ANIMAL"
-      ],
+      "flags": ["AQUATIC", "RES_WATE", "ANIMAL"],
       "flavor": {
         "ja": "それはとても大きな肉食の魚だ。",
         "en": "A very large carnivorous fish."
@@ -20219,9 +19584,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SCARE"
-        ]
+        "list": ["SCARE"]
       },
       "flavor": {
         "ja": "四つの首を持った奇妙な雑種の爬虫類で、蓄えた財宝を守っている。",
@@ -20292,11 +19655,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "TPORT",
-          "BLINK",
-          "TELE_AWAY"
-        ]
+        "list": ["TPORT", "BLINK", "TELE_AWAY"]
       },
       "flavor": {
         "ja": "この怪物はあなたを押し潰すだろう。",
@@ -20527,10 +19886,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "SLOW",
-          "FORGET"
-        ]
+        "list": ["SLOW", "FORGET"]
       },
       "flavor": {
         "ja": "暗黒の心を持った黒きヌメノール人だ。",
@@ -20681,11 +20037,7 @@
       ],
       "skill": {
         "probability": "1_IN_15",
-        "list": [
-          "TPORT",
-          "DRAIN_MANA",
-          "SHRIEK"
-        ]
+        "list": ["TPORT", "DRAIN_MANA", "SHRIEK"]
       },
       "flavor": {
         "ja": "それは悲しげに泣き叫ぶ、女性の姿をしたゴーストだ。",
@@ -20906,11 +20258,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "SLOW",
-          "CONF",
-          "BO_ACID"
-        ]
+        "list": ["SLOW", "CONF", "BO_ACID"]
       },
       "flavor": {
         "ja": "きらきらと輝く目をした、人型の石像だ。",
@@ -20973,9 +20321,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "DRAIN_MANA"
-        ]
+        "list": ["DRAIN_MANA"]
       },
       "flavor": {
         "ja": "アリクイに似た動物で、その長い鼻には反魔力が充満している。",
@@ -21035,14 +20381,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "HEAL",
-          "CONF",
-          "DARKNESS",
-          "S_MONSTER",
-          "S_SPIDER",
-          "MISSILE"
-        ]
+        "list": ["HEAL", "CONF", "DARKNESS", "S_MONSTER", "S_SPIDER", "MISSILE"]
       },
       "flavor": {
         "ja": "自然の中で鍛えられた強靭な体を持つ、屈強なダークエルフだ。",
@@ -21208,13 +20547,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BLINK",
-          "SCARE",
-          "CAUSE_1",
-          "MISSILE",
-          "DARKNESS"
-        ]
+        "list": ["BLINK", "SCARE", "CAUSE_1", "MISSILE", "DARKNESS"]
       },
       "flavor": {
         "ja": "字の読み方を知っているという非常に賢いトロルだ。",
@@ -21357,14 +20690,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "HEAL",
-          "SCARE",
-          "CAUSE_3",
-          "BLIND",
-          "FORGET",
-          "HASTE"
-        ]
+        "list": ["HEAL", "SCARE", "CAUSE_3", "BLIND", "FORGET", "HASTE"]
       },
       "flavor": {
         "ja": "深海の悪魔のエイで、吸血鬼のような能力を持っている。",
@@ -21426,12 +20752,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BR_COLD",
-          "BO_ICEE",
-          "BO_COLD",
-          "BA_COLD"
-        ]
+        "list": ["BR_COLD", "BO_ICEE", "BO_COLD", "BA_COLD"]
       },
       "flavor": {
         "ja": "鋭い角をもった怪物：「２本足でも４本足でも６本足でも歩くとされる、グリーンランドの氷に住む神話上の生物、毛むくじゃらの」(ヘイゼル・ヒールド、東谷真知子訳「博物館の恐怖」『クトゥルー１』、青心社文庫、p.239)",
@@ -21609,10 +20930,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "SPECIAL",
-          "S_KIN"
-        ]
+        "list": ["SPECIAL", "S_KIN"]
       },
       "flavor": {
         "ja": "マンウェに遣わされた偉大な大鷲は人の言葉を話し、マイアールと同じ魂を持っていると言われる。グワイヒアは大鷲の王であり、一族の中で最も強く、速い。これが風の支配者と呼ばれる所以である。",
@@ -21703,12 +21021,7 @@
           "damage_dice": "1d10"
         }
       ],
-      "flags": [
-        "INVISIBLE",
-        "BASH_DOOR",
-        "DROP_CORPSE",
-        "ANIMAL"
-      ],
+      "flags": ["INVISIBLE", "BASH_DOOR", "DROP_CORPSE", "ANIMAL"],
       "flavor": {
         "ja": "それは巨大な豹で、その肩からはハサミの付いた触手が生えている。",
         "en": "It is a huge black panther, clubbed tentacles sprouting from its shoulders."
@@ -21816,11 +21129,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BLIND",
-          "CONF",
-          "TPORT"
-        ]
+        "list": ["BLIND", "CONF", "TPORT"]
       },
       "flavor": {
         "ja": "忠実な下僕であり熟練した戦士だ。",
@@ -21929,11 +21238,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "SCARE",
-          "CAUSE_2",
-          "DARKNESS"
-        ]
+        "list": ["SCARE", "CAUSE_2", "DARKNESS"]
       },
       "flavor": {
         "ja": "それは実体があるように見えるが、実際は白い霧でできた幽霊のようなものだ。",
@@ -22005,12 +21310,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "FORGET"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "FORGET"]
       },
       "flavor": {
         "ja": "小さな腰巻きを身につけた下級の天使だ。その鋼鉄のような肌はどんなものでもはじき返す。",
@@ -22080,10 +21380,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "SCARE",
-          "HOLD"
-        ]
+        "list": ["SCARE", "HOLD"]
       },
       "flavor": {
         "ja": "この腐敗した凶々しい者の体からは腐肉の塊が滴り落ちている。完全な人間の形をしているわけではないが、限りなく人間に良く似ている場合もある。前かがみの姿勢で２本足で歩き、何処となく犬に似ている。皮膚はゴムのような感じでカビがこびりついており、耳はぴんと立っている。半分に割れた蹄と、穴を掘るのに使う鱗のある鉤爪を持つ。夜行性で、人間のたくさん住む場所の近くにおり、腐肉を好んで食らう。泣くように、或いはとてつもない早口で話す。",
@@ -22161,14 +21458,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "HEAL",
-          "SCARE",
-          "BO_ACID",
-          "BA_ACID",
-          "TPORT",
-          "S_MONSTER"
-        ]
+        "list": ["HEAL", "SCARE", "BO_ACID", "BA_ACID", "TPORT", "S_MONSTER"]
       },
       "flavor": {
         "ja": "魔法の帽子によって透明になり、この貪欲なドワーフは自分の富によって世界を支配することを画策している。",
@@ -22336,10 +21626,10 @@
         "character": "$",
         "color": "Light Green"
       },
-      "speed": 10,
-      "hit_point": "20d25",
-      "vision": 5,
-      "armor_class": 50,
+      "speed": 20,
+      "hit_point": "60d25",
+      "vision": 15,
+      "armor_class": 100,
       "alertness": 10,
       "level": 27,
       "rarity": 4,
@@ -22487,10 +21777,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BO_FIRE",
-          "BA_FIRE"
-        ]
+        "list": ["BO_FIRE", "BA_FIRE"]
       },
       "flavor": {
         "ja": "変化と混沌の神<ティーンチ>の下僕だ。逆さになったキノコに似ていて、二本の柔軟な腕がある。",
@@ -22621,9 +21908,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "SCARE"
-        ]
+        "list": ["SCARE"]
       },
       "flavor": {
         "ja": "魔法の突然変異により創られた、首のない忌まわしいヒューマノイドだ。",
@@ -22681,9 +21966,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_SOUN"
-        ]
+        "list": ["BR_SOUN"]
       },
       "flavor": {
         "ja": "ぼんやりとした犬のような姿をしているが、その動きはあまりにも速くて目でとらえることができない。足下の大地が共鳴して震えているような気がする。",
@@ -22741,9 +22024,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_NEXU"
-        ]
+        "list": ["BR_NEXU"]
       },
       "flavor": {
         "ja": "歪んだ空間を繋ぎ合わせると、ぼんやりと犬のような姿が見える。それともただの気のせいだろうか？",
@@ -22802,13 +22083,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "HEAL",
-          "HOLD",
-          "TRAPS",
-          "BA_COLD",
-          "S_MONSTER"
-        ]
+        "list": ["HEAL", "HOLD", "TRAPS", "BA_COLD", "S_MONSTER"]
       },
       "flavor": {
         "ja": "ソーサラーの着る黒いローブに身を包んだ、ぞっとするようなオーガだ。",
@@ -23000,18 +22275,10 @@
           "damage_dice": "2d4"
         }
       ],
-      "flags": [
-        "BASH_DOOR",
-        "CAN_FLY",
-        "DROP_CORPSE",
-        "IM_FIRE",
-        "RIDING"
-      ],
+      "flags": ["BASH_DOOR", "CAN_FLY", "DROP_CORPSE", "IM_FIRE", "RIDING"],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BR_FIRE"
-        ]
+        "list": ["BR_FIRE"]
       },
       "flavor": {
         "ja": "ゴーゴン、山羊、ドラゴンの三つの首を持ち、それらがライオンの胴体から生えている。",
@@ -23069,10 +22336,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "SCARE",
-          "HASTE"
-        ]
+        "list": ["SCARE", "HASTE"]
       },
       "flavor": {
         "ja": "象よりも大きな鳥で、頭部は馬に似ており、羽毛ではなく鱗が全身に生えている。",
@@ -23127,9 +22391,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BO_ELEC"
-        ]
+        "list": ["BO_ELEC"]
       },
       "flavor": {
         "ja": "魂を持った電気で、人間のような姿をしている。狂ったように跳ね回るこのモンスターの周りには火花と電撃が常に巻き起こっている。渦巻くように辺りを跳躍しながら冒険者に近寄ってくる。",
@@ -23193,12 +22455,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "HEAL",
-          "BLIND",
-          "MIND_BLAST",
-          "DARKNESS"
-        ]
+        "list": ["HEAL", "BLIND", "MIND_BLAST", "DARKNESS"]
       },
       "flavor": {
         "ja": "ヘビの亡霊のような姿で、上半身は美しい女性のようだ。それはこの種の生物の中で最も強い。",
@@ -23297,11 +22554,7 @@
           "damage_dice": "1d4"
         }
       ],
-      "flags": [
-        "BASH_DOOR",
-        "EVIL",
-        "DEMON"
-      ],
+      "flags": ["BASH_DOOR", "EVIL", "DEMON"],
       "flavor": {
         "ja": "堕落と快楽の神<スラーネッシュ>のペットで、大きな蠍の尻尾と人間の顔、そして表皮は爬虫類のようだ。",
         "en": "Slaanesh's pet, a large scorpion-like creature with a human face and reptile skin."
@@ -23363,10 +22616,7 @@
       ],
       "skill": {
         "probability": "1_IN_15",
-        "list": [
-          "S_DEMON",
-          "SHRIEK"
-        ]
+        "list": ["S_DEMON", "SHRIEK"]
       },
       "flavor": {
         "ja": "墓場でしばしば発見できる。",
@@ -23435,10 +22685,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "SCARE",
-          "BA_POIS"
-        ]
+        "list": ["SCARE", "BA_POIS"]
       },
       "flavor": {
         "ja": "毒を滴らす五つの首を持った奇妙な雑種の爬虫類だ。",
@@ -23576,12 +22823,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BLIND",
-          "SCARE",
-          "CAUSE_3",
-          "DARKNESS"
-        ]
+        "list": ["BLIND", "SCARE", "CAUSE_3", "DARKNESS"]
       },
       "flavor": {
         "ja": "彼は漆黒のプレートアーマーに身を包み、威嚇的に冒険者を見つめる。",
@@ -23637,12 +22879,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BO_WATE",
-          "BO_COLD",
-          "BO_ICEE",
-          "BO_MANA"
-        ]
+        "list": ["BO_WATE", "BO_COLD", "BO_ICEE", "BO_MANA"]
       },
       "flavor": {
         "ja": "この素晴らしい魔法のタツノオトシゴを見たら感心して夢中になってしまうだろう。",
@@ -24256,9 +23493,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BR_POIS"
-        ]
+        "list": ["BR_POIS"]
       },
       "flavor": {
         "ja": "愚かな冒険者を餌食にする邪悪な爬虫類だ。その目に深く睨まれると魂がしぼんでいくかのようだ。",
@@ -24388,9 +23623,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_ACID"
-        ]
+        "list": ["BR_ACID"]
       },
       "flavor": {
         "ja": "全長数百メートルに及ぶミミズに似た巨大な怪物。貪欲で、あらゆるものを食らい尽くす。ヤディス星の文明を滅ぼしたのはこの生物であり、今でもヤディスの台地を貪り続けているという。光を嫌い、穴の中に住んでいる。口から有毒な酸を含んだ粘液を噴出する。「カーターが見つめているときですら、一匹のドールは数百フィートにまでそびえたち、粘液にまみれる青白い先端をカーターに向けた」(Ｈ・Ｐ・ラヴクラフト＆Ｅ・ホフマン・プライス、大瀧啓裕訳「銀の鍵の門を越えて」『ラヴクラフト全集６』、創元推理文庫、p.152)",
@@ -24464,13 +23697,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "HEAL",
-          "HASTE",
-          "BLIND",
-          "CONF",
-          "SCARE"
-        ]
+        "list": ["HEAL", "HASTE", "BLIND", "CONF", "SCARE"]
       },
       "flavor": {
         "ja": "聖なるオーラで守られた下級の天使だ。その逞しい体と比べてみると、自分の体はなんとも貧弱に感じられる。",
@@ -24591,14 +23818,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "CAUSE_2",
-          "BLINK",
-          "S_MONSTER"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "CAUSE_2", "BLINK", "S_MONSTER"]
       },
       "flavor": {
         "ja": "カオスに汚染された床のタイルだ。",
@@ -24664,10 +23884,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "SCARE",
-          "BR_ELEC"
-        ]
+        "list": ["SCARE", "BR_ELEC"]
       },
       "flavor": {
         "ja": "それはまさにこれから伝説を作らんとするかのような活力に満ちた姿をしている。まだ柔らかいその鱗は深い青色をしていて、全身から火花を発している。",
@@ -24732,10 +23949,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "SCARE",
-          "BR_COLD"
-        ]
+        "list": ["SCARE", "BR_COLD"]
       },
       "flavor": {
         "ja": "それはまさにこれから伝説を作らんとするかのような活力に満ちた姿をしている。まだ柔らかいその鱗は青白い色をしている。それが息を吐くと突き刺すような冷気がやってくる。",
@@ -24800,10 +24014,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "SCARE",
-          "BR_POIS"
-        ]
+        "list": ["SCARE", "BR_POIS"]
       },
       "flavor": {
         "ja": "それはまさにこれから伝説を作らんとするかのような活力に満ちた姿をしている。まだ柔らかいその鱗は深い緑色をしている。不潔なガスがその鱗からしみ出ている。",
@@ -24867,10 +24078,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "SCARE",
-          "BR_CONF"
-        ]
+        "list": ["SCARE", "BR_CONF"]
       },
       "flavor": {
         "ja": "それはまさにこれから伝説を作らんとするかのような活力に満ちた姿をしている。まだ柔らかいその鱗は豊かな青銅色をしている。",
@@ -24934,9 +24142,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "BR_POIS"
-        ]
+        "list": ["BR_POIS"]
       },
       "flavor": {
         "ja": "青白く、ハゲで、デブで、無毛のトロルだ。その醜さは言葉では言い表せない。息の臭さは言うに及ばない。",
@@ -25247,10 +24453,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "SPECIAL",
-          "S_KIN"
-        ]
+        "list": ["SPECIAL", "S_KIN"]
       },
       "flavor": {
         "ja": "マンウェに遣わされた偉大な大鷲は人の言葉を話し、マイアールと同じ魂を持っていると言われる。ソロンドールは全ての大鷲のうちで最初に現れた者であり、最強かつ最大の王だ。その巨大な体を前にすればモルゴスの卑小な召使い達は逃げ惑うことしか出来無い。",
@@ -25360,11 +24563,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "SCARE",
-          "CAUSE_3",
-          "DARKNESS"
-        ]
+        "list": ["SCARE", "CAUSE_3", "DARKNESS"]
       },
       "flavor": {
         "ja": "それは幽霊のような存在で、その目はいつまでも冒険者を睨みつけている。",
@@ -25426,13 +24625,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "SLOW",
-          "CONF",
-          "SCARE",
-          "DARKNESS",
-          "BR_NETH"
-        ]
+        "list": ["SLOW", "CONF", "SCARE", "DARKNESS", "BR_NETH"]
       },
       "flavor": {
         "ja": "それは暗黒に覆われたドラゴンのような姿をしている。赤い目が暗闇の中で光を発している。",
@@ -25639,9 +24832,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BR_POIS"
-        ]
+        "list": ["BR_POIS"]
       },
       "flavor": {
         "ja": "鋼板のような硬い皮膚を持った牛のようなモンスターだ。危険なブレスに注意しろ!",
@@ -25771,11 +24962,7 @@
       ],
       "skill": {
         "probability": "1_IN_15",
-        "list": [
-          "BLIND",
-          "HOLD",
-          "DRAIN_MANA"
-        ]
+        "list": ["BLIND", "HOLD", "DRAIN_MANA"]
       },
       "flavor": {
         "ja": "あなたはその存在を信じていない。",
@@ -25931,10 +25118,7 @@
       ],
       "skill": {
         "probability": "1_IN_1",
-        "list": [
-          "BLINK",
-          "TELE_AWAY"
-        ]
+        "list": ["BLINK", "TELE_AWAY"]
       },
       "flavor": {
         "ja": "それは非常に不安定で奇妙な脈打つ肉の塊だ。",
@@ -26074,11 +25258,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BR_ELEC",
-          "BR_ACID",
-          "BR_POIS"
-        ]
+        "list": ["BR_ELEC", "BR_ACID", "BR_POIS"]
       },
       "flavor": {
         "ja": "船をまるごと水中にひきずりこんでしまう能力に加え、このモンスターは遠くからあなたにダメージを与えることができる。",
@@ -26146,13 +25326,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SCARE",
-          "HOLD",
-          "DARKNESS",
-          "S_UNDEAD",
-          "ANIM_DEAD"
-        ]
+        "list": ["SCARE", "HOLD", "DARKNESS", "S_UNDEAD", "ANIM_DEAD"]
       },
       "flavor": {
         "ja": "この腐敗した凶々しい者の体からは腐肉の塊が滴り落ちている。完全な人間の形をしているわけではないが、限りなく人間に良く似ている場合もある。前かがみの姿勢で２本足で歩き、何処となく犬に似ている。皮膚はゴムのような感じでカビがこびりついており、耳はぴんと立っている。半分に割れた蹄と、穴を掘るのに使う鱗のある鉤爪を持つ。夜行性で、人間のたくさん住む場所の近くにおり、腐肉を好んで食らう。泣くように、或いはとてつもない早口で話す。",
@@ -26304,9 +25478,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "FORGET"
-        ]
+        "list": ["FORGET"]
       },
       "flavor": {
         "ja": "緑の苔の大集団だ。以前にも出会ったことがあるような気がするが、どうしても思い出せない。",
@@ -26368,14 +25540,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BLINK",
-          "TELE_TO",
-          "CONF",
-          "SCARE",
-          "BO_ELEC",
-          "BA_ELEC"
-        ]
+        "list": ["BLINK", "TELE_TO", "CONF", "SCARE", "BO_ELEC", "BA_ELEC"]
       },
       "flavor": {
         "ja": "背の高さが 8 メートルもある、稲妻に身を包んだ巨人だ。",
@@ -26437,12 +25602,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "FORGET",
-          "CAUSE_2",
-          "HOLD",
-          "SLOW"
-        ]
+        "list": ["FORGET", "CAUSE_2", "HOLD", "SLOW"]
       },
       "flavor": {
         "ja": "それは二本の小さな眼柄と中央に大きな目を持っている。",
@@ -26707,9 +25867,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "HEAL"
-        ]
+        "list": ["HEAL"]
       },
       "flavor": {
         "ja": "純白の法衣を身にまとった、拳法に熟練した修行僧だ。",
@@ -27108,12 +26266,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "HEAL",
-          "S_SPIDER",
-          "BA_CHAO",
-          "S_DEMON"
-        ]
+        "list": ["HEAL", "S_SPIDER", "BA_CHAO", "S_DEMON"]
       },
       "flavor": {
         "ja": "カオスの達人で、ログルスを操る能力により恐れられている。",
@@ -27184,12 +26337,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "HOLD",
-          "SCARE",
-          "CAUSE_2",
-          "DARKNESS"
-        ]
+        "list": ["HOLD", "SCARE", "CAUSE_2", "DARKNESS"]
       },
       "flavor": {
         "ja": "それは実体を持った悪夢のような幽霊だ。",
@@ -27319,13 +26467,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SLOW",
-          "CONF",
-          "SCARE",
-          "BR_DISE",
-          "BR_CHAO"
-        ]
+        "list": ["SLOW", "CONF", "SCARE", "BR_DISE", "BR_CHAO"]
       },
       "flavor": {
         "ja": "カオスの力で歪んだドラゴンだ。それは一見すると醜いようだが、眼前で刻々と輝きながら変化する姿は独特の美しさを持っている。",
@@ -27391,13 +26533,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SLOW",
-          "CONF",
-          "SCARE",
-          "BR_SOUN",
-          "BR_SHAR"
-        ]
+        "list": ["SLOW", "CONF", "SCARE", "BR_SOUN", "BR_SHAR"]
       },
       "flavor": {
         "ja": "このドラゴンは頭が良くてずる賢い。攻撃をされても、ものともせずにせせら笑っている。",
@@ -27538,13 +26674,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SLOW",
-          "CONF",
-          "SCARE",
-          "BR_LITE",
-          "BR_DARK"
-        ]
+        "list": ["SLOW", "CONF", "SCARE", "BR_LITE", "BR_DARK"]
       },
       "flavor": {
         "ja": "精霊の力を持ったドラゴンで、光と影を自由に操ることができる。その白く輝く瞳は暗黒の者から恐れられている。",
@@ -27738,12 +26868,7 @@
       ],
       "skill": {
         "probability": "1_IN_15",
-        "list": [
-          "BLIND",
-          "HOLD",
-          "DRAIN_MANA",
-          "FORGET"
-        ]
+        "list": ["BLIND", "HOLD", "DRAIN_MANA", "FORGET"]
       },
       "flavor": {
         "ja": "ほとんど生き物のようだが、実は「ログルス」により作られた幻影にすぎない。",
@@ -27812,12 +26937,7 @@
       ],
       "skill": {
         "probability": "1_IN_15",
-        "list": [
-          "BLIND",
-          "HOLD",
-          "DRAIN_MANA",
-          "FORGET"
-        ]
+        "list": ["BLIND", "HOLD", "DRAIN_MANA", "FORGET"]
       },
       "flavor": {
         "ja": "幻のような泣き叫ぶ魂だ。その悲鳴を聞くと、純粋な邪悪がもたらす強烈な冷気が体の芯まで入り込んでくる。",
@@ -27955,9 +27075,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BO_FIRE"
-        ]
+        "list": ["BO_FIRE"]
       },
       "flavor": {
         "ja": "それは高くそびえ立つような火炎地獄だ。",
@@ -28107,9 +27225,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BO_COLD"
-        ]
+        "list": ["BO_COLD"]
       },
       "flavor": {
         "ja": "それは高くそびえ立つ水の竜巻だ。",
@@ -28173,13 +27289,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_ACID",
-          "BR_POIS",
-          "BR_COLD",
-          "BR_FIRE",
-          "BR_ELEC"
-        ]
+        "list": ["BR_ACID", "BR_POIS", "BR_COLD", "BR_FIRE", "BR_ELEC"]
       },
       "flavor": {
         "ja": "虹色に輝くこのハウンドは美しく、しかも非常に危険だ。",
@@ -28414,11 +27524,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "TPORT",
-          "BLINK",
-          "BA_CHAO"
-        ]
+        "list": ["TPORT", "BLINK", "BA_CHAO"]
       },
       "flavor": {
         "ja": "混沌の宮廷の女王ダラの息子で、ログルス使いである彼の心は復讐心で捻じ曲がっている。彼は復讐を果たすため魔法の儀式によって人間トランプとなった。”「どこでも移動できたとしても無意味だ」ジャスラは言った。「お前がどこにいても間抜けならね。」”（ロジャー・ゼラズニイ、アンバー８「混沌の徴」）",
@@ -28951,9 +28057,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BO_ACID"
-        ]
+        "list": ["BO_ACID"]
       },
       "flavor": {
         "ja": "それは岩でできたそびえ立つような姿をしていて、凄まじい力を持った拳が付いている。",
@@ -29017,9 +28121,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BO_ELEC"
-        ]
+        "list": ["BO_ELEC"]
       },
       "flavor": {
         "ja": "それはそびえ立つような風の竜巻だ。",
@@ -29086,9 +28188,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_FIRE"
-        ]
+        "list": ["BR_FIRE"]
       },
       "flavor": {
         "ja": "ドゥーム・ドレイクは訓練されたファイア・ドレイクで、常に対になって行動し獲物を求めている。",
@@ -29149,10 +28249,7 @@
       ],
       "skill": {
         "probability": "1_IN_12",
-        "list": [
-          "BR_ELEC",
-          "BR_FIRE"
-        ]
+        "list": ["BR_ELEC", "BR_FIRE"]
       },
       "flavor": {
         "ja": "羽の生えた、石の肌をした悪魔だ。",
@@ -29205,12 +28302,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLINK",
-          "TPORT",
-          "TELE_TO",
-          "CAUSE_1"
-        ]
+        "list": ["BLINK", "TPORT", "TELE_TO", "CAUSE_1"]
       },
       "flavor": {
         "ja": "この小さなモンスターの目は悪魔のように輝いている。",
@@ -29446,13 +28538,7 @@
       ],
       "skill": {
         "probability": "1_IN_15",
-        "list": [
-          "BLIND",
-          "DRAIN_MANA",
-          "SCARE",
-          "BO_COLD",
-          "FORGET"
-        ]
+        "list": ["BLIND", "DRAIN_MANA", "SCARE", "BO_COLD", "FORGET"]
       },
       "flavor": {
         "ja": "頭の無い幽霊のような姿だ。",
@@ -29523,13 +28609,7 @@
       ],
       "skill": {
         "probability": "1_IN_15",
-        "list": [
-          "BLIND",
-          "HOLD",
-          "CONF",
-          "DRAIN_MANA",
-          "BO_NETH"
-        ]
+        "list": ["BLIND", "HOLD", "CONF", "DRAIN_MANA", "BO_NETH"]
       },
       "flavor": {
         "ja": "それを見れば誰でも叫び声をあげたくなるような存在感を持っている。その恐ろしげな黒い体はまるで死が実体を持ったかのような姿で、この世の全ての秩序に反して無理矢理に存在しているかのようだ。",
@@ -29696,10 +28776,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "DARKNESS",
-          "BO_FIRE"
-        ]
+        "list": ["DARKNESS", "BO_FIRE"]
       },
       "flavor": {
         "ja": "それはそびえ立つような漆黒の塊で、熱で火花を上げている。",
@@ -29874,9 +28951,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_GRAV"
-        ]
+        "list": ["BR_GRAV"]
       },
       "flavor": {
         "ja": "重力の束縛から解放されたこの異常な生物は、壁や天井でさえもまるで床のように歩くことができる。このモンスターの周りで重力が歪んでいるのを見ると、大地も突然不安定なものに思えてくる。",
@@ -30008,9 +29083,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_INER"
-        ]
+        "list": ["BR_INER"]
       },
       "flavor": {
         "ja": "奇怪なことだが、この犬は全然動いていないように見えるにも関わらず、何故か恐ろしい勢いで近づいてくるのだ。それを見ているだけで疲労してくる。",
@@ -30068,9 +29141,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BR_FORC"
-        ]
+        "list": ["BR_FORC"]
       },
       "flavor": {
         "ja": "深い褐色の何かの形が目の前に浮かんでいる。その犬のような形があなたに触れるとあたかも物体が当たったかのような衝撃を受ける。それが\"歩く\"時、ダンジョンの床がまるで強い打撃を受けたようにへこむのが見える。",
@@ -30198,10 +29269,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BO_ACID",
-          "BA_ACID"
-        ]
+        "list": ["BO_ACID", "BA_ACID"]
       },
       "flavor": {
         "ja": "それはそびえ立つような汚物の塊で、見るも汚らわしいウーズだ。",
@@ -30265,10 +29333,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "SCARE",
-          "BR_ACID"
-        ]
+        "list": ["SCARE", "BR_ACID"]
       },
       "flavor": {
         "ja": "それはまさにこれから伝説を作らんとするかのような活力に満ちた姿をしている。まだ柔らかいその鱗は深い黒色をしている。体からは酸が滴り落ちている。",
@@ -30315,12 +29380,7 @@
           "damage_dice": "4d6"
         }
       ],
-      "flags": [
-        "BASH_DOOR",
-        "DROP_CORPSE",
-        "ANIMAL",
-        "RIDING"
-      ],
+      "flags": ["BASH_DOOR", "DROP_CORPSE", "ANIMAL", "RIDING"],
       "flavor": {
         "ja": "巨大な象のような姿で、その目は狂気に歪んでいる。",
         "en": "A massive elephantine form with eyes twisted by madness."
@@ -30430,10 +29490,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SCARE",
-          "BR_COLD"
-        ]
+        "list": ["SCARE", "BR_COLD"]
       },
       "flavor": {
         "ja": "大きなドラゴンで、微かにきらめく白色の鱗を持っている。",
@@ -30681,10 +29738,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "FORGET",
-          "MIND_BLAST"
-        ]
+        "list": ["FORGET", "MIND_BLAST"]
       },
       "flavor": {
         "ja": "ほとんど生き物のようだが、実は「パターン」により作られた幻影にすぎない。",
@@ -30749,12 +29803,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "HOLD",
-          "SCARE",
-          "CAUSE_3",
-          "DARKNESS"
-        ]
+        "list": ["HOLD", "SCARE", "CAUSE_3", "DARKNESS"]
       },
       "flavor": {
         "ja": "それは実体があるように見えるが、実際は灰色の霧でできた幽霊のようなものだ。その周りには死のような冷たさの大気が充満している。",
@@ -30813,9 +29862,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BO_FIRE"
-        ]
+        "list": ["BO_FIRE"]
       },
       "flavor": {
         "ja": "生ける者たちへ復讐するために墓から甦った亡霊だ。気味の悪い、背の高い骸骨の姿で壊れたプレートメイルを身につけている。",
@@ -30885,14 +29932,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SCARE",
-          "BR_ACID",
-          "BR_FIRE",
-          "BR_COLD",
-          "BR_ELEC",
-          "BR_POIS"
-        ]
+        "list": ["SCARE", "BR_ACID", "BR_FIRE", "BR_COLD", "BR_ELEC", "BR_POIS"]
       },
       "flavor": {
         "ja": "それはまさにこれから伝説を作らんとするかのような活力に満ちた姿をしている。全身が魔法のように美しく輝く鱗に覆われている。",
@@ -31078,10 +30118,7 @@
       ],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "SCARE",
-          "BR_SOUN"
-        ]
+        "list": ["SCARE", "BR_SOUN"]
       },
       "flavor": {
         "ja": "それはまさにこれから伝説を作らんとするかのような活力に満ちた姿をしている。まだ柔らかいその鱗は曇った金色をしていて、全身で光を反射している。",
@@ -31148,10 +30185,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SCARE",
-          "BR_ELEC"
-        ]
+        "list": ["SCARE", "BR_ELEC"]
       },
       "flavor": {
         "ja": "大きなドラゴンで、深く淡い青色の鱗を持っている。",
@@ -31217,10 +30251,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SCARE",
-          "BR_POIS"
-        ]
+        "list": ["SCARE", "BR_POIS"]
       },
       "flavor": {
         "ja": "大きなドラゴンで、深く淡い緑色の鱗を持っている。",
@@ -31282,11 +30313,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "CONF",
-          "SCARE",
-          "BR_CONF"
-        ]
+        "list": ["CONF", "SCARE", "BR_CONF"]
       },
       "flavor": {
         "ja": "大きなドラゴンで、豊かな青銅色の鱗を持っている。",
@@ -31352,10 +30379,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "SCARE",
-          "BR_FIRE"
-        ]
+        "list": ["SCARE", "BR_FIRE"]
       },
       "flavor": {
         "ja": "それはまさにこれから伝説を作らんとするかのような活力に満ちた姿をしている。まだ柔らかいその鱗は深い赤色をしていて、全身から熱を発している。",
@@ -31526,11 +30550,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BO_FIRE",
-          "BA_FIRE",
-          "S_DEMON"
-        ]
+        "list": ["BO_FIRE", "BA_FIRE", "S_DEMON"]
       },
       "flavor": {
         "ja": "それは火炎と憎悪によって作られた人間のような姿をしたモンスターだ。",
@@ -31631,11 +30651,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLINK",
-          "DARKNESS",
-          "S_DEMON"
-        ]
+        "list": ["BLINK", "DARKNESS", "S_DEMON"]
       },
       "flavor": {
         "ja": "昆虫のような四肢と大きな球状の眼を持つ醜い悪魔だ。",
@@ -31774,10 +30790,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BO_ICEE",
-          "BA_COLD"
-        ]
+        "list": ["BO_ICEE", "BA_COLD"]
       },
       "flavor": {
         "ja": "それはそびえ立つような氷河だ。",
@@ -32028,10 +31041,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "TELE_TO",
-          "S_KIN"
-        ]
+        "list": ["TELE_TO", "S_KIN"]
       },
       "flavor": {
         "ja": "混沌の貴族で、武術の達人として有名。正々堂々と戦うことを好む。",
@@ -32079,13 +31089,7 @@
           "damage_dice": "5d2"
         }
       ],
-      "flags": [
-        "FORCE_MAXHP",
-        "BASH_DOOR",
-        "EVIL",
-        "CAN_FLY",
-        "RES_CHAO"
-      ],
+      "flags": ["FORCE_MAXHP", "BASH_DOOR", "EVIL", "CAN_FLY", "RES_CHAO"],
       "flavor": {
         "ja": "一つの大きな眼球と二つの小さな眼柄を持っていて、その眼で睨み殺すことができる。",
         "en": "It has two eyestalks and a large central eye. Its gaze can kill."
@@ -32202,9 +31206,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BR_PLAS"
-        ]
+        "list": ["BR_PLAS"]
       },
       "flavor": {
         "ja": "素早く、危険なドラゴン型の生物だ。混沌の宮廷で暗殺のために飼育され訓練されている。「--あずき色の体、ステンドグラスのような翼。その姿は死の予感と共に獲物を狩るカマキリを思い出させた。刺のついた首輪と、短い毛皮からあらゆる方向に突き出した刺のような爪。それは希少で、危険で、高度な知性を持つ混沌の獣だった。」(ロジャー・ゼラズニイ, アンバー７「アンバーの血」)",
@@ -32336,10 +31338,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BR_CONF",
-          "BR_CHAO"
-        ]
+        "list": ["BR_CONF", "BR_CHAO"]
       },
       "flavor": {
         "ja": "「蝶に似ていたが、その翼で太陽までが暗くなるほどの大きさだった。…蝶の身体が人間で、孔雀色の羽根か羽毛でおおわれているのが見てとれた。」(マイクル・ムアコック、井辻朱美訳「白き狼の宿命」<エルリック・サーガ３>早川書房、p198)",
@@ -32394,10 +31393,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SLOW",
-          "BR_TIME"
-        ]
+        "list": ["SLOW", "BR_TIME"]
       },
       "flavor": {
         "ja": "あなたはまだそれを見たことがない。",
@@ -32462,9 +31458,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "BR_FORC"
-        ]
+        "list": ["BR_FORC"]
       },
       "flavor": {
         "ja": "「この種族の体は一部だけが物質... 翼はおろか、目に見える飛行手段は何もないのに、空を飛ぶ力を持っていた... 恐ろしいほど柔軟なことや一時的に姿を見えなくすることについて、あいまいなほのめかしがある...」(Ｈ・Ｐ・ラヴクラフト、大瀧啓裕訳「時間からの影」『ラヴクラフト全集３』、創元推理文庫、pp.242-244)",
@@ -32533,9 +31527,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "S_ANT"
-        ]
+        "list": ["S_ANT"]
       },
       "flavor": {
         "ja": "彼女は激怒しているが、それはあなたが彼女の子供を傷つけたからだ。",
@@ -32606,12 +31598,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BLINK",
-          "TPORT",
-          "CONF",
-          "CAUSE_2"
-        ]
+        "list": ["BLINK", "TPORT", "CONF", "CAUSE_2"]
       },
       "flavor": {
         "ja": "発光する奇妙な光球だ。それは消えたり現れたりしながら、冒険者を少しずつ引き寄せているようだ。その踊るような奇妙な動きをみていると、何故かじっとしていられなくなる。",
@@ -32651,14 +31638,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "CONF",
-          "HOLD",
-          "DRAIN_MANA",
-          "FORGET",
-          "MIND_BLAST",
-          "SHRIEK"
-        ]
+        "list": ["CONF", "HOLD", "DRAIN_MANA", "FORGET", "MIND_BLAST", "SHRIEK"]
       },
       "flavor": {
         "ja": "「憎悪をこめて睨みつける瞼のない巨大な目。頭から突き出している節のある巻きひげは、宇宙的なリズムを持った螺旋を描いているようだ。黒光りがする触毛が一杯生えている十本の脚。三角の鱗粉に覆われた、半円形の畝のある翅。どう言い表しても、突進して来るあのものの、魂も消し飛ぶばかりの恐ろしさを伝えることはとてもできない。ぬらぬらと濡れた、三つもある口が動くのが見えたと思うと同時に、それは襲いかかってきた」(Ｊ・ラムゼイ・キャンベル、山中清子訳「妖虫」『真ク・リトル・リトル神話大系９』、国書刊行会、pp.151-152)",
@@ -32719,10 +31699,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "BO_PLAS",
-          "BA_FIRE"
-        ]
+        "list": ["BO_PLAS", "BA_FIRE"]
       },
       "flavor": {
         "ja": "それは憎悪が溶けてできたような塊で光を発している。",
@@ -32892,9 +31869,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_NEXU"
-        ]
+        "list": ["BR_NEXU"]
       },
       "flavor": {
         "ja": "生命を持った魔法のエネルギーの竜巻だ。",
@@ -32949,9 +31924,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_PLAS"
-        ]
+        "list": ["BR_PLAS"]
       },
       "flavor": {
         "ja": "強烈な火炎の渦巻きで、冒険者の足下の床を焦がしている。",
@@ -33017,11 +31990,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "CONF",
-          "SCARE",
-          "BR_FIRE"
-        ]
+        "list": ["CONF", "SCARE", "BR_FIRE"]
       },
       "flavor": {
         "ja": "大きなドラゴンで、深く淡い赤色の鱗を持っている。",
@@ -33084,11 +32053,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "CONF",
-          "SCARE",
-          "BR_SOUN"
-        ]
+        "list": ["CONF", "SCARE", "BR_SOUN"]
       },
       "flavor": {
         "ja": "大きなドラゴンで、微かに金色に輝く鱗を持っている。",
@@ -33156,13 +32121,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "SLOW",
-          "CONF",
-          "SCARE",
-          "BLIND",
-          "BR_SHAR"
-        ]
+        "list": ["SLOW", "CONF", "SCARE", "BLIND", "BR_SHAR"]
       },
       "flavor": {
         "ja": "奇妙な水晶のようなドラゴンだ。光が屈折して輝いてできる虹のような色が冒険者の目を眩ませる。",
@@ -33228,10 +32187,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SCARE",
-          "BR_ACID"
-        ]
+        "list": ["SCARE", "BR_ACID"]
       },
       "flavor": {
         "ja": "大きなドラゴンで、漆黒の鱗を持っている。",
@@ -33457,14 +32413,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "S_KIN",
-          "S_DEMON",
-          "BO_WATE",
-          "BA_WATE",
-          "BO_ACID",
-          "BA_ACID"
-        ]
+        "list": ["S_KIN", "S_DEMON", "BO_WATE", "BA_WATE", "BO_ACID", "BA_ACID"]
       },
       "flavor": {
         "ja": "ディープワンがサイズ・年齢の面で大きく成長したもの。並外れて大きな体を持ち、下半身は脚が退化して魚のようになっている。年齢は何百万歳にもなると考えられている。深きものどもの王：「単眼巨人ポリュフェーモスを思わせるその忌まわしい巨体は、悪夢にあらわれる途方もない怪物のように...」(Ｈ・Ｐ・ラヴクラフト、大瀧啓裕訳「ダゴン」『ラヴクラフト全集３』、創元推理文庫、pp.16)",
@@ -33613,13 +32562,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BLIND",
-          "SCARE",
-          "CAUSE_3",
-          "BO_NETH",
-          "S_MONSTERS"
-        ]
+        "list": ["BLIND", "SCARE", "CAUSE_3", "BO_NETH", "S_MONSTERS"]
       },
       "flavor": {
         "ja": "それは古代の鎧に身を包んだ人間だ。その兜の下には悪意に満ちた目が輝き、その視線が火炎の槍のように突き刺さってくる。",
@@ -33750,9 +32693,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_TIME"
-        ]
+        "list": ["BR_TIME"]
       },
       "flavor": {
         "ja": "かつてそれに会ったことはない。",
@@ -33800,10 +32741,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BR_LITE",
-          "SHRIEK"
-        ]
+        "list": ["BR_LITE", "SHRIEK"]
       },
       "flavor": {
         "ja": "輝く光が柱状になったモンスターで、その眩しさは目にダメージを与える。風を切り裂いて動き回るにつれて、刻々と姿を変化させている。それはのろし火のように辺りのモンスターを眠りから目覚めさせる。",
@@ -33870,12 +32808,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_ELEC"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_ELEC"]
       },
       "flavor": {
         "ja": "巨大なドラゴンで、全身が稲妻で覆われている。",
@@ -33935,12 +32868,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_CONF"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_CONF"]
       },
       "flavor": {
         "ja": "色の流れに身を包まれた巨大なドラゴンだ。",
@@ -34086,12 +33014,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "HOLD",
-          "SCARE",
-          "CAUSE_3",
-          "BO_NETH"
-        ]
+        "list": ["HOLD", "SCARE", "CAUSE_3", "BO_NETH"]
       },
       "flavor": {
         "ja": "この亡霊が生み出す悪夢に囚われたら最期、あなたは永遠に目覚めることはないだろう。",
@@ -34248,10 +33171,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BO_PLAS",
-          "BA_FIRE"
-        ]
+        "list": ["BO_PLAS", "BA_FIRE"]
       },
       "flavor": {
         "ja": "そびえ立つ炎のエレメンタルで、全てを見分けがつかないまでに焼き尽くす。",
@@ -34322,13 +33242,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "BLIND",
-          "HOLD",
-          "SCARE",
-          "CAUSE_3",
-          "BO_NETH"
-        ]
+        "list": ["BLIND", "HOLD", "SCARE", "CAUSE_3", "BO_NETH"]
       },
       "flavor": {
         "ja": "影をまとった人間のような姿で、真空でできているかのような奇妙な外見をしている。それは冒険者の方に手をさしのべている。",
@@ -34389,11 +33303,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "BLIND",
-          "CONF",
-          "BO_FIRE"
-        ]
+        "list": ["BLIND", "CONF", "BO_FIRE"]
       },
       "flavor": {
         "ja": "「愕然とさせられる異様な黒い生物で、体表のすべらかでてらてらしているところは鯨に似て、不快な角はたがいにむかいあって湾曲し、蝙蝠の翼は音もなくはばたき、ものをつかめる手は醜く、針毛突起のある尾は不穏にもいたずらにうち震えるのだった。そして最悪なのは、言葉を発しもしなければ笑い声をあげもしないことで、微笑すらうかべないのは、笑いをうかべる顔というものがなく、顔があるべきところに意味ありげな空白があるばかりだからに他ならない」(Ｈ・Ｐ・ラヴクラフト、大瀧啓裕訳「未知なるカダスを夢に求めて」『ラヴクラフト全集６』、創元推理文庫、p.217)",
@@ -34457,9 +33367,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BO_PLAS"
-        ]
+        "list": ["BO_PLAS"]
       },
       "flavor": {
         "ja": "山羊の頭を持つ低位の魔王で、簡単には倒せない。",
@@ -34530,12 +33438,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_POIS",
-          "BR_FIRE",
-          "SCARE",
-          "CONF"
-        ]
+        "list": ["BR_POIS", "BR_FIRE", "SCARE", "CONF"]
       },
       "flavor": {
         "ja": "奇怪な爬虫類の混合生物で、毒液を滴らせる６つの頭と12本の脚を持つ。",
@@ -34841,11 +33744,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "SCARE",
-          "BA_POIS",
-          "BR_POIS"
-        ]
+        "list": ["SCARE", "BA_POIS", "BR_POIS"]
       },
       "flavor": {
         "ja": "毒を滴らす七つの首を持った奇妙な雑種の爬虫類だ。",
@@ -34928,12 +33827,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BO_ICEE",
-          "BO_WATE",
-          "BA_COLD",
-          "BA_WATE"
-        ]
+        "list": ["BO_ICEE", "BO_WATE", "BA_COLD", "BA_WATE"]
       },
       "flavor": {
         "ja": "玉座に一人の女が座っていた。その髪はところどころに銀色のまじった緑色だった。その目は翡翠の月のようにまん丸く、その眉はオリーブ色のかもめの翼のように高く弧を描いていた。口は小さく、顎も小さく、頬は高く広く、丸かった。白金の飾り環がその眉を横切り、水晶のネックレスがその首に垂れ、その先のサファイヤが、露出した美しい乳房の間できらめいていた。乳首も緑色をしていた。青い鱗の半ズボンに、銀色のベルト。右手にピンク色の珊瑚の王笏。それぞれの指に、それぞれ色合いの異なる青い石のはまった指輪。彼女は口をきく時、笑顔を見せなかった。（ロジャー・ゼラズニイ、岡部宏之訳「アンバーの九王子」早川書房、p.131）",
@@ -35090,12 +33984,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_COLD"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_COLD"]
       },
       "flavor": {
         "ja": "巨大なドラゴンで、頭の先から爪の先まで冷気に覆われている。",
@@ -35161,12 +34050,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_POIS"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_POIS"]
       },
       "flavor": {
         "ja": "毒の霧に身を包んだ巨大なドラゴンだ。",
@@ -35583,12 +34467,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_ACID"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_ACID"]
       },
       "flavor": {
         "ja": "巨大なドラゴンで、滴る酸が池のようになって周りの床を溶かしている。",
@@ -35647,11 +34526,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_CHAO",
-          "BR_NEXU",
-          "BR_NUKE"
-        ]
+        "list": ["BR_CHAO", "BR_NEXU", "BR_NUKE"]
       },
       "flavor": {
         "ja": "渦巻く螺旋状の霧で、常に形を変えている。",
@@ -36084,11 +34959,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BLINK",
-          "TPORT",
-          "S_UNDEAD"
-        ]
+        "list": ["BLINK", "TPORT", "S_UNDEAD"]
       },
       "flavor": {
         "ja": "それは死と退廃の悪臭を振りまく、脈動する肉塊だ。",
@@ -36156,12 +35027,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "HEAL",
-          "TELE_TO",
-          "SCARE",
-          "S_MONSTERS"
-        ]
+        "list": ["HEAL", "TELE_TO", "SCARE", "S_MONSTERS"]
       },
       "flavor": {
         "ja": "それは力と憎悪のオーラを発散する、背丈が 10 メートル近くある人間型のモンスターだ。",
@@ -36230,11 +35096,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "SCARE",
-          "BO_FIRE",
-          "BR_FIRE"
-        ]
+        "list": ["SCARE", "BO_FIRE", "BR_FIRE"]
       },
       "flavor": {
         "ja": "煙を立ち昇らせる九つの首を持った奇妙な雑種の爬虫類だ。",
@@ -36294,10 +35156,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BLIND",
-          "S_DRAGON"
-        ]
+        "list": ["BLIND", "S_DRAGON"]
       },
       "flavor": {
         "ja": "この逃げ足の速い女性の魔術師はドラゴンに特別に好かれており、常にドラゴンと一緒に戦う。",
@@ -36622,12 +35481,7 @@
           "damage_dice": "2d6"
         }
       ],
-      "flags": [
-        "BASH_DOOR",
-        "DROP_SKELETON",
-        "DROP_CORPSE",
-        "EVIL"
-      ],
+      "flags": ["BASH_DOOR", "DROP_SKELETON", "DROP_CORPSE", "EVIL"],
       "flavor": {
         "ja": "それは人間と雄牛の混血したモンスターだ。",
         "en": "It is a cross between a human and a bull."
@@ -36779,12 +35633,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "SLOW",
-          "CONF",
-          "SCARE",
-          "BR_NETH"
-        ]
+        "list": ["SLOW", "CONF", "SCARE", "BR_NETH"]
       },
       "flavor": {
         "ja": "それは暗黒に包まれたドラゴンのようなモンスターだ。その真の姿を把握することはできないが、その邪悪な気は感じとることができる。",
@@ -36851,12 +35700,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_FIRE"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_FIRE"]
       },
       "flavor": {
         "ja": "巨大なドラゴンで、その鼻孔から立ち昇る幾筋もの煙と、辺りに充満する高熱で息が苦しくなる。",
@@ -36921,12 +35765,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_SOUN"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_SOUN"]
       },
       "flavor": {
         "ja": "後光に身を包まれた巨大なドラゴンだ。",
@@ -36996,12 +35835,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "SLOW",
-          "CONF",
-          "SCARE",
-          "BR_SHAR"
-        ]
+        "list": ["SLOW", "CONF", "SCARE", "BR_SHAR"]
       },
       "flavor": {
         "ja": "巨大な水晶のようなドラゴンだ。それは一歩動く度に硝子の擦れ合うような不快な音と、幻惑的な光を辺り一面に満ちさせる。",
@@ -37058,13 +35892,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BLIND",
-          "S_DEMON",
-          "CONF",
-          "SCARE",
-          "DARKNESS"
-        ]
+        "list": ["BLIND", "S_DEMON", "CONF", "SCARE", "DARKNESS"]
       },
       "flavor": {
         "ja": "この年老いたしわくちゃ婆はカオスの魔女だと噂されている...しかし君は魔女なんか信じていないんだろう？",
@@ -37124,10 +35952,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BLIND",
-          "CONF"
-        ]
+        "list": ["BLIND", "CONF"]
       },
       "flavor": {
         "ja": "二本の棍棒を乱暴に振り回す悪魔だ。",
@@ -37192,14 +36017,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "CAUSE_3",
-          "FORGET",
-          "S_DEMON"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "CAUSE_3", "FORGET", "S_DEMON"]
       },
       "flavor": {
         "ja": "それは小さな背丈のデーモンだ。その動きは硬い体からは想像もつかない電光石火のスピードで、その力は死と破壊の竜巻を巻き起こす。",
@@ -37264,10 +36082,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BR_NUKE",
-          "BA_WATE"
-        ]
+        "list": ["BR_NUKE", "BA_WATE"]
       },
       "flavor": {
         "ja": "超巨大な鯨のミュータントで、陸を歩く二本の足を発達させている。",
@@ -37495,11 +36310,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "SCARE",
-          "BA_NUKE",
-          "BLIND"
-        ]
+        "list": ["SCARE", "BA_NUKE", "BLIND"]
       },
       "flavor": {
         "ja": "魔法の突然変異により創られた、首のない忌まわしいヒューマノイドだ。",
@@ -37961,11 +36772,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BO_FIRE",
-          "S_DEMON",
-          "CONF"
-        ]
+        "list": ["BO_FIRE", "S_DEMON", "CONF"]
       },
       "flavor": {
         "ja": "大きな翼を持つグロテスクな生物。「ハスター」に奉仕しており、宇宙空間を高速で飛翔する能力を持つ。頭部、胸部、腹部という昆虫のような体をしており、胸部と腹部から二本ずつ脚が生えている。腹部は飛行の為の常磁性器官フーンが大部分を占めている。うるさい音を立てる活動的な怪物で、どんな時もキーキーと金切り声を上げている。獲物に忍び寄る時以外は、大体音を立てているようだ。脚はかなりしっかりした作りをしているが、ほとんど歩くということは無く、常時飛行している。「訓練をうけた従順な有翼の雑種生物が、群をなし、なめらかに翼をはためかせてやってきたのだ。烏でもなく、土龍でもなく、禿鷹にあらず、蟻にあらず、吸血蝙蝠ともちがい、腐れただれた人間ともちがい、わたしには思いだせない、思いだしてはならないものだった」(Ｈ・Ｐ・ラヴクラフト、大瀧啓裕訳「魔宴」『ラヴクラフト全集５』、創元推理文庫、pp.67)",
@@ -38040,12 +36847,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "CAUSE_3",
-          "BO_WATE",
-          "BO_MANA",
-          "BA_CHAO"
-        ]
+        "list": ["CAUSE_3", "BO_WATE", "BO_MANA", "BA_CHAO"]
       },
       "flavor": {
         "ja": "かの狂人の息子はログルス使いで、父親と同じくらい危険だ。",
@@ -38206,13 +37008,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BO_FIRE",
-          "BO_ACID",
-          "S_DEMON",
-          "MIND_BLAST",
-          "DARKNESS"
-        ]
+        "list": ["BO_FIRE", "BO_ACID", "S_DEMON", "MIND_BLAST", "DARKNESS"]
       },
       "flavor": {
         "ja": "「そいつらは石の通路に這いつくばって... だがしかし、そいつらはツァトゥガにさえ似てなかった。恐るべし、像を崇めていたのは、不定形の黒いねばねばした塊だったのだ」(ゼリア・ビショップ、渡辺健一郎訳「俘囚の塚」『真ク・リトル・リトル神話大系１０』、国書刊行会、p.163)",
@@ -38279,12 +37075,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BLIND",
-          "CONF",
-          "S_DEMON",
-          "BR_DARK"
-        ]
+        "list": ["BLIND", "CONF", "S_DEMON", "BR_DARK"]
       },
       "flavor": {
         "ja": "体長約１２メートル程の、コウモリのような翼を持つ、巨大な黒い蛇か芋虫に似た生き物。翼が１枚のものと、２枚のものの２種類が存在する。体の形は常に変化して捻じれたりくねったりしている。彼らは我々の住む次元と隣接した次元との間に存在している。素早く動き回り、大きな喉声を発して会話する。非常に高い知性を持っており、人間の言葉を話す事も出来るようだ。強い光に弱く、太陽光から逃れる習性がある。日中ではせいぜい２、３時間しか耐えられない。ナイアルラトホテップによく仕え、猟犬として活躍する事が多い。（ダーレス「暗黒の儀式」）",
@@ -38430,9 +37221,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BO_NETH"
-        ]
+        "list": ["BO_NETH"]
       },
       "flavor": {
         "ja": "ぼんやりとした人間のような姿をした強力な暗黒の精霊だ。滑るように近づいては、その剃刀のような爪で冒険者の生命を奪い、力を得るためにその魂を吸い取る。",
@@ -38588,13 +37377,7 @@
       ],
       "skill": {
         "probability": "1_IN_15",
-        "list": [
-          "BLIND",
-          "HOLD",
-          "CONF",
-          "DRAIN_MANA",
-          "BO_NETH"
-        ]
+        "list": ["BLIND", "HOLD", "CONF", "DRAIN_MANA", "BO_NETH"]
       },
       "flavor": {
         "ja": "それを見れば誰でも叫び声をあげたくなるような存在感を持っている。その恐ろしげな黒い体はまるで死が実体を持ったかのような姿で、この世の全ての秩序に反して無理矢理に存在しているかのようだ。",
@@ -38665,11 +37448,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BR_POIS",
-          "BR_DARK",
-          "BR_NETH"
-        ]
+        "list": ["BR_POIS", "BR_DARK", "BR_NETH"]
       },
       "flavor": {
         "ja": "大型のバシリスクで、古代ドラゴンに似た姿をしている。",
@@ -38738,9 +37517,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BA_WATE"
-        ]
+        "list": ["BA_WATE"]
       },
       "flavor": {
         "ja": "深海の怪物で、その貪欲な口は数え切れないほどの船乗り達に引導を渡してきた。",
@@ -38817,13 +37594,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BLIND",
-          "HEAL",
-          "BA_DARK",
-          "HASTE",
-          "CONF"
-        ]
+        "list": ["BLIND", "HEAL", "BA_DARK", "HASTE", "CONF"]
       },
       "artifacts": [
         {
@@ -38896,10 +37667,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "SHRIEK",
-          "S_HOUND"
-        ]
+        "list": ["SHRIEK", "S_HOUND"]
       },
       "flavor": {
         "ja": "厄介なゼファーハウンド達を支配するアンデッドだ。",
@@ -39012,13 +37780,7 @@
           "damage_dice": "4d6"
         }
       ],
-      "flags": [
-        "FRIENDS",
-        "DROP_CORPSE",
-        "BASH_DOOR",
-        "ANIMAL",
-        "RIDING"
-      ],
+      "flags": ["FRIENDS", "DROP_CORPSE", "BASH_DOOR", "ANIMAL", "RIDING"],
       "flavor": {
         "ja": "巨大な象のような姿で、その目は狂気に歪んでいる。",
         "en": "A massive elephantine form with eyes twisted by madness."
@@ -39251,13 +38013,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLIND",
-          "CONF",
-          "BR_LITE",
-          "BR_DARK",
-          "BR_CONF"
-        ]
+        "list": ["BLIND", "CONF", "BR_LITE", "BR_DARK", "BR_CONF"]
       },
       "flavor": {
         "ja": "精霊界から来た光輝く巨大なドラゴンである天上界ドラゴンは光と闇の支配者だ。それは異質な世界の影で体を覆って、その存在を消滅させる。",
@@ -39327,12 +38083,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BLIND",
-          "CAUSE_2",
-          "S_DEMON",
-          "HEAL"
-        ]
+        "list": ["BLIND", "CAUSE_2", "S_DEMON", "HEAL"]
       },
       "flavor": {
         "ja": "３～６メートルの、のたうつ巨大な塊であり、ロープのような黒い触肢で形作られている。塊の表面にはシワの寄ったいくつもの大きな口がついており、緑色の涎を垂らしている。樹幹のような足には蹄があり、棺桶を開いた時のような臭いを発している。黒い仔山羊は「シュブ＝ニグラス」の千匹の仔に当たる生き物である。「道にいる黒いものは木じゃなかった。なにか黒くて大きいものが、ロープのような腕をいっぱいくねらせて伸ばしながら、じっとうずくまって待ちかまえていた... 丘をのぼってきた... ぼくの夢に出てきた黒いものだった―森から出てくるまっ黒のねばねばしたゼリーみたいな木のばけもんだ。そいつは腹ばってきたけど、ひづめと口と蛇みたいな腕をつかって、すべるように進んでいた」(ロバート・ブロック、三宅初江訳「無人の家で発見された手記」『クトゥルー１』、青心社文庫、pp.199-200、p.201、pp.202-203)",
@@ -39401,12 +38152,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "DRAIN_MANA",
-          "BR_DISE",
-          "BR_NETH",
-          "TPORT"
-        ]
+        "list": ["DRAIN_MANA", "BR_DISE", "BR_NETH", "TPORT"]
       },
       "flavor": {
         "ja": "「異次元の色彩」は外宇宙から飛来した、知覚力のある有機体だが、純粋な色として出現する。気体ではなく、非物質的な存在である。無定型のキラキラ輝く色の断片として知覚される。我々が知っているスペクトルとは異なる、奇妙な色合いでチカチカと明滅する。地面の上を流れるように移動したり、空を飛んだりする。非物質的で実態はないが、「色」に触れるとネバネバした不健康な蒸気に触れたような感じがする。強い光を嫌い、日中は暗くて涼しい隠れ家に身を潜めている。「井戸からもれる燐光は... もはや輝いているのではなかった。ほとばしっているのだ。そしていいようもない色の無定形の流れは井戸を離れると、直接空に昇っていくように見えた」(Ｈ・Ｐ・ラヴクラフト、大瀧啓裕訳「宇宙からの色」『ラヴクラフト全集４』、創元推理文庫、p.44)",
@@ -39483,10 +38229,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BO_ACID",
-          "BA_ACID"
-        ]
+        "list": ["BO_ACID", "BA_ACID"]
       },
       "flavor": {
         "ja": "塔のように眼前に立ちふさがる石の精霊だ。クェイカーが近づくと壁や天井は砕けて岩石となってしまう。",
@@ -39544,13 +38287,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLINK",
-          "TPORT",
-          "TELE_TO",
-          "CAUSE_3",
-          "ANIM_DEAD"
-        ]
+        "list": ["BLINK", "TPORT", "TELE_TO", "CAUSE_3", "ANIM_DEAD"]
       },
       "flavor": {
         "ja": "やっかいな小型のアンデッドだ。彼らは自分たちを造った邪悪な魔法使いの名を連呼している。「ブルース！ブルース！…」",
@@ -39787,12 +38524,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "HEAL",
-          "TELE_TO",
-          "S_KIN",
-          "BR_COLD"
-        ]
+        "list": ["HEAL", "TELE_TO", "S_KIN", "BR_COLD"]
       },
       "flavor": {
         "ja": "北欧神話のフロスト・ジャイアントの首領で、巨人にしてはとても頭がいい。その魔力でトールやロキらの一行を翻弄したこともある。",
@@ -39858,12 +38590,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BR_TIME",
-          "SLOW",
-          "HASTE",
-          "HEAL"
-        ]
+        "list": ["BR_TIME", "SLOW", "HASTE", "HEAL"]
       },
       "flavor": {
         "ja": "子供ぐらいの大きさの、人間型のミイラのような姿をしている。体中皺だらけで、１度も呼吸したことが無い中絶胎児のようである。手の先には骨のような鉤爪がついており、腕は常に真っ直ぐ前に伸ばされている。時間と死と崩壊の神。上空からの灰色の光の柱から姿を現わし、触れた相手に老化と死を与える。犠牲者の体は最終的には塵の山となってしまい、クァチル・ウタウスはそこに足跡だけを残していく。（スミス「塵を踏むもの」）",
@@ -40099,11 +38826,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BO_ELEC",
-          "BA_COLD",
-          "BA_ELEC"
-        ]
+        "list": ["BO_ELEC", "BA_COLD", "BA_ELEC"]
       },
       "flavor": {
         "ja": "そびえ立つような風の精霊である魔法使いアリエルは、その卓越したスピードで冒険者の攻撃を巧みにかわす。",
@@ -40168,13 +38891,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "SCARE",
-          "BO_FIRE",
-          "BO_PLAS",
-          "BA_FIRE",
-          "BR_FIRE"
-        ]
+        "list": ["SCARE", "BO_FIRE", "BO_PLAS", "BA_FIRE", "BR_FIRE"]
       },
       "flavor": {
         "ja": "煙を発する十一の首を持った、奇妙な雑種の爬虫類だ。",
@@ -40401,12 +39118,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLIND",
-          "SLOW",
-          "CONF",
-          "BR_POIS"
-        ],
+        "list": ["BLIND", "SLOW", "CONF", "BR_POIS"],
         "shoot": "5d8"
       },
       "flavor": {
@@ -40477,11 +39189,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "CONF",
-          "CAUSE_3",
-          "BR_COLD"
-        ]
+        "list": ["CONF", "CAUSE_3", "BR_COLD"]
       },
       "flavor": {
         "ja": "太古の賢明なるドラゴンであるスカサは、長い年月を通してその知能に磨きをかけてきた。彼の鱗は冷気で覆われていて、そのブレスは空気中に氷のシャワーをまき散らす。",
@@ -40776,12 +39484,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "SCARE",
-          "HOLD",
-          "DRAIN_MANA",
-          "BR_NETH"
-        ]
+        "list": ["SCARE", "HOLD", "DRAIN_MANA", "BR_NETH"]
       },
       "flavor": {
         "ja": "背の高い黒ずくめの指輪の幽鬼で、恐怖のオーラを発している。「かれらの蒼白い顔には鋭い無慈悲な目が燃えていました。黒いマントの下には灰色の長衣をまとっていました。灰色の顔には銀のかぶとがかぶせられていました。やせさらばえた手には鋼の剣が握られていました。」（J.R.R.トールキン、瀬田貞二・田中明子訳 新版指輪物語） ",
@@ -40854,11 +39557,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "CONF",
-          "CAUSE_3",
-          "BR_FIRE"
-        ]
+        "list": ["CONF", "CAUSE_3", "BR_FIRE"]
       },
       "flavor": {
         "ja": "スマウグはウルローキの生き残りの一匹であり、信じ難たいずる賢さと知能をそなえたファイア・ドレイクだ。空を飛ぶスピードはドラゴンの中でも秀でており、その火炎のブレスは伝説的ですらある。",
@@ -41009,9 +39708,7 @@
       ],
       "skill": {
         "probability": "1_IN_12",
-        "list": [
-          "HEAL"
-        ]
+        "list": ["HEAL"]
       },
       "flavor": {
         "ja": "彼らは善なる目的のため闘う。あなたは悪の手先と見なされているようだ。",
@@ -41057,11 +39754,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLINK",
-          "TPORT",
-          "TELE_TO"
-        ]
+        "list": ["BLINK", "TPORT", "TELE_TO"]
       },
       "flavor": {
         "ja": "目的のためなら死をも恐れないレプラコーンだ。爆弾を持ってテロ攻撃を行なう...",
@@ -41139,12 +39832,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "CONF",
-          "SCARE",
-          "BR_COLD",
-          "BR_NETH"
-        ]
+        "list": ["CONF", "SCARE", "BR_COLD", "BR_NETH"]
       },
       "flavor": {
         "ja": "朽ち果てたドラゴンの骨に邪悪な魔法が宿ったモンスターだ。それは命あるものの魂を吸いながらさまよい歩いている。",
@@ -41213,11 +39901,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "HEAL",
-          "TELE_TO",
-          "S_MONSTERS"
-        ]
+        "list": ["HEAL", "TELE_TO", "S_MONSTERS"]
       },
       "flavor": {
         "ja": " 12 メートルもの身長がある人間型のモンスターで、歩くだけで大地が揺れる。全身から立ち昇る力のオーラは冒険者の勇気を打ち砕こうとするかのようだ。冒険者が挑みかかると彼の憎悪は一層燃え上がる。",
@@ -41290,13 +39974,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "HOLD",
-          "SCARE",
-          "BR_FIRE",
-          "BR_POIS",
-          "BR_NETH"
-        ]
+        "list": ["HOLD", "SCARE", "BR_FIRE", "BR_POIS", "BR_NETH"]
       },
       "flavor": {
         "ja": "翼のあるバシリスクだ。その身体に蓄えた邪悪な毒と力を見せつけるべく虎視眈々と冒険者を狙っている。",
@@ -41367,10 +40045,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_FIRE",
-          "BR_ACID"
-        ]
+        "list": ["BR_FIRE", "BR_ACID"]
       },
       "flavor": {
         "ja": "巨大な水棲のドラゴンで、その甲羅は小さな島ほどの大きさがある。ドラゴン亀と呼んでいる者達もいる。",
@@ -41441,13 +40116,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "HOLD",
-          "SCARE",
-          "BR_NEXU",
-          "BR_POIS",
-          "BR_NETH"
-        ]
+        "list": ["HOLD", "SCARE", "BR_NEXU", "BR_POIS", "BR_NETH"]
       },
       "flavor": {
         "ja": "非常に危険なアンデッドで、不気味な緑色の光に包まれたティラノサウルスの骸骨のようだ。",
@@ -41811,11 +40480,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "CONF",
-          "CAUSE_3",
-          "BR_FIRE"
-        ]
+        "list": ["CONF", "CAUSE_3", "BR_FIRE"]
       },
       "flavor": {
         "ja": "古代の屈強なドラゴンであるイタンガストは、そこに立っているだけでも冒険者の肉体を焦がしてしまうほどの熱気を帯びている。彼が冒険者を軽蔑的な眼差しで見つめるとき、その鼻孔からは幾筋もの煙が吹き上がる。",
@@ -41953,13 +40618,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BR_FIRE",
-          "BR_POIS",
-          "SCARE",
-          "CAUSE_3",
-          "CONF"
-        ]
+        "list": ["BR_FIRE", "BR_POIS", "SCARE", "CAUSE_3", "CONF"]
       },
       "flavor": {
         "ja": "北欧神話の強大な竜であるファフナーは元々巨人だったが、自分の兄弟を殺して財宝を手に入れ、自ら竜に変身して財宝を貪欲に見張るようになった。",
@@ -42089,14 +40748,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "S_DEMON",
-          "SHRIEK",
-          "CONF",
-          "SCARE",
-          "MIND_BLAST",
-          "BLIND"
-        ]
+        "list": ["S_DEMON", "SHRIEK", "CONF", "SCARE", "MIND_BLAST", "BLIND"]
       },
       "flavor": {
         "ja": "中国のツァン高原の地下にある、死滅した都市アラオザルに棲む２匹の怪物。盛り上がった肉塊に、無数の触手が生えており、「ホゥーホゥー」という吼え声を発している。ツァールは２つの体を持っているのか、触手で繋がっているのか、定かではない。「不気味な緑色の薄闇のなかにうずくまっているものは、慄然たる恐怖にみなぎる生ける塊、感覚をもって震える凶まがしい肉の山であって、その触腕が地下洞窟のいたるところに長ながとのばされ、異様な唸るような音を発している一方、生物の体のなかからは蕭然たる音が発せられていたからだった」(オーガスト・ダーレス＆マーク・スコラー、後藤敏夫訳「潜伏するもの」『クトゥルー８』、青心社文庫、p.154)",
@@ -42168,12 +40820,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "CONF",
-          "CAUSE_3",
-          "BR_FIRE",
-          "S_DRAGON"
-        ]
+        "list": ["CONF", "CAUSE_3", "BR_FIRE", "S_DRAGON"]
       },
       "flavor": {
         "ja": "グラウルングは全てのドラゴン族の祖であり、長きに渡って最強の座を誇っている。彼は自分の一族にはどんな命令でも与えることができ、好きなときに召喚することもできる。彼の吐く火炎こそが、本物のドラゴンの火炎なのである。",
@@ -42240,9 +40887,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BR_FIRE"
-        ]
+        "list": ["BR_FIRE"]
       },
       "flavor": {
         "ja": "巨大な海獣で、その表皮はほとんど貫通不能だ。",
@@ -42314,13 +40959,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BR_NETH",
-          "BR_COLD",
-          "BR_DARK",
-          "S_HOUND",
-          "S_UNDEAD"
-        ]
+        "list": ["BR_NETH", "BR_COLD", "BR_DARK", "S_HOUND", "S_UNDEAD"]
       },
       "flavor": {
         "ja": "ガルムは巨大な猟犬だ。心が捻じ曲がった者や臆病な死に方をした者の魂が罰を受けている地獄で何者も逃がさないように見張っている。",
@@ -42453,14 +41092,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "HOLD",
-          "BLINK",
-          "CONF",
-          "S_DEMON",
-          "BRAIN_SMASH",
-          "BR_NETH"
-        ]
+        "list": ["HOLD", "BLINK", "CONF", "S_DEMON", "BRAIN_SMASH", "BR_NETH"]
       },
       "flavor": {
         "ja": "禍々しく、頑強で、翼を持ち、角が生えた悪魔で、その爪は石の壁をも切り裂く。",
@@ -42765,10 +41397,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BO_PLAS",
-          "BA_FIRE"
-        ]
+        "list": ["BO_PLAS", "BA_FIRE"]
       },
       "flavor": {
         "ja": "破壊的な魔法の火器を持ち、ハンマーを装備した好戦的なミノタウロスだ。",
@@ -42828,9 +41457,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_NETH"
-        ]
+        "list": ["BR_NETH"]
       },
       "flavor": {
         "ja": "この野獣に相対すると魂が引き裂かれるような冷気を感じる。この暗黒のゴーストのようなモンスターは大きな犬の姿をしている。",
@@ -42890,9 +41517,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BR_TIME"
-        ]
+        "list": ["BR_TIME"]
       },
       "flavor": {
         "ja": "デジャヴのような感じを覚えるが、気のせいなのだろうか？一見すると小さな子犬か歯の抜けた老犬のようだ。それと戦うのは諦めてとっとと寝るべきだ。",
@@ -42955,9 +41580,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_PLAS"
-        ]
+        "list": ["BR_PLAS"]
       },
       "flavor": {
         "ja": "巨大な犬の姿をした純粋なエネルギーの塊だ。このモンスターが近づいてくると辺りの大気が歪みはじめる。冒険者の肉体は恐怖を察知して、髪の毛は逆立ち、手は汗ばんでくる。",
@@ -42998,11 +41621,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BLINK",
-          "TPORT",
-          "S_DEMON"
-        ]
+        "list": ["BLINK", "TPORT", "S_DEMON"]
       },
       "flavor": {
         "ja": "脈動する肉の塊で、その内部は地獄の業火に輝いている。この世界そのものがこのモンスターの存在を嫌悪しているように感じる。",
@@ -43075,12 +41694,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_ELEC"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_ELEC"]
       },
       "flavor": {
         "ja": "冥界で強大な力を蓄えて現世に舞い戻ってきたドラゴンだ。この竜一匹が生み出す電気は一つの街に一年中灯りを灯すことができる。",
@@ -43217,13 +41831,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "SLOW",
-          "BO_MANA",
-          "BO_PLAS",
-          "BA_ELEC",
-          "BR_FORC"
-        ],
+        "list": ["SLOW", "BO_MANA", "BO_PLAS", "BA_ELEC", "BR_FORC"],
         "shoot": "12d13"
       },
       "flavor": {
@@ -43372,10 +41980,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "TRAPS",
-          "S_KIN"
-        ]
+        "list": ["TRAPS", "S_KIN"]
       },
       "artifacts": [
         {
@@ -43968,12 +42573,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BLINK",
-          "TELE_TO",
-          "BR_NETH",
-          "BR_TIME"
-        ]
+        "list": ["BLINK", "TELE_TO", "BR_NETH", "BR_TIME"]
       },
       "flavor": {
         "ja": "恐ろしい姿をした四つ足の不死の動物。曲がりくねった舌を持ち、青い膿のような臭い嫌らしい粘液をダラダラと垂らしている。体液には酸素などを欠いており、我々の知る生物学とはまったく異質の原理で構成されている。宇宙の邪悪の全てが、痩せて飢えきった体に凝縮しているという。地球の遠い過去、普通の生命体がまだ進化していない時代に住んでいる。時間の「角」に生息しており、他の生き物が「曲線」を先祖としているのとは違っている。人間及び他の生き物の中にある何かを追い求めて、時空を超えて犠牲者を追いかける。時間の「角」と関係する為、部屋の隅などの１２０度以内の角度のある所から出現する。まず部屋の隅から煙が生じ、そこから頭が現われ、全体が姿を見せる。人間が一度でもティンダロスの猟犬と接触すると、猟犬はその人間を何処までも追いかけてくる。「やつらはやせて、渇いているんだ... 宇宙の邪悪のすべてが、やつらのやせて飢えきった体に凝縮していた。いや、やつらに体があったんだろうか。一瞬目にしただけだから、よくわからない」(フランク・ベルナップ・ロング、大瀧啓裕訳「ティンダロスの猟犬」『クトゥルー５』、青心社文庫、p.58)",
@@ -44130,12 +42730,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_COLD"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_COLD"]
       },
       "flavor": {
         "ja": "冥界で強大な力を蓄えて現世に舞い戻ってきたドラゴンだ。魂まで凍らされないように気をつけろ！",
@@ -44779,12 +43374,7 @@
       ],
       "skill": {
         "probability": "1_IN_1",
-        "list": [
-          "BO_MANA",
-          "BO_NETH",
-          "BA_NETH",
-          "S_UNDEAD"
-        ]
+        "list": ["BO_MANA", "BO_NETH", "BA_NETH", "S_UNDEAD"]
       },
       "flavor": {
         "ja": "それは宙に浮かぶ血走った目玉だ。無害だと思ったのも無理はないが…。",
@@ -44908,9 +43498,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_CHAO"
-        ]
+        "list": ["BR_CHAO"]
       },
       "flavor": {
         "ja": "空虚で実体を持たない破壊的な渦巻きだ。",
@@ -45349,12 +43937,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_FIRE"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_FIRE"]
       },
       "flavor": {
         "ja": "冥界で強大な力を蓄えて現世に舞い戻ってきたドラゴンだ。この激烈な炎の前では、あなたは生きていた証をこの世に残せないかもしれない！",
@@ -45563,11 +44146,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BLINK",
-          "TPORT",
-          "S_DRAGON"
-        ]
+        "list": ["BLINK", "TPORT", "S_DRAGON"]
       },
       "flavor": {
         "ja": "それはかつてはドラゴンの死骸だったようだが、今は魔法のバクテリアによって汚らしい堕落した方法で生を与えられている。",
@@ -46209,14 +44788,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_ACID",
-          "S_DRAGON",
-          "S_HI_DRAGON"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_ACID", "S_DRAGON", "S_HI_DRAGON"]
       },
       "flavor": {
         "ja": "「突進する顎」という名を持つこのドラゴンは、死を単なるゲームくらいにしか思っていない。グラウルングの一族のどんなドラゴンも彼には匹敵しない。",
@@ -47224,11 +45796,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "TELE_TO",
-          "HEAL",
-          "S_KIN"
-        ]
+        "list": ["TELE_TO", "HEAL", "S_KIN"]
       },
       "flavor": {
         "ja": "「美しさ―冷静さ―超然とした態度―落ち着き―尊大さ―飼い慣らし得ない支配者的風格―静かに滑るように歩む猫。このような完全無欠さの半分でも備えた生き物がほかにいるだろうか？」",
@@ -47293,10 +45861,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "CAUSE_4",
-          "BR_CHAO"
-        ]
+        "list": ["CAUSE_4", "BR_CHAO"]
       },
       "flavor": {
         "ja": "「わが子よ，ジャバーウォックに油断するなかれ！食らいつくその顎，かきむしるその爪！」",
@@ -47356,9 +45921,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_CHAO"
-        ]
+        "list": ["BR_CHAO"]
       },
       "flavor": {
         "ja": "絶えずその姿を変化させる犬のようなモンスターで、争乱と混乱を渇望しているかのように冒険者に突進してくる。それは戦闘に関してカミカゼ精神を持っていることは明らかだ。目に見えるその姿は常に疑わしいものがある。",
@@ -47681,14 +46244,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_CHAO",
-          "BR_DISE",
-          "S_DRAGON"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_CHAO", "BR_DISE", "S_DRAGON"]
       },
       "flavor": {
         "ja": "刻々とその姿を変化させる屈強なドラゴンだ。見る度に、美しかったり汚らわしかったりする。なんとか現実の姿を現そうとしているが、その体はカオスの力で歪んでいる。正にその存在自体が周りの世界を歪めている。",
@@ -47757,14 +46313,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_SOUN",
-          "BR_SHAR",
-          "S_DRAGON"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_SOUN", "BR_SHAR", "S_DRAGON"]
       },
       "flavor": {
         "ja": "高い知性を持った屈強なドラゴンだ。それは全世界を支配することを望んでおり、他の生命体を軽蔑しきっている。それは自分に従わない者はすべて足下に踏みつぶされるべき単なる虫けらだと思っている。",
@@ -47913,9 +46462,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BR_ELEC"
-        ]
+        "list": ["BR_ELEC"]
       },
       "flavor": {
         "ja": "このエレメンタルは力の化身だ。巨大な北極熊に似ていて、頭があるべき場所には大きな口が開いている。",
@@ -49217,11 +47764,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BLINK",
-          "TELE_TO",
-          "S_HI_DRAGON"
-        ]
+        "list": ["BLINK", "TELE_TO", "S_HI_DRAGON"]
       },
       "flavor": {
         "ja": "鱗が付いた強力な肉塊だ。それは脈動し、鼓動しながら様々な色に変化している。",
@@ -49263,11 +47806,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BLINK",
-          "TELE_TO",
-          "S_HI_UNDEAD"
-        ]
+        "list": ["BLINK", "TELE_TO", "S_HI_UNDEAD"]
       },
       "flavor": {
         "ja": "強力な腐った肉の塊だ。それが脈動し、身もだえすると吐き気を催すような悪臭が辺りに充満する。",
@@ -49685,14 +48224,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "HEAL",
-          "TPORT",
-          "TELE_TO",
-          "SCARE",
-          "BLIND",
-          "S_MONSTERS"
-        ]
+        "list": ["HEAL", "TPORT", "TELE_TO", "SCARE", "BLIND", "S_MONSTERS"]
       },
       "flavor": {
         "ja": "ジェラードは他のアンバーの王子に比べればそれほど心は捻じ曲がってないが、その力は他のアンバーの王子達が束になっても絶対にかなわない。「大きな強そうな男。まったくぼくと瓜二つだが、そいつの顎の方が重い。そして、こいつはぼくよりも大きいが、のろい、とぼくは知っている、こいつの力ときたら伝説の力士ほどもある。青と灰色の部屋着を羽織り腰のあたりを、幅の広い黒いベルトで留め、笑って立っている。首には重い紐で、銀の狩猟用のホルンをかけている。顎のへりと口のまわりに軽いひげ。右手にはワインのゴブレット。」（ロジャー・ゼラズニイ、岡部宏之訳「アンバーの九王子」早川書房、pp.47-48）",
@@ -50309,14 +48841,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BR_POIS",
-          "BR_NUKE",
-          "BR_ACID",
-          "S_HYDRA",
-          "S_KIN",
-          "S_DEMON"
-        ]
+        "list": ["BR_POIS", "BR_NUKE", "BR_ACID", "S_HYDRA", "S_KIN", "S_DEMON"]
       },
       "flavor": {
         "ja": "「半人半蛇の蛇の神... 中央平原の部族のあがめる蛇神イグは―もっと南方のケツァルコアトルやククルカンの祖形になったもののようだが―... なかば擬人化された奇妙な魔物であるらしい」(ゼリア・ビショップ、東谷真知子訳「イグの呪い」『クトゥルー７』、青心社文庫、p.231、pp.235-236)",
@@ -50406,9 +48931,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_CHAO"
-        ]
+        "list": ["BR_CHAO"]
       },
       "flavor": {
         "ja": "混沌の宮廷から召喚された、意識を持ったログルスの塊だ。無秩序に広がって全てを破壊していく。「…スヒュイは手をゆっくり離した。両手の間では黒い塊が沸騰し、さっきまで岩であった混沌とした場所から左右に伸びて、長く黒い溝を作った。そこには無でありかつ激しいというパラドクスがあった。彼はじっと立ち、黒い塊をその場に固定した。少し経って彼は言った。「こいつは解放して暴走させることができる。あるいは命令を与えてから解放することもできる。」 彼がそれ以上言わないので僕は尋ねた。「するとどうなるんだい？影の世界を完全に破壊しつくすまで広がり続けるのかい？」 （ロジャー・ゼラズニイ、アンバー７「アンバーの血」）",
@@ -50472,9 +48995,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "ROCKET"
-        ]
+        "list": ["ROCKET"]
       },
       "flavor": {
         "ja": "響き渡る金属的な足音がこの巨大な、半悪魔半機械の怪物の到来を告げる。その火力には何者もかなわない。",
@@ -50922,11 +49443,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BRAIN_SMASH",
-          "S_HI_UNDEAD",
-          "S_HI_DRAGON"
-        ]
+        "list": ["BRAIN_SMASH", "S_HI_UNDEAD", "S_HI_DRAGON"]
       },
       "flavor": {
         "ja": "クイルスルグの帝王は沸騰しているかのような巨大な肉の塊で、初歩的な知能を持っている。それは脈打つ度に様々な色に変化している。それは身を守るためにはとにかく助けを呼ぶことしか知らない。",
@@ -51068,10 +49585,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BR_FIRE",
-          "S_KIN"
-        ]
+        "list": ["BR_FIRE", "S_KIN"]
       },
       "flavor": {
         "ja": "巨大な燃える塊のように見え、絶え間なく形を変えている。高温のプラズマ生命体と考えられている。地球から２７光年離れたフォーマルハウト星或いはその地殻に生息しているが、地球上に召喚することも可能である。「しかし目に片手をかざしていても、この呪われた場所から空に流れていく巨大な無定形の存在も、木木の上で生ける炎のようにわだかまっている巨大な存在も目にしないわけにはいかなかった」(オーガスト・ダーレス、岩村光博訳「闇に潜みつくもの」『クトゥルー４』、青心社文庫、p.240)",
@@ -51431,13 +49945,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "MIND_BLAST",
-          "BO_ELEC",
-          "BO_MANA",
-          "BA_ELEC",
-          "PSY_SPEAR"
-        ]
+        "list": ["MIND_BLAST", "BO_ELEC", "BO_MANA", "BA_ELEC", "PSY_SPEAR"]
       },
       "flavor": {
         "ja": "地獄界から現れた、羽を持った人間型のモンスターであるパズズは、冒険者の運命を勝手に決めつけては残酷に笑いかける。",
@@ -51593,9 +50101,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_FIRE"
-        ]
+        "list": ["BR_FIRE"]
       },
       "flavor": {
         "ja": "アンバーの周りのアーデンの森を護るジュリアンが従えている獰猛な猟犬。熱を発して輝く巨大な犬で、火炎がその鼻孔から滴っている。",
@@ -51850,13 +50356,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BR_DISE",
-          "BR_PLAS",
-          "BR_NUKE",
-          "BR_POIS",
-          "BR_ACID"
-        ]
+        "list": ["BR_DISE", "BR_PLAS", "BR_NUKE", "BR_POIS", "BR_ACID"]
       },
       "flavor": {
         "ja": "『ゴヂラ』は汚染された海から現れた。その怒りを恐れよ！ゴヂラの破壊力にかなうものはいない！",
@@ -52411,11 +50911,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BR_FIRE",
-          "BR_COLD",
-          "BR_DISE"
-        ]
+        "list": ["BR_FIRE", "BR_COLD", "BR_DISE"]
       },
       "flavor": {
         "ja": "巨大な伝説の爬虫類であるタラスクは、魔法に対する免疫を持ち、殺すことができないと噂されている。その怒りを恐れよ。彼のもたらす破壊は何人も止めることはできない。",
@@ -52488,14 +50984,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_FIRE",
-          "S_DEMON",
-          "S_HI_UNDEAD"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_FIRE", "S_DEMON", "S_HI_UNDEAD"]
       },
       "artifacts": [
         {
@@ -52575,10 +51064,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "S_MONSTERS",
-          "S_HOUND"
-        ]
+        "list": ["S_MONSTERS", "S_HOUND"]
       },
       "flavor": {
         "ja": "ドラウグルインはサウロンの恐るべき専属護衛だ。彼は人間の精神を持った恐ろしく巨大な狼であり、全ての狼の首領でもある。",
@@ -52758,12 +51244,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BR_NEXU",
-          "BR_NETH",
-          "BR_COLD",
-          "BR_FIRE"
-        ]
+        "list": ["BR_NEXU", "BR_NETH", "BR_COLD", "BR_FIRE"]
       },
       "flavor": {
         "ja": "魔王アザトートの玉座の周囲を踊る、異形の神々の一柱。死と腐敗と衰退を栄養にして生きている。我々の世界に召喚された場合、ガス状の形態で地球の核まで浸透し、そこから火柱となって地上に噴き出してくる。「噴出する病的な緑色の焔の柱... 深遠かつ人知を越えた地の底から火山の様にほとばしり、健全な焔が落とすはずの影を作らず、硝石をおぞましくも毒々しい緑青で包む。そのような激しい燃焼に反してそこに熱はなく、ただ死と腐敗の湿気があるのみだ。」（ラヴクラフト「祝祭」）",
@@ -52830,10 +51311,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "ROCKET",
-          "S_CYBER"
-        ]
+        "list": ["ROCKET", "S_CYBER"]
       },
       "flavor": {
         "ja": "最強のサイバーデーモンで、彼らの王であり支配者である。",
@@ -53098,11 +51576,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BR_DARK",
-          "BR_POIS",
-          "BR_COLD"
-        ]
+        "list": ["BR_DARK", "BR_POIS", "BR_COLD"]
       },
       "flavor": {
         "ja": "北欧神話でロキと女巨人アングルボザの間に生まれた途方もなく巨大な狼で、空腹を満たすために太陽を食べ、神々をデザートとして残しておくぐらいの事をすることができる。",
@@ -53766,12 +52240,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BA_DARK",
-          "BR_FIRE",
-          "BR_NETH",
-          "S_HOUND"
-        ]
+        "list": ["BA_DARK", "BR_FIRE", "BR_NETH", "S_HOUND"]
       },
       "flavor": {
         "ja": "３つ首の恐ろしい形相のヘルハウンドだ。相手に向かって牙をむき吠えると同時に炎がその体から楽しげに燃え上がる。",
@@ -53843,9 +52312,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BA_WATE"
-        ]
+        "list": ["BA_WATE"]
       },
       "flavor": {
         "ja": "北欧神話でロキと女巨人アングルボザの間に生まれた大蛇だ。このミドガルドの大蛇は定命の人間の世界をまるごと囲んでしまうほど巨大な胴体をしている。神々でさえも粉微塵に砕いてしまうことができる。",
@@ -53928,10 +52395,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BR_DISI",
-          "BO_MANA"
-        ]
+        "list": ["BR_DISI", "BO_MANA"]
       },
       "flavor": {
         "ja": "『破壊スル者』は北欧神話の神々により作られた究極の武器で、世界に審判を下すために宇宙から到来した神に対抗するため作られた。不幸にして『破壊スル者』は凶暴化し目に入るもの全てを破壊するようになった。この謎の破壊者を倒すことはほとんど不可能で、もしそれが物体を完全に崩壊させる力を発動させた時、「ラグナロク」の日は近いと言われている。",
@@ -54012,12 +52476,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BR_FIRE",
-          "BR_NETH",
-          "S_KIN",
-          "S_DEMON"
-        ]
+        "list": ["BR_FIRE", "BR_NETH", "S_KIN", "S_DEMON"]
       },
       "artifacts": [
         {
@@ -54791,10 +53250,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BLINK",
-          "MIND_BLAST"
-        ]
+        "list": ["BLINK", "MIND_BLAST"]
       },
       "flavor": {
         "ja": "それはそこにあり、かつそこにない。",
@@ -55056,11 +53512,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "HEAL",
-          "INVULNER",
-          "DISPEL"
-        ]
+        "list": ["HEAL", "INVULNER", "DISPEL"]
       },
       "flavor": {
         "ja": "四本の触腕をもった巨大な漆黒の牡蛎のような怪物だ。冥界で生まれたこの怪物は獲物を追うことはなく、不幸な冒険者が近くにやってくるまで闇の中で蠕いている。",
@@ -55087,12 +53539,7 @@
       "rarity": 2,
       "exp": 25,
       "odds_correction_ratio": 300,
-      "flags": [
-        "NEVER_BLOW",
-        "RAND_25",
-        "ANIMAL",
-        "WILD_WOOD"
-      ],
+      "flags": ["NEVER_BLOW", "RAND_25", "ANIMAL", "WILD_WOOD"],
       "skill": {
         "probability": "1_IN_1",
         "shoot": "4d6"
@@ -55269,9 +53716,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BO_NETH"
-        ]
+        "list": ["BO_NETH"]
       },
       "flavor": {
         "ja": "漆黒の法衣を身にまとい、暗殺拳に熟練した修行僧だ。",
@@ -55336,14 +53781,7 @@
       ],
       "skill": {
         "probability": "1_IN_1",
-        "list": [
-          "BLINK",
-          "BO_MANA",
-          "BA_CHAO",
-          "BA_FIRE",
-          "TPORT",
-          "PSY_SPEAR"
-        ]
+        "list": ["BLINK", "BO_MANA", "BA_CHAO", "BA_FIRE", "TPORT", "PSY_SPEAR"]
       },
       "flavor": {
         "ja": "硬い金属に包まれたスライムだ。",
@@ -55525,12 +53963,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "ROCKET",
-          "HEAL",
-          "BLINK",
-          "INVULNER"
-        ]
+        "list": ["ROCKET", "HEAL", "BLINK", "INVULNER"]
       },
       "artifacts": [
         {
@@ -55611,13 +54044,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BR_NETH",
-          "BR_DARK",
-          "SCARE",
-          "BLINK",
-          "SHRIEK"
-        ]
+        "list": ["BR_NETH", "BR_DARK", "SCARE", "BLINK", "SHRIEK"]
       },
       "flavor": {
         "ja": "それは冥界から闇を呼び寄せてダンジョンに混沌をもたらしている。それの周りでは空間が歪み、姿をはっきりと捉えることができない。",
@@ -55684,12 +54111,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "BA_COLD",
-          "BO_ICEE",
-          "BO_WATE",
-          "BA_ELEC"
-        ]
+        "list": ["BA_COLD", "BO_ICEE", "BO_WATE", "BA_ELEC"]
       },
       "flavor": {
         "ja": "ダンジョンを揺るがすこの巨大なトロルは、氷と稲光を撒き散らしながらやって来る。身の丈１０メートル、六つの頭をもつこの怪物はあなたの厚かましさに怒り狂っている。",
@@ -55782,11 +54204,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "SCARE",
-          "BR_POIS",
-          "BR_DARK"
-        ]
+        "list": ["SCARE", "BR_POIS", "BR_DARK"]
       },
       "flavor": {
         "ja": "忌まわしい腐肉を食らい巨大な大きさに成長したこのモルゴスの奴隷は常に活きのいい獲物を求めている。",
@@ -55863,12 +54281,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "SCARE",
-          "S_KIN",
-          "WORLD",
-          "TELE_TO"
-        ]
+        "list": ["SCARE", "S_KIN", "WORLD", "TELE_TO"]
       },
       "artifacts": [
         {
@@ -55923,9 +54336,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "SPECIAL"
-        ]
+        "list": ["SPECIAL"]
       },
       "flavor": {
         "ja": "怒りに狂った王蟲の群は瘴気をまき散らしながら突進してくる。",
@@ -56548,9 +54959,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BR_MANA"
-        ]
+        "list": ["BR_MANA"]
       },
       "flavor": {
         "ja": "強力なオーラを発している犬型生物だ。それは魔法のような感じがする？",
@@ -56601,9 +55010,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BO_MANA"
-        ]
+        "list": ["BO_MANA"]
       },
       "flavor": {
         "ja": "やつれた人間のような上半身が巨大な蜘蛛の体についた醜い怪物だ。恐ろしい叫び声をあげながら突進してくる。",
@@ -56648,13 +55055,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "ROCKET",
-          "BLINK",
-          "BR_POIS",
-          "BR_CHAO",
-          "BR_NEXU"
-        ],
+        "list": ["ROCKET", "BLINK", "BR_POIS", "BR_CHAO", "BR_NEXU"],
         "shoot": "15d10"
       },
       "flavor": {
@@ -56726,12 +55127,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_POIS"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_POIS"]
       },
       "flavor": {
         "ja": "冥界で強大な力を蓄えて現世に舞い戻ってきたドラゴンだ。息が詰まるほどの猛烈な瘴気を撒き散らしている。",
@@ -56801,11 +55197,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "CAUSE_3",
-          "BO_WATE",
-          "BO_MANA"
-        ]
+        "list": ["CAUSE_3", "BO_WATE", "BO_MANA"]
       },
       "flavor": {
         "ja": "かつて屈強さを誇ったこの戦士の肉体はサウロンの力に完全に支配され、今ではほとんど意思を持たない邪悪なアンデッドに成り下がってしまった。",
@@ -56858,13 +55250,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BO_ELEC",
-          "MISSILE",
-          "BLINK",
-          "S_MONSTER",
-          "BA_ELEC"
-        ]
+        "list": ["BO_ELEC", "MISSILE", "BLINK", "S_MONSTER", "BA_ELEC"]
       },
       "flavor": {
         "ja": "ディジニは風の属性を持つジンだ。周りにつむじ風をまとったディジニがあなたを睨んでいる。",
@@ -56917,11 +55303,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BO_FIRE",
-          "BO_PLAS",
-          "BA_FIRE"
-        ]
+        "list": ["BO_FIRE", "BO_PLAS", "BA_FIRE"]
       },
       "flavor": {
         "ja": "イフリートは火の属性を持つジンだ。炎につつまれた赤い巨人があなたを睨んでいる。",
@@ -56993,9 +55375,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BLINK"
-        ]
+        "list": ["BLINK"]
       },
       "flavor": {
         "ja": "このトロルはトロルの中の王だ。彼は依然としてトロルであり、頭は良くないが、その力はさらに強力だ。彼は一人でいる事はなく常に手下を連れている。",
@@ -57117,9 +55497,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "ROCKET"
-        ]
+        "list": ["ROCKET"]
       },
       "flavor": {
         "ja": "彼はその恐ろしい重火器の狙いをあなたに向けている。",
@@ -57177,9 +55555,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BR_SHAR"
-        ]
+        "list": ["BR_SHAR"]
       },
       "flavor": {
         "ja": "凄まじい音を立てて吹き付ける剃刀のように鋭い破片の塊だ。魔法によってその形を維持されている。",
@@ -57349,13 +55725,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "HEAL",
-          "BLINK",
-          "TPORT",
-          "BA_FIRE",
-          "BA_COLD"
-        ],
+        "list": ["HEAL", "BLINK", "TPORT", "BA_FIRE", "BA_COLD"],
         "shoot": "7d6"
       },
       "flavor": {
@@ -57518,11 +55888,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "DARKNESS",
-          "BO_ACID",
-          "HOLD"
-        ]
+        "list": ["DARKNESS", "BO_ACID", "HOLD"]
       },
       "flavor": {
         "ja": "鱗状の皮膚を持った頑丈なクラーケンだ。",
@@ -57576,10 +55942,7 @@
       ],
       "skill": {
         "probability": "1_IN_11",
-        "list": [
-          "BR_NUKE",
-          "BR_POIS"
-        ]
+        "list": ["BR_NUKE", "BR_POIS"]
       },
       "flavor": {
         "ja": "巨大な口を持っているように見えるどっしりとしたキノコだ。このキノコはどこにでも生えて周りの空気を濃い瘴気で汚染する。",
@@ -57773,21 +56136,10 @@
           "damage_dice": "2d6"
         }
       ],
-      "flags": [
-        "COLD_BLOOD",
-        "NO_SLEEP",
-        "NO_CONF",
-        "NO_FEAR",
-        "NONLIVING"
-      ],
+      "flags": ["COLD_BLOOD", "NO_SLEEP", "NO_CONF", "NO_FEAR", "NONLIVING"],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "SCARE",
-          "BLIND",
-          "CONF",
-          "S_MONSTER"
-        ]
+        "list": ["SCARE", "BLIND", "CONF", "S_MONSTER"]
       },
       "flavor": {
         "ja": "英雄達が地に存在し、比類なき力を持った魔法の武器が作られていた遠い過去の時代の強力な武器の一つだ。その刺の付いた刃からは血が滴っている。",
@@ -57859,13 +56211,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "DRAIN_MANA",
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "S_KIN"
-        ]
+        "list": ["DRAIN_MANA", "BLIND", "CONF", "SCARE", "S_KIN"]
       },
       "flavor": {
         "ja": "彼女の子どもたちすべてがベトベトだと思ってるだろう！",
@@ -58014,9 +56360,7 @@
       ],
       "skill": {
         "probability": "1_IN_1",
-        "list": [
-          "MISSILE"
-        ]
+        "list": ["MISSILE"]
       },
       "flavor": {
         "ja": "空中に浮かぶ金属製の宝珠だ。邪悪な意思を持ち、常にあなたに攻撃の狙いを付けている。",
@@ -58056,13 +56400,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BR_NETH",
-          "BR_DISE",
-          "BR_TIME",
-          "BR_NEXU",
-          "BR_POIS"
-        ]
+        "list": ["BR_NETH", "BR_DISE", "BR_TIME", "BR_NEXU", "BR_POIS"]
       },
       "flavor": {
         "ja": "死から蘇ったチョウチンアンコウだ。",
@@ -58187,10 +56525,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "HEAL",
-          "S_SPIDER"
-        ]
+        "list": ["HEAL", "S_SPIDER"]
       },
       "flavor": {
         "ja": "彼はクマであれトラであれ一撃で沈めるべく、絶え間ない特訓を続けている。",
@@ -58260,10 +56595,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "HEAL",
-          "S_SPIDER"
-        ]
+        "list": ["HEAL", "S_SPIDER"]
       },
       "flavor": {
         "ja": "素手での戦いに習熟した修験者は、一撃で敵を気絶させることができる。彼にとって自然は味方であり、自然界の生物を召喚することもできる。またその鍛えられた精神力によって容易に自分の傷を治癒する。",
@@ -58337,10 +56669,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "HEAL",
-          "S_SPIDER"
-        ]
+        "list": ["HEAL", "S_SPIDER"]
       },
       "flavor": {
         "ja": "彼は修験道を極めつつあるが、決して自分に驕ることはない。まだまだ彼は自然界の生物を完全には操れておらず、そのことを苦悩している。しかし彼は絶望せず、一歩ずつ着実に進み続けている。",
@@ -58448,11 +56777,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "DARKNESS",
-          "CAUSE_4",
-          "BO_ICEE"
-        ]
+        "list": ["DARKNESS", "CAUSE_4", "BO_ICEE"]
       },
       "flavor": {
         "ja": "水中での生活に適応したナーガだ。魚のような尾ヒレとエラを持っている。",
@@ -58605,13 +56930,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BLINK",
-          "HOLD",
-          "BLIND",
-          "CONF",
-          "SCARE"
-        ]
+        "list": ["BLINK", "HOLD", "BLIND", "CONF", "SCARE"]
       },
       "flavor": {
         "ja": "かつてはブル・ゲイツの究極兵器であり、全ての多元世界に破滅をもたらす恐怖の存在だった。弱点はCSSにJavaScriptと呼ばれる電脳兵器だが、どちらもこの世界には存在しない。",
@@ -58665,10 +56984,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_ELEC",
-          "BO_ELEC"
-        ]
+        "list": ["BR_ELEC", "BO_ELEC"]
       },
       "flavor": {
         "ja": "可愛いネズミだ。しかし静電気が溜まっている。",
@@ -58711,19 +57027,10 @@
           "damage_dice": "3d5"
         }
       ],
-      "flags": [
-        "IM_COLD",
-        "DROP_1D2",
-        "NONLIVING",
-        "AURA_COLD"
-      ],
+      "flags": ["IM_COLD", "DROP_1D2", "NONLIVING", "AURA_COLD"],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_COLD",
-          "BO_COLD",
-          "BA_COLD"
-        ]
+        "list": ["BR_COLD", "BO_COLD", "BA_COLD"]
       },
       "flavor": {
         "ja": "顔に雪がさかんに降りかかるので、巳之吉は目をさました。小屋の戸はむりにこじ開けられて、小屋の中に一人の女―すっかり白い装いをした女がいるのが、雪明かりで見えた。女は茂作のうえに身をかがめて、息を吹きかけていた。―その息は、きらきらする白い煙のようであった。(怪談・奇談 ラフカディオ・ハーン、田代三千稔訳 角川文庫)",
@@ -58760,10 +57067,7 @@
           "damage_dice": "1d8"
         }
       ],
-      "flags": [
-        "WEIRD_MIND",
-        "DROP_CORPSE"
-      ],
+      "flags": ["WEIRD_MIND", "DROP_CORPSE"],
       "flavor": {
         "ja": "キノコ王国を裏切り混沌に魂を売った憎むべき悪のキノコだ。",
         "en": "A renegade mushroom from the Mushroom Kingdom that has been corruptedby chaos.  It is quite angry and it marches towards you."
@@ -58852,11 +57156,7 @@
           "damage_dice": "5d8"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "DROP_SKELETON",
-        "DROP_CORPSE"
-      ],
+      "flags": ["ANIMAL", "DROP_SKELETON", "DROP_CORPSE"],
       "flavor": {
         "ja": "それを捕えた者には $1,000,000 の賞金が出るといわれている。",
         "en": "It is snake-like but much wider in the middle than the ends.  You've heard rumors of someone paying 1,000,000 gold for one captured alive."
@@ -58920,14 +57220,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BA_FIRE",
-          "HASTE",
-          "HOLD",
-          "CONF",
-          "BLIND",
-          "INVULNER"
-        ]
+        "list": ["BA_FIRE", "HASTE", "HOLD", "CONF", "BLIND", "INVULNER"]
       },
       "flavor": {
         "ja": "赤い帽子と口髭がよく似合う、ダンディな配管工だ。",
@@ -58993,10 +57286,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BR_FIRE",
-          "SCARE"
-        ]
+        "list": ["BR_FIRE", "SCARE"]
       },
       "flavor": {
         "ja": "亀のような外見をしているが、火を吐き、凶暴な性格をしている。彼は常にキノコ王国を征服しようとたくらんでいる。",
@@ -59741,13 +58031,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "S_DEMON",
-          "BA_CHAO",
-          "BO_PLAS",
-          "BR_FIRE",
-          "BR_PLAS"
-        ]
+        "list": ["S_DEMON", "BA_CHAO", "BO_PLAS", "BR_FIRE", "BR_PLAS"]
       },
       "flavor": {
         "ja": "脚が４本。腕は９本。両脇から角が出ている丈高めの黄金の冠をかぶる。体色は青。牙を持つ。女神イシターを封印したと伝えられる。",
@@ -59824,10 +58108,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "CAUSE_4",
-          "TELE_TO"
-        ]
+        "list": ["CAUSE_4", "TELE_TO"]
       },
       "flavor": {
         "ja": "一子相伝とされる北斗神拳の伝承者だ。力が全てを支配すると思われた時代にあって愛に生き、愛のために戦っている。",
@@ -59949,12 +58230,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "CONF",
-          "HOLD",
-          "CAUSE_3",
-          "HEAL"
-        ]
+        "list": ["CONF", "HOLD", "CAUSE_3", "HEAL"]
       },
       "flavor": {
         "ja": "彼は純白のプレートアーマーに身を包み、威嚇的に冒険者を見つめる。",
@@ -60106,12 +58382,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLIND",
-          "CONF",
-          "BR_FIRE",
-          "S_DEMON"
-        ]
+        "list": ["BLIND", "CONF", "BR_FIRE", "S_DEMON"]
       },
       "flavor": {
         "ja": "それは全身が炎で覆われた屈強な人間型のモンスターだ。",
@@ -60174,9 +58445,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_NETH"
-        ]
+        "list": ["BR_NETH"]
       },
       "flavor": {
         "ja": "魔法によって蘇り不死の存在になったドラゴンの骸骨だ。",
@@ -60812,11 +59081,7 @@
           "damage_dice": "2d4"
         }
       ],
-      "flags": [
-        "DROP_CORPSE",
-        "RAND_50",
-        "ANIMAL"
-      ],
+      "flags": ["DROP_CORPSE", "RAND_50", "ANIMAL"],
       "skill": {
         "probability": "1_IN_2",
         "shoot": "4d6"
@@ -61405,10 +59670,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "SHRIEK",
-          "MIND_BLAST"
-        ]
+        "list": ["SHRIEK", "MIND_BLAST"]
       },
       "flavor": {
         "ja": "可愛らしい純心無垢なスライムモルドだ。触れて死ね！",
@@ -61479,10 +59741,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_SHAR",
-          "TELE_TO"
-        ]
+        "list": ["BR_SHAR", "TELE_TO"]
       },
       "flavor": {
         "ja": "銀河ボディビルコンテスト十連続グランドチャンピオン。必殺技はボ帝ビルカッター。",
@@ -61507,9 +59766,7 @@
       "level": 1,
       "rarity": 255,
       "exp": 0,
-      "flags": [
-        "KAGE"
-      ],
+      "flags": ["KAGE"],
       "flavor": {
         "ja": "その正体は誰も知らない。",
         "en": "Nobody knows its true character."
@@ -61565,14 +59822,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "CAUSE_2",
-          "BA_POIS",
-          "S_MONSTER"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "CAUSE_2", "BA_POIS", "S_MONSTER"]
       },
       "flavor": {
         "ja": "放置された箱に化けている奇妙な生物の像に化けている奇妙な生物で、愚かな冒険者がその毒のある爪の射程に入るのを待ち構えている。",
@@ -61636,14 +59886,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BA_ELEC",
-          "HASTE",
-          "HOLD",
-          "CONF",
-          "BLIND",
-          "INVULNER"
-        ]
+        "list": ["BA_ELEC", "HASTE", "HOLD", "CONF", "BLIND", "INVULNER"]
       },
       "flavor": {
         "ja": "断じてマリオの類似品ではない！(本人主張)",
@@ -61707,9 +59950,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_SOUN"
-        ]
+        "list": ["BR_SOUN"]
       },
       "flavor": {
         "ja": "お前のものは俺のもの。俺のものは俺のもの。",
@@ -61785,11 +60026,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BRAIN_SMASH",
-          "BR_COLD",
-          "BA_COLD"
-        ]
+        "list": ["BRAIN_SMASH", "BR_COLD", "BA_COLD"]
       },
       "flavor": {
         "ja": "ロードスの古代竜の中で最も年輪と叡智を重ねたドラゴンで、邪悪な存在から土地を守っている。",
@@ -61864,11 +60101,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BRAIN_SMASH",
-          "BR_ACID",
-          "BA_WATE"
-        ]
+        "list": ["BRAIN_SMASH", "BR_ACID", "BA_WATE"]
       },
       "flavor": {
         "ja": "ロードスの古代竜の一匹で、破壊を巻き起こすため深海からやってくる。",
@@ -61943,12 +60176,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BRAIN_SMASH",
-          "BR_DARK",
-          "BR_NETH",
-          "BA_NETH"
-        ]
+        "list": ["BRAIN_SMASH", "BR_DARK", "BR_NETH", "BA_NETH"]
       },
       "flavor": {
         "ja": "ロードスの古代竜の一匹で、暗黒と地獄のブレスで破壊を引き起こす。",
@@ -62024,12 +60252,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BRAIN_SMASH",
-          "BR_SOUN",
-          "BR_LITE",
-          "BR_MANA"
-        ]
+        "list": ["BRAIN_SMASH", "BR_SOUN", "BR_LITE", "BR_MANA"]
       },
       "flavor": {
         "ja": "ロードスの古代竜の一匹で、モス王国を支配し、守護するために戦う。",
@@ -62105,11 +60328,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BRAIN_SMASH",
-          "BR_FIRE",
-          "BA_FIRE"
-        ]
+        "list": ["BRAIN_SMASH", "BR_FIRE", "BA_FIRE"]
       },
       "flavor": {
         "ja": "ロードスの古代竜の一匹で、その火炎のブレスで全てを焼き尽くす。",
@@ -62324,9 +60543,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "S_DRAGON"
-        ]
+        "list": ["S_DRAGON"]
       },
       "flavor": {
         "ja": "冒険者の武器を奪い、さらにドラゴンをけしかける事で、このコウモリは多くの冒険者に死をもたらして来た。",
@@ -62394,12 +60611,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "HOLD",
-          "SCARE",
-          "DARKNESS",
-          "BLIND"
-        ]
+        "list": ["HOLD", "SCARE", "DARKNESS", "BLIND"]
       },
       "flavor": {
         "ja": "険しい顔つきのダークエルフで、黒玉のように輝く薄い金属の鎧を常に身につけている。彼自身の手による強力な魔法の武具で身を固めており、強敵と呼ぶに相応しい相手だ。",
@@ -62545,12 +60757,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "HEAL",
-          "HASTE",
-          "TELE_AWAY",
-          "S_MONSTERS"
-        ]
+        "list": ["HEAL", "HASTE", "TELE_AWAY", "S_MONSTERS"]
       },
       "flavor": {
         "ja": "ヌメノール国第25代にして最後の王だ。彼はサウロンを捕えるも、逆にその甘言に誑かされ、至福の地アマンへ兵を向け、それが結局はヌメノールを滅亡に導くことになる。",
@@ -62683,12 +60890,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "HOLD"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "HOLD"]
       }
     },
     {
@@ -62743,10 +60945,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_ELEC",
-          "BA_ELEC"
-        ]
+        "list": ["BR_ELEC", "BA_ELEC"]
       },
       "flavor": {
         "ja": "これは雷鳥でもなければ国際救助隊でもない。",
@@ -62808,14 +61007,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BLIND",
-          "HOLD",
-          "SCARE",
-          "CAUSE_4",
-          "BO_NETH",
-          "S_UNDEAD"
-        ]
+        "list": ["BLIND", "HOLD", "SCARE", "CAUSE_4", "BO_NETH", "S_UNDEAD"]
       },
       "flavor": {
         "ja": "この不吉なモンスターは自分の首を脇に抱え、死を告げにやってくる。",
@@ -62908,12 +61100,7 @@
           "damage_dice": "1d10"
         }
       ],
-      "flags": [
-        "DROP_CORPSE",
-        "ANIMAL",
-        "BASH_DOOR",
-        "WILD_MOUNTAIN"
-      ],
+      "flags": ["DROP_CORPSE", "ANIMAL", "BASH_DOOR", "WILD_MOUNTAIN"],
       "flavor": {
         "ja": "頭がサル、胴はタヌキ、尾はヘビ、手足はトラで、鳴き声はトラツグミに似ていたという奇妙な生物だ。非常に変わった外見をしていて、近寄りがたい雰囲気がある。",
         "en": "This strange hybrid has the head of a monkey, the body of a racoon dog, the legs of a tiger and a tail that is the front half of a snake.  It makes an eerie, sorrowful cry, like that of a scaly thrush, and is wreathed with clouds of black smoke."
@@ -63029,11 +61216,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "SCARE",
-          "CAUSE_2",
-          "S_MONSTER"
-        ]
+        "list": ["SCARE", "CAUSE_2", "S_MONSTER"]
       },
       "flavor": {
         "ja": "猫が年老いると次第に高い知能と分かれた尻尾を持ち、猫又になるという。",
@@ -63275,13 +61458,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLIND",
-          "SHRIEK",
-          "DISPEL",
-          "INVULNER",
-          "S_ANGEL"
-        ]
+        "list": ["BLIND", "SHRIEK", "DISPEL", "INVULNER", "S_ANGEL"]
       },
       "flavor": {
         "ja": "龍の鱗に牛の尾、馬の蹄を持ち、角の生えた四本足の聖なる獣で、王者が仁のある政治を行った時に姿を現わすと言われている。",
@@ -63328,13 +61505,7 @@
           "damage_dice": "4d10"
         }
       ],
-      "flags": [
-        "DROP_2D2",
-        "ANIMAL",
-        "NO_SLEEP",
-        "CAN_FLY",
-        "RIDING"
-      ],
+      "flags": ["DROP_2D2", "ANIMAL", "NO_SLEEP", "CAN_FLY", "RIDING"],
       "flavor": {
         "ja": "翼の生えた天駆ける白馬だ。",
         "en": "It is a large white horse with wings."
@@ -63513,11 +61684,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BO_ACID",
-          "BO_PLAS",
-          "BA_ACID"
-        ]
+        "list": ["BO_ACID", "BO_PLAS", "BA_ACID"]
       },
       "flavor": {
         "ja": "ダオは大地の属性を持つジンだ。大地の元素界からやってきた。",
@@ -63568,12 +61735,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BO_WATE",
-          "BA_WATE",
-          "BLINK",
-          "S_MONSTER"
-        ]
+        "list": ["BO_WATE", "BA_WATE", "BLINK", "S_MONSTER"]
       },
       "flavor": {
         "ja": "マリードは水の属性を持つジンだ。それは海で生まれ、その筋肉は潮流から、その歯は真珠から作られたと言われている。",
@@ -63629,9 +61791,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "DARKNESS"
-        ]
+        "list": ["DARKNESS"]
       },
       "flavor": {
         "ja": "彼女はその仕える主のためにワーグの群れを駆る。その目は恐るべき奸智を秘め、ほの赤く光る。",
@@ -63700,13 +61860,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "HEAL",
-          "BLIND",
-          "CONF",
-          "CAUSE_2",
-          "MIND_BLAST"
-        ]
+        "list": ["HEAL", "BLIND", "CONF", "CAUSE_2", "MIND_BLAST"]
       },
       "flavor": {
         "ja": "主であったドワーフ王スロールがオークに惨殺された後、その王アゾグに小銭を渡され敢えて生かされた哀れな老従者だ。後にドワーフ達の報復そのものは成されたようだが、今の孤独な彼は、一族を追われたのだろうか？自ら恥じて去ったのだろうか？",
@@ -63755,12 +61909,7 @@
           "damage_dice": "1d5"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "DROP_CORPSE",
-        "DROP_SKELETON",
-        "RIDING"
-      ],
+      "flags": ["ANIMAL", "DROP_CORPSE", "DROP_SKELETON", "RIDING"],
       "flavor": {
         "ja": "それは馬鳥ともいい、空を飛ぶことができない。代わりに陸を素早く駆け抜けることができる。",
         "en": "It is also called a horse bird.  It can run quickly instead of being able to fly."
@@ -63805,13 +61954,7 @@
           "damage_dice": "2d6"
         }
       ],
-      "flags": [
-        "ANIMAL",
-        "CAN_FLY",
-        "DROP_CORPSE",
-        "DROP_SKELETON",
-        "RIDING"
-      ]
+      "flags": ["ANIMAL", "CAN_FLY", "DROP_CORPSE", "DROP_SKELETON", "RIDING"]
     },
     {
       "id": 999,
@@ -64183,12 +62326,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BA_FIRE",
-          "HOLD",
-          "BO_FIRE",
-          "HEAL"
-        ]
+        "list": ["BA_FIRE", "HOLD", "BO_FIRE", "HEAL"]
       },
       "artifacts": [
         {
@@ -64436,11 +62574,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "TPORT",
-          "HOLD",
-          "S_DEMON"
-        ]
+        "list": ["TPORT", "HOLD", "S_DEMON"]
       },
       "flavor": {
         "ja": "深紅のローブを身にまとってたたずむ、邪悪に歪んだ人間だ。",
@@ -64574,13 +62708,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "TPORT",
-          "HASTE",
-          "TELE_AWAY",
-          "TELE_LEVEL",
-          "BLINK"
-        ]
+        "list": ["TPORT", "HASTE", "TELE_AWAY", "TELE_LEVEL", "BLINK"]
       },
       "flavor": {
         "ja": "金なら1匹、銀なら5匹でもれなくおもちゃのカンヅメが当たります。",
@@ -64633,13 +62761,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "TPORT",
-          "HASTE",
-          "TELE_AWAY",
-          "TELE_LEVEL",
-          "BLINK"
-        ]
+        "list": ["TPORT", "HASTE", "TELE_AWAY", "TELE_LEVEL", "BLINK"]
       },
       "flavor": {
         "ja": "金なら1匹、銀なら5匹でもれなくおもちゃのカンヅメが当たります。",
@@ -64759,11 +62881,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BA_FIRE",
-          "HASTE",
-          "SPECIAL"
-        ]
+        "list": ["BA_FIRE", "HASTE", "SPECIAL"]
       }
     },
     //#
@@ -64831,10 +62949,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BO_MANA",
-          "BLINK"
-        ]
+        "list": ["BO_MANA", "BLINK"]
       }
     },
     //#
@@ -64960,12 +63075,7 @@
           "damage_dice": "1d2"
         }
       ],
-      "flags": [
-        "RAND_50",
-        "CAN_FLY",
-        "WEIRD_MIND",
-        "ANIMAL"
-      ]
+      "flags": ["RAND_50", "CAN_FLY", "WEIRD_MIND", "ANIMAL"]
     },
     {
       "id": 1018,
@@ -65033,10 +63143,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BR_FORC",
-          "TELE_TO"
-        ]
+        "list": ["BR_FORC", "TELE_TO"]
       },
       "flavor": {
         "ja": "ラオウは北斗神拳伝承者ケンシロウの義兄であり北斗神拳の使い手である。激動の闇の時代に、己の信念で新たな時代を築こうとした。",
@@ -65279,10 +63386,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "TELE_TO",
-          "BO_MANA"
-        ]
+        "list": ["TELE_TO", "BO_MANA"]
       },
       "flavor": {
         "ja": "逞しい人間のようだが、猿の尻尾が付いている。これこそがサイヤ人の証だ。その戦闘力は人間を凌駕し、多くの破壊を呼び起こすだろう。",
@@ -65385,13 +63489,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BLINK",
-          "TPORT",
-          "TELE_TO",
-          "CONF",
-          "TRAPS"
-        ]
+        "list": ["BLINK", "TPORT", "TELE_TO", "CONF", "TRAPS"]
       },
       "flavor": {
         "ja": "その技、だれにも真似はできない。今さら財産を守っても手遅れだ。彼は魔法を学び、罠を仕掛けることを覚えているのだ。",
@@ -65719,9 +63817,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_COLD"
-        ]
+        "list": ["BR_COLD"]
       },
       "flavor": {
         "ja": "憎めない顔をした小柄な悪魔だ。",
@@ -65788,9 +63884,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "S_KIN"
-        ]
+        "list": ["S_KIN"]
       },
       "flavor": {
         "ja": "南蛮の王。諸葛亮に七度擒にされる。",
@@ -65936,14 +64030,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "HOLD",
-          "SCARE",
-          "CAUSE_3",
-          "BR_CONF",
-          "BR_NETH",
-          "BR_CHAO"
-        ]
+        "list": ["HOLD", "SCARE", "CAUSE_3", "BR_CONF", "BR_NETH", "BR_CHAO"]
       },
       "flavor": {
         "ja": "インドネシア大統領の第三夫人。彼女の顔は千隻もの船を沈めるほどだが、スカルノは面食いではない。",
@@ -66014,11 +64101,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BR_ACID",
-          "BR_POIS",
-          "S_KIN"
-        ]
+        "list": ["BR_ACID", "BR_POIS", "S_KIN"]
       },
       "flavor": {
         "ja": "大きなハサミを持つ図体の大きな昆虫だ。岩を溶かして獲物に辿り着くべく、酸の毒を体に滲ませている。",
@@ -66169,10 +64252,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "TRAPS",
-          "BLINK"
-        ]
+        "list": ["TRAPS", "BLINK"]
       },
       "flavor": {
         "ja": "気をつけろ！姿を見たときはすでに罠に囲まれているぞ。",
@@ -66297,14 +64377,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "HEAL",
-          "CAUSE_1",
-          "CAUSE_2",
-          "SLOW",
-          "SCARE",
-          "BLIND"
-        ]
+        "list": ["HEAL", "CAUSE_1", "CAUSE_2", "SLOW", "SCARE", "BLIND"]
       },
       "flavor": {
         "ja": "己が信じる神のために戦う戦士で、異宗教、異宗派の者とは敵対している。",
@@ -66342,21 +64415,10 @@
           "damage_dice": "5d4"
         }
       ],
-      "flags": [
-        "HUMAN",
-        "DROP_1D2",
-        "TAKE_ITEM",
-        "OPEN_DOOR",
-        "BASH_DOOR"
-      ],
+      "flags": ["HUMAN", "DROP_1D2", "TAKE_ITEM", "OPEN_DOOR", "BASH_DOOR"],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "MISSILE",
-          "S_MONSTER",
-          "BO_ELEC",
-          "BLINK"
-        ],
+        "list": ["MISSILE", "S_MONSTER", "BO_ELEC", "BLINK"],
         "shoot": "5d6"
       },
       "flavor": {
@@ -66398,9 +64460,7 @@
       ],
       "skill": {
         "probability": "1_IN_1",
-        "list": [
-          "SPECIAL"
-        ]
+        "list": ["SPECIAL"]
       },
       "flavor": {
         "ja": "周囲の環境に合わせてその姿を変えると言われる生物だ。",
@@ -66443,9 +64503,7 @@
       ],
       "skill": {
         "probability": "1_IN_1",
-        "list": [
-          "SPECIAL"
-        ]
+        "list": ["SPECIAL"]
       },
       "flavor": {
         "ja": "カメレオンの王は、その眷属たるカメレオン達と同じように、周囲の環境に合わせてその姿を変えることができる。",
@@ -66577,12 +64635,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BO_COLD",
-          "BA_COLD",
-          "BO_ICEE",
-          "BR_COLD"
-        ]
+        "list": ["BO_COLD", "BA_COLD", "BO_ICEE", "BR_COLD"]
       },
       "flavor": {
         "ja": "ディオが隠れ棲む館の門番であるこの鳥は犬が大好物なのかもしれない。",
@@ -66684,9 +64737,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_DISI"
-        ]
+        "list": ["BR_DISI"]
       },
       "flavor": {
         "ja": "周囲のものが渦巻き状に分解されていくのが見える。",
@@ -66819,9 +64870,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "HASTE"
-        ]
+        "list": ["HASTE"]
       },
       "flavor": {
         "ja": "黄色の法衣を身にまとった、拳法に熟練した修行僧だ。",
@@ -67178,15 +65227,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "HEAL",
-          "HASTE",
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "TPORT",
-          "BLINK"
-        ]
+        "list": ["HEAL", "HASTE", "BLIND", "CONF", "SCARE", "TPORT", "BLINK"]
       },
       "flavor": {
         "ja": "しわくちゃの肌を持つみすぼらしい姿の人間型モンスターだ。実存と非実存の間を行ったり来たりしている。",
@@ -67236,12 +65277,7 @@
       ],
       "skill": {
         "probability": "1_IN_12",
-        "list": [
-          "BLIND",
-          "SLOW",
-          "CONF",
-          "SCARE"
-        ]
+        "list": ["BLIND", "SLOW", "CONF", "SCARE"]
       },
       "flavor": {
         "ja": "精神の技を習い始めた見習いだ。",
@@ -67292,12 +65328,7 @@
       ],
       "skill": {
         "probability": "1_IN_12",
-        "list": [
-          "BLIND",
-          "SLOW",
-          "CONF",
-          "SCARE"
-        ]
+        "list": ["BLIND", "SLOW", "CONF", "SCARE"]
       },
       "flavor": {
         "ja": "精神の技を習い始めた見習いだ。",
@@ -67615,9 +65646,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "TELE_AWAY"
-        ]
+        "list": ["TELE_AWAY"]
       },
       "flavor": {
         "ja": "彼は全ての街に一億ゴールド寄付した。",
@@ -67860,9 +65889,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "S_KIN"
-        ]
+        "list": ["S_KIN"]
       },
       "flavor": {
         "ja": "この巨大なシラミはシラミを愛するあまりシラミになってしまった哀れな人間のなれの果てだ。",
@@ -68002,9 +66029,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BR_DARK"
-        ]
+        "list": ["BR_DARK"]
       },
       "flavor": {
         "ja": "地蔵大菩薩の化身である蛸法師によって呼び寄せられた蛸の大群だ。「…この時、俄かに、ごうごうと海辺が大きな音を立てて、その海から何千何万という大蛸小蛸の大群が、口から墨を吹き出し吐きかけて、敵軍目がけて攻めかかるんや。忽ちに、辺り一面、闇夜の如くに真っ暗になってしもて、蛸の吹き出す毒気にむせたんかしらんけど、もんどり打って馬から落ちる奴、そこらへひっくり返る奴と、ばたばたばたばたと倒れて…」"
@@ -68074,12 +66099,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_ACID"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_ACID"]
       },
       "flavor": {
         "ja": "冥界で強大な力を蓄えて現世に舞い戻ってきたドラゴンだ。生半可な鎧では肉体ごと溶かされてしまうだろう！",
@@ -68199,13 +66219,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "TELE_AWAY",
-          "TPORT",
-          "HASTE",
-          "BLINK",
-          "HEAL"
-        ],
+        "list": ["TELE_AWAY", "TPORT", "HASTE", "BLINK", "HEAL"],
         "shoot": "16d6"
       },
       "flavor": {
@@ -68274,9 +66288,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BR_DISI"
-        ]
+        "list": ["BR_DISI"]
       },
       "flavor": {
         "ja": "彼は今は滅びた一族、スクークム族の最後の生き残りだ。「ウォーケンは物質の分子を振動させることができる超能力者なのだ！」（荒木飛呂彦「バオー来訪者」）"
@@ -68387,9 +66399,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "HEAL"
-        ]
+        "list": ["HEAL"]
       },
       "flavor": {
         "ja": "怒ったり驚いたりしたとき、発光カヴーは眩しい光の爆発で身を守る。",
@@ -68576,9 +66586,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "SHRIEK"
-        ]
+        "list": ["SHRIEK"]
       },
       "flavor": {
         "ja": "南蛮王孟獲の妻だ。彼女は火の神の化身と言われている。その武勇を侮るな。",
@@ -68705,10 +66713,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BA_POIS",
-          "BLINK"
-        ]
+        "list": ["BA_POIS", "BLINK"]
       },
       "flavor": {
         "ja": "南蛮随一の知恵者と言われる有力領主だ。彼の知略は蜀軍を苦しめた。",
@@ -68773,10 +66778,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "S_ANT",
-          "S_SPIDER"
-        ]
+        "list": ["S_ANT", "S_SPIDER"]
       },
       "flavor": {
         "ja": "南蛮を支配する酋長の一人だ。彼の動物軍団には孟獲も絶大な信頼を寄せる。ただしカラクリは嫌いだ。",
@@ -69051,9 +67053,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLINK"
-        ],
+        "list": ["BLINK"],
         "shoot": "5d6"
       },
       "flavor": {
@@ -69213,9 +67213,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "SHRIEK"
-        ]
+        "list": ["SHRIEK"]
       },
       "flavor": {
         "ja": "こいつは獲物を石像のようにしちまうんだ。気をつけろ！素手で触ると石になっちまうぞ。",
@@ -69275,9 +67273,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BRAIN_SMASH"
-        ]
+        "list": ["BRAIN_SMASH"]
       },
       "flavor": {
         "ja": "惑星チロンに生息する他の生物を精神攻撃する原住生物。「マインドウォームは命ある惑星の自然な自己防衛手段である。白血球と呼んでもいい。同化していない考えが危険を及ぼすおそれのある世界で、マインドウォームは知覚力のある精神エネルギーが集まった場所を探し出し、それを容赦なく効率的に破壊する。」(理事長プラヴィン・ラル「マインドウォーム・マインドウォーム」)(シド・マイヤーズ・アルファ・ケンタウリ)"
@@ -69343,10 +67339,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BRAIN_SMASH",
-          "S_KIN"
-        ]
+        "list": ["BRAIN_SMASH", "S_KIN"]
       },
       "flavor": {
         "ja": "惑星チロンに生息するマインドウォームの海の運び手となっている生物。「アイル・オブ・ディープは単一の生き物ではなく、何千という細い管状の水棲生物が集まって出来たコロニーです。これは惑星の大陸を恐怖に陥れているマインドウォームを媒介する生物でもあり、粘り気のある糊状の物質を分泌します。それがあのような殻の形に固まってコロニーを浮かび上がらせ、巨大な島のごとく見えるのです。」(レディー・ディアドラ・スカイ「惑星の比較生物学」)(シド・マイヤーズ・アルファ・ケンタウリ)"
@@ -69406,9 +67399,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BRAIN_SMASH"
-        ]
+        "list": ["BRAIN_SMASH"]
       },
       "flavor": {
         "ja": "惑星チロンに生息する蝗のように飛び回るマインドウォームの亜種。(シド・マイヤーズ・アルファ・ケンタウリ)"
@@ -69488,10 +67479,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "SHRIEK",
-          "S_KIN"
-        ]
+        "list": ["SHRIEK", "S_KIN"]
       },
       "flavor": {
         "ja": "近江国三上山に棲み、琵琶湖の魚を喰らい竜神一族を苦しめた巨大なムカデだ。その大きさは三上山を七巻半もする。俵藤太秀郷の矢を跳ね返し、彼を慌てさせた。「三上山を七巻半と聞けばすごいが、鉢巻にはちょいと足りない。」(落語「矢橋船」)",
@@ -69545,9 +67533,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "SHRIEK"
-        ],
+        "list": ["SHRIEK"],
         "shoot": "1d12"
       },
       "alliance": "JURAL",
@@ -69707,10 +67693,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BO_FIRE",
-          "BA_FIRE"
-        ]
+        "list": ["BO_FIRE", "BA_FIRE"]
       },
       "flavor": {
         "ja": "ボーレタリアが色のない霧に包まれた後、オーラント王の手先として彼の地を統率する異形の者だ。その醜く太った体を揺らしながら、不気味な笑いと共に火の玉を繰り出し、三日月の斧で襲いかかって来る。",
@@ -69749,10 +67732,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BO_MANA",
-          "BR_MANA"
-        ]
+        "list": ["BO_MANA", "BR_MANA"]
       },
       "flavor": {
         "ja": "この青く輝く巨大な蝶は、鱗を持たぬ白竜シースの手によって生み出された。",
@@ -69994,9 +67974,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BLIND"
-        ]
+        "list": ["BLIND"]
       },
       "flavor": {
         "ja": "それはまさにこれから伝説を作らんとするかのような活力に満ちた姿をしている。その光沢のある肉体は液状にうごめいていて、変幻自在に形を変えている。",
@@ -70063,9 +68041,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLIND"
-        ]
+        "list": ["BLIND"]
       },
       "flavor": {
         "ja": "大きなドラゴンで、銀色にうごめく鱗を持っている。",
@@ -70130,9 +68106,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLIND"
-        ]
+        "list": ["BLIND"]
       },
       "flavor": {
         "ja": "冷たい輝きと共に変幻自在の姿を見せる巨大なドラゴンだ。",
@@ -70743,12 +68717,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "TPORT",
-          "BO_FIRE",
-          "BO_ELEC",
-          "S_DEMON"
-        ]
+        "list": ["TPORT", "BO_FIRE", "BO_ELEC", "S_DEMON"]
       },
       "flavor": {
         "ja": "半人半魔のプレインズウォーカー、ティボルトは苦痛と騒乱が、自分を含めた全ての人々に及ぶことを常に望んでいる。",
@@ -71023,9 +68992,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_FIRE"
-        ]
+        "list": ["BR_FIRE"]
       },
       "flavor": {
         "ja": "大木を焼き尽くすほどの強力な炎を吐き出すことができるようになったコボルドだ。コボルド仲間の間でも暑苦しいと煙たがれることがある。",
@@ -71076,10 +69043,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_COLD",
-          "BR_FORC"
-        ]
+        "list": ["BR_COLD", "BR_FORC"]
       },
       "flavor": {
         "ja": "部屋の全てを永遠に凍りつかせるほどの強力な冷気を吐き出すことができる。それの周りではダイアモンドダストを見ることができるという。こいつが話すジョークの質はお察しの通りだ。",
@@ -71131,9 +69095,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_ELEC"
-        ]
+        "list": ["BR_ELEC"]
       },
       "flavor": {
         "ja": "君は見たことがあるだろうか、あのヱヅソンの忌まわしい実験を！このコボルドはあれと同じことができる！",
@@ -71184,9 +69146,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_ACID"
-        ]
+        "list": ["BR_ACID"]
       },
       "flavor": {
         "ja": "ああ、何ということだ！このコボルドが吐き出す酸はロウソクをも溶かしてしまう！",
@@ -71235,10 +69195,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_POIS",
-          "BR_TIME"
-        ]
+        "list": ["BR_POIS", "BR_TIME"]
       },
       "flavor": {
         "ja": "気をつけろ！やつの毒は大の大人を無力な子供に変えてしまう！",
@@ -71291,10 +69248,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "S_KIN",
-          "SHRIEK"
-        ]
+        "list": ["S_KIN", "SHRIEK"]
       },
       "flavor": {
         "ja": "「悪いなのび太、このダンジョンは3人用なんだ」しかし、彼に群がる金の亡者は明らかに3人よりも多い！",
@@ -71352,9 +69306,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BO_FIRE"
-        ],
+        "list": ["BO_FIRE"],
         "shoot": "8d4"
       },
       "flavor": {
@@ -71417,10 +69369,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "S_KIN",
-          "BO_ELEC"
-        ],
+        "list": ["S_KIN", "BO_ELEC"],
         "shoot": "10d10"
       },
       "flavor": {
@@ -71868,14 +69817,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "SCARE",
-          "BLIND",
-          "CONF",
-          "HOLD",
-          "BO_NETH",
-          "BR_NETH"
-        ]
+        "list": ["SCARE", "BLIND", "CONF", "HOLD", "BO_NETH", "BR_NETH"]
       },
       "flavor": {
         "ja": "奪衣婆と懸衣翁に仕え、三途の川に佇む鬼だ。それは時々賽の河原を見回って、積石塚を破壊して回る。",
@@ -72399,12 +70341,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "CAUSE_2",
-          "MISSILE",
-          "SCARE",
-          "S_KIN"
-        ]
+        "list": ["CAUSE_2", "MISSILE", "SCARE", "S_KIN"]
       },
       "flavor": {
         "ja": "悪知恵の働くイタチどもの頭領だ。イタチだけでなく、その恐怖を引き起こす威圧感でネズミ達をも従わせている。あなたの冒険は間もなく打ち切られるだろう。",
@@ -72575,9 +70512,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "MIND_BLAST"
-        ]
+        "list": ["MIND_BLAST"]
       },
       "flavor": {
         "ja": "それは痩せこけた巨人の姿をしていて、人食いの罪を犯した者を同族にすると言われている。",
@@ -72642,11 +70577,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BA_ELEC",
-          "BR_SOUN",
-          "S_DRAGON"
-        ]
+        "list": ["BA_ELEC", "BR_SOUN", "S_DRAGON"]
       },
       "escorts": [
         {
@@ -72733,11 +70664,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "BO_PLAS",
-          "BA_FIRE",
-          "BR_POIS"
-        ]
+        "list": ["BO_PLAS", "BA_FIRE", "BR_POIS"]
       },
       "escorts": [
         {
@@ -72827,11 +70754,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BA_FIRE",
-          "S_DEMON",
-          "BR_FIRE"
-        ]
+        "list": ["BA_FIRE", "S_DEMON", "BR_FIRE"]
       },
       "escorts": [
         {
@@ -72916,11 +70839,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BO_ICEE",
-          "BA_COLD",
-          "BR_COLD"
-        ]
+        "list": ["BO_ICEE", "BA_COLD", "BR_COLD"]
       },
       "escorts": [
         {
@@ -73016,10 +70935,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_ACID",
-          "BA_ACID"
-        ]
+        "list": ["BR_ACID", "BA_ACID"]
       },
       "escorts": [
         {
@@ -73097,9 +71013,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "ROCKET"
-        ]
+        "list": ["ROCKET"]
       },
       "escorts": [
         {
@@ -73155,11 +71069,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BO_MANA",
-          "MISSILE",
-          "BLINK"
-        ]
+        "list": ["BO_MANA", "MISSILE", "BLINK"]
       },
       "flavor": {
         "ja": "それは人の命を部品にし、鉄の翼を纏って戦場を駆け、敵味方共に幾多の血を流し続けた者達の亡霊だ。",
@@ -73205,9 +71115,7 @@
       ],
       "skill": {
         "probability": "1_IN_12",
-        "list": [
-          "BA_FIRE"
-        ]
+        "list": ["BA_FIRE"]
       },
       "flavor": {
         "ja": "彼は幸せな家族を根絶やしにするため、日々笑い声の聞こえてくる家庭を不幸の底に沈めている。彼は自分の行いを償うつもりはない。",
@@ -73250,10 +71158,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "MISSILE",
-          "ROCKET"
-        ],
+        "list": ["MISSILE", "ROCKET"],
         "shoot": "2d6"
       },
       "flavor": {
@@ -73307,10 +71212,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "S_KIN",
-          "BLIND"
-        ]
+        "list": ["S_KIN", "BLIND"]
       },
       "flavor": {
         "ja": "それはあらゆる生き物を餌食にしようと待ち構えている。",
@@ -73535,9 +71437,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "MISSILE"
-        ]
+        "list": ["MISSILE"]
       },
       "flavor": {
         "ja": "なんてこった、こいつ泡のくせに撃ち返してくるぞ！",
@@ -73591,9 +71491,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "MISSILE"
-        ]
+        "list": ["MISSILE"]
       },
       "flavor": {
         "ja": "不気味な動きをして撃ち返してくる、やや大きな泡だ。潰すと小さな泡になる。",
@@ -73646,9 +71544,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "MISSILE"
-        ]
+        "list": ["MISSILE"]
       },
       "flavor": {
         "ja": "不気味な動きをして撃ち返してくる大きな泡だ。潰しても中々なくならない。",
@@ -73701,9 +71597,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "MISSILE"
-        ]
+        "list": ["MISSILE"]
       },
       "flavor": {
         "ja": "不気味な動きをして撃ち返してくる巨大な泡だ。逃げるか潰すか二つに一つだ！",
@@ -73752,10 +71646,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BR_ELEC",
-          "BR_PLAS"
-        ]
+        "list": ["BR_ELEC", "BR_PLAS"]
       },
       "flavor": {
         "ja": "こいつの背後には近寄るな！",
@@ -73798,10 +71689,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BR_ELEC",
-          "BR_PLAS"
-        ]
+        "list": ["BR_ELEC", "BR_PLAS"]
       },
       "flavor": {
         "ja": "鉄獄に降り立ったモアイだ。こいつの吐き出すイオンリングは破壊できない。",
@@ -73844,10 +71732,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BR_ELEC",
-          "BR_PLAS"
-        ]
+        "list": ["BR_ELEC", "BR_PLAS"]
       },
       "flavor": {
         "ja": "トーテムポール状に積み上がったモアイだ。倒してもきりがない。",
@@ -73915,13 +71800,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "S_KIN",
-          "HOLD",
-          "CONF",
-          "BLIND",
-          "HEAL"
-        ]
+        "list": ["S_KIN", "HOLD", "CONF", "BLIND", "HEAL"]
       },
       "flavor": {
         "ja": "バクテリアン軍が放った強大な刺客だ。それは大量のプチモアイを生み出す。",
@@ -73984,9 +71863,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "HASTE"
-        ]
+        "list": ["HASTE"]
       },
       "flavor": {
         "ja": "避けきれたら君も上級者だ！",
@@ -74041,9 +71918,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "S_KIN"
-        ]
+        "list": ["S_KIN"]
       },
       "flavor": {
         "ja": "金のためだけに鬼を狩るプライドのない男だ。この愚かな者は敵の力量を見極めることができない。",
@@ -74081,13 +71956,7 @@
           "damage_dice": "1d12"
         }
       ],
-      "flags": [
-        "NAZGUL",
-        "FORCE_MAXHP",
-        "HUMAN",
-        "UNDEAD",
-        "DROP_60"
-      ],
+      "flags": ["NAZGUL", "FORCE_MAXHP", "HUMAN", "UNDEAD", "DROP_60"],
       "skill": {
         "probability": "1_IN_6",
         "shoot": "6d7"
@@ -74312,13 +72181,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "S_MONSTERS",
-          "SCARE",
-          "BA_DARK",
-          "BA_NETH",
-          "BR_POIS"
-        ]
+        "list": ["S_MONSTERS", "SCARE", "BA_DARK", "BA_NETH", "BR_POIS"]
       },
       "flavor": {
         "ja": "この半分がニンフで半分は蛇の神聖にして手の付けられない女怪は、数々のモンスターの母となった。",
@@ -74512,9 +72375,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BO_ELEC"
-        ]
+        "list": ["BO_ELEC"]
       },
       "flavor": {
         "ja": "緑色の法衣を身にまとった、拳法に熟練した高位の修行僧だ。",
@@ -74580,9 +72441,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "HEAL"
-        ]
+        "list": ["HEAL"]
       },
       "flavor": {
         "ja": "純白の法衣を身にまとった、拳法に熟練した高位の修行僧だ。",
@@ -74650,9 +72509,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "HASTE"
-        ]
+        "list": ["HASTE"]
       },
       "flavor": {
         "ja": "黄色の法衣を身にまとった、拳法に熟練した高位の修行僧だ。",
@@ -74718,9 +72575,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BO_NETH"
-        ]
+        "list": ["BO_NETH"]
       },
       "flavor": {
         "ja": "漆黒の法衣を身にまとい、暗殺拳に熟練した高位の修行僧だ。",
@@ -74872,12 +72727,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "HEAL",
-          "MIND_BLAST",
-          "S_SPIDER",
-          "S_HOUND"
-        ]
+        "list": ["HEAL", "MIND_BLAST", "S_SPIDER", "S_HOUND"]
       },
       "flavor": {
         "ja": "彼は後進を指導できるほどに肉体も精神も鍛え上げた修験者だ。彼の拳は岩の死線を捉えて一撃で砕くことができる。",
@@ -74947,12 +72797,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "HEAL",
-          "MIND_BLAST",
-          "S_SPIDER",
-          "S_HOUND"
-        ]
+        "list": ["HEAL", "MIND_BLAST", "S_SPIDER", "S_HOUND"]
       },
       "flavor": {
         "ja": "彼は修験道を真に極めた数少ない者であり、全ての種類の肉弾戦をマスターしている。そしてこの世界の自然界の生物に顎で命令を与えることができる。",
@@ -75010,11 +72855,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "TPORT",
-          "HOLD",
-          "S_DEMON"
-        ]
+        "list": ["TPORT", "HOLD", "S_DEMON"]
       },
       "flavor": {
         "ja": "この男は間もなく悪魔に取り込まれるだろう。それほどまでに彼は強い祈りを悪魔に捧げ続けている。",
@@ -75321,12 +73162,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "HOLD",
-          "SCARE",
-          "CAUSE_3",
-          "BO_NETH"
-        ]
+        "list": ["HOLD", "SCARE", "CAUSE_3", "BO_NETH"]
       },
       "flavor": {
         "ja": "この強力なあの世の者が近づいてくると、自分の魂が肉体から引き裂かれるようだ。",
@@ -75601,11 +73437,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "HEAL",
-          "TELE_TO",
-          "S_MONSTERS"
-        ]
+        "list": ["HEAL", "TELE_TO", "S_MONSTERS"]
       },
       "flavor": {
         "ja": "この巨人は天に届かんばかりの体躯で暴れ回っている。洞窟や階段の一部は彼らが通り過ぎた跡だ。",
@@ -75676,12 +73508,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_ACID"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_ACID"]
       },
       "flavor": {
         "ja": "巨大でとても強力なドラゴンだ。激しく蒸気を吹きだす酸を地面に滴らせ、滴った酸はダンジョンの岩石をあっという間に溶解し穴を空けている…これがあなたに当たったらどうなることか！",
@@ -75748,12 +73575,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_ACID"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_ACID"]
       },
       "flavor": {
         "ja": "この世で最も強力で凶悪なドラゴンの一体だ。近付いただけでその息吹に溶かされてしまうだろう！",
@@ -75826,12 +73648,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_ELEC"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_ELEC"]
       },
       "flavor": {
         "ja": "力に満ちた巨大なドラゴンだ。その山のような体の周りには嵐が巻き起こり、稲妻が光っている。深い青色の鱗が光を反射して、この生物の隆々たる筋肉を浮き彫りにしている。それは冒険者を軽蔑すべき者とみなしている。",
@@ -75900,12 +73717,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_ELEC"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_ELEC"]
       },
       "flavor": {
         "ja": "この世で最も強力で凶悪なドラゴンの一体だ。近付いただけでその息吹で黒焦げにされてしまうだろう！",
@@ -75980,12 +73792,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_FIRE"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_FIRE"]
       },
       "flavor": {
         "ja": "それは信じ難たい程の力を持った巨大なドラゴンで、その体からは常に炎が吹き上がっている。その周りに立ちこめる熱気だけでも冒険者を火傷させるのには充分であり、そのほんの一瞥だけでも冒険者を燃え上がらせるには十分だ。冒険者はこの生物の前では自分がなんと無力であるのかを痛感するだろう。",
@@ -76055,12 +73862,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_FIRE"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_FIRE"]
       },
       "flavor": {
         "ja": "この世で最も強力で凶悪なドラゴンの一体だ。その息吹はあなたの身体を骨一本残さず焼き尽くす！",
@@ -76133,12 +73935,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_COLD"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_COLD"]
       },
       "flavor": {
         "ja": "恐るべき破壊能力を持った巨大なドラゴンだ。このような冷気はかつて感じたことがないし、このような冷たい眼差しはかつて見たことがない。素早く逃げないと恐るべき怒りを呼び覚ましてしまうだろう！",
@@ -76207,12 +74004,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_COLD"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_COLD"]
       },
       "flavor": {
         "ja": "この世で最も強力で凶悪なドラゴンの一体だ。その息吹はあなたが近付いただけでフロアごと氷漬けにしてしまうだろう！",
@@ -76283,12 +74075,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_POIS"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_POIS"]
       },
       "flavor": {
         "ja": "信じられない程の破壊的な力を持った巨大なドラゴンだ。有毒な霧が近くの部屋に充満し、ほとんど息ができない。逃げられるうちに逃げろ！",
@@ -76355,12 +74142,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_POIS"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_POIS"]
       },
       "flavor": {
         "ja": "この世で最も強力で凶悪なドラゴンの一体だ。一息でも浴びてしまえば、遺族はあなたの遺体に近付くことすらできなくなる！",
@@ -76699,12 +74481,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "SLOW",
-          "CONF",
-          "SCARE",
-          "BR_SHAR"
-        ]
+        "list": ["SLOW", "CONF", "SCARE", "BR_SHAR"]
       },
       "flavor": {
         "ja": "巨大な水晶のようなドラゴンだ。冒険者の体をバラバラに切り刻むことができる爪と、剃刀のように鋭い歯を持っている。それが動くと光が反射して体中が奇妙な色にきらめく。",
@@ -76770,12 +74547,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_SOUN"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_SOUN"]
       },
       "flavor": {
         "ja": "ダンジョンの天井を崩し新しい地形を生み出すほどの力強い咆哮を放つドラゴンだ。",
@@ -76840,11 +74612,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SCARE",
-          "BR_FIRE",
-          "BA_FIRE"
-        ]
+        "list": ["SCARE", "BR_FIRE", "BA_FIRE"]
       },
       "flavor": {
         "ja": "このドラゴンはアルドゥイン復活の報を受け、イの一番に駆けつけた最も忠実な部下だ。街の衛兵ごときは軽く焼き尽くす。",
@@ -76908,11 +74676,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SCARE",
-          "BR_COLD",
-          "BA_COLD"
-        ]
+        "list": ["SCARE", "BR_COLD", "BA_COLD"]
       },
       "flavor": {
         "ja": "冥界から舞い戻ってきたドラゴンの一体だ。街の衛兵ごときは軽く氷像にしてしまう。",
@@ -76981,13 +74745,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "SCARE",
-          "BA_ELEC",
-          "BR_FIRE",
-          "BR_COLD",
-          "BR_SOUN"
-        ]
+        "list": ["SCARE", "BA_ELEC", "BR_FIRE", "BR_COLD", "BR_SOUN"]
       },
       "flavor": {
         "ja": "他のドラゴンに漏れず天より高いプライドを持ち、挑発にはすぐ乗るタチだ。",
@@ -77049,10 +74807,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "HEAL",
-          "CAUSE_3"
-        ],
+        "list": ["HEAL", "CAUSE_3"],
         "shoot": "8d8"
       },
       "flavor": {
@@ -77124,13 +74879,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "SCARE",
-          "BA_ELEC",
-          "BR_FIRE",
-          "BR_COLD",
-          "BR_SOUN"
-        ]
+        "list": ["SCARE", "BA_ELEC", "BR_FIRE", "BR_COLD", "BR_SOUN"]
       },
       "flavor": {
         "ja": "このドラゴンは邪悪なる同族達に対抗するために存在する。厳しい修行を行えば、その果てにドラゴンの力を手に入れられると伝えられている。",
@@ -77204,12 +74953,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "SCARE",
-          "BR_FIRE",
-          "BR_SOUN",
-          "BR_NETH"
-        ]
+        "list": ["SCARE", "BR_FIRE", "BR_SOUN", "BR_NETH"]
       },
       "flavor": {
         "ja": "あまりにも永い間冥界にい続けたため、現世で肉体を保つことが困難になったドラゴンだ。それはあなたの実力を十分に認めている。",
@@ -77573,14 +75317,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "TPORT",
-          "BA_DARK",
-          "S_UNDEAD",
-          "S_KIN",
-          "S_HI_UNDEAD",
-          "HEAL"
-        ]
+        "list": ["TPORT", "BA_DARK", "S_UNDEAD", "S_KIN", "S_HI_UNDEAD", "HEAL"]
       },
       "flavor": {
         "ja": "太陽の光をこの大地から消しさそろうとしている恐るべき吸血鬼だ。そのためには眷属をも容易く使い捨てにする、冷酷な男でもある。",
@@ -77685,9 +75422,7 @@
       ],
       "skill": {
         "probability": "1_IN_9",
-        "list": [
-          "BA_COLD"
-        ],
+        "list": ["BA_COLD"],
         "shoot": "7d7"
       },
       "flavor": {
@@ -77749,9 +75484,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BA_COLD"
-        ],
+        "list": ["BA_COLD"],
         "shoot": "8d9"
       },
       "flavor": {
@@ -77816,12 +75549,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "SCARE",
-          "BA_COLD",
-          "BR_COLD",
-          "BR_SOUN"
-        ],
+        "list": ["SCARE", "BA_COLD", "BR_COLD", "BR_SOUN"],
         "shoot": "10d9"
       },
       "flavor": {
@@ -77884,13 +75612,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "SCARE",
-          "BA_COLD",
-          "BR_COLD",
-          "BR_SOUN",
-          "S_UNDEAD"
-        ],
+        "list": ["SCARE", "BA_COLD", "BR_COLD", "BR_SOUN", "S_UNDEAD"],
         "shoot": "12d10"
       },
       "flavor": {
@@ -78179,9 +75901,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BA_POIS"
-        ],
+        "list": ["BA_POIS"],
         "shoot": "8d8"
       },
       "flavor": {
@@ -78237,13 +75957,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "BA_POIS",
-          "BR_POIS",
-          "CONF",
-          "HOLD",
-          "BLIND"
-        ],
+        "list": ["BA_POIS", "BR_POIS", "CONF", "HOLD", "BLIND"],
         "shoot": "13d8"
       },
       "flavor": {
@@ -78304,13 +76018,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "BA_POIS",
-          "BR_POIS",
-          "CONF",
-          "HOLD",
-          "BLIND"
-        ],
+        "list": ["BA_POIS", "BR_POIS", "CONF", "HOLD", "BLIND"],
         "shoot": "15d10"
       },
       "flavor": {
@@ -78371,14 +76079,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BA_ELEC",
-          "BA_POIS",
-          "BR_POIS",
-          "CONF",
-          "HOLD",
-          "BLIND"
-        ],
+        "list": ["BA_ELEC", "BA_POIS", "BR_POIS", "CONF", "HOLD", "BLIND"],
         "shoot": "18d10"
       },
       "flavor": {
@@ -78440,14 +76141,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BA_ELEC",
-          "BA_POIS",
-          "BR_POIS",
-          "CONF",
-          "HOLD",
-          "BLIND"
-        ],
+        "list": ["BA_ELEC", "BA_POIS", "BR_POIS", "CONF", "HOLD", "BLIND"],
         "shoot": "21d10"
       },
       "flavor": {
@@ -78498,14 +76192,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BA_ELEC",
-          "BA_POIS",
-          "BR_POIS",
-          "CONF",
-          "HOLD",
-          "BLIND"
-        ],
+        "list": ["BA_ELEC", "BA_POIS", "BR_POIS", "CONF", "HOLD", "BLIND"],
         "shoot": "11d8"
       },
       "flavor": {
@@ -78561,14 +76248,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BA_ELEC",
-          "BA_POIS",
-          "BR_POIS",
-          "CONF",
-          "HOLD",
-          "BLIND"
-        ],
+        "list": ["BA_ELEC", "BA_POIS", "BR_POIS", "CONF", "HOLD", "BLIND"],
         "shoot": "13d10"
       },
       "flavor": {
@@ -78629,14 +76309,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BA_ELEC",
-          "BA_POIS",
-          "BR_POIS",
-          "CONF",
-          "HOLD",
-          "BLIND"
-        ],
+        "list": ["BA_ELEC", "BA_POIS", "BR_POIS", "CONF", "HOLD", "BLIND"],
         "shoot": "15d12"
       },
       "flavor": {
@@ -78696,14 +76369,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BA_ELEC",
-          "BA_POIS",
-          "BR_POIS",
-          "CONF",
-          "HOLD",
-          "BLIND"
-        ],
+        "list": ["BA_ELEC", "BA_POIS", "BR_POIS", "CONF", "HOLD", "BLIND"],
         "shoot": "20d13"
       },
       "flavor": {
@@ -78764,14 +76430,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BA_ELEC",
-          "BA_POIS",
-          "BR_POIS",
-          "CONF",
-          "HOLD",
-          "BLIND"
-        ],
+        "list": ["BA_ELEC", "BA_POIS", "BR_POIS", "CONF", "HOLD", "BLIND"],
         "shoot": "21d15"
       },
       "flavor": {
@@ -79021,10 +76680,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BR_FIRE",
-          "SCARE"
-        ]
+        "list": ["BR_FIRE", "SCARE"]
       },
       "flavor": {
         "ja": "人々の悪意によって真夜中に魂を刈り取られた哀れな犬達の末路だ。",
@@ -79083,12 +76739,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "S_KIN",
-          "BR_FIRE",
-          "SCARE",
-          "HOLD"
-        ]
+        "list": ["S_KIN", "BR_FIRE", "SCARE", "HOLD"]
       },
       "escorts": [
         {
@@ -79236,9 +76887,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "HASTE"
-        ]
+        "list": ["HASTE"]
       },
       "flavor": {
         "ja": "彼女ができました…（「月刊チェヨンス」アオリ文、号不明）",
@@ -79311,13 +76960,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "CONF",
-          "SCARE",
-          "BR_COLD",
-          "BR_DARK",
-          "BR_NETH"
-        ]
+        "list": ["CONF", "SCARE", "BR_COLD", "BR_DARK", "BR_NETH"]
       },
       "flavor": {
         "ja": "古代の偉大なドラゴンの骸骨に、最も危険な魔法によって生命を吹き込んだものだ。餌食に素早い一撃を食らわせ、その生命を吸い取っては空腹を満たしている。",
@@ -79385,13 +77028,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "HOLD",
-          "SCARE",
-          "BR_FIRE",
-          "BR_POIS",
-          "BR_NETH"
-        ]
+        "list": ["HOLD", "SCARE", "BR_FIRE", "BR_POIS", "BR_NETH"]
       },
       "flavor": {
         "ja": "ドラゴンとバシリスクの混血であるドラコリスクは、深く突き刺すような視線で冒険者を睨みつける。その邪悪なブレスは、自分の足下の大地ですら燃え上がらせる。",
@@ -79457,11 +77094,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_POIS",
-          "BR_DARK",
-          "BR_NETH"
-        ]
+        "list": ["BR_POIS", "BR_DARK", "BR_NETH"]
       },
       "flavor": {
         "ja": "巨大なバシリスクで、ワイアームに似た姿をしている。",
@@ -79520,9 +77153,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BO_PLAS"
-        ]
+        "list": ["BO_PLAS"]
       },
       "flavor": {
         "ja": "山羊の頭を持つ高位の魔王で、簡単には倒せない。",
@@ -79606,13 +77237,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BLINK",
-          "HOLD",
-          "BLIND",
-          "CONF",
-          "SCARE"
-        ]
+        "list": ["BLINK", "HOLD", "BLIND", "CONF", "SCARE"]
       },
       "flavor": {
         "ja": "ブル・ゲイツの新たなる究極兵器だ。それは世界を牛耳るコングロマリットから多額の援助を得て、インターネット・エクスプローダーから不気味なまでに強化されている。",
@@ -79678,10 +77303,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_SOUN",
-          "BR_PLAS"
-        ]
+        "list": ["BR_SOUN", "BR_PLAS"]
       },
       "flavor": {
         "ja": "ブル・ゲイツの究極兵器「インターネット・エクスプローダー」による世界征服計画に対抗してジョーブツが製造した至高の兵器だ。それはけたたましい音と、あらゆる電子機器を誤動作させる電磁波で彼らの邪悪な欲望に対抗している。",
@@ -79822,13 +77444,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BR_NETH",
-          "S_MONSTERS",
-          "S_DEMON",
-          "S_HOUND",
-          "SCARE"
-        ]
+        "list": ["BR_NETH", "S_MONSTERS", "S_DEMON", "S_HOUND", "SCARE"]
       },
       "flavor": {
         "ja": "２つ首と蛇の尾を持つ猟犬だ。彼はエキドナの長子であり、スフィンクスとネメアのライオンの父たる一族の男系筆頭の魔神だ。彼が呼びかければハデスの家臣も応える。",
@@ -80010,12 +77626,7 @@
           "damage_dice": "2d3"
         }
       ],
-      "flags": [
-        "AQUATIC",
-        "ANIMAL",
-        "WILD_ALL",
-        "RES_WATE"
-      ],
+      "flags": ["AQUATIC", "ANIMAL", "WILD_ALL", "RES_WATE"],
       "flavor": {
         "ja": "この魚は英語ではキマイラと言い、継ぎ接ぎめいた姿から合成魔獣の名を付けられた。それは毒針を持っている。",
         "en": "This fish is also known as a ghost shark and is named after the hybrid monster due to its patchwork-like appearance.  It has a poisoned stinger."
@@ -80125,11 +77736,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "SHRIEK",
-          "S_KIN",
-          "BR_ACID"
-        ]
+        "list": ["SHRIEK", "S_KIN", "BR_ACID"]
       },
       "escorts": [
         {
@@ -80281,9 +77888,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BA_ACID"
-        ]
+        "list": ["BA_ACID"]
       },
       "flavor": {
         "ja": "この龍虫が多数合体すると百足龍虫になる。百足龍虫時の脊髄にあたる部分には眼と思われる器官がついている。",
@@ -80351,9 +77956,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BA_ACID"
-        ]
+        "list": ["BA_ACID"]
       },
       "flavor": {
         "ja": "巨大な百足の正体は多数の巨大生物が合体した生物だった。百足龍虫から分離した群体は独立した龍虫として活動を始める。",
@@ -80426,9 +78029,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BA_ACID"
-        ]
+        "list": ["BA_ACID"]
       },
       "flavor": {
         "ja": "巨大生物の最終進化形態、ビルよりも高く長い全長を持つ雄大なムカデだ。無数の突起から土砂降りのように酸を降り注がせる。",
@@ -80497,10 +78098,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "SCARE",
-          "BO_PLAS"
-        ]
+        "list": ["SCARE", "BO_PLAS"]
       },
       "flavor": {
         "ja": "悪の組織によって造られたかのような、灰色の魔法使いの姿をした悪夢的ロボットだ。機械の力を畏れよ！",
@@ -80579,12 +78177,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "SHRIEK",
-          "BA_FIRE",
-          "PSY_SPEAR",
-          "S_KIN"
-        ]
+        "list": ["SHRIEK", "BA_FIRE", "PSY_SPEAR", "S_KIN"]
       },
       "flavor": {
         "ja": "ブレッタの夢想とゾートの執着心が生み出した、勇者の幻影。倒す度に夢の中のゾートは執念を増し、それと反対にブレッタの夢は醒めていく。 ",
@@ -80624,11 +78217,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BLINK",
-          "TPORT",
-          "S_ANGEL"
-        ]
+        "list": ["BLINK", "TPORT", "S_ANGEL"]
       },
       "flavor": {
         "ja": "天使の残骸が、邪悪な魔法で結合した塊だ。それは神々しくも禍々しく脈打っている。",
@@ -80667,11 +78256,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BLINK",
-          "TELE_TO",
-          "S_MONSTERS"
-        ]
+        "list": ["BLINK", "TELE_TO", "S_MONSTERS"]
       },
       "flavor": {
         "ja": "それは脈打つ強力な肉の塊だ。 ",
@@ -80729,11 +78314,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "HASTE",
-          "HEAL",
-          "CAUSE_2"
-        ]
+        "list": ["HASTE", "HEAL", "CAUSE_2"]
       },
       "flavor": {
         "ja": "二足で歩き、人語を解す妖精猫。このケット・シーは猫の王国に仕える剣士のようだ。あなたを王に献上する獲物と見なしている。",
@@ -80770,10 +78351,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "TELE_TO",
-          "S_KIN"
-        ]
+        "list": ["TELE_TO", "S_KIN"]
       },
       "flavor": {
         "ja": "陶器でできた猫の置物だ！手招きするとがっぽがっぽだ！",
@@ -80836,13 +78414,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "HOLD",
-          "BR_ACID",
-          "BR_DISE",
-          "BR_NEXU",
-          "BR_GRAV"
-        ]
+        "list": ["HOLD", "BR_ACID", "BR_DISE", "BR_NEXU", "BR_GRAV"]
       },
       "flavor": {
         "ja": "破壊神シヴァの力を持った革の靴だ。",
@@ -81032,9 +78604,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BR_GRAV"
-        ]
+        "list": ["BR_GRAV"]
       },
       "flavor": {
         "ja": "かわいい陸行性のカラスだ。よく群れをなして行儀よく動き回っている。",
@@ -81091,11 +78661,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BA_ELEC",
-          "BR_GRAV",
-          "TELE_AWAY"
-        ]
+        "list": ["BA_ELEC", "BR_GRAV", "TELE_AWAY"]
       },
       "flavor": {
         "ja": "それは頭を踏まれたくらいでは温厚だが、お尻に杭を打ち込まれると激怒する。",
@@ -81159,11 +78725,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BA_WATE",
-          "HASTE",
-          "S_UNDEAD"
-        ]
+        "list": ["BA_WATE", "HASTE", "S_UNDEAD"]
       },
       "flavor": {
         "ja": "人が跨がれるほど巨大なキュウリに四本の棒を刺すことで誕生した馬だ。足が早い。先祖の霊を乗せるはずだが、乗り手が見つからなかったため適当な霊を乗せている。瑞々しい体からは汁が噴き出す。",
@@ -81227,12 +78789,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BA_WATE",
-          "BR_INER",
-          "SLOW",
-          "TELE_TO"
-        ]
+        "list": ["BA_WATE", "BR_INER", "SLOW", "TELE_TO"]
       },
       "flavor": {
         "ja": "人が跨がれるほど巨大なナスに四本の棒を刺すことで誕生した牛だ。足が遅い。先祖の霊を乗せるはずだが、乗り手が見つからないため適当な霊を乗せていこうとしている。瑞々しい体からは汁が噴き出す。",
@@ -81309,11 +78866,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BRAIN_SMASH",
-          "DARKNESS",
-          "SCARE"
-        ]
+        "list": ["BRAIN_SMASH", "DARKNESS", "SCARE"]
       },
       "flavor": {
         "ja": "それはこの世で最も忌まわしい生き物の一つである。それは相手からあらゆる幸せな気持ちを吸い取り、後には不幸しか残さない。それのそばでは動く気力すら沸かなくなるため、刑務所の看守として登用されている。最近、闇の勢力が力を拡大するに連れて、一部が野に放たれてしまったようだ。"
@@ -81367,10 +78920,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "SHRIEK",
-          "TELE_TO"
-        ]
+        "list": ["SHRIEK", "TELE_TO"]
       },
       "flavor": {
         "ja": "伝承のセイレーンは歌声で船を難破させたが、鉄獄のセイレーンはもっと手っ取り早い方法を知っている。",
@@ -81496,14 +79046,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BA_FIRE",
-          "BA_LITE",
-          "HEAL",
-          "HOLD",
-          "CONF",
-          "BLIND"
-        ]
+        "list": ["BA_FIRE", "BA_LITE", "HEAL", "HOLD", "CONF", "BLIND"]
       }
     },
     {
@@ -81550,9 +79093,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "MISSILE"
-        ]
+        "list": ["MISSILE"]
       },
       "flavor": {
         "ja": "たった数枚の古ぼけた写真が、この妖精がかつて実在したことの唯一の証拠だ。 ",
@@ -81706,14 +79247,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BO_ELEC",
-          "BA_ELEC",
-          "BR_ELEC",
-          "BLINK",
-          "HOLD",
-          "CAUSE_3"
-        ]
+        "list": ["BO_ELEC", "BA_ELEC", "BR_ELEC", "BLINK", "HOLD", "CAUSE_3"]
       },
       "flavor": {
         "ja": "彼女はかつて愛する人を殺され、その怒りで瞳は怨讐の意思に満ち満ちている。二人の仲を切り裂いたのが神官であったことから、鉄獄でもあらゆる宗教施設とその遺跡を破壊し続けている。",
@@ -81779,12 +79313,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BA_DARK",
-          "CAUSE_3",
-          "SCARE",
-          "FORGET"
-        ]
+        "list": ["BA_DARK", "CAUSE_3", "SCARE", "FORGET"]
       },
       "flavor": {
         "ja": "彼は\"第三の大扉\"の内側に住み、銀髪をまとった少年の姿をしている。彼の右手からはほんのりと林檎の甘酸っぱい香りがする。それは死んだ部下からの贈り物らしい。",
@@ -82000,14 +79529,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "BR_LITE",
-          "BR_DARK",
-          "BR_CONF"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "BR_LITE", "BR_DARK", "BR_CONF"]
       },
       "flavor": {
         "ja": "冒険者の蛮勇。後悔の境界は崩壊の慟哭を伴って、奔流の集合を展開させる。光と闇の奏でる音階はこのドラゴンの強大さを示す証拠となり、あなたの活気を失わせる。この餌の匂いに敏感なドラゴンは深い洞窟の奥でウラヌスとセレーネの力を支配している。冒険者はこの不徳なドラゴンを斃す栄光の誘惑に駆られるだろうが、それは傑作な風刺画の材料にしかならない。胴体へ結合された二つの恐ろしげな首はあなたを単なる世俗で怠慢な獲物としか見ていない。あなたの行く末が天国か地獄かは、戦ってみれば分かるだろう。あなたの墓標に一輪の千屈菜が添えられんことを。",
@@ -82071,9 +79593,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "TRAPS"
-        ]
+        "list": ["TRAPS"]
       },
       "artifacts": [
         {
@@ -82475,9 +79995,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "BR_CHAO"
-        ]
+        "list": ["BR_CHAO"]
       },
       "flavor": {
         "ja": "ネズミのような頭部から蛸のような足が生えている危険な生物だ。",
@@ -82548,14 +80066,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BR_FIRE",
-          "BA_FIRE",
-          "BR_COLD",
-          "BA_COLD",
-          "HOLD",
-          "HASTE"
-        ]
+        "list": ["BR_FIRE", "BA_FIRE", "BR_COLD", "BA_COLD", "HOLD", "HASTE"]
       },
       "flavor": {
         "ja": "大魔王に仕える高位のアンデッド。4つの腕でそれぞれ異なる武器を振るう。",
@@ -82644,9 +80155,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "INVULNER"
-        ]
+        "list": ["INVULNER"]
       },
       "flavor": {
         "ja": "臆病で鈍臭いがさっぱりした性格の少年。よく「電話」をしている。",
@@ -82702,11 +80211,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "INVULNER",
-          "WORLD",
-          "TELE_TO"
-        ]
+        "list": ["INVULNER", "WORLD", "TELE_TO"]
       },
       "flavor": {
         "ja": "イタリアを中心に活動するギャング組織「パッショーネ」のボス。何人たりとも自分の過去や情報を探ることを許さず、組織にも一切顔を出さないという臆病ともとれてしまうほどの用心深さから、その正体を知る者は最高幹部も含めて全くいない。「誰だろうとわたしの永遠の絶頂をおびやかす者は許さない 決して 確実に消え去ってもらう」",
@@ -82771,9 +80276,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "S_KIN"
-        ]
+        "list": ["S_KIN"]
       },
       "flavor": {
         "ja": "イタリアのギャング組織「パッショーネ」の特殊部隊「ボス親衛隊」の一人にして、ボスの切り札。食人カビを散布するスタンド「グリーン・ディ」によってローマ市民を虐殺した。",
@@ -82979,10 +80482,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BA_FIRE",
-          "BR_FIRE"
-        ]
+        "list": ["BA_FIRE", "BR_FIRE"]
       },
       "flavor": {
         "ja": "それは熱く燃えている。（任天堂『マザー２』）",
@@ -83019,12 +80519,7 @@
           "damage_dice": "3d4"
         }
       ],
-      "flags": [
-        "BASH_DOOR",
-        "WILD_GRASS",
-        "ANIMAL",
-        "PASS_WALL"
-      ],
+      "flags": ["BASH_DOOR", "WILD_GRASS", "ANIMAL", "PASS_WALL"],
       "flavor": {
         "ja": "この恐るべき虎は、さる殿様の屋敷に飾ってある屏風から毎晩抜け出しては人を食い殺していた。そこで殿様は坊主に退治を依頼して屏風からこの虎を出した。しかし坊主は捕まえ損ね、虎はそのまま逃げ出してしまった。それから幾星霜、この虎は鉄獄に居着いて繁殖している。",
         "en": "This terrifying tiger used to escape nightly from the folding screen in a lord's mansion and eat people.  So the lord asked a child priest to get rid of the tiger.  The priest exorcised the tiger from the screen but did not catch it afterwards.  Now it roams as it wills.  Now it is settled in the Angband and breeding."
@@ -83206,12 +80701,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "INVULNER",
-          "SCARE",
-          "TELE_TO",
-          "BR_TIME"
-        ]
+        "list": ["INVULNER", "SCARE", "TELE_TO", "BR_TIME"]
       },
       "flavor": {
         "ja": "リンギル。それはノルドールの上級王フィンゴルフィンの武器。氷の柱の如く輝いている。彼は生前は少佐で、あの剣の力をいつまでも探し続けている。彼はこの剣の力を再び思い知ることになるだろう。",
@@ -83271,9 +80761,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "TRAPS"
-        ]
+        "list": ["TRAPS"]
       },
       "escorts": [
         {
@@ -83736,13 +81224,7 @@
           "damage_dice": "3d6"
         }
       ],
-      "flags": [
-        "WILD_ONLY",
-        "FRIENDS",
-        "ANIMAL",
-        "EVIL",
-        "WILD_ALL"
-      ],
+      "flags": ["WILD_ONLY", "FRIENDS", "ANIMAL", "EVIL", "WILD_ALL"],
       "flavor": {
         "ja": "十五夜になると盗難バイクで往来の邪魔をする迷惑系暴走族だ。",
         "en": "It is one of an annoying runaway tribe that interferes with traffic on stolen motorcycles under the autumn full moon."
@@ -83813,13 +81295,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "SCARE",
-          "HOLD",
-          "CONF",
-          "BLIND",
-          "BR_CHAO"
-        ]
+        "list": ["SCARE", "HOLD", "CONF", "BLIND", "BR_CHAO"]
       },
       "flavor": {
         "ja": "世界で最も巨大な軍産複合体の一つ、マクドネルド社に籍を置くテロリストだ。彼は様々な人々を動脈硬化によって緩やかな死へと追いやった。",
@@ -84171,12 +81647,7 @@
           "damage_dice": "1d5"
         }
       ],
-      "flags": [
-        "CAN_FLY",
-        "WILD_GRASS",
-        "ANIMAL",
-        "DROP_SKELETON"
-      ],
+      "flags": ["CAN_FLY", "WILD_GRASS", "ANIMAL", "DROP_SKELETON"],
       "flavor": {
         "ja": "それは奇妙な電波を飛ばしている。",
         "en": "It emits strange microwaves."
@@ -84272,10 +81743,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_ELEC",
-          "BO_ELEC"
-        ]
+        "list": ["BR_ELEC", "BO_ELEC"]
       },
       "flavor": {
         "ja": "かわいらしい外見をしているが、油断すると思わぬ衝撃を受けるだろう。",
@@ -84333,10 +81801,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_ELEC",
-          "BO_ELEC"
-        ]
+        "list": ["BR_ELEC", "BO_ELEC"]
       },
       "flavor": {
         "ja": "世界中で大人気のゲーム、パチパチモンスター略してパチモンのキャラだ。それは家だけでなく職場でもこっそり酒を飲んでいる。",
@@ -84394,10 +81859,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_ELEC",
-          "BO_ELEC"
-        ]
+        "list": ["BR_ELEC", "BO_ELEC"]
       },
       "flavor": {
         "ja": "世界中で大人気のゲーム、パチパチモンスター略してパチモンのキャラだ。普段は前足が震えている。一滴でも飲んだら寝るまで飲むのを止められない。",
@@ -84450,10 +81912,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BLINK",
-          "TPORT"
-        ]
+        "list": ["BLINK", "TPORT"]
       },
       "flavor": {
         "ja": "彼女は決して資本の犬ではない。",
@@ -84590,10 +82049,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BR_FIRE",
-          "BA_FIRE"
-        ]
+        "list": ["BR_FIRE", "BA_FIRE"]
       },
       "flavor": {
         "ja": "コレカラスターの火山内に潜む、全身が溶岩で出来た怪物だ。",
@@ -84667,9 +82123,7 @@
       ],
       "skill": {
         "probability": "1_IN_7",
-        "list": [
-          "DISPEL"
-        ]
+        "list": ["DISPEL"]
       },
       "escorts": [
         {
@@ -84751,14 +82205,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BR_FIRE",
-          "BA_FIRE",
-          "BA_ELEC",
-          "MISSILE",
-          "HASTE",
-          "HEAL"
-        ]
+        "list": ["BR_FIRE", "BA_FIRE", "BA_ELEC", "MISSILE", "HASTE", "HEAL"]
       },
       "escorts": [
         {
@@ -84985,10 +82432,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BO_FIRE",
-          "BA_POIS"
-        ],
+        "list": ["BO_FIRE", "BA_POIS"],
         "shoot": "13d1"
       },
       "flavor": {
@@ -85056,13 +82500,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_ACID",
-          "BR_ELEC",
-          "BA_ELEC",
-          "BA_ACID",
-          "S_KIN"
-        ]
+        "list": ["BR_ACID", "BR_ELEC", "BA_ELEC", "BA_ACID", "S_KIN"]
       },
       "flavor": {
         "ja": "名状しがたい外見をしているが、油断すると思わぬ衝撃を受けるだろう。",
@@ -85117,13 +82555,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "HASTE",
-          "BLINK",
-          "TPORT",
-          "S_KIN",
-          "CONF"
-        ]
+        "list": ["HASTE", "BLINK", "TPORT", "S_KIN", "CONF"]
       },
       "escorts": [
         {
@@ -85275,10 +82707,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_ELEC",
-          "BO_ELEC"
-        ]
+        "list": ["BR_ELEC", "BO_ELEC"]
       },
       "flavor": {
         "ja": "とうとうスピードに手を出してしまったパチモンだ。それは常に虫が這いずる感覚と戦っている。",
@@ -85403,11 +82832,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BR_PLAS",
-          "BO_PLAS",
-          "S_KIN"
-        ]
+        "list": ["BR_PLAS", "BO_PLAS", "S_KIN"]
       },
       "flavor": {
         "ja": "この世すべての超常現象はプラズマで説明できると豪語する教授だ。全身にプラズマ改造を施し、もはや人間とは言い難いものになっている。混沌のサーペントも彼にとってはプラズマの一種である。",
@@ -85710,14 +83135,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "CAUSE_2",
-          "BA_POIS",
-          "S_MONSTER"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "CAUSE_2", "BA_POIS", "S_MONSTER"]
       },
       "flavor": {
         "ja": "放置された箱に化けている奇妙な生物の像に化けている奇妙な生物の像に化けている奇妙な生物で、愚かな冒険者がその毒のある爪の射程に入るのを待ち構えている。",
@@ -85776,14 +83194,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "CAUSE_2",
-          "BA_POIS",
-          "S_MONSTER"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "CAUSE_2", "BA_POIS", "S_MONSTER"]
       },
       "flavor": {
         "ja": "放置された箱に化けている奇妙な生物の像に化けている奇妙な生物の像に化けている奇妙な生物の像に化けている奇妙な生物で、愚かな冒険者がその毒のある爪の射程に入るのを待ち構えている。",
@@ -85842,14 +83253,7 @@
       ],
       "skill": {
         "probability": "1_IN_3",
-        "list": [
-          "BLIND",
-          "CONF",
-          "SCARE",
-          "CAUSE_2",
-          "BA_POIS",
-          "S_MONSTER"
-        ]
+        "list": ["BLIND", "CONF", "SCARE", "CAUSE_2", "BA_POIS", "S_MONSTER"]
       },
       "flavor": {
         "ja": "放置された箱に化けている奇妙な生物の像に化けている奇妙な生物の像に化けている奇妙な生物の像に化けている奇妙な生物の像に化けている奇妙な生物の像に化けている奇妙な生物の像に化けている奇妙な生物の像に化けている奇妙な生物の像に化けている奇妙な生物の像に化けている奇妙な生物の像に化けている奇妙な生物で、愚かな冒険者がその毒のある爪の射程に入るのを待ち構えている。",
@@ -85924,10 +83328,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BR_NUKE",
-          "TPORT"
-        ]
+        "list": ["BR_NUKE", "TPORT"]
       },
       "flavor": {
         "ja": "白い馬に乗った「災厄」そのものだ。あなたを病に苦しめるだろう。",
@@ -86004,10 +83405,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "TPORT",
-          "BR_INER"
-        ]
+        "list": ["TPORT", "BR_INER"]
       },
       "flavor": {
         "ja": "黒い馬に乗り秤を持った「飢餓」そのものだ。あなたを飢えに苦しめるだろう。",
@@ -86083,11 +83481,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "HAND_DOOM",
-          "TPORT",
-          "BR_NETH"
-        ]
+        "list": ["HAND_DOOM", "TPORT", "BR_NETH"]
       },
       "flavor": {
         "ja": "蒼ざめた馬に乗った「死」そのものだ。あなたを死に至らしめるだろう。",
@@ -86449,9 +83843,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BO_FIRE"
-        ]
+        "list": ["BO_FIRE"]
       },
       "flavor": {
         "ja": "それはとても丸っこくて体の上部に8本、下部に4本の角があり、浮遊する一つ目の悪魔だ。その裂けたような口からプラズマの弾を発射してくる。",
@@ -86506,9 +83898,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BA_FIRE"
-        ]
+        "list": ["BA_FIRE"]
       },
       "flavor": {
         "ja": "この両腕に砲がある太っちょが出す火の弾は悪夢そのものだ。",
@@ -86551,9 +83941,7 @@
       ],
       "skill": {
         "probability": "1_IN_1",
-        "list": [
-          "BO_PLAS"
-        ]
+        "list": ["BO_PLAS"]
       },
       "flavor": {
         "ja": "それは脳みそのような生き物で、蜘蛛のような脚を4つ持つ機械に乗っている。",
@@ -86599,9 +83987,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_VOID"
-        ]
+        "list": ["BR_VOID"]
       },
       "flavor": {
         "ja": "空虚な渦巻きだ。",
@@ -86648,9 +84034,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_ABYSS"
-        ]
+        "list": ["BR_ABYSS"]
       },
       "flavor": {
         "ja": "深淵の渦巻きだ。",
@@ -86972,12 +84356,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "ROCKET",
-          "PSY_SPEAR",
-          "BO_LITE",
-          "S_KIN"
-        ],
+        "list": ["ROCKET", "PSY_SPEAR", "BO_LITE", "S_KIN"],
         "shoot": "12d12"
       },
       "escorts": [
@@ -87033,10 +84412,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "PSY_SPEAR",
-          "BO_LITE"
-        ]
+        "list": ["PSY_SPEAR", "BO_LITE"]
       },
       "flavor": {
         "ja": "ラフィーIIの艤装の一部で、兎を模したプロペラのない未来的なドローンだ。光の矢が放たれるようになっており、それが通ったものには風穴が空く。",
@@ -87097,11 +84473,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BA_WATE",
-          "BO_WATE",
-          "HASTE"
-        ]
+        "list": ["BA_WATE", "BO_WATE", "HASTE"]
       },
       "flavor": {
         "ja": "青いローブを羽織るこの骸骨は雨を降らせ溺死させようとしている。",
@@ -87140,10 +84512,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BO_FIRE",
-          "BA_FIRE"
-        ]
+        "list": ["BO_FIRE", "BA_FIRE"]
       },
       "flavor": {
         "ja": "それを倒すととてもいい経験になりそうだ。",
@@ -87182,11 +84551,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "BR_FIRE",
-          "BA_FIRE",
-          "BO_FIRE"
-        ]
+        "list": ["BR_FIRE", "BA_FIRE", "BO_FIRE"]
       },
       "flavor": {
         "ja": "それを倒すととてもいい経験になりそうだ。",
@@ -87266,13 +84631,7 @@
       ],
       "skill": {
         "probability": "1_IN_5",
-        "list": [
-          "BR_FIRE",
-          "BR_NETH",
-          "BO_METEOR",
-          "S_DRAGON",
-          "HEAL"
-        ]
+        "list": ["BR_FIRE", "BR_NETH", "BO_METEOR", "S_DRAGON", "HEAL"]
       },
       "flavor": {
         "ja": "ドラゴン族の長にして何百年もの間魔王に仕えている幹部で、多数の巨大なドラゴンを従え、数の暴力で冒険者を圧倒する。「目の前に広がるのは、まるで煉獄のような戦場だ。数百、数千ものドラゴンが火山の上空を旋回している。その中で最も目を引くのは間違いなく、体長数百メートルに及び、全身が烈火に包まれた一体だ。そいつこそがメガフレイムドラゴン、ドラゴン族の長にして、魔王が最も信頼する幹部なのだ。」(Manjuu、Yostar、Yongshi『アズールレーン』、「ゼロから頑張る魔王討伐」、25章「メガフレイムドラゴン討伐！」)",
@@ -87351,9 +84710,7 @@
       "skill": {
         "probability": "1_IN_6",
         "shoot": "190d1",
-        "list": [
-          "BO_METEOR"
-        ]
+        "list": ["BO_METEOR"]
       },
       "flavor": {
         "ja": "彼女は元々優しい心の持ち主だったが、とある学園の者に利用され、大罪を犯し大事なものを根こそぎ奪われた。哀れで救いたくなるような者であると同時に軽蔑・嫌悪に値する者でもある。その目は復讐の炎に燃えており、復讐の妨げとなるあなたはどうしようもないゴミとみなされている。",
@@ -87416,9 +84773,7 @@
       ],
       "skill": {
         "probability": "1_IN_10",
-        "list": [
-          "SHRIEK"
-        ]
+        "list": ["SHRIEK"]
       },
       "flavor": {
         "ja": "それは冒険者の来店を待っている。持ち物を狙って…",
@@ -87487,9 +84842,7 @@
       ],
       "skill": {
         "probability": "1_IN_8",
-        "list": [
-          "BR_DISE"
-        ]
+        "list": ["BR_DISE"]
       },
       "flavor": {
         "ja": "奇妙に輝きながら地面を這いずる粘体だ。触れたものを分別なしに体内に取り込んでいるようだ。",
@@ -87555,9 +84908,7 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "TELE_TO"
-        ]
+        "list": ["TELE_TO"]
       },
       "flavor": {
         "ja": "斃れた巨人が邪悪な術で再び動き出したものだ。かつてのような力強さは感じられないが、汚れた一撃には注意が必要だ。",
@@ -87634,10 +84985,7 @@
       ],
       "skill": {
         "probability": "1_IN_4",
-        "list": [
-          "TELE_TO",
-          "S_KIN"
-        ]
+        "list": ["TELE_TO", "S_KIN"]
       },
       "flavor": {
         "ja": "やった！虹色の宝箱だ！ 特別品のアイテムが入っているに違いない！",
@@ -87687,10 +85035,7 @@
       ],
       "skill": {
         "probability": "1_IN_2",
-        "list": [
-          "BO_MANA",
-          "TELE_TO"
-        ]
+        "list": ["BO_MANA", "TELE_TO"]
       },
       "flavor": {
         "ja": "金の宝箱だ！ いいアイテムが期待できそうだ！",
@@ -87857,14 +85202,700 @@
       ],
       "skill": {
         "probability": "1_IN_6",
-        "list": [
-          "BR_CONF",
-          "CONF"
-        ]
+        "list": ["BR_CONF", "CONF"]
       },
       "flavor": {
         "ja": "ヘビとヤモリが混合した生物で、それに睨まれるとまともな判断をすることにも一苦労させられる。",
         "en": "It is a mixed snake and gecko. When you glared by it, you'll struggle with a normal thinking even."
+      }
+    },
+    {
+      "id": 1371,
+      "name": {
+        "ja": "オブシディアン・ゴーレム",
+        "en": "Obsidian golem"
+      },
+      "symbol": {
+        "character": "g",
+        "color": "Dark Gray"
+      },
+      "speed": 0,
+      "hit_point": "14d8",
+      "vision": 20,
+      "armor_class": 50,
+      "alertness": 10,
+      "level": 14,
+      "rarity": 4,
+      "exp": 70,
+      "blows": [
+        {
+          "method": "SLASH",
+          "effect": "HURT",
+          "damage_dice": "2d10"
+        },
+        {
+          "method": "SLASH",
+          "effect": "HURT",
+          "damage_dice": "2d10"
+        }
+      ],
+      "flags": [
+        "COLD_BLOOD",
+        "EMPTY_MIND",
+        "BASH_DOOR",
+        "IM_FIRE",
+        "IM_COLD",
+        "IM_ELEC",
+        "IM_POIS",
+        "NO_CONF",
+        "NO_SLEEP",
+        "NO_FEAR",
+        "NONLIVING",
+        "ONLY_GOLD",
+        "DROP_3D2",
+        "DROP_4D2",
+        "DROP_OBSIDIAN"
+      ],
+      "flavor": {
+        "ja": "それは黒い宝石で造られた堂々たる巨像だ。",
+        "en": "It is a massive statue of black jewels."
+      }
+    },
+    {
+      "id": 1372,
+      "name": {
+        "ja": "エメラルド・ゴーレム",
+        "en": "Emerald golem"
+      },
+      "symbol": {
+        "character": "g",
+        "color": "Light Green"
+      },
+      "speed": 0,
+      "hit_point": "80d10",
+      "vision": 20,
+      "armor_class": 80,
+      "alertness": 10,
+      "level": 24,
+      "rarity": 4,
+      "exp": 400,
+      "blows": [
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "3d8"
+        },
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "5d5"
+        },
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "5d5"
+        }
+      ],
+      "flags": [
+        "COLD_BLOOD",
+        "EMPTY_MIND",
+        "BASH_DOOR",
+        "IM_FIRE",
+        "IM_COLD",
+        "IM_ELEC",
+        "IM_POIS",
+        "NO_CONF",
+        "NO_SLEEP",
+        "NO_FEAR",
+        "NONLIVING",
+        "ONLY_GOLD",
+        "DROP_3D2",
+        "DROP_4D2",
+        "DROP_EMERALD"
+      ],
+      "flavor": {
+        "ja": "それは緑の宝石で造られた堂々たる巨像だ。それは値段にしたら相当高価だろう！",
+        "en": "It is a massive statue of green jewels. It looks expensive!"
+      }
+    },
+    {
+      "id": 1373,
+      "name": {
+        "ja": "サファイア・ゴーレム",
+        "en": "Sapphire golem"
+      },
+      "symbol": {
+        "character": "g",
+        "color": "Blue"
+      },
+      "speed": 0,
+      "hit_point": "80d12",
+      "vision": 20,
+      "armor_class": 90,
+      "alertness": 10,
+      "level": 26,
+      "rarity": 4,
+      "exp": 500,
+      "blows": [
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "3d8"
+        },
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "5d5"
+        },
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "5d5"
+        }
+      ],
+      "flags": [
+        "COLD_BLOOD",
+        "EMPTY_MIND",
+        "BASH_DOOR",
+        "IM_FIRE",
+        "IM_COLD",
+        "IM_ELEC",
+        "IM_POIS",
+        "NO_CONF",
+        "NO_SLEEP",
+        "NO_FEAR",
+        "NONLIVING",
+        "ONLY_GOLD",
+        "DROP_3D2",
+        "DROP_4D2",
+        "DROP_SAPPHIRE"
+      ],
+      "flavor": {
+        "ja": "それは青い宝石で造られた堂々たる巨像だ。それは値段にしたら相当高価だろう！",
+        "en": "It is a massive statue of blue jewels. It looks expensive!"
+      }
+    },
+    {
+      "id": 1374,
+      "name": {
+        "ja": "ルビー・ゴーレム",
+        "en": "Ruby golem"
+      },
+      "symbol": {
+        "character": "g",
+        "color": "Light Red"
+      },
+      "speed": 0,
+      "hit_point": "80d12",
+      "vision": 20,
+      "armor_class": 90,
+      "alertness": 10,
+      "level": 26,
+      "rarity": 4,
+      "exp": 500,
+      "blows": [
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "3d8"
+        },
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "5d5"
+        },
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "5d5"
+        }
+      ],
+      "flags": [
+        "COLD_BLOOD",
+        "EMPTY_MIND",
+        "BASH_DOOR",
+        "IM_FIRE",
+        "IM_COLD",
+        "IM_ELEC",
+        "IM_POIS",
+        "NO_CONF",
+        "NO_SLEEP",
+        "NO_FEAR",
+        "NONLIVING",
+        "ONLY_GOLD",
+        "DROP_3D2",
+        "DROP_4D2",
+        "DROP_RUBY"
+      ],
+      "flavor": {
+        "ja": "それは赤い宝石で造られた堂々たる巨像だ。それは値段にしたら相当高価だろう！",
+        "en": "It is a massive statue of red jewels. It looks expensive!"
+      }
+    },
+    {
+      "id": 1375,
+      "name": {
+        "ja": "ダイヤモンド・ゴーレム",
+        "en": "Diamond golem"
+      },
+      "symbol": {
+        "character": "g",
+        "color": "White"
+      },
+      "speed": 0,
+      "hit_point": "80d14",
+      "vision": 20,
+      "armor_class": 100,
+      "alertness": 10,
+      "level": 28,
+      "rarity": 4,
+      "exp": 600,
+      "blows": [
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "3d8"
+        },
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "5d5"
+        },
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "5d5"
+        }
+      ],
+      "flags": [
+        "COLD_BLOOD",
+        "EMPTY_MIND",
+        "BASH_DOOR",
+        "IM_FIRE",
+        "IM_COLD",
+        "IM_ELEC",
+        "IM_POIS",
+        "NO_CONF",
+        "NO_SLEEP",
+        "NO_FEAR",
+        "NONLIVING",
+        "ONLY_GOLD",
+        "DROP_3D2",
+        "DROP_4D2",
+        "DROP_DIAMOND"
+      ],
+      "flavor": {
+        "ja": "それは金剛石で造られた堂々たる巨像だ。それは値段にしたら相当高価だろう！",
+        "en": "It is a massive statue of diamonds. It looks expensive!"
+      }
+    },
+    {
+      "id": 1376,
+      "name": {
+        "ja": "ライト・ボルテックス",
+        "en": "Light vortex"
+      },
+      "symbol": {
+        "character": "v",
+        "color": "Orange"
+      },
+      "speed": 0,
+      "hit_point": "12d12",
+      "vision": 100,
+      "armor_class": 30,
+      "alertness": 0,
+      "level": 25,
+      "rarity": 1,
+      "exp": 200,
+      "odds_correction_ratio": 150,
+      "flags": [
+        "RAND_50",
+        "CAN_FLY",
+        "SELF_LITE_1",
+        "SELF_LITE_2",
+        "EMPTY_MIND",
+        "BASH_DOOR",
+        "POWERFUL",
+        "RES_LITE",
+        "HURT_DARK",
+        "NO_FEAR",
+        "NO_CONF",
+        "NO_SLEEP",
+        "NO_STUN",
+        "NONLIVING"
+      ],
+      "skill": {
+        "probability": "1_IN_6",
+        "list": ["BR_LITE"]
+      },
+      "flavor": {
+        "ja": "それは渦を巻く光で、時折閃光を放っている。",
+        "en": "It is a swirling light, with occasional flashes."
+      }
+    },
+    {
+      "id": 1377,
+      "name": {
+        "ja": "シャドウ・ボルテックス",
+        "en": "Shadow vortex"
+      },
+      "symbol": {
+        "character": "v",
+        "color": "Dark Gray"
+      },
+      "speed": 0,
+      "hit_point": "12d12",
+      "vision": 100,
+      "armor_class": 30,
+      "alertness": 0,
+      "level": 25,
+      "rarity": 1,
+      "exp": 200,
+      "odds_correction_ratio": 150,
+      "flags": [
+        "RAND_50",
+        "CAN_FLY",
+        "SELF_DARK_2",
+        "EMPTY_MIND",
+        "BASH_DOOR",
+        "POWERFUL",
+        "RES_DARK",
+        "HURT_LITE",
+        "NO_FEAR",
+        "NO_CONF",
+        "NO_SLEEP",
+        "NO_STUN",
+        "NONLIVING"
+      ],
+      "skill": {
+        "probability": "1_IN_6",
+        "list": ["BR_DARK"]
+      },
+      "flavor": {
+        "ja": "それは渦を巻く影で、時折暗黒の波動を放っている。",
+        "en": "It was a swirling shadow, occasionally emitting dark waves."
+      }
+    },
+    {
+      "id": 1378,
+      "name": {
+        "ja": "クリーピング・オブシディアン",
+        "en": "Creeping obsidians"
+      },
+      "symbol": {
+        "character": "$",
+        "color": "Dark Gray"
+      },
+      "speed": 5,
+      "hit_point": "14d11",
+      "vision": 10,
+      "armor_class": 50,
+      "alertness": 10,
+      "level": 12,
+      "rarity": 6,
+      "exp": 50,
+      "blows": [
+        {
+          "method": "SLASH",
+          "effect": "HURT",
+          "damage_dice": "2d10"
+        },
+        {
+          "method": "SLASH",
+          "effect": "HURT",
+          "damage_dice": "2d10"
+        }
+      ],
+      "flags": [
+        "ONLY_GOLD",
+        "DROP_3D2",
+        "DROP_OBSIDIAN",
+        "COLD_BLOOD",
+        "BASH_DOOR",
+        "ANIMAL",
+        "IM_POIS",
+        "NO_CONF",
+        "NO_SLEEP"
+      ],
+      "flavor": {
+        "ja": "それは黒い宝石の塊で、何千もの小さな足で前によろめき歩く。",
+        "en": "It is a pile of black jewels, shambling forward on thousands of tiny legs."
+      }
+    },
+    {
+      "id": 1379,
+      "name": {
+        "ja": "クリーピング・ガーネット",
+        "en": "Creeping garnets"
+      },
+      "symbol": {
+        "character": "$",
+        "color": "Red"
+      },
+      "speed": 5,
+      "hit_point": "16d8",
+      "vision": 10,
+      "armor_class": 70,
+      "alertness": 10,
+      "level": 14,
+      "rarity": 6,
+      "exp": 70,
+      "blows": [
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "2d8"
+        },
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "2d8"
+        }
+      ],
+      "flags": [
+        "ONLY_GOLD",
+        "DROP_3D2",
+        "DROP_GARNET",
+        "COLD_BLOOD",
+        "BASH_DOOR",
+        "ANIMAL",
+        "IM_POIS",
+        "NO_CONF",
+        "NO_SLEEP"
+      ],
+      "flavor": {
+        "ja": "それは赤い宝石の塊で、何千もの小さな足で前によろめき歩く。",
+        "en": "It is a pile of red jewels, shambling forward on thousands of tiny legs."
+      }
+    },
+    {
+      "id": 1380,
+      "name": {
+        "ja": "クリーピング・オパール",
+        "en": "Creeping opals"
+      },
+      "symbol": {
+        "character": "$",
+        "color": "Light Gray"
+      },
+      "speed": 5,
+      "hit_point": "32d8",
+      "vision": 10,
+      "armor_class": 60,
+      "alertness": 10,
+      "level": 22,
+      "rarity": 6,
+      "exp": 100,
+      "blows": [
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "2d8"
+        },
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "2d8"
+        }
+      ],
+      "flags": [
+        "ONLY_GOLD",
+        "DROP_3D2",
+        "DROP_OPAL",
+        "COLD_BLOOD",
+        "BASH_DOOR",
+        "ANIMAL",
+        "IM_POIS",
+        "NO_CONF",
+        "NO_SLEEP"
+      ],
+      "flavor": {
+        "ja": "それは白い宝石の塊で、何千もの小さな足で前によろめき歩く。",
+        "en": "It is a pile of white jewels, shambling forward on thousands of tiny legs."
+      }
+    },
+    {
+      "id": 1381,
+      "name": {
+        "ja": "クリーピング・エメラルド",
+        "en": "Creeping emeralds"
+      },
+      "symbol": {
+        "character": "$",
+        "color": "Green"
+      },
+      "speed": 5,
+      "hit_point": "34d8",
+      "vision": 10,
+      "armor_class": 80,
+      "alertness": 10,
+      "level": 24,
+      "rarity": 6,
+      "exp": 150,
+      "blows": [
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "2d9"
+        },
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "2d9"
+        }
+      ],
+      "flags": [
+        "ONLY_GOLD",
+        "DROP_3D2",
+        "DROP_EMERALD",
+        "COLD_BLOOD",
+        "BASH_DOOR",
+        "ANIMAL",
+        "IM_POIS",
+        "NO_CONF",
+        "NO_SLEEP"
+      ],
+      "flavor": {
+        "ja": "それは緑の宝石の塊で、何千もの小さな足で前によろめき歩く。",
+        "en": "It is a pile of green jewels, shambling forward on thousands of tiny legs."
+      }
+    },
+    {
+      "id": 1382,
+      "name": {
+        "ja": "クリーピング・サファイア",
+        "en": "Creeping saphires"
+      },
+      "symbol": {
+        "character": "$",
+        "color": "Blue"
+      },
+      "speed": 5,
+      "hit_point": "34d8",
+      "vision": 10,
+      "armor_class": 90,
+      "alertness": 10,
+      "level": 26,
+      "rarity": 6,
+      "exp": 150,
+      "blows": [
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "2d10"
+        },
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "2d10"
+        }
+      ],
+      "flags": [
+        "ONLY_GOLD",
+        "DROP_3D2",
+        "DROP_SAPPHIRE",
+        "COLD_BLOOD",
+        "BASH_DOOR",
+        "ANIMAL",
+        "IM_POIS",
+        "NO_CONF",
+        "NO_SLEEP"
+      ],
+      "flavor": {
+        "ja": "それは青い宝石の塊で、何千もの小さな足で前によろめき歩く。",
+        "en": "It is a pile of blue jewels, shambling forward on thousands of tiny legs."
+      }
+    },
+    {
+      "id": 1383,
+      "name": {
+        "ja": "クリーピング・ルビー",
+        "en": "Creeping rubies"
+      },
+      "symbol": {
+        "character": "$",
+        "color": "Red"
+      },
+      "speed": 5,
+      "hit_point": "34d8",
+      "vision": 10,
+      "armor_class": 90,
+      "alertness": 10,
+      "level": 28,
+      "rarity": 6,
+      "exp": 150,
+      "blows": [
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "2d10"
+        },
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "2d10"
+        }
+      ],
+      "flags": [
+        "ONLY_GOLD",
+        "DROP_3D2",
+        "DROP_RUBY",
+        "COLD_BLOOD",
+        "BASH_DOOR",
+        "ANIMAL",
+        "IM_POIS",
+        "NO_CONF",
+        "NO_SLEEP"
+      ],
+      "flavor": {
+        "ja": "それは赤い宝石の塊で、何千もの小さな足で前によろめき歩く。",
+        "en": "It is a pile of red jewels, shambling forward on thousands of tiny legs."
+      }
+    },
+    {
+      "id": 1384,
+      "name": {
+        "ja": "クリーピング・ダイヤモンド",
+        "en": "Creeping diamonds"
+      },
+      "symbol": {
+        "character": "$",
+        "color": "White"
+      },
+      "speed": 10,
+      "hit_point": "40d8",
+      "vision": 15,
+      "armor_class": 100,
+      "alertness": 10,
+      "level": 32,
+      "rarity": 6,
+      "exp": 200,
+      "blows": [
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "3d10"
+        },
+        {
+          "method": "HIT",
+          "effect": "HURT",
+          "damage_dice": "3d10"
+        }
+      ],
+      "flags": [
+        "ONLY_GOLD",
+        "DROP_4D2",
+        "DROP_DIAMOND",
+        "COLD_BLOOD",
+        "BASH_DOOR",
+        "ANIMAL",
+        "IM_POIS",
+        "NO_CONF",
+        "NO_SLEEP"
+      ],
+      "flavor": {
+        "ja": "それは白い宝石の塊で、何千もの小さな足で前によろめき歩く。",
+        "en": "It is a pile of white jewels, shambling forward on thousands of tiny legs."
       }
     }
   ]

--- a/src/info-reader/race-info-tokens-table.cpp
+++ b/src/info-reader/race-info-tokens-table.cpp
@@ -424,7 +424,6 @@ const std::unordered_map<std::string_view, MonsterDropType> r_info_drop_flags = 
     { "DROP_2D2", MonsterDropType::DROP_2D2 },
     { "DROP_3D2", MonsterDropType::DROP_3D2 },
     { "DROP_4D2", MonsterDropType::DROP_4D2 },
-    { "DROP_NASTY", MonsterDropType::DROP_NASTY },
     { "DROP_COPPER", MonsterDropType::DROP_COPPER },
     { "DROP_SILVER", MonsterDropType::DROP_SILVER },
     { "DROP_GARNET", MonsterDropType::DROP_GARNET },
@@ -436,6 +435,8 @@ const std::unordered_map<std::string_view, MonsterDropType> r_info_drop_flags = 
     { "DROP_EMERALD", MonsterDropType::DROP_EMERALD },
     { "DROP_MITHRIL", MonsterDropType::DROP_MITHRIL },
     { "DROP_ADAMANTITE", MonsterDropType::DROP_ADAMANTITE },
+    { "DROP_OBSIDIAN", MonsterDropType::DROP_OBSIDIAN },
+    { "DROP_NASTY", MonsterDropType::DROP_NASTY },
 };
 
 const std::unordered_map<std::string_view, MonsterWildernessType> r_info_wilderness_flags = {

--- a/src/monster-race/race-drop-flags.h
+++ b/src/monster-race/race-drop-flags.h
@@ -24,6 +24,7 @@ enum class MonsterDropType {
     DROP_EMERALD = 20,
     DROP_MITHRIL = 21,
     DROP_ADAMANTITE = 22,
-    DROP_NASTY = 23,
+    DROP_OBSIDIAN = 23,
+    DROP_NASTY = 24,
     MAX,
 };


### PR DESCRIPTION
新規追加モンスターの一部が感知範囲0になっていたので修正。
ついでにクリーピング系統の感知範囲と速度も少し修正した。

・金→ 感知範囲5 速度0
・銀銅→ 感知範囲5 速度-10
・ダイヤミスリル→ 感知範囲15 速度+10
・アダマンタイト→ 感知範囲15 速度+20
・その他宝石→ 感知範囲10 速度+5

非常に狭い感知範囲なことは変えず、上位種は若干優秀というフレーバーに留める。