### PR TITLE
Avoid extra temporary string when dumping stack traces

### DIFF
--- a/src/main-unix/stack-trace-unix.cpp
+++ b/src/main-unix/stack-trace-unix.cpp
@@ -42,9 +42,12 @@ std::string StackTrace::dump() const
 {
     std::ostringstream oss;
     for (auto frame_no = 0; const auto &frame : this->frames) {
-        oss << '#' << frame_no++ << ' '
-            << (frame.symbol_name.empty() ? "(No symbol)" : frame.symbol_name + "()");
-        oss << '\n';
+        oss << '#' << frame_no++ << ' ';
+        if (frame.symbol_name.empty()) {
+            oss << "(No symbol)\n";
+        } else {
+            oss << frame.symbol_name << "()\n";
+        }
     }
     return oss.str();
 }

--- a/src/main-win/stack-trace-win.cpp
+++ b/src/main-win/stack-trace-win.cpp
@@ -86,8 +86,12 @@ std::string StackTrace::dump() const
 {
     std::ostringstream oss;
     for (auto frame_no = 0; const auto &frame : this->frames) {
-        oss << '#' << frame_no++ << ' '
-            << (frame.symbol_name.empty() ? "(No symbol)" : frame.symbol_name + "()");
+        oss << '#' << frame_no++ << ' ';
+        if (frame.symbol_name.empty()) {
+            oss << "(No symbol)";
+        } else {
+            oss << frame.symbol_name << "()";
+        }
         if (!frame.file.empty()) {
             oss << " at " << frame.file << ':' << frame.line_num;
         }


### PR DESCRIPTION
Suggested by Gemini here, https://github.com/hengband/hengband/pull/5204 .