### PR TITLE
変愚「Fix character overlap on macOS ncurses terminal (Fixes #2142, #2143) #5292」のマージ

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,13 @@ AX_CXX_COMPILE_STDCXX(20, [noext], [mandatory])
 CXXFLAGS="$saved_CXXFLAGS"
 PKG_PROG_PKG_CONFIG
 
+dnl Detect macOS host
+AC_CANONICAL_HOST
+is_macos=no
+case "${host_os}" in
+  darwin*) is_macos=yes ;;
+esac
+
 AC_MSG_CHECKING([whether the compiler is Clang])
 AC_COMPILE_IFELSE(
   [AC_LANG_SOURCE([[
@@ -84,9 +91,27 @@ AM_CONDITIONAL([PCH], [test x$enable_pch = xyes])
 
 dnl Checks for libraries.
 dnl Replace `main' with a function in -lncurses:
-AC_CHECK_LIB(ncursesw, initscr, [AC_DEFINE(USE_GCU, 1, [Allow -mGCU environment]) AC_DEFINE(USE_NCURSES, 1, [Use ncurses]) LIBS="$LIBS -lncursesw"])
+AC_CHECK_LIB(ncursesw, initscr, [
+  AC_DEFINE(USE_GCU, 1, [Allow -mGCU environment]) 
+  AC_DEFINE(USE_NCURSES, 1, [Use ncurses]) 
+  LIBS="$LIBS -lncursesw"
+  
+  dnl Define MACOS_TERMINAL_UTF8 for macOS ncursesw builds
+  if test "x$is_macos" = "xyes"; then
+     AC_DEFINE(MACOS_TERMINAL_UTF8, 1, [Enable UTF-8 width fix for macOS terminal])
+  fi
+])
 if test "$ac_cv_lib_ncursesw_initscr" != yes; then
-  AC_CHECK_LIB(ncurses, initscr, [AC_DEFINE(USE_GCU, 1, [Allow -mGCU environment]) AC_DEFINE(USE_NCURSES, 1, [Use ncurses]) LIBS="$LIBS -lncurses"])
+  AC_CHECK_LIB(ncurses, initscr, [
+    AC_DEFINE(USE_GCU, 1, [Allow -mGCU environment]) 
+    AC_DEFINE(USE_NCURSES, 1, [Use ncurses]) 
+    LIBS="$LIBS -lncurses"
+    
+    dnl Define MACOS_TERMINAL_UTF8 for macOS ncurses builds
+    if test "x$is_macos" = "xyes"; then
+       AC_DEFINE(MACOS_TERMINAL_UTF8, 1, [Enable UTF-8 width fix for macOS terminal])
+    fi
+  ])
   if test "$ac_cv_lib_ncurses_initscr" != yes; then
     AC_CHECK_LIB(curses, initscr, [AC_DEFINE(USE_GCU, 1, [Allow -mGCU environment]) LIBS="$LIBS -lcurses"])
     if test "$ac_cv_lib_curses_initscr" != yes; then


### PR DESCRIPTION
In macOS Terminal (UTF-8), ambiguous-width characters such as ★, ☆, and … often overlap with adjacent text when using the GCU (ncurses) frontend.

This commit introduces a safe, display-only correction:
1. Update configure.ac to detect macOS and enable the UTF-8 fix.
2. In main-gcu.cpp, appends a space after these characters during rendering.

This ensures correct visual alignment without affecting internal game data, save files, or character dumps.