### PR TITLE
変愚「Provide an implementation of StackTrace on systems with backtrace() #5204」のマージ

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -190,6 +190,29 @@ AC_FUNC_STRFTIME
 AC_FUNC_VPRINTF
 AC_CHECK_FUNCS(gethostname mkdir select socket strtol vsnprintf mkstemp usleep)
 
+dnl On Linux, backtrace() may need additional linker flags to produce useful
+dnl symbol names.  With the GNU linker, the necessary option is
+dnl --export-dynamic or, if using the compiler to do the linking, -rdynamic.
+dnl Use -rdynamic on any platform where it is accepted.  If a platform
+dnl requires linking additional libraries to use backtrace(), this may have
+dnl to be modified as it only accounts for FreeBSD/NetBSD/OpenBSD where
+dnl libexecinfo needs to be linked to have access to backtrace().
+AC_SEARCH_LIBS([backtrace], [execinfo],
+  [AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([[
+      #include <execinfo.h>
+      int main() { void *a[100]; int n; n = (int)backtrace(a, 100); return (n != 0) ? 0 : 1; }
+    ]])],
+    [AC_DEFINE([HAVE_BACKTRACE], [1], [Define if backtrace and backtrace_symbols exist.])
+    ac_save_LDFLAGS="$LDFLAGS"
+    LDFLAGS="$LDFLAGS -rdynamic"
+    AC_LINK_IFELSE(
+      [AC_LANG_SOURCE([[
+        int main() { return 0; }
+      ]])],
+      [],
+      [LDFLAGS="$ac_save_LDFLAGS"])])])
+
 AC_CONFIG_FILES(Makefile src/Makefile lib/Makefile lib/apex/Makefile \
 	lib/bone/Makefile lib/data/Makefile \
 	lib/edit/Makefile lib/edit/quests/Makefile lib/edit/towns/Makefile \

--- a/src/main-unix/stack-trace-unix.cpp
+++ b/src/main-unix/stack-trace-unix.cpp
@@ -1,6 +1,55 @@
+#include "system/h-basic.h"
 #include "util/stack-trace.h"
+#ifdef HAVE_BACKTRACE
+#include <cstdlib>
+#include <execinfo.h>
+#include <sstream>
+#include <utility>
+#endif // HAVE_BACKTRACE
 
 namespace util {
+
+#ifdef HAVE_BACKTRACE
+
+constexpr auto FRAMES_TO_CAPTURE_MAX = 100;
+
+struct StackTrace::Frame {
+    void *address;
+    std::string symbol_name;
+};
+
+StackTrace::StackTrace()
+{
+    void *addrs[FRAMES_TO_CAPTURE_MAX];
+    auto count = backtrace(addrs, FRAMES_TO_CAPTURE_MAX);
+    auto names = backtrace_symbols(addrs, count);
+
+    if (names) {
+        try {
+            for (auto i = 0; i < count; i++) {
+                Frame frame{ addrs[i], names[i] };
+                this->frames.push_back(std::move(frame));
+            }
+        } catch (...) {
+        }
+        std::free(names);
+    }
+}
+
+StackTrace::~StackTrace() = default;
+
+std::string StackTrace::dump() const
+{
+    std::ostringstream oss;
+    for (auto frame_no = 0; const auto &frame : this->frames) {
+        oss << '#' << frame_no++ << ' '
+            << (frame.symbol_name.empty() ? "(No symbol)" : frame.symbol_name + "()");
+        oss << '\n';
+    }
+    return oss.str();
+}
+
+#else
 
 struct StackTrace::Frame {
 };
@@ -15,5 +64,7 @@ std::string StackTrace::dump() const
 {
     return "Not implemented\n";
 }
+
+#endif // else HAVE_BACKTRACE
 
 } // namespace util


### PR DESCRIPTION
Such systems include Linux with glibc 2.1 or later, macOS 10.5 or later, FreeBSD 10.0 or later, NetBSD 7.0 or later, and OpenBSD 7.0 or later.

With "THROW_EXCEPTION(std::runtime_error, "Test Exception");" inserted after the call to process_monster_arena() in WorldTurnProcessor::process_world(), the stack trace on Linux (Debian 6.1 on a i686 system; stock version of gcc 12.2.0) when the exception triggers is (dropped leading '#' after the fact so they are not skipped in the commit message):

0 src/hengband(_ZN4util10StackTraceC2Ev+0x49) [0x756569]() 1 src/hengband(_ZN7angband9exception6detail15throw_exceptionISt13runtime_errorEEvSt17basic_string_viewIcSt11char_traitsIcEENSt10filesystem7__cxx114pathEi+0x40) [0x5e3520]() 2 src/hengband(_ZN18WorldTurnProcessor13process_worldEv+0xf4) [0x95ec34]() 3 src/hengband(_Z15process_dungeonP10PlayerTypeb+0x671) [0x6452d1]() 4 src/hengband(_Z9play_gameP10PlayerTypebb+0x5f3) [0x63b103]() 5 src/hengband(main+0x2bd) [0x558ded]()
6 /lib/i386-linux-gnu/libc.so.6(+0x232d5) [0xb784e2d5]() 7 /lib/i386-linux-gnu/libc.so.6(__libc_start_main+0x88) [0xb784e398]() 8 src/hengband(_start+0x27) [0x5b9267]()

On macOS 12.7.6 (clang 14.0.0; macOS-specific front end), the stack trace when that same exception triggers is:

0 0   hengband                            0x000000010e168ac8 _ZN4util10StackTraceC2Ev + 72()
1 1   hengband                            0x000000010e00e5c4 _ZN7angband9exception6detail15throw_exceptionISt13runtime_errorEEvNSt3__117basic_string_viewIcNS4_11char_traitsIcEEEENS4_4__fs10filesystem4pathEi + 52()
2 2   hengband                            0x000000010e387890 _ZN18WorldTurnProcessor13process_worldEv + 144()
3 3   hengband                            0x000000010e0654d9 _Z15process_dungeonP10PlayerTypeb + 1321()
4 4   hengband                            0x000000010e05d0a5 _Z9play_gameP10PlayerTypebb + 2229()
5 5   hengband                            0x000000010e393e37 -[AngbandAppDelegate beginGame] + 4199()
6 6   hengband                            0x000000010e3968db -[AngbandAppDelegate applicationDidFinishLaunching:] + 27()
7 7   CoreFoundation                      0x00007ff81f41268c __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 12()
8 8   CoreFoundation                      0x00007ff81f4afaa2 ___CFXRegistrationPost_block_invoke + 49()
9 9   CoreFoundation                      0x00007ff81f4afa20 _CFXRegistrationPost + 496()
10 10  CoreFoundation                      0x00007ff81f3e42f8 _CFXNotificationPost + 735()
11 11  Foundation                          0x00007ff82022358e -[NSNotificationCenter postNotificationName:object:userInfo:] + 82()
12 12  AppKit                              0x00007ff821e62357 -[NSApplication _postDidFinishNotification] + 306()
13 13  AppKit                              0x00007ff821e620a7 -[NSApplication _sendFinishLaunchingNotification] + 208()
14 14  AppKit                              0x00007ff821e5fc78 -[NSApplication(NSAppleEventHandling) _handleAEOpenEvent:] + 541()
15 15  AppKit                              0x00007ff821e5f8cf -[NSApplication(NSAppleEventHandling) _handleCoreEvent:withReplyEvent:] + 665()
16 16  Foundation                          0x00007ff82024e4b4 -[NSAppleEventManager dispatchRawAppleEvent:withRawReply:handlerRefCon:] + 308()
17 17  Foundation                          0x00007ff82024e326 _NSAppleEventManagerGenericHandler + 80()
18 18  AE                                  0x00007ff825ad8484 _AppleEventsCheckInAppWithBlock + 14323()
19 19  AE                                  0x00007ff825ad7cee _AppleEventsCheckInAppWithBlock + 12381()
20 20  AE                                  0x00007ff825ad1343 aeProcessAppleEvent + 419()
21 21  HIToolbox                           0x00007ff8280dece2 AEProcessAppleEvent + 54()
22 22  AppKit                              0x00007ff821e59efe _DPSNextEvent + 2036()
23 23  AppKit                              0x00007ff821e58166 -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1394()
24 24  AppKit                              0x00007ff821e4a818 -[NSApplication run] + 586()
25 25  AppKit                              0x00007ff821e1e79a NSApplicationMain + 817()
26 26  hengband                            0x000000010e397169 main + 9()
27 27  dyld                                0x000000011020852e start + 462()