### PR TITLE
変愚「[Fix] 新規キャラクター作成時にクラッシュ #4757」のマージ

### DIFF
--- a/src/system/dungeon/dungeon-record.cpp
+++ b/src/system/dungeon/dungeon-record.cpp
@@ -135,7 +135,7 @@ bool DungeonRecords::empty() const
 void DungeonRecords::reset_all()
 {
     for (auto &[_, record] : this->records) {
-        record.reset();
+        record->reset();
     }
 }
 


### PR DESCRIPTION
DungeonRecord::reset() を呼ぶつもりが std::shared_ptr::reset() を呼んで しまっており、その後のアクセスがヌルポアクセスとなりクラッシュしている。
正しく DungeonRecord::reset() を呼ぶように修正する。