### PR TITLE
[Fix] 【バグ】 自動拾いに"読めない"と書いたときの挙動が以前と違う

### DIFF
--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -309,8 +309,11 @@ bool is_autopick_match(PlayerType *player_ptr, const ItemEntity *o_ptr, const au
         }
     }
 
-    if (entry.has(FLG_UNREADABLE) && check_book_realm(player_ptr, bi_key)) {
-        return false;
+    if (entry.has(FLG_UNREADABLE)) {
+        const auto unreadable_book = bi_key.is_spell_book() && !check_book_realm(player_ptr, bi_key);
+        if (!unreadable_book) {
+            return false;
+        }
     }
 
     PlayerClass pc(player_ptr);


### PR DESCRIPTION
fix #5240

"読めない"魔法書に関連する自動拾い判別式の間違いを修正。