### PR TITLE
変愚「[Fix] shape_buffer関数の文字列分割位置がおかしい #3117」のマージ

### DIFF
--- a/src/util/buffer-shaper.cpp
+++ b/src/util/buffer-shaper.cpp
@@ -1,6 +1,7 @@
 #include "util/buffer-shaper.h"
 #include "locale/japanese.h"
 #include <algorithm>
+#include <array>
 
 /*!
  * @brief 文字列を指定した最大長を目安として分割する
@@ -26,10 +27,12 @@ std::vector<std::string> shape_buffer(std::string_view sv, size_t maxlen)
     std::vector<std::string> result;
     std::string line;
     auto separate_pos = 0U;
+    std::array<bool, 2> is_kanji{}; // [0]:現在の文字 [1]:一つ前の文字
 
     while (line.length() < sv.length()) {
-        const auto is_kanji = _(iskanji(sv[line.length()]), false);
-        auto ch = sv.substr(line.length(), is_kanji ? 2 : 1);
+        is_kanji[1] = is_kanji[0];
+        is_kanji[0] = _(iskanji(sv[line.length()]), false);
+        auto ch = sv.substr(line.length(), is_kanji[0] ? 2 : 1);
         const auto is_newline = ch[0] == '\n';
 
         if ((ch.length() == 1) && !isprint(ch[0])) {
@@ -37,7 +40,7 @@ std::vector<std::string> shape_buffer(std::string_view sv, size_t maxlen)
         }
 
         if ((line.length() + ch.length() >= maxlen) || is_newline) {
-            if ((ch[0] == ' ') || (line.length() >= separate_pos * 2) || (is_kanji && !is_kinsoku(ch))) {
+            if ((ch[0] == ' ') || (line.length() >= separate_pos * 2) || (is_kanji[0] && !is_kinsoku(ch))) {
                 sv.remove_prefix(line.length());
             } else {
                 line.erase(separate_pos);
@@ -50,10 +53,11 @@ std::vector<std::string> shape_buffer(std::string_view sv, size_t maxlen)
             result.push_back(std::move(line));
             line.clear();
             separate_pos = 0;
+            is_kanji.fill(false);
             continue;
         }
 
-        if ((ch[0] == ' ') || is_kanji) {
+        if ((ch[0] == ' ') || is_kanji[0] || is_kanji[1]) {
             separate_pos = line.length();
         }
 


### PR DESCRIPTION
日本語と英語がスペースを開けずに繋がった文章で英語部分で折り返しが発生す
ると分割位置がおかしくなる。
例えば「日本語english」のenglishの途中で折り返すと「日本」「語english」
と分割されてしまう。「日本語」「english」と分割されるように修正する。