### PR TITLE
[Fix] 破邪の呪文「神の怒り」の説明文修正

### DIFF
--- a/lib/edit/SpellDefinitions.jsonc
+++ b/lib/edit/SpellDefinitions.jsonc
@@ -4167,8 +4167,8 @@
                 "en": "Wrath of the God"
               },
               "description": {
-                "ja": "ターゲットの周囲に分解の球を多数落とす。",
-                "en": "Drops many balls of disintegration near the target."
+                "ja": "超巨大な分解の球を放つ。",
+                "en": "Fires a huge ball of disintegration."
               }
             },
             {


### PR DESCRIPTION
分解級を多数放つ以前の仕様から、単発の巨大分解級へと変更されていることへの対応。