### PR TITLE
refactor: get_ac() を CreatureEntity の純粋仮想メソッドとして追加（Phase 5）

### DIFF
--- a/src/combat/attack-accuracy.cpp
+++ b/src/combat/attack-accuracy.cpp
@@ -79,7 +79,7 @@ bool check_hit_from_monster_to_player(CreatureEntity &creature, int power, DEPTH
     }
     int i = (power + (level * 3));
 
-    int ac = creature.ac + creature.to_a;
+    int ac = creature.get_ac();
     if (creature.special_attack & ATTACK_SUIKEN) {
         ac += (creature.level * 2);
     }

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -172,7 +172,7 @@ static int check_hit_from_monster_to_player(CreatureEntity &creature, int power)
     }
 
     /* Total armor */
-    ac = creature.ac + creature.to_a;
+    ac = creature.get_ac();
 
     /* Power competes against Armor */
     if (randint1(power) > ((ac * 3) / 4)) {

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -169,7 +169,7 @@ bool MonsterAttackPlayer::process_monster_blows()
         }
 
         // フレーバーの打撃は必中扱い。それ以外は通常の命中判定を行う。
-        this->ac = player.ac + player.to_a;
+        this->ac = player.get_ac();
         bool hit;
         if (this->effect == RaceBlowEffectType::FLAVOR) {
             hit = true;

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -268,7 +268,7 @@ static int blow_damcalc(const MonsterEntity &monster, CreatureEntity &creature, 
         return dam;
     }
 
-    ARMOUR_CLASS ac = creature.ac + creature.to_a;
+    ARMOUR_CLASS ac = creature.get_ac();
     bool check_wraith_form = true;
     switch (blow.effect) {
     case RaceBlowEffectType::SUPERHURT: {

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -259,6 +259,12 @@ public:
     virtual bool is_player() const = 0;
 
     /*!
+     * @brief クリーチャーの実効ACを取得
+     * @return 実効AC値（プレイヤーは ac + to_a、モンスターは総合AC）
+     */
+    virtual int get_ac() const = 0;
+
+    /*!
      * @brief クリーチャーの時限効果の残りターン数を取得
      * @param effect 取得する時限効果の種別
      * @return 残りターン数（0なら効果なし）

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -116,7 +116,7 @@ public:
     Pos2D get_target_position() const;
     bool can_ring_boss_call_nazgul() const;
     std::string build_looking_description(bool needs_attitude) const;
-    int get_ac() const;
+    int get_ac() const override;
 
     void set_individual_speed(bool force_fixed_speed);
     void set_position(const Pos2D &pos);

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -165,6 +165,11 @@ bool PlayerType::is_player() const
     return true;
 }
 
+int PlayerType::get_ac() const
+{
+    return this->ac + this->to_a;
+}
+
 short PlayerType::get_timed_effect(CreatureTimedEffect effect) const
 {
     const auto &eff = *this->effects();

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -63,6 +63,8 @@ public:
 
     bool is_player() const override;
 
+    int get_ac() const override;
+
     short get_timed_effect(CreatureTimedEffect effect) const override;
 
     bool is_confused() const override;


### PR DESCRIPTION
- CreatureEntity に virtual int get_ac() const = 0 を追加
- PlayerType::get_ac() を ac + to_a として実装
- MonsterEntity::get_ac() に override キーワードを追加
- 呼び出し側で creature.ac + creature.to_a を creature.get_ac() に統一 (attack-accuracy.cpp, trap.cpp, monster-attack-player.cpp, warning.cpp)