### PR TITLE
refactor: wizard-spells.h の関数ポインタ型を CreatureEntity& に変更（Issue #8113）

### DIFF
--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -39,7 +39,6 @@
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
 #include "system/monster-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/grid-selector.h"
 #include "target/target-checker.h"
@@ -58,7 +57,7 @@ namespace {
 const std::vector<debug_spell_command> debug_spell_commands_list = {
     // { 2, "vanish dungeon", { .spell2 = { vanish_dungeon } } },
     // { 2, "unique detection", { .spell2 = { activate_unique_detection } } },
-    // { 3, "true healing", { .spell3 = { true_healing } } },
+    { 3, "true healing", { .spell3 = { true_healing } } },
     // TODO:    { 2, "drop weapons", { .spell2 = { drop_weapons } } },
     { 2, "alchemy", { .spell2 = { alchemy } } },
     { 4, "ty curse", { .spell4 = { activate_ty_curse } } },
@@ -153,9 +152,6 @@ void wiz_summon_specific_monster_common(CreatureEntity &creature, MonraceId monr
  */
 void wiz_debug_spell(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
-
     const auto spell = input_string("SPELL: ", 50);
     if (!spell.has_value()) {
         return;
@@ -176,7 +172,7 @@ void wiz_debug_spell(CreatureEntity &creature)
                 return;
             }
 
-            (d.command_function.spell3.spell_function)(player_ptr, *power);
+            (d.command_function.spell3.spell_function)(creature, *power);
             return;
         }
         case 4: {
@@ -185,7 +181,7 @@ void wiz_debug_spell(CreatureEntity &creature)
             return;
         }
         case 5:
-            (d.command_function.spell5.spell_function)(player_ptr);
+            (d.command_function.spell5.spell_function)(creature);
             return;
         case 6:
             (d.command_function.spell6.spell_function)(creature);

--- a/src/wizard/wizard-spells.h
+++ b/src/wizard/wizard-spells.h
@@ -7,10 +7,9 @@ enum class MonraceId : int16_t;
 
 class CreatureEntity;
 class FloorType;
-class PlayerType;
 typedef union spell_functions {
     struct debug_spell_type1 {
-        bool (*spell_function)(PlayerType *, FloorType *);
+        bool (*spell_function)(CreatureEntity &, FloorType *);
     } spell1;
 
     struct debug_spell_type2 {
@@ -18,7 +17,7 @@ typedef union spell_functions {
     } spell2;
 
     struct debug_spell_type3 {
-        bool (*spell_function)(PlayerType *, int);
+        bool (*spell_function)(CreatureEntity &, int);
     } spell3;
 
     struct debug_spell_type4 { // 実質 ty curse
@@ -26,7 +25,7 @@ typedef union spell_functions {
     } spell4;
 
     struct debug_spell_type5 {
-        void (*spell_function)(PlayerType *);
+        void (*spell_function)(CreatureEntity &);
     } spell5;
 
     struct debug_spell_type6 {


### PR DESCRIPTION
- spell1/spell3/spell5 の PlayerType* 引数を CreatureEntity& に変更
- wiz_debug_spell から不要な player_ptr ローカル変数を除去
- true_healing エントリのコメントアウトを解除（spell3 として有効化）
- wizard-spells.cpp から不要な #include "system/player-type-definition.h" を削除