### PR TITLE
(Interface)[Fix] zを充てられた青魔法が選択できずキャンセルになる。

### DIFF
--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -122,7 +122,7 @@ static tl::optional<BlueMagicType> select_blue_magic_kind_by_symbol()
     constexpr auto candidate_desc = _("[A]ボルト, [B]ボール, [C]ブレス, [D]召喚, [E]その他:",
         "[A] bolt, [B] ball, [C] breath, [D] summoning, [E] others:");
     while (true) {
-        const auto command = input_command(candidate_desc, true);
+        const auto command = input_command(candidate_desc);
         if (!command) {
             return tl::nullopt;
         }
@@ -368,8 +368,8 @@ static tl::optional<MonsterAbilityType> select_learnt_spells_by_symbol(PlayerTyp
     while (!selected_spell.has_value()) {
         auto choice = '\0';
         if (!first_show_list) {
-            const auto choice_opt = input_command(prompt, false);
-            if (!choice_opt.has_value()) {
+            const auto choice_opt = input_command(prompt);
+            if (!choice_opt) {
                 break;
             }
 
@@ -432,7 +432,7 @@ static tl::optional<MonsterAbilityType> select_learnt_spells_by_menu(PlayerType 
     while (!selected_spell.has_value()) {
         describe_blue_magic_name(player_ptr, menu_line, bluemage_data, spells);
 
-        const auto choice = input_command(prompt, true);
+        const auto choice = input_command(prompt);
         if (!choice) {
             break;
         }

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -240,8 +240,8 @@ static int get_mane_power(PlayerType *player_ptr, int *sn, bool baigaesi)
         if (choice == ESCAPE) {
             choice = ' ';
         } else {
-            const auto new_choice = input_command(prompt, true);
-            if (!new_choice.has_value()) {
+            const auto new_choice = input_command(prompt);
+            if (!new_choice) {
                 break;
             }
 

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -544,8 +544,8 @@ void do_cmd_pet(PlayerType *player_ptr)
             if (choice == ESCAPE) {
                 choice = ' ';
             } else {
-                const auto new_choice = input_command(prompt, true);
-                if (!new_choice.has_value()) {
+                const auto new_choice = input_command(prompt);
+                if (!new_choice) {
                     break;
                 }
 

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -395,8 +395,8 @@ static int get_spell(PlayerType *player_ptr, SPELL_IDX *sn, std::string_view pro
         if (choice == ESCAPE) {
             choice = ' ';
         } else {
-            const auto new_choice = input_command(prompt, true);
-            if (!new_choice.has_value()) {
+            const auto new_choice = input_command(prompt);
+            if (!new_choice) {
                 break;
             }
 

--- a/src/cmd-io/cmd-floor.cpp
+++ b/src/cmd-io/cmd-floor.cpp
@@ -72,8 +72,8 @@ void do_cmd_locate(PlayerType *player_ptr)
         const auto prompt = format(fmt, y2 / (hgt / 2), y2 % (hgt / 2), x2 / (wid / 2), x2 % (wid / 2), dirstring.data());
         auto dir = Direction::none();
         while (!dir) {
-            const auto command = input_command(prompt, true);
-            if (!command.has_value()) {
+            const auto command = input_command(prompt);
+            if (!command) {
                 break;
             }
 

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -158,7 +158,7 @@ static tl::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, bool
         screen_load();
     } else {
         while (true) {
-            const auto choice = input_command(_("[A] 杖, [B] 魔法棒, [C] ロッド:", "[A] staff, [B] wand, [C] rod:"), true);
+            const auto choice = input_command(_("[A] 杖, [B] 魔法棒, [C] ロッド:", "[A] staff, [B] wand, [C] rod:"));
             if (!choice) {
                 return tl::nullopt;
             }

--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -298,7 +298,7 @@ bool input_check_strict(PlayerType *player_ptr, std::string_view prompt, EnumCla
  *
  * Returns TRUE unless the character is "Escape"
  */
-tl::optional<char> input_command(std::string_view prompt, bool z_escape)
+tl::optional<char> input_command(std::string_view prompt)
 {
     msg_erase();
     prt(prompt, 0, 0);
@@ -310,8 +310,7 @@ tl::optional<char> input_command(std::string_view prompt, bool z_escape)
     }
 
     prt("", 0, 0);
-    const auto is_z = (command == 'z') || (command == 'Z');
-    if ((command == ESCAPE) || (z_escape && is_z)) {
+    if (command == ESCAPE) {
         return tl::nullopt;
     }
 

--- a/src/core/asking-player.h
+++ b/src/core/asking-player.h
@@ -20,7 +20,7 @@ tl::optional<std::string> input_string(std::string_view prompt, int len, std::st
 bool input_check(std::string_view prompt);
 bool input_check_strict(PlayerType *player_ptr, std::string_view prompt, UserCheck one_mode);
 bool input_check_strict(PlayerType *player_ptr, std::string_view prompt, EnumClassFlagGroup<UserCheck> mode);
-tl::optional<char> input_command(std::string_view prompt, bool z_escape = false);
+tl::optional<char> input_command(std::string_view prompt);
 int input_quantity(int max, std::string_view initial_prompt = "");
 void pause_line(int row);
 tl::optional<int> input_integer(std::string_view prompt, int min, int max, int initial_value = 0);

--- a/src/market/building-monster.cpp
+++ b/src/market/building-monster.cpp
@@ -32,13 +32,12 @@ bool research_mon(PlayerType *player_ptr)
     screen_save();
     constexpr auto prompt = _("モンスターの文字を入力して下さい(記号 or ^A全,^Uユ,^N非ユ,^M名前):",
         "Enter character to be identified(^A:All,^U:Uniqs,^N:Non uniqs,^M:Name): ");
-    const auto sym_opt = input_command(prompt, false);
-    if (!sym_opt.has_value()) {
+    const auto sym = input_command(prompt);
+    if (!sym) {
         screen_load();
         return false;
     }
 
-    const auto sym = sym_opt.value();
     IDX ident_i;
     for (ident_i = 0; ident_info[ident_i]; ++ident_i) {
         if (sym == ident_info[ident_i][0]) {
@@ -158,7 +157,7 @@ bool research_mon(PlayerType *player_ptr)
                 handle_stuff(player_ptr);
                 screen_roff(player_ptr, monrace_id, MONSTER_LORE_RESEARCH);
                 notpicked = false;
-                old_sym = sym;
+                old_sym = *sym;
                 old_i = i;
             }
 

--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -59,7 +59,7 @@ static bool select_ammo_creation_type(ammo_creation_type &type, PLAYER_LEVEL ple
     }
 
     while (type == AMMO_NONE) {
-        const auto ch = input_command(prompt, true);
+        const auto ch = input_command(prompt);
         if (!ch) {
             return false;
         }

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -737,8 +737,8 @@ bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_browse)
         if (choice == ESCAPE) {
             choice = ' ';
         } else {
-            const auto new_choice = input_command(prompt, true);
-            if (!new_choice.has_value()) {
+            const auto new_choice = input_command(prompt);
+            if (!new_choice) {
                 break;
             }
 

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -149,8 +149,8 @@ bool MindPowerGetter::decide_mind_choice(std::string_view prompt, const bool onl
         if (this->choice == ESCAPE) {
             this->choice = ' ';
         } else {
-            const auto command = input_command(prompt, true);
-            if (!command.has_value()) {
+            const auto command = input_command(prompt);
+            if (!command) {
                 break;
             }
 

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -228,8 +228,8 @@ static COMMAND_CODE choose_essence(void)
                 prt(format("  %c) %s", 'a' + i, menu_name[i]), 2 + i, 14);
             }
 
-            const auto new_choice = input_command(_("何を付加しますか:", "Command :"), true);
-            if (!new_choice.has_value()) {
+            const auto new_choice = input_command(_("何を付加しますか:", "Command :"));
+            if (!new_choice) {
                 screen_load();
                 return 0;
             }
@@ -624,7 +624,7 @@ void do_cmd_kaji(PlayerType *player_ptr, bool only_browse)
                     prt(_("  d) エッセンス付加", "  d) Add essence"), 5, 14);
                     prt(_("  e) 武器/防具強化", "  e) Enchant weapon/armor"), 6, 14);
                     std::string prompt = _(format("どの能力を%sますか:", only_browse ? "調べ" : "使い"), "Command :");
-                    const auto choice = input_command(prompt, true);
+                    const auto choice = input_command(prompt);
                     if (!choice) {
                         screen_load();
                         return;

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -137,7 +137,7 @@ std::pair<bool, tl::optional<char>> SpellHex::select_spell_stopping(std::string_
 {
     while (true) {
         this->display_casting_spells_list();
-        const auto choice_opt = input_command(prompt, true);
+        const auto choice_opt = input_command(prompt);
         if (!choice_opt) {
             return { false, tl::nullopt };
         }

--- a/src/target/target-getter.cpp
+++ b/src/target/target-getter.cpp
@@ -58,7 +58,7 @@ Direction get_aim_dir(PlayerType *player_ptr, bool enable_repeat)
                 ? _("方向 ('5'でターゲットへ, '*'でターゲット再選択, ESCで中断)? ", "Direction ('5' for target, '*' to re-target, Escape to cancel)? ")
                 : _("方向 ('*'でターゲット選択, ESCで中断)? ", "Direction ('*' to choose a target, Escape to cancel)? ");
 
-        const auto command_opt = input_command(prompt, true);
+        const auto command_opt = input_command(prompt);
         if (!command_opt) {
             project_length = 0;
             return Direction::none();
@@ -117,7 +117,7 @@ Direction get_direction(PlayerType *player_ptr)
 
     constexpr auto prompt = _("方向 (ESCで中断)? ", "Direction (Escape to cancel)? ");
     while (!dir) {
-        const auto command = input_command(prompt, true);
+        const auto command = input_command(prompt);
         if (!command) {
             return Direction::none();
         }
@@ -176,7 +176,7 @@ Direction get_rep_dir(PlayerType *player_ptr, bool under)
     const auto prompt = under ? _("方向 ('.'足元, ESCで中断)? ", "Direction ('.' at feet, Escape to cancel)? ")
                               : _("方向 (ESCで中断)? ", "Direction (Escape to cancel)? ");
     while (!dir) {
-        const auto command = input_command(prompt, true);
+        const auto command = input_command(prompt);
         if (!command) {
             return Direction::none();
         }


### PR DESCRIPTION
 * Discordでの相談につき、`imput_command()` の zキーキャンセルそのものが無用と判断しオミット。