### PR TITLE
refactor: dungeon/dungeon-processor - PlayerType* → CreatureEntity& (第一引数置換)\n\nprocess_dungeon() および static ヘルパー redraw_character_xtra() の第一引数を PlayerType * から CreatureEntity & に変更

### DIFF
--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -388,7 +388,7 @@ static void process_game_turn(PlayerType *player_ptr)
     auto &world = AngbandWorld::get_instance();
     world.play_time.unpause();
     while (true) {
-        process_dungeon(player_ptr, load_game);
+        process_dungeon(*player_ptr, load_game);
         world.character_xtra = true;
         handle_stuff(*player_ptr);
         world.character_xtra = false;

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -44,7 +44,7 @@
 #include "world/world-turn-processor.h"
 #include "world/world.h"
 
-static void redraw_character_xtra(PlayerType *player_ptr)
+static void redraw_character_xtra(CreatureEntity &creature)
 {
     auto &world = AngbandWorld::get_instance();
     world.character_xtra = true;
@@ -81,7 +81,7 @@ static void redraw_character_xtra(PlayerType *player_ptr)
         StatusRecalculatingFlag::FLOW,
     };
     rfu.set_flags(flags_srf);
-    handle_stuff(*player_ptr);
+    handle_stuff(creature);
     world.character_xtra = false;
 }
 
@@ -99,8 +99,9 @@ static void redraw_character_xtra(PlayerType *player_ptr)
  * the user dies, or the game is terminated.\n
  * </p>
  */
-void process_dungeon(PlayerType *player_ptr, bool load_game)
+void process_dungeon(CreatureEntity &creature, bool load_game)
 {
+    auto *player_ptr = static_cast<PlayerType *>(&creature);
     auto &floor = *player_ptr->current_floor_ptr;
     auto &world = AngbandWorld::get_instance();
     floor.base_level = floor.dun_level;
@@ -143,7 +144,7 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
     verify_panel(*player_ptr);
     msg_erase();
 
-    redraw_character_xtra(player_ptr);
+    redraw_character_xtra(*player_ptr);
     auto flags_srf = {
         StatusRecalculatingFlag::BONUS,
         StatusRecalculatingFlag::HP,

--- a/src/dungeon/dungeon-processor.h
+++ b/src/dungeon/dungeon-processor.h
@@ -1,4 +1,4 @@
 #pragma once
 
-class PlayerType;
-void process_dungeon(PlayerType *player_ptr, bool load_game);
+class CreatureEntity;
+void process_dungeon(CreatureEntity &creature, bool load_game);


### PR DESCRIPTION
…。\n\n- redraw_character_xtra: handle_stuff() が CreatureEntity & を受け取るため\n  キャスト不要で完全に CreatureEntity & ネイティブ呼び出しに統一。\n- process_dungeon: auto *player_ptr = static_cast<PlayerType *>(&creature);\n  パターンにより PlayerType 固有のメンバアクセスを維持。\n\n呼び出し元 (core/game-play.cpp) も合わせて修正。"