### PR TITLE
変愚「[Feature] AbstracMapWrapperによるボイラープレートの削減 #4769」のマージ

### DIFF
--- a/Bakabakaband/Bakabakaband/Bakabakaband.vcxproj
+++ b/Bakabakaband/Bakabakaband/Bakabakaband.vcxproj
@@ -1513,6 +1513,7 @@
     <ClInclude Include="..\..\src\tracking\baseitem-tracker.h" />
     <ClInclude Include="..\..\src\tracking\health-bar-tracker.h" />
     <ClInclude Include="..\..\src\tracking\lore-tracker.h" />
+    <ClInclude Include="..\..\src\util\abstract-map-wrapper.h" />
     <ClInclude Include="..\..\src\util\abstract-vector-wrapper.h" />
     <ClInclude Include="..\..\src\util\bit-flags-calculator.h" />
     <ClInclude Include="..\..\src\util\buffer-shaper.h" />

--- a/Bakabakaband/Bakabakaband/Bakabakaband.vcxproj.filters
+++ b/Bakabakaband/Bakabakaband/Bakabakaband.vcxproj.filters
@@ -5376,6 +5376,9 @@
     <ClInclude Include="..\..\src\alliance\alliance-megadeth.h">
       <Filter>alliance</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\util\abstract-map-wrapper.h">
+      <Filter>util</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\util\abstract-vector-wrapper.h">
       <Filter>util</Filter>
     </ClInclude>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1001,6 +1001,7 @@ hengband_SOURCES = \
 	tracking/health-bar-tracker.cpp tracking/health-bar-tracker.h \
 	tracking/lore-tracker.cpp tracking/lore-tracker.h \
 	\
+	util/abstract-map-wrapper.h \
 	util/abstract-vector-wrapper.h \
 	util/angband-files.cpp util/angband-files.h \
 	util/buffer-shaper.cpp util/buffer-shaper.h \

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -133,61 +133,6 @@ const QuestType &QuestList::get_quest(QuestId id) const
     return this->quests.at(id);
 }
 
-std::map<QuestId, QuestType>::iterator QuestList::begin()
-{
-    return this->quests.begin();
-}
-
-std::map<QuestId, QuestType>::const_iterator QuestList::begin() const
-{
-    return this->quests.cbegin();
-}
-
-std::map<QuestId, QuestType>::iterator QuestList::end()
-{
-    return this->quests.end();
-}
-
-std::map<QuestId, QuestType>::const_iterator QuestList::end() const
-{
-    return this->quests.cend();
-}
-
-std::map<QuestId, QuestType>::reverse_iterator QuestList::rbegin()
-{
-    return this->quests.rbegin();
-}
-
-std::map<QuestId, QuestType>::const_reverse_iterator QuestList::rbegin() const
-{
-    return this->quests.crbegin();
-}
-
-std::map<QuestId, QuestType>::reverse_iterator QuestList::rend()
-{
-    return this->quests.rend();
-}
-
-std::map<QuestId, QuestType>::const_reverse_iterator QuestList::rend() const
-{
-    return this->quests.crend();
-}
-
-std::map<QuestId, QuestType>::iterator QuestList::find(QuestId id)
-{
-    return this->quests.find(id);
-}
-
-std::map<QuestId, QuestType>::const_iterator QuestList::find(QuestId id) const
-{
-    return this->quests.find(id);
-}
-
-size_t QuestList::size() const
-{
-    return this->quests.size();
-}
-
 std::vector<QuestId> QuestList::get_sorted_quest_ids() const
 {
     std::vector<QuestId> quest_ids;

--- a/src/dungeon/quest.h
+++ b/src/dungeon/quest.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "system/angband.h"
+#include "util/abstract-map-wrapper.h"
 #include "util/enum-converter.h"
 #include "util/enum-range.h"
 #include <map>
@@ -134,7 +135,7 @@ public:
     const MonraceDefinition &get_bounty() const;
 };
 
-class QuestList final {
+class QuestList final : public util::AbstractMapWrapper<QuestId, QuestType> {
 public:
     QuestList(const QuestList &) = delete;
     QuestList(QuestList &&) = delete;
@@ -145,23 +146,17 @@ public:
     void initialize();
     QuestType &get_quest(QuestId id);
     const QuestType &get_quest(QuestId id) const;
-    std::map<QuestId, QuestType>::iterator begin();
-    std::map<QuestId, QuestType>::const_iterator begin() const;
-    std::map<QuestId, QuestType>::iterator end();
-    std::map<QuestId, QuestType>::const_iterator end() const;
-    std::map<QuestId, QuestType>::reverse_iterator rbegin();
-    std::map<QuestId, QuestType>::const_reverse_iterator rbegin() const;
-    std::map<QuestId, QuestType>::reverse_iterator rend();
-    std::map<QuestId, QuestType>::const_reverse_iterator rend() const;
-    std::map<QuestId, QuestType>::iterator find(QuestId id);
-    std::map<QuestId, QuestType>::const_iterator find(QuestId id) const;
-    size_t size() const;
     std::vector<QuestId> get_sorted_quest_ids() const;
 
 private:
     static QuestList instance;
     std::map<QuestId, QuestType> quests;
     QuestList() = default;
+
+    std::map<QuestId, QuestType> &get_inner_container() override
+    {
+        return this->quests;
+    }
 
     bool order_completed(QuestId id1, QuestId id2) const;
 };

--- a/src/load/quest-loader.cpp
+++ b/src/load/quest-loader.cpp
@@ -64,7 +64,7 @@ static void load_quest_details(PlayerType *player_ptr, QuestType *q_ptr, const Q
 static bool is_loadable_quest(const QuestId q_idx, const byte max_rquests_load)
 {
     const auto &quests = QuestList::get_instance();
-    if (quests.find(q_idx) != quests.end()) {
+    if (quests.contains(q_idx)) {
         return true;
     }
 

--- a/src/system/artifact-type-definition.cpp
+++ b/src/system/artifact-type-definition.cpp
@@ -120,46 +120,6 @@ ArtifactList &ArtifactList::get_instance()
     return instance;
 }
 
-std::map<FixedArtifactId, ArtifactType>::iterator ArtifactList::begin()
-{
-    return this->artifacts.begin();
-}
-
-std::map<FixedArtifactId, ArtifactType>::iterator ArtifactList::end()
-{
-    return this->artifacts.end();
-}
-
-std::map<FixedArtifactId, ArtifactType>::const_iterator ArtifactList::begin() const
-{
-    return this->artifacts.cbegin();
-}
-
-std::map<FixedArtifactId, ArtifactType>::const_iterator ArtifactList::end() const
-{
-    return this->artifacts.cend();
-}
-
-std::map<FixedArtifactId, ArtifactType>::reverse_iterator ArtifactList::rbegin()
-{
-    return this->artifacts.rbegin();
-}
-
-std::map<FixedArtifactId, ArtifactType>::reverse_iterator ArtifactList::rend()
-{
-    return this->artifacts.rend();
-}
-
-std::map<FixedArtifactId, ArtifactType>::const_reverse_iterator ArtifactList::rbegin() const
-{
-    return this->artifacts.crbegin();
-}
-
-std::map<FixedArtifactId, ArtifactType>::const_reverse_iterator ArtifactList::rend() const
-{
-    return this->artifacts.crend();
-}
-
 const ArtifactType &ArtifactList::get_artifact(const FixedArtifactId fa_id) const
 {
     if (fa_id == FixedArtifactId::NONE) {

--- a/src/system/artifact-type-definition.h
+++ b/src/system/artifact-type-definition.h
@@ -4,6 +4,7 @@
 #include "object-enchant/trg-types.h"
 #include "system/angband.h"
 #include "system/baseitem/baseitem-key.h"
+#include "util/abstract-map-wrapper.h"
 #include "util/dice.h"
 #include "util/flag-group.h"
 #include <map>
@@ -51,7 +52,7 @@ private:
 };
 
 class ItemEntity;
-class ArtifactList {
+class ArtifactList : public util::AbstractMapWrapper<FixedArtifactId, ArtifactType> {
 public:
     ArtifactList(const ArtifactList &) = delete;
     ArtifactList(ArtifactList &&) = delete;
@@ -60,14 +61,6 @@ public:
     ~ArtifactList() = default;
 
     static ArtifactList &get_instance();
-    std::map<FixedArtifactId, ArtifactType>::iterator begin();
-    std::map<FixedArtifactId, ArtifactType>::iterator end();
-    std::map<FixedArtifactId, ArtifactType>::const_iterator begin() const;
-    std::map<FixedArtifactId, ArtifactType>::const_iterator end() const;
-    std::map<FixedArtifactId, ArtifactType>::reverse_iterator rbegin();
-    std::map<FixedArtifactId, ArtifactType>::reverse_iterator rend();
-    std::map<FixedArtifactId, ArtifactType>::const_reverse_iterator rbegin() const;
-    std::map<FixedArtifactId, ArtifactType>::const_reverse_iterator rend() const;
     const ArtifactType &get_artifact(const FixedArtifactId fa_id) const;
     ArtifactType &get_artifact(const FixedArtifactId fa_id);
 
@@ -82,4 +75,9 @@ private:
     static ArtifactType dummy;
 
     std::map<FixedArtifactId, ArtifactType> artifacts{};
+
+    std::map<FixedArtifactId, ArtifactType> &get_inner_container() override
+    {
+        return this->artifacts;
+    }
 };

--- a/src/system/dungeon/dungeon-list.cpp
+++ b/src/system/dungeon/dungeon-list.cpp
@@ -34,56 +34,6 @@ std::shared_ptr<const DungeonDefinition> DungeonList::get_dungeon_shared(Dungeon
     return this->dungeons.at(dungeon_id);
 }
 
-std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::iterator DungeonList::begin()
-{
-    return this->dungeons.begin();
-}
-
-std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::const_iterator DungeonList::begin() const
-{
-    return this->dungeons.cbegin();
-}
-
-std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::iterator DungeonList::end()
-{
-    return this->dungeons.end();
-}
-
-std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::const_iterator DungeonList::end() const
-{
-    return this->dungeons.cend();
-}
-
-std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::reverse_iterator DungeonList::rbegin()
-{
-    return this->dungeons.rbegin();
-}
-
-std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::const_reverse_iterator DungeonList::rbegin() const
-{
-    return this->dungeons.crbegin();
-}
-
-std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::reverse_iterator DungeonList::rend()
-{
-    return this->dungeons.rend();
-}
-
-std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::const_reverse_iterator DungeonList::rend() const
-{
-    return this->dungeons.crend();
-}
-
-size_t DungeonList::size() const
-{
-    return this->dungeons.size();
-}
-
-bool DungeonList::empty() const
-{
-    return this->dungeons.empty();
-}
-
 void DungeonList::emplace(DungeonId dungeon_id, DungeonDefinition &&definition)
 {
     this->dungeons.emplace(dungeon_id, std::make_shared<DungeonDefinition>(std::move(definition)));

--- a/src/system/dungeon/dungeon-list.h
+++ b/src/system/dungeon/dungeon-list.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
+#include "util/abstract-map-wrapper.h"
 #include <map>
 #include <memory>
 
 enum class DungeonId;
 class DungeonDefinition;
-class DungeonList {
+class DungeonList : public util::AbstractMapWrapper<DungeonId, std::shared_ptr<DungeonDefinition>> {
 public:
     DungeonList(DungeonList &&) = delete;
     DungeonList(const DungeonList &) = delete;
@@ -24,16 +25,6 @@ public:
     const DungeonDefinition &get_dungeon(DungeonId dungeon_id) const;
     std::shared_ptr<DungeonDefinition> get_dungeon_shared(DungeonId dungeon_id);
     std::shared_ptr<const DungeonDefinition> get_dungeon_shared(DungeonId dungeon_id) const;
-    std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::iterator begin();
-    std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::const_iterator begin() const;
-    std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::iterator end();
-    std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::const_iterator end() const;
-    std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::reverse_iterator rbegin();
-    std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::const_reverse_iterator rbegin() const;
-    std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::reverse_iterator rend();
-    std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::const_reverse_iterator rend() const;
-    size_t size() const;
-    bool empty() const;
     void emplace(DungeonId dungeon_id, DungeonDefinition &&definition);
     void retouch();
 
@@ -42,4 +33,9 @@ private:
     static DungeonList instance;
 
     std::map<DungeonId, std::shared_ptr<DungeonDefinition>> dungeons;
+
+    std::map<DungeonId, std::shared_ptr<DungeonDefinition>> &get_inner_container() override
+    {
+        return this->dungeons;
+    }
 };

--- a/src/system/dungeon/dungeon-record.cpp
+++ b/src/system/dungeon/dungeon-record.cpp
@@ -80,56 +80,6 @@ std::shared_ptr<const DungeonRecord> DungeonRecords::get_record_shared(DungeonId
     return this->records.at(dungeon_id);
 }
 
-std::map<DungeonId, std::shared_ptr<DungeonRecord>>::iterator DungeonRecords::begin()
-{
-    return this->records.begin();
-}
-
-std::map<DungeonId, std::shared_ptr<DungeonRecord>>::const_iterator DungeonRecords::begin() const
-{
-    return this->records.cbegin();
-}
-
-std::map<DungeonId, std::shared_ptr<DungeonRecord>>::iterator DungeonRecords::end()
-{
-    return this->records.end();
-}
-
-std::map<DungeonId, std::shared_ptr<DungeonRecord>>::const_iterator DungeonRecords::end() const
-{
-    return this->records.cend();
-}
-
-std::map<DungeonId, std::shared_ptr<DungeonRecord>>::reverse_iterator DungeonRecords::rbegin()
-{
-    return this->records.rbegin();
-}
-
-std::map<DungeonId, std::shared_ptr<DungeonRecord>>::const_reverse_iterator DungeonRecords::rbegin() const
-{
-    return this->records.crbegin();
-}
-
-std::map<DungeonId, std::shared_ptr<DungeonRecord>>::reverse_iterator DungeonRecords::rend()
-{
-    return this->records.rend();
-}
-
-std::map<DungeonId, std::shared_ptr<DungeonRecord>>::const_reverse_iterator DungeonRecords::rend() const
-{
-    return this->records.crend();
-}
-
-size_t DungeonRecords::size() const
-{
-    return this->records.size();
-}
-
-bool DungeonRecords::empty() const
-{
-    return this->records.empty();
-}
-
 void DungeonRecords::reset_all()
 {
     for (auto &[_, record] : this->records) {

--- a/src/system/dungeon/dungeon-record.h
+++ b/src/system/dungeon/dungeon-record.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "util/abstract-map-wrapper.h"
 #include <map>
 #include <memory>
 #include <optional>
@@ -28,7 +29,7 @@ private:
 
 enum class DungeonId;
 class DungeonDefinition;
-class DungeonRecords {
+class DungeonRecords : public util::AbstractMapWrapper<DungeonId, std::shared_ptr<DungeonRecord>> {
 public:
     DungeonRecords(DungeonRecords &&) = delete;
     DungeonRecords(const DungeonRecords &) = delete;
@@ -41,16 +42,6 @@ public:
     const DungeonRecord &get_record(DungeonId dungeon_id) const;
     std::shared_ptr<DungeonRecord> get_record_shared(DungeonId dungeon_id);
     std::shared_ptr<const DungeonRecord> get_record_shared(DungeonId dungeon_id) const;
-    std::map<DungeonId, std::shared_ptr<DungeonRecord>>::iterator begin();
-    std::map<DungeonId, std::shared_ptr<DungeonRecord>>::const_iterator begin() const;
-    std::map<DungeonId, std::shared_ptr<DungeonRecord>>::iterator end();
-    std::map<DungeonId, std::shared_ptr<DungeonRecord>>::const_iterator end() const;
-    std::map<DungeonId, std::shared_ptr<DungeonRecord>>::reverse_iterator rbegin();
-    std::map<DungeonId, std::shared_ptr<DungeonRecord>>::const_reverse_iterator rbegin() const;
-    std::map<DungeonId, std::shared_ptr<DungeonRecord>>::reverse_iterator rend();
-    std::map<DungeonId, std::shared_ptr<DungeonRecord>>::const_reverse_iterator rend() const;
-    size_t size() const;
-    bool empty() const;
     void reset_all();
 
     std::vector<DungeonId> collect_entered_dungeon_ids() const;
@@ -59,4 +50,9 @@ private:
     DungeonRecords();
     static DungeonRecords instance;
     std::map<DungeonId, std::shared_ptr<DungeonRecord>> records;
+
+    std::map<DungeonId, std::shared_ptr<DungeonRecord>> &get_inner_container() override
+    {
+        return this->records;
+    }
 };

--- a/src/system/monrace/monrace-list.cpp
+++ b/src/system/monrace/monrace-list.cpp
@@ -53,51 +53,6 @@ bool MonraceList::is_tsuchinoko(MonraceId monrace_id)
     return monrace_id == MonraceId::TSUCHINOKO;
 }
 
-std::map<MonraceId, MonraceDefinition>::iterator MonraceList::begin()
-{
-    return monraces_info.begin();
-}
-
-std::map<MonraceId, MonraceDefinition>::const_iterator MonraceList::begin() const
-{
-    return monraces_info.cbegin();
-}
-
-std::map<MonraceId, MonraceDefinition>::iterator MonraceList::end()
-{
-    return monraces_info.end();
-}
-
-std::map<MonraceId, MonraceDefinition>::const_iterator MonraceList::end() const
-{
-    return monraces_info.cend();
-}
-
-std::map<MonraceId, MonraceDefinition>::reverse_iterator MonraceList::rbegin()
-{
-    return monraces_info.rbegin();
-}
-
-std::map<MonraceId, MonraceDefinition>::const_reverse_iterator MonraceList::rbegin() const
-{
-    return monraces_info.crbegin();
-}
-
-std::map<MonraceId, MonraceDefinition>::reverse_iterator MonraceList::rend()
-{
-    return monraces_info.rend();
-}
-
-std::map<MonraceId, MonraceDefinition>::const_reverse_iterator MonraceList::rend() const
-{
-    return monraces_info.crend();
-}
-
-size_t MonraceList::size() const
-{
-    return monraces_info.size();
-}
-
 MonraceDefinition &MonraceList::emplace(MonraceId monrace_id)
 {
     return monraces_info.emplace_hint(monraces_info.end(), monrace_id, MonraceDefinition{})->second;

--- a/src/system/monrace/monrace-list.h
+++ b/src/system/monrace/monrace-list.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "util/abstract-map-wrapper.h"
 #include <map>
 #include <optional>
 #include <set>
@@ -17,7 +18,7 @@ enum class MonraceId : short;
 class MonraceDefinition;
 extern std::map<MonraceId, MonraceDefinition> monraces_info;
 
-class MonraceList {
+class MonraceList : public util::AbstractMapWrapper<MonraceId, MonraceDefinition> {
 public:
     MonraceList(MonraceList &&) = delete;
     MonraceList(const MonraceList &) = delete;
@@ -29,15 +30,6 @@ public:
     static MonraceList &get_instance();
     static MonraceId empty_id();
     static bool is_tsuchinoko(MonraceId monrace_id);
-    std::map<MonraceId, MonraceDefinition>::iterator begin();
-    std::map<MonraceId, MonraceDefinition>::const_iterator begin() const;
-    std::map<MonraceId, MonraceDefinition>::iterator end();
-    std::map<MonraceId, MonraceDefinition>::const_iterator end() const;
-    std::map<MonraceId, MonraceDefinition>::reverse_iterator rbegin();
-    std::map<MonraceId, MonraceDefinition>::const_reverse_iterator rbegin() const;
-    std::map<MonraceId, MonraceDefinition>::reverse_iterator rend();
-    std::map<MonraceId, MonraceDefinition>::const_reverse_iterator rend() const;
-    size_t size() const;
     MonraceDefinition &emplace(MonraceId monrace_id);
     std::map<MonraceId, MonraceDefinition> &get_raw_map();
     MonraceDefinition &get_monrace(MonraceId monrace_id);
@@ -70,4 +62,9 @@ private:
     static MonraceList instance;
 
     const static std::map<MonraceId, std::set<MonraceId>> unified_uniques;
+
+    std::map<MonraceId, MonraceDefinition> &get_inner_container() override
+    {
+        return monraces_info;
+    }
 };

--- a/src/util/abstract-map-wrapper.h
+++ b/src/util/abstract-map-wrapper.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <map>
+
+namespace util {
+
+/*!
+ * @brief std::map をラップする抽象クラス
+ *
+ * @tparam K ラップする std::map のキーの型
+ * @tparam V ラップする std::map の値の型
+ */
+template <typename K, typename V>
+class AbstractMapWrapper {
+public:
+    using Container = std::map<K, V>;
+    using Iterator = typename Container::iterator;
+    using ConstIterator = typename Container::const_iterator;
+    using ReverseIterator = typename Container::reverse_iterator;
+    using ConstReverseIterator = typename Container::const_reverse_iterator;
+
+    virtual ~AbstractMapWrapper() = default;
+
+    Iterator begin() noexcept
+    {
+        return this->get_inner_container().begin();
+    }
+    ConstIterator begin() const noexcept
+    {
+        return this->get_inner_container().begin();
+    }
+    Iterator end() noexcept
+    {
+        return this->get_inner_container().end();
+    }
+    ConstIterator end() const noexcept
+    {
+        return this->get_inner_container().end();
+    }
+    ConstIterator cbegin() const noexcept
+    {
+        return this->get_inner_container().cbegin();
+    }
+    ConstIterator cend() const noexcept
+    {
+        return this->get_inner_container().cend();
+    }
+    ReverseIterator rbegin() noexcept
+    {
+        return this->get_inner_container().rbegin();
+    }
+    ConstReverseIterator rbegin() const noexcept
+    {
+        return this->get_inner_container().rbegin();
+    }
+    ReverseIterator rend() noexcept
+    {
+        return this->get_inner_container().rend();
+    }
+    ConstReverseIterator rend() const noexcept
+    {
+        return this->get_inner_container().rend();
+    }
+    ConstReverseIterator crbegin() const noexcept
+    {
+        return this->get_inner_container().crbegin();
+    }
+    ConstReverseIterator crend() const noexcept
+    {
+        return this->get_inner_container().crend();
+    }
+
+    bool empty() const noexcept
+    {
+        return this->get_inner_container().empty();
+    }
+    size_t size() const noexcept
+    {
+        return this->get_inner_container().size();
+    }
+    bool contains(const K &key) const
+    {
+        return this->get_inner_container().contains(key);
+    }
+
+private:
+    virtual Container &get_inner_container() = 0;
+
+    const Container &get_inner_container() const
+    {
+        return static_cast<const Container &>(const_cast<AbstractMapWrapper *>(this)->get_inner_container());
+    }
+};
+
+}


### PR DESCRIPTION
std::mapをラップする抽象クラスAbstractMapWrapperを導入し、
std::mapをラップしているクラスをAbstractMapWrapperを継承する形に
変更することで、内部のコンテナに移譲するだけのボイラープレートを削減する。