### PR TITLE
refactor: CreatureTimedEffect enum と get_timed_effect() の実装 (Phase 3 Step 1)

### DIFF
--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -53,6 +53,26 @@ Pos2D CreatureEntity::get_neighbor(const Direction &dir) const
     return this->get_position() + dir.vec();
 }
 
+bool CreatureEntity::is_stunned() const
+{
+    return this->get_timed_effect(CreatureTimedEffect::STUN) > 0;
+}
+
+bool CreatureEntity::is_confused() const
+{
+    return this->get_timed_effect(CreatureTimedEffect::CONFUSION) > 0;
+}
+
+bool CreatureEntity::is_fearful() const
+{
+    return this->get_timed_effect(CreatureTimedEffect::FEAR) > 0;
+}
+
+bool CreatureEntity::is_invulnerable() const
+{
+    return this->get_timed_effect(CreatureTimedEffect::INVULNERABILITY) > 0;
+}
+
 /*!
  * @brief ツリー構造インシデント数加算
  * @param incident_id 階層構造のインシデントID（例: "root/attack/critical"）

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -9,6 +9,7 @@
 #include "player/player-personality-types.h"
 #include "player/player-skill.h"
 #include "system/angband.h"
+#include "system/creature-timed-effect-types.h"
 #include "system/system-variables.h"
 #include "util/dice.h"
 #include "util/flag-group.h"
@@ -256,6 +257,37 @@ public:
      * @return プレイヤーならtrue、モンスターならfalse
      */
     virtual bool is_player() const = 0;
+
+    /*!
+     * @brief クリーチャーの時限効果の残りターン数を取得
+     * @param effect 取得する時限効果の種別
+     * @return 残りターン数（0なら効果なし）
+     */
+    virtual short get_timed_effect(CreatureTimedEffect effect) const = 0;
+
+    /*!
+     * @brief クリーチャーが朦朧状態かどうかを判定
+     * @return 朦朧状態ならtrue
+     */
+    virtual bool is_stunned() const;
+
+    /*!
+     * @brief クリーチャーが混乱状態かどうかを判定
+     * @return 混乱状態ならtrue
+     */
+    virtual bool is_confused() const;
+
+    /*!
+     * @brief クリーチャーが恐怖状態かどうかを判定
+     * @return 恐怖状態ならtrue
+     */
+    virtual bool is_fearful() const;
+
+    /*!
+     * @brief クリーチャーが無敵状態かどうかを判定
+     * @return 無敵状態ならtrue
+     */
+    virtual bool is_invulnerable() const;
 
     /*!
      * @brief 指定した固定アーティファクトを装備しているかどうか調べる

--- a/src/system/creature-timed-effect-types.h
+++ b/src/system/creature-timed-effect-types.h
@@ -1,0 +1,16 @@
+#pragma once
+
+/*!
+ * @brief クリーチャー（プレイヤー・モンスター共通）の時限効果の種別
+ * @details PlayerType の TimedEffects および MonsterEntity の mtimed と対応する
+ */
+enum class CreatureTimedEffect {
+    STUN, /*!< 朦朧 / Stun */
+    CONFUSION, /*!< 混乱 / Confusion */
+    FEAR, /*!< 恐怖 / Fear */
+    INVULNERABILITY, /*!< 無敵 / Invulnerability */
+    ACCELERATION, /*!< 加速 / Acceleration (Fast) */
+    DECELERATION, /*!< 減速 / Deceleration (Slow) */
+    SLEEP_OR_PARALYSIS, /*!< 眠り・麻痺 / Sleep or Paralysis */
+    MAX,
+};

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -285,6 +285,28 @@ bool MonsterEntity::is_invulnerable() const
     return this->get_remaining_invulnerability() > 0;
 }
 
+short MonsterEntity::get_timed_effect(CreatureTimedEffect effect) const
+{
+    switch (effect) {
+    case CreatureTimedEffect::STUN:
+        return this->mtimed.at(MonsterTimedEffect::STUN);
+    case CreatureTimedEffect::CONFUSION:
+        return this->mtimed.at(MonsterTimedEffect::CONFUSION);
+    case CreatureTimedEffect::FEAR:
+        return this->mtimed.at(MonsterTimedEffect::FEAR);
+    case CreatureTimedEffect::INVULNERABILITY:
+        return this->mtimed.at(MonsterTimedEffect::INVULNERABILITY);
+    case CreatureTimedEffect::ACCELERATION:
+        return this->mtimed.at(MonsterTimedEffect::FAST);
+    case CreatureTimedEffect::DECELERATION:
+        return this->mtimed.at(MonsterTimedEffect::SLOW);
+    case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
+        return this->mtimed.at(MonsterTimedEffect::SLEEP);
+    default:
+        return 0;
+    }
+}
+
 /*
  * @brief 悪夢モード、一時加速、一時減速に基づくモンスターの現在速度を返す
  */

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -93,10 +93,11 @@ public:
     bool is_asleep() const;
     bool is_accelerated() const;
     bool is_decelerated() const;
-    bool is_stunned() const;
-    bool is_confused() const;
-    bool is_fearful() const;
-    bool is_invulnerable() const;
+    bool is_stunned() const override;
+    bool is_confused() const override;
+    bool is_fearful() const override;
+    bool is_invulnerable() const override;
+    short get_timed_effect(CreatureTimedEffect effect) const override;
     byte get_temporary_speed() const;
     int get_speed() const override;
     bool has_living_flag(bool is_apperance = false) const;

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -221,3 +221,26 @@ bool PlayerType::is_player() const
 {
     return true;
 }
+
+short PlayerType::get_timed_effect(CreatureTimedEffect effect) const
+{
+    const auto &eff = *this->effects();
+    switch (effect) {
+    case CreatureTimedEffect::STUN:
+        return eff.stun().current();
+    case CreatureTimedEffect::CONFUSION:
+        return eff.confusion().current();
+    case CreatureTimedEffect::FEAR:
+        return eff.fear().current();
+    case CreatureTimedEffect::INVULNERABILITY:
+        return this->invuln;
+    case CreatureTimedEffect::ACCELERATION:
+        return eff.acceleration().current();
+    case CreatureTimedEffect::DECELERATION:
+        return eff.deceleration().current();
+    case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
+        return eff.paralysis().current();
+    default:
+        return 0;
+    }
+}

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -65,6 +65,8 @@ public:
     bool is_dead() const override;
 
     bool is_player() const override;
+
+    short get_timed_effect(CreatureTimedEffect effect) const override;
 };
 
 extern PlayerType *p_ptr;


### PR DESCRIPTION
…

- src/system/creature-timed-effect-types.h を新規追加
  - プレイヤー・モンスター共通の時限効果列挙型 CreatureTimedEffect を定義
  - STUN / CONFUSION / FEAR / INVULNERABILITY / ACCELERATION / DECELERATION / SLEEP_OR_PARALYSIS
- CreatureEntity に pure virtual get_timed_effect() と状態チェックメソッドを追加
  - is_stunned() / is_confused() / is_fearful() / is_invulnerable() は get_timed_effect() を使うデフォルト実装
- MonsterEntity::get_timed_effect() を override 実装
  - MonsterTimedEffect へのマッピングで mtimed を参照
  - 既存の is_stunned() 等に override マークを追加
- PlayerType::get_timed_effect() を override 実装
  - effects() オブジェクト経由で各効果の current() を返す
  - INVULNERABILITY は直接フィールド invuln を参照