### PR TITLE
refactor: MonsterEntity::current_floor_ptr を CreatureEntity に統合（Phase 6）

### DIFF
--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -32,7 +32,6 @@ MonsterEntity::MonsterEntity()
     this->r_idx = MonraceId::PLAYER; // デフォルトはプレイヤー（無効な状態）
     this->ap_r_idx = MonraceId::PLAYER;
     this->patron = 0; // パトロンなし
-    this->current_floor_ptr = nullptr;
 }
 
 /*!
@@ -902,11 +901,6 @@ int MonsterEntity::get_current_hp() const
 int MonsterEntity::get_max_hp() const
 {
     return this->maxhp;
-}
-
-FloorType *MonsterEntity::get_floor() const
-{
-    return this->current_floor_ptr;
 }
 
 int MonsterEntity::get_level() const

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -36,8 +36,6 @@ public:
     MonsterEntity(const MonsterEntity &) = default;
     MonsterEntity &operator=(const MonsterEntity &) = default;
 
-    FloorType *current_floor_ptr{}; /*!< 所在フロアID（現状はFloorType構造体によるオブジェクトは1つしかないためソースコード設計上の意義以外はない）*/
-
 /* Sub-alignment flags for neutral monsters */
 #define SUB_ALIGN_NEUTRAL 0x0000 /*!< モンスターのサブアライメント:中立 */
 #define SUB_ALIGN_EVIL 0x0001 /*!< モンスターのサブアライメント:善 */
@@ -137,7 +135,6 @@ public:
 
     bool is_valid() const override;
     bool is_dead() const override;
-    FloorType *get_floor() const override;
 
     int get_level() const override;
     bool is_player() const override;


### PR DESCRIPTION
- MonsterEntity が持つ独自の current_floor_ptr フィールドを削除 （CreatureEntity::current_floor_ptr をシャドウしていた冗長フィールド）
- MonsterEntity::get_floor() override を削除 （基底クラス CreatureEntity::get_floor() のデフォルト実装で代替）
- コンストラクタ内の current_floor_ptr = nullptr 初期化を削除 （基底クラスのフィールド初期化子 {} で代替）

これにより floor ポインタは CreatureEntity に一元化され、
monster.current_floor_ptr は基底クラスのフィールドを直接参照する。