### PR TITLE
refactor: PlayerType * の内部キャストを CreatureEntity & に統合 (5ファイル)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,216 @@
+# CLAUDE.md — bakabakaband 開発ガイド
+
+## プロジェクト概要
+
+bakabakaband は Hengband をベースにした日本語ローグライクゲーム（C++）。
+現在の最重要課題は **PlayerType / MonsterEntity の CreatureEntity への統合リファクタリング**。
+
+---
+
+## CreatureEntity 統合リファクタリング
+
+### 目的
+
+プレイヤー（`PlayerType`）とモンスター（`MonsterEntity`）を共通の `CreatureEntity` スーパークラスで扱えるようにし、ダメージ処理・状態効果・行動 AI などのロジックを両者で共通化する。
+
+**最終目標:** `MonsterEntity` を `CreatureEntity` に完全吸収し、モンスター固有データは別の軽量構造体（`MonsterProfile` 的な位置づけ）に分離する。将来的にはモンスターも `CreatureEntity` 単体で表現できる状態を目指す。
+
+### クラス階層
+
+```
+CreatureEntity  (基底クラス)  src/system/creature-entity.h
+├── PlayerType               src/system/player-type-definition.h
+└── MonsterEntity            src/system/monster-entity.h
+```
+
+### 純粋仮想メソッド（必ず両クラスで実装）
+
+| メソッド | 説明 |
+|---|---|
+| `get_current_hp()` | 現在 HP |
+| `get_max_hp()` | 最大 HP |
+| `is_valid()` | 生存中かどうか |
+| `is_dead()` | 死亡しているか |
+| `is_player()` | プレイヤーなら true |
+
+### CreatureEntity が持つ主なフィールド（移動済み）
+
+- 座標: `x`, `y`, `oldpx`, `oldpy`
+- HP: `hp`, `maxhp`, `max_maxhp`, `hp_frac`
+- MP: `csp`, `msp`, `csp_frac`
+- 能力値: `stat_cur[]`, `stat_max[]`, `stat_use[]` 等
+- スキル: `skill_dis`, `skill_dev`, `skill_sav` 等
+- タイムドエフェクト: `invuln`, `hero`, `oppose_fire` 等多数
+- 経験値: `exp`, `max_exp`, `max_max_exp`, `exp_frac`
+- 速度・エネルギー: `speed`, `energy_need`
+- AC: `ac`, `to_a`
+- レベル: `level`
+- 名前: `name`
+
+---
+
+## コーディング規約
+
+### 関数シグネチャ
+
+```cpp
+// NG: 古い形式（プレイヤーのみ）
+void some_function(PlayerType *player_ptr);
+
+// OK: 新しい形式（プレイヤー・モンスター共用）
+void some_function(CreatureEntity &creature);
+```
+
+新規関数、または既存関数を修正する際は可能な限り `CreatureEntity &` を使うこと。
+
+### 型キャスト
+
+型の分岐が必要な場合は `is_player()` で判定してからキャストする：
+
+```cpp
+if (creature.is_player()) {
+    auto &player = static_cast<PlayerType &>(creature);
+    // プレイヤー固有の処理
+} else {
+    auto &monster = static_cast<MonsterEntity &>(creature);
+    // モンスター固有の処理
+}
+```
+
+キャストは最小限に。可能な限りバーチャルメソッドで処理すること。
+
+---
+
+## 残タスク ロードマップ
+
+### Phase 1: 関数シグネチャの統一（継続中）
+
+`PlayerType *player_ptr` を引数に取る関数を `CreatureEntity &creature` に変更する。
+
+**手順:**
+1. `grep -r "PlayerType \*" src/` で対象を列挙
+2. 関数の呼び出し元を確認
+3. `PlayerType *player_ptr` → `CreatureEntity &creature` に変更
+4. 内部の `player_ptr->` アクセスを `creature.` に変更
+5. `PlayerType` 固有機能が必要な箇所のみキャストを使用
+6. PR は機能単位（例：`do_cmd_xxx` 系、`spell_xxx` 系）でまとめる
+
+### Phase 2: 状態チェックの仮想化
+
+`MonsterEntity` には `is_confused()`, `is_stunned()`, `is_fearful()`, `is_invulnerable()` 等が実装済み。
+これらを `CreatureEntity` の仮想メソッドとして定義し、`PlayerType` にも実装することで両者で共通に扱えるようにする。
+
+```cpp
+// CreatureEntity に追加予定
+virtual bool is_stunned() const = 0;
+virtual bool is_confused() const = 0;
+virtual bool is_fearful() const = 0;
+virtual bool is_invulnerable() const = 0;
+```
+
+### Phase 3: タイムドエフェクトの統一
+
+**現状の不一致:**
+- `PlayerType` のタイムドエフェクトは `CreatureEntity` の直接フィールド（`hero`, `invuln` 等）
+- `MonsterEntity` は `std::map<MonsterTimedEffect, short> mtimed` で管理
+
+**方針（検討中）:**
+- 共通インターフェースとして `get_timed_effect(type)` / `set_timed_effect(type, value)` 仮想メソッドを定義
+- または統一列挙型 `CreatureTimedEffect` を作成して両者を同一 map で管理
+
+### Phase 4: ダメージ処理の完全統一
+
+**現状:**
+- プレイヤー: `take_hit(CreatureEntity &, int damage_type, int damage, ...)` in `player-damage.cpp`
+- モンスター: `MonsterDamageProcessor(CreatureEntity &).mon_take_hit(...)` in `monster-damage.cpp`
+
+**目標:** 単一のエントリポイントから両者を処理できるようにする。
+死亡処理・落とすアイテム・メッセージ等の副作用は仮想メソッドに委譲：
+
+```cpp
+// CreatureEntity に追加予定
+virtual void on_death(std::string_view cause) = 0;
+virtual void on_take_hit(int damage) {}
+```
+
+### Phase 5: AC・防御の統一
+
+`MonsterEntity::get_ac()` が実装済み。`CreatureEntity` の仮想メソッドとして昇格させる。
+
+```cpp
+// CreatureEntity に追加予定
+virtual int get_ac() const = 0;
+```
+
+### Phase 6: フロアポインタの整理
+
+`current_floor_ptr` が `MonsterEntity` の直接フィールドとして残存。
+`get_floor()` 仮想メソッドは既に `CreatureEntity` に存在するので、各サブクラスでの実装を整理する。
+
+---
+
+## MonsterEntity 固有フィールドの扱い方針
+
+モンスター固有フィールドは最終的に以下の方針で整理する。
+
+### Phase 7: 汎用化できるフィールドを CreatureEntity に移動
+
+| フィールド | 移動方針 |
+|---|---|
+| `cdis` | テンポラリ変数。`get_floor()` 経由で計算に変更し削除 |
+| `target_y`, `target_x` | `CreatureEntity` に汎用 `target` 座標として移動 |
+| `mflag` (一部) | `CreatureEntity` の汎用フラグ（ペット・フレンドリー等）として移動 |
+
+### Phase 8: MonsterEntity の完全吸収
+
+最終目標として `MonsterEntity` クラスそのものを廃止し、モンスター固有データを別構造体に切り出す。
+
+**方針:**
+- `MonsterEntity` の残存フィールドを `MonsterSpecificData` 的な構造体にまとめ、`CreatureEntity` の `optional<MonsterSpecificData>` として保持する
+- または `MonsterProfile` として `MonraceDefinition` 側に置き、`CreatureEntity` から `MonraceId` で参照する
+
+```
+// 最終形イメージ
+CreatureEntity
+├── 共通フィールド（HP, 座標, 速度, 状態...）
+├── optional<PlayerProfile>   // プレイヤー固有データ
+└── optional<MonsterProfile>  // モンスター固有データ（alliance, smart 等）
+```
+
+**移行しない（モンスター種族定義側に残す）フィールド:**
+
+| フィールド | 残す場所 |
+|---|---|
+| `sub_align` | モンスター種族定義（`MonraceDefinition`）に近い概念 |
+| `mtimed` | `MonsterProfile` 内 |
+| `mflag`, `mflag2` | `MonsterProfile` 内 |
+| `hold_o_idx_list` | `MonsterProfile` 内 |
+| `alliance_idx` | `MonsterProfile` 内 |
+| `smart` | `MonsterProfile` 内 |
+| `parent_m_idx` | `MonsterProfile` 内 |
+| `transform_r_idx` 等 | `MonsterProfile` 内 |
+
+---
+
+## 開発フロー
+
+### PR の粒度
+
+1 PR = 1 つの論理的な変更。例：
+- `「do_cmd_xxx 系関数の引数を CreatureEntity & に変更」`
+- `「is_confused() を CreatureEntity の仮想メソッド化」`
+
+### ブランチ命名
+
+`refactor/` プレフィックスを使用：
+- `refactor/creature-entity-status-check`
+- `refactor/creature-entity-timed-effects`
+- `refactor/creature-entity-damage-unified`
+
+### ビルド確認
+
+```bash
+cmake --build build --config Debug
+```
+
+ローグライクの性質上、自動テストは困難なため変更後はゲームを起動して基本動作を確認すること。

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -80,19 +80,18 @@ void effect_player_nuke(CreatureEntity &creature, EffectPlayerType *ep_ptr)
         return;
     }
 
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     (void)BadStatusSetter(creature).mod_poison(randint0(ep_ptr->dam) + 10);
     if (one_in_(5)) { /* 6 */
         msg_print(_("奇形的な変身を遂げた！", "You undergo a freakish metamorphosis!"));
         if (one_in_(4)) { /* 4 */
             do_poly_self(creature);
         } else {
-            status_shuffle(*player_ptr);
+            status_shuffle(creature);
         }
     }
 
     if (one_in_(6)) {
-        inventory_damage(*player_ptr, BreakerAcid(), 2);
+        inventory_damage(creature, BreakerAcid(), 2);
     }
 }
 
@@ -163,9 +162,8 @@ void effect_player_plasma(CreatureEntity &creature, EffectPlayerType *ep_ptr)
         (void)BadStatusSetter(creature).mod_stun(plus_stun);
     }
 
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     if (!(has_resist_fire(creature) || is_oppose_fire(creature) || has_immune_fire(creature))) {
-        inventory_damage(*player_ptr, BreakerAcid(), 3);
+        inventory_damage(creature, BreakerAcid(), 3);
     }
 }
 
@@ -185,10 +183,9 @@ void effect_player_nether(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     bool evaded = check_multishadow(creature);
 
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     if (CreatureRace(&creature).equals(PlayerRaceType::SPECTRE)) {
         if (!evaded) {
-            hp_player(*player_ptr, ep_ptr->dam / 4);
+            hp_player(creature, ep_ptr->dam / 4);
         }
         ep_ptr->get_damage = 0;
         return;
@@ -222,7 +219,6 @@ void effect_player_water(CreatureEntity &creature, EffectPlayerType *ep_ptr)
     }
 
     ep_ptr->dam = ep_ptr->dam * calc_water_damage_rate(creature, CALC_RAND) / 100;
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
 
     BIT_FLAGS has_res_water = has_resist_water(creature);
     BadStatusSetter bss(creature);
@@ -236,7 +232,7 @@ void effect_player_water(CreatureEntity &creature, EffectPlayerType *ep_ptr)
         }
 
         if (one_in_(5) && !has_res_water) {
-            inventory_damage(*player_ptr, BreakerCold(), 3);
+            inventory_damage(creature, BreakerCold(), 3);
         }
     }
 
@@ -255,7 +251,6 @@ void effect_player_chaos(CreatureEntity &creature, EffectPlayerType *ep_ptr)
         return;
     }
 
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     BadStatusSetter bss(creature);
     if (!has_resist_conf(creature) && !has_resist_chaos(creature)) {
         (void)bss.mod_confusion(randint0(20) + 10);
@@ -273,8 +268,8 @@ void effect_player_chaos(CreatureEntity &creature, EffectPlayerType *ep_ptr)
     }
 
     if (!has_resist_chaos(creature) || one_in_(9)) {
-        inventory_damage(*player_ptr, BreakerElec(), 2);
-        inventory_damage(*player_ptr, BreakerFire(), 2);
+        inventory_damage(creature, BreakerElec(), 2);
+        inventory_damage(creature, BreakerFire(), 2);
     }
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
@@ -292,9 +287,8 @@ void effect_player_shards(CreatureEntity &creature, EffectPlayerType *ep_ptr)
         (void)BadStatusSetter(creature).mod_cut(static_cast<TIME_EFFECT>(ep_ptr->dam));
     }
 
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     if (!has_resist_shard(creature) || one_in_(13)) {
-        inventory_damage(*player_ptr, BreakerCold(), 2);
+        inventory_damage(creature, BreakerCold(), 2);
     }
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
@@ -313,9 +307,8 @@ void effect_player_sound(CreatureEntity &creature, EffectPlayerType *ep_ptr)
         (void)BadStatusSetter(creature).mod_stun(plus_stun);
     }
 
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     if (!has_resist_sound(creature) || one_in_(13)) {
-        inventory_damage(*player_ptr, BreakerCold(), 2);
+        inventory_damage(creature, BreakerCold(), 2);
     }
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
@@ -359,9 +352,8 @@ void effect_player_nexus(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     ep_ptr->dam = ep_ptr->dam * calc_nexus_damage_rate(creature, CALC_RAND) / 100;
 
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     if (!has_resist_shard(creature) && !check_multishadow(creature)) {
-        apply_nexus(*ep_ptr->m_ptr, *player_ptr);
+        apply_nexus(*ep_ptr->m_ptr, creature);
     }
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
@@ -395,9 +387,8 @@ void effect_player_rocket(CreatureEntity &creature, EffectPlayerType *ep_ptr)
         (void)bss.mod_cut((ep_ptr->dam / 2));
     }
 
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     if (!has_resist_shard(creature) || one_in_(12)) {
-        inventory_damage(*player_ptr, BreakerCold(), 3);
+        inventory_damage(creature, BreakerCold(), 3);
     }
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
@@ -429,8 +420,7 @@ void effect_player_lite(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     ep_ptr->dam = ep_ptr->dam * calc_lite_damage_rate(creature, CALC_RAND) / 100;
 
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    CreatureRace race(player_ptr);
+    CreatureRace race(&creature);
     if (race.life() == PlayerRaceLifeType::UNDEAD && race.tr_flags().has(TR_VUL_LITE)) {
         if (!check_multishadow(creature)) {
             msg_print(_("光で肉体が焦がされた！", "The light scorches your flesh!"));
@@ -439,11 +429,11 @@ void effect_player_lite(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 
-    if (!player_ptr->wraith_form || check_multishadow(creature)) {
+    if (!creature.wraith_form || check_multishadow(creature)) {
         return;
     }
 
-    player_ptr->wraith_form = 0;
+    creature.wraith_form = 0;
     msg_print(_("閃光のため非物質的な影の存在でいられなくなった。", "The light forces you out of your incorporeal shadow form."));
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
@@ -483,7 +473,6 @@ void effect_player_dark(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
 static void effect_player_time_addition(CreatureEntity &creature)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     switch (randint1(10)) {
     case 1:
     case 2:
@@ -502,10 +491,10 @@ static void effect_player_time_addition(CreatureEntity &creature)
     case 7:
     case 8:
     case 9:
-        msg_print(player_ptr->decrease_ability_random());
+        msg_print(static_cast<PlayerType *>(&creature)->decrease_ability_random());
         break;
     case 10:
-        msg_print(player_ptr->decrease_ability_all());
+        msg_print(static_cast<PlayerType *>(&creature)->decrease_ability_all());
         break;
     }
 }
@@ -544,23 +533,22 @@ void effect_player_gravity(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     msg_print(_("周辺の重力がゆがんだ。", "Gravity warps around you."));
 
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     if (!check_multishadow(creature)) {
         teleport_player(creature, 5, TELEPORT_PASSIVE);
         BadStatusSetter bss(creature);
-        if (!player_ptr->levitation) {
+        if (!creature.levitation) {
             (void)bss.mod_deceleration(randint0(4) + 4, false);
         }
 
-        if (!(has_resist_sound(creature) || player_ptr->levitation)) {
+        if (!(has_resist_sound(creature) || creature.levitation)) {
             const auto plus_stun = randnum1<short>((ep_ptr->dam > 90) ? 35 : (ep_ptr->dam / 3 + 5));
             (void)bss.mod_stun(plus_stun);
         }
     }
 
     ep_ptr->dam = ep_ptr->dam * calc_gravity_damage_rate(creature, CALC_RAND) / 100;
-    if (!player_ptr->levitation || one_in_(13)) {
-        inventory_damage(*player_ptr, BreakerCold(), 2);
+    if (!creature.levitation || one_in_(13)) {
+        inventory_damage(creature, BreakerCold(), 2);
     }
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
@@ -610,12 +598,11 @@ void effect_player_meteor(CreatureEntity &creature, EffectPlayerType *ep_ptr)
     }
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     if (!has_resist_shard(creature) || one_in_(13)) {
         if (!has_immune_fire(creature)) {
-            inventory_damage(*player_ptr, BreakerFire(), 2);
+            inventory_damage(creature, BreakerFire(), 2);
         }
-        inventory_damage(*player_ptr, BreakerCold(), 2);
+        inventory_damage(creature, BreakerCold(), 2);
     }
 }
 
@@ -666,17 +653,16 @@ void effect_player_hand_doom(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
 void effect_player_void(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     auto effect_mes = creature.effects()->blindness().is_blind() ? _("何かに身体が引っ張りこまれる！", "Something absorbs you!")
                                                                  : _("周辺の空間が歪んだ。", "Sight warps around you.");
     msg_print(effect_mes);
-    if (!check_multishadow(creature) && !player_ptr->levitation && !player_ptr->anti_tele) {
+    if (!check_multishadow(creature) && !creature.levitation && !creature.anti_tele) {
         (void)BadStatusSetter(creature).mod_deceleration(randint0(4) + 4, false);
     }
 
     ep_ptr->dam = ep_ptr->dam * calc_void_damage_rate(creature, CALC_RAND) / 100;
-    if (!player_ptr->levitation || one_in_(13)) {
-        inventory_damage(*player_ptr, BreakerCold(), 2);
+    if (!creature.levitation || one_in_(13)) {
+        inventory_damage(creature, BreakerCold(), 2);
     }
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
@@ -693,8 +679,7 @@ void effect_player_abyss(CreatureEntity &creature, EffectPlayerType *ep_ptr)
         return;
     }
 
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    if (!player_ptr->levitation) {
+    if (!creature.levitation) {
         (void)bss.mod_deceleration(randint0(4) + 4, false);
     }
 
@@ -749,8 +734,7 @@ void effect_player_spider_string(CreatureEntity &creature, EffectPlayerType *ep_
     }
 
     // 装備品に影響（糸で汚れる）
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    inventory_damage(*player_ptr, BreakerAcid(), 5);
+    inventory_damage(creature, BreakerAcid(), 5);
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }

--- a/src/monster-attack/monster-attack-status.cpp
+++ b/src/monster-attack/monster-attack-status.cpp
@@ -23,20 +23,19 @@
 
 void process_blind_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    if (has_resist_blind(*player_ptr) || check_multishadow(*player_ptr)) {
+    if (has_resist_blind(creature) || check_multishadow(creature)) {
         return;
     }
 
     auto is_dio = monap_ptr->m_ptr->r_idx == MonraceId::DIO;
     auto dio_msg = _("どうだッ！この血の目潰しはッ！", "How is it! This blood-blinding!");
-    if (is_dio && CreatureRace(player_ptr).equals(PlayerRaceType::SKELETON)) {
+    if (is_dio && CreatureRace(&creature).equals(PlayerRaceType::SKELETON)) {
         msg_print(dio_msg);
         msg_print(_("しかし、あなたには元々目はなかった！", "However, you don't have eyes!"));
         return;
     }
 
-    if (!BadStatusSetter(*player_ptr).mod_blindness(10 + randint1(monap_ptr->rlev))) {
+    if (!BadStatusSetter(creature).mod_blindness(10 + randint1(monap_ptr->rlev))) {
         return;
     }
 
@@ -49,105 +48,100 @@ void process_blind_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_p
 
 void process_terrify_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    if (check_multishadow(*player_ptr)) {
+    if (check_multishadow(creature)) {
         return;
     }
 
     const auto &monrace = monap_ptr->m_ptr->get_monrace();
-    if (has_resist_fear(*player_ptr)) {
+    if (has_resist_fear(creature)) {
         msg_print(_("しかし恐怖に侵されなかった！", "You stand your ground!"));
         monap_ptr->obvious = true;
         return;
     }
 
-    if (randint0(100 + monrace.level / 2) < player_ptr->skill_sav) {
+    if (randint0(100 + monrace.level / 2) < creature.skill_sav) {
         msg_print(_("しかし恐怖に侵されなかった！", "You stand your ground!"));
         monap_ptr->obvious = true;
         return;
     }
 
-    if (BadStatusSetter(*player_ptr).mod_fear(3 + randint1(monap_ptr->rlev))) {
+    if (BadStatusSetter(creature).mod_fear(3 + randint1(monap_ptr->rlev))) {
         monap_ptr->obvious = true;
     }
 }
 
 void process_paralyze_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    if (check_multishadow(*player_ptr)) {
+    if (check_multishadow(creature)) {
         return;
     }
 
     const auto &monrace = monap_ptr->m_ptr->get_monrace();
-    if (player_ptr->free_act) {
+    if (creature.free_act) {
         msg_print(_("しかし効果がなかった！", "You are unaffected!"));
         monap_ptr->obvious = true;
         return;
     }
 
-    if (randint0(100 + monrace.level / 2) < player_ptr->skill_sav) {
+    if (randint0(100 + monrace.level / 2) < creature.skill_sav) {
         msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
         monap_ptr->obvious = true;
         return;
     }
 
-    const auto is_paralyzed = player_ptr->effects()->paralysis().is_paralyzed();
-    if (!is_paralyzed && BadStatusSetter(*player_ptr).set_paralysis(3 + randint1(monap_ptr->rlev))) {
+    const auto is_paralyzed = creature.effects()->paralysis().is_paralyzed();
+    if (!is_paralyzed && BadStatusSetter(creature).set_paralysis(3 + randint1(monap_ptr->rlev))) {
         monap_ptr->obvious = true;
     }
 }
 
 void process_lose_all_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    if (do_dec_stat(*player_ptr, A_STR)) {
+    if (do_dec_stat(creature, A_STR)) {
         monap_ptr->obvious = true;
     }
 
-    if (do_dec_stat(*player_ptr, A_DEX)) {
+    if (do_dec_stat(creature, A_DEX)) {
         monap_ptr->obvious = true;
     }
 
-    if (do_dec_stat(*player_ptr, A_CON)) {
+    if (do_dec_stat(creature, A_CON)) {
         monap_ptr->obvious = true;
     }
 
-    if (do_dec_stat(*player_ptr, A_INT)) {
+    if (do_dec_stat(creature, A_INT)) {
         monap_ptr->obvious = true;
     }
 
-    if (do_dec_stat(*player_ptr, A_WIS)) {
+    if (do_dec_stat(creature, A_WIS)) {
         monap_ptr->obvious = true;
     }
 
-    if (do_dec_stat(*player_ptr, A_CHR)) {
+    if (do_dec_stat(creature, A_CHR)) {
         monap_ptr->obvious = true;
     }
 }
 
 void process_stun_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    if (has_resist_sound(*player_ptr) || check_multishadow(*player_ptr)) {
+    if (has_resist_sound(creature) || check_multishadow(creature)) {
         return;
     }
 
     const auto &monrace = monap_ptr->m_ptr->get_monrace();
-    if (BadStatusSetter(*player_ptr).mod_stun(10 + randint1(monrace.level / 4))) {
+    if (BadStatusSetter(creature).mod_stun(10 + randint1(monrace.level / 4))) {
         monap_ptr->obvious = true;
     }
 }
 
 void process_groin_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    if (check_multishadow(*player_ptr)) {
+    if (check_multishadow(creature)) {
         return;
     }
 
     // 男性または両性の場合のみ追加効果
-    const bool is_vulnerable = (player_ptr->psex == SEX_MALE) || (player_ptr->psex == SEX_BISEXUAL);
+    const bool is_vulnerable = (creature.psex == SEX_MALE) || (creature.psex == SEX_BISEXUAL);
 
     if (is_vulnerable) {
         // 追加ダメージを与える（元のダメージの50%追加）
@@ -156,7 +150,7 @@ void process_groin_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_p
 
         // 朦朧状態を付与
         const auto &monrace = monap_ptr->m_ptr->get_monrace();
-        if (BadStatusSetter(*player_ptr).mod_stun(15 + randint1(monrace.level / 3))) {
+        if (BadStatusSetter(creature).mod_stun(15 + randint1(monrace.level / 3))) {
             monap_ptr->obvious = true;
         }
 
@@ -168,8 +162,7 @@ void process_groin_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_p
 
 void process_monster_attack_time(CreatureEntity &creature)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    if (has_resist_time(*player_ptr) || check_multishadow(*player_ptr)) {
+    if (has_resist_time(creature) || check_multishadow(creature)) {
         return;
     }
 
@@ -179,21 +172,21 @@ void process_monster_attack_time(CreatureEntity &creature)
     case 3:
     case 4:
     case 5:
-        if (CreatureRace(player_ptr).equals(PlayerRaceType::ANDROID)) {
+        if (CreatureRace(&creature).equals(PlayerRaceType::ANDROID)) {
             break;
         }
 
         msg_print(_("人生が逆戻りした気がする。", "You feel like a chunk of the past has been ripped away."));
-        lose_exp(creature, 100 + (player_ptr->exp / 100) * MON_DRAIN_LIFE);
+        lose_exp(creature, 100 + (creature.exp / 100) * MON_DRAIN_LIFE);
         break;
     case 6:
     case 7:
     case 8:
     case 9:
-        msg_print(player_ptr->decrease_ability_random());
+        msg_print(static_cast<PlayerType *>(&creature)->decrease_ability_random());
         break;
     case 10:
-        msg_print(player_ptr->decrease_ability_all());
+        msg_print(static_cast<PlayerType *>(&creature)->decrease_ability_all());
         break;
     }
 }

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -35,7 +35,6 @@
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
 #include "system/monster-entity.h"
-#include "system/player-type-definition.h"
 #include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
@@ -47,18 +46,17 @@
  */
 static void calc_blow_poison(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     if (monap_ptr->explode) {
         return;
     }
 
-    if (!(has_resist_pois(*player_ptr) || is_oppose_pois(*player_ptr)) && !check_multishadow(*player_ptr) && BadStatusSetter(*player_ptr).mod_poison(randint1(monap_ptr->rlev) + 5)) {
+    if (!(has_resist_pois(creature) || is_oppose_pois(creature)) && !check_multishadow(creature) && BadStatusSetter(creature).mod_poison(randint1(monap_ptr->rlev) + 5)) {
         monap_ptr->obvious = true;
     }
 
-    monap_ptr->damage = monap_ptr->damage * calc_nuke_damage_rate(*player_ptr) / 100;
-    monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-    update_smart_learn(*player_ptr, monap_ptr->m_idx, DRS_POIS);
+    monap_ptr->damage = monap_ptr->damage * calc_nuke_damage_rate(creature) / 100;
+    monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+    update_smart_learn(creature, monap_ptr->m_idx, DRS_POIS);
 }
 
 /*!
@@ -68,22 +66,21 @@ static void calc_blow_poison(CreatureEntity &creature, MonsterAttackPlayer *mona
  */
 static void calc_blow_disenchant(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     if (monap_ptr->explode) {
         return;
     }
 
-    if (!has_resist_disen(*player_ptr) && !check_multishadow(*player_ptr) && apply_disenchant(creature, 0)) {
-        update_creature(*player_ptr);
+    if (!has_resist_disen(creature) && !check_multishadow(creature) && apply_disenchant(creature, 0)) {
+        update_creature(creature);
         monap_ptr->obvious = true;
     }
 
-    if (has_resist_disen(*player_ptr)) {
+    if (has_resist_disen(creature)) {
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 4) / 9;
     }
 
-    monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-    update_smart_learn(*player_ptr, monap_ptr->m_idx, DRS_DISEN);
+    monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+    update_smart_learn(creature, monap_ptr->m_idx, DRS_DISEN);
 }
 
 /*!
@@ -94,31 +91,30 @@ static void calc_blow_disenchant(CreatureEntity &creature, MonsterAttackPlayer *
  */
 static void calc_blow_un_power(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     int damage_ratio = 1000;
-    if (has_dec_mana(*player_ptr)) {
+    if (has_dec_mana(creature)) {
         damage_ratio -= 75;
     }
 
-    if (has_easy_spell(*player_ptr)) {
+    if (has_easy_spell(creature)) {
         damage_ratio -= 75;
     }
 
-    bool is_magic_mastery = has_magic_mastery(*player_ptr) != 0;
+    bool is_magic_mastery = has_magic_mastery(creature) != 0;
     if (is_magic_mastery) {
         damage_ratio -= 75;
     }
 
     monap_ptr->damage = monap_ptr->damage * damage_ratio / 1000;
-    monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-    if (player_ptr->is_dead() || check_multishadow(*player_ptr)) {
+    monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+    if (creature.is_dead() || check_multishadow(creature)) {
         return;
     }
 
     int max_draining_item = is_magic_mastery ? 5 : 10;
     for (int i = 0; i < max_draining_item; i++) {
         auto i_idx = randnum0<short>(INVEN_PACK);
-        monap_ptr->o_ptr = player_ptr->inventory[i_idx].get();
+        monap_ptr->o_ptr = creature.inventory[i_idx].get();
         if (!monap_ptr->o_ptr->is_valid()) {
             continue;
         }
@@ -136,18 +132,17 @@ static void calc_blow_un_power(CreatureEntity &creature, MonsterAttackPlayer *mo
  */
 static void calc_blow_blind(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    if (has_resist_blind(*player_ptr)) {
+    if (has_resist_blind(creature)) {
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 3) / 8;
     }
 
-    monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-    if (player_ptr->is_dead()) {
+    monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+    if (creature.is_dead()) {
         return;
     }
 
     process_blind_attack(creature, monap_ptr);
-    update_smart_learn(*player_ptr, monap_ptr->m_idx, DRS_BLIND);
+    update_smart_learn(creature, monap_ptr->m_idx, DRS_BLIND);
 }
 
 /*!
@@ -157,25 +152,24 @@ static void calc_blow_blind(CreatureEntity &creature, MonsterAttackPlayer *monap
  */
 static void calc_blow_confusion(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     if (monap_ptr->explode) {
         return;
     }
 
-    if (has_resist_conf(*player_ptr)) {
+    if (has_resist_conf(creature)) {
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 3) / 8;
     }
 
-    monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-    if (player_ptr->is_dead()) {
+    monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+    if (creature.is_dead()) {
         return;
     }
 
-    if (!has_resist_conf(*player_ptr) && !check_multishadow(*player_ptr) && BadStatusSetter(*player_ptr).mod_confusion(3 + randint1(monap_ptr->rlev))) {
+    if (!has_resist_conf(creature) && !check_multishadow(creature) && BadStatusSetter(creature).mod_confusion(3 + randint1(monap_ptr->rlev))) {
         monap_ptr->obvious = true;
     }
 
-    update_smart_learn(*player_ptr, monap_ptr->m_idx, DRS_CONF);
+    update_smart_learn(creature, monap_ptr->m_idx, DRS_CONF);
 }
 
 /*!
@@ -185,18 +179,17 @@ static void calc_blow_confusion(CreatureEntity &creature, MonsterAttackPlayer *m
  */
 static void calc_blow_fear(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    if (has_resist_fear(*player_ptr)) {
+    if (has_resist_fear(creature)) {
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 3) / 8;
     }
 
-    monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-    if (player_ptr->is_dead()) {
+    monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+    if (creature.is_dead()) {
         return;
     }
 
     process_terrify_attack(creature, monap_ptr);
-    update_smart_learn(*player_ptr, monap_ptr->m_idx, DRS_FEAR);
+    update_smart_learn(creature, monap_ptr->m_idx, DRS_FEAR);
 }
 
 /*!
@@ -206,18 +199,17 @@ static void calc_blow_fear(CreatureEntity &creature, MonsterAttackPlayer *monap_
  */
 static void calc_blow_paralysis(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    if (has_free_act(*player_ptr)) {
+    if (has_free_act(creature)) {
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 3) / 8;
     }
 
-    monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-    if (player_ptr->is_dead()) {
+    monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+    if (creature.is_dead()) {
         return;
     }
 
     process_paralyze_attack(creature, monap_ptr);
-    update_smart_learn(*player_ptr, monap_ptr->m_idx, DRS_FREE);
+    update_smart_learn(creature, monap_ptr->m_idx, DRS_FREE);
 }
 
 /*!
@@ -227,21 +219,20 @@ static void calc_blow_paralysis(CreatureEntity &creature, MonsterAttackPlayer *m
  */
 static void calc_blow_drain_exp(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr, const int drain_value, const int hold_exp_prob)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    int32_t d = Dice::roll(drain_value, 6) + (player_ptr->exp / 100) * MON_DRAIN_LIFE;
+    int32_t d = Dice::roll(drain_value, 6) + (creature.exp / 100) * MON_DRAIN_LIFE;
     monap_ptr->obvious = true;
     int damage_ratio = 1000;
-    if (has_hold_exp(*player_ptr)) {
+    if (has_hold_exp(creature)) {
         damage_ratio -= 75;
     }
 
-    if (has_resist_neth(*player_ptr)) {
+    if (has_resist_neth(creature)) {
         damage_ratio -= 75;
     }
 
     monap_ptr->damage = monap_ptr->damage * damage_ratio / 1000;
-    monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-    if (player_ptr->is_dead() || check_multishadow(*player_ptr)) {
+    monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+    if (creature.is_dead() || check_multishadow(creature)) {
         return;
     }
 
@@ -255,17 +246,16 @@ static void calc_blow_drain_exp(CreatureEntity &creature, MonsterAttackPlayer *m
  */
 static void calc_blow_time(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     if (monap_ptr->explode) {
         return;
     }
 
     process_monster_attack_time(creature);
-    if (has_resist_time(*player_ptr)) {
+    if (has_resist_time(creature)) {
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 4) / 9;
     }
 
-    monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+    monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
 }
 
 /*!
@@ -275,15 +265,14 @@ static void calc_blow_time(CreatureEntity &creature, MonsterAttackPlayer *monap_
  */
 static void calc_blow_drain_life(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    int32_t d = Dice::roll(60, 6) + (player_ptr->exp / 100) * MON_DRAIN_LIFE;
+    int32_t d = Dice::roll(60, 6) + (creature.exp / 100) * MON_DRAIN_LIFE;
     monap_ptr->obvious = true;
-    if (player_ptr->hold_exp) {
+    if (creature.hold_exp) {
         monap_ptr->damage = monap_ptr->damage * 9 / 10;
     }
 
-    monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-    if (player_ptr->is_dead() || check_multishadow(*player_ptr)) {
+    monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+    if (creature.is_dead() || check_multishadow(creature)) {
         return;
     }
 
@@ -298,39 +287,37 @@ static void calc_blow_drain_life(CreatureEntity &creature, MonsterAttackPlayer *
  */
 static void calc_blow_drain_mana(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     monap_ptr->obvious = true;
     int damage_ratio = 100;
-    if (has_dec_mana(*player_ptr)) {
+    if (has_dec_mana(creature)) {
         damage_ratio -= 5;
     }
 
-    if (has_easy_spell(*player_ptr)) {
+    if (has_easy_spell(creature)) {
         damage_ratio -= 5;
     }
 
-    if (has_magic_mastery(*player_ptr)) {
+    if (has_magic_mastery(creature)) {
         damage_ratio -= 5;
     }
 
     monap_ptr->damage = monap_ptr->damage * damage_ratio / 100;
     process_drain_mana(creature, monap_ptr);
-    update_smart_learn(*player_ptr, monap_ptr->m_idx, DRS_MANA);
+    update_smart_learn(creature, monap_ptr->m_idx, DRS_MANA);
 }
 
 static void calc_blow_inertia(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    if (player_ptr->effects()->acceleration().is_fast() || (static_cast<CreatureEntity &>(*player_ptr).get_speed() >= 130)) {
+    if (creature.effects()->acceleration().is_fast() || (static_cast<CreatureEntity &>(creature).get_speed() >= 130)) {
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 4) / 9;
     }
 
-    monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-    if (player_ptr->is_dead() || check_multishadow(*player_ptr)) {
+    monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+    if (creature.is_dead() || check_multishadow(creature)) {
         return;
     }
 
-    if (BadStatusSetter(*player_ptr).mod_deceleration(4 + randint0(monap_ptr->rlev / 10), false)) {
+    if (BadStatusSetter(creature).mod_deceleration(4 + randint0(monap_ptr->rlev / 10), false)) {
         monap_ptr->obvious = true;
     }
 }
@@ -340,11 +327,10 @@ static void calc_blow_inertia(CreatureEntity &creature, MonsterAttackPlayer *mon
  */
 static void calc_blow_hungry(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    if (player_ptr->regenerate) {
+    if (creature.regenerate) {
         monap_ptr->damage = monap_ptr->damage * 2;
     }
-    if (player_ptr->slow_digest) {
+    if (creature.slow_digest) {
         monap_ptr->damage = monap_ptr->damage / 2;
     }
 
@@ -353,7 +339,6 @@ static void calc_blow_hungry(CreatureEntity &creature, MonsterAttackPlayer *mona
 
 void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     switch (monap_ptr->effect) {
     case RaceBlowEffectType::NONE:
         // ここには来ないはずだが、何らかのバグで来た場合はプレイヤーの不利益に
@@ -361,11 +346,11 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
         monap_ptr->damage = 0;
         break;
     case RaceBlowEffectType::SUPERHURT: { /* AC軽減あり / Player armor reduces total damage */
-        if (((randint1(monap_ptr->rlev * 2 + 300) > (monap_ptr->ac + 200)) || one_in_(13)) && !check_multishadow(*player_ptr)) {
+        if (((randint1(monap_ptr->rlev * 2 + 300) > (monap_ptr->ac + 200)) || one_in_(13)) && !check_multishadow(creature)) {
             monap_ptr->damage -= (monap_ptr->damage * ((monap_ptr->ac < 150) ? monap_ptr->ac : 150) / 250);
             msg_print(_("痛恨の一撃！", "It was a critical hit!"));
             monap_ptr->damage = std::max(monap_ptr->damage, monap_ptr->damage * 2);
-            monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+            monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
             break;
         }
     }
@@ -373,7 +358,7 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
     case RaceBlowEffectType::HURT: { /* AC軽減あり / Player armor reduces total damage */
         monap_ptr->obvious = true;
         monap_ptr->damage -= (monap_ptr->damage * ((monap_ptr->ac < 150) ? monap_ptr->ac : 150) / 250);
-        monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+        monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
         break;
     }
     case RaceBlowEffectType::POISON:
@@ -386,8 +371,8 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
         calc_blow_un_power(creature, monap_ptr);
         break;
     case RaceBlowEffectType::EAT_GOLD:
-        monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-        if (monap_ptr->m_ptr->is_confused() || player_ptr->is_dead() || check_multishadow(*player_ptr)) {
+        monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+        if (monap_ptr->m_ptr->is_confused() || creature.is_dead() || check_multishadow(creature)) {
             break;
         }
 
@@ -395,7 +380,7 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
         process_eat_gold(creature, monap_ptr);
         break;
     case RaceBlowEffectType::EAT_ITEM: {
-        monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+        monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
         if (!check_eat_item(creature, monap_ptr)) {
             break;
         }
@@ -405,8 +390,8 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
     }
 
     case RaceBlowEffectType::EAT_FOOD: {
-        monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-        if (player_ptr->is_dead() || check_multishadow(*player_ptr)) {
+        monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+        if (creature.is_dead() || check_multishadow(creature)) {
             break;
         }
 
@@ -414,9 +399,9 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
         break;
     }
     case RaceBlowEffectType::EAT_LITE: {
-        monap_ptr->o_ptr = player_ptr->inventory[INVEN_LITE].get();
-        monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-        if (player_ptr->is_dead() || check_multishadow(*player_ptr)) {
+        monap_ptr->o_ptr = creature.inventory[INVEN_LITE].get();
+        monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+        if (creature.is_dead() || check_multishadow(creature)) {
             break;
         }
 
@@ -430,9 +415,9 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
 
         monap_ptr->obvious = true;
         msg_print(_("酸を浴びせられた！", "You are covered in acid!"));
-        monap_ptr->get_damage += acid_dam(*player_ptr, monap_ptr->damage, monap_ptr->ddesc, false);
-        update_creature(*player_ptr);
-        update_smart_learn(*player_ptr, monap_ptr->m_idx, DRS_ACID);
+        monap_ptr->get_damage += acid_dam(creature, monap_ptr->damage, monap_ptr->ddesc, false);
+        update_creature(creature);
+        update_smart_learn(creature, monap_ptr->m_idx, DRS_ACID);
         break;
     }
     case RaceBlowEffectType::ELEC: {
@@ -442,8 +427,8 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
 
         monap_ptr->obvious = true;
         msg_print(_("電撃を浴びせられた！", "You are struck by electricity!"));
-        monap_ptr->get_damage += elec_dam(*player_ptr, monap_ptr->damage, monap_ptr->ddesc, false);
-        update_smart_learn(*player_ptr, monap_ptr->m_idx, DRS_ELEC);
+        monap_ptr->get_damage += elec_dam(creature, monap_ptr->damage, monap_ptr->ddesc, false);
+        update_smart_learn(creature, monap_ptr->m_idx, DRS_ELEC);
         break;
     }
     case RaceBlowEffectType::FIRE: {
@@ -453,8 +438,8 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
 
         monap_ptr->obvious = true;
         msg_print(_("全身が炎に包まれた！", "You are enveloped in flames!"));
-        monap_ptr->get_damage += fire_dam(*player_ptr, monap_ptr->damage, monap_ptr->ddesc, false);
-        update_smart_learn(*player_ptr, monap_ptr->m_idx, DRS_FIRE);
+        monap_ptr->get_damage += fire_dam(creature, monap_ptr->damage, monap_ptr->ddesc, false);
+        update_smart_learn(creature, monap_ptr->m_idx, DRS_FIRE);
         break;
     }
     case RaceBlowEffectType::COLD: {
@@ -464,8 +449,8 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
 
         monap_ptr->obvious = true;
         msg_print(_("全身が冷気で覆われた！", "You are covered with frost!"));
-        monap_ptr->get_damage += cold_dam(*player_ptr, monap_ptr->damage, monap_ptr->ddesc, false);
-        update_smart_learn(*player_ptr, monap_ptr->m_idx, DRS_COLD);
+        monap_ptr->get_damage += cold_dam(creature, monap_ptr->damage, monap_ptr->ddesc, false);
+        update_smart_learn(creature, monap_ptr->m_idx, DRS_COLD);
         break;
     }
     case RaceBlowEffectType::BLIND:
@@ -504,9 +489,9 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
     case RaceBlowEffectType::SHATTER: { /* AC軽減あり / Player armor reduces total damage */
         monap_ptr->obvious = true;
         monap_ptr->damage -= (monap_ptr->damage * ((monap_ptr->ac < 150) ? monap_ptr->ac : 150) / 250);
-        monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+        monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
         if (monap_ptr->damage > 23 || monap_ptr->explode) {
-            earthquake(*player_ptr, monap_ptr->m_ptr->get_position(), 8, monap_ptr->m_idx);
+            earthquake(creature, monap_ptr->m_ptr->get_position(), 8, monap_ptr->m_idx);
         }
 
         break;
@@ -539,8 +524,8 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
         calc_blow_inertia(creature, monap_ptr);
         break;
     case RaceBlowEffectType::STUN:
-        monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-        if (player_ptr->is_dead()) {
+        monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+        if (creature.is_dead()) {
             break;
         }
         process_stun_attack(creature, monap_ptr);
@@ -554,11 +539,11 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
         calc_blow_hungry(creature, monap_ptr);
         break;
     case RaceBlowEffectType::CHAOS: {
-        update_smart_learn(*player_ptr, monap_ptr->m_idx, DRS_CHAOS);
-        monap_ptr->damage = monap_ptr->damage * calc_chaos_damage_rate(*player_ptr, CALC_RAND) / 100;
-        monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+        update_smart_learn(creature, monap_ptr->m_idx, DRS_CHAOS);
+        monap_ptr->damage = monap_ptr->damage * calc_chaos_damage_rate(creature, CALC_RAND) / 100;
+        monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
 
-        const auto has_chaos_resist = has_resist_chaos(*player_ptr);
+        const auto has_chaos_resist = has_resist_chaos(creature);
 
         if (!has_chaos_resist) {
             monap_ptr->obvious = true;
@@ -566,11 +551,11 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
         if (randint1(5) < 3) {
             monap_ptr->obvious = true;
             if (!has_chaos_resist) {
-                if (player_ptr->is_dead() || check_multishadow(*player_ptr)) {
+                if (creature.is_dead() || check_multishadow(creature)) {
                     return;
                 }
 
-                int32_t d = Dice::roll(60, 6) + (player_ptr->exp / 100) * MON_DRAIN_LIFE;
+                int32_t d = Dice::roll(60, 6) + (creature.exp / 100) * MON_DRAIN_LIFE;
 
                 bool resist_drain = check_drain_hp(creature, d);
                 process_drain_life(monap_ptr, resist_drain);
@@ -579,71 +564,71 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
         }
         if (one_in_(250)) {
             monap_ptr->obvious = true;
-            const auto &floor = *player_ptr->current_floor_ptr;
+            const auto &floor = *creature.current_floor_ptr;
             if (floor.is_underground() && (!floor.is_in_quest() || !QuestType::is_fixed(floor.quest_number))) {
                 if (monap_ptr->damage > 23 || monap_ptr->explode) {
                     msg_print(_("カオスの力でダンジョンが崩れ始める！", "The dungeon tumbles by the chaotic power!"));
-                    earthquake(*player_ptr, monap_ptr->m_ptr->get_position(), 8, monap_ptr->m_idx);
+                    earthquake(creature, monap_ptr->m_ptr->get_position(), 8, monap_ptr->m_idx);
                     break;
                 }
             }
         }
         if (!one_in_(10)) {
-            if (player_ptr->is_dead()) {
+            if (creature.is_dead()) {
                 return;
             }
             monap_ptr->obvious = true;
 
-            if (!has_chaos_resist && !has_resist_conf(*player_ptr) && !check_multishadow(*player_ptr) && BadStatusSetter(*player_ptr).mod_confusion(3 + randint1(monap_ptr->rlev))) {
+            if (!has_chaos_resist && !has_resist_conf(creature) && !check_multishadow(creature) && BadStatusSetter(creature).mod_confusion(3 + randint1(monap_ptr->rlev))) {
                 monap_ptr->obvious = true;
             }
             break;
         }
 
         if (one_in_(2)) {
-            if (player_ptr->is_dead()) {
+            if (creature.is_dead()) {
                 return;
             }
             monap_ptr->obvious = true;
 
-            if (!has_chaos_resist && player_ptr->anti_tele == 0) {
+            if (!has_chaos_resist && creature.anti_tele == 0) {
                 msg_print(_("突然体が浮きだした！", "Your body floats suddenly!"));
-                teleport_player(*player_ptr, 50, TELEPORT_PASSIVE);
+                teleport_player(creature, 50, TELEPORT_PASSIVE);
             }
         } else if (!has_chaos_resist) {
-            if (player_ptr->is_dead()) {
+            if (creature.is_dead()) {
                 return;
             }
             monap_ptr->obvious = true;
 
             msg_print(_("あなたの身体はカオスの力で捻じ曲げられた！", "Your body is twisted by chaos!"));
-            (void)gain_mutation(*player_ptr, 0);
+            (void)gain_mutation(creature, 0);
         }
     } break;
 
     case RaceBlowEffectType::DEFECATE: { /* AC軽減あり / Player armor reduces total damage */
         monap_ptr->obvious = true;
         monap_ptr->damage -= (monap_ptr->damage * ((monap_ptr->ac < 150) ? monap_ptr->ac : 150) / 250);
-        monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-        if (monap_ptr->damage * 2 > randint1(player_ptr->hp)) {
-            player_defecate(*player_ptr);
+        monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+        if (monap_ptr->damage * 2 > randint1(creature.hp)) {
+            player_defecate(creature);
         }
         break;
     }
 
     case RaceBlowEffectType::SANITY_BLAST: {
-        monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-        if (player_ptr->is_dead()) {
+        monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+        if (creature.is_dead()) {
             break;
         }
-        sanity_blast(*player_ptr);
+        sanity_blast(creature);
         break;
     }
 
     case RaceBlowEffectType::GROIN_ATTACK: { /* AC軽減あり / Player armor reduces total damage */
         monap_ptr->damage -= (monap_ptr->damage * ((monap_ptr->ac < 150) ? monap_ptr->ac : 150) / 250);
-        monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
-        if (player_ptr->is_dead()) {
+        monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+        if (creature.is_dead()) {
             break;
         }
         process_groin_attack(creature, monap_ptr);
@@ -651,9 +636,9 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
     }
 
     case RaceBlowEffectType::LOCKUP: { /* AC軽減あり / Player armor reduces total damage */
-        if (player_ptr->anti_tele == 0) {
-            teleport_player(*player_ptr, 50, TELEPORT_PASSIVE);
-            wall_creation(creature, player_ptr->y, player_ptr->x);
+        if (creature.anti_tele == 0) {
+            teleport_player(creature, 50, TELEPORT_PASSIVE);
+            wall_creation(creature, creature.y, creature.x);
         }
         break;
     }
@@ -661,17 +646,17 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
     case RaceBlowEffectType::DESTROY_ASSHOLE: { /* AC軽減あり / Player armor reduces total damage */
         monap_ptr->obvious = true;
         monap_ptr->damage -= (monap_ptr->damage * ((monap_ptr->ac < 150) ? monap_ptr->ac : 150) / 250);
-        monap_ptr->get_damage += take_hit(*player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
+        monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
 
         // ダメージ量の最大HPに対する比率を計算
-        int damage_ratio = (monap_ptr->damage * 100) / player_ptr->maxhp;
+        int damage_ratio = (monap_ptr->damage * 100) / creature.maxhp;
 
         // 20%以上のダメージで肛門破壊の変異発生判定
         if (damage_ratio >= 20) {
             int chance = damage_ratio - 15; // 20%で5%、50%で35%、100%で85%の確率
             if (randint1(100) <= chance) {
                 msg_print(_("あなたの肛門が完全に破壊された！", "Your asshole has been completely destroyed!"));
-                (void)gain_mutation(*player_ptr, static_cast<int>(PlayerMutationType::DESTROYED_ASSHOLE));
+                (void)gain_mutation(creature, static_cast<int>(PlayerMutationType::DESTROYED_ASSHOLE));
             } else {
                 msg_print(_("肛門に激痛が走った！", "Your asshole is in severe pain!"));
             }

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -30,7 +30,6 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monster-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "timed-effect/timed-effects.h"
 #include "tracking/health-bar-tracker.h"
@@ -63,10 +62,9 @@ mspell_cast_msg_bad_status_to_monster::mspell_cast_msg_bad_status_to_monster(con
 void spell_badstatus_message_to_player(CreatureEntity &creature, MONSTER_IDX m_idx, const mspell_cast_msg_bad_status_to_player &msgs, bool resist,
     bool saved_throw)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    const auto m_name = monster_name(*player_ptr, m_idx);
+    const auto m_name = monster_name(creature, m_idx);
 
-    disturb(*player_ptr, true, true);
+    disturb(creature, true, true);
     if (creature.effects()->blindness().is_blind()) {
         msg_format(msgs.blind, m_name.data());
     } else {
@@ -94,13 +92,12 @@ void spell_badstatus_message_to_player(CreatureEntity &creature, MONSTER_IDX m_i
 void spell_badstatus_message_to_mons(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, const mspell_cast_msg_bad_status_to_monster &msgs, bool resist,
     bool saved_throw)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     auto &floor = *creature.current_floor_ptr;
-    bool see_either = see_monster(*player_ptr, m_idx) || see_monster(*player_ptr, t_idx);
-    bool see_t = see_monster(*player_ptr, t_idx);
+    bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
+    bool see_t = see_monster(creature, t_idx);
     bool known = monster_near_player(floor, m_idx, t_idx);
-    const auto m_name = monster_name(*player_ptr, m_idx);
-    const auto t_name = monster_name(*player_ptr, t_idx);
+    const auto m_name = monster_name(creature, m_idx);
+    const auto t_name = monster_name(creature, t_idx);
 
     if (known) {
         if (see_either) {
@@ -140,21 +137,20 @@ void spell_badstatus_message_to_mons(CreatureEntity &creature, MONSTER_IDX m_idx
  */
 MonsterSpellResult spell_RF5_DRAIN_MANA(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    const auto m_name = monster_name(*player_ptr, m_idx);
-    const auto t_name = monster_name(*player_ptr, t_idx);
+    const auto m_name = monster_name(creature, m_idx);
+    const auto t_name = monster_name(creature, t_idx);
 
     if (target_type == MONSTER_TO_PLAYER) {
-        disturb(*player_ptr, true, true);
-    } else if (target_type == MONSTER_TO_MONSTER && see_monster(*player_ptr, m_idx)) {
+        disturb(creature, true, true);
+    } else if (target_type == MONSTER_TO_MONSTER && see_monster(creature, m_idx)) {
         /* Basic message */
         msg_format(_("%s^は精神エネルギーを%sから吸いとった。", "%s^ draws psychic energy from %s."), m_name.data(), t_name.data());
     }
 
-    const auto dam = monspell_damage(*player_ptr, MonsterAbilityType::DRAIN_MANA, m_idx, DAM_ROLL);
-    const auto proj_res = pointed(*player_ptr, y, x, m_idx, AttributeType::DRAIN_MANA, dam, target_type);
+    const auto dam = monspell_damage(creature, MonsterAbilityType::DRAIN_MANA, m_idx, DAM_ROLL);
+    const auto proj_res = pointed(creature, y, x, m_idx, AttributeType::DRAIN_MANA, dam, target_type);
     if (target_type == MONSTER_TO_PLAYER) {
-        update_smart_learn(*player_ptr, m_idx, DRS_MANA);
+        update_smart_learn(creature, m_idx, DRS_MANA);
     }
 
     auto res = MonsterSpellResult::make_valid();
@@ -176,25 +172,24 @@ MonsterSpellResult spell_RF5_DRAIN_MANA(CreatureEntity &creature, POSITION y, PO
  */
 MonsterSpellResult spell_RF5_MIND_BLAST(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     const auto &monster = creature.current_floor_ptr->m_list[m_idx];
     bool seen = (!creature.effects()->blindness().is_blind() && monster.ml);
-    const auto m_name = monster_name(*player_ptr, m_idx);
-    const auto t_name = monster_name(*player_ptr, t_idx);
+    const auto m_name = monster_name(creature, m_idx);
+    const auto t_name = monster_name(creature, t_idx);
 
     if (target_type == MONSTER_TO_PLAYER) {
-        disturb(*player_ptr, true, true);
+        disturb(creature, true, true);
         if (!seen) {
             msg_print(_("何かがあなたの精神に念を放っているようだ。", "You feel something focusing on your mind."));
         } else {
             msg_format(_("%s^があなたの瞳をじっとにらんでいる。", "%s^ gazes deep into your eyes."), m_name.data());
         }
-    } else if (target_type == MONSTER_TO_MONSTER && see_monster(*player_ptr, m_idx)) {
+    } else if (target_type == MONSTER_TO_MONSTER && see_monster(creature, m_idx)) {
         msg_format(_("%s^は%sをじっと睨んだ。", "%s^ gazes intently at %s."), m_name.data(), t_name.data());
     }
 
-    const auto dam = monspell_damage(*player_ptr, MonsterAbilityType::MIND_BLAST, m_idx, DAM_ROLL);
-    const auto proj_res = pointed(*player_ptr, y, x, m_idx, AttributeType::MIND_BLAST, dam, target_type);
+    const auto dam = monspell_damage(creature, MonsterAbilityType::MIND_BLAST, m_idx, DAM_ROLL);
+    const auto proj_res = pointed(creature, y, x, m_idx, AttributeType::MIND_BLAST, dam, target_type);
 
     auto res = MonsterSpellResult::make_valid(dam);
     res.learnable = proj_res.affected_player;
@@ -215,25 +210,24 @@ MonsterSpellResult spell_RF5_MIND_BLAST(CreatureEntity &creature, POSITION y, PO
  */
 MonsterSpellResult spell_RF5_BRAIN_SMASH(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     const auto &monster = creature.current_floor_ptr->m_list[m_idx];
     bool seen = (!creature.effects()->blindness().is_blind() && monster.ml);
-    const auto m_name = monster_name(*player_ptr, m_idx);
-    const auto t_name = monster_name(*player_ptr, t_idx);
+    const auto m_name = monster_name(creature, m_idx);
+    const auto t_name = monster_name(creature, t_idx);
 
     if (target_type == MONSTER_TO_PLAYER) {
-        disturb(*player_ptr, true, true);
+        disturb(creature, true, true);
         if (!seen) {
             msg_print(_("何かがあなたの精神に念を放っているようだ。", "You feel something focusing on your mind."));
         } else {
             msg_format(_("%s^があなたの瞳をじっとにらんでいる。", "%s^ gazes deep into your eyes."), m_name.data());
         }
-    } else if (target_type == MONSTER_TO_MONSTER && see_monster(*player_ptr, m_idx)) {
+    } else if (target_type == MONSTER_TO_MONSTER && see_monster(creature, m_idx)) {
         msg_format(_("%s^は%sをじっと睨んだ。", "%s^ gazes intently at %s."), m_name.data(), t_name.data());
     }
 
-    const auto dam = monspell_damage(*player_ptr, MonsterAbilityType::BRAIN_SMASH, m_idx, DAM_ROLL);
-    const auto proj_res = pointed(*player_ptr, y, x, m_idx, AttributeType::BRAIN_SMASH, dam, target_type);
+    const auto dam = monspell_damage(creature, MonsterAbilityType::BRAIN_SMASH, m_idx, DAM_ROLL);
+    const auto proj_res = pointed(creature, y, x, m_idx, AttributeType::BRAIN_SMASH, dam, target_type);
 
     auto res = MonsterSpellResult::make_valid(dam);
     res.learnable = proj_res.affected_player;
@@ -251,7 +245,6 @@ MonsterSpellResult spell_RF5_BRAIN_SMASH(CreatureEntity &creature, POSITION y, P
  */
 MonsterSpellResult spell_RF5_SCARE(MONSTER_IDX m_idx, CreatureEntity &creature, MONSTER_IDX t_idx, int target_type)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
@@ -262,8 +255,8 @@ MonsterSpellResult spell_RF5_SCARE(MONSTER_IDX m_idx, CreatureEntity &creature, 
     bool resist, saving_throw;
 
     if (target_type == MONSTER_TO_PLAYER) {
-        resist = (has_resist_fear(*player_ptr) != 0);
-        saving_throw = (randint0(100 + rlev / 2) < player_ptr->skill_sav);
+        resist = (has_resist_fear(creature) != 0);
+        saving_throw = (randint0(100 + rlev / 2) < creature.skill_sav);
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^が何かをつぶやくと、恐ろしげな音が聞こえた。", "%s^ mumbles, and you hear scary noises."),
             _("%s^が恐ろしげな幻覚を作り出した。", "%s^ casts a fearful illusion."), _("しかし恐怖に侵されなかった。", "You refuse to be frightened."),
@@ -272,10 +265,10 @@ MonsterSpellResult spell_RF5_SCARE(MONSTER_IDX m_idx, CreatureEntity &creature, 
         spell_badstatus_message_to_player(creature, m_idx, msg, resist, saving_throw);
 
         if (!resist && !saving_throw) {
-            (void)BadStatusSetter(*player_ptr).mod_fear(randint0(4) + 4);
+            (void)BadStatusSetter(creature).mod_fear(randint0(4) + 4);
         }
 
-        update_smart_learn(*player_ptr, m_idx, DRS_FEAR);
+        update_smart_learn(creature, m_idx, DRS_FEAR);
         return res;
     }
 
@@ -309,7 +302,6 @@ MonsterSpellResult spell_RF5_SCARE(MONSTER_IDX m_idx, CreatureEntity &creature, 
  */
 MonsterSpellResult spell_RF5_BLIND(MONSTER_IDX m_idx, CreatureEntity &creature, MONSTER_IDX t_idx, int target_type)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
@@ -320,8 +312,8 @@ MonsterSpellResult spell_RF5_BLIND(MONSTER_IDX m_idx, CreatureEntity &creature, 
     bool resist, saving_throw;
 
     if (target_type == MONSTER_TO_PLAYER) {
-        resist = (has_resist_blind(*player_ptr) != 0);
-        saving_throw = (randint0(100 + rlev / 2) < player_ptr->skill_sav);
+        resist = (has_resist_blind(creature) != 0);
+        saving_throw = (randint0(100 + rlev / 2) < creature.skill_sav);
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
             _("%s^が呪文を唱えてあなたの目をくらました！", "%s^ casts a spell, burning your eyes!"), _("しかし効果がなかった！", "You are unaffected!"),
@@ -330,10 +322,10 @@ MonsterSpellResult spell_RF5_BLIND(MONSTER_IDX m_idx, CreatureEntity &creature, 
         spell_badstatus_message_to_player(creature, m_idx, msg, resist, saving_throw);
 
         if (!resist && !saving_throw) {
-            (void)BadStatusSetter(*player_ptr).set_blindness(12 + randint0(4));
+            (void)BadStatusSetter(creature).set_blindness(12 + randint0(4));
         }
 
-        update_smart_learn(*player_ptr, m_idx, DRS_BLIND);
+        update_smart_learn(creature, m_idx, DRS_BLIND);
         return res;
     }
 
@@ -342,7 +334,7 @@ MonsterSpellResult spell_RF5_BLIND(MONSTER_IDX m_idx, CreatureEntity &creature, 
     }
 
     concptr msg_default;
-    const auto t_name = monster_name(*player_ptr, t_idx);
+    const auto t_name = monster_name(creature, t_idx);
 
     if (streq(t_name.data(), "it")) {
         msg_default = _("%sは呪文を唱えて%sの目を焼き付かせた。", "%s^ casts a spell, burning %ss eyes.");
@@ -375,7 +367,6 @@ MonsterSpellResult spell_RF5_BLIND(MONSTER_IDX m_idx, CreatureEntity &creature, 
  */
 MonsterSpellResult spell_RF5_CONF(MONSTER_IDX m_idx, CreatureEntity &creature, MONSTER_IDX t_idx, int target_type)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
@@ -386,8 +377,8 @@ MonsterSpellResult spell_RF5_CONF(MONSTER_IDX m_idx, CreatureEntity &creature, M
     bool resist, saving_throw;
 
     if (target_type == MONSTER_TO_PLAYER) {
-        resist = (has_resist_conf(*player_ptr) != 0);
-        saving_throw = (randint0(100 + rlev / 2) < player_ptr->skill_sav);
+        resist = (has_resist_conf(creature) != 0);
+        saving_throw = (randint0(100 + rlev / 2) < creature.skill_sav);
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^が何かをつぶやくと、頭を悩ます音がした。", "%s^ mumbles, and you hear puzzling noises."),
             _("%s^が誘惑的な幻覚を作り出した。", "%s^ creates a mesmerising illusion."),
@@ -397,10 +388,10 @@ MonsterSpellResult spell_RF5_CONF(MONSTER_IDX m_idx, CreatureEntity &creature, M
         spell_badstatus_message_to_player(creature, m_idx, msg, resist, saving_throw);
 
         if (!resist && !saving_throw) {
-            (void)BadStatusSetter(*player_ptr).mod_confusion(randint0(4) + 4);
+            (void)BadStatusSetter(creature).mod_confusion(randint0(4) + 4);
         }
 
-        update_smart_learn(*player_ptr, m_idx, DRS_CONF);
+        update_smart_learn(creature, m_idx, DRS_CONF);
         return res;
     }
 
@@ -434,7 +425,6 @@ MonsterSpellResult spell_RF5_CONF(MONSTER_IDX m_idx, CreatureEntity &creature, M
  */
 MonsterSpellResult spell_RF5_HOLD(MONSTER_IDX m_idx, CreatureEntity &creature, MONSTER_IDX t_idx, int target_type)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
@@ -445,8 +435,8 @@ MonsterSpellResult spell_RF5_HOLD(MONSTER_IDX m_idx, CreatureEntity &creature, M
     bool resist, saving_throw;
 
     if (target_type == MONSTER_TO_PLAYER) {
-        resist = (player_ptr->free_act != 0);
-        saving_throw = (randint0(100 + rlev / 2) < player_ptr->skill_sav);
+        resist = (creature.free_act != 0);
+        saving_throw = (randint0(100 + rlev / 2) < creature.skill_sav);
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
             _("%s^があなたの目をじっと見つめた！", "%s^ stares deep into your eyes!"), _("しかし効果がなかった！", "You are unaffected!"),
@@ -455,10 +445,10 @@ MonsterSpellResult spell_RF5_HOLD(MONSTER_IDX m_idx, CreatureEntity &creature, M
         spell_badstatus_message_to_player(creature, m_idx, msg, (bool)resist, saving_throw);
 
         if (!resist && !saving_throw) {
-            (void)BadStatusSetter(*player_ptr).mod_paralysis(randint0(4) + 4);
+            (void)BadStatusSetter(creature).mod_paralysis(randint0(4) + 4);
         }
 
-        update_smart_learn(*player_ptr, m_idx, DRS_FREE);
+        update_smart_learn(creature, m_idx, DRS_FREE);
         return res;
     }
 
@@ -492,18 +482,17 @@ MonsterSpellResult spell_RF5_HOLD(MONSTER_IDX m_idx, CreatureEntity &creature, M
  */
 MonsterSpellResult spell_RF6_HASTE(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
-    bool see_m = see_monster(*player_ptr, m_idx);
+    bool see_m = see_monster(creature, m_idx);
     const auto &monster = creature.current_floor_ptr->m_list[m_idx];
-    const auto m_name = monster_name(*player_ptr, m_idx);
-    const auto m_poss = monster_desc(*player_ptr, monster, MD_PRON_VISIBLE | MD_POSSESSIVE);
+    const auto m_name = monster_name(creature, m_idx);
+    const auto m_poss = monster_desc(creature, monster, MD_PRON_VISIBLE | MD_POSSESSIVE);
 
     mspell_cast_msg msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が自分の体に念を送った。", format("%%s^ concentrates on %s body.", m_poss.data())),
         _("%s^が自分の体に念を送った。", format("%%s^ concentrates on %s body.", m_poss.data())),
         _("%s^が自分の体に念を送った。", format("%%s^ concentrates on %s body.", m_poss.data())));
 
-    monspell_message_base(*player_ptr, m_idx, t_idx, msg, creature.effects()->blindness().is_blind(), target_type);
+    monspell_message_base(creature, m_idx, t_idx, msg, creature.effects()->blindness().is_blind(), target_type);
 
     if (set_monster_fast(*creature.current_floor_ptr, m_idx, monster.get_remaining_acceleration() + 100)) {
         if (target_type == MONSTER_TO_PLAYER || (target_type == MONSTER_TO_MONSTER && see_m)) {
@@ -524,7 +513,6 @@ MonsterSpellResult spell_RF6_HASTE(CreatureEntity &creature, MONSTER_IDX m_idx, 
  */
 MonsterSpellResult spell_RF5_SLOW(MONSTER_IDX m_idx, CreatureEntity &creature, MONSTER_IDX t_idx, int target_type)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
@@ -535,8 +523,8 @@ MonsterSpellResult spell_RF5_SLOW(MONSTER_IDX m_idx, CreatureEntity &creature, M
     bool resist, saving_throw;
 
     if (target_type == MONSTER_TO_PLAYER) {
-        resist = (has_resist_conf(*player_ptr) != 0);
-        saving_throw = (randint0(100 + rlev / 2) < player_ptr->skill_sav);
+        resist = (has_resist_conf(creature) != 0);
+        saving_throw = (randint0(100 + rlev / 2) < creature.skill_sav);
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^があなたの筋力を吸い取ろうとした！", "%s^ drains power from your muscles!"),
             _("%s^があなたの筋力を吸い取ろうとした！", "%s^ drains power from your muscles!"), _("しかし効果がなかった！", "You are unaffected!"),
@@ -545,10 +533,10 @@ MonsterSpellResult spell_RF5_SLOW(MONSTER_IDX m_idx, CreatureEntity &creature, M
         spell_badstatus_message_to_player(creature, m_idx, msg, resist, saving_throw);
 
         if (!resist && !saving_throw) {
-            (void)BadStatusSetter(*player_ptr).mod_deceleration(randint0(4) + 4, false);
+            (void)BadStatusSetter(creature).mod_deceleration(randint0(4) + 4, false);
         }
 
-        update_smart_learn(*player_ptr, m_idx, DRS_FREE);
+        update_smart_learn(creature, m_idx, DRS_FREE);
         return res;
     }
 
@@ -557,7 +545,7 @@ MonsterSpellResult spell_RF5_SLOW(MONSTER_IDX m_idx, CreatureEntity &creature, M
     }
 
     concptr msg_default;
-    const auto t_name = monster_name(*player_ptr, t_idx);
+    const auto t_name = monster_name(creature, t_idx);
 
     if (streq(t_name.data(), "it")) {
         msg_default = _("%sが%sの筋肉から力を吸いとった。", "%s^ drains power from %ss muscles.");
@@ -591,7 +579,6 @@ MonsterSpellResult spell_RF5_SLOW(MONSTER_IDX m_idx, CreatureEntity &creature, M
  */
 MonsterSpellResult spell_RF6_HEAL(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     const auto res = MonsterSpellResult::make_valid();
 
     mspell_cast_msg msg;
@@ -600,14 +587,14 @@ MonsterSpellResult spell_RF6_HEAL(CreatureEntity &creature, MONSTER_IDX m_idx, M
     DEPTH rlev = monster_level_idx(floor, m_idx);
     const auto is_blind = creature.effects()->blindness().is_blind();
     const auto seen = (!is_blind && monster.ml);
-    const auto m_poss = monster_desc(*player_ptr, monster, MD_PRON_VISIBLE | MD_POSSESSIVE);
+    const auto m_poss = monster_desc(creature, monster, MD_PRON_VISIBLE | MD_POSSESSIVE);
 
     msg.to_player_true = _("%s^が何かをつぶやいた。", "%s^ mumbles.");
     msg.to_mons_true = _("%s^は自分の傷に念を集中した。", format("%%s^ concentrates on %s wounds.", m_poss.data()));
     msg.to_player_false = _("%s^が自分の傷に集中した。", format("%%s^ concentrates on %s wounds.", m_poss.data()));
     msg.to_mons_false = _("%s^は自分の傷に念を集中した。", format("%%s^ concentrates on %s wounds.", m_poss.data()));
 
-    monspell_message_base(*player_ptr, m_idx, t_idx, msg, is_blind, target_type);
+    monspell_message_base(creature, m_idx, t_idx, msg, is_blind, target_type);
 
     monster.hp += (rlev * 6);
     if (monster.hp >= monster.maxhp) {
@@ -625,7 +612,7 @@ MonsterSpellResult spell_RF6_HEAL(CreatureEntity &creature, MONSTER_IDX m_idx, M
         msg.to_mons_false = _("%s^は体力を回復したようだ。", "%s^ looks healthier.");
     }
 
-    monspell_message_base(*player_ptr, m_idx, t_idx, msg, !seen, target_type);
+    monspell_message_base(creature, m_idx, t_idx, msg, !seen, target_type);
     HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
     if (monster.is_riding()) {
         RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
@@ -637,8 +624,8 @@ MonsterSpellResult spell_RF6_HEAL(CreatureEntity &creature, MONSTER_IDX m_idx, M
 
     (void)set_monster_monfear(*creature.current_floor_ptr, m_idx, 0);
 
-    if (see_monster(*player_ptr, m_idx)) {
-        const auto m_name = monster_name(*player_ptr, m_idx);
+    if (see_monster(creature, m_idx)) {
+        const auto m_name = monster_name(creature, m_idx);
         msg_print(_(format("%s^は勇気を取り戻した。", m_name.data()), format("%s^ recovers %s courage.", m_name.data(), m_poss.data())));
     }
 
@@ -656,18 +643,17 @@ MonsterSpellResult spell_RF6_HEAL(CreatureEntity &creature, MONSTER_IDX m_idx, M
  */
 MonsterSpellResult spell_RF6_INVULNER(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     const auto &monster = creature.current_floor_ptr->m_list[m_idx];
     bool seen = (!creature.effects()->blindness().is_blind() && monster.ml);
     mspell_cast_msg msg(_("%s^が何かを力強くつぶやいた。", "%s^ mumbles powerfully."),
         _("%s^が何かを力強くつぶやいた。", "%s^ mumbles powerfully."), _("%sは無傷の球の呪文を唱えた。", "%s^ casts a Globe of Invulnerability."),
         _("%sは無傷の球の呪文を唱えた。", "%s^ casts a Globe of Invulnerability."));
 
-    monspell_message_base(*player_ptr, m_idx, t_idx, msg, !seen, target_type);
+    monspell_message_base(creature, m_idx, t_idx, msg, !seen, target_type);
 
     if (monster.ml) {
         MonraceId r_idx = monster.r_idx;
-        const auto m_name = monster_desc(*player_ptr, monster, MD_NONE);
+        const auto m_name = monster_desc(creature, monster, MD_NONE);
         switch (r_idx) {
         case MonraceId::MARIO:
         case MonraceId::LUIGI:
@@ -698,17 +684,16 @@ MonsterSpellResult spell_RF6_INVULNER(CreatureEntity &creature, MONSTER_IDX m_id
  */
 MonsterSpellResult spell_RF6_FORGET(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    auto *player_ptr = static_cast<PlayerType *>(&creature);
     DEPTH rlev = monster_level_idx(*creature.current_floor_ptr, m_idx);
-    const auto m_name = monster_name(*player_ptr, m_idx);
+    const auto m_name = monster_name(creature, m_idx);
 
-    disturb(*player_ptr, true, true);
+    disturb(creature, true, true);
 
     msg_format(_("%s^があなたの記憶を消去しようとしている。", "%s^ tries to blank your mind."), m_name.data());
 
-    if (randint0(100 + rlev / 2) < player_ptr->skill_sav) {
+    if (randint0(100 + rlev / 2) < creature.skill_sav) {
         msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
-    } else if (lose_all_info(*player_ptr)) {
+    } else if (lose_all_info(creature)) {
         msg_print(_("記憶が薄れてしまった。", "Your memories fade away."));
     }
 

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -7,6 +7,7 @@
 #include "monster-attack/monster-attack-table.h"
 #include "mspell/mspell-damage-calculator.h"
 #include "player-base/player-race.h"
+#include "player-info/race-types.h"
 #include "player/player-status-flags.h"
 #include "player/player-status-resist.h"
 #include "system/creature-entity.h"
@@ -17,7 +18,6 @@
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monster-entity.h"
-#include "system/player-type-definition.h"
 #include "target/projection-path-calculator.h"
 #include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
@@ -243,11 +243,11 @@ static void spell_damcalc(CreatureEntity &creature, const MonsterEntity &monster
  * @param m_idx 魔法を行使するモンスターのID
  * @param max 算出した最大ダメージを返すポインタ
  */
-static void spell_damcalc_by_spellnum(PlayerType *player_ptr, MonsterAbilityType ms_type, AttributeType typ, MONSTER_IDX m_idx, int *max)
+static void spell_damcalc_by_spellnum(CreatureEntity &creature, MonsterAbilityType ms_type, AttributeType typ, MONSTER_IDX m_idx, int *max)
 {
-    const auto &monster = player_ptr->current_floor_ptr->m_list[m_idx];
-    int dam = monspell_damage(*player_ptr, ms_type, m_idx, DAM_MAX);
-    spell_damcalc(*player_ptr, monster, typ, dam, max);
+    const auto &monster = creature.current_floor_ptr->m_list[m_idx];
+    int dam = monspell_damage(creature, ms_type, m_idx, DAM_MAX);
+    spell_damcalc(creature, monster, typ, dam, max);
 }
 
 /*!
@@ -336,8 +336,6 @@ static int blow_damcalc(const MonsterEntity &monster, CreatureEntity &creature, 
  */
 bool process_warning(CreatureEntity &creature, POSITION xx, POSITION yy)
 {
-    auto player_ptr = static_cast<PlayerType *>(&creature);
-
     const Pos2D pos(yy, xx);
     constexpr auto warning_aware_range = 12;
     int dam_max = 0;
@@ -376,108 +374,108 @@ bool process_warning(CreatureEntity &creature, POSITION xx, POSITION yy)
 
                 if (dungeon.flags.has_not(DungeonFeatureType::NO_MAGIC)) {
                     if (flags.has(MonsterAbilityType::BA_CHAO)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_CHAO, AttributeType::CHAOS, grid.m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(creature, MonsterAbilityType::BA_CHAO, AttributeType::CHAOS, grid.m_idx, &dam_max0);
                     }
                     if (flags.has(MonsterAbilityType::BA_MANA)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_MANA, AttributeType::MANA, grid.m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(creature, MonsterAbilityType::BA_MANA, AttributeType::MANA, grid.m_idx, &dam_max0);
                     }
                     if (flags.has(MonsterAbilityType::BA_DARK)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_DARK, AttributeType::DARK, grid.m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(creature, MonsterAbilityType::BA_DARK, AttributeType::DARK, grid.m_idx, &dam_max0);
                     }
                     if (flags.has(MonsterAbilityType::BA_LITE)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_LITE, AttributeType::LITE, grid.m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(creature, MonsterAbilityType::BA_LITE, AttributeType::LITE, grid.m_idx, &dam_max0);
                     }
                     if (flags.has(MonsterAbilityType::HAND_DOOM)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::HAND_DOOM, AttributeType::HAND_DOOM, grid.m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(creature, MonsterAbilityType::HAND_DOOM, AttributeType::HAND_DOOM, grid.m_idx, &dam_max0);
                     }
                     if (flags.has(MonsterAbilityType::PSY_SPEAR)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::PSY_SPEAR, AttributeType::PSY_SPEAR, grid.m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(creature, MonsterAbilityType::PSY_SPEAR, AttributeType::PSY_SPEAR, grid.m_idx, &dam_max0);
                     }
                     if (flags.has(MonsterAbilityType::BA_VOID)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_VOID, AttributeType::VOID_MAGIC, grid.m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(creature, MonsterAbilityType::BA_VOID, AttributeType::VOID_MAGIC, grid.m_idx, &dam_max0);
                     }
                     if (flags.has(MonsterAbilityType::BA_ABYSS)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_ABYSS, AttributeType::ABYSS, grid.m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(creature, MonsterAbilityType::BA_ABYSS, AttributeType::ABYSS, grid.m_idx, &dam_max0);
                     }
                 }
 
                 if (flags.has(MonsterAbilityType::ROCKET)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::ROCKET, AttributeType::ROCKET, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::ROCKET, AttributeType::ROCKET, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_ACID)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_ACID, AttributeType::ACID, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_ACID, AttributeType::ACID, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_ELEC)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_ELEC, AttributeType::ELEC, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_ELEC, AttributeType::ELEC, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_FIRE)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_FIRE, AttributeType::FIRE, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_FIRE, AttributeType::FIRE, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_COLD)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_COLD, AttributeType::COLD, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_COLD, AttributeType::COLD, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_POIS)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_POIS, AttributeType::POIS, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_POIS, AttributeType::POIS, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_NETH)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_NETH, AttributeType::NETHER, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_NETH, AttributeType::NETHER, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_LITE)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_LITE, AttributeType::LITE, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_LITE, AttributeType::LITE, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_DARK)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_DARK, AttributeType::DARK, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_DARK, AttributeType::DARK, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_CONF)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_CONF, AttributeType::CONFUSION, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_CONF, AttributeType::CONFUSION, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_SOUN)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_SOUN, AttributeType::SOUND, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_SOUN, AttributeType::SOUND, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_CHAO)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_CHAO, AttributeType::CHAOS, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_CHAO, AttributeType::CHAOS, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_DISE)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_DISE, AttributeType::DISENCHANT, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_DISE, AttributeType::DISENCHANT, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_NEXU)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_NEXU, AttributeType::NEXUS, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_NEXU, AttributeType::NEXUS, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_TIME)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_TIME, AttributeType::TIME, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_TIME, AttributeType::TIME, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_INER)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_INER, AttributeType::INERTIAL, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_INER, AttributeType::INERTIAL, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_GRAV)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_GRAV, AttributeType::GRAVITY, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_GRAV, AttributeType::GRAVITY, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_SHAR)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_SHAR, AttributeType::SHARDS, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_SHAR, AttributeType::SHARDS, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_PLAS)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_PLAS, AttributeType::PLASMA, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_PLAS, AttributeType::PLASMA, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_FORC)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_FORC, AttributeType::FORCE, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_FORC, AttributeType::FORCE, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_MANA)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_MANA, AttributeType::MANA, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_MANA, AttributeType::MANA, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_NUKE)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_NUKE, AttributeType::NUKE, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_NUKE, AttributeType::NUKE, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_DISI)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_DISI, AttributeType::DISINTEGRATE, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_DISI, AttributeType::DISINTEGRATE, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_VOID)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_VOID, AttributeType::VOID_MAGIC, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_VOID, AttributeType::VOID_MAGIC, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_ABYSS)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_ABYSS, AttributeType::ABYSS, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_ABYSS, AttributeType::ABYSS, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_FECES)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_FECES, AttributeType::DIRT, grid.m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(creature, MonsterAbilityType::BR_FECES, AttributeType::DIRT, grid.m_idx, &dam_max0);
                 }
             }
             /* Monster melee attacks */
@@ -516,8 +514,8 @@ bool process_warning(CreatureEntity &creature, POSITION xx, POSITION yy)
     if (dam_max > old_damage) {
         old_damage = dam_max * 3 / 2;
 
-        if (dam_max > player_ptr->hp / 2) {
-            auto *o_ptr = choose_warning_item(*player_ptr);
+        if (dam_max > creature.hp / 2) {
+            auto *o_ptr = choose_warning_item(creature);
             std::string item_name;
             if (o_ptr != nullptr) {
                 item_name = describe_flavor(creature, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
@@ -540,7 +538,7 @@ bool process_warning(CreatureEntity &creature, POSITION xx, POSITION yy)
         return true;
     }
 
-    auto *o_ptr = choose_warning_item(*player_ptr);
+    auto *o_ptr = choose_warning_item(creature);
     std::string item_name;
     if (o_ptr != nullptr) {
         item_name = describe_flavor(creature, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));


### PR DESCRIPTION
- object/warning.cpp: spell_damcalc_by_spellnum の第一引数を PlayerType * から CreatureEntity & に変更、process_warning の内部キャスト削除
- monster-attack/monster-attack-status.cpp: 全関数の player_ptr キャストを削除し CreatureEntity & で直接アクセス
- monster-attack/monster-attack-switcher.cpp: 同上
- mspell/mspell-status.cpp: 全 14 箇所のキャストを削除
- effect/effect-player-resist-hurt.cpp: 同上 (PlayerType 固有の decrease_ability_* のみインラインキャストで対応)