### PR TITLE
refactor: dungeon/quest-completion-checker - PlayerType* → CreatureEntity& (コンストラクタ

### DIFF
--- a/src/dungeon/quest-completion-checker.cpp
+++ b/src/dungeon/quest-completion-checker.cpp
@@ -17,8 +17,8 @@
 #include <algorithm>
 #include <range/v3/algorithm.hpp>
 
-QuestCompletionChecker::QuestCompletionChecker(PlayerType *player_ptr, const MonsterEntity &monster)
-    : player_ptr(player_ptr)
+QuestCompletionChecker::QuestCompletionChecker(CreatureEntity &creature, const MonsterEntity &monster)
+    : player_ptr(static_cast<PlayerType *>(&creature))
     , m_ptr(&monster)
     , quest_idx(QuestId::NONE)
 {
@@ -51,8 +51,9 @@ void QuestCompletionChecker::complete()
     this->make_reward(pos);
 }
 
-static bool check_quest_completion(PlayerType *player_ptr, const QuestType &quest, const MonsterEntity &monster)
+static bool check_quest_completion(CreatureEntity &creature, const QuestType &quest, const MonsterEntity &monster)
 {
+    auto *player_ptr = static_cast<PlayerType *>(&creature);
     const auto &floor = *player_ptr->current_floor_ptr;
     if (quest.status != QuestStatusType::TAKEN) {
         return false;
@@ -93,7 +94,7 @@ void QuestCompletionChecker::set_quest_idx()
     if (inside_quest(this->quest_idx)) {
         return;
     }
-    auto q = std::find_if(quests.rbegin(), quests.rend(), [this](auto q) { return check_quest_completion(this->player_ptr, q.second, *this->m_ptr); });
+    auto q = std::find_if(quests.rbegin(), quests.rend(), [this](auto q) { return check_quest_completion(*this->player_ptr, q.second, *this->m_ptr); });
 
     if (q != quests.rend()) {
         this->quest_idx = q->first;

--- a/src/dungeon/quest-completion-checker.h
+++ b/src/dungeon/quest-completion-checker.h
@@ -2,6 +2,7 @@
 
 #include "dungeon/quest.h"
 #include "system/angband.h"
+#include "system/creature-entity.h"
 #include "util/point-2d.h"
 #include <tuple>
 
@@ -11,7 +12,7 @@ class PlayerType;
 class QuestType;
 class QuestCompletionChecker {
 public:
-    QuestCompletionChecker(PlayerType *player_ptr, const MonsterEntity &monster);
+    QuestCompletionChecker(CreatureEntity &creature, const MonsterEntity &monster);
     virtual ~QuestCompletionChecker() = default;
 
     void complete();

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -434,7 +434,7 @@ void monster_death(CreatureEntity &creature, MONSTER_IDX m_idx, bool drop_item, 
         do_cmd_redraw(player_ptr);
     }
 
-    QuestCompletionChecker(player_ptr, *md.m_ptr).complete();
+    QuestCompletionChecker(*player_ptr, *md.m_ptr).complete();
     on_defeat_arena_monster(creature, &md);
     if (md.m_ptr->is_riding() && process_fall_off_horse(player_ptr, -1, false)) {
         msg_print(_("地面に落とされた。", "You have fallen from the pet you were riding."));

--- a/src/monster-floor/monster-runaway.cpp
+++ b/src/monster-floor/monster-runaway.cpp
@@ -121,7 +121,7 @@ bool runaway_monster(CreatureEntity &creature, turn_flags *turn_flags_ptr, MONST
     }
 
     escape_monster(creature, turn_flags_ptr, monster, m_name.data());
-    QuestCompletionChecker(player_ptr, monster).complete();
+    QuestCompletionChecker(*player_ptr, monster).complete();
     delete_monster_idx(creature, m_idx);
     return true;
 }

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -34,7 +34,7 @@
 void set_pet(CreatureEntity &creature, MonsterEntity &monster)
 {
     auto *player_ptr = static_cast<PlayerType *>(&creature);
-    QuestCompletionChecker(player_ptr, monster).complete();
+    QuestCompletionChecker(*player_ptr, monster).complete();
     monster.mflag2.set(MonsterConstantFlagType::PET);
     monster.alliance_idx = AllianceType::NONE;
     if (monster.get_monrace().kind_flags.has_none_of(alignment_mask)) {

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -212,7 +212,7 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
         return;
     }
 
-    QuestCompletionChecker(player_ptr, monster).complete();
+    QuestCompletionChecker(*player_ptr, monster).complete();
     if (record_named_pet && monster.is_named_pet()) {
         const auto m2_name = monster_desc(*player_ptr, monster, MD_INDEF_VISIBLE);
         exe_write_diary(floor, DiaryKind::NAMED_PET, RECORD_NAMED_PET_TELE_LEVEL, m2_name);


### PR DESCRIPTION
…)\n\nQuestCompletionChecker のコンストラクタ引数を\nPlayerType *player_ptr → CreatureEntity &creature に変更。\nコンストラクタ内で static_cast<PlayerType *>(&creature) によりキャストして\nprivate メンバ player_ptr に格納。\nstaticヘルパー check_quest_completion も同様に変更。\n\n呼び出し元 (spells-world.cpp, monster-runaway.cpp,\nmonster-death.cpp, monster-status-setter.cpp) も合わせて修正。"