### PR TITLE
refactor: Phase 7 — cdis・target_y/target_x を CreatureEntity に汎用化

### DIFF
--- a/src/effect/effect-monster-util.cpp
+++ b/src/effect/effect-monster-util.cpp
@@ -47,7 +47,7 @@ EffectMonster::EffectMonster(CreatureEntity &creature, MONSTER_IDX src_idx, POSI
     this->seen = this->m_ptr->ml;
     this->seen_msg = is_seen(creature, *this->m_ptr);
     this->slept = this->m_ptr->is_asleep();
-    this->known = (this->m_ptr->cdis <= MAX_PLAYER_SIGHT) || AngbandSystem::get_instance().is_phase_out();
+    this->known = (Grid::calc_distance(creature.get_position(), this->m_ptr->get_position()) <= MAX_PLAYER_SIGHT) || AngbandSystem::get_instance().is_phase_out();
     this->note_dies = this->m_ptr->get_died_message();
     this->caster_lev = (this->is_monster() && (this->m_caster_ptr != nullptr)) ? this->m_caster_ptr->get_monrace().level : (creature.level * 2);
 }

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -132,7 +132,7 @@ static MonraceDefinition &set_pet_params(CreatureEntity &creature, const int cur
     monster.ml = true;
     monster.mtimed[MonsterTimedEffect::SLEEP] = 0;
     monster.hold_o_idx_list.clear();
-    monster.target_y = 0;
+    monster.reset_target();
     auto &r_ref = monster.get_real_monrace();
     if (!ironman_nightmare) {
         monster.mflag.set(MonsterTemporaryFlagType::PREVENT_MAGIC);

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -877,7 +877,7 @@ bool change_wild_mode(CreatureEntity &creature, bool encount)
             has_pet = true;
         }
 
-        if (monster.is_asleep() || (monster.cdis > MAX_PLAYER_SIGHT) || !monster.is_hostile()) {
+        if (monster.is_asleep() || (Grid::calc_distance(creature.get_position(), monster.get_position()) > MAX_PLAYER_SIGHT) || !monster.is_hostile()) {
             continue;
         }
 

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -469,10 +469,8 @@ void hit_trap(CreatureEntity &creature, bool break_trap)
                 if (evil_idx && good_idx) {
                     auto &monster_evil = floor.m_list[evil_idx];
                     auto &monster_good = floor.m_list[good_idx];
-                    monster_evil.target_y = monster_good.y;
-                    monster_evil.target_x = monster_good.x;
-                    monster_good.target_y = monster_evil.y;
-                    monster_good.target_x = monster_evil.x;
+                    monster_evil.set_target(monster_good.get_position());
+                    monster_good.set_target(monster_evil.get_position());
                 }
             }
         }

--- a/src/load/old/monster-loader-savefile50.cpp
+++ b/src/load/old/monster-loader-savefile50.cpp
@@ -62,8 +62,8 @@ void MonsterLoader50::rd_monster(MonsterEntity &monster)
     monster.mtimed[MonsterTimedEffect::STUN] = any_bits(flags, SaveDataMonsterFlagType::STUNNED) ? rd_byte() : 0;
     monster.mtimed[MonsterTimedEffect::CONFUSION] = any_bits(flags, SaveDataMonsterFlagType::CONFUSED) ? rd_byte() : 0;
     monster.mtimed[MonsterTimedEffect::FEAR] = any_bits(flags, SaveDataMonsterFlagType::MONFEAR) ? rd_byte() : 0;
-    monster.target_y = any_bits(flags, SaveDataMonsterFlagType::TARGET_Y) ? rd_s16b() : 0;
-    monster.target_x = any_bits(flags, SaveDataMonsterFlagType::TARGET_X) ? rd_s16b() : 0;
+    monster.target.y = any_bits(flags, SaveDataMonsterFlagType::TARGET_Y) ? rd_s16b() : 0;
+    monster.target.x = any_bits(flags, SaveDataMonsterFlagType::TARGET_X) ? rd_s16b() : 0;
     monster.mtimed[MonsterTimedEffect::INVULNERABILITY] = any_bits(flags, SaveDataMonsterFlagType::INVULNER) ? rd_byte() : 0;
     monster.mflag.clear();
     monster.mflag2.clear();

--- a/src/melee/melee-postprocess.cpp
+++ b/src/melee/melee-postprocess.cpp
@@ -34,6 +34,7 @@
 #include "player/player-personality-types.h"
 #include "system/angband-system.h"
 #include "system/floor/floor-info.h"
+#include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
@@ -69,7 +70,7 @@ mam_pp_type::mam_pp_type(CreatureEntity &creature, MONSTER_IDX m_idx, int dam, b
     , src_idx(src_idx)
 {
     this->seen = is_seen(creature, *this->m_ptr);
-    this->known = this->m_ptr->cdis <= MAX_PLAYER_SIGHT;
+    this->known = Grid::calc_distance(creature.get_position(), this->m_ptr->get_position()) <= MAX_PLAYER_SIGHT;
     this->m_name = monster_desc(creature, *this->m_ptr, 0);
 }
 
@@ -298,7 +299,7 @@ void mon_take_hit_mon(CreatureEntity &creature, MONSTER_IDX m_idx, int dam, bool
     make_monster_fear(creature, mam_pp_ptr);
     if ((dam > 0) && !monster.is_pet() && !monster.is_friendly() && (mam_pp_ptr->src_idx != m_idx)) {
         const auto &monster_src = floor.m_list[src_idx];
-        if (monster_src.is_pet() && !creature.is_located_at({ monster.target_y, monster.target_x })) {
+        if (monster_src.is_pet() && !creature.is_located_at(monster.get_target_position())) {
             monster.set_target(monster_src.get_position());
         }
     }

--- a/src/melee/melee-spell-flags-checker.cpp
+++ b/src/melee/melee-spell-flags-checker.cpp
@@ -43,12 +43,13 @@ static void decide_melee_spell_target(CreatureEntity &creature, melee_spell_type
 static void decide_indirection_melee_spell(CreatureEntity &creature, melee_spell_type *ms_ptr)
 {
     const auto &monster_from = *ms_ptr->m_ptr;
-    if ((ms_ptr->target_idx != 0) || (monster_from.target_y == 0)) {
+    const auto target_pos = monster_from.get_target_position();
+    if ((ms_ptr->target_idx != 0) || (target_pos.y == 0)) {
         return;
     }
 
     const auto &floor = *creature.current_floor_ptr;
-    ms_ptr->target_idx = floor.grid_array[monster_from.target_y][monster_from.target_x].m_idx;
+    ms_ptr->target_idx = floor.get_grid(target_pos).m_idx;
     if (ms_ptr->target_idx == 0) {
         return;
     }

--- a/src/melee/melee-util.cpp
+++ b/src/melee/melee-util.cpp
@@ -4,6 +4,7 @@
 #include "melee/melee-switcher.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
+#include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
@@ -39,7 +40,8 @@ mam_type *initialize_mam_type(CreatureEntity &creature, mam_type *mam_ptr, MONST
     mam_ptr->blinked = false;
     mam_ptr->power = 0;
     mam_ptr->obvious = false;
-    mam_ptr->known = (mam_ptr->m_ptr->cdis <= MAX_PLAYER_SIGHT) || (mam_ptr->t_ptr->cdis <= MAX_PLAYER_SIGHT);
+    const auto p_pos = creature.get_position();
+    mam_ptr->known = (Grid::calc_distance(p_pos, mam_ptr->m_ptr->get_position()) <= MAX_PLAYER_SIGHT) || (Grid::calc_distance(p_pos, mam_ptr->t_ptr->get_position()) <= MAX_PLAYER_SIGHT);
     mam_ptr->fear = false;
     mam_ptr->dead = false;
     return mam_ptr;

--- a/src/monster-floor/monster-direction.cpp
+++ b/src/monster-floor/monster-direction.cpp
@@ -14,6 +14,7 @@
 #include "spell/range-calc.h"
 #include "system/angband-system.h"
 #include "system/floor/floor-info.h"
+#include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monster-entity.h"
 #include "target/projection-path-calculator.h"
@@ -32,16 +33,19 @@ static bool decide_pet_approch_direction(CreatureEntity &creature, const Monster
         return false;
     }
 
+    const auto p_pos = creature.get_position();
+    const auto cdis_from = Grid::calc_distance(p_pos, monster_from.get_position());
+    const auto cdis_to = Grid::calc_distance(p_pos, monster_to.get_position());
     if (creature.pet_follow_distance < 0) {
-        if (monster_to.cdis <= (0 - creature.pet_follow_distance)) {
+        if (cdis_to <= (0 - creature.pet_follow_distance)) {
             return true;
         }
-    } else if ((monster_from.cdis < monster_to.cdis) && (monster_to.cdis > creature.pet_follow_distance)) {
+    } else if ((cdis_from < cdis_to) && (cdis_to > creature.pet_follow_distance)) {
         return true;
     }
 
     const auto &monrace = monster_from.get_monrace();
-    return monrace.aaf < monster_to.cdis;
+    return monrace.aaf < cdis_to;
 }
 
 /*!
@@ -196,10 +200,11 @@ static tl::optional<MonsterMovementDirectionList> decide_pet_movement_direction(
         return mmdl;
     }
 
+    const auto cdis = Grid::calc_distance(creature.get_position(), monster.get_position());
     auto &pet_follow_distance = creature.pet_follow_distance;
-    const auto avoid = ((pet_follow_distance < 0) && (monster.cdis <= (0 - pet_follow_distance)));
-    const auto lonely = (!avoid && (monster.cdis > pet_follow_distance));
-    const auto distant = (monster.cdis > PET_SEEK_DIST);
+    const auto avoid = ((pet_follow_distance < 0) && (cdis <= (0 - pet_follow_distance)));
+    const auto lonely = (!avoid && (cdis > pet_follow_distance));
+    const auto distant = (cdis > PET_SEEK_DIST);
     if (!avoid && !lonely && !distant) {
         return MonsterMovementDirectionList::random_move(m_idx);
     }
@@ -235,7 +240,7 @@ tl::optional<MonsterMovementDirectionList> decide_monster_movement_direction(Cre
         return MonsterMovementDirectionList::random_move(m_idx);
     }
 
-    if (monrace.behavior_flags.has(MonsterBehaviorType::NEVER_MOVE) && (monster.cdis > 1)) {
+    if (monrace.behavior_flags.has(MonsterBehaviorType::NEVER_MOVE) && (Grid::calc_distance(creature.get_position(), monster.get_position()) > 1)) {
         return MonsterMovementDirectionList::random_move(m_idx);
     }
 

--- a/src/monster-floor/monster-lite.cpp
+++ b/src/monster-floor/monster-lite.cpp
@@ -160,7 +160,7 @@ void update_mon_lite(CreatureEntity &creature)
         for (auto i = 1; i < floor.m_max; i++) {
             const auto &monster = floor.m_list[i];
             const auto &monrace = monster.get_monrace();
-            if (!monster.is_valid() || (monster.cdis > dis_lim)) {
+            if (!monster.is_valid() || (Grid::calc_distance(p_pos, monster.get_position()) > dis_lim)) {
                 continue;
             }
 

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -572,22 +572,23 @@ void process_sound(CreatureEntity &creature, MONSTER_IDX m_idx)
         return;
     }
     const auto m_name = std::string(_("それ", "It"));
+    const auto cdis = Grid::calc_distance(creature.get_position(), monster.get_position());
 
-    if (monster.cdis <= MAX_PLAYER_SIGHT / 2) {
+    if (cdis <= MAX_PLAYER_SIGHT / 2) {
         const auto message = monrace.get_message(m_name, MonsterMessageType::WALK_CLOSERANGE);
         if (message) {
             show_sound_message(creature, *message);
         }
         return;
     }
-    if (monster.cdis <= MAX_PLAYER_SIGHT) {
+    if (cdis <= MAX_PLAYER_SIGHT) {
         const auto message = monrace.get_message(m_name, MonsterMessageType::WALK_MIDDLERANGE);
         if (message) {
             show_sound_message(creature, *message);
         }
         return;
     }
-    if (monster.cdis <= MAX_PLAYER_SIGHT * 2) {
+    if (cdis <= MAX_PLAYER_SIGHT * 2) {
         const auto message = monrace.get_message(m_name, MonsterMessageType::WALK_LONGRANGE);
         if (message) {
             show_sound_message(creature, *message);
@@ -615,7 +616,7 @@ void process_speak(CreatureEntity &creature, MONSTER_IDX m_idx, POSITION oy, POS
     const auto &monster = floor.m_list[m_idx];
     const auto &monrace = monster.get_monrace();
     constexpr auto chance_speak = 8;
-    auto vociferous = monrace.r_misc_flags.has(MonsterMiscType::VOCIFEROUS) && (monster.cdis <= MAX_PLAYER_SIGHT * 2) && one_in_(chance_speak / 3 + 1);
+    auto vociferous = monrace.r_misc_flags.has(MonsterMiscType::VOCIFEROUS) && (Grid::calc_distance(creature.get_position(), monster.get_position()) <= MAX_PLAYER_SIGHT * 2) && one_in_(chance_speak / 3 + 1);
     const auto p_pos = creature.get_position();
     const auto can_speak = monster.get_appearance_monrace().speak_flags.any();
     if ((!vociferous) && (!can_speak || !aware || !floor.has_los_at({ oy, ox }) || !projectable(floor, pos, p_pos))) {

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -41,11 +41,12 @@ bool mon_will_run(CreatureEntity &creature, MONSTER_IDX m_idx)
         return true;
     }
 
+    const auto cdis = Grid::calc_distance(creature.get_position(), monster.get_position());
     if (monster.is_pet()) {
-        return (creature.pet_follow_distance < 0) && (monster.cdis <= (0 - creature.pet_follow_distance));
+        return (creature.pet_follow_distance < 0) && (cdis <= (0 - creature.pet_follow_distance));
     }
 
-    if (monster.cdis > MAX_PLAYER_SIGHT + 5) {
+    if (cdis > MAX_PLAYER_SIGHT + 5) {
         return false;
     }
 
@@ -53,7 +54,7 @@ bool mon_will_run(CreatureEntity &creature, MONSTER_IDX m_idx)
         return true;
     }
 
-    if (monster.cdis <= 5) {
+    if (cdis <= 5) {
         return false;
     }
 
@@ -477,7 +478,7 @@ public:
 
         std::vector<std::unique_ptr<const MonsterMoveGridDecider>> deciders;
 
-        if (!will_run && monster.target_y) {
+        if (!will_run && monster.get_target_position().y) {
             deciders.push_back(std::make_unique<SpecificTargetMoveGridDecider>(creature_ptr, m_idx));
         }
 

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -379,7 +379,6 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
         m_ptr->mtimed[mte] = 0;
     }
 
-    m_ptr->cdis = 0;
     m_ptr->reset_target();
     m_ptr->name.clear();
     m_ptr->exp = 0;

--- a/src/monster/monster-compaction.cpp
+++ b/src/monster/monster-compaction.cpp
@@ -120,7 +120,7 @@ void compact_monsters(CreatureEntity &creature, int size)
             if (monster.is_riding()) {
                 continue;
             }
-            if ((cur_dis > 0) && (monster.cdis < cur_dis)) {
+            if ((cur_dis > 0) && (Grid::calc_distance(creature.get_position(), monster.get_position()) < cur_dis)) {
                 continue;
             }
 

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -281,7 +281,7 @@ void process_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
      *  Forward movements failed, but now received LOS attack!
      *  Try to flow by smell.
      */
-    if (player.no_flowed && count > 2 && monster.target_y) {
+    if (player.no_flowed && count > 2 && monster.get_target_position().y) {
         monster.mflag2.reset(MonsterConstantFlagType::NOFLOW);
     }
 
@@ -762,7 +762,7 @@ bool cast_spell(CreatureEntity &creature, MONSTER_IDX m_idx, bool aware)
     }
 
     auto counter_attack = false;
-    if (monster_from.target_y) {
+    if (monster_from.get_target_position().y) {
         const auto pos_to = monster_from.get_target_position();
         const auto t_m_idx = floor.get_grid(pos_to).m_idx;
         const auto &monster_to = floor.m_list[t_m_idx];
@@ -912,7 +912,7 @@ void sweep_monster_process(CreatureEntity &creature)
             continue;
         }
 
-        if ((monster.cdis >= MAX_MONSTER_SENSING) || !decide_process_continue(creature, monster)) {
+        if ((Grid::calc_distance(creature.get_position(), monster.get_position()) >= MAX_MONSTER_SENSING) || !decide_process_continue(creature, monster)) {
             continue;
         }
 
@@ -1006,17 +1006,18 @@ bool decide_process_continue(CreatureEntity &creature, MonsterEntity &monster)
         monster.mflag2.reset(MonsterConstantFlagType::NOFLOW);
     }
 
-    if (monster.cdis <= (monster.is_pet() ? (monrace.aaf > MAX_PLAYER_SIGHT ? MAX_PLAYER_SIGHT : monrace.aaf) : monrace.aaf)) {
+    const auto cdis = Grid::calc_distance(creature.get_position(), monster.get_position());
+    if (cdis <= (monster.is_pet() ? (monrace.aaf > MAX_PLAYER_SIGHT ? MAX_PLAYER_SIGHT : monrace.aaf) : monrace.aaf)) {
         return true;
     }
 
-    auto should_continue = (monster.cdis <= MAX_PLAYER_SIGHT) || AngbandSystem::get_instance().is_phase_out();
+    auto should_continue = (cdis <= MAX_PLAYER_SIGHT) || AngbandSystem::get_instance().is_phase_out();
     should_continue &= creature.current_floor_ptr->has_los_at({ monster.y, monster.x }) || has_aggravate(creature);
     if (should_continue) {
         return true;
     }
 
-    if (monster.target_y) {
+    if (monster.get_target_position().y) {
         return true;
     }
 
@@ -1035,7 +1036,7 @@ bool process_stalking(CreatureEntity &creature, MONSTER_IDX m_idx)
     }
 
     // モンスターからプレイヤーの距離が空いているなら何もしない
-    if (monster.cdis > STALKER_DISTANCE_THRESHOLD) {
+    if (Grid::calc_distance(creature.get_position(), monster.get_position()) > STALKER_DISTANCE_THRESHOLD) {
         return false;
     }
 

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -15,6 +15,7 @@
 #include "monster/monster-update.h"
 #include "system/angband-system.h"
 #include "system/floor/floor-info.h"
+#include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
 #include "system/monster-entity.h"
@@ -111,18 +112,19 @@ static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_
 {
     auto &floor = *creature.current_floor_ptr;
     const auto &monster = floor.m_list[m_idx];
+    const auto cdis = Grid::calc_distance(creature.get_position(), monster.get_position());
     switch (mte) {
     case MonsterTimedEffect::SLEEP: {
         auto &monrace = monster.get_monrace();
         auto is_wakeup = false;
-        if (monster.cdis < MAX_MONSTER_SENSING) {
+        if (cdis < MAX_MONSTER_SENSING) {
             /* Handle "sensing radius" */
-            if (monster.cdis <= (monster.is_pet() ? ((monrace.aaf > MAX_PLAYER_SIGHT) ? MAX_PLAYER_SIGHT : monrace.aaf) : monrace.aaf)) {
+            if (cdis <= (monster.is_pet() ? ((monrace.aaf > MAX_PLAYER_SIGHT) ? MAX_PLAYER_SIGHT : monrace.aaf) : monrace.aaf)) {
                 is_wakeup = true;
             }
 
             /* Handle "sight" and "aggravation" */
-            else if ((monster.cdis <= MAX_PLAYER_SIGHT) && floor.has_los_at({ monster.y, monster.x })) {
+            else if ((cdis <= MAX_PLAYER_SIGHT) && floor.has_los_at({ monster.y, monster.x })) {
                 is_wakeup = true;
             }
         }
@@ -145,7 +147,7 @@ static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_
 
         /* Hack -- amount of "waking" */
         /* Wake up faster near the player */
-        auto d = (monster.cdis < MAX_MONSTER_SENSING / 2) ? (MAX_MONSTER_SENSING / monster.cdis) : 1;
+        auto d = (cdis < MAX_MONSTER_SENSING / 2) ? (MAX_MONSTER_SENSING / cdis) : 1;
 
         /* Hack -- amount of "waking" is affected by speed of player */
         d = (d * speed_to_energy(creature.get_speed())) / 10;

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -196,10 +196,6 @@ static um_type *initialize_um_type(CreatureEntity &creature, um_type *um_ptr, MO
 
 static POSITION decide_updated_distance(CreatureEntity &creature, um_type *um_ptr)
 {
-    if (!um_ptr->full) {
-        return um_ptr->m_ptr->cdis;
-    }
-
     int dy = (creature.y > um_ptr->fy) ? (creature.y - um_ptr->fy) : (um_ptr->fy - creature.y);
     int dx = (creature.x > um_ptr->fx) ? (creature.x - um_ptr->fx) : (um_ptr->fx - creature.x);
     POSITION distance = (dy > dx) ? (dy + (dx >> 1)) : (dx + (dy >> 1));
@@ -211,7 +207,6 @@ static POSITION decide_updated_distance(CreatureEntity &creature, um_type *um_pt
         distance = 1;
     }
 
-    um_ptr->m_ptr->cdis = distance;
     return distance;
 }
 

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -28,6 +28,7 @@
 #include "system/dungeon/dungeon-definition.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "system/floor/floor-info.h"
+#include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monster-entity.h"
 #include "system/redrawing-flags-updater.h"
@@ -316,7 +317,7 @@ bool make_attack_spell(CreatureEntity &creature, MONSTER_IDX m_idx)
     const auto &m_ref = *msa_ptr->m_ptr;
     auto should_prevent = m_ref.mflag.has(MonsterTemporaryFlagType::PREVENT_MAGIC);
     should_prevent |= !m_ref.is_hostile();
-    should_prevent |= (m_ref.cdis > AngbandSystem::get_instance().get_max_range()) && !m_ref.target_y;
+    should_prevent |= (Grid::calc_distance(creature.get_position(), m_ref.get_position()) > AngbandSystem::get_instance().get_max_range()) && !m_ref.get_target_position().y;
     if (should_prevent) {
         return false;
     }

--- a/src/mspell/mspell-attack/mspell-ball.cpp
+++ b/src/mspell/mspell-attack/mspell-ball.cpp
@@ -39,7 +39,7 @@ static bool message_fire_ball(CreatureEntity &creature, MONSTER_IDX m_idx, MONST
 
 static bool message_water_ball(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto known = monster_near_player(*creature.current_floor_ptr, m_idx, t_idx);
+    auto known = monster_near_player(creature, m_idx, t_idx);
     auto see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
     auto mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     auto mon_to_player = (target_type == MONSTER_TO_PLAYER);

--- a/src/mspell/mspell-attack/mspell-breath.cpp
+++ b/src/mspell/mspell-attack/mspell-breath.cpp
@@ -51,7 +51,7 @@ static void message_breath(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_
     auto &floor = *creature.current_floor_ptr;
     const auto &monster = floor.m_list[m_idx];
     auto see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    auto known = monster_near_player(floor, m_idx, t_idx);
+    auto known = monster_near_player(creature, m_idx, t_idx);
     auto mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     auto mon_to_player = (target_type == MONSTER_TO_PLAYER);
     const auto m_name = monster_name(creature, m_idx);

--- a/src/mspell/mspell-lite.cpp
+++ b/src/mspell/mspell-lite.cpp
@@ -139,10 +139,11 @@ static void check_lite_area_by_mspell(CreatureEntity &creature, msa_type *msa_pt
 {
     const auto &system = AngbandSystem::get_instance();
     auto light_by_disintegration = msa_ptr->ability_flags.has(MonsterAbilityType::BR_DISI);
-    light_by_disintegration &= msa_ptr->m_ptr->cdis < system.get_max_range() / 2;
     const auto pos = msa_ptr->get_position();
     const auto p_pos = creature.get_position();
     const auto m_pos = msa_ptr->m_ptr->get_position();
+    const auto cdis = Grid::calc_distance(p_pos, m_pos);
+    light_by_disintegration &= cdis < system.get_max_range() / 2;
     const auto &floor = *creature.current_floor_ptr;
     light_by_disintegration &= in_disintegration_range(floor, m_pos, pos);
     light_by_disintegration &= one_in_(10) || (projectable(floor, pos, m_pos) && one_in_(2));
@@ -153,7 +154,7 @@ static void check_lite_area_by_mspell(CreatureEntity &creature, msa_type *msa_pt
     }
 
     auto light_by_lite = msa_ptr->ability_flags.has(MonsterAbilityType::BR_LITE);
-    light_by_lite &= msa_ptr->m_ptr->cdis < system.get_max_range() / 2;
+    light_by_lite &= cdis < system.get_max_range() / 2;
     light_by_lite &= los(floor, m_pos, pos);
     light_by_lite &= one_in_(5);
     if (light_by_lite) {
@@ -162,7 +163,7 @@ static void check_lite_area_by_mspell(CreatureEntity &creature, msa_type *msa_pt
         return;
     }
 
-    if (msa_ptr->ability_flags.has_not(MonsterAbilityType::BA_LITE) || (msa_ptr->m_ptr->cdis > system.get_max_range())) {
+    if (msa_ptr->ability_flags.has_not(MonsterAbilityType::BA_LITE) || (cdis > system.get_max_range())) {
         return;
     }
 
@@ -173,22 +174,23 @@ static void check_lite_area_by_mspell(CreatureEntity &creature, msa_type *msa_pt
     }
 }
 
-static void decide_lite_breath(msa_type *msa_ptr)
+static void decide_lite_breath(CreatureEntity &creature, msa_type *msa_ptr)
 {
     if (msa_ptr->success) {
         return;
     }
 
-    if (msa_ptr->m_ptr->target_y && msa_ptr->m_ptr->target_x) {
-        msa_ptr->y = msa_ptr->m_ptr->target_y;
-        msa_ptr->x = msa_ptr->m_ptr->target_x;
+    const auto target_pos = msa_ptr->m_ptr->get_target_position();
+    if (target_pos.y && target_pos.x) {
+        msa_ptr->y = target_pos.y;
+        msa_ptr->x = target_pos.x;
         msa_ptr->ability_flags &= RF_ABILITY_INDIRECT_MASK;
         msa_ptr->success = true;
     }
 
     auto should_set = msa_ptr->y_br_lite == 0;
     should_set |= msa_ptr->x_br_lite == 0;
-    should_set |= msa_ptr->m_ptr->cdis > AngbandSystem::get_instance().get_max_range() / 2;
+    should_set |= Grid::calc_distance(creature.get_position(), msa_ptr->m_ptr->get_position()) > AngbandSystem::get_instance().get_max_range() / 2;
     should_set |= !one_in_(5);
     if (should_set) {
         return;
@@ -223,7 +225,7 @@ bool decide_lite_projection(CreatureEntity &creature, msa_type *msa_ptr)
         }
     }
 
-    decide_lite_breath(msa_ptr);
+    decide_lite_breath(creature, msa_ptr);
     return msa_ptr->success;
 }
 

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -51,7 +51,7 @@ static MonsterSpellResult spell_RF6_SPECIAL_UNIFICATION(CreatureEntity &creature
     const auto &monster = floor.m_list[m_idx];
     auto dummy_y = monster.y;
     auto dummy_x = monster.x;
-    if (see_monster(creature, m_idx) && monster_near_player(floor, m_idx, 0)) {
+    if (see_monster(creature, m_idx) && monster_near_player(creature, m_idx, 0)) {
         disturb(creature, true, true);
     }
 
@@ -142,11 +142,10 @@ static MonsterSpellResult spell_RF6_SPECIAL_ROLENTO(CreatureEntity &creature, PO
     int count = 0, k;
     int num = 1 + randint1(3);
     BIT_FLAGS mode = 0L;
-    const auto &floor = *creature.current_floor_ptr;
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
     bool mon_to_mon = target_type == MONSTER_TO_MONSTER;
     bool mon_to_player = target_type == MONSTER_TO_PLAYER;
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何か大量に投げた。", "%s^ spreads something."),
         _("%s^は手榴弾をばらまいた。", "%s^ throws some hand grenades."), _("%s^は手榴弾をばらまいた。", "%s^ throws some hand grenades."));

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -94,7 +94,7 @@ void spell_badstatus_message_to_mons(CreatureEntity &creature, MONSTER_IDX m_idx
     auto &floor = *creature.current_floor_ptr;
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
     bool see_t = see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
     const auto m_name = monster_name(creature, m_idx);
     const auto t_name = monster_name(creature, t_idx);
 

--- a/src/mspell/mspell-summon.cpp
+++ b/src/mspell/mspell-summon.cpp
@@ -158,7 +158,7 @@ MonsterSpellResult spell_RF6_S_KIN(CreatureEntity &creature, POSITION y, POSITIO
     const auto m_poss = monster_desc(creature, monster, MD_PRON_VISIBLE | MD_POSSESSIVE);
 
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     summon_disturb(creature, target_type, known, see_either);
 
@@ -270,7 +270,7 @@ MonsterSpellResult spell_RF6_S_CYBER(CreatureEntity &creature, POSITION y, POSIT
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^がサイバーデーモンを召喚した！", "%s^ magically summons Cyberdemons!"),
         _("%s^がサイバーデーモンを召喚した！", "%s^ magically summons Cyberdemons!"));
@@ -289,7 +289,7 @@ MonsterSpellResult spell_RF6_S_CYBER(CreatureEntity &creature, POSITION y, POSIT
         msg_print(_("重厚な足音が近くで聞こえる。", "You hear heavy steps nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -317,7 +317,7 @@ MonsterSpellResult spell_RF6_S_MONSTER(CreatureEntity &creature, POSITION y, POS
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."), _("%s^が魔法で仲間を召喚した！", "%s^ magically summons help!"),
         _("%s^が魔法で仲間を召喚した！", "%s^ magically summons help!"));
@@ -340,7 +340,7 @@ MonsterSpellResult spell_RF6_S_MONSTER(CreatureEntity &creature, POSITION y, POS
         msg_print(_("何かが間近に現れた音がする。", "You hear something appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -368,7 +368,7 @@ MonsterSpellResult spell_RF6_S_MONSTERS(CreatureEntity &creature, POSITION y, PO
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法でモンスターを召喚した！", "%s^ magically summons monsters!"), _("%s^が魔法でモンスターを召喚した！", "%s^ magically summons monsters!"));
@@ -391,7 +391,7 @@ MonsterSpellResult spell_RF6_S_MONSTERS(CreatureEntity &creature, POSITION y, PO
         msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -419,7 +419,7 @@ MonsterSpellResult spell_RF6_S_ANT(CreatureEntity &creature, POSITION y, POSITIO
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."), _("%s^が魔法でアリを召喚した。", "%s^ magically summons ants."),
         _("%s^が魔法でアリを召喚した。", "%s^ magically summons ants."));
@@ -436,7 +436,7 @@ MonsterSpellResult spell_RF6_S_ANT(CreatureEntity &creature, POSITION y, POSITIO
         msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -464,7 +464,7 @@ MonsterSpellResult spell_RF6_S_SPIDER(CreatureEntity &creature, POSITION y, POSI
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."), _("%s^が魔法でクモを召喚した。", "%s^ magically summons spiders."),
         _("%s^が魔法でクモを召喚した。", "%s^ magically summons spiders."));
@@ -481,7 +481,7 @@ MonsterSpellResult spell_RF6_S_SPIDER(CreatureEntity &creature, POSITION y, POSI
         msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -509,7 +509,7 @@ MonsterSpellResult spell_RF6_S_HOUND(CreatureEntity &creature, POSITION y, POSIT
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法でハウンドを召喚した。", "%s^ magically summons hounds."), _("%s^が魔法でハウンドを召喚した。", "%s^ magically summons hounds."));
@@ -526,7 +526,7 @@ MonsterSpellResult spell_RF6_S_HOUND(CreatureEntity &creature, POSITION y, POSIT
         msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -554,7 +554,7 @@ MonsterSpellResult spell_RF6_S_HYDRA(CreatureEntity &creature, POSITION y, POSIT
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法でヒドラを召喚した。", "%s^ magically summons hydras."), _("%s^が魔法でヒドラを召喚した。", "%s^ magically summons hydras."));
@@ -571,7 +571,7 @@ MonsterSpellResult spell_RF6_S_HYDRA(CreatureEntity &creature, POSITION y, POSIT
         msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -599,7 +599,7 @@ MonsterSpellResult spell_RF6_S_FAIRY(CreatureEntity &creature, POSITION y, POSIT
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法でフェアリーを召喚した。", "%s^ magically summons fairies."), _("%s^が魔法でフェアリーを召喚した。", "%s^ magically summons fairies."));
@@ -616,7 +616,7 @@ MonsterSpellResult spell_RF6_S_FAIRY(CreatureEntity &creature, POSITION y, POSIT
         msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -644,7 +644,7 @@ MonsterSpellResult spell_RF6_S_APE(CreatureEntity &creature, POSITION y, POSITIO
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法で類人猿を召喚した。", "%s^ magically summons apes."), _("%s^が魔法で類人猿を召喚した。", "%s^ magically summons apes."));
@@ -661,7 +661,7 @@ MonsterSpellResult spell_RF6_S_APE(CreatureEntity &creature, POSITION y, POSITIO
         msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -689,7 +689,7 @@ MonsterSpellResult spell_RF6_S_BIRD(CreatureEntity &creature, POSITION y, POSITI
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法で鳥を召喚した。", "%s^ magically summons birds."), _("%s^が魔法で鳥を召喚した。", "%s^ magically summons birds."));
@@ -706,7 +706,7 @@ MonsterSpellResult spell_RF6_S_BIRD(CreatureEntity &creature, POSITION y, POSITI
         msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -733,7 +733,7 @@ MonsterSpellResult spell_RF6_S_ANGEL(CreatureEntity &creature, POSITION y, POSIT
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法で天使を召喚した！", "%s^ magically summons an angel!"), _("%s^が魔法で天使を召喚した！", "%s^ magically summons an angel!"));
@@ -764,7 +764,7 @@ MonsterSpellResult spell_RF6_S_ANGEL(CreatureEntity &creature, POSITION y, POSIT
         }
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -791,7 +791,7 @@ MonsterSpellResult spell_RF6_S_DEMON(CreatureEntity &creature, POSITION y, POSIT
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^は魔法で混沌の宮廷から悪魔を召喚した！", "%s^ magically summons a demon from the Courts of Chaos!"),
@@ -809,7 +809,7 @@ MonsterSpellResult spell_RF6_S_DEMON(CreatureEntity &creature, POSITION y, POSIT
         msg_print(_("何かが間近に現れた音がする。", "You hear something appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -836,7 +836,7 @@ MonsterSpellResult spell_RF6_S_UNDEAD(CreatureEntity &creature, POSITION y, POSI
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法でアンデッドの強敵を召喚した！", "%s^ magically summons an undead adversary!"),
@@ -854,7 +854,7 @@ MonsterSpellResult spell_RF6_S_UNDEAD(CreatureEntity &creature, POSITION y, POSI
         msg_print(_("何かが間近に現れた音がする。", "You hear something appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -882,7 +882,7 @@ MonsterSpellResult spell_RF6_S_DRAGON(CreatureEntity &creature, POSITION y, POSI
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法でドラゴンを召喚した！", "%s^ magically summons a dragon!"), _("%s^が魔法でドラゴンを召喚した！", "%s^ magically summons a dragon!"));
@@ -903,7 +903,7 @@ MonsterSpellResult spell_RF6_S_DRAGON(CreatureEntity &creature, POSITION y, POSI
         msg_print(_("何かが間近に現れた音がする。", "You hear something appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -932,7 +932,7 @@ MonsterSpellResult spell_RF6_S_HI_UNDEAD(CreatureEntity &creature, POSITION y, P
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     summon_disturb(creature, target_type, known, see_either);
 
@@ -961,7 +961,7 @@ MonsterSpellResult spell_RF6_S_HI_UNDEAD(CreatureEntity &creature, POSITION y, P
         msg_print(_("間近で何か多くのものが這い回る音が聞こえる。", "You hear many creepy things appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -989,7 +989,7 @@ MonsterSpellResult spell_RF6_S_HI_DRAGON(CreatureEntity &creature, POSITION y, P
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法で古代ドラゴンを召喚した！", "%s^ magically summons ancient dragons!"),
@@ -1013,7 +1013,7 @@ MonsterSpellResult spell_RF6_S_HI_DRAGON(CreatureEntity &creature, POSITION y, P
         msg_print(_("多くの力強いものが間近に現れた音が聞こえる。", "You hear many powerful things appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -1041,7 +1041,7 @@ MonsterSpellResult spell_RF6_S_AMBERITES(CreatureEntity &creature, POSITION y, P
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^がアンバーの王族を召喚した！", "%s^ magically summons Lords of Amber!"),
@@ -1059,7 +1059,7 @@ MonsterSpellResult spell_RF6_S_AMBERITES(CreatureEntity &creature, POSITION y, P
         msg_print(_("何者かが次元を超えて現れた気配がした。", "You feel shadow shifting by immortal beings."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -1087,7 +1087,7 @@ MonsterSpellResult spell_RF6_S_CHOASIANS(CreatureEntity &creature, POSITION y, P
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が混沌の王族を召喚した！", "%s^ magically summons Lords of Chaos!"),
@@ -1105,7 +1105,7 @@ MonsterSpellResult spell_RF6_S_CHOASIANS(CreatureEntity &creature, POSITION y, P
         msg_print(_("混沌のざわめきが響いた。", "You feel chaotic entities materializing nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -1133,7 +1133,7 @@ MonsterSpellResult spell_RF6_S_UNIQUE(CreatureEntity &creature, POSITION y, POSI
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法で特別な強敵を召喚した！", "%s^ magically summons special opponents!"),
@@ -1169,7 +1169,7 @@ MonsterSpellResult spell_RF6_S_UNIQUE(CreatureEntity &creature, POSITION y, POSI
             uniques_are_summoned ? _("力強いもの", "powerful things") : _("もの", "things"));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -1197,7 +1197,7 @@ MonsterSpellResult spell_RF6_S_DEAD_UNIQUE(CreatureEntity &creature, POSITION y,
     auto mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     auto mon_to_player = (target_type == MONSTER_TO_PLAYER);
     auto see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    auto known = monster_near_player(floor, m_idx, t_idx);
+    auto known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
         _("%s^が魔法で特別な強敵を蘇らせた！", "%^s magically animates special opponents!"),
@@ -1215,7 +1215,7 @@ MonsterSpellResult spell_RF6_S_DEAD_UNIQUE(CreatureEntity &creature, POSITION y,
         msg_format(_("多くの力強いものが間近に蘇った音が聞こえる。", "You hear many powerful things animate nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -1252,11 +1252,11 @@ MonsterSpellResult spell_RF6_S_NASTY(CreatureEntity &creature, POSITION y, POSIT
         count += summon_specific(creature, y, x, rlev, SUMMON_NASTY, (PM_ALLOW_GROUP)) ? 1 : 0;
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon && mon_to_player) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon && mon_to_player) {
         msg_format(_("クッソ汚いものが間近にひしめく音が聞こえる。", "You hear many nasty things crowding nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -1295,11 +1295,11 @@ MonsterSpellResult spell_RF6_S_GOLEM(CreatureEntity &creature, POSITION y, POSIT
         count += summon_specific(creature, y, x, rlev, SUMMON_GOLEM, (PM_ALLOW_GROUP)) ? 1 : 0;
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon && mon_to_player) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon && mon_to_player) {
         msg_format(_("ゴーレムが間近にひしめく音が聞こえる。", "You hear many golems crowding nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -1337,11 +1337,11 @@ MonsterSpellResult spell_RF6_S_CATS(CreatureEntity &creature, POSITION y, POSITI
         count += summon_specific(creature, y, x, rlev, SUMMON_CATS, (PM_ALLOW_GROUP)) ? 1 : 0;
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon && mon_to_player) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon && mon_to_player) {
         msg_format(_("猫が間近にたくさんいる音が聞こえる。", "You hear many cats crowding nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -1380,11 +1380,11 @@ MonsterSpellResult spell_RF6_S_PERVERTS(CreatureEntity &creature, POSITION y, PO
         count += summon_specific(creature, y, x, rlev, SUMMON_PERVERTS, (PM_ALLOW_GROUP)) ? 1 : 0;
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon && mon_to_player) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon && mon_to_player) {
         msg_format(_("変質者が間近にたくさんいる気配を感じる。", "You sense many perverts crowding nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -1423,11 +1423,11 @@ MonsterSpellResult spell_RF6_S_PUYO(CreatureEntity &creature, POSITION y, POSITI
         count += summon_specific(creature, y, x, rlev, SUMMON_PUYO, (PM_ALLOW_GROUP)) ? 1 : 0;
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon && mon_to_player) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon && mon_to_player) {
         msg_format(_("ぷよが間近にたくさんいる音が聞こえる。", "You hear many puyo crowding nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -1475,7 +1475,7 @@ MonsterSpellResult spell_RF6_S_HOMO(CreatureEntity &creature, POSITION y, POSITI
         msg_print(_("何かが間近に現れた音がする。", "You hear something appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -1501,7 +1501,7 @@ MonsterSpellResult spell_RF6_S_WALL(CreatureEntity &creature, POSITION y, POSITI
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法で壁を召喚した！", "%s^ magically summons walls!"),
@@ -1519,7 +1519,7 @@ MonsterSpellResult spell_RF6_S_WALL(CreatureEntity &creature, POSITION y, POSITI
         msg_print(_("何かが間近に現れた音がする。", "You hear something appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -1546,7 +1546,7 @@ MonsterSpellResult spell_RF6_S_INSECT(CreatureEntity &creature, POSITION y, POSI
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法で昆虫を召喚した！", "%s^ magically summons insects!"),
@@ -1564,7 +1564,7 @@ MonsterSpellResult spell_RF6_S_INSECT(CreatureEntity &creature, POSITION y, POSI
         msg_print(_("何かが間近に現れた音がする。", "You hear something appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 
@@ -1588,7 +1588,7 @@ MonsterSpellResult spell_RF6_S_ELDRAZI(CreatureEntity &creature, POSITION y, POS
 {
     auto &floor = *creature.current_floor_ptr;
     auto rlev = monster_level_idx(floor, m_idx);
-    const auto known = monster_near_player(floor, m_idx, t_idx);
+    const auto known = monster_near_player(creature, m_idx, t_idx);
     const auto see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
     const auto mon_to_mon = (target_type == MONSTER_TO_MONSTER);
 
@@ -1608,7 +1608,7 @@ MonsterSpellResult spell_RF6_S_ELDRAZI(CreatureEntity &creature, POSITION y, POS
         msg_print(_("何かが間近に現れた音がする。", "You hear something appear nearby."));
     }
 
-    if (monster_near_player(floor, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
+    if (monster_near_player(creature, m_idx, t_idx) && !see_monster(creature, t_idx) && count && mon_to_mon) {
         floor.monster_noise = true;
     }
 

--- a/src/mspell/mspell-util.cpp
+++ b/src/mspell/mspell-util.cpp
@@ -4,6 +4,7 @@
 #include "grid/grid.h"
 #include "monster/monster-info.h"
 #include "system/floor/floor-info.h"
+#include "system/grid-type-definition.h"
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
 #include "view/display-messages.h"
@@ -40,11 +41,13 @@ bool see_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
  * @param t_idx モンスターID二体目
  * @return モンスター2体のどちらかがプレイヤーの近くに居ればTRUE、どちらも遠ければFALSEを返す。
  */
-bool monster_near_player(const FloorType &floor, MONSTER_IDX m_idx, MONSTER_IDX t_idx)
+bool monster_near_player(const CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx)
 {
+    const auto &floor = *creature.current_floor_ptr;
+    const auto p_pos = creature.get_position();
     const auto &monster = floor.m_list[m_idx];
     const auto &monster_target = floor.m_list[t_idx];
-    return (monster.cdis <= MAX_PLAYER_SIGHT) || (monster_target.cdis <= MAX_PLAYER_SIGHT);
+    return (Grid::calc_distance(p_pos, monster.get_position()) <= MAX_PLAYER_SIGHT) || (Grid::calc_distance(p_pos, monster_target.get_position()) <= MAX_PLAYER_SIGHT);
 }
 
 /*!
@@ -62,7 +65,7 @@ bool monspell_message_base(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_
     auto &player = static_cast<PlayerType &>(creature);
     bool notice = false;
     auto &floor = *creature.current_floor_ptr;
-    bool known = monster_near_player(floor, m_idx, t_idx);
+    bool known = monster_near_player(creature, m_idx, t_idx);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);

--- a/src/mspell/mspell-util.h
+++ b/src/mspell/mspell-util.h
@@ -11,7 +11,6 @@
 #define RF5_SPELL_START 32 * 4
 #define RF6_SPELL_START 32 * 5
 
-class FloorType;
 class CreatureEntity;
 
 struct mspell_cast_msg {
@@ -46,7 +45,7 @@ struct mspell_cast_msg_simple {
 };
 
 bool see_monster(CreatureEntity &creature, MONSTER_IDX m_idx);
-bool monster_near_player(const FloorType &floor, MONSTER_IDX m_idx, MONSTER_IDX t_idx);
+bool monster_near_player(const CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx);
 bool monspell_message_base(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, const mspell_cast_msg &msgs, bool msg_flag_aux, int target_type);
 bool monspell_message(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, const mspell_cast_msg_blind &msgs, int target_type);
 void simple_monspell_message(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, const mspell_cast_msg_simple &msgs, int target_type);

--- a/src/save/monster-entity-writer.cpp
+++ b/src/save/monster-entity-writer.cpp
@@ -84,11 +84,11 @@ uint32_t MonsterEntityWriter::write_monster_flags() const
         set_bits(flags, SaveDataMonsterFlagType::MONFEAR);
     }
 
-    if (this->monster.target_y) {
+    if (this->monster.target.y) {
         set_bits(flags, SaveDataMonsterFlagType::TARGET_Y);
     }
 
-    if (this->monster.target_x) {
+    if (this->monster.target.x) {
         set_bits(flags, SaveDataMonsterFlagType::TARGET_X);
     }
 
@@ -181,11 +181,11 @@ void MonsterEntityWriter::write_monster_info(uint32_t flags) const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::TARGET_Y)) {
-        wr_s16b((int16_t)this->monster.target_y);
+        wr_s16b((int16_t)this->monster.target.y);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::TARGET_X)) {
-        wr_s16b((int16_t)this->monster.target_x);
+        wr_s16b((int16_t)this->monster.target.x);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::INVULNER)) {

--- a/src/spell-kind/spells-genocide.cpp
+++ b/src/spell-kind/spells-genocide.cpp
@@ -21,6 +21,7 @@
 #include "player/player-damage.h"
 #include "system/angband-system.h"
 #include "system/floor/floor-info.h"
+#include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
@@ -182,7 +183,7 @@ bool mass_genocide(CreatureEntity &creature, int power, bool player_cast)
         if (!monster.is_valid()) {
             continue;
         }
-        if (monster.cdis > MAX_PLAYER_SIGHT) {
+        if (Grid::calc_distance(creature.get_position(), monster.get_position()) > MAX_PLAYER_SIGHT) {
             continue;
         }
 
@@ -222,7 +223,7 @@ bool mass_genocide_undead(CreatureEntity &creature, int power, bool player_cast)
         if (!monster.has_undead_flag()) {
             continue;
         }
-        if (monster.cdis > MAX_PLAYER_SIGHT) {
+        if (Grid::calc_distance(creature.get_position(), monster.get_position()) > MAX_PLAYER_SIGHT) {
             continue;
         }
 

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -20,6 +20,7 @@
 #include "monster/monster-status.h"
 #include "monster/smart-learn-types.h"
 #include "system/floor/floor-info.h"
+#include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
@@ -224,7 +225,7 @@ void aggravate_monsters(CreatureEntity &creature, MONSTER_IDX src_idx)
             continue;
         }
 
-        if (monster.cdis < MAX_PLAYER_SIGHT * 2) {
+        if (Grid::calc_distance(creature.get_position(), monster.get_position()) < MAX_PLAYER_SIGHT * 2) {
             if (monster.is_asleep()) {
                 (void)set_monster_csleep(floor, i, 0);
                 sleep = true;

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -520,7 +520,7 @@ void teleport_away_followable(CreatureEntity &creature, MONSTER_IDX m_idx)
     const auto &monster = floor.m_list[m_idx];
     const auto old_m_pos = monster.get_position();
     bool old_ml = monster.ml;
-    POSITION old_cdis = monster.cdis;
+    const auto old_cdis = Grid::calc_distance(creature.get_position(), old_m_pos);
 
     teleport_away(creature, m_idx, MAX_PLAYER_SIGHT * 2 + 5, TELEPORT_SPONTANEOUS);
 

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -67,6 +67,32 @@ Pos2D CreatureEntity::get_neighbor(const Direction &dir) const
     return this->get_position() + dir.vec();
 }
 
+/*!
+ * @brief クリーチャーの攻撃目標座標を設定
+ * @param pos 目標座標
+ */
+void CreatureEntity::set_target(const Pos2D &pos)
+{
+    this->target = pos;
+}
+
+/*!
+ * @brief クリーチャーの攻撃目標座標をリセット
+ */
+void CreatureEntity::reset_target()
+{
+    this->target = {};
+}
+
+/*!
+ * @brief クリーチャーの攻撃目標座標を取得
+ * @return 目標座標
+ */
+Pos2D CreatureEntity::get_target_position() const
+{
+    return this->target;
+}
+
 bool CreatureEntity::is_stunned() const
 {
     return this->get_timed_effect(CreatureTimedEffect::STUN) > 0;

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -167,6 +167,23 @@ public:
     Pos2D get_neighbor(const Direction &dir) const;
 
     /*!
+     * @brief クリーチャーの攻撃目標座標を設定
+     * @param pos 目標座標
+     */
+    void set_target(const Pos2D &pos);
+
+    /*!
+     * @brief クリーチャーの攻撃目標座標をリセット
+     */
+    void reset_target();
+
+    /*!
+     * @brief クリーチャーの攻撃目標座標を取得
+     * @return 目標座標
+     */
+    Pos2D get_target_position() const;
+
+    /*!
      * @brief クリーチャーの現在HPを取得
      * @return 現在HP
      */
@@ -430,6 +447,8 @@ public:
 
     POSITION run_py{}; /*!< 走行中の目標Y座標 / Target Y position while running */
     POSITION run_px{}; /*!< 走行中の目標X座標 / Target X position while running */
+
+    Pos2D target{}; /*!< 攻撃目標座標 (0,0 は未設定) / Attack target position ({0,0} means none) */
 
     bool ambush_flag{}; /*!< 待ち伏せフラグ / Ambush flag */
 

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -595,24 +595,6 @@ tl::optional<bool> MonsterEntity::order_pet_hp(const MonsterEntity &other) const
 }
 
 /*!
- * @brief モンスターの目標地点をセットする
- * @param pos 目標座標
- */
-void MonsterEntity::set_target(const Pos2D &pos)
-{
-    this->target_y = pos.y;
-    this->target_x = pos.x;
-}
-
-/*!
- * @brief モンスターの目標地点をリセットする
- */
-void MonsterEntity::reset_target()
-{
-    this->set_target({ 0, 0 });
-}
-
-/*!
  * @brief モンスターを友好的にする
  */
 void MonsterEntity::set_friendly()
@@ -797,11 +779,6 @@ bool MonsterEntity::is_riding() const
 Pos2D MonsterEntity::get_position() const
 {
     return { this->y, this->x };
-}
-
-Pos2D MonsterEntity::get_target_position() const
-{
-    return { this->target_y, this->target_x };
 }
 
 bool MonsterEntity::can_ring_boss_call_nazgul() const

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -49,13 +49,10 @@ public:
     int death_count{}; /*!< 自壊するまでの残りターン数 */
     std::map<MonsterTimedEffect, short> mtimed; /*!< 与えられた時限効果の残りターン / Timed status counter */
 
-    POSITION cdis{}; /*!< 現在のプレイヤーから距離(逐一計算を避けるためのテンポラリ変数) Current dis from player */
     EnumClassFlagGroup<MonsterTemporaryFlagType> mflag{}; /*!< モンスター個体に与えられた特殊フラグ1 (セーブ不要) / Extra monster flags */
     EnumClassFlagGroup<MonsterConstantFlagType> mflag2{}; /*!< モンスター個体に与えられた特殊フラグ2 (セーブ必要) / Extra monster flags */
     bool ml{}; /*!< モンスターがプレイヤーにとって視認できるか(処理のためのテンポラリ変数) Monster is "visible" */
     ObjectIndexList hold_o_idx_list{}; /*!< モンスターが所持しているアイテムのリスト / Object list being held (if any) */
-    POSITION target_y{}; /*!< モンスターの攻撃目標対象Y座標 / Can attack !los player */
-    POSITION target_x{}; /*!< モンスターの攻撃目標対象X座標 /  Can attack !los player */
 
     /* TODO: クローン、ペット、有効化は意義が異なるので別変数に切り離すこと。save/loadのバージョン更新が面倒そうだけど */
     EnumClassFlagGroup<MonsterSmartLearnType> smart{}; /*!< モンスターのプレイヤーに対する学習状態 / Field for "smart_learn" - Some bit-flags for the "smart" field */
@@ -112,7 +109,6 @@ public:
     tl::optional<bool> order_pet_dismission(const MonsterEntity &other) const;
     bool is_riding() const;
     Pos2D get_position() const override;
-    Pos2D get_target_position() const;
     bool can_ring_boss_call_nazgul() const;
     std::string build_looking_description(bool needs_attitude) const;
     int get_ac() const override;
@@ -124,8 +120,6 @@ public:
     void set_hostile();
     void make_lore_treasure(int num_item, int num_gold) const;
     void reset_chameleon_polymorph();
-    void set_target(const Pos2D &pos);
-    void reset_target();
     void set_friendly();
     void initialize_equivalent_player_races();
     void initialize_equivalent_player_classes();

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -727,7 +727,7 @@ void wiz_zap_surrounding_monsters(CreatureEntity &creature)
     const auto &floor = *creature.current_floor_ptr;
     for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
         const auto &monster = floor.m_list[i];
-        if (!monster.is_valid() || (i == creature.riding) || (monster.cdis > MAX_PLAYER_SIGHT)) {
+        if (!monster.is_valid() || (i == creature.riding) || (Grid::calc_distance(creature.get_position(), monster.get_position()) > MAX_PLAYER_SIGHT)) {
             continue;
         }
 


### PR DESCRIPTION
- MonsterEntity::cdis を削除し、全参照を Grid::calc_distance() によるインライン計算に置換
- MonsterEntity::target_y / target_x を削除し、CreatureEntity::target (Pos2D) に統合
  - set_target() / reset_target() / get_target_position() を CreatureEntity に追加
- monster_near_player() のシグネチャを FloorType& → CreatureEntity& に変更
- セーブ/ロード (savefile50) を target フィールド対応に更新