### PR TITLE
(System)[Refactor] aspells-beam関数をCreatureEntity&に変更

### DIFF
--- a/src/cmd-item/cmd-zaprod.cpp
+++ b/src/cmd-item/cmd-zaprod.cpp
@@ -168,7 +168,7 @@ int rod_effect(PlayerType *player_ptr, int sval, const Direction &dir, bool *use
     }
 
     case SV_ROD_DISARMING: {
-        if (disarm_trap(player_ptr, dir)) {
+        if (disarm_trap(*player_ptr, dir)) {
             ident = true;
         }
         if (powerful && disarm_traps_touch(*player_ptr)) {
@@ -269,7 +269,7 @@ int rod_effect(PlayerType *player_ptr, int sval, const Direction &dir, bool *use
 
     case SV_ROD_STONE_TO_MUD: {
         int dam = powerful ? 40 + randint1(60) : 20 + randint1(30);
-        if (wall_to_mud(player_ptr, dir, dam)) {
+        if (wall_to_mud(*player_ptr, dir, dam)) {
             ident = true;
         }
         break;

--- a/src/cmd-item/cmd-zapwand.cpp
+++ b/src/cmd-item/cmd-zapwand.cpp
@@ -122,7 +122,7 @@ bool wand_effect(PlayerType *player_ptr, int sval, const Direction &dir, bool po
     }
 
     case SV_WAND_DISARMING: {
-        if (disarm_trap(player_ptr, dir)) {
+        if (disarm_trap(*player_ptr, dir)) {
             ident = true;
         }
         if (powerful && disarm_traps_touch(*player_ptr)) {
@@ -132,7 +132,7 @@ bool wand_effect(PlayerType *player_ptr, int sval, const Direction &dir, bool po
     }
 
     case SV_WAND_TRAP_DOOR_DEST: {
-        if (destroy_door(player_ptr, dir)) {
+        if (destroy_door(*player_ptr, dir)) {
             ident = true;
         }
         if (powerful && destroy_doors_touch(*player_ptr)) {
@@ -143,7 +143,7 @@ bool wand_effect(PlayerType *player_ptr, int sval, const Direction &dir, bool po
 
     case SV_WAND_STONE_TO_MUD: {
         int dam = powerful ? 40 + randint1(60) : 20 + randint1(30);
-        if (wall_to_mud(player_ptr, dir, dam)) {
+        if (wall_to_mud(*player_ptr, dir, dam)) {
             ident = true;
         }
         break;

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -1509,7 +1509,7 @@ bool switch_element_execution(CreatureEntity &creature)
             return false;
         }
 
-        (void)wall_to_mud(&player, dir, plev * 3 / 2);
+        (void)wall_to_mud(player, dir, plev * 3 / 2);
         return true;
     }
     case ElementRealmType::DARKNESS:

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -127,7 +127,7 @@ bool activate_stone_mud(CreatureEntity &creature)
     }
 
     auto &player = static_cast<PlayerType &>(creature);
-    wall_to_mud(&player, dir, 20 + randint1(30));
+    wall_to_mud(player, dir, 20 + randint1(30));
     return true;
 }
 

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -377,7 +377,7 @@ bool switch_race_racial_execution(CreatureEntity &creature, const int32_t comman
             return false;
         }
 
-        (void)wall_to_mud(player_ptr, dir, 20 + randint1(30));
+        (void)wall_to_mud(*player_ptr, dir, 20 + randint1(30));
         return true;
     }
     case PlayerRaceType::HALF_TITAN:

--- a/src/realm/realm-arcane.cpp
+++ b/src/realm/realm-arcane.cpp
@@ -66,7 +66,7 @@ tl::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spel
                 return tl::nullopt;
             }
 
-            wizard_lock(player_ptr, dir);
+            wizard_lock(*player_ptr, dir);
         }
     } break;
 
@@ -126,7 +126,7 @@ tl::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spel
                 return tl::nullopt;
             }
 
-            destroy_door(player_ptr, dir);
+            destroy_door(*player_ptr, dir);
         }
     } break;
 
@@ -302,7 +302,7 @@ tl::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spel
                 return tl::nullopt;
             }
 
-            wall_to_mud(player_ptr, dir, base + dice.roll());
+            wall_to_mud(*player_ptr, dir, base + dice.roll());
         }
     } break;
 

--- a/src/realm/realm-crusade.cpp
+++ b/src/realm/realm-crusade.cpp
@@ -82,7 +82,7 @@ tl::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spe
                 return tl::nullopt;
             }
 
-            destroy_door(player_ptr, dir);
+            destroy_door(*player_ptr, dir);
         }
     } break;
 

--- a/src/realm/realm-nature.cpp
+++ b/src/realm/realm-nature.cpp
@@ -193,7 +193,7 @@ tl::optional<std::string> do_nature_spell(CreatureEntity &creature, SPELL_IDX sp
                 return tl::nullopt;
             }
 
-            wall_to_mud(player_ptr, dir, base + dice.roll());
+            wall_to_mud(creature, dir, base + dice.roll());
         }
     } break;
 

--- a/src/spell-kind/spells-beam.cpp
+++ b/src/spell-kind/spells-beam.cpp
@@ -2,53 +2,53 @@
 #include "effect/attribute-types.h"
 #include "effect/effect-characteristics.h"
 #include "spell-kind/spells-launcher.h"
-#include "system/player-type-definition.h"
+#include "system/creature-entity.h"
 
 /*!
  * @brief 岩石溶解処理
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param creature クリーチャーへの参照
  * @param dir 方向(5ならばグローバル変数 target_col/target_row の座標を目標にする)
  * @param dam 威力
  * @return 作用が実際にあった場合TRUEを返す
  */
-bool wall_to_mud(PlayerType *player_ptr, const Direction &dir, int dam)
+bool wall_to_mud(CreatureEntity &creature, const Direction &dir, int dam)
 {
     BIT_FLAGS flg = PROJECT_BEAM | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL;
-    return project_hook(*player_ptr, AttributeType::KILL_WALL, dir, dam, flg);
+    return project_hook(creature, AttributeType::KILL_WALL, dir, dam, flg);
 }
 
 /*!
  * @brief 魔法の施錠処理
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param creature クリーチャーへの参照
  * @param dir 方向(5ならばグローバル変数 target_col/target_row の座標を目標にする)
  * @return 作用が実際にあった場合TRUEを返す
  */
-bool wizard_lock(PlayerType *player_ptr, const Direction &dir)
+bool wizard_lock(CreatureEntity &creature, const Direction &dir)
 {
     BIT_FLAGS flg = PROJECT_BEAM | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL;
-    return project_hook(*player_ptr, AttributeType::JAM_DOOR, dir, 20 + randint1(30), flg);
+    return project_hook(creature, AttributeType::JAM_DOOR, dir, 20 + randint1(30), flg);
 }
 
 /*!
  * @brief ドア破壊処理
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param creature クリーチャーへの参照
  * @param dir 方向(5ならばグローバル変数 target_col/target_row の座標を目標にする)
  * @return 作用が実際にあった場合TRUEを返す
  */
-bool destroy_door(PlayerType *player_ptr, const Direction &dir)
+bool destroy_door(CreatureEntity &creature, const Direction &dir)
 {
     BIT_FLAGS flg = PROJECT_BEAM | PROJECT_GRID | PROJECT_ITEM;
-    return project_hook(*player_ptr, AttributeType::KILL_DOOR, dir, 0, flg);
+    return project_hook(creature, AttributeType::KILL_DOOR, dir, 0, flg);
 }
 
 /*!
  * @brief トラップ解除処理
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param creature クリーチャーへの参照
  * @param dir 方向(5ならばグローバル変数 target_col/target_row の座標を目標にする)
  * @return 作用が実際にあった場合TRUEを返す
  */
-bool disarm_trap(PlayerType *player_ptr, const Direction &dir)
+bool disarm_trap(CreatureEntity &creature, const Direction &dir)
 {
     BIT_FLAGS flg = PROJECT_BEAM | PROJECT_GRID | PROJECT_ITEM;
-    return project_hook(*player_ptr, AttributeType::KILL_TRAP, dir, 0, flg);
+    return project_hook(creature, AttributeType::KILL_TRAP, dir, 0, flg);
 }

--- a/src/spell-kind/spells-beam.h
+++ b/src/spell-kind/spells-beam.h
@@ -1,8 +1,8 @@
 #pragma once
 
+class CreatureEntity;
 class Direction;
-class PlayerType;
-bool wall_to_mud(PlayerType *player_ptr, const Direction &dir, int dam);
-bool wizard_lock(PlayerType *player_ptr, const Direction &dir);
-bool destroy_door(PlayerType *player_ptr, const Direction &dir);
-bool disarm_trap(PlayerType *player_ptr, const Direction &dir);
+bool wall_to_mud(CreatureEntity &creature, const Direction &dir, int dam);
+bool wizard_lock(CreatureEntity &creature, const Direction &dir);
+bool destroy_door(CreatureEntity &creature, const Direction &dir);
+bool disarm_trap(CreatureEntity &creature, const Direction &dir);

--- a/src/world/world-alliance-processor.cpp
+++ b/src/world/world-alliance-processor.cpp
@@ -1,15 +1,15 @@
 #include "world/world-alliance-processor.h"
 #include "alliance/alliance.h"
-#include "system/player-type-definition.h"
+#include "system/creature-entity.h"
 
 /*!
  * @brief 全アライアンスの自然回復処理を実行する
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param creature クリーチャーへの参照
  * @details 10ゲームターンごとに呼び出され、各アライアンスのbase_powerをnatural_recovery分回復させる
  */
-void process_alliance_recovery(PlayerType *player_ptr)
+void process_alliance_recovery(CreatureEntity &creature)
 {
-    (void)player_ptr; // 現在は未使用だが、将来的に使用する可能性があるため引数として保持
+    (void)creature; // 現在は未使用だが、将来的に使用する可能性があるため引数として保持
 
     // 全アライアンスの自然回復を処理
     for (const auto &[alliance_type, alliance_ptr] : alliance_list) {

--- a/src/world/world-alliance-processor.h
+++ b/src/world/world-alliance-processor.h
@@ -1,5 +1,5 @@
 #pragma once
 
-class PlayerType;
+class CreatureEntity;
 
-void process_alliance_recovery(PlayerType *player_ptr);
+void process_alliance_recovery(CreatureEntity &creature);

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -98,7 +98,7 @@ void WorldTurnProcessor::process_world()
     process_terrain_effects(this->player_ptr);
     process_world_aux_mutation(this->player_ptr);
     process_world_aux_sudden_attack(this->player_ptr);
-    process_alliance_recovery(this->player_ptr);
+    process_alliance_recovery(*this->player_ptr);
     execute_cursed_items_effect(this->player_ptr);
     recharge_magic_items(this->player_ptr);
     sense_inventory1(this->player_ptr);


### PR DESCRIPTION
- wall_to_mud, wizard_lock, destroy_door, disarm_trapをPlayerType*からCreatureEntity&に変更

- 全ての呼び出し箇所を*player_ptrまたはcreatureを直接渡すように更新

- project_hookが既にCreatureEntity&を受け取るため、キャストなしで使用可能