### PR TITLE
refactor: dungeon/quest - PlayerType* → CreatureEntity& (第一引数置換)

### DIFF
--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -159,7 +159,7 @@ void player_birth(CreatureEntity &creature, std::optional<QuestId> initial_quest
 
         // クエストに突入
         if (quest.dungeon == DungeonId::WILDERNESS) {
-            exe_enter_quest(player_ptr, *initial_quest_id);
+            exe_enter_quest(*player_ptr, *initial_quest_id);
         }
     }
 }

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -163,7 +163,7 @@ void init_dungeon_quests(CreatureEntity &creature)
     for (auto quest_id : RANDOM_QUEST_ID_RANGE) {
         auto &quest = quests.get_quest(quest_id);
         quest.status = QuestStatusType::TAKEN;
-        determine_random_questor(player_ptr, quest);
+        determine_random_questor(*player_ptr, quest);
         auto &monrace = quest.get_bounty();
         monrace.misc_flags.set(MonsterMiscType::QUESTOR);
         quest.max_num = 1;

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -111,7 +111,7 @@ void do_cmd_go_up(CreatureEntity &creature)
 
         sound(SoundKind::STAIRWAY);
 
-        leave_quest_check(&player);
+        leave_quest_check(player);
         floor.quest_number = i2enum<QuestId>(grid.special);
         const auto quest_id = floor.quest_number;
         auto &quest = quests.get_quest(quest_id);
@@ -157,13 +157,13 @@ void do_cmd_go_up(CreatureEntity &creature)
     auto &quest = quests.get_quest(quest_number);
 
     if (inside_quest(quest_number) && quest.type == QuestKindType::RANDOM) {
-        leave_quest_check(&player);
+        leave_quest_check(player);
         floor.quest_number = QuestId::NONE;
     }
 
     auto up_num = 0;
     if (inside_quest(quest_number) && quest.type != QuestKindType::RANDOM) {
-        leave_quest_check(&player);
+        leave_quest_check(player);
         floor.quest_number = i2enum<QuestId>(grid.special);
         floor.dun_level = 0;
         up_num = 0;
@@ -239,7 +239,7 @@ void do_cmd_go_down(CreatureEntity &creature)
 
     const auto is_fall_trap = terrain.flags.has(TerrainCharacteristics::TRAP);
     if (terrain.flags.has(TerrainCharacteristics::QUEST_ENTER)) {
-        do_cmd_quest(&player);
+        do_cmd_quest(player);
         return;
     }
 
@@ -256,8 +256,8 @@ void do_cmd_go_down(CreatureEntity &creature)
 
         sound(SoundKind::STAIRWAY);
 
-        leave_quest_check(&player);
-        leave_tower_check(&player);
+        leave_quest_check(player);
+        leave_tower_check(player);
         floor.quest_number = i2enum<QuestId>(grid.special);
 
         auto &quests = QuestList::get_instance();

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -280,7 +280,7 @@ void do_cmd_wield(CreatureEntity &creature)
         slot = need_switch_wielding;
     }
 
-    check_find_art_quest_completion(player_ptr, o_ptr);
+    check_find_art_quest_completion(*player_ptr, o_ptr);
     if (player_ptr->ppersonality == PERSONALITY_MUNCHKIN) {
         identify_item(creature, o_ptr);
         autopick_alter_item(player_ptr, i_idx, false);

--- a/src/dungeon/quest-completion-checker.cpp
+++ b/src/dungeon/quest-completion-checker.cpp
@@ -129,7 +129,7 @@ void QuestCompletionChecker::complete_kill_number()
 {
     this->q_ptr->cur_num++;
     if (this->q_ptr->cur_num >= this->q_ptr->num_mon) {
-        complete_quest(this->player_ptr, this->quest_idx);
+        complete_quest(*this->player_ptr, this->quest_idx);
         this->q_ptr->cur_num = 0;
     }
 }
@@ -143,7 +143,7 @@ void QuestCompletionChecker::complete_kill_all()
     if (any_bits(this->q_ptr->flags, QUEST_FLAG_SILENT)) {
         this->q_ptr->status = QuestStatusType::FINISHED;
     } else {
-        complete_quest(this->player_ptr, this->quest_idx);
+        complete_quest(*this->player_ptr, this->quest_idx);
     }
 }
 
@@ -158,7 +158,7 @@ std::tuple<bool, bool> QuestCompletionChecker::complete_random()
         return std::make_tuple(false, false);
     }
 
-    complete_quest(this->player_ptr, this->quest_idx);
+    complete_quest(*this->player_ptr, this->quest_idx);
     auto create_stairs = false;
     if (none_bits(this->q_ptr->flags, QUEST_FLAG_PRESET)) {
         create_stairs = true;
@@ -182,7 +182,7 @@ void QuestCompletionChecker::complete_kill_any_level()
 {
     this->q_ptr->cur_num++;
     if (this->q_ptr->cur_num >= this->q_ptr->max_num) {
-        complete_quest(this->player_ptr, this->quest_idx);
+        complete_quest(*this->player_ptr, this->quest_idx);
         this->q_ptr->cur_num = 0;
     }
 }
@@ -203,7 +203,7 @@ void QuestCompletionChecker::complete_tower()
     is_tower_completed &= quests.get_quest(QuestId::TOWER2).status == QuestStatusType::STAGE_COMPLETED;
     is_tower_completed &= quests.get_quest(QuestId::TOWER3).status == QuestStatusType::STAGE_COMPLETED;
     if (is_tower_completed) {
-        complete_quest(this->player_ptr, QuestId::TOWER1);
+        complete_quest(*this->player_ptr, QuestId::TOWER1);
     }
 }
 

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -23,6 +23,7 @@
 #include "player/player-personality-types.h"
 #include "player/player-status.h"
 #include "system/artifact-type-definition.h"
+#include "system/creature-entity.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/floor/floor-info.h" // @todo 相互参照、将来的に削除する.
 #include "system/grid-type-definition.h"
@@ -151,8 +152,9 @@ bool QuestList::order_completed(QuestId id1, QuestId id2) const
  * @brief ランダムクエストの討伐ユニークを決める / Determine the random quest uniques
  * @param quest クエスト構造体への参照
  */
-void determine_random_questor(PlayerType *player_ptr, QuestType &quest)
+void determine_random_questor(CreatureEntity &creature, QuestType &quest)
 {
+    auto *player_ptr = static_cast<PlayerType *>(&creature);
     get_mon_num_prep_enum(*player_ptr, MonraceHook::QUEST);
     const auto &monraces = MonraceList::get_instance();
     MonraceId r_idx;
@@ -191,8 +193,9 @@ void record_quest_final_status(QuestType *q_ptr, PLAYER_LEVEL lev, QuestStatusTy
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param quest_id 達成状態にしたいクエストのID
  */
-void complete_quest(PlayerType *player_ptr, QuestId quest_id)
+void complete_quest(CreatureEntity &creature, QuestId quest_id)
 {
+    auto *player_ptr = static_cast<PlayerType *>(&creature);
     auto &quests = QuestList::get_instance();
     auto &quest = quests.get_quest(quest_id);
     switch (quest.type) {
@@ -227,8 +230,9 @@ void complete_quest(PlayerType *player_ptr, QuestId quest_id)
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param o_ptr 入手したオブジェクトの構造体参照ポインタ
  */
-void check_find_art_quest_completion(PlayerType *player_ptr, ItemEntity *o_ptr)
+void check_find_art_quest_completion(CreatureEntity &creature, ItemEntity *o_ptr)
 {
+    auto *player_ptr = static_cast<PlayerType *>(&creature);
     const auto &quests = QuestList::get_instance();
     /* Check if completed a quest */
     for (const auto &[quest_id, quest] : quests) {
@@ -236,7 +240,7 @@ void check_find_art_quest_completion(PlayerType *player_ptr, ItemEntity *o_ptr)
         found_artifact &= (quest.status == QuestStatusType::TAKEN);
         found_artifact &= (o_ptr->is_specific_artifact(quest.reward_fa_id));
         if (found_artifact) {
-            complete_quest(player_ptr, quest_id);
+            complete_quest(*player_ptr, quest_id);
         }
     }
 }
@@ -281,8 +285,9 @@ void quest_discovery(QuestId quest_id)
  * @brief クエスト階層から離脱する際の処理
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-void leave_quest_check(PlayerType *player_ptr)
+void leave_quest_check(CreatureEntity &creature)
 {
+    auto *player_ptr = static_cast<PlayerType *>(&creature);
     leaving_quest = player_ptr->current_floor_ptr->quest_number;
     if (!inside_quest(leaving_quest)) {
         return;
@@ -330,8 +335,9 @@ void leave_quest_check(PlayerType *player_ptr)
 /*!
  * @brief 「塔」クエストの各階層から離脱する際の処理
  */
-void leave_tower_check(PlayerType *player_ptr)
+void leave_tower_check(CreatureEntity &creature)
 {
+    auto *player_ptr = static_cast<PlayerType *>(&creature);
     auto &quests = QuestList::get_instance();
     leaving_quest = player_ptr->current_floor_ptr->quest_number;
 
@@ -355,8 +361,9 @@ void leave_tower_check(PlayerType *player_ptr)
 /*!
  * @brief Player enters a new quest
  */
-void exe_enter_quest(PlayerType *player_ptr, QuestId quest_id)
+void exe_enter_quest(CreatureEntity &creature, QuestId quest_id)
 {
+    auto *player_ptr = static_cast<PlayerType *>(&creature);
     const auto &quests = QuestList::get_instance();
     if (quests.get_quest(quest_id).type != QuestKindType::RANDOM) {
         player_ptr->current_floor_ptr->dun_level = 1;
@@ -369,8 +376,9 @@ void exe_enter_quest(PlayerType *player_ptr, QuestId quest_id)
  * @brief クエスト入り口にプレイヤーが乗った際の処理 / Do building commands
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-void do_cmd_quest(PlayerType *player_ptr)
+void do_cmd_quest(CreatureEntity &creature)
 {
+    auto *player_ptr = static_cast<PlayerType *>(&creature);
     if (AngbandWorld::get_instance().is_wild_mode()) {
         return;
     }
@@ -394,9 +402,9 @@ void do_cmd_quest(PlayerType *player_ptr)
 
     player_ptr->oldpy = 0;
     player_ptr->oldpx = 0;
-    leave_quest_check(player_ptr);
+    leave_quest_check(*player_ptr);
 
-    exe_enter_quest(player_ptr, i2enum<QuestId>(floor.get_grid(player_ptr->get_position()).special));
+    exe_enter_quest(*player_ptr, i2enum<QuestId>(floor.get_grid(player_ptr->get_position()).special));
 }
 
 bool inside_quest(QuestId id)

--- a/src/dungeon/quest.h
+++ b/src/dungeon/quest.h
@@ -166,16 +166,16 @@ extern QuestId leaving_quest;
 
 constexpr auto QUEST_TEST_LINES_MAX = 10;
 
+class CreatureEntity;
 class FloorType;
 class ItemEntity;
-class PlayerType;
-void determine_random_questor(PlayerType *player_ptr, QuestType &quest);
+void determine_random_questor(CreatureEntity &creature, QuestType &quest);
 void record_quest_final_status(QuestType *q_ptr, PLAYER_LEVEL lev, QuestStatusType stat);
-void complete_quest(PlayerType *player_ptr, QuestId quest_num);
-void check_find_art_quest_completion(PlayerType *player_ptr, ItemEntity *o_ptr);
+void complete_quest(CreatureEntity &creature, QuestId quest_num);
+void check_find_art_quest_completion(CreatureEntity &creature, ItemEntity *o_ptr);
 void quest_discovery(QuestId quest_id);
-void leave_quest_check(PlayerType *player_ptr);
-void leave_tower_check(PlayerType *player_ptr);
-void exe_enter_quest(PlayerType *player_ptr, QuestId quest_id);
-void do_cmd_quest(PlayerType *player_ptr);
+void leave_quest_check(CreatureEntity &creature);
+void leave_tower_check(CreatureEntity &creature);
+void exe_enter_quest(CreatureEntity &creature, QuestId quest_id);
+void do_cmd_quest(CreatureEntity &creature);
 bool inside_quest(QuestId quest_id);

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -483,7 +483,7 @@ void jump_floor(PlayerType *player_ptr, DungeonId dun_idx, DEPTH depth)
     }
 
     floor.inside_arena = false;
-    leave_quest_check(player_ptr);
+    leave_quest_check(*player_ptr);
     auto to = !floor.is_underground()
                   ? _("地上", "the surface")
                   : format(_("%d階(%s)", "level %d of %s"), floor.dun_level, floor.get_dungeon_definition().name.data());

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -78,7 +78,7 @@ void pattern_teleport(PlayerType *player_ptr)
     }
 
     floor.dun_level = command_arg;
-    leave_quest_check(player_ptr);
+    leave_quest_check(*player_ptr);
     if (record_stair) {
         exe_write_diary(floor, DiaryKind::PAT_TELE, 0);
     }

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -265,7 +265,7 @@ void process_player_pickup_item(CreatureEntity &creature, OBJECT_IDX o_idx)
 
     record_item_name = describe_flavor(player_ptr, *picked_item_ptr, OD_NAME_ONLY);
     record_turn = AngbandWorld::get_instance().game_turn;
-    check_find_art_quest_completion(player_ptr, &picked_slot_item);
+    check_find_art_quest_completion(*player_ptr, &picked_slot_item);
 }
 
 /*!

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -322,7 +322,7 @@ void process_command(CreatureEntity &creature)
         break;
     }
     case SPECIAL_KEY_QUEST: {
-        do_cmd_quest(player_ptr);
+        do_cmd_quest(*player_ptr);
         break;
     }
     case '<': {

--- a/src/load/quest-loader.cpp
+++ b/src/load/quest-loader.cpp
@@ -51,7 +51,7 @@ static void load_quest_details(PlayerType *player_ptr, QuestType *q_ptr, const Q
     q_ptr->r_idx = i2enum<MonraceId>(rd_s16b());
     if ((q_ptr->type == QuestKindType::RANDOM) && !q_ptr->get_bounty().is_valid()) {
         auto &quests = QuestList::get_instance();
-        determine_random_questor(player_ptr, quests.get_quest(loading_quest_id));
+        determine_random_questor(*player_ptr, quests.get_quest(loading_quest_id));
     }
     q_ptr->reward_fa_id = i2enum<FixedArtifactId>(rd_s16b());
     if (q_ptr->has_reward()) {

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -270,9 +270,9 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
     } else if (terrain_new.flags.has(TerrainCharacteristics::QUEST_EXIT)) {
         const auto &quests = QuestList::get_instance();
         if (quests.get_quest(floor.quest_number).type == QuestKindType::FIND_EXIT) {
-            complete_quest(&player, floor.quest_number);
+            complete_quest(player, floor.quest_number);
         }
-        leave_quest_check(&player);
+        leave_quest_check(player);
         floor.quest_number = i2enum<QuestId>(grid_new.special);
         floor.dun_level = 0;
         if (!floor.is_in_quest()) {

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -156,7 +156,7 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
             }
 
             fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::UP, FloorChangeMode::RANDOM_PLACE, FloorChangeMode::RANDOM_CONNECT });
-            leave_quest_check(player_ptr);
+            leave_quest_check(*player_ptr);
             floor.quest_number = QuestId::NONE;
             player_ptr->leaving = true;
         }

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -121,7 +121,7 @@ void wiz_enter_quest(CreatureEntity &creature)
     auto &quest = quests.get_quest(*quest_id);
     quest.status = QuestStatusType::TAKEN;
     if (quest.dungeon == DungeonId::WILDERNESS) {
-        exe_enter_quest(player_ptr, *quest_id);
+        exe_enter_quest(*player_ptr, *quest_id);
     }
 }
 
@@ -141,7 +141,7 @@ void wiz_complete_quest(CreatureEntity &creature)
 
     const auto &quests = QuestList::get_instance();
     if (quests.get_quest(floor.quest_number).status == QuestStatusType::TAKEN) {
-        complete_quest(player_ptr, floor.quest_number);
+        complete_quest(*player_ptr, floor.quest_number);
     }
 }
 

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -92,8 +92,8 @@ void execute_recall(CreatureEntity &creature)
 
         floor.dun_level = 0;
         floor.reset_dungeon_index();
-        leave_quest_check(&player);
-        leave_tower_check(&player);
+        leave_quest_check(player);
+        leave_tower_check(player);
         floor.quest_number = QuestId::NONE;
         player.leaving = true;
         sound(SoundKind::TPLEVEL);


### PR DESCRIPTION
…rc/dungeon/quest.h, quest.cpp の全7関数\n(determine_random_questor, complete_quest, check_find_art_quest_completion,\nleave_quest_check, leave_tower_check, exe_enter_quest, do_cmd_quest)\nの第一引数を PlayerType * から CreatureEntity & に変更。\n関数内部では auto *player_ptr = static_cast<PlayerType *>(&creature);\nパターンにより既存ロジックを維持。\n\n呼び出し元 (world-movement-processor.cpp, wizard-game-modifier.cpp,\nplayer-move.cpp, game-play-initializer.cpp, quest-loader.cpp,\nplayer-inventory.cpp, floor-leaver.cpp, spells-world.cpp,\ncharacter-builder.cpp, input-key-processor.cpp, pattern-walk.cpp,\ncmd-equipment.cpp) も合わせて修正。"