### PR TITLE
refactor: hpmp/hp-mp-processor - PlayerType* → CreatureEntity& (第一引数置換)

### DIFF
--- a/src/blue-magic/blue-magic-caster.cpp
+++ b/src/blue-magic/blue-magic-caster.cpp
@@ -293,7 +293,7 @@ static bool switch_cast_blue_magic(CreatureEntity &creature, bmc_type *bmc_ptr)
         return cast_blue_hand_doom(creature, bmc_ptr);
     case MonsterAbilityType::HEAL: {
         msg_print(_("自分の傷に念を集中した。", "You concentrate on your wounds!"));
-        (void)hp_player(player_ptr, bmc_ptr->plev * 4);
+        (void)hp_player(*player_ptr, bmc_ptr->plev * 4);
         BadStatusSetter bss(creature);
         (void)bss.set_stun(0);
         (void)bss.set_cut(0);

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -722,7 +722,7 @@ static bool use_mane(CreatureEntity &creature, MonsterAbilityType spell)
     }
     case MonsterAbilityType::HEAL: {
         msg_print(_("自分の傷に念を集中した。", "You concentrate on your wounds!"));
-        (void)hp_player(player_ptr, plev * 6);
+        (void)hp_player(*player_ptr, plev * 6);
         BadStatusSetter bss(creature);
         (void)bss.set_stun(0);
         (void)bss.set_cut(0);

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -387,7 +387,7 @@ static bool exe_eat_food_type_object(CreatureEntity &creature, const BaseitemKey
     case SV_FOOD_WAYBREAD:
         msg_print(_("これはひじょうに美味だ。", "That tastes very good."));
         (void)bss.set_poison(0);
-        (void)hp_player(player_ptr, Dice::roll(4, 8));
+        (void)hp_player(*player_ptr, Dice::roll(4, 8));
         return true;
     case SV_FOOD_PINT_OF_ALE:
     case SV_FOOD_PINT_OF_WINE:

--- a/src/effect/effect-monster-spirit.cpp
+++ b/src/effect/effect-monster-spirit.cpp
@@ -35,7 +35,7 @@ ProcessResult effect_monster_drain_mana(PlayerType *player_ptr, EffectMonster *e
 
     if (!em_ptr->is_monster()) {
         msg_format(_("%sから精神エネルギーを吸いとった。", "You draw psychic energy from %s."), em_ptr->m_name);
-        (void)hp_player(player_ptr, em_ptr->dam);
+        (void)hp_player(*player_ptr, em_ptr->dam);
         em_ptr->dam = 0;
         return ProcessResult::PROCESS_CONTINUE;
     }

--- a/src/effect/effect-player-oldies.cpp
+++ b/src/effect/effect-player-oldies.cpp
@@ -16,7 +16,7 @@ void effect_player_old_heal(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
         msg_print(_("何らかの攻撃によって気分がよくなった。", "You are hit by something invigorating!"));
     }
 
-    (void)hp_player(player_ptr, ep_ptr->dam);
+    (void)hp_player(*player_ptr, ep_ptr->dam);
     ep_ptr->dam = 0;
 }
 

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -188,7 +188,7 @@ void effect_player_nether(CreatureEntity &creature, EffectPlayerType *ep_ptr)
     auto *player_ptr = static_cast<PlayerType *>(&creature);
     if (CreatureRace(&creature).equals(PlayerRaceType::SPECTRE)) {
         if (!evaded) {
-            hp_player(player_ptr, ep_ptr->dam / 4);
+            hp_player(*player_ptr, ep_ptr->dam / 4);
         }
         ep_ptr->get_damage = 0;
         return;

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -58,9 +58,10 @@
  * @details
  * ダメージを受けた場合、自然回復できない。
  */
-static bool deal_damege_by_feat(PlayerType *player_ptr, const Grid &grid, concptr msg_levitation, concptr msg_normal,
-    std::function<PERCENTAGE(CreatureEntity &)> damage_rate, std::function<void(PlayerType *, int)> additional_effect)
+static bool deal_damege_by_feat(CreatureEntity &creature, const Grid &grid, concptr msg_levitation, concptr msg_normal,
+    std::function<PERCENTAGE(CreatureEntity &)> damage_rate, std::function<void(CreatureEntity &, int)> additional_effect)
 {
+    auto *player_ptr = static_cast<PlayerType *>(&creature);
     const auto &terrain = grid.get_terrain();
     auto damage = 0;
     if (terrain.flags.has(TerrainCharacteristics::CHAOS_TAINTED) || terrain.flags.has(TerrainCharacteristics::PLASMA)) {
@@ -87,20 +88,20 @@ static bool deal_damege_by_feat(PlayerType *player_ptr, const Grid &grid, concpt
 
     if (player_ptr->levitation) {
         msg_print(msg_levitation);
-        constexpr auto mes = _("%sの上に浮遊したダメージ", "flying over %s");
+        constexpr auto mes = _("%%s\u306e\u4e0a\u306b\u6d6e\u904a\u3057\u305f\u30c0\u30e1\u30fc\u30b8", "flying over %%s");
         take_hit(*player_ptr, DAMAGE_NOESCAPE, damage, format(mes, grid.get_terrain(TerrainKind::MIMIC).name.data()));
 
         if (additional_effect != nullptr) {
-            additional_effect(player_ptr, damage);
+            additional_effect(creature, damage);
         }
     } else {
         const auto p_pos = player_ptr->get_position();
         const auto &name = player_ptr->current_floor_ptr->get_grid(p_pos).get_terrain(TerrainKind::MIMIC).name;
-        msg_format(_("%s%s！", "The %s %s!"), name.data(), msg_normal);
+        msg_format(_("%%s%%s\uff01", "The %%s %%s!"), name.data(), msg_normal);
         take_hit(*player_ptr, DAMAGE_NOESCAPE, damage, name);
 
         if (additional_effect != nullptr) {
-            additional_effect(player_ptr, damage);
+            additional_effect(creature, damage);
         }
     }
 
@@ -111,8 +112,9 @@ static bool deal_damege_by_feat(PlayerType *player_ptr, const Grid &grid, concpt
  * @brief 10ゲームターンが進行するごとにプレイヤーのHPとMPの増減処理を行う。
  *  / Handle timed damage and regeneration every 10 game turns
  */
-void process_player_hp_mp(PlayerType *player_ptr)
+void process_player_hp_mp(CreatureEntity &creature)
 {
+    auto *player_ptr = static_cast<PlayerType *>(&creature);
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto &grid = floor.get_grid(player_ptr->get_position());
     const auto &terrain = grid.get_terrain();
@@ -121,7 +123,7 @@ void process_player_hp_mp(PlayerType *player_ptr)
     int regen_amount = PY_REGEN_NORMAL;
     const auto effects = player_ptr->effects();
     if (terrain.flags.has(TerrainCharacteristics::RUNE_HEALING)) {
-        hp_player(player_ptr, 2 + player_ptr->level / 6);
+        hp_player(creature, 2 + player_ptr->level / 6);
     }
 
     const auto &player_poison = effects->poison();
@@ -167,7 +169,7 @@ void process_player_hp_mp(PlayerType *player_ptr)
     if (terrain.flags.has(TerrainCharacteristics::LAVA) && !is_invuln(*player_ptr) && !has_immune_fire(*player_ptr)) {
         constexpr auto mes_leviation = _("熱で火傷した！", "The heat burns you!");
         constexpr auto mes_normal = _("で火傷した！", "burns you!");
-        if (deal_damege_by_feat(player_ptr, grid, mes_leviation, mes_normal, calc_fire_damage_rate, nullptr)) {
+        if (deal_damege_by_feat(creature, grid, mes_leviation, mes_normal, calc_fire_damage_rate, nullptr)) {
             cave_no_regen = true;
             sound(SoundKind::TERRAIN_DAMAGE);
         }
@@ -176,7 +178,7 @@ void process_player_hp_mp(PlayerType *player_ptr)
     if (terrain.flags.has(TerrainCharacteristics::COLD_PUDDLE) && !is_invuln(*player_ptr) && !has_immune_cold(*player_ptr)) {
         constexpr auto mes_leviation = _("冷気に覆われた！", "The cold engulfs you!");
         constexpr auto mes_normal = _("に凍えた！", "frostbites you!");
-        if (deal_damege_by_feat(player_ptr, grid, mes_leviation, mes_normal, calc_cold_damage_rate, nullptr)) {
+        if (deal_damege_by_feat(creature, grid, mes_leviation, mes_normal, calc_cold_damage_rate, nullptr)) {
             cave_no_regen = true;
             sound(SoundKind::TERRAIN_DAMAGE);
         }
@@ -185,7 +187,7 @@ void process_player_hp_mp(PlayerType *player_ptr)
     if (terrain.flags.has(TerrainCharacteristics::ELEC_PUDDLE) && !is_invuln(*player_ptr) && !has_immune_elec(*player_ptr)) {
         constexpr auto mes_leviation = _("電撃を受けた！", "The electricity shocks you!");
         constexpr auto mes_normal = _("に感電した！", "shocks you!");
-        if (deal_damege_by_feat(player_ptr, grid, mes_leviation, mes_normal, calc_elec_damage_rate, nullptr)) {
+        if (deal_damege_by_feat(creature, grid, mes_leviation, mes_normal, calc_elec_damage_rate, nullptr)) {
             cave_no_regen = true;
             sound(SoundKind::TERRAIN_DAMAGE);
         }
@@ -194,7 +196,7 @@ void process_player_hp_mp(PlayerType *player_ptr)
     if (terrain.flags.has(TerrainCharacteristics::ACID_PUDDLE) && !is_invuln(*player_ptr) && !has_immune_acid(*player_ptr)) {
         constexpr auto mes_leviation = _("酸が飛び散った！", "The acid melts you!");
         constexpr auto mes_normal = _("に溶かされた！", "melts you!");
-        if (deal_damege_by_feat(player_ptr, grid, mes_leviation, mes_normal, calc_acid_damage_rate, nullptr)) {
+        if (deal_damege_by_feat(creature, grid, mes_leviation, mes_normal, calc_acid_damage_rate, nullptr)) {
             cave_no_regen = true;
             sound(SoundKind::TERRAIN_DAMAGE);
         }
@@ -203,8 +205,9 @@ void process_player_hp_mp(PlayerType *player_ptr)
     if (terrain.flags.has(TerrainCharacteristics::POISON_PUDDLE) && !is_invuln(*player_ptr)) {
         constexpr auto mes_leviation = _("毒気を吸い込んだ！", "The gas poisons you!");
         constexpr auto mes_normal = _("に毒された！", "poisons you!");
-        if (deal_damege_by_feat(player_ptr, grid, mes_leviation, mes_normal, calc_pois_damage_rate,
-                [](PlayerType *player_ptr, int damage) {
+        if (deal_damege_by_feat(creature, grid, mes_leviation, mes_normal, calc_pois_damage_rate,
+                [](CreatureEntity &creature, int damage) {
+                    auto *player_ptr = static_cast<PlayerType *>(&creature);
                     if (!has_resist_pois(*player_ptr)) {
                         (void)BadStatusSetter(*player_ptr).mod_poison(static_cast<TIME_EFFECT>(damage));
                     }
@@ -215,8 +218,9 @@ void process_player_hp_mp(PlayerType *player_ptr)
     }
 
     if (terrain.flags.has(TerrainCharacteristics::DUNG_POOL) && !is_invuln(*player_ptr)) {
-        cave_no_regen = deal_damege_by_feat(player_ptr, grid, _("糞が飛び散った！", "The feced scatter to you!"), _("に浸かった！", "tainted you!"),
-            calc_acid_damage_rate, [](PlayerType *player_ptr, int damage) {
+        cave_no_regen = deal_damege_by_feat(creature, grid, _("糞が飛び散った！", "The feced scatter to you!"), _("に浸かった！", "tainted you!"),
+            calc_acid_damage_rate, [](CreatureEntity &creature, int damage) {
+                auto *player_ptr = static_cast<PlayerType *>(&creature);
                 if (!has_resist_pois(*player_ptr)) {
                     (void)BadStatusSetter(*player_ptr).mod_poison(static_cast<TIME_EFFECT>(damage));
                 }
@@ -247,18 +251,18 @@ void process_player_hp_mp(PlayerType *player_ptr)
     }
 
     if (terrain.flags.has(TerrainCharacteristics::PLASMA) && !is_invuln(*player_ptr)) {
-        cave_no_regen = deal_damege_by_feat(player_ptr, grid, _("に包まれた!", "engulfs you!"), _("に包まれた!", "engulfs you"), calc_plasma_damage_rate, NULL);
+        cave_no_regen = deal_damege_by_feat(creature, grid, _("に包まれた!", "engulfs you!"), _("に包まれた!", "engulfs you"), calc_plasma_damage_rate, NULL);
         sound(SoundKind::TERRAIN_DAMAGE);
     }
 
     if (terrain.flags.has(TerrainCharacteristics::CHAOS_TAINTED) && !is_invuln(*player_ptr)) {
-        cave_no_regen = deal_damege_by_feat(player_ptr, grid, _("に汚染された!", "taints you!"),
+        cave_no_regen = deal_damege_by_feat(creature, grid, _("に汚染された!", "taints you!"),
             _("に汚染された!", "taints you"), calc_chaos_damage_rate_rand, NULL);
         sound(SoundKind::TERRAIN_DAMAGE);
     }
 
     if (terrain.flags.has(TerrainCharacteristics::VOID) && !is_invuln(*player_ptr)) {
-        cave_no_regen = deal_damege_by_feat(player_ptr, grid, _("に巻き込まれて己の存在が薄れていく!", "erases your existence!"),
+        cave_no_regen = deal_damege_by_feat(creature, grid, _("に巻き込まれて己の存在が薄れていく!", "erases your existence!"),
             _("に巻き込まれて己の存在が薄れていく!", "erases your existence!"), calc_void_damage_rate_rand, NULL);
         sound(SoundKind::TERRAIN_DAMAGE);
     }
@@ -435,9 +439,9 @@ void process_player_hp_mp(PlayerType *player_ptr)
         upkeep_factor += 100;
     }
 
-    regenmana(*player_ptr, upkeep_factor, regen_amount);
+    regenmana(creature, upkeep_factor, regen_amount);
     if (pc.equals(PlayerClassType::MAGIC_EATER)) {
-        regenmagic(*player_ptr, regen_amount);
+        regenmagic(creature, regen_amount);
     }
 
     if ((player_ptr->csp == 0) && (player_ptr->csp_frac == 0)) {
@@ -474,15 +478,16 @@ void process_player_hp_mp(PlayerType *player_ptr)
 
     regen_amount = (regen_amount * player_ptr->mutant_regenerate_mod) / 100;
     if ((player_ptr->hp < player_ptr->maxhp) && !cave_no_regen) {
-        regenhp(*player_ptr, regen_amount);
+        regenhp(creature, regen_amount);
     }
 }
 
 /*
  * Increase players hit points, notice effects
  */
-bool hp_player(PlayerType *player_ptr, int num)
+bool hp_player(CreatureEntity &creature, int num)
 {
+    auto *player_ptr = static_cast<PlayerType *>(&creature);
     int vir;
     vir = virtue_number(static_cast<CreatureEntity &>(*player_ptr), Virtue::VITALITY);
 

--- a/src/hpmp/hp-mp-processor.h
+++ b/src/hpmp/hp-mp-processor.h
@@ -1,5 +1,5 @@
 #pragma once
 
-class PlayerType;
-void process_player_hp_mp(PlayerType *player_ptr);
-bool hp_player(PlayerType *player_ptr, int num);
+class CreatureEntity;
+void process_player_hp_mp(CreatureEntity &creature);
+bool hp_player(CreatureEntity &creature, int num);

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -467,7 +467,7 @@ static bool cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx)
     case ElementSpells::PERCEPT:
         return psychometry(&player);
     case ElementSpells::CURE:
-        (void)hp_player(&player, Dice::roll(2, 8));
+        (void)hp_player(player, Dice::roll(2, 8));
         (void)BadStatusSetter(creature).mod_cut(-10);
         return true;
     case ElementSpells::BOLT_2ND: {
@@ -480,7 +480,7 @@ static bool cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx)
         const auto typ = get_element_spells_type(creature, power.elem);
         if (fire_bolt_or_beam(creature, plev, typ, dir, dam)) {
             if (typ == AttributeType::HYPODYNAMIA) {
-                (void)hp_player(&player, dam / 2);
+                (void)hp_player(player, dam / 2);
             }
         }
 
@@ -523,7 +523,7 @@ static bool cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx)
         const auto typ = get_element_spells_type(creature, power.elem);
         if (fire_breath(creature, typ, dir, dam, 3)) {
             if (typ == AttributeType::HYPODYNAMIA) {
-                (void)hp_player(&player, dam / 2);
+                (void)hp_player(player, dam / 2);
             }
         }
 
@@ -565,7 +565,7 @@ static bool cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx)
         const auto typ = get_element_spells_type(creature, power.elem);
         if (fire_ball(creature, typ, dir, dam, 3)) {
             if (typ == AttributeType::HYPODYNAMIA) {
-                (void)hp_player(&player, dam / 2);
+                (void)hp_player(player, dam / 2);
             }
         }
 
@@ -605,7 +605,7 @@ static bool cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx)
         const auto typ = get_element_spells_type(creature, power.elem);
         if (fire_ball(creature, typ, dir, dam, 4)) {
             if (typ == AttributeType::HYPODYNAMIA) {
-                (void)hp_player(&player, dam / 2);
+                (void)hp_player(player, dam / 2);
             }
         }
 

--- a/src/mind/mind-mindcrafter.cpp
+++ b/src/mind/mind-mindcrafter.cpp
@@ -257,7 +257,7 @@ bool cast_mindcrafter_spell(PlayerType *player_ptr, MindMindcrafterType spell)
         (void)bss.set_fear(0);
         (void)bss.set_stun(0);
         if (!is_fast(*player_ptr) || !is_hero(*player_ptr)) {
-            hp_player(player_ptr, plev);
+            hp_player(*player_ptr, plev);
         }
 
         t = 10 + randint1((plev * 3) / 2);

--- a/src/mind/mind-warrior-mage.cpp
+++ b/src/mind/mind-warrior-mage.cpp
@@ -36,7 +36,7 @@ bool comvert_mp_to_hp(CreatureEntity &creature)
     auto &player = static_cast<PlayerType &>(creature);
     if (player.csp >= player.level / 5) {
         player.csp -= player.level / 5;
-        hp_player(&player, player.level);
+        hp_player(player, player.level);
     } else {
         msg_print(_("変換に失敗した。", "You failed to convert."));
     }

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -299,13 +299,13 @@ void process_world_aux_mutation(PlayerType *player_ptr)
         msg_erase();
 
         if ((player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & (CAVE_GLOW | CAVE_MNDK)) == CAVE_GLOW) {
-            hp_player(player_ptr, 10);
+            hp_player(*player_ptr, 10);
         }
 
         auto &item = *player_ptr->inventory[INVEN_LITE];
         if (item.bi_key.tval() == ItemKindType::LITE) {
             if (!item.is_fixed_artifact() && (item.fuel > 0)) {
-                hp_player(player_ptr, item.fuel / 20);
+                hp_player(*player_ptr, item.fuel / 20);
                 item.fuel /= 2;
                 msg_print(_("光源からエネルギーを吸収した！", "You absorb energy from your light!"));
                 notice_lite_change(*player_ptr, &item);
@@ -313,7 +313,7 @@ void process_world_aux_mutation(PlayerType *player_ptr)
         }
 
         if (player_ptr->tim_emission > 0) {
-            hp_player(player_ptr, player_ptr->tim_emission);
+            hp_player(*player_ptr, player_ptr->tim_emission);
             set_tim_emission(*player_ptr, 0, true);
             msg_print(_("あなたは自身の光をエネルギーとして吸収した！", "You absorb energy from your own light!"));
         }
@@ -505,7 +505,7 @@ void process_world_aux_mutation(PlayerType *player_ptr)
                 healing = wounds;
             }
 
-            hp_player(player_ptr, healing);
+            hp_player(*player_ptr, healing);
             player_ptr->csp -= healing;
             RedrawingFlagsUpdater::get_instance().set_flags(flags);
         }

--- a/src/object-activation/activation-bolt-ball.cpp
+++ b/src/object-activation/activation-bolt-ball.cpp
@@ -131,7 +131,7 @@ bool activate_bolt_drain_1(CreatureEntity &creature)
     auto &player = static_cast<PlayerType &>(creature);
     for (int dummy = 0; dummy < 3; dummy++) {
         if (hypodynamic_bolt(creature, dir, 50)) {
-            hp_player(&player, 50);
+            hp_player(player, 50);
         }
     }
 
@@ -148,7 +148,7 @@ bool activate_bolt_drain_2(CreatureEntity &creature)
     auto &player = static_cast<PlayerType &>(creature);
     for (int dummy = 0; dummy < 3; dummy++) {
         if (hypodynamic_bolt(creature, dir, 100)) {
-            hp_player(&player, 100);
+            hp_player(player, 100);
         }
     }
 

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -201,7 +201,7 @@ bool activate_cure_lw(CreatureEntity &creature)
 {
     auto &player = static_cast<PlayerType &>(creature);
     (void)BadStatusSetter(player).set_fear(0);
-    (void)hp_player(&player, 30);
+    (void)hp_player(player, 30);
     return true;
 }
 

--- a/src/object-activation/activation-resistance.cpp
+++ b/src/object-activation/activation-resistance.cpp
@@ -200,7 +200,7 @@ bool activate_ultimate_resistance(CreatureEntity &creature)
     TIME_EFFECT v = randint1(25) + 25;
     (void)BadStatusSetter(creature).set_fear(0);
     (void)set_hero(creature, v, false);
-    (void)hp_player(player_ptr, 10);
+    (void)hp_player(*player_ptr, 10);
     (void)set_blessed(creature, v, false);
     (void)set_oppose_acid(creature, v, false);
     (void)set_oppose_elec(creature, v, false);

--- a/src/player-attack/blood-sucking-processor.cpp
+++ b/src/player-attack/blood-sucking-processor.cpp
@@ -160,7 +160,7 @@ static void drain_result(PlayerType *player_ptr, player_attack_type *pa_ptr, boo
     }
 
     drain_heal = (drain_heal * player_ptr->mutant_regenerate_mod) / 100;
-    hp_player(player_ptr, drain_heal);
+    hp_player(*player_ptr, drain_heal);
 }
 
 /*!

--- a/src/racial/racial-vampire.cpp
+++ b/src/racial/racial-vampire.cpp
@@ -42,7 +42,7 @@ bool vampirism(CreatureEntity &creature)
     }
 
     if (creature.food < PY_FOOD_FULL) {
-        (void)hp_player(static_cast<PlayerType *>(&creature), dummy);
+        (void)hp_player(creature, dummy);
     } else {
         msg_print(_("あなたは空腹ではありません。", "You were not hungry."));
     }

--- a/src/realm/realm-crusade.cpp
+++ b/src/realm/realm-crusade.cpp
@@ -236,7 +236,7 @@ tl::optional<std::string> do_crusade_spell(CreatureEntity &creature, SPELL_IDX s
         if (cast) {
             BadStatusSetter bss(creature);
             dispel_evil(creature, randint1(dam_sides));
-            hp_player(player_ptr, heal);
+            hp_player(*player_ptr, heal);
             (void)bss.set_fear(0);
             (void)bss.set_poison(0);
             (void)bss.set_stun(0);
@@ -427,7 +427,7 @@ tl::optional<std::string> do_crusade_spell(CreatureEntity &creature, SPELL_IDX s
             confuse_monsters(creature, power);
             turn_monsters(creature, power);
             stasis_monsters(creature, power);
-            hp_player(player_ptr, heal);
+            hp_player(*player_ptr, heal);
         }
     } break;
 

--- a/src/realm/realm-death.cpp
+++ b/src/realm/realm-death.cpp
@@ -291,7 +291,7 @@ tl::optional<std::string> do_death_spell(CreatureEntity &creature, SPELL_IDX spe
                 chg_virtue(creature, Virtue::SACRIFICE, -1);
                 chg_virtue(creature, Virtue::VITALITY, -1);
 
-                hp_player(player_ptr, dam);
+                hp_player(*player_ptr, dam);
 
                 /*
                  * Gain nutritional sustenance:
@@ -419,7 +419,7 @@ tl::optional<std::string> do_death_spell(CreatureEntity &creature, SPELL_IDX spe
 
             for (i = 0; i < 3; i++) {
                 if (hypodynamic_bolt(creature, dir, dam)) {
-                    hp_player(player_ptr, dam);
+                    hp_player(*player_ptr, dam);
                 }
             }
         }

--- a/src/realm/realm-nature.cpp
+++ b/src/realm/realm-nature.cpp
@@ -173,7 +173,7 @@ tl::optional<std::string> do_nature_spell(CreatureEntity &creature, SPELL_IDX sp
 
         if (cast) {
             BadStatusSetter bss(creature);
-            hp_player(player_ptr, dice.roll());
+            hp_player(*player_ptr, dice.roll());
             (void)bss.set_cut(0);
             (void)bss.set_poison(0);
         }

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -183,7 +183,7 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
             }
 
             if (cont) {
-                hp_player(player_ptr, dice.roll());
+                hp_player(*player_ptr, dice.roll());
             }
         }
 
@@ -243,7 +243,7 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         if (cast) {
             msg_print(_("激しい戦いの歌を歌った．．．", "You start singing a song of intense fighting..."));
 
-            (void)hp_player(player_ptr, 10);
+            (void)hp_player(*player_ptr, 10);
             (void)BadStatusSetter(creature).set_fear(0);
             RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::HP);
             start_singing(creature, spell, MUSIC_HERO);
@@ -737,7 +737,7 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
 
         if (cast) {
             msg_print(_("英雄の歌を口ずさんだ．．．", "You chant a powerful, heroic call to arms..."));
-            (void)hp_player(player_ptr, 10);
+            (void)hp_player(*player_ptr, 10);
             (void)BadStatusSetter(creature).set_fear(0);
             RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::HP);
             start_singing(creature, spell, MUSIC_SHERO);
@@ -782,7 +782,7 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         }
 
         if (cont) {
-            hp_player(player_ptr, dice.roll());
+            hp_player(*player_ptr, dice.roll());
             BadStatusSetter bss(creature);
             (void)bss.set_stun(0);
             (void)bss.set_cut(0);

--- a/src/specific-object/blade-turner.cpp
+++ b/src/specific-object/blade-turner.cpp
@@ -23,7 +23,7 @@ bool activate_bladeturner(CreatureEntity &creature)
     (void)BadStatusSetter(creature).set_fear(0);
     (void)set_hero(creature, randint1(50) + 50, false);
     auto *player_ptr = static_cast<PlayerType *>(&creature);
-    (void)hp_player(player_ptr, 10);
+    (void)hp_player(*player_ptr, 10);
     (void)set_blessed(creature, randint1(50) + 50, false);
     (void)set_oppose_acid(creature, randint1(50) + 50, false);
     (void)set_oppose_elec(creature, randint1(50) + 50, false);

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -507,5 +507,5 @@ void cast_wonder(CreatureEntity &creature, const Direction &dir)
     dispel_monsters(creature, 150);
     slow_monsters(creature, plev);
     sleep_monsters(creature, plev);
-    hp_player(&player, 300);
+    hp_player(player, 300);
 }

--- a/src/spell/spells-staff-only.cpp
+++ b/src/spell/spells-staff-only.cpp
@@ -44,7 +44,7 @@ bool cleansing_nova(CreatureEntity &creature, bool magic, bool powerful)
         ident = true;
     }
 
-    if (hp_player(static_cast<PlayerType *>(&creature), 50)) {
+    if (hp_player(creature, 50)) {
         ident = true;
     }
 

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -316,7 +316,7 @@ bool life_stream(CreatureEntity &creature, bool message, bool virtue_change)
     (void)restore_all_status(creature);
     (void)set_berserk(*player_ptr, 0, true);
     handle_stuff(*player_ptr);
-    hp_player(player_ptr, 5000);
+    hp_player(*player_ptr, 5000);
 
     return true;
 }
@@ -337,7 +337,7 @@ bool heroism(CreatureEntity &creature, int base)
         ident = true;
     }
 
-    if (hp_player(player_ptr, 10)) {
+    if (hp_player(*player_ptr, 10)) {
         ident = true;
     }
 
@@ -360,7 +360,7 @@ bool berserk(CreatureEntity &creature, int base)
         ident = true;
     }
 
-    if (hp_player(player_ptr, 30)) {
+    if (hp_player(*player_ptr, 30)) {
         ident = true;
     }
 
@@ -375,7 +375,7 @@ bool cure_light_wounds(CreatureEntity &creature, int pow)
     }
 
     auto ident = false;
-    if (hp_player(player_ptr, pow)) {
+    if (hp_player(*player_ptr, pow)) {
         ident = true;
     }
 
@@ -403,7 +403,7 @@ bool cure_serious_wounds(CreatureEntity &creature, int pow)
     }
 
     auto ident = false;
-    if (hp_player(player_ptr, pow)) {
+    if (hp_player(*player_ptr, pow)) {
         ident = true;
     }
 
@@ -435,7 +435,7 @@ bool cure_critical_wounds(CreatureEntity &creature, int pow)
     }
 
     auto ident = false;
-    if (hp_player(player_ptr, pow)) {
+    if (hp_player(*player_ptr, pow)) {
         ident = true;
     }
 
@@ -475,7 +475,7 @@ bool true_healing(CreatureEntity &creature, int pow)
     }
 
     auto ident = false;
-    if (hp_player(player_ptr, pow)) {
+    if (hp_player(*player_ptr, pow)) {
         ident = true;
     }
 

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -568,7 +568,7 @@ void cast_invoke_spirits(CreatureEntity &creature, const Direction &dir)
         dispel_monsters(creature, 150);
         slow_monsters(creature, plev);
         sleep_monsters(creature, plev);
-        hp_player(&player, 300);
+        hp_player(player, 300);
     }
 
     if (die < 31) {

--- a/src/status/shape-changer.cpp
+++ b/src/status/shape-changer.cpp
@@ -38,7 +38,7 @@ void do_poly_wounds(PlayerType *player_ptr)
     }
 
     msg_print(_("傷がより軽いものに変化した。", "Your wounds are polymorphed into less serious ones."));
-    hp_player(player_ptr, change);
+    hp_player(*player_ptr, change);
     BadStatusSetter bss(*player_ptr);
     if (!nasty_effect) {
         (void)bss.mod_cut(change / 2);

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -92,7 +92,7 @@ void WorldTurnProcessor::process_world()
 
     ring_nightmare_bell(prev_min);
     starve_player(*this->player_ptr);
-    process_player_hp_mp(this->player_ptr);
+    process_player_hp_mp(*this->player_ptr);
     reduce_magic_effects_timeout(this->player_ptr);
     reduce_lite_life(*this->player_ptr);
     process_terrain_effects(this->player_ptr);


### PR DESCRIPTION
\n\nprocess_player_hp_mp, hp_player, deal_damege_by_feat (static) の\n第一引数を PlayerType * から CreatureEntity & に変更。\ndeal_damege_by_feat の additional_effect コールバック型も\nstd::function<void(PlayerType *, int)> → std::function<void(CreatureEntity &, int)> に変更。\n各関数内で auto *player_ptr = static_cast<PlayerType *>(&creature);\nパターンにより PlayerType 固有のメンバアクセスを維持。"