### PR TITLE
[Fix] 帰還と上り階段なしオプションで始めるとクエスト内で移動できない

### DIFF
--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -157,7 +157,7 @@ void WorldTurnProcessor::process_downward()
 {
     /* 帰還無しモード時のレベルテレポバグ対策 / Fix for level teleport bugs on ironman_downward.*/
     auto &floor = *this->player_ptr->current_floor_ptr;
-    if (!ironman_downward || (floor.dungeon_id == DungeonId::ANGBAND) || !floor.is_underground()) {
+    if (!ironman_downward || (floor.dungeon_id == DungeonId::ANGBAND) || !floor.is_underground() || floor.is_in_quest()) {
         return;
     }
 


### PR DESCRIPTION
fix #5244

該当の条件式に不足があったため、修正した。