### PR TITLE
変愚「[Fix] 繰り返しコマンドで床置きアイテムを壊した時の不具合 #5193」のマージ

### DIFF
--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -34,6 +34,7 @@
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/projection-path-calculator.h"
+#include "util/finalizer.h"
 #include "view/display-messages.h"
 #include "window/display-sub-windows.h"
 #include "wizard/wizard-messages.h"
@@ -267,6 +268,8 @@ void delete_object_idx(PlayerType *player_ptr, OBJECT_IDX o_idx)
     ranges::replace(list, back_i_idx, o_idx);
     item_ptr = floor.o_list.back();
     floor.o_list.pop_back();
+
+    floor.prevent_repeat_floor_item_idx = true;
 
     static constexpr auto flags = {
         SubWindowRedrawingFlag::FLOOR_ITEMS,
@@ -561,6 +564,8 @@ ItemEntity *choose_object(PlayerType *player_ptr, short *initial_i_idx, concptr 
     if (initial_i_idx) {
         *initial_i_idx = INVEN_NONE;
     }
+
+    const auto enable_repeat = util::make_finalizer([&] { player_ptr->current_floor_ptr->prevent_repeat_floor_item_idx = false; });
 
     FixItemTesterSetter setter(item_tester);
     short i_idx;

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -54,15 +54,21 @@ static bool check_floor_item_tag_aux(PlayerType *player_ptr, FloorItemSelection 
         return false;
     }
 
+    const auto &floor = *player_ptr->current_floor_ptr;
+
     if (*prev_tag && command_cmd) {
         fis_ptr->floor_num = scan_floor_items(player_ptr, fis_ptr->floor_list, player_ptr->y, player_ptr->x, SCAN_FLOOR_ITEM_TESTER | SCAN_FLOOR_ONLY_MARKED, item_tester);
-        if (get_tag_floor(*player_ptr->current_floor_ptr, &fis_ptr->k, *prev_tag, fis_ptr->floor_list, fis_ptr->floor_num)) {
+        if (get_tag_floor(floor, &fis_ptr->k, *prev_tag, fis_ptr->floor_list, fis_ptr->floor_num)) {
             cp = -fis_ptr->floor_list[fis_ptr->k];
             command_cmd = 0;
             return true;
         }
 
         *prev_tag = '\0';
+        return false;
+    }
+
+    if (floor.prevent_repeat_floor_item_idx || std::cmp_greater_equal(-cp, floor.o_list.size())) {
         return false;
     }
 

--- a/src/system/floor/floor-info.h
+++ b/src/system/floor/floor-info.h
@@ -85,6 +85,7 @@ public:
     GAME_TURN generated_turn = 0; /* Turn when level began */
 
     std::vector<std::shared_ptr<ItemEntity>> o_list; /*!< The array of dungeon items [max_o_idx] */
+    bool prevent_repeat_floor_item_idx = false;
 
     std::vector<MonsterEntity> m_list; /*!< The array of dungeon monsters [max_m_idx] */
     MONSTER_IDX m_max = 0; /* Number of allocated monsters */


### PR DESCRIPTION
繰り返しコマンドでアイテムを指定するとアイテム配列の要素番号が記録
されるが、アイテムが削除された時に配列の要素の書き換えが起きるため
おかしな挙動が発生してしまう。
アイテムが消えた時は繰り返しコマンド内でのアイテム要素番号の繰り返しを
禁止するフラグを立て、繰り返しコマンドがアイテム選択で中断するように
する。