### PR TITLE
refactor: dungeon/quest-monster-placer - PlayerType* → CreatureEntity& (第一引数置換)\n\nplace_quest_monsters() の第一引数を PlayerType * から CreatureEntity & に変更

### DIFF
--- a/src/dungeon/quest-monster-placer.cpp
+++ b/src/dungeon/quest-monster-placer.cpp
@@ -4,10 +4,10 @@
 #include "monster-floor/monster-generator.h"
 #include "monster-floor/place-monster-types.h"
 #include "monster/monster-info.h"
+#include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "util/bit-flags-calculator.h"
 
@@ -16,9 +16,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @return 成功したならばTRUEを返す
  */
-bool place_quest_monsters(PlayerType *player_ptr)
+bool place_quest_monsters(CreatureEntity &creature)
 {
-    const auto &floor = *player_ptr->current_floor_ptr;
+    const auto &floor = *creature.current_floor_ptr;
     const auto &quests = QuestList::get_instance();
     for (const auto &[quest_id, quest] : quests) {
         auto no_quest_monsters = quest.status != QuestStatusType::TAKEN;
@@ -54,11 +54,11 @@ bool place_quest_monsters(PlayerType *player_ptr)
                         continue;
                     }
 
-                    if (!monster_can_enter(player_ptr, pos.y, pos.x, monrace, 0)) {
+                    if (!monster_can_enter(&creature, pos.y, pos.x, monrace, 0)) {
                         continue;
                     }
 
-                    if (Grid::calc_distance(pos, player_ptr->get_position()) < 10) {
+                    if (Grid::calc_distance(pos, creature.get_position()) < 10) {
                         continue;
                     }
 
@@ -73,7 +73,7 @@ bool place_quest_monsters(PlayerType *player_ptr)
                     return false;
                 }
 
-                if (place_specific_monster(*player_ptr, pos.y, pos.x, quest.r_idx, mode)) {
+                if (place_specific_monster(creature, pos.y, pos.x, quest.r_idx, mode)) {
                     break;
                 }
 

--- a/src/dungeon/quest-monster-placer.h
+++ b/src/dungeon/quest-monster-placer.h
@@ -1,4 +1,4 @@
 #pragma once
 
-class PlayerType;
-bool place_quest_monsters(PlayerType *player_ptr);
+class CreatureEntity;
+bool place_quest_monsters(CreatureEntity &creature);

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -425,7 +425,7 @@ static bool check_place_necessary_objects(CreatureEntity &creature, DungeonData 
     }
 
     player.set_position(*p_pos);
-    if (!place_quest_monsters(&player)) {
+    if (!place_quest_monsters(player)) {
         dd_ptr->why = _("クエストモンスター配置に失敗", "Failed to place a quest monster");
         return false;
     }

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -298,7 +298,7 @@ static void new_floor_allocation(PlayerType *player_ptr, saved_floor_type *sf_pt
     }
     delete_items(*player_ptr, std::move(delete_i_idx_list));
 
-    (void)place_quest_monsters(player_ptr);
+    (void)place_quest_monsters(*player_ptr);
     GAME_TURN alloc_times = absence_ticks / alloc_chance;
     if (randint0(alloc_chance) < (absence_ticks % alloc_chance)) {
         alloc_times++;


### PR DESCRIPTION
…。\n実装内の player_ptr→ アクセスをすべて creature. に置換し、\nmonster_can_enter、place_specific_monster を CreatureEntity ネイティブ呼び出しに統一。\nplayer-type-definition.h の include を creature-entity.h に差し替え。\n\n呼び出し元 (cave-generator.cpp, floor-changer.cpp) も合わせて修正。"