### PR TITLE
[Fix] レベルアップ報酬で全回復したときのカオスパトロンのメッセージ

### DIFF
--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -345,6 +345,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             break;
         case REW_HEAL_FUL:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
+            msg_print(_("「甦るがよい、我が下僕よ！」", "'Rise, my servant!'"));
             (void)restore_level(static_cast<CreatureEntity &>(*this->player_ptr));
             (void)restore_all_status(this->player_ptr);
             (void)true_healing(this->player_ptr, 5000);


### PR DESCRIPTION
レベルアップ報酬で全回復したとき、「◯◯の声が響き渡った:」とだけ
表示されて、続くセリフが表示されない。
リファクタリングの過程でセリフの部分が誤って削除されたようなので、
2.2.1r2のセリフを復活させる。