### PR TITLE
refactor: PlayerType * 引数・メンバを PlayerType & に変換（Phase 1 残り）

### DIFF
--- a/src/io-dump/player-status-dump-json.cpp
+++ b/src/io-dump/player-status-dump-json.cpp
@@ -49,36 +49,36 @@ static std::string localized_to_utf8_safe(const LocalizedString &ls)
  * @param j JSON オブジェクト
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-static void add_basic_info_to_json(nlohmann::json &j, PlayerType *player_ptr)
+static void add_basic_info_to_json(nlohmann::json &j, PlayerType &player)
 {
-    j["basic"]["name"] = to_utf8_safe(player_ptr->name);
-    j["basic"]["sex"] = localized_to_utf8_safe(sex_info[player_ptr->psex].title);
-    j["basic"]["race"] = localized_to_utf8_safe(player_ptr->race->title);
-    j["basic"]["class"] = localized_to_utf8_safe(class_info.at(player_ptr->pclass).title);
-    j["basic"]["level"] = player_ptr->level;
-    j["basic"]["experience"] = player_ptr->exp;
-    j["basic"]["max_experience"] = player_ptr->max_exp;
+    j["basic"]["name"] = to_utf8_safe(player.name);
+    j["basic"]["sex"] = localized_to_utf8_safe(sex_info[player.psex].title);
+    j["basic"]["race"] = localized_to_utf8_safe(player.race->title);
+    j["basic"]["class"] = localized_to_utf8_safe(class_info.at(player.pclass).title);
+    j["basic"]["level"] = player.level;
+    j["basic"]["experience"] = player.exp;
+    j["basic"]["max_experience"] = player.max_exp;
 
-    if (player_ptr->mimic_form != MimicKindType::NONE) {
-        j["basic"]["mimic_form"] = localized_to_utf8_safe(mimic_info.at(player_ptr->mimic_form).title);
+    if (player.mimic_form != MimicKindType::NONE) {
+        j["basic"]["mimic_form"] = localized_to_utf8_safe(mimic_info.at(player.mimic_form).title);
     }
 
     // 性格
-    j["basic"]["personality"] = localized_to_utf8_safe(personality_info[player_ptr->ppersonality].title);
+    j["basic"]["personality"] = localized_to_utf8_safe(personality_info[player.ppersonality].title);
 
     // 領域
-    if (player_ptr->realm1 != RealmType::NONE) {
-        j["basic"]["realm1"] = localized_to_utf8_safe(PlayerRealm::get_name(player_ptr->realm1));
+    if (player.realm1 != RealmType::NONE) {
+        j["basic"]["realm1"] = localized_to_utf8_safe(PlayerRealm::get_name(player.realm1));
     }
-    if (player_ptr->realm2 != RealmType::NONE) {
-        j["basic"]["realm2"] = localized_to_utf8_safe(PlayerRealm::get_name(player_ptr->realm2));
+    if (player.realm2 != RealmType::NONE) {
+        j["basic"]["realm2"] = localized_to_utf8_safe(PlayerRealm::get_name(player.realm2));
     }
 
     // 年齢、身長、体重
-    j["basic"]["age"] = player_ptr->age;
-    j["basic"]["height"] = player_ptr->ht;
-    j["basic"]["weight"] = player_ptr->wt;
-    j["basic"]["prestige"] = player_ptr->prestige;
+    j["basic"]["age"] = player.age;
+    j["basic"]["height"] = player.ht;
+    j["basic"]["weight"] = player.wt;
+    j["basic"]["prestige"] = player.prestige;
 }
 
 /*!
@@ -86,7 +86,7 @@ static void add_basic_info_to_json(nlohmann::json &j, PlayerType *player_ptr)
  * @param j JSON オブジェクト
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-static void add_stats_to_json(nlohmann::json &j, PlayerType *player_ptr)
+static void add_stats_to_json(nlohmann::json &j, PlayerType &player)
 {
     nlohmann::json stats = nlohmann::json::array();
 
@@ -94,10 +94,10 @@ static void add_stats_to_json(nlohmann::json &j, PlayerType *player_ptr)
     for (int i = 0; i < A_MAX; i++) {
         nlohmann::json stat;
         stat["name"] = stat_names[i];
-        stat["current"] = player_ptr->stat_cur[i];
-        stat["max"] = player_ptr->stat_max[i];
-        stat["use"] = player_ptr->stat_use[i];
-        stat["top"] = player_ptr->stat_top[i];
+        stat["current"] = player.stat_cur[i];
+        stat["max"] = player.stat_max[i];
+        stat["use"] = player.stat_use[i];
+        stat["top"] = player.stat_top[i];
         stats.push_back(stat);
     }
 
@@ -109,21 +109,21 @@ static void add_stats_to_json(nlohmann::json &j, PlayerType *player_ptr)
  * @param j JSON オブジェクト
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-static void add_status_to_json(nlohmann::json &j, PlayerType *player_ptr)
+static void add_status_to_json(nlohmann::json &j, PlayerType &player)
 {
-    j["status"]["hitpoints"] = player_ptr->hp;
-    j["status"]["max_hitpoints"] = player_ptr->maxhp;
-    j["status"]["mana"] = player_ptr->csp;
-    j["status"]["max_mana"] = player_ptr->msp;
-    j["status"]["armor_class"] = player_ptr->ac;
-    j["status"]["display_armor_class"] = player_ptr->dis_ac;
+    j["status"]["hitpoints"] = player.hp;
+    j["status"]["max_hitpoints"] = player.maxhp;
+    j["status"]["mana"] = player.csp;
+    j["status"]["max_mana"] = player.msp;
+    j["status"]["armor_class"] = player.ac;
+    j["status"]["display_armor_class"] = player.dis_ac;
 
     // 所持金とアイテム
-    j["status"]["gold"] = player_ptr->au;
+    j["status"]["gold"] = player.au;
 
     // ダンジョン情報
-    j["status"]["dungeon_level"] = player_ptr->current_floor_ptr->dun_level;
-    const auto &dungeon_record = DungeonRecords::get_instance().get_record(player_ptr->recall_dungeon);
+    j["status"]["dungeon_level"] = player.current_floor_ptr->dun_level;
+    const auto &dungeon_record = DungeonRecords::get_instance().get_record(player.recall_dungeon);
     j["status"]["max_dungeon_level"] = dungeon_record.get_max_level();
 
     // ターン数
@@ -136,16 +136,16 @@ static void add_status_to_json(nlohmann::json &j, PlayerType *player_ptr)
  * @param j JSON オブジェクト
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-static void add_combat_to_json(nlohmann::json &j, PlayerType *player_ptr)
+static void add_combat_to_json(nlohmann::json &j, PlayerType &player)
 {
-    j["combat"]["base_to_hit"] = player_ptr->to_h_b;
-    j["combat"]["melee_to_hit"] = player_ptr->to_h_m;
-    j["combat"]["melee_to_damage"] = player_ptr->to_d_m;
-    j["combat"]["ranged_to_hit"] = player_ptr->to_h_b;
+    j["combat"]["base_to_hit"] = player.to_h_b;
+    j["combat"]["melee_to_hit"] = player.to_h_m;
+    j["combat"]["melee_to_damage"] = player.to_d_m;
+    j["combat"]["ranged_to_hit"] = player.to_h_b;
 
     // 攻撃回数
-    j["combat"]["num_blow"] = player_ptr->num_blow[0];
-    j["combat"]["num_fire"] = player_ptr->num_fire;
+    j["combat"]["num_blow"] = player.num_blow[0];
+    j["combat"]["num_fire"] = player.num_fire;
 }
 
 /*!
@@ -153,18 +153,18 @@ static void add_combat_to_json(nlohmann::json &j, PlayerType *player_ptr)
  * @param j JSON オブジェクト
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-static void add_skills_to_json(nlohmann::json &j, PlayerType *player_ptr)
+static void add_skills_to_json(nlohmann::json &j, PlayerType &player)
 {
-    j["skills"]["fighting"] = player_ptr->skill_thn;
-    j["skills"]["shooting"] = player_ptr->skill_thb;
-    j["skills"]["saving_throw"] = player_ptr->skill_sav;
-    j["skills"]["stealth"] = player_ptr->skill_stl;
-    j["skills"]["perception"] = player_ptr->skill_fos;
-    j["skills"]["searching"] = player_ptr->skill_srh;
-    j["skills"]["disarming"] = player_ptr->skill_dis;
-    j["skills"]["magic_device"] = player_ptr->skill_dev;
-    j["skills"]["infravision"] = player_ptr->see_infra;
-    j["skills"]["speed"] = player_ptr->speed - 110;
+    j["skills"]["fighting"] = player.skill_thn;
+    j["skills"]["shooting"] = player.skill_thb;
+    j["skills"]["saving_throw"] = player.skill_sav;
+    j["skills"]["stealth"] = player.skill_stl;
+    j["skills"]["perception"] = player.skill_fos;
+    j["skills"]["searching"] = player.skill_srh;
+    j["skills"]["disarming"] = player.skill_dis;
+    j["skills"]["magic_device"] = player.skill_dev;
+    j["skills"]["infravision"] = player.see_infra;
+    j["skills"]["speed"] = player.speed - 110;
 }
 
 /*!
@@ -172,20 +172,20 @@ static void add_skills_to_json(nlohmann::json &j, PlayerType *player_ptr)
  * @param j JSON オブジェクト
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-static void add_death_info_to_json(nlohmann::json &j, PlayerType *player_ptr)
+static void add_death_info_to_json(nlohmann::json &j, PlayerType &player)
 {
-    if (player_ptr->is_dead()) {
+    if (player.is_dead()) {
         j["death"]["is_dead"] = true;
-        j["death"]["cause"] = to_utf8_safe(player_ptr->died_from);
-        if (player_ptr->killer_monrace_id != MonraceId::PLAYER) {
-            j["death"]["killer_id"] = enum2i(player_ptr->killer_monrace_id);
+        j["death"]["cause"] = to_utf8_safe(player.died_from);
+        if (player.killer_monrace_id != MonraceId::PLAYER) {
+            j["death"]["killer_id"] = enum2i(player.killer_monrace_id);
         }
-        if (!player_ptr->last_message.empty()) {
-            j["death"]["last_message"] = to_utf8_safe(player_ptr->last_message);
+        if (!player.last_message.empty()) {
+            j["death"]["last_message"] = to_utf8_safe(player.last_message);
         }
     }
 
-    if (player_ptr->is_true_winner()) {
+    if (player.is_true_winner()) {
         j["death"]["is_winner"] = true;
     }
 }
@@ -195,12 +195,12 @@ static void add_death_info_to_json(nlohmann::json &j, PlayerType *player_ptr)
  * @param j JSON オブジェクト
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-static void add_history_to_json(nlohmann::json &j, PlayerType *player_ptr)
+static void add_history_to_json(nlohmann::json &j, PlayerType &player)
 {
     nlohmann::json history = nlohmann::json::array();
     for (int i = 0; i < 4; i++) {
-        if (player_ptr->history[i][0] != '\0') {
-            history.push_back(to_utf8_safe(player_ptr->history[i]));
+        if (player.history[i][0] != '\0') {
+            history.push_back(to_utf8_safe(player.history[i]));
         }
     }
     j["history"] = history;
@@ -213,7 +213,7 @@ static void add_history_to_json(nlohmann::json &j, PlayerType *player_ptr)
  */
 std::string dump_player_status_json(CreatureEntity &creature)
 {
-    auto *player_ptr = &static_cast<PlayerType &>(creature);
+    auto &player = static_cast<PlayerType &>(creature);
     nlohmann::json j;
 
     // バージョン情報
@@ -223,25 +223,25 @@ std::string dump_player_status_json(CreatureEntity &creature)
     };
 
     // 基本情報
-    add_basic_info_to_json(j, player_ptr);
+    add_basic_info_to_json(j, player);
 
     // 能力値
-    add_stats_to_json(j, player_ptr);
+    add_stats_to_json(j, player);
 
     // 状態
-    add_status_to_json(j, player_ptr);
+    add_status_to_json(j, player);
 
     // 戦闘能力
-    add_combat_to_json(j, player_ptr);
+    add_combat_to_json(j, player);
 
     // スキル
-    add_skills_to_json(j, player_ptr);
+    add_skills_to_json(j, player);
 
     // 死亡/勝利情報
-    add_death_info_to_json(j, player_ptr);
+    add_death_info_to_json(j, player);
 
     // 履歴
-    add_history_to_json(j, player_ptr);
+    add_history_to_json(j, player);
 
     // 整形して返す
     return j.dump(2);

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -53,7 +53,7 @@ private:
     tl::optional<std::pair<Direction, bool>> switch_next_grid_command();
     void decide_change_panel(const Direction &dir, bool move_fast);
 
-    PlayerType *player_ptr;
+    PlayerType &player;
     target_type mode;
     Pos2D pos_target;
     bool done = false;
@@ -63,7 +63,7 @@ private:
 };
 
 TargetSetter::TargetSetter(CreatureEntity &creature, target_type mode)
-    : player_ptr(static_cast<PlayerType *>(&creature))
+    : player(static_cast<PlayerType &>(creature))
     , mode(mode)
     , pos_target(creature.get_position())
     , pos_interests(target_set_prepare(creature, mode))
@@ -82,7 +82,7 @@ static bool set_travel_goal(CreatureEntity &creature, const Pos2D &pos)
 
 /*!
  * @brief フォーカスを当てるべきマップ描画の基準座標を指定する
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param creature クリーチャーへの参照
  * @param pos 変更先のフロア座標
  * @details
  * Handle a request to change the current panel
@@ -184,15 +184,15 @@ tl::optional<int> TargetSetter::pick_nearest_interest_target(const Pos2D &pos, c
 
 std::string TargetSetter::describe_projectablity() const
 {
-    change_panel_xy(*this->player_ptr, this->pos_target);
+    change_panel_xy(this->player, this->pos_target);
     if ((this->mode & TARGET_LOOK) == 0) {
-        print_path(*this->player_ptr, this->pos_target.y, this->pos_target.x);
+        print_path(this->player, this->pos_target.y, this->pos_target.x);
     }
 
-    const auto &floor = *this->player_ptr->current_floor_ptr;
+    const auto &floor = *this->player.current_floor_ptr;
     std::string info;
     const auto &grid = floor.get_grid(this->pos_target);
-    if (target_able(*this->player_ptr, grid.m_idx)) {
+    if (target_able(this->player, grid.m_idx)) {
         info = _("q止 t決 p自 o現 +次 -前", "q,t,p,o,+,-,<dir>");
     } else {
         info = _("q止 p自 o現 +次 -前", "q,p,o,+,-,<dir>");
@@ -206,10 +206,10 @@ std::string TargetSetter::describe_projectablity() const
         return info;
     }
 
-    const auto p_pos = this->player_ptr->get_position();
+    const auto p_pos = this->player.get_position();
     const auto cheatinfo = format(" X:%d Y:%d LOS:%d LOP:%d",
         this->pos_target.x, this->pos_target.y,
-        los(*this->player_ptr->current_floor_ptr, p_pos, this->pos_target),
+        los(*this->player.current_floor_ptr, p_pos, this->pos_target),
         projectable(floor, p_pos, this->pos_target));
     return info.append(cheatinfo);
 }
@@ -218,7 +218,7 @@ char TargetSetter::examine_target_grid(std::string_view info, tl::optional<targe
 {
     const auto target_mode = append_mode ? i2enum<target_type>(this->mode | *append_mode) : this->mode;
     while (true) {
-        const auto query = examine_grid(*this->player_ptr, this->pos_target.y, this->pos_target.x, target_mode, info.data());
+        const auto query = examine_grid(this->player, this->pos_target.y, this->pos_target.x, target_mode, info.data());
         if (query != '\0') {
             return (use_menu && (query == '\r')) ? 't' : query;
         }
@@ -258,14 +258,14 @@ Direction TargetSetter::switch_target_input()
     case '.':
     case '5':
     case '0': {
-        const auto &grid = this->player_ptr->current_floor_ptr->get_grid(this->pos_target);
-        if (!target_able(*this->player_ptr, grid.m_idx)) {
+        const auto &grid = this->player.current_floor_ptr->get_grid(this->pos_target);
+        if (!target_able(this->player, grid.m_idx)) {
             bell();
             return Direction::none();
         }
 
-        health_track(*this->player_ptr, grid.m_idx);
-        this->target = Target::create_monster_target(*this->player_ptr, grid.m_idx);
+        health_track(this->player, grid.m_idx);
+        this->target = Target::create_monster_target(this->player, grid.m_idx);
         this->done = true;
         return Direction::none();
     }
@@ -278,14 +278,14 @@ Direction TargetSetter::switch_target_input()
         this->change_interest_index(-1);
         return Direction::none();
     case 'p': {
-        verify_panel(*this->player_ptr);
+        verify_panel(this->player);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
         rfu.set_flag(MainWindowRedrawingFlag::MAP);
         rfu.set_flag(SubWindowRedrawingFlag::OVERHEAD);
-        handle_stuff(*this->player_ptr);
-        this->pos_interests = target_set_prepare(*this->player_ptr, this->mode);
-        this->pos_target = this->player_ptr->get_position();
+        handle_stuff(this->player);
+        this->pos_interests = target_set_prepare(this->player, this->mode);
+        this->pos_target = this->player.get_position();
     }
         [[fallthrough]];
     case 'o':
@@ -294,7 +294,7 @@ Direction TargetSetter::switch_target_input()
     case 'm':
         return Direction::none();
     case 'g':
-        this->done = set_travel_goal(*this->player_ptr, this->pos_target);
+        this->done = set_travel_goal(this->player, this->pos_target);
         return Direction::none();
     default: {
         const char queried_command = rogue_like_commands ? 'x' : 'l';
@@ -326,7 +326,7 @@ tl::optional<int> TargetSetter::check_panel_changed(const Direction &dir)
     const auto pos = is_point_interest ? this->pos_interests[*this->interest_index] : this->pos_target;
 
     // 新たな描画範囲を用いて "interesting" 座標リストを更新。
-    this->pos_interests = target_set_prepare(*this->player_ptr, this->mode);
+    this->pos_interests = target_set_prepare(this->player, this->mode);
 
     // 新たな "interesting" 座標一覧からターゲットを探す。
     return pick_nearest_interest_target(pos, dir);
@@ -340,7 +340,7 @@ tl::optional<int> TargetSetter::check_panel_changed(const Direction &dir)
 tl::optional<int> TargetSetter::sweep_targets(const Direction &dir, int panel_row_min_initial, int panel_col_min_initial)
 {
     auto [dy, dx] = dir.vec();
-    while (change_panel(*this->player_ptr, dy, dx)) {
+    while (change_panel(this->player, dy, dx)) {
         // カーソル移動に伴い、必要なだけ描画範囲を更新。
         // "interesting" 座標リストおよび現在のターゲットも更新。
         const auto target_index = this->check_panel_changed(dir);
@@ -357,9 +357,9 @@ tl::optional<int> TargetSetter::sweep_targets(const Direction &dir, int panel_ro
     rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     rfu.set_flag(SubWindowRedrawingFlag::OVERHEAD);
-    handle_stuff(*this->player_ptr);
+    handle_stuff(this->player);
 
-    this->pos_interests = target_set_prepare(*this->player_ptr, this->mode);
+    this->pos_interests = target_set_prepare(this->player, this->mode);
 
     auto &[y, x] = this->pos_target;
     x += dx;
@@ -374,12 +374,12 @@ tl::optional<int> TargetSetter::sweep_targets(const Direction &dir, int panel_ro
     }
 
     if ((y >= panel_row_min + hgt) || (y < panel_row_min) || (x >= panel_col_min + wid) || (x < panel_col_min)) {
-        if (change_panel(*this->player_ptr, dy, dx)) {
-            this->pos_interests = target_set_prepare(*this->player_ptr, this->mode);
+        if (change_panel(this->player, dy, dx)) {
+            this->pos_interests = target_set_prepare(this->player, this->mode);
         }
     }
 
-    const auto &floor = *this->player_ptr->current_floor_ptr;
+    const auto &floor = *this->player.current_floor_ptr;
     x = std::clamp(x, 1, floor.width - 2);
     y = std::clamp(y, 1, floor.height - 2);
     return tl::nullopt;
@@ -393,7 +393,7 @@ bool TargetSetter::set_target_grid()
 
     this->pos_target = this->pos_interests[*this->interest_index];
 
-    fix_floor_item_list(*this->player_ptr, this->pos_target);
+    fix_floor_item_list(this->player, this->pos_target);
 
     const auto dir = this->switch_target_input();
     if (!dir) {
@@ -414,10 +414,10 @@ std::string TargetSetter::describe_grid_wizard() const
         return "";
     }
 
-    const auto &floor = *this->player_ptr->current_floor_ptr;
+    const auto &floor = *this->player.current_floor_ptr;
     const auto &grid = floor.get_grid(this->pos_target);
     constexpr auto fmt = " X:%d Y:%d LOS:%d LOP:%d SPECIAL:%d";
-    const auto p_pos = this->player_ptr->get_position();
+    const auto p_pos = this->player.get_position();
     const auto is_los = los(floor, p_pos, this->pos_target);
     const auto is_projectable = projectable(floor, p_pos, this->pos_target);
     const auto cheatinfo = format(fmt, this->pos_target.x, this->pos_target.y, is_los, is_projectable, grid.special);
@@ -446,18 +446,18 @@ tl::optional<std::pair<Direction, bool>> TargetSetter::switch_next_grid_command(
     case '.':
     case '5':
     case '0':
-        this->target = Target::create_grid_target(*this->player_ptr, this->pos_target);
+        this->target = Target::create_grid_target(this->player, this->pos_target);
         this->done = true;
         return tl::nullopt;
     case 'p': {
-        verify_panel(*this->player_ptr);
+        verify_panel(this->player);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
         rfu.set_flag(MainWindowRedrawingFlag::MAP);
         rfu.set_flag(SubWindowRedrawingFlag::OVERHEAD);
-        handle_stuff(*this->player_ptr);
-        this->pos_interests = target_set_prepare(*this->player_ptr, this->mode);
-        this->pos_target = this->player_ptr->get_position();
+        handle_stuff(this->player);
+        this->pos_interests = target_set_prepare(this->player, this->mode);
+        this->pos_target = this->player.get_position();
         return tl::nullopt;
     }
     case 'o':
@@ -483,7 +483,7 @@ tl::optional<std::pair<Direction, bool>> TargetSetter::switch_next_grid_command(
         return tl::nullopt;
     }
     case 'g':
-        this->done = set_travel_goal(*this->player_ptr, this->pos_target);
+        this->done = set_travel_goal(this->player, this->pos_target);
         return tl::nullopt;
     default:
         const auto dir = get_keymap_dir(query);
@@ -518,11 +518,11 @@ void TargetSetter::decide_change_panel(const Direction &dir, bool move_fast)
     should_change_panel |= y < panel_row_min;
     should_change_panel |= x >= panel_col_min + wid;
     should_change_panel |= x < panel_col_min;
-    if (should_change_panel && change_panel(*this->player_ptr, dy, dx)) {
-        this->pos_interests = target_set_prepare(*this->player_ptr, this->mode);
+    if (should_change_panel && change_panel(this->player, dy, dx)) {
+        this->pos_interests = target_set_prepare(this->player, this->mode);
     }
 
-    const auto &floor = *this->player_ptr->current_floor_ptr;
+    const auto &floor = *this->player.current_floor_ptr;
     x = std::clamp(x, 1, floor.width - 2);
     y = std::clamp(y, 1, floor.height - 2);
 }
@@ -535,10 +535,10 @@ void TargetSetter::sweep_target_grids()
         }
 
         if ((this->mode & TARGET_LOOK) == 0) {
-            print_path(*this->player_ptr, this->pos_target.y, this->pos_target.x);
+            print_path(this->player, this->pos_target.y, this->pos_target.x);
         }
 
-        fix_floor_item_list(*this->player_ptr, this->pos_target);
+        fix_floor_item_list(this->player, this->pos_target);
 
         if (auto dir_and_velocity = this->switch_next_grid_command(); dir_and_velocity) {
             const auto &[dir, move_fast] = *dir_and_velocity;


### PR DESCRIPTION
- io-dump/player-status-dump-json.cpp: 7つのstatic内部関数の引数を PlayerType * → PlayerType & に変換、dump_player_status_json() 内の ローカル変数も auto * → auto & に変更
- target/target-setter.cpp: TargetSetter のメンバ PlayerType *player_ptr を PlayerType &player に変換、コンストラクタ初期化子・全アクセス箇所を更新

これにより Phase 1 の PlayerType * 残存箇所をすべて解消。