### PR TITLE
refactor: Phase 8 — MonsterProfile 構造体を導入し MonsterEntity 固有フィールドを分離（Issue #8115）

### DIFF
--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -151,20 +151,20 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
     std::string m_name;
     bool can_move = true;
     bool do_past = false;
-    if (grid.has_monster() && (monster.ml || p_can_enter || p_can_kill_walls)) {
+    if (grid.has_monster() && (monster.get_monster_profile().ml || p_can_enter || p_can_kill_walls)) {
         const auto &monrace = monster.get_monrace();
         const auto effects = player.effects();
         const auto is_stunned = effects->stun().is_stunned();
         auto can_cast = !effects->confusion().is_confused();
         const auto is_hallucinated = effects->hallucination().is_hallucinated();
         can_cast &= !is_hallucinated;
-        can_cast &= monster.ml;
+        can_cast &= monster.get_monster_profile().ml;
         can_cast &= !is_stunned;
         can_cast &= player.muta.has_not(PlayerMutationType::BERS_RAGE) || !player.is_shero();
         if (!monster.is_hostile() && can_cast && pattern_seq(player, pos) && (p_can_enter || p_can_kill_walls)) {
             (void)set_monster_csleep(*player.current_floor_ptr, grid.m_idx, 0);
             m_name = monster_desc(player, monster, 0);
-            if (monster.ml) {
+            if (monster.get_monster_profile().ml) {
                 if (!is_hallucinated) {
                     LoreTracker::get_instance().set_trackee(monster.ap_r_idx);
                 }

--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -273,7 +273,7 @@ bool exe_mutation_power(CreatureEntity &creature, PlayerMutationType power)
         can_banish &= !floor.inside_arena;
         can_banish &= !floor.is_in_quest();
         can_banish &= (monrace.level < randint1(creature.level + 50));
-        can_banish &= monster.mflag2.has_not(MonsterConstantFlagType::NOGENO);
+        can_banish &= monster.get_monster_profile().mflag2.has_not(MonsterConstantFlagType::NOGENO);
         if (can_banish) {
             if (record_named_pet && monster.is_named_pet()) {
                 const auto m_name = monster_desc(creature, monster, MD_INDEF_VISIBLE);
@@ -287,7 +287,7 @@ bool exe_mutation_power(CreatureEntity &creature, PlayerMutationType power)
 
         msg_print(_("祈りは効果がなかった！", "Your invocation is ineffectual!"));
         if (one_in_(13)) {
-            monster.mflag2.set(MonsterConstantFlagType::NOGENO);
+            monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::NOGENO);
         }
 
         return true;

--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -215,7 +215,7 @@ static bool run_test(CreatureEntity &creature)
         const auto &grid = floor.get_grid(pos);
         if (grid.has_monster()) {
             const auto &monster = floor.m_list[grid.m_idx];
-            if (monster.ml) {
+            if (monster.get_monster_profile().ml) {
                 return true;
             }
         }

--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -162,7 +162,7 @@ Direction decide_travel_step_dir(CreatureEntity &creature, const Direction &prev
         const auto &grid = floor.get_grid(pos);
         if (grid.has_monster()) {
             const auto &monster = floor.m_list[grid.m_idx];
-            if (monster.ml) {
+            if (monster.get_monster_profile().ml) {
                 return Direction::none();
             }
         }

--- a/src/alliance/alliance.cpp
+++ b/src/alliance/alliance.cpp
@@ -268,7 +268,7 @@ bool Alliance::is_hostile_to(const MonsterEntity &monster_other, const MonraceDe
     if (monrace.kind_flags.has(MonsterKindType::GOOD)) {
         sub_align2 |= SUB_ALIGN_GOOD;
     }
-    return MonsterEntity::check_sub_alignments(monster_other.sub_align, sub_align2);
+    return MonsterEntity::check_sub_alignments(monster_other.get_monster_profile().sub_align, sub_align2);
 }
 
 /*!

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -110,7 +110,7 @@ static void natural_attack(CreatureEntity &creature, MONSTER_IDX m_idx, PlayerMu
 
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     bool is_hit = (monrace.kind_flags.has_not(MonsterKindType::QUANTUM)) || !randint0(2);
-    is_hit &= test_hit_norm(creature, chance, monster.get_ac(), monster.ml);
+    is_hit &= test_hit_norm(creature, chance, monster.get_ac(), monster.get_monster_profile().ml);
     if (!is_hit) {
         sound(SoundKind::MISS);
         msg_format(_("ミス！ %sにかわされた。", "You miss %s."), m_name.data());
@@ -183,7 +183,7 @@ static void headbutt_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *f
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     creature.plus_incident_tree("HEADBUTT", 1);
     bool is_hit = (monrace.kind_flags.has_not(MonsterKindType::QUANTUM)) || !randint0(2);
-    is_hit &= test_hit_norm(creature, chance, monster.get_ac(), monster.ml);
+    is_hit &= test_hit_norm(creature, chance, monster.get_ac(), monster.get_monster_profile().ml);
 
     if (!is_hit) {
         sound(SoundKind::MISS);
@@ -274,7 +274,7 @@ static void bodyslam_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *f
 
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     bool is_hit = (monrace.kind_flags.has_not(MonsterKindType::QUANTUM)) || !randint0(2);
-    is_hit &= test_hit_norm(creature, chance, monster.get_ac(), monster.ml);
+    is_hit &= test_hit_norm(creature, chance, monster.get_ac(), monster.get_monster_profile().ml);
 
     if (!is_hit) {
         sound(SoundKind::MISS);
@@ -375,7 +375,7 @@ bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_opti
     const auto m_name = monster_desc(creature, monster, 0);
     const auto effects = creature.effects();
     const auto is_hallucinated = effects->hallucination().is_hallucinated();
-    if (monster.ml) {
+    if (monster.get_monster_profile().ml) {
         if (!is_hallucinated) {
             LoreTracker::get_instance().set_trackee(monster.ap_r_idx);
         }
@@ -385,7 +385,7 @@ bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_opti
 
     const auto is_confused = effects->confusion().is_confused();
     const auto is_stunned = effects->stun().is_stunned();
-    if (monster.is_female() && !(is_stunned || is_confused || is_hallucinated || !monster.ml)) {
+    if (monster.is_female() && !(is_stunned || is_confused || is_hallucinated || !monster.get_monster_profile().ml)) {
         if (creature.is_wielding(FixedArtifactId::ZANTETSU)) {
             sound(SoundKind::ATTACK_FAILED);
             msg_print(_("拙者、おなごは斬れぬ！", "I can not attack women!"));
@@ -399,7 +399,7 @@ bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_opti
         return false;
     }
 
-    if (!monster.is_hostile() && !(is_stunned || is_confused || is_hallucinated || creature.is_shero() || !monster.ml)) {
+    if (!monster.is_hostile() && !(is_stunned || is_confused || is_hallucinated || creature.is_shero() || !monster.get_monster_profile().ml)) {
         if (creature.is_wielding(FixedArtifactId::STORMBRINGER)) {
             msg_format(_("黒い刃は強欲に%sを攻撃した！", "Your black blade greedily attacks %s!"), m_name.data());
             chg_virtue(creature, Virtue::INDIVIDUALISM, 1);
@@ -420,7 +420,7 @@ bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_opti
     }
 
     if (effects->fear().is_fearful()) {
-        if (monster.ml) {
+        if (monster.get_monster_profile().ml) {
             sound(SoundKind::ATTACK_FAILED);
             msg_format(_("恐くて%sを攻撃できない！", "You are too fearful to attack %s!"), m_name.data());
         } else {
@@ -471,11 +471,11 @@ bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_opti
         }
     }
 
-    if (fear && monster.ml && !mdeath) {
+    if (fear && monster.get_monster_profile().ml && !mdeath) {
         // 1/20の確率で恐怖せず狂乱状態になる
         if (one_in_(20)) {
             auto &current_monster = floor.m_list[grid.m_idx];
-            current_monster.mflag2.set(MonsterConstantFlagType::FRENZY);
+            current_monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::FRENZY);
             (void)set_monster_monfear(*creature.current_floor_ptr, grid.m_idx, 0);
             sound(SoundKind::FLEE);
             msg_format(_("%s^は恐怖を怒りに変えて狂乱状態になった！", "%s^ turns fear into rage and goes berserk!"), m_name.data());
@@ -547,7 +547,7 @@ bool do_cmd_headbutt(CreatureEntity &creature)
     // 敵対的でないモンスターへの確認
     const auto is_stunned = effects->stun().is_stunned();
     const auto is_hallucinated = effects->hallucination().is_hallucinated();
-    if (!monster.is_hostile() && !(is_stunned || is_confused || is_hallucinated || creature.is_shero() || !monster.ml)) {
+    if (!monster.is_hostile() && !(is_stunned || is_confused || is_hallucinated || creature.is_shero() || !monster.get_monster_profile().ml)) {
         if (!CreatureClass(creature).equals(PlayerClassType::BERSERKER)) {
             if (!input_check(_("本当に頭突きしますか？", "Really headbutt it? "))) {
                 msg_format(_("%sへの頭突きを止めた。", "You stop to avoid headbutting %s."), m_name.data());
@@ -566,11 +566,11 @@ bool do_cmd_headbutt(CreatureEntity &creature)
     msg_format(_("%sに向かって勢いよく頭突きした！", "You charge forward with a powerful headbutt at %s!"), m_name.data());
     headbutt_attack(creature, grid.m_idx, &fear, &mdeath);
 
-    if (fear && monster.ml && !mdeath) {
+    if (fear && monster.get_monster_profile().ml && !mdeath) {
         // 1/20の確率で恐怖せず狂乱状態になる
         if (one_in_(20)) {
             auto &current_monster = floor.m_list[grid.m_idx];
-            current_monster.mflag2.set(MonsterConstantFlagType::FRENZY);
+            current_monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::FRENZY);
             (void)set_monster_monfear(*creature.current_floor_ptr, grid.m_idx, 0);
             sound(SoundKind::FLEE);
             msg_format(_("%s^は恐怖を怒りに変えて狂乱状態になった！", "%s^ turns fear into rage and goes berserk!"), m_name.data());
@@ -638,11 +638,11 @@ void do_cmd_body_slam(CreatureEntity &creature)
     msg_format(_("%sに向かって全力で体当たりを仕掛けた！", "You charge at %s with a full body slam!"), m_name.data());
     bodyslam_attack(creature, m_idx, &fear, &mdeath);
 
-    if (fear && monster.ml && !mdeath) {
+    if (fear && monster.get_monster_profile().ml && !mdeath) {
         // 1/20の確率で恐怖せず狂乱状態になる
         if (one_in_(20)) {
             auto &current_monster = floor.m_list[m_idx];
-            current_monster.mflag2.set(MonsterConstantFlagType::FRENZY);
+            current_monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::FRENZY);
             (void)set_monster_monfear(*creature.current_floor_ptr, m_idx, 0);
             sound(SoundKind::FLEE);
             msg_format(_("%s^は恐怖を怒りに変えて狂乱状態になった！", "%s^ turns fear into rage and goes berserk!"), m_name.data());
@@ -678,7 +678,7 @@ static void enema_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *fear
 
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     bool is_hit = (monrace.kind_flags.has_not(MonsterKindType::QUANTUM)) || !randint0(2);
-    is_hit &= test_hit_norm(creature, chance, monster.get_ac(), monster.ml);
+    is_hit &= test_hit_norm(creature, chance, monster.get_ac(), monster.get_monster_profile().ml);
 
     if (!is_hit) {
         sound(SoundKind::MISS);
@@ -779,11 +779,11 @@ void do_cmd_enema(CreatureEntity &creature)
     msg_format(_("%sに向かって全力で浣腸を仕掛けた！", "You charge at %s with a full enema!"), m_name.data());
     enema_attack(creature, m_idx, &fear, &mdeath);
 
-    if (fear && monster.ml && !mdeath) {
+    if (fear && monster.get_monster_profile().ml && !mdeath) {
         // 1/20の確率で恐怖せず狂乱状態になる
         if (one_in_(20)) {
             auto &current_monster = floor.m_list[m_idx];
-            current_monster.mflag2.set(MonsterConstantFlagType::FRENZY);
+            current_monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::FRENZY);
             (void)set_monster_monfear(*creature.current_floor_ptr, m_idx, 0);
             sound(SoundKind::FLEE);
             msg_format(_("%s^は恐怖を怒りに変えて狂乱状態になった！", "%s^ turns fear into rage and goes berserk!"), m_name.data());

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -104,7 +104,7 @@ void do_cmd_pet_dismiss(CreatureEntity &creature)
             handle_stuff(creature);
             constexpr auto mes = _("%sを放しますか？ [Yes/No/Unnamed (%d体)]", "Dismiss %s? [Yes/No/Unnamed (%d remain)]");
             msg_format(mes, friend_name.data(), num_pet_index - i);
-            if (monster.ml) {
+            if (monster.get_monster_profile().ml) {
                 move_cursor_relative(monster.y, monster.x);
             }
 
@@ -229,7 +229,7 @@ bool do_cmd_riding(CreatureEntity &creature, bool force)
 
         const auto &monster = player.current_floor_ptr->m_list[grid.m_idx];
 
-        if (!grid.has_monster() || !monster.ml) {
+        if (!grid.has_monster() || !monster.get_monster_profile().ml) {
             msg_print(_("その場所にはモンスターはいません。", "There is no monster here."));
             return false;
         }
@@ -695,7 +695,7 @@ void do_cmd_pet(CreatureEntity &creature)
             creature.pet_t_m_idx = 0;
         } else {
             const auto &grid = creature.current_floor_ptr->get_grid(*pos);
-            if (grid.has_monster() && (creature.current_floor_ptr->m_list[grid.m_idx].ml)) {
+            if (grid.has_monster() && (creature.current_floor_ptr->m_list[grid.m_idx].get_monster_profile().ml)) {
                 creature.pet_t_m_idx = creature.current_floor_ptr->get_grid(*pos).m_idx;
                 creature.pet_follow_distance = PET_DESTROY_DIST;
             } else {

--- a/src/combat/attack-accuracy.cpp
+++ b/src/combat/attack-accuracy.cpp
@@ -141,7 +141,7 @@ static bool decide_attack_hit(CreatureEntity &creature, player_attack_type *pa_p
     } else if (CreatureClass(creature).equals(PlayerClassType::NINJA) && ((pa_ptr->backstab || pa_ptr->surprise_attack) && !monrace.resistance_flags.has(MonsterResistanceType::RESIST_ALL))) {
         success_hit = true;
     } else {
-        success_hit = test_hit_norm(creature, chance, pa_ptr->m_ptr->get_ac(), pa_ptr->m_ptr->ml);
+        success_hit = test_hit_norm(creature, chance, pa_ptr->m_ptr->get_ac(), pa_ptr->m_ptr->get_monster_profile().ml);
     }
 
     if ((pa_ptr->mode == HISSATSU_MAJIN) && one_in_(2)) {

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -742,7 +742,7 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
                 auto &monrace = monster.get_monrace();
 
                 /* Check the visibility */
-                auto visible = monster.ml;
+                auto visible = monster.get_monster_profile().ml;
 
                 /* Note the collision */
                 hit_body = true;
@@ -765,7 +765,7 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
                 }
 
                 /* Did we hit it (penalize range) */
-                if (test_hit_fire(creature, chance - cur_dis, monster, monster.ml, item_name.data())) {
+                if (test_hit_fire(creature, chance - cur_dis, monster, monster.get_monster_profile().ml, item_name.data())) {
                     bool fear = false;
                     auto tdam = tdam_base; //!< @note 実際に与えるダメージ
                     auto base_dam = tdam; //!< @note 補正前の与えるダメージ(無傷、全ての耐性など)
@@ -786,7 +786,7 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
 
                         msg_format(_("%sが%sに命中した。", "The %s hits %s."), item_name.data(), m_name.data());
 
-                        if (monster.ml) {
+                        if (monster.get_monster_profile().ml) {
                             if (!creature.effects()->hallucination().is_hallucinated()) {
                                 tracker.set_trackee(monster.ap_r_idx);
                             }
@@ -874,7 +874,7 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
                             anger_monster(creature, monster);
                         }
 
-                        if (fear && monster.ml) {
+                        if (fear && monster.get_monster_profile().ml) {
                             sound(SoundKind::FLEE);
                             msg_format(_("%s^は恐怖して逃げ出した！", "%s^ flees in terror!"), m_name.data());
                         }
@@ -972,7 +972,7 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
 
             /* Carry object */
             auto &monster = floor.m_list[m_idx];
-            monster.hold_o_idx_list.add(floor, item_idx);
+            monster.get_monster_profile().hold_o_idx_list.add(floor, item_idx);
         } else if (floor.has_terrain_characteristics(pos_impact, TerrainCharacteristics::PROJECTION)) {
             /* Drop (or break) near that location */
             drop_ammo_near(creature, fire_item, pos_impact, j);

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -128,7 +128,7 @@ void process_player(CreatureEntity &creature)
                 continue;
             }
 
-            monster.mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+            monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
             update_monster(creature, m_idx, false);
         }
 
@@ -348,28 +348,28 @@ void process_player(CreatureEntity &creature)
                 const auto &monrace = monster.get_appearance_monrace();
 
                 // モンスターのシンボル/カラーの更新
-                if (monster.ml && monrace.visual_flags.has_any_of({ MonsterVisualType::MULTI_COLOR, MonsterVisualType::SHAPECHANGER })) {
+                if (monster.get_monster_profile().ml && monrace.visual_flags.has_any_of({ MonsterVisualType::MULTI_COLOR, MonsterVisualType::SHAPECHANGER })) {
                     lite_spot(creature, monster.get_position());
                 }
 
                 // 出現して即魔法を使わないようにするフラグを落とす処理
-                if (monster.mflag.has(MonsterTemporaryFlagType::PREVENT_MAGIC)) {
-                    monster.mflag.reset(MonsterTemporaryFlagType::PREVENT_MAGIC);
+                if (monster.get_monster_profile().mflag.has(MonsterTemporaryFlagType::PREVENT_MAGIC)) {
+                    monster.get_monster_profile().mflag.reset(MonsterTemporaryFlagType::PREVENT_MAGIC);
                 }
 
-                if (monster.mflag.has(MonsterTemporaryFlagType::SANITY_BLAST)) {
-                    monster.mflag.reset(MonsterTemporaryFlagType::SANITY_BLAST);
+                if (monster.get_monster_profile().mflag.has(MonsterTemporaryFlagType::SANITY_BLAST)) {
+                    monster.get_monster_profile().mflag.reset(MonsterTemporaryFlagType::SANITY_BLAST);
                     sanity_blast(creature, m_idx);
                 }
 
                 // 感知中のモンスターのフラグを落とす処理
                 // 感知したターンはMFLAG2_SHOWを落とし、次のターンに感知中フラグのMFLAG2_MARKを落とす
-                if (monster.mflag2.has(MonsterConstantFlagType::MARK)) {
-                    if (monster.mflag2.has(MonsterConstantFlagType::SHOW)) {
-                        monster.mflag2.reset(MonsterConstantFlagType::SHOW);
+                if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::MARK)) {
+                    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::SHOW)) {
+                        monster.get_monster_profile().mflag2.reset(MonsterConstantFlagType::SHOW);
                     } else {
-                        monster.mflag2.reset(MonsterConstantFlagType::MARK);
-                        monster.ml = false;
+                        monster.get_monster_profile().mflag2.reset(MonsterConstantFlagType::MARK);
+                        monster.get_monster_profile().ml = false;
                         update_monster(creature, m_idx, false);
                         HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
                         if (monster.is_riding()) {

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -34,17 +34,17 @@ static void effect_monster_charm_resist(CreatureEntity &creature, EffectMonster 
         em_ptr->obvious = false;
 
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate(creature)) {
         em_ptr->note = _("はあなたに敵意を抱いている！", " hates you too much!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
         em_ptr->note = _("はあなたを玩具だと思い込んでいる！", " thinks you are a toy!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
     } else {
         em_ptr->note = _("は突然友好的になったようだ！", " suddenly seems friendly!");
@@ -98,17 +98,17 @@ ProcessResult effect_monster_control_undead(CreatureEntity &creature, EffectMons
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate(creature)) {
         em_ptr->note = _("はあなたに敵意を抱いている！", " hates you too much!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
         em_ptr->note = _("はあなたを玩具だと思い込んでいる！", " thinks you are a toy!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
     } else {
         em_ptr->note = _("は既にあなたの奴隷だ！", " is in your thrall!");
@@ -139,17 +139,17 @@ ProcessResult effect_monster_control_demon(CreatureEntity &creature, EffectMonst
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate(creature)) {
         em_ptr->note = _("はあなたに敵意を抱いている！", " hates you too much!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
         em_ptr->note = _("はあなたを玩具だと思い込んでいる！", " thinks you are a toy!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
     } else {
         em_ptr->note = _("は既にあなたの奴隷だ！", " is in your thrall!");
@@ -180,17 +180,17 @@ ProcessResult effect_monster_control_animal(CreatureEntity &creature, EffectMons
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate(creature)) {
         em_ptr->note = _("はあなたに敵意を抱いている！", " hates you too much!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
         em_ptr->note = _("はあなたを玩具だと思い込んでいる！", " thinks you are a toy!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
     } else {
         em_ptr->note = _("はなついた。", " is tamed!");
@@ -226,17 +226,17 @@ ProcessResult effect_monster_charm_living(CreatureEntity &creature, EffectMonste
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate(creature)) {
         em_ptr->note = _("はあなたに敵意を抱いている！", " hates you too much!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
         em_ptr->note = _("はあなたを玩具だと思い込んでいる！", " thinks you are a toy!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
     } else {
         em_ptr->note = _("を支配した。", " is tamed!");
@@ -364,14 +364,14 @@ static bool effect_monster_crusade_domination(CreatureEntity &creature, EffectMo
 
     bool failed = em_ptr->r_ptr->misc_flags.has(MonsterMiscType::QUESTOR);
     failed |= em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
-    failed |= em_ptr->m_ptr->mflag2.has(MonsterConstantFlagType::NOPET);
+    failed |= em_ptr->m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::NOPET);
     failed |= has_aggravate(creature);
     failed |= has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY);
     failed |= (em_ptr->r_ptr->level + 10) > randint1(em_ptr->dam);
 
     if (failed) {
         if (one_in_(4)) {
-            em_ptr->m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
         }
 
         return false;
@@ -435,7 +435,7 @@ static int calcutate_capturable_hp(CreatureEntity &creature, const MonsterEntity
  */
 static void effect_monster_captured(CreatureEntity &creature, EffectMonster *em_ptr, tl::optional<CapturedMonsterType *> tmp_cap_mon_ptr)
 {
-    if (em_ptr->m_ptr->mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
+    if (em_ptr->m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
         em_ptr->m_ptr->reset_chameleon_polymorph();
     }
 
@@ -446,7 +446,7 @@ static void effect_monster_captured(CreatureEntity &creature, EffectMonster *em_
     cap_mon_ptr->current_hp = static_cast<short>(em_ptr->m_ptr->hp);
     cap_mon_ptr->max_hp = static_cast<short>(em_ptr->m_ptr->max_maxhp);
     cap_mon_ptr->name = em_ptr->m_ptr->name;
-    cap_mon_ptr->mflag2 = em_ptr->m_ptr->mflag2;
+    cap_mon_ptr->mflag2 = em_ptr->m_ptr->get_monster_profile().mflag2;
     if (em_ptr->m_ptr->is_riding() && process_fall_off_horse(creature, -1, false)) {
         msg_print(_("地面に落とされた。", format("You have fallen from %s.", em_ptr->m_name)));
     }

--- a/src/effect/effect-monster-evil.cpp
+++ b/src/effect/effect-monster-evil.cpp
@@ -112,7 +112,7 @@ ProcessResult effect_monster_turn_undead(CreatureEntity &creature, EffectMonster
 
     em_ptr->do_fear = Dice::roll(3, (em_ptr->dam / 2)) + 1;
     if (em_ptr->r_ptr->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10 ||
-        em_ptr->m_ptr->mflag2.has(MonsterConstantFlagType::FRENZY)) {
+        em_ptr->m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::FRENZY)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         em_ptr->do_fear = 0;
@@ -140,7 +140,7 @@ ProcessResult effect_monster_turn_evil(CreatureEntity &creature, EffectMonster *
 
     em_ptr->do_fear = Dice::roll(3, (em_ptr->dam / 2)) + 1;
     if (em_ptr->r_ptr->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10 ||
-        em_ptr->m_ptr->mflag2.has(MonsterConstantFlagType::FRENZY)) {
+        em_ptr->m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::FRENZY)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         em_ptr->do_fear = 0;
@@ -159,7 +159,7 @@ ProcessResult effect_monster_turn_all(EffectMonster *em_ptr)
     em_ptr->do_fear = Dice::roll(3, (em_ptr->dam / 2)) + 1;
     if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ||
         em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_FEAR) ||
-        em_ptr->m_ptr->mflag2.has(MonsterConstantFlagType::FRENZY) ||
+        em_ptr->m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::FRENZY) ||
         (em_ptr->r_ptr->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;

--- a/src/effect/effect-monster-util.cpp
+++ b/src/effect/effect-monster-util.cpp
@@ -44,7 +44,7 @@ EffectMonster::EffectMonster(CreatureEntity &creature, MONSTER_IDX src_idx, POSI
     this->m_ptr = &floor.m_list[this->g_ptr->m_idx];
     this->m_caster_ptr = this->is_monster() ? &floor.m_list[this->src_idx] : nullptr;
     this->r_ptr = &this->m_ptr->get_monrace();
-    this->seen = this->m_ptr->ml;
+    this->seen = this->m_ptr->get_monster_profile().ml;
     this->seen_msg = is_seen(creature, *this->m_ptr);
     this->slept = this->m_ptr->is_asleep();
     this->known = (Grid::calc_distance(creature.get_position(), this->m_ptr->get_position()) <= MAX_PLAYER_SIGHT) || AngbandSystem::get_instance().is_phase_out();

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -73,7 +73,7 @@ static ProcessResult is_affective(EffectMonster *em_ptr)
     if (em_ptr->m_ptr->hp < 0) {
         return ProcessResult::PROCESS_FALSE;
     }
-    if (em_ptr->m_ptr->mflag.has_not(MonsterTemporaryFlagType::PRESENT_AT_TURN_START)) {
+    if (em_ptr->m_ptr->get_monster_profile().mflag.has_not(MonsterTemporaryFlagType::PRESENT_AT_TURN_START)) {
         return ProcessResult::PROCESS_FALSE;
     }
     if (em_ptr->is_monster() || !em_ptr->m_ptr->is_riding()) {
@@ -180,7 +180,7 @@ static ProcessResult exe_affect_monster_by_effect(CreatureEntity &creature, Effe
  */
 static void effect_damage_killed_pet(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    bool sad = em_ptr->m_ptr->is_pet() && !(em_ptr->m_ptr->ml);
+    bool sad = em_ptr->m_ptr->is_pet() && !(em_ptr->m_ptr->get_monster_profile().ml);
     if (em_ptr->known && !em_ptr->note.empty()) {
         angband_strcpy(em_ptr->m_name, monster_desc(creature, *em_ptr->m_ptr, MD_TRUE_NAME), sizeof(em_ptr->m_name));
         if (em_ptr->see_s_msg) {
@@ -471,7 +471,7 @@ static void effect_damage_piles_confusion(CreatureEntity &creature, EffectMonste
 static void effect_damage_piles_fear(CreatureEntity &creature, EffectMonster *em_ptr)
 {
     if (em_ptr->do_fear == 0 || em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_FEAR) ||
-        em_ptr->m_ptr->mflag2.has(MonsterConstantFlagType::FRENZY)) {
+        em_ptr->m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::FRENZY)) {
         return;
     }
 

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -65,7 +65,7 @@ void effect_player_drain_mana(CreatureEntity &creature, EffectPlayerType *ep_ptr
         rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
-    if (ep_ptr->m_ptr->ml) {
+    if (ep_ptr->m_ptr->get_monster_profile().ml) {
         msg_format(_("%s^は気分が良さそうだ。", "%s^ appears healthier."), ep_ptr->m_name.data());
     }
 

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -291,7 +291,7 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
                     }
 
                     if (is_seen(player, monster)) {
-                        const auto m_name = monster.ml ? monster_desc(static_cast<PlayerType &>(player), monster, 0) : std::string(_("それ", "It"));
+                        const auto m_name = monster.get_monster_profile().ml ? monster_desc(static_cast<PlayerType &>(player), monster, 0) : std::string(_("それ", "It"));
                         sound(SoundKind::REFLECT);
                         const auto reflect_message = monrace.get_message(m_name, MonsterMessageType::MESSAGE_REFLECT);
                         if (reflect_message) {
@@ -384,7 +384,7 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
             const auto &grid = floor.get_grid(pos_project);
             if (grid.has_monster()) {
                 auto &monster = floor.m_list[grid.m_idx];
-                if (monster.ml) {
+                if (monster.get_monster_profile().ml) {
                     if (!player.effects()->hallucination().is_hallucinated()) {
                         tracker.set_trackee(monster.ap_r_idx);
                     }

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -135,7 +135,7 @@ static void parse_qtw_D(CreatureEntity &creature, qtwg_type *qtwg_ptr, char *s)
 
             const auto m_idx = place_specific_monster(*player_ptr, *qtwg_ptr->y, *qtwg_ptr->x, monrace_id, (PM_ALLOW_SLEEP | PM_NO_KAGE));
             if (clone && m_idx) {
-                floor.m_list[*m_idx].mflag2.set(MonsterConstantFlagType::CLONED);
+                floor.m_list[*m_idx].get_monster_profile().mflag2.set(MonsterConstantFlagType::CLONED);
                 monrace.cur_num = old_cur_num;
                 monrace.mob_num = old_mob_num;
                 monrace.max_num = old_max_num;

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -129,13 +129,13 @@ static MonraceDefinition &set_pet_params(CreatureEntity &creature, const int cur
     monster.y = cy;
     monster.x = cx;
     monster.current_floor_ptr = player_ptr->current_floor_ptr;
-    monster.ml = true;
-    monster.mtimed[MonsterTimedEffect::SLEEP] = 0;
-    monster.hold_o_idx_list.clear();
+    monster.get_monster_profile().ml = true;
+    monster.get_monster_profile().mtimed[MonsterTimedEffect::SLEEP] = 0;
+    monster.get_monster_profile().hold_o_idx_list.clear();
     monster.reset_target();
     auto &r_ref = monster.get_real_monrace();
     if (!ironman_nightmare) {
-        monster.mflag.set(MonsterTemporaryFlagType::PREVENT_MAGIC);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::PREVENT_MAGIC);
     }
 
     return r_ref;

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -291,7 +291,7 @@ static void generate_gambling_arena(CreatureEntity &creature)
             continue;
         }
 
-        monster.mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+        monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
         update_monster(*player_ptr, i, false);
     }
 }

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -148,7 +148,7 @@ static void preserve_pet(CreatureEntity &creature)
     record_pet_diary(creature);
     for (MONSTER_IDX i = player_ptr->current_floor_ptr->m_max - 1; i >= 1; i--) {
         const auto &monster = player_ptr->current_floor_ptr->m_list[i];
-        const auto parent_r_idx = player_ptr->current_floor_ptr->m_list[monster.parent_m_idx].r_idx;
+        const auto parent_r_idx = player_ptr->current_floor_ptr->m_list[monster.get_monster_profile().parent_m_idx].r_idx;
         if (!monster.has_parent() || MonraceList::is_valid(parent_r_idx)) {
             continue;
         }

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -329,7 +329,7 @@ ObjectIndexList &get_o_idx_list_contains(FloorType &floor, OBJECT_IDX o_idx)
     auto *o_ptr = floor.o_list[o_idx].get();
 
     if (o_ptr->is_held_by_monster()) {
-        return floor.m_list[o_ptr->held_m_idx].hold_o_idx_list;
+        return floor.m_list[o_ptr->held_m_idx].get_monster_profile().hold_o_idx_list;
     } else {
         return floor.grid_array[o_ptr->iy][o_ptr->ix].o_idx_list;
     }

--- a/src/floor/geometry.cpp
+++ b/src/floor/geometry.cpp
@@ -141,5 +141,5 @@ bool is_seen(CreatureEntity &creature, const MonsterEntity &monster)
     const auto p_pos = creature.get_position();
     const auto m_pos = monster.get_position();
     is_inside_view |= player_can_see_bold(creature, m_pos.y, m_pos.x) && projectable(*creature.current_floor_ptr, p_pos, m_pos);
-    return monster.ml && is_inside_view;
+    return monster.get_monster_profile().ml && is_inside_view;
 }

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -400,7 +400,7 @@ static errr set_mon_flags(const nlohmann::json &flag_data, MonraceDefinition &mo
                 if (s_tokens.size() == 2 && s_tokens[0] == "ALLIANCE") {
                     for (auto a : alliance_list) {
                         if (a.second->tag == s_tokens[1]) {
-                            r_ptr->alliance_idx = static_cast<AllianceType>(a.second->id);
+                            r_ptr->get_monster_profile().alliance_idx = static_cast<AllianceType>(a.second->id);
                         }
                     }
                     continue;

--- a/src/io/cursor.cpp
+++ b/src/io/cursor.cpp
@@ -53,7 +53,7 @@ void print_path(CreatureEntity &creature, POSITION y, POSITION x)
         const auto &grid = floor.get_grid(pos_path);
         if (panel_contains(pos_path)) {
             DisplaySymbolPair symbol_pair({ default_color, '\0' }, { default_color, '*' });
-            if (grid.has_monster() && floor.m_list[grid.m_idx].ml) {
+            if (grid.has_monster() && floor.m_list[grid.m_idx].get_monster_profile().ml) {
                 symbol_pair = map_info(creature, pos_path);
                 auto &symbol_foreground = symbol_pair.symbol_foreground;
                 if (!symbol_foreground.is_ascii_graphics()) {

--- a/src/load/old/monster-loader-savefile50.cpp
+++ b/src/load/old/monster-loader-savefile50.cpp
@@ -26,9 +26,9 @@ void MonsterLoader50::rd_monster(MonsterEntity &monster)
 
     if (loading_savefile_version_is_older_than(16)) {
         MonraceDefinition *r_ptr = &MonraceList::get_instance().get_monrace(monster.r_idx);
-        monster.alliance_idx = r_ptr->alliance_idx;
+        monster.get_monster_profile().alliance_idx = r_ptr->alliance_idx;
     } else {
-        monster.alliance_idx = i2enum<AllianceType>(rd_s32b());
+        monster.get_monster_profile().alliance_idx = i2enum<AllianceType>(rd_s32b());
     }
 
     monster.y = rd_byte();
@@ -47,8 +47,8 @@ void MonsterLoader50::rd_monster(MonsterEntity &monster)
     monster.dealt_damage = rd_s32b();
 
     monster.ap_r_idx = any_bits(flags, SaveDataMonsterFlagType::AP_R_IDX) ? i2enum<MonraceId>(rd_s16b()) : monster.r_idx;
-    monster.sub_align = any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN) ? rd_byte() : 0;
-    monster.mtimed[MonsterTimedEffect::SLEEP] = any_bits(flags, SaveDataMonsterFlagType::SLEEP) ? rd_s16b() : 0;
+    monster.get_monster_profile().sub_align = any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN) ? rd_byte() : 0;
+    monster.get_monster_profile().mtimed[MonsterTimedEffect::SLEEP] = any_bits(flags, SaveDataMonsterFlagType::SLEEP) ? rd_s16b() : 0;
     monster.speed = rd_byte();
     monster.energy_need = rd_s16b();
     if (loading_savefile_version_is_older_than(38)) {
@@ -57,33 +57,33 @@ void MonsterLoader50::rd_monster(MonsterEntity &monster)
     } else {
         monster.ac = rd_s16b();
     }
-    monster.mtimed[MonsterTimedEffect::FAST] = any_bits(flags, SaveDataMonsterFlagType::FAST) ? rd_byte() : 0;
-    monster.mtimed[MonsterTimedEffect::SLOW] = any_bits(flags, SaveDataMonsterFlagType::SLOW) ? rd_byte() : 0;
-    monster.mtimed[MonsterTimedEffect::STUN] = any_bits(flags, SaveDataMonsterFlagType::STUNNED) ? rd_byte() : 0;
-    monster.mtimed[MonsterTimedEffect::CONFUSION] = any_bits(flags, SaveDataMonsterFlagType::CONFUSED) ? rd_byte() : 0;
-    monster.mtimed[MonsterTimedEffect::FEAR] = any_bits(flags, SaveDataMonsterFlagType::MONFEAR) ? rd_byte() : 0;
+    monster.get_monster_profile().mtimed[MonsterTimedEffect::FAST] = any_bits(flags, SaveDataMonsterFlagType::FAST) ? rd_byte() : 0;
+    monster.get_monster_profile().mtimed[MonsterTimedEffect::SLOW] = any_bits(flags, SaveDataMonsterFlagType::SLOW) ? rd_byte() : 0;
+    monster.get_monster_profile().mtimed[MonsterTimedEffect::STUN] = any_bits(flags, SaveDataMonsterFlagType::STUNNED) ? rd_byte() : 0;
+    monster.get_monster_profile().mtimed[MonsterTimedEffect::CONFUSION] = any_bits(flags, SaveDataMonsterFlagType::CONFUSED) ? rd_byte() : 0;
+    monster.get_monster_profile().mtimed[MonsterTimedEffect::FEAR] = any_bits(flags, SaveDataMonsterFlagType::MONFEAR) ? rd_byte() : 0;
     monster.target.y = any_bits(flags, SaveDataMonsterFlagType::TARGET_Y) ? rd_s16b() : 0;
     monster.target.x = any_bits(flags, SaveDataMonsterFlagType::TARGET_X) ? rd_s16b() : 0;
-    monster.mtimed[MonsterTimedEffect::INVULNERABILITY] = any_bits(flags, SaveDataMonsterFlagType::INVULNER) ? rd_byte() : 0;
-    monster.mflag.clear();
-    monster.mflag2.clear();
+    monster.get_monster_profile().mtimed[MonsterTimedEffect::INVULNERABILITY] = any_bits(flags, SaveDataMonsterFlagType::INVULNER) ? rd_byte() : 0;
+    monster.get_monster_profile().mflag.clear();
+    monster.get_monster_profile().mflag2.clear();
     if (any_bits(flags, SaveDataMonsterFlagType::SMART)) {
         if (loading_savefile_version_is_older_than(2)) {
             auto tmp32u = rd_u32b();
-            migrate_bitflag_to_flaggroup(monster.smart, tmp32u);
+            migrate_bitflag_to_flaggroup(monster.get_monster_profile().smart, tmp32u);
 
             // 3.0.0Alpha10以前のSM_CLONED(ビット位置22)、SM_PET(23)、SM_FRIEDLY(28)をMFLAG2に移行する
             // ビット位置の定義はなくなるので、ビット位置の値をハードコードする。
             std::bitset<32> rd_bits(tmp32u);
-            monster.mflag2[MonsterConstantFlagType::CLONED] = rd_bits[22];
-            monster.mflag2[MonsterConstantFlagType::PET] = rd_bits[23];
-            monster.mflag2[MonsterConstantFlagType::FRIENDLY] = rd_bits[28];
-            monster.smart.reset(i2enum<MonsterSmartLearnType>(22)).reset(i2enum<MonsterSmartLearnType>(23)).reset(i2enum<MonsterSmartLearnType>(28));
+            monster.get_monster_profile().mflag2[MonsterConstantFlagType::CLONED] = rd_bits[22];
+            monster.get_monster_profile().mflag2[MonsterConstantFlagType::PET] = rd_bits[23];
+            monster.get_monster_profile().mflag2[MonsterConstantFlagType::FRIENDLY] = rd_bits[28];
+            monster.get_monster_profile().smart.reset(i2enum<MonsterSmartLearnType>(22)).reset(i2enum<MonsterSmartLearnType>(23)).reset(i2enum<MonsterSmartLearnType>(28));
         } else {
-            rd_FlagGroup(monster.smart, rd_byte);
+            rd_FlagGroup(monster.get_monster_profile().smart, rd_byte);
         }
     } else {
-        monster.smart.clear();
+        monster.get_monster_profile().smart.clear();
     }
 
     monster.exp = any_bits(flags, SaveDataMonsterFlagType::EXP) ? rd_u32b() : 0;
@@ -91,9 +91,9 @@ void MonsterLoader50::rd_monster(MonsterEntity &monster)
         if (loading_savefile_version_is_older_than(2)) {
             auto tmp8u = rd_byte();
             constexpr auto base = enum2i(MonsterConstantFlagType::KAGE);
-            migrate_bitflag_to_flaggroup(monster.mflag2, tmp8u, base, 7);
+            migrate_bitflag_to_flaggroup(monster.get_monster_profile().mflag2, tmp8u, base, 7);
         } else {
-            rd_FlagGroup(monster.mflag2, rd_byte);
+            rd_FlagGroup(monster.get_monster_profile().mflag2, rd_byte);
         }
     }
 
@@ -103,7 +103,7 @@ void MonsterLoader50::rd_monster(MonsterEntity &monster)
         monster.name.clear();
     }
 
-    monster.parent_m_idx = any_bits(flags, SaveDataMonsterFlagType::PARENT) ? rd_s16b() : 0;
+    monster.get_monster_profile().parent_m_idx = any_bits(flags, SaveDataMonsterFlagType::PARENT) ? rd_s16b() : 0;
 
     // バージョン40以降: 所持金、身長、体重の読み込み
     if (loading_savefile_version_is_older_than(40)) {
@@ -159,18 +159,18 @@ void MonsterLoader50::rd_monster(MonsterEntity &monster)
 
     // バージョン43以降: 変身情報の読み込み
     if (loading_savefile_version_is_older_than(43)) {
-        monster.transform_r_idx = MonraceId::PLAYER;
-        monster.transform_hp_threshold = 0;
-        monster.has_transformed = false;
+        monster.get_monster_profile().transform_r_idx = MonraceId::PLAYER;
+        monster.get_monster_profile().transform_hp_threshold = 0;
+        monster.get_monster_profile().has_transformed = false;
     } else {
         if (any_bits(flags, SaveDataMonsterFlagType::TRANSFORM)) {
-            monster.transform_r_idx = i2enum<MonraceId>(rd_s16b());
-            monster.transform_hp_threshold = rd_byte();
-            monster.has_transformed = rd_byte() != 0;
+            monster.get_monster_profile().transform_r_idx = i2enum<MonraceId>(rd_s16b());
+            monster.get_monster_profile().transform_hp_threshold = rd_byte();
+            monster.get_monster_profile().has_transformed = rd_byte() != 0;
         } else {
-            monster.transform_r_idx = MonraceId::PLAYER;
-            monster.transform_hp_threshold = 0;
-            monster.has_transformed = false;
+            monster.get_monster_profile().transform_r_idx = MonraceId::PLAYER;
+            monster.get_monster_profile().transform_hp_threshold = 0;
+            monster.get_monster_profile().has_transformed = false;
         }
     }
 

--- a/src/main/scene-table-monster.cpp
+++ b/src/main/scene-table-monster.cpp
@@ -83,8 +83,8 @@ static bool is_high_rate(CreatureEntity &creature, MONSTER_IDX m_idx1, MONSTER_I
     }
 
     /* Shadowers first (あやしい影) */
-    if (monster1.mflag2.has(MonsterConstantFlagType::KAGE) != monster2.mflag2.has(MonsterConstantFlagType::KAGE)) {
-        return monster1.mflag2.has(MonsterConstantFlagType::KAGE);
+    if (monster1.get_monster_profile().mflag2.has(MonsterConstantFlagType::KAGE) != monster2.get_monster_profile().mflag2.has(MonsterConstantFlagType::KAGE)) {
+        return monster1.get_monster_profile().mflag2.has(MonsterConstantFlagType::KAGE);
     }
 
     /* Unknown monsters first */
@@ -140,7 +140,7 @@ static bool scene_monster(CreatureEntity &creature, scene_type *value)
 {
     const auto &monster = creature.current_floor_ptr->m_list[scene_target_monster.m_idx];
 
-    if (monster.mflag2.has(MonsterConstantFlagType::KAGE)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::KAGE)) {
         value->type = TERM_XTRA_MUSIC_BASIC;
         value->val = MUSIC_BASIC_SHADOWER;
         return true;

--- a/src/melee/melee-postprocess.cpp
+++ b/src/melee/melee-postprocess.cpp
@@ -76,7 +76,7 @@ mam_pp_type::mam_pp_type(CreatureEntity &creature, MONSTER_IDX m_idx, int dam, b
 
 static void prepare_redraw(mam_pp_type *mam_pp_ptr)
 {
-    if (!mam_pp_ptr->m_ptr->ml) {
+    if (!mam_pp_ptr->m_ptr->get_monster_profile().ml) {
         return;
     }
 

--- a/src/melee/melee-spell.cpp
+++ b/src/melee/melee-spell.cpp
@@ -61,7 +61,7 @@ static void process_special_melee_spell(CreatureEntity &creature, melee_spell_ty
 {
     auto &player = static_cast<PlayerType &>(creature);
     CreatureClass pc(player);
-    bool is_special_magic = ms_ptr->m_ptr->ml;
+    bool is_special_magic = ms_ptr->m_ptr->get_monster_profile().ml;
     is_special_magic &= ms_ptr->maneable;
     is_special_magic &= AngbandWorld::get_instance().timewalk_m_idx == 0;
     is_special_magic &= !player.is_blind();

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -97,7 +97,7 @@ static void aura_fire_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
         msg_format(_("%s^は突然熱くなった！", "%s^ is suddenly very hot!"), mam_ptr->m_name);
     }
 
-    if (mam_ptr->m_ptr->ml && is_original_ap_and_seen(player, *mam_ptr->t_ptr)) {
+    if (mam_ptr->m_ptr->get_monster_profile().ml && is_original_ap_and_seen(player, *mam_ptr->t_ptr)) {
         monrace_target.aura_flags.set(MonsterAuraType::FIRE);
     }
 
@@ -125,7 +125,7 @@ static void aura_cold_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
         msg_format(_("%s^は突然寒くなった！", "%s^ is suddenly very cold!"), mam_ptr->m_name);
     }
 
-    if (monster.ml && is_original_ap_and_seen(player, *mam_ptr->t_ptr)) {
+    if (monster.get_monster_profile().ml && is_original_ap_and_seen(player, *mam_ptr->t_ptr)) {
         monrace_target.aura_flags.set(MonsterAuraType::COLD);
     }
 
@@ -153,7 +153,7 @@ static void aura_elec_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
         msg_format(_("%s^は電撃を食らった！", "%s^ gets zapped!"), mam_ptr->m_name);
     }
 
-    if (monster.ml && is_original_ap_and_seen(player, *mam_ptr->t_ptr)) {
+    if (monster.get_monster_profile().ml && is_original_ap_and_seen(player, *mam_ptr->t_ptr)) {
         monrace_target.aura_flags.set(MonsterAuraType::ELEC);
     }
 
@@ -182,7 +182,7 @@ static bool check_same_monster(CreatureEntity &creature, mam_type *mam_ptr)
 
 static void redraw_health_bar(mam_type *mam_ptr)
 {
-    if (!mam_ptr->t_ptr->ml) {
+    if (!mam_ptr->t_ptr->get_monster_profile().ml) {
         return;
     }
 

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -169,9 +169,9 @@ bool rush_attack(CreatureEntity &creature, bool *mdeath)
         const auto &monster = floor.m_list[grid_new.m_idx];
         if (tm_idx != grid_new.m_idx) {
 #ifdef JP
-            msg_format("%s%sが立ちふさがっている！", tm_idx > 0 ? "別の" : "", monster.ml ? "モンスター" : "何か");
+            msg_format("%s%sが立ちふさがっている！", tm_idx > 0 ? "別の" : "", monster.get_monster_profile().ml ? "モンスター" : "何か");
 #else
-            msg_format("There is %s in the way!", monster.ml ? (tm_idx > 0 ? "another monster" : "a monster") : "someone");
+            msg_format("There is %s in the way!", monster.get_monster_profile().ml ? (tm_idx > 0 ? "another monster" : "a monster") : "someone");
 #endif
         } else if (!creature.is_located_at(p_pos_new)) {
             const auto m_name = monster_desc(creature, monster, 0);
@@ -225,13 +225,13 @@ void process_surprise_attack(CreatureEntity &creature, player_attack_type *pa_pt
     }
 
     auto ninja_data = CreatureClass(creature).get_specific_data<ninja_data_type>();
-    if (pa_ptr->m_ptr->is_asleep() && pa_ptr->m_ptr->ml) {
+    if (pa_ptr->m_ptr->is_asleep() && pa_ptr->m_ptr->get_monster_profile().ml) {
         /* Can't backstab creatures that we can't see, right? */
         pa_ptr->backstab = true;
     } else if ((ninja_data && ninja_data->s_stealth) && (randint0(tmp) > (monrace.level + 20)) &&
-               pa_ptr->m_ptr->ml && !monrace.resistance_flags.has(MonsterResistanceType::RESIST_ALL)) {
+               pa_ptr->m_ptr->get_monster_profile().ml && !monrace.resistance_flags.has(MonsterResistanceType::RESIST_ALL)) {
         pa_ptr->surprise_attack = true;
-    } else if (pa_ptr->m_ptr->is_fearful() && pa_ptr->m_ptr->ml) {
+    } else if (pa_ptr->m_ptr->is_fearful() && pa_ptr->m_ptr->get_monster_profile().ml) {
         pa_ptr->stab_fleeing = true;
     }
 }

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -530,7 +530,7 @@ void musou_counterattack(CreatureEntity &creature, MonsterAttackPlayer *monap_pt
 {
     auto &player = static_cast<PlayerType &>(creature);
     const auto is_musou = CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU);
-    if ((!player.counter && !is_musou) || !monap_ptr->alive || player.is_dead() || !monap_ptr->m_ptr->ml || (player.csp <= 7)) {
+    if ((!player.counter && !is_musou) || !monap_ptr->alive || player.is_dead() || !monap_ptr->m_ptr->get_monster_profile().ml || (player.csp <= 7)) {
         return;
     }
 

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -455,7 +455,7 @@ void MonsterAttackPlayer::process_monster_attack_evasion()
 void MonsterAttackPlayer::describe_attack_evasion()
 {
     auto &player = static_cast<PlayerType &>(*this->creature_ptr);
-    if (!this->m_ptr->ml) {
+    if (!this->m_ptr->get_monster_profile().ml) {
         return;
     }
 
@@ -560,7 +560,7 @@ void MonsterAttackPlayer::postprocess_monster_blows()
         monrace.r_deaths++;
     }
 
-    if (this->m_ptr->ml && this->fear && this->alive && !player.is_dead()) {
+    if (this->m_ptr->get_monster_profile().ml && this->fear && this->alive && !player.is_dead()) {
         sound(SoundKind::FLEE);
         msg_format(_("%s^は恐怖で逃げ出した！", "%s^ flees in terror!"), this->m_name);
     }
@@ -601,9 +601,9 @@ void MonsterAttackPlayer::process_sadist_reaction()
         (void)set_monster_monfear(*player.current_floor_ptr, this->m_idx, 0);
 
         // 一時的な攻撃力上昇（怒り状態付与）
-        this->m_ptr->mflag2.set(MonsterConstantFlagType::ANGER);
+        this->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::ANGER);
 
-        if (this->m_ptr->ml) {
+        if (this->m_ptr->get_monster_profile().ml) {
             msg_format(_("%s^は他者の苦痛に興奮している！", "%s^ gets excited by others' pain!"), this->m_name);
         }
     }

--- a/src/monster-attack/monster-attack-processor.cpp
+++ b/src/monster-attack/monster-attack-processor.cpp
@@ -134,7 +134,7 @@ bool process_monster_attack_to_monster(CreatureEntity &creature, turn_flags *tur
     do_kill_body &= !monster_to.is_riding();
     const bool is_same_alliance_intelligent = (monrace_from.alliance_idx != AllianceType::NONE && monrace_from.alliance_idx == monrace_to.alliance_idx && monrace_from.behavior_flags.has_not(MonsterBehaviorType::STUPID));
     do_kill_body &= !is_same_alliance_intelligent;
-    const bool is_same_summon_parent = (monster_from.parent_m_idx == monster_to.parent_m_idx && monrace_from.behavior_flags.has_not(MonsterBehaviorType::STUPID)) || (monster_from.mflag2.has(MonsterConstantFlagType::PET) != monster_to.mflag2.has(MonsterConstantFlagType::PET));
+    const bool is_same_summon_parent = (monster_from.get_monster_profile().parent_m_idx == monster_to.get_monster_profile().parent_m_idx && monrace_from.behavior_flags.has_not(MonsterBehaviorType::STUPID)) || (monster_from.get_monster_profile().mflag2.has(MonsterConstantFlagType::PET) != monster_to.get_monster_profile().mflag2.has(MonsterConstantFlagType::PET));
     do_kill_body &= !is_same_summon_parent;
     if (do_kill_body || monster_from.is_hostile_to_melee(monster_to) || monster_from.is_confused()) {
         return exe_monster_attack_to_monster(creature, m_idx, grid);

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -119,7 +119,7 @@ static void move_item_to_monster(CreatureEntity &creature, MonsterAttackPlayer *
 
     item.marked.clear().set(OmType::TOUCHED);
     item.held_m_idx = monap_ptr->m_idx;
-    monap_ptr->m_ptr->hold_o_idx_list.add(*creature.current_floor_ptr, o_idx);
+    monap_ptr->m_ptr->get_monster_profile().hold_o_idx_list.add(*creature.current_floor_ptr, o_idx);
 }
 
 /*!
@@ -296,7 +296,7 @@ void process_drain_life(MonsterAttackPlayer *monap_ptr, const bool resist_drain)
         RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
-    if (monap_ptr->m_ptr->ml && did_heal) {
+    if (monap_ptr->m_ptr->get_monster_profile().ml && did_heal) {
         msg_format(_("%sは体力を回復したようだ。", "%s^ appears healthier."), monap_ptr->m_name);
     }
 }

--- a/src/monster-floor/monster-death-util.cpp
+++ b/src/monster-floor/monster-death-util.cpp
@@ -22,8 +22,8 @@ MonsterDeath::MonsterDeath(FloorType &floor, short m_idx, bool drop_item)
     });
     this->do_item = this->r_ptr->drop_flags.has_not(MonsterDropType::ONLY_GOLD);
     this->do_item |= this->r_ptr->drop_flags.has_any_of({ MonsterDropType::DROP_GOOD, MonsterDropType::DROP_GREAT });
-    this->cloned = this->m_ptr->mflag2.has(MonsterConstantFlagType::CLONED);
-    this->is_chameleon = this->m_ptr->mflag2.has(MonsterConstantFlagType::CHAMELEON);
+    this->cloned = this->m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::CLONED);
+    this->is_chameleon = this->m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::CHAMELEON);
     this->drop_chosen_item = drop_item && !this->cloned && !this->is_chameleon && !floor.inside_arena && !AngbandSystem::get_instance().is_phase_out() && !this->m_ptr->is_pet();
 }
 

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -290,7 +290,7 @@ static int decide_drop_numbers(CreatureEntity &creature, MonsterDeath *md_ptr, c
         drop_numbers += Dice::roll(4, 2);
     }
 
-    if (md_ptr->m_ptr->mflag2.has(MonsterConstantFlagType::SANTA)) {
+    if (md_ptr->m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::SANTA)) {
         drop_numbers += Dice::roll(3, 3);
     }
 
@@ -336,7 +336,7 @@ static void drop_items_golds(CreatureEntity &creature, MonsterDeath *md_ptr, int
     }
 
     floor.object_level = floor.base_level;
-    auto visible = md_ptr->m_ptr->ml && !creature.effects()->hallucination().is_hallucinated();
+    auto visible = md_ptr->m_ptr->get_monster_profile().ml && !creature.effects()->hallucination().is_hallucinated();
     visible |= (md_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE));
     if (visible && (dump_item || dump_gold)) {
         md_ptr->m_ptr->make_lore_treasure(dump_item, dump_gold);
@@ -404,7 +404,7 @@ void monster_death(CreatureEntity &creature, MONSTER_IDX m_idx, bool drop_item, 
     }
 
     // プレイヤーしかユニークを倒せないのでここで時間を記録
-    if (md.r_ptr->kind_flags.has(MonsterKindType::UNIQUE) && md.m_ptr->mflag2.has_not(MonsterConstantFlagType::CLONED)) {
+    if (md.r_ptr->kind_flags.has(MonsterKindType::UNIQUE) && md.m_ptr->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::CLONED)) {
         world.play_time.update();
         md.r_ptr->defeat_time = world.play_time.elapsed_sec();
         md.r_ptr->defeat_level = creature.level;
@@ -416,7 +416,7 @@ void monster_death(CreatureEntity &creature, MONSTER_IDX m_idx, bool drop_item, 
 
     write_pet_death(creature, &md);
     on_dead_explosion(creature, &md);
-    if (md.m_ptr->mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
+    if (md.m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
         md.m_ptr->reset_chameleon_polymorph();
         md.r_ptr = &md.m_ptr->get_monrace();
     }

--- a/src/monster-floor/monster-generator.cpp
+++ b/src/monster-floor/monster-generator.cpp
@@ -133,7 +133,7 @@ tl::optional<MONSTER_IDX> multiply_monster(CreatureEntity &creature, MONSTER_IDX
         return tl::nullopt;
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::NOPET)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::NOPET)) {
         mode |= PM_NO_PET;
     }
 
@@ -142,8 +142,8 @@ tl::optional<MONSTER_IDX> multiply_monster(CreatureEntity &creature, MONSTER_IDX
         return tl::nullopt;
     }
 
-    if (clone || monster.mflag2.has(MonsterConstantFlagType::CLONED)) {
-        floor.m_list[*multiplied_m_idx].mflag2.set({ MonsterConstantFlagType::CLONED, MonsterConstantFlagType::NOPET });
+    if (clone || monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::CLONED)) {
+        floor.m_list[*multiplied_m_idx].get_monster_profile().mflag2.set({ MonsterConstantFlagType::CLONED, MonsterConstantFlagType::NOPET });
     }
 
     return multiplied_m_idx;
@@ -381,7 +381,7 @@ bool alloc_horde(CreatureEntity &creature, POSITION y, POSITION x, summon_specif
         return true;
     }
 
-    const auto &monrace = monentity.mflag2.has(MonsterConstantFlagType::CHAMELEON) ? monentity.get_monrace() : MonraceList::get_instance().get_monrace(*monrace_id);
+    const auto &monrace = monentity.get_monster_profile().mflag2.has(MonsterConstantFlagType::CHAMELEON) ? monentity.get_monrace() : MonraceList::get_instance().get_monrace(*monrace_id);
     msg_format(_("モンスターの大群(%c)", "Monster horde (%c)."), monrace.symbol_definition.character);
     return true;
 }

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -478,10 +478,10 @@ bool process_monster_movement(CreatureEntity &creature, turn_flags *turn_flags_p
         const auto p_pos = creature.get_position(); //!< @details 関数が長すぎてプレイヤーの座標が不変であることを保証できない.
         const auto m_pos = monster.get_position();
         const auto is_projectable = projectable(floor, p_pos, m_pos);
-        const auto can_see = disturb_near && monster.mflag.has(MonsterTemporaryFlagType::VIEW) && is_projectable;
+        const auto can_see = disturb_near && monster.get_monster_profile().mflag.has(MonsterTemporaryFlagType::VIEW) && is_projectable;
         const auto is_high_level = disturb_high && (apparent_monrace.r_tkills > 0) && (apparent_monrace.level >= creature.level);
         const auto is_unknown_level = disturb_unknown && (apparent_monrace.r_tkills == 0);
-        if (monster.ml && (disturb_move || can_see || is_high_level || is_unknown_level)) {
+        if (monster.get_monster_profile().ml && (disturb_move || can_see || is_high_level || is_unknown_level)) {
             if (monster.is_hostile()) {
                 disturb(creature, false, true);
             }
@@ -568,7 +568,7 @@ void process_sound(CreatureEntity &creature, MONSTER_IDX m_idx)
     const auto &monster = floor.m_list[m_idx];
     const auto &monrace = monster.get_monrace();
 
-    if (monster.ml || creature.skill_srh < randint1(100)) {
+    if (monster.get_monster_profile().ml || creature.skill_srh < randint1(100)) {
         return;
     }
     const auto m_name = std::string(_("それ", "It"));
@@ -623,7 +623,7 @@ void process_speak(CreatureEntity &creature, MONSTER_IDX m_idx, POSITION oy, POS
         return;
     }
 
-    const auto m_name = monster.ml ? monster_desc(creature, monster, 0) : std::string(_("それ", "It"));
+    const auto m_name = monster.get_monster_profile().ml ? monster_desc(creature, monster, 0) : std::string(_("それ", "It"));
     const auto message_type = get_speak_type(monster);
     if (!message_type) {
         return;

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -135,7 +135,7 @@ static void monster_pickup_object(CreatureEntity &creature, turn_flags *turn_fla
     if (is_unpickable_object) {
         if (turn_flags_ptr->do_take && monrace.behavior_flags.has(MonsterBehaviorType::STUPID)) {
             turn_flags_ptr->did_take_item = true;
-            if (monster.ml && player_can_see_bold(creature, ny, nx)) {
+            if (monster.get_monster_profile().ml && player_can_see_bold(creature, ny, nx)) {
                 msg_format(_("%s^は%sを拾おうとしたが、だめだった。", "%s^ tries to pick up %s, but fails."), m_name.data(), o_name.data());
             }
         }
@@ -154,7 +154,7 @@ static void monster_pickup_object(CreatureEntity &creature, turn_flags *turn_fla
         o_ptr->marked &= { OmType::TOUCHED };
         o_ptr->iy = o_ptr->ix = 0;
         o_ptr->held_m_idx = m_idx;
-        monster.hold_o_idx_list.add(*creature.current_floor_ptr, this_o_idx);
+        monster.get_monster_profile().hold_o_idx_list.add(*creature.current_floor_ptr, this_o_idx);
         RedrawingFlagsUpdater::get_instance().set_flag(SubWindowRedrawingFlag::FOUND_ITEMS);
         return;
     }
@@ -216,7 +216,7 @@ void update_object_by_monster_movement(CreatureEntity &creature, turn_flags *tur
  */
 void monster_drop_carried_objects(CreatureEntity &creature, MonsterEntity &monster)
 {
-    for (auto it = monster.hold_o_idx_list.begin(); it != monster.hold_o_idx_list.end();) {
+    for (auto it = monster.get_monster_profile().hold_o_idx_list.begin(); it != monster.get_monster_profile().hold_o_idx_list.end();) {
         const auto this_o_idx = *it++;
         auto drop_item = creature.current_floor_ptr->o_list[this_o_idx]->clone();
         drop_item.held_m_idx = 0;
@@ -224,5 +224,5 @@ void monster_drop_carried_objects(CreatureEntity &creature, MonsterEntity &monst
         (void)drop_near(creature, drop_item, monster.get_position());
     }
 
-    monster.hold_o_idx_list.clear();
+    monster.get_monster_profile().hold_o_idx_list.clear();
 }

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -73,14 +73,14 @@ void delete_monster_idx(CreatureEntity &creature, short m_idx)
     }
 
     floor.get_grid(m_pos).m_idx = 0;
-    delete_items(creature, monster.hold_o_idx_list);
+    delete_items(creature, monster.get_monster_profile().hold_o_idx_list);
 
     // 召喚元のモンスターが消滅した時は、召喚されたモンスターのparent_m_idxが
     // 召喚されたモンスター自身のm_idxを指すようにする
     for (MONSTER_IDX child_m_idx = 1; child_m_idx < floor.m_max; child_m_idx++) {
         auto &child_monster = floor.m_list[child_m_idx];
-        if (child_monster.is_valid() && child_monster.parent_m_idx == m_idx) {
-            child_monster.parent_m_idx = child_m_idx;
+        if (child_monster.is_valid() && child_monster.get_monster_profile().parent_m_idx == m_idx) {
+            child_monster.get_monster_profile().parent_m_idx = child_m_idx;
         }
     }
 

--- a/src/monster-floor/monster-safety-hiding.cpp
+++ b/src/monster-floor/monster-safety-hiding.cpp
@@ -44,7 +44,7 @@ static coordinate_candidate sweep_safe_coordinate(CreatureEntity &creature, MONS
             continue;
         }
 
-        if (monster.mflag2.has_not(MonsterConstantFlagType::NOFLOW)) {
+        if (monster.get_monster_profile().mflag2.has_not(MonsterConstantFlagType::NOFLOW)) {
             const auto dist = grid.get_distance(monrace.get_grid_flow_type());
             if (dist == 0) {
                 continue;

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -120,7 +120,7 @@ public:
         const auto &monster = floor.m_list[m_idx];
         const auto &monrace = monster.get_monrace();
         const auto m_pos = monster.get_position();
-        const auto no_flow = monster.mflag2.has(MonsterConstantFlagType::NOFLOW) && (floor.get_grid(m_pos).get_cost(monrace.get_grid_flow_type()) > 2);
+        const auto no_flow = monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::NOFLOW) && (floor.get_grid(m_pos).get_cost(monrace.get_grid_flow_type()) > 2);
 
         // 単に反対側に逃げる(あまり賢くない方法)場合の移動先
         const auto pos_run_away_simple = m_pos + (m_pos - pos_move);
@@ -470,7 +470,7 @@ public:
         const auto gf = monrace.get_grid_flow_type();
         const auto dist_to_player = m_grid.get_distance(gf); // 経由グリッド数換算(Grid::dists)による距離
         const auto distance_to_player = Grid::calc_distance(m_pos, p_pos); // Grid::calc_distance()による直線距離
-        const auto no_flow = monster.mflag2.has(MonsterConstantFlagType::NOFLOW) && (m_grid.get_cost(gf) > 2);
+        const auto no_flow = monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::NOFLOW) && (m_grid.get_cost(gf) > 2);
         const auto can_pass_wall = monrace.feature_flags.has(MonsterFeatureType::PASS_WALL) && (!monster.is_riding() || has_pass_wall(*creature_ptr));
         const auto can_kill_wall = monrace.feature_flags.has(MonsterFeatureType::KILL_WALL) && !monster.is_riding();
         const auto is_visible_from_player = m_grid.has_los() && projectable(floor, p_pos, m_pos);

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -258,25 +258,25 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     // モンスターの能力値をランダムに初期化
     get_stats(m_ptr);
 
-    m_ptr->alliance_idx = monrace.alliance_idx;
+    m_ptr->get_monster_profile().alliance_idx = monrace.alliance_idx;
 
-    m_ptr->mflag.clear();
-    m_ptr->mflag2.clear();
+    m_ptr->get_monster_profile().mflag.clear();
+    m_ptr->get_monster_profile().mflag2.clear();
     m_ptr->current_floor_ptr = player.current_floor_ptr;
 
     if (monrace.misc_flags.has(MonsterMiscType::CHAMELEON)) {
         m_ptr->r_idx = r_idx;
         choose_chameleon_polymorph(player, g_ptr->m_idx, g_ptr->get_terrain_id(), summoner_m_idx);
-        m_ptr->mflag2.set(MonsterConstantFlagType::CHAMELEON);
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::CHAMELEON);
     } else if (any_bits(mode, PM_CHAMELEON_FINAL_SUMMON)) {
         m_ptr->r_idx = r_idx;
         m_ptr->ap_r_idx = r_idx;
-        m_ptr->mflag2.set(MonsterConstantFlagType::CHAMELEON);
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::CHAMELEON);
     } else {
         m_ptr->r_idx = r_idx;
         if (any_bits(mode, PM_KAGE) && none_bits(mode, PM_FORCE_PET)) {
             m_ptr->ap_r_idx = MonraceId::KAGE;
-            m_ptr->mflag2.set(MonsterConstantFlagType::KAGE);
+            m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::KAGE);
         } else {
             m_ptr->ap_r_idx = initial_r_appearance(const_cast<CreatureEntity &>(player), r_idx, mode);
         }
@@ -286,14 +286,14 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     const auto is_summoned = summoner_m_idx.has_value();
     const MonsterEntity &summoner = floor.m_list[summoner_m_idx.value_or(0)];
 
-    auto same_appearance_as_parent = m_ptr->mflag2.has_not(MonsterConstantFlagType::CHAMELEON);
+    auto same_appearance_as_parent = m_ptr->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::CHAMELEON);
     same_appearance_as_parent &= any_bits(mode, PM_MULTIPLY);
     same_appearance_as_parent &= is_summoned && !summoner.is_original_ap();
 
     if (same_appearance_as_parent) {
         m_ptr->ap_r_idx = summoner.ap_r_idx;
-        if (summoner.mflag2.has(MonsterConstantFlagType::KAGE)) {
-            m_ptr->mflag2.set(MonsterConstantFlagType::KAGE);
+        if (summoner.get_monster_profile().mflag2.has(MonsterConstantFlagType::KAGE)) {
+            m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::KAGE);
         }
     }
 
@@ -301,73 +301,73 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     struct tm *t = localtime(&now);
     if (t->tm_mon == 11 && t->tm_mday >= 24 && t->tm_mday <= 25 && one_in_(6)) {
         if (none_bits(mode, PM_MULTIPLY | PM_KAGE) && m_ptr->r_idx != MonraceId::SANTA) {
-            m_ptr->mflag2.set(MonsterConstantFlagType::SANTA);
+            m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::SANTA);
         }
     }
 
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) && one_in_(100)) {
-        m_ptr->mflag2.set(MonsterConstantFlagType::HUGE);
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::HUGE);
     } else if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
-               m_ptr->mflag2.has_not(MonsterConstantFlagType::HUGE) && one_in_(15)) {
-        m_ptr->mflag2.set(MonsterConstantFlagType::LARGE);
+               m_ptr->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::HUGE) && one_in_(15)) {
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::LARGE);
     }
 
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
-        m_ptr->mflag2.has_not(MonsterConstantFlagType::LARGE) &&
-        m_ptr->mflag2.has_not(MonsterConstantFlagType::HUGE) && one_in_(18)) {
-        m_ptr->mflag2.set(MonsterConstantFlagType::SMALL);
+        m_ptr->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::LARGE) &&
+        m_ptr->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::HUGE) && one_in_(18)) {
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::SMALL);
     }
 
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
         monrace.kind_flags.has_not(MonsterKindType::NONLIVING) && one_in_(20)) {
-        m_ptr->mflag2.set(MonsterConstantFlagType::FAT);
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::FAT);
     } else if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
                monrace.kind_flags.has_not(MonsterKindType::NONLIVING) &&
-               m_ptr->mflag2.has_not(MonsterConstantFlagType::FAT) && one_in_(25)) {
-        m_ptr->mflag2.set(MonsterConstantFlagType::GAUNT);
+               m_ptr->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::FAT) && one_in_(25)) {
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::GAUNT);
     }
 
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
         monrace.kind_flags.has(MonsterKindType::HUMAN) && one_in_(80)) {
-        m_ptr->mflag2.set(MonsterConstantFlagType::NAKED);
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NAKED);
     }
 
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
         monrace.kind_flags.has_not(MonsterKindType::NONLIVING) &&
         monrace.kind_flags.has_not(MonsterKindType::UNDEAD) && one_in_(50)) {
-        m_ptr->mflag2.set(MonsterConstantFlagType::ZOMBIFIED);
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::ZOMBIFIED);
     }
 
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
         monrace.misc_flags.has(MonsterMiscType::NO_WAIFUZATION) && one_in_(20)) {
-        m_ptr->mflag2.set(MonsterConstantFlagType::WAIFUIZED);
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::WAIFUIZED);
     }
 
     // 違法改造フラグの付与
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
         (monrace.kind_flags.has(MonsterKindType::GOLEM) || monrace.kind_flags.has(MonsterKindType::ROBOT)) &&
         one_in_(40)) {
-        m_ptr->mflag2.set(MonsterConstantFlagType::ILLEGAL_MODIFIED);
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::ILLEGAL_MODIFIED);
     }
 
     // 軽量化フラグの付与
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
         monrace.kind_flags.has(MonsterKindType::GOLEM) &&
         one_in_(15)) {
-        m_ptr->mflag2.set(MonsterConstantFlagType::LIGHTWEIGHT);
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::LIGHTWEIGHT);
     }
 
-    if (m_ptr->mflag2.has_not(MonsterConstantFlagType::CHAMELEON) && is_summoned && new_monrace.kind_flags.has_none_of(alignment_mask)) {
-        m_ptr->sub_align = summoner.sub_align;
-    } else if (m_ptr->mflag2.has(MonsterConstantFlagType::CHAMELEON) && new_monrace.kind_flags.has(MonsterKindType::UNIQUE) && !is_summoned) {
-        m_ptr->sub_align = SUB_ALIGN_NEUTRAL;
+    if (m_ptr->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::CHAMELEON) && is_summoned && new_monrace.kind_flags.has_none_of(alignment_mask)) {
+        m_ptr->get_monster_profile().sub_align = summoner.get_monster_profile().sub_align;
+    } else if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::CHAMELEON) && new_monrace.kind_flags.has(MonsterKindType::UNIQUE) && !is_summoned) {
+        m_ptr->get_monster_profile().sub_align = SUB_ALIGN_NEUTRAL;
     } else {
-        m_ptr->sub_align = SUB_ALIGN_NEUTRAL;
+        m_ptr->get_monster_profile().sub_align = SUB_ALIGN_NEUTRAL;
         if (new_monrace.kind_flags.has(MonsterKindType::EVIL)) {
-            set_bits(m_ptr->sub_align, SUB_ALIGN_EVIL);
+            set_bits(m_ptr->get_monster_profile().sub_align, SUB_ALIGN_EVIL);
         }
         if (new_monrace.kind_flags.has(MonsterKindType::GOOD)) {
-            set_bits(m_ptr->sub_align, SUB_ALIGN_GOOD);
+            set_bits(m_ptr->get_monster_profile().sub_align, SUB_ALIGN_GOOD);
         }
     }
 
@@ -376,7 +376,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     m_ptr->current_floor_ptr = &floor;
 
     for (const auto mte : MONSTER_TIMED_EFFECT_RANGE) {
-        m_ptr->mtimed[mte] = 0;
+        m_ptr->get_monster_profile().mtimed[mte] = 0;
     }
 
     m_ptr->reset_target();
@@ -384,25 +384,25 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     m_ptr->exp = 0;
 
     if (is_summoned) {
-        m_ptr->parent_m_idx = *summoner_m_idx;
+        m_ptr->get_monster_profile().parent_m_idx = *summoner_m_idx;
         if (summoner.get_monrace().kind_flags.has(MonsterKindType::QUYLTHLUG)) {
-            m_ptr->mflag2.set(MonsterConstantFlagType::QUYLTHLUG_BORN);
+            m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::QUYLTHLUG_BORN);
         }
     } else {
-        m_ptr->parent_m_idx = 0;
+        m_ptr->get_monster_profile().parent_m_idx = 0;
     }
 
     // 変身情報のコピー
-    m_ptr->transform_r_idx = new_monrace.transform_r_idx;
-    m_ptr->transform_hp_threshold = new_monrace.transform_hp_threshold;
-    m_ptr->has_transformed = false;
+    m_ptr->get_monster_profile().transform_r_idx = new_monrace.transform_r_idx;
+    m_ptr->get_monster_profile().transform_hp_threshold = new_monrace.transform_hp_threshold;
+    m_ptr->get_monster_profile().has_transformed = false;
 
     if (any_bits(mode, PM_CLONE)) {
-        m_ptr->mflag2.set(MonsterConstantFlagType::CLONED);
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::CLONED);
     }
 
     if (any_bits(mode, PM_NO_PET)) {
-        m_ptr->mflag2.set(MonsterConstantFlagType::NOPET);
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
     }
 
     // モンスターのフラグに基づいて対応するプレイヤー種族IDと職業IDを初期化
@@ -415,7 +415,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     // 所持金を初期化（能力値に基づいて計算）
     get_money_for_creature(m_ptr);
 
-    m_ptr->ml = false;
+    m_ptr->get_monster_profile().ml = false;
     if (any_bits(mode, PM_FORCE_PET)) {
         set_pet(player, *m_ptr);
     } else {
@@ -424,15 +424,15 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
         should_be_friendly |= any_bits(mode, PM_FORCE_FRIENDLY);
         auto force_hostile = monster_has_hostile_to_player(player, 0, -1, new_monrace);
         force_hostile |= floor.inside_arena;
-        if (m_ptr->alliance_idx != AllianceType::NONE) {
-            should_be_friendly |= alliance_list.at(m_ptr->alliance_idx)->isFriendly(player);
+        if (m_ptr->get_monster_profile().alliance_idx != AllianceType::NONE) {
+            should_be_friendly |= alliance_list.at(m_ptr->get_monster_profile().alliance_idx)->isFriendly(player);
         }
         if (should_be_friendly && !force_hostile) {
             m_ptr->set_friendly();
         }
     }
 
-    m_ptr->mtimed[MonsterTimedEffect::SLEEP] = 0;
+    m_ptr->get_monster_profile().mtimed[MonsterTimedEffect::SLEEP] = 0;
     if (any_bits(mode, PM_ALLOW_SLEEP) && new_monrace.sleep && !ironman_nightmare) {
         int val = new_monrace.sleep;
         (void)set_monster_csleep(floor, g_ptr->m_idx, (val * 2) + randint1(val * 10));
@@ -444,36 +444,36 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
         m_ptr->max_maxhp = new_monrace.hit_dice.roll();
     }
 
-    if (m_ptr->mflag2.has(MonsterConstantFlagType::HUGE)) {
+    if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::HUGE)) {
         m_ptr->max_maxhp *= (randint1(8) + 15) / 8;
         m_ptr->max_maxhp = std::min(MONSTER_MAXHP, m_ptr->max_maxhp);
-    } else if (m_ptr->mflag2.has(MonsterConstantFlagType::LARGE)) {
+    } else if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::LARGE)) {
         m_ptr->max_maxhp *= (randint1(5) + 10) / 8;
         m_ptr->max_maxhp = std::min(MONSTER_MAXHP, m_ptr->max_maxhp);
     }
-    if (m_ptr->mflag2.has(MonsterConstantFlagType::SMALL)) {
+    if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::SMALL)) {
         m_ptr->max_maxhp *= (randint1(2) + 4) / 8;
         m_ptr->max_maxhp = std::max(1, m_ptr->max_maxhp);
     }
-    if (m_ptr->mflag2.has(MonsterConstantFlagType::FAT)) {
+    if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::FAT)) {
         m_ptr->max_maxhp *= (randint1(3) + 8) / 8;
         m_ptr->max_maxhp = std::min(MONSTER_MAXHP, m_ptr->max_maxhp);
     }
-    if (m_ptr->mflag2.has(MonsterConstantFlagType::GAUNT)) {
+    if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::GAUNT)) {
         m_ptr->max_maxhp *= (randint1(3) + 4) / 8;
         m_ptr->max_maxhp = std::max(1, m_ptr->max_maxhp);
     }
-    if (m_ptr->mflag2.has(MonsterConstantFlagType::ZOMBIFIED)) {
+    if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::ZOMBIFIED)) {
         m_ptr->max_maxhp *= (randint1(3) + 5) / 8;
         m_ptr->max_maxhp = std::max(1, m_ptr->max_maxhp);
         // ゾンビ化したモンスターにUNDEADフラグを付与
         m_ptr->get_monrace().kind_flags.set(MonsterKindType::UNDEAD);
     }
-    if (m_ptr->mflag2.has(MonsterConstantFlagType::ILLEGAL_MODIFIED)) {
+    if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::ILLEGAL_MODIFIED)) {
         m_ptr->max_maxhp *= (randint1(3) + 10) / 8; // 1.5倍～1.75倍のHPボーナス
         m_ptr->max_maxhp = std::min(MONSTER_MAXHP, m_ptr->max_maxhp);
     }
-    if (m_ptr->mflag2.has(MonsterConstantFlagType::LIGHTWEIGHT)) {
+    if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::LIGHTWEIGHT)) {
         m_ptr->max_maxhp *= (randint1(2) + 5) / 8; // 0.625倍～0.75倍のHP減少
         m_ptr->max_maxhp = std::max(1, m_ptr->max_maxhp);
     }
@@ -502,30 +502,30 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
 
     m_ptr->dealt_damage = 0;
     if (monrace.suicide_dice_num && monrace.suicide_dice_side) {
-        m_ptr->death_count = Dice::roll(monrace.suicide_dice_num, monrace.suicide_dice_side);
+        m_ptr->get_monster_profile().death_count = Dice::roll(monrace.suicide_dice_num, monrace.suicide_dice_side);
     }
 
     m_ptr->set_individual_speed(floor.inside_arena);
 
     // Initialize AC from monster race
     m_ptr->ac = new_monrace.ac;
-    if (m_ptr->mflag2.has(MonsterConstantFlagType::ILLEGAL_MODIFIED)) {
+    if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::ILLEGAL_MODIFIED)) {
         m_ptr->ac += randint1(10) + 5; // +6～+15のACボーナス
     }
 
-    if (m_ptr->mflag2.has(MonsterConstantFlagType::HUGE)) {
+    if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::HUGE)) {
         m_ptr->speed -= randint1(2) + 2;
     }
-    if (m_ptr->mflag2.has(MonsterConstantFlagType::GAUNT)) {
+    if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::GAUNT)) {
         m_ptr->speed -= randint1(3);
     }
-    if (m_ptr->mflag2.has(MonsterConstantFlagType::SMALL)) {
+    if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::SMALL)) {
         m_ptr->speed += randint1(2) + 1;
     }
-    if (m_ptr->mflag2.has(MonsterConstantFlagType::ILLEGAL_MODIFIED)) {
+    if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::ILLEGAL_MODIFIED)) {
         m_ptr->speed += randint1(5) + 3; // +3～+7の加速ボーナス
     }
-    if (m_ptr->mflag2.has(MonsterConstantFlagType::LIGHTWEIGHT)) {
+    if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::LIGHTWEIGHT)) {
         m_ptr->speed += randint1(3) + 2; // +2～+4の加速ボーナス
     }
 
@@ -540,7 +540,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     }
 
     if (!ironman_nightmare) {
-        m_ptr->mflag.set(MonsterTemporaryFlagType::PREVENT_MAGIC);
+        m_ptr->get_monster_profile().mflag.set(MonsterTemporaryFlagType::PREVENT_MAGIC);
     }
 
     auto is_awake_lightning_monster = new_monrace.brightness_flags.has_any_of(self_ld_mask);

--- a/src/monster-floor/quantum-effect.cpp
+++ b/src/monster-floor/quantum-effect.cpp
@@ -31,7 +31,7 @@ static void vanish_nonunique(CreatureEntity &creature, MONSTER_IDX m_idx, bool s
 
     monster_death(creature, m_idx, false, AttributeType::QUANTUM_VANISH);
     delete_monster_idx(creature, m_idx);
-    if (monster.is_pet() && !(monster.ml)) {
+    if (monster.is_pet() && !(monster.get_monster_profile().ml)) {
         msg_print(_("少しの間悲しい気分になった。", "You feel sad for a moment."));
     }
 }

--- a/src/monster/monster-compaction.cpp
+++ b/src/monster/monster-compaction.cpp
@@ -37,7 +37,7 @@ static void compact_monsters_aux(CreatureEntity &creature, MONSTER_IDX i1, MONST
     auto &grid = floor.grid_array[y][x];
     grid.m_idx = i2;
 
-    for (const auto this_o_idx : monster.hold_o_idx_list) {
+    for (const auto this_o_idx : monster.get_monster_profile().hold_o_idx_list) {
         ItemEntity *o_ptr;
         o_ptr = floor.o_list[this_o_idx].get();
         o_ptr->held_m_idx = i2;
@@ -67,8 +67,8 @@ static void compact_monsters_aux(CreatureEntity &creature, MONSTER_IDX i1, MONST
         for (int i = 1; i < floor.m_max; i++) {
             MonsterEntity *m2_ptr = &floor.m_list[i];
 
-            if (m2_ptr->parent_m_idx == i1) {
-                m2_ptr->parent_m_idx = i2;
+            if (m2_ptr->get_monster_profile().parent_m_idx == i1) {
+                m2_ptr->get_monster_profile().parent_m_idx = i2;
             }
         }
     }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -163,7 +163,7 @@ bool MonsterDamageProcessor::process_dead_exp_virtue(std::string_view note, cons
     ac.change_virtue();
     if (monrace.kind_flags.has(MonsterKindType::UNIQUE) && record_destroy_uniq) {
         std::stringstream ss;
-        ss << monrace.name << (monster.mflag2.has(MonsterConstantFlagType::CLONED) ? _("(クローン)", "(Clone)") : "");
+        ss << monrace.name << (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::CLONED) ? _("(クローン)", "(Clone)") : "");
         exe_write_diary(*player.current_floor_ptr, DiaryKind::UNIQUE, 0, ss.str());
     }
 
@@ -194,7 +194,7 @@ void MonsterDamageProcessor::death_special_flag_monster()
         }
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
         auto &real_monrace = monster.get_real_monrace();
         monrace_id = monster.get_real_monrace_id();
         if (real_monrace.r_sights < MAX_SHORT) {
@@ -202,7 +202,7 @@ void MonsterDamageProcessor::death_special_flag_monster()
         }
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::CLONED)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::CLONED)) {
         return;
     }
 
@@ -243,12 +243,12 @@ void MonsterDamageProcessor::increase_kill_numbers()
     }
 
     const auto is_hallucinated = player.effects()->hallucination().is_hallucinated();
-    if (((monster.ml == 0) || is_hallucinated) && monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {
+    if (((monster.get_monster_profile().ml == 0) || is_hallucinated) && monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {
         return;
     }
 
     auto &monraces = MonraceList::get_instance();
-    if (monster.mflag2.has(MonsterConstantFlagType::KAGE)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::KAGE)) {
         auto &shadower = monraces.get_monrace(MonraceId::KAGE);
         shadower.increment_pkills();
         shadower.increment_tkills();
@@ -351,7 +351,7 @@ void MonsterDamageProcessor::show_kill_message(std::string_view note, std::strin
         return;
     }
 
-    if (!monster.ml) {
+    if (!monster.get_monster_profile().ml) {
         auto mes = this->creature.is_echizen() ? _("せっかくだから%sを殺した。", "Because it's time, you have killed %s.")
                                                : _("%sを殺した。", "You have killed %s.");
         msg_format(mes, m_name.data());
@@ -397,11 +397,11 @@ void MonsterDamageProcessor::show_bounty_message(std::string_view m_name)
     auto &floor = *player.current_floor_ptr;
     auto &monster = floor.m_list[this->m_idx];
     const auto &monrace = monster.get_real_monrace();
-    if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) || monster.mflag2.has(MonsterConstantFlagType::CLONED) || vanilla_town) {
+    if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) || monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::CLONED) || vanilla_town) {
         return;
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
         return;
     }
 
@@ -510,7 +510,7 @@ void MonsterDamageProcessor::add_monster_fear()
 
     const auto &monrace = monster.get_monrace();
     if (monster.is_fearful() || monrace.resistance_flags.has(MonsterResistanceType::NO_FEAR) ||
-        monster.mflag2.has(MonsterConstantFlagType::FRENZY)) {
+        monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::FRENZY)) {
         return;
     }
 
@@ -548,7 +548,7 @@ void MonsterDamageProcessor::process_masochist_reaction()
             auto heal_amount = randint1(this->dam / 4 + 1);
             monster.hp = std::min(monster.hp + heal_amount, monster.maxhp);
 
-            if (monster.ml) {
+            if (monster.get_monster_profile().ml) {
                 msg_format(_("%s^は苦痛に悦んでいる！", "%s^ seems to enjoy the pain!"), monster.get_monrace().name.data());
             }
         }
@@ -577,7 +577,7 @@ void MonsterDamageProcessor::process_sadist_reaction()
         // 一時的な加速効果付与（興奮状態）
         (void)set_monster_fast(*player.current_floor_ptr, this->m_idx, monster.get_remaining_acceleration() + 100);
 
-        if (monster.ml) {
+        if (monster.get_monster_profile().ml) {
             msg_format(_("%s^は他者の苦痛に興奮している！", "%s^ gets excited by others' pain!"), monster.get_monrace().name.data());
         }
     }
@@ -593,28 +593,28 @@ bool MonsterDamageProcessor::check_and_process_hp_transform()
     auto &monster = player.current_floor_ptr->m_list[this->m_idx];
 
     // 変身条件のチェック
-    if (monster.has_transformed) {
+    if (monster.get_monster_profile().has_transformed) {
         return false; // 既に変身済み
     }
 
-    if (!MonraceList::is_valid(monster.transform_r_idx) || monster.transform_hp_threshold == 0) {
+    if (!MonraceList::is_valid(monster.get_monster_profile().transform_r_idx) || monster.get_monster_profile().transform_hp_threshold == 0) {
         return false; // 変身設定がない
     }
 
     // HP閾値チェック（最大HPの%で判定）
     const auto hp_percent = (100 * monster.hp) / monster.maxhp;
-    if (hp_percent > monster.transform_hp_threshold) {
+    if (hp_percent > monster.get_monster_profile().transform_hp_threshold) {
         return false; // まだ変身しない
     }
 
     // 変身先の種族情報を取得
-    const auto new_r_idx = monster.transform_r_idx;
+    const auto new_r_idx = monster.get_monster_profile().transform_r_idx;
     auto &new_monrace = MonraceList::get_instance().get_monrace(new_r_idx);
 
     // 変身前の情報を保存
     const auto old_hp = monster.hp;
     const auto old_maxhp = monster.max_maxhp;
-    const auto old_sub_align = monster.sub_align;
+    const auto old_sub_align = monster.get_monster_profile().sub_align;
     const auto old_name = monster_desc(player, monster, MD_INDEF_VISIBLE);
 
     // 種族カウンターの更新
@@ -638,17 +638,17 @@ bool MonsterDamageProcessor::check_and_process_hp_transform()
     monster.hp = old_hp * monster.maxhp / old_maxhp;
 
     // 変身フラグを設定
-    monster.has_transformed = true;
+    monster.get_monster_profile().has_transformed = true;
 
     // 変身先の変身情報をコピー
-    monster.transform_r_idx = new_monrace.transform_r_idx;
-    monster.transform_hp_threshold = new_monrace.transform_hp_threshold;
+    monster.get_monster_profile().transform_r_idx = new_monrace.transform_r_idx;
+    monster.get_monster_profile().transform_hp_threshold = new_monrace.transform_hp_threshold;
 
     // アライメントを維持
-    monster.sub_align = old_sub_align;
+    monster.get_monster_profile().sub_align = old_sub_align;
 
     // メッセージ表示
-    if (monster.ml) {
+    if (monster.get_monster_profile().ml) {
         const auto new_name = monster_desc(player, monster, MD_INDEF_VISIBLE);
         msg_format(_("％sは％sに変身した！", "％s^ transforms into ％s!"),
             old_name.data(), new_name.data());

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -94,7 +94,7 @@ static std::string get_monster_personal_pronoun(const int kind, const BIT_FLAGS 
 
 static tl::optional<std::string> decide_monster_personal_pronoun(const MonsterEntity &monster, const BIT_FLAGS mode)
 {
-    const auto seen = any_bits(mode, MD_ASSUME_VISIBLE) || (none_bits(mode, MD_ASSUME_HIDDEN) && monster.ml);
+    const auto seen = any_bits(mode, MD_ASSUME_VISIBLE) || (none_bits(mode, MD_ASSUME_HIDDEN) && monster.get_monster_profile().ml);
     const auto pron = (seen && any_bits(mode, MD_PRON_VISIBLE)) || (!seen && any_bits(mode, MD_PRON_HIDDEN));
     if (seen && !pron) {
         return tl::nullopt;
@@ -170,7 +170,7 @@ static tl::optional<std::string> get_fake_monster_name(const CreatureEntity &cre
         return tl::nullopt;
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::CHAMELEON) && none_bits(mode, MD_TRUE_NAME)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::CHAMELEON) && none_bits(mode, MD_TRUE_NAME)) {
         return _(replace_monster_name_undefined(name), format("%s?", name.data()));
     }
 
@@ -214,7 +214,7 @@ static std::string describe_non_pet(const CreatureEntity &creature, const Monste
 
 static std::string add_cameleon_name(const MonsterEntity &monster, const BIT_FLAGS mode)
 {
-    if (none_bits(mode, MD_IGNORE_HALLU) || monster.mflag2.has_not(MonsterConstantFlagType::CHAMELEON)) {
+    if (none_bits(mode, MD_IGNORE_HALLU) || monster.get_monster_profile().mflag2.has_not(MonsterConstantFlagType::CHAMELEON)) {
         return "";
     }
 
@@ -249,12 +249,12 @@ std::string monster_desc(CreatureEntity &subject, const MonsterEntity &monster, 
     const auto name = get_describing_monster_name(monster, is_hallucinated, mode);
     std::stringstream ss;
 
-    if (monster.parent_m_idx > 0) {
-        const auto parent_monster = subject.current_floor_ptr->m_list[monster.parent_m_idx];
+    if (monster.get_monster_profile().parent_m_idx > 0) {
+        const auto parent_monster = subject.current_floor_ptr->m_list[monster.get_monster_profile().parent_m_idx];
         // 親ID＝自身のIDでは主を失った状態なのでスキップ
         if (parent_monster.r_idx != monster.r_idx) {
-            auto parent_name = subject.current_floor_ptr->m_list[monster.parent_m_idx].get_monrace().name;
-            if (monster.mflag2.has(MonsterConstantFlagType::QUYLTHLUG_BORN)) {
+            auto parent_name = subject.current_floor_ptr->m_list[monster.get_monster_profile().parent_m_idx].get_monrace().name;
+            if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::QUYLTHLUG_BORN)) {
                 ss << parent_name << _("が産んだ", "-born ");
             } else if (monrace.misc_flags.has(MonsterMiscType::BREAK_DOWN)) {
                 ss << parent_name << _("が率いる", "leads ");
@@ -265,63 +265,63 @@ std::string monster_desc(CreatureEntity &subject, const MonsterEntity &monster, 
     }
 
 #ifdef JP
-    if (monster.mflag2.has(MonsterConstantFlagType::SANTA)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::SANTA)) {
         ss << "サンタと化した";
     }
 #endif
 #ifndef JP
-    if (monster.mflag2.has(MonsterConstantFlagType::SANTA)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::SANTA)) {
         ss << "Santa turned ";
     }
 #endif
 
-    if (monster.mflag2.has(MonsterConstantFlagType::ANGER)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::ANGER)) {
         ss << _("怒れる", "angry ");
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::WAIFUIZED)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::WAIFUIZED)) {
         ss << _("美少女化した", "waifuized ");
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::HUGE)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::HUGE)) {
         ss << _("超大型の", "huge ");
-    } else if (monster.mflag2.has(MonsterConstantFlagType::LARGE)) {
+    } else if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::LARGE)) {
         ss << _("大型の", "large ");
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::SMALL)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::SMALL)) {
         ss << _("小柄な", "small ");
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::FAT)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::FAT)) {
         ss << _("肥満した", "fat ");
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::GAUNT)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::GAUNT)) {
         ss << _("やせ衰えた", "gaunt ");
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::ZOMBIFIED)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::ZOMBIFIED)) {
         ss << _("ゾンビと化した", "zombified ");
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::NAKED)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::NAKED)) {
         ss << _("全裸の", "naked ");
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::ILLEGAL_MODIFIED)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::ILLEGAL_MODIFIED)) {
         ss << _("違法改造の", "illegally modified ");
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::LIGHTWEIGHT)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::LIGHTWEIGHT)) {
         ss << _("軽量化した", "lightweight ");
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::DEFECATED)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::DEFECATED)) {
         ss << _("脱糞した", "defecated ");
     }
 
-    if (monster.mflag2.has(MonsterConstantFlagType::VOMITED)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::VOMITED)) {
         ss << _("嘔吐した", "vomited ");
     }
 

--- a/src/monster/monster-info.cpp
+++ b/src/monster/monster-info.cpp
@@ -231,7 +231,7 @@ bool monster_has_hostile_to_other_monster(const MonsterEntity &monster_other, co
 
 bool is_original_ap_and_seen(CreatureEntity &subject, const MonsterEntity &monster)
 {
-    return monster.ml && !subject.effects()->hallucination().is_hallucinated() && monster.is_original_ap();
+    return monster.get_monster_profile().ml && !subject.effects()->hallucination().is_hallucinated() && monster.is_original_ap();
 }
 
 /*!

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -146,7 +146,7 @@ void process_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
     turn_flags_ptr->see_m = is_seen(player, monster);
 
     decide_drop_from_monster(creature, m_idx, turn_flags_ptr->is_riding_mon);
-    if (monster.mflag2.has(MonsterConstantFlagType::CHAMELEON) && one_in_(13) && !monster.is_asleep()) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::CHAMELEON) && one_in_(13) && !monster.is_asleep()) {
         const auto &floor = *creature.current_floor_ptr;
         const auto old_m_name = monster_desc(creature, monster, 0);
         const auto &monrace = monster.get_monrace();
@@ -198,7 +198,7 @@ void process_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
     mark_monsters_present(player);
 
     turn_flags_ptr->aware = process_stealth(creature, m_idx);
-    if (monrace.behavior_flags.has(MonsterBehaviorType::FRIENDLY_STANDBY) && monster.mflag2.has(MonsterConstantFlagType::FRIENDLY)) {
+    if (monrace.behavior_flags.has(MonsterBehaviorType::FRIENDLY_STANDBY) && monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::FRIENDLY)) {
         return;
     }
 
@@ -254,7 +254,7 @@ void process_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
     process_speak(creature, m_idx, oy, ox, turn_flags_ptr->aware);
 
     // 狂乱状態のモンスターは魔法を使わず、プレイヤーに隣接していれば攻撃のみを行う
-    if (monster.mflag2.has(MonsterConstantFlagType::FRENZY)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::FRENZY)) {
         const auto dy = std::abs(monster.y - creature.y);
         const auto dx = std::abs(monster.x - creature.x);
         if (dy <= 1 && dx <= 1 && turn_flags_ptr->aware) {
@@ -282,7 +282,7 @@ void process_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
      *  Try to flow by smell.
      */
     if (player.no_flowed && count > 2 && monster.get_target_position().y) {
-        monster.mflag2.reset(MonsterConstantFlagType::NOFLOW);
+        monster.get_monster_profile().mflag2.reset(MonsterConstantFlagType::NOFLOW);
     }
 
     if (!turn_flags_ptr->do_turn && !turn_flags_ptr->do_move && !monster.is_fearful() && !turn_flags_ptr->is_riding_mon && turn_flags_ptr->aware) {
@@ -301,7 +301,7 @@ void process_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
         return;
     }
 
-    if (monster.ml) {
+    if (monster.get_monster_profile().ml) {
         chg_virtue(creature, Virtue::COMPASSION, -1);
     }
 }
@@ -382,12 +382,12 @@ bool vanish_summoned_children(CreatureEntity &creature, MONSTER_IDX m_idx, bool 
     }
 
     // parent_m_idxが自分自身を指している場合は召喚主は消滅している
-    if (monster.parent_m_idx != m_idx && floor.m_list[monster.parent_m_idx].is_valid()) {
+    if (monster.get_monster_profile().parent_m_idx != m_idx && floor.m_list[monster.get_monster_profile().parent_m_idx].is_valid()) {
         return false;
     }
 
     const auto m_name = monster_desc(creature, monster, 0);
-    if (monster.mflag2.has(MonsterConstantFlagType::QUYLTHLUG_BORN)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::QUYLTHLUG_BORN)) {
         if (see_m) {
             msg_format(_("%sは崩壊して朽ち果てた。", "%s^ crumbles into dust."), m_name.data());
         }
@@ -395,7 +395,7 @@ bool vanish_summoned_children(CreatureEntity &creature, MONSTER_IDX m_idx, bool 
         if (see_m) {
             msg_format(_("%sは主を失い消え去った。", "%s^ disappears without a master."), m_name.data());
         }
-    } else if (monster.mflag2.has(MonsterConstantFlagType::PET)) {
+    } else if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::PET)) {
         if (see_m) {
             msg_format(_("%sは消え去った。", "%s^ disappears."), m_name.data());
         }
@@ -436,7 +436,7 @@ bool awake_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
     }
 
     (void)set_monster_csleep(*creature.current_floor_ptr, m_idx, 0);
-    if (monster.ml) {
+    if (monster.get_monster_profile().ml) {
         const auto m_name = monster_desc(creature, monster, 0);
         msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());
     }
@@ -532,7 +532,7 @@ void process_special(CreatureEntity &creature, MONSTER_IDX m_idx)
     can_do_special &= randint1(100) <= monrace.freq_spell;
 
     // 違法改造モンスターの自滅処理
-    if (monster.mflag2.has(MonsterConstantFlagType::ILLEGAL_MODIFIED) && one_in_(50)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::ILLEGAL_MODIFIED) && one_in_(50)) {
         const auto m_name = monster_desc(creature, monster, 0);
         const auto pos = monster.get_position();
         msg_format(_("%sが突然機能停止し、爆発した！", "%s suddenly malfunctions and explodes!"), m_name.data());
@@ -556,7 +556,7 @@ void process_special(CreatureEntity &creature, MONSTER_IDX m_idx)
 
     for (int k = 0; k < A_MAX; k++) {
         if (auto summoned_m_idx = summon_specific(creature, monster.y, monster.x, rlev, SUMMON_MOLD, (PM_ALLOW_GROUP | p_mode), m_idx)) {
-            if (creature.current_floor_ptr->m_list[*summoned_m_idx].ml) {
+            if (creature.current_floor_ptr->m_list[*summoned_m_idx].get_monster_profile().ml) {
                 count++;
             }
         }
@@ -606,10 +606,10 @@ bool decide_monster_multiplication(CreatureEntity &creature, MONSTER_IDX m_idx, 
     constexpr auto chance_reproduction = 8;
     if ((k < 4) && (!k || !randint0(k * chance_reproduction))) {
         if (auto multiplied_m_idx = multiply_monster(player, m_idx, monrace.idx, false, (monster.is_pet() ? PM_FORCE_PET : 0))) {
-            if (creature.current_floor_ptr->m_list[*multiplied_m_idx].ml && is_original_ap_and_seen(creature, monster)) {
+            if (creature.current_floor_ptr->m_list[*multiplied_m_idx].get_monster_profile().ml && is_original_ap_and_seen(creature, monster)) {
                 monrace.r_misc_flags.set(MonsterMiscType::MULTIPLY);
             }
-            if (floor.m_list[*multiplied_m_idx].ml && is_original_ap_and_seen(creature, monster)) {
+            if (floor.m_list[*multiplied_m_idx].get_monster_profile().ml && is_original_ap_and_seen(creature, monster)) {
                 monrace.r_misc_flags.set(MonsterMiscType::MULTIPLY);
             }
             return true;
@@ -727,7 +727,7 @@ bool process_monster_spawn_monster(CreatureEntity &creature, MONSTER_IDX m_idx, 
         if (randint1(deno) <= num) {
             if (multiply_monster(player, m_idx, idx, false, (m_ptr->is_pet() ? PM_FORCE_PET : 0))) {
                 auto &monster = creature.current_floor_ptr->m_list[m_idx];
-                if (monster.ml && is_original_ap_and_seen(creature, *m_ptr)) {
+                if (monster.get_monster_profile().ml && is_original_ap_and_seen(creature, *m_ptr)) {
                     r_ptr->misc_flags.set(MonsterMiscType::MULTIPLY);
                 }
                 return true;
@@ -753,7 +753,7 @@ bool cast_spell(CreatureEntity &creature, MONSTER_IDX m_idx, bool aware)
     const auto &monrace = monster_from.get_monrace();
 
     // 狂乱状態のモンスターは魔法を使わない
-    if (monster_from.mflag2.has(MonsterConstantFlagType::FRENZY)) {
+    if (monster_from.get_monster_profile().mflag2.has(MonsterConstantFlagType::FRENZY)) {
         return false;
     }
 
@@ -802,23 +802,23 @@ bool process_monster_fear(CreatureEntity &creature, turn_flags *turn_flags_ptr, 
     const auto &monrace = m_ptr->get_monrace();
 
     if (monrace.resistance_flags.has_not(MonsterResistanceType::NO_DEFECATE) &&
-        m_ptr->mflag2.has_not(MonsterConstantFlagType::DEFECATED) &&
+        m_ptr->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::DEFECATED) &&
         m_ptr->is_fearful() && one_in_(20)) {
         msg_format(_("%s^は恐怖のあまり脱糞した！", "%s^ was defecated because of fear!"), m_name.data());
         ItemEntity item;
         item.generate(baseitems.lookup_baseitem_id({ ItemKindType::JUNK, SV_JUNK_FECES }));
         (void)drop_near(creature, item, m_ptr->get_position());
-        m_ptr->mflag2.set(MonsterConstantFlagType::DEFECATED);
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::DEFECATED);
     }
 
     if (monrace.resistance_flags.has_not(MonsterResistanceType::NO_VOMIT) &&
-        m_ptr->mflag2.has_not(MonsterConstantFlagType::VOMITED) &&
+        m_ptr->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::VOMITED) &&
         m_ptr->is_fearful() && one_in_(20)) {
         msg_format(_("%s^は恐怖のあまり嘔吐した！", "%s^ vomited in fear!"), m_name.data());
         ItemEntity item;
         item.generate(baseitems.lookup_baseitem_id({ ItemKindType::JUNK, SV_JUNK_VOMITTING }));
         (void)drop_near(creature, item, m_ptr->get_position());
-        m_ptr->mflag2.set(MonsterConstantFlagType::VOMITED);
+        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::VOMITED);
     }
 
     const auto &monster = creature.current_floor_ptr->m_list[m_idx];
@@ -925,9 +925,9 @@ void sweep_monster_process(CreatureEntity &creature)
         monster.energy_need += ENERGY_NEED();
         auto m_name = monster_desc(creature, monster, 0);
 
-        if (monster.death_count > 0) {
-            monster.death_count--;
-            if (monster.death_count == 0) {
+        if (monster.get_monster_profile().death_count > 0) {
+            monster.get_monster_profile().death_count--;
+            if (monster.get_monster_profile().death_count == 0) {
                 bool fear;
                 monster.max_maxhp = monster.maxhp = monster.hp = -1;
                 MonsterDamageProcessor mdp(player, m_idx, 0, &fear, AttributeType::ATTACK);
@@ -950,7 +950,7 @@ void sweep_monster_process(CreatureEntity &creature)
                 pow *= 3;
             }
             if (r_ptr.level < randint0(pow)) {
-                if (monster.ml) {
+                if (monster.get_monster_profile().ml) {
                     msg_format(_("%sは%sに絡めとられて動けなかった！", "%s wes entangled in the %s and could not move!"), m_name.data(), f_ptr.name.data());
                 }
                 if (r_ptr.kind_flags.has(MonsterKindType::HENTAI)) {
@@ -983,7 +983,7 @@ void sweep_monster_process(CreatureEntity &creature)
         process_monster(creature, m_idx);
         monster.reset_target();
         if (player.no_flowed && one_in_(3)) {
-            monster.mflag2.set(MonsterConstantFlagType::NOFLOW);
+            monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::NOFLOW);
         }
 
         if (!player.playing || player.is_dead() || player.leaving) {
@@ -1003,7 +1003,7 @@ bool decide_process_continue(CreatureEntity &creature, MonsterEntity &monster)
     const auto &monrace = monster.get_monrace();
     auto &player = static_cast<PlayerType &>(creature);
     if (!player.no_flowed) {
-        monster.mflag2.reset(MonsterConstantFlagType::NOFLOW);
+        monster.get_monster_profile().mflag2.reset(MonsterConstantFlagType::NOFLOW);
     }
 
     const auto cdis = Grid::calc_distance(creature.get_position(), monster.get_position());

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -34,10 +34,10 @@
 void set_pet(CreatureEntity &creature, MonsterEntity &monster)
 {
     QuestCompletionChecker(creature, monster).complete();
-    monster.mflag2.set(MonsterConstantFlagType::PET);
-    monster.alliance_idx = AllianceType::NONE;
+    monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::PET);
+    monster.get_monster_profile().alliance_idx = AllianceType::NONE;
     if (monster.get_monrace().kind_flags.has_none_of(alignment_mask)) {
-        monster.sub_align = SUB_ALIGN_NEUTRAL;
+        monster.get_monster_profile().sub_align = SUB_ALIGN_NEUTRAL;
     }
 }
 
@@ -86,13 +86,13 @@ bool set_monster_csleep(FloorType &floor, MONSTER_IDX m_idx, int v)
         }
     }
 
-    monster.mtimed[MonsterTimedEffect::SLEEP] = (int16_t)v;
+    monster.get_monster_profile().mtimed[MonsterTimedEffect::SLEEP] = (int16_t)v;
     if (!notice) {
         return false;
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (monster.ml) {
+    if (monster.get_monster_profile().ml) {
         HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
         if (monster.is_riding()) {
             rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
@@ -131,7 +131,7 @@ bool set_monster_fast(FloorType &floor, MONSTER_IDX m_idx, int v)
         }
     }
 
-    monster.mtimed[MonsterTimedEffect::FAST] = (int16_t)v;
+    monster.get_monster_profile().mtimed[MonsterTimedEffect::FAST] = (int16_t)v;
     if (!notice) {
         return false;
     }
@@ -168,7 +168,7 @@ bool set_monster_slow(FloorType &floor, MONSTER_IDX m_idx, int v)
         }
     }
 
-    monster.mtimed[MonsterTimedEffect::SLOW] = (int16_t)v;
+    monster.get_monster_profile().mtimed[MonsterTimedEffect::SLOW] = (int16_t)v;
     if (!notice) {
         return false;
     }
@@ -205,7 +205,7 @@ bool set_monster_stunned(FloorType &floor, MONSTER_IDX m_idx, int v)
         }
     }
 
-    monster.mtimed[MonsterTimedEffect::STUN] = (int16_t)v;
+    monster.get_monster_profile().mtimed[MonsterTimedEffect::STUN] = (int16_t)v;
     return notice;
 }
 
@@ -234,7 +234,7 @@ bool set_monster_confused(FloorType &floor, MONSTER_IDX m_idx, int v)
         }
     }
 
-    monster.mtimed[MonsterTimedEffect::CONFUSION] = (int16_t)v;
+    monster.get_monster_profile().mtimed[MonsterTimedEffect::CONFUSION] = (int16_t)v;
     return notice;
 }
 
@@ -251,7 +251,7 @@ bool set_monster_monfear(FloorType &floor, MONSTER_IDX m_idx, int v)
     bool notice = false;
 
     // 狂乱状態のモンスターは恐怖しない
-    if (monster.mflag2.has(MonsterConstantFlagType::FRENZY) && v > 0) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::FRENZY) && v > 0) {
         return false;
     }
 
@@ -269,13 +269,13 @@ bool set_monster_monfear(FloorType &floor, MONSTER_IDX m_idx, int v)
         }
     }
 
-    monster.mtimed[MonsterTimedEffect::FEAR] = (int16_t)v;
+    monster.get_monster_profile().mtimed[MonsterTimedEffect::FEAR] = (int16_t)v;
 
     if (!notice) {
         return false;
     }
 
-    if (monster.ml) {
+    if (monster.get_monster_profile().ml) {
         HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
         if (monster.is_riding()) {
             RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
@@ -314,12 +314,12 @@ bool set_monster_invulner(FloorType &floor, MONSTER_IDX m_idx, int v, bool energ
         }
     }
 
-    monster.mtimed[MonsterTimedEffect::INVULNERABILITY] = (int16_t)v;
+    monster.get_monster_profile().mtimed[MonsterTimedEffect::INVULNERABILITY] = (int16_t)v;
     if (!notice) {
         return false;
     }
 
-    if (monster.ml) {
+    if (monster.get_monster_profile().ml) {
         HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
         if (monster.is_riding()) {
             RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -171,7 +171,7 @@ static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_
         }
 
         /* Notice the "waking up" */
-        if (monster.ml) {
+        if (monster.get_monster_profile().ml) {
             const auto m_name = monster_desc(creature, monster, 0);
             msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());
         }
@@ -311,19 +311,19 @@ void dispel_monster_status(CreatureEntity &creature, MONSTER_IDX m_idx)
     const auto &monster = floor.m_list[m_idx];
     const auto m_name = monster_desc(creature, monster, 0);
     if (set_monster_invulner(floor, m_idx, 0, true)) {
-        if (monster.ml) {
+        if (monster.get_monster_profile().ml) {
             msg_format(_("%sはもう無敵ではない。", "%s^ is no longer invulnerable."), m_name.data());
         }
     }
 
     if (set_monster_fast(floor, m_idx, 0)) {
-        if (monster.ml) {
+        if (monster.get_monster_profile().ml) {
             msg_format(_("%sはもう加速されていない。", "%s^ is no longer fast."), m_name.data());
         }
     }
 
     if (set_monster_slow(floor, m_idx, 0)) {
-        if (monster.ml) {
+        if (monster.get_monster_profile().ml) {
             msg_format(_("%sはもう減速されていない。", "%s^ is no longer slow."), m_name.data());
         }
     }
@@ -364,7 +364,7 @@ void monster_gain_exp(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId mon
     }
 
     monster.exp += new_exp;
-    if (monster.mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
         return;
     }
 
@@ -379,7 +379,7 @@ void monster_gain_exp(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId mon
 
     const auto old_hp = monster.hp;
     const auto old_maxhp = monster.max_maxhp;
-    const auto old_sub_align = monster.sub_align;
+    const auto old_sub_align = monster.get_monster_profile().sub_align;
 
     /* Hack -- Reduce the racial counter of previous monster */
     monster.get_real_monrace().decrement_current_numbers();
@@ -409,20 +409,20 @@ void monster_gain_exp(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId mon
 
     /* Sub-alignment of a monster */
     if (!monster.is_pet() && new_monrace.kind_flags.has_none_of(alignment_mask)) {
-        monster.sub_align = old_sub_align;
+        monster.get_monster_profile().sub_align = old_sub_align;
     } else {
-        monster.sub_align = SUB_ALIGN_NEUTRAL;
+        monster.get_monster_profile().sub_align = SUB_ALIGN_NEUTRAL;
         if (new_monrace.kind_flags.has(MonsterKindType::EVIL)) {
-            monster.sub_align |= SUB_ALIGN_EVIL;
+            monster.get_monster_profile().sub_align |= SUB_ALIGN_EVIL;
         }
 
         if (new_monrace.kind_flags.has(MonsterKindType::GOOD)) {
-            monster.sub_align |= SUB_ALIGN_GOOD;
+            monster.get_monster_profile().sub_align |= SUB_ALIGN_GOOD;
         }
     }
 
     monster.exp = 0;
-    if (monster.is_pet() || monster.ml) {
+    if (monster.is_pet() || monster.get_monster_profile().ml) {
         const auto is_hallucinated = creature.effects()->hallucination().is_hallucinated();
         if (!ignore_unview || player_can_see_bold(creature, monster.y, monster.x)) {
             if (is_hallucinated) {
@@ -442,7 +442,7 @@ void monster_gain_exp(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId mon
         }
 
         /* Now you feel very close to this pet. */
-        monster.parent_m_idx = 0;
+        monster.get_monster_profile().parent_m_idx = 0;
     }
 
     update_monster(creature, m_idx, false);

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -241,7 +241,7 @@ static bool update_weird_telepathy(CreatureEntity &creature, um_type *um_ptr, MO
     }
 
     um_ptr->flag = true;
-    monster.mflag.set(MonsterTemporaryFlagType::ESP);
+    monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
     if (monster.is_original_ap() && !creature.effects()->hallucination().is_hallucinated()) {
         monrace.r_misc_flags.set(MonsterMiscType::WEIRD_MIND);
         update_smart_stupid_flags(monrace);
@@ -258,7 +258,7 @@ static void update_telepathy_sight(CreatureEntity &creature, um_type *um_ptr, MO
     const auto is_hallucinated = creature.effects()->hallucination().is_hallucinated();
     if (CreatureClass(player).samurai_stance_is(SamuraiStanceType::MUSOU)) {
         um_ptr->flag = true;
-        um_ptr->m_ptr->mflag.set(MonsterTemporaryFlagType::ESP);
+        um_ptr->m_ptr->get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (um_ptr->m_ptr->is_original_ap() && !is_hallucinated) {
             update_smart_stupid_flags(monrace);
         }
@@ -283,7 +283,7 @@ static void update_telepathy_sight(CreatureEntity &creature, um_type *um_ptr, MO
     }
 
     um_ptr->flag = true;
-    monster.mflag.set(MonsterTemporaryFlagType::ESP);
+    monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
     if (monster.is_original_ap() && !is_hallucinated) {
         update_smart_stupid_flags(monrace);
     }
@@ -297,7 +297,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
     const auto is_hallucinated = creature.effects()->hallucination().is_hallucinated();
     if ((player.esp_animal) && monrace.kind_flags.has(MonsterKindType::ANIMAL)) {
         um_ptr->flag = true;
-        monster.mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::ANIMAL);
         }
@@ -305,7 +305,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((player.esp_animal) && monrace.kind_flags.has(MonsterKindType::WEREWOLF)) {
         um_ptr->flag = true;
-        monster.mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::WEREWOLF);
         }
@@ -313,7 +313,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((player.esp_nasty) && monrace.kind_flags.has(MonsterKindType::NASTY)) {
         um_ptr->flag = true;
-        um_ptr->m_ptr->mflag.set(MonsterTemporaryFlagType::ESP);
+        um_ptr->m_ptr->get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (is_original_ap_and_seen(player, *um_ptr->m_ptr) && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::NASTY);
         }
@@ -321,7 +321,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((player.esp_homo) && monrace.kind_flags.has(MonsterKindType::HOMO_SEXUAL)) {
         um_ptr->flag = true;
-        um_ptr->m_ptr->mflag.set(MonsterTemporaryFlagType::ESP);
+        um_ptr->m_ptr->get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (is_original_ap_and_seen(player, *um_ptr->m_ptr) && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::HOMO_SEXUAL);
         }
@@ -329,7 +329,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((player.esp_undead) && monster.has_undead_flag()) {
         um_ptr->flag = true;
-        monster.mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::UNDEAD);
         }
@@ -337,7 +337,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((player.esp_demon) && monrace.kind_flags.has(MonsterKindType::DEMON)) {
         um_ptr->flag = true;
-        monster.mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::DEMON);
         }
@@ -345,7 +345,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((player.esp_orc) && monrace.kind_flags.has(MonsterKindType::ORC)) {
         um_ptr->flag = true;
-        monster.mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::ORC);
         }
@@ -353,7 +353,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((player.esp_troll) && monrace.kind_flags.has(MonsterKindType::TROLL)) {
         um_ptr->flag = true;
-        monster.mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::TROLL);
         }
@@ -361,7 +361,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((player.esp_giant) && monrace.kind_flags.has(MonsterKindType::GIANT)) {
         um_ptr->flag = true;
-        monster.mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::GIANT);
         }
@@ -369,7 +369,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((player.esp_dragon) && monrace.kind_flags.has(MonsterKindType::DRAGON)) {
         um_ptr->flag = true;
-        monster.mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::DRAGON);
         }
@@ -377,7 +377,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((player.esp_human) && monrace.kind_flags.has(MonsterKindType::HUMAN)) {
         um_ptr->flag = true;
-        monster.mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::HUMAN);
         }
@@ -385,7 +385,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((player.esp_evil) && monrace.kind_flags.has(MonsterKindType::EVIL)) {
         um_ptr->flag = true;
-        monster.mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::EVIL);
         }
@@ -393,7 +393,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((player.esp_good) && monrace.kind_flags.has(MonsterKindType::GOOD)) {
         um_ptr->flag = true;
-        monster.mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::GOOD);
         }
@@ -401,7 +401,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((player.esp_nonliving) && monrace.kind_flags.has(MonsterKindType::NONLIVING) && monrace.kind_flags.has_none_of({ MonsterKindType::DEMON, MonsterKindType::UNDEAD })) {
         um_ptr->flag = true;
-        monster.mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::NONLIVING);
         }
@@ -409,7 +409,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((player.esp_unique) && monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
         um_ptr->flag = true;
-        monster.mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::UNIQUE);
         }
@@ -466,7 +466,7 @@ static void decide_sight_invisible_monster(CreatureEntity &creature, um_type *um
     auto &monster = *um_ptr->m_ptr;
     auto &monrace = monster.get_monrace();
 
-    monster.mflag.reset(MonsterTemporaryFlagType::ESP);
+    monster.get_monster_profile().mflag.reset(MonsterTemporaryFlagType::ESP);
 
     if (distance > (um_ptr->in_darkness ? MAX_PLAYER_SIGHT / 2 : MAX_PLAYER_SIGHT)) {
         return;
@@ -514,11 +514,11 @@ static void update_invisible_monster(CreatureEntity &creature, um_type *um_ptr, 
 {
     auto &player = static_cast<PlayerType &>(creature);
     auto &monster = *um_ptr->m_ptr;
-    if (monster.ml) {
+    if (monster.get_monster_profile().ml) {
         return;
     }
 
-    monster.ml = true;
+    monster.get_monster_profile().ml = true;
     lite_spot(player, um_ptr->get_position());
 
     HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
@@ -538,7 +538,7 @@ static void update_invisible_monster(CreatureEntity &creature, um_type *um_ptr, 
 
     const auto &world = AngbandWorld::get_instance();
     if (world.is_loading_now && world.character_dungeon && !AngbandSystem::get_instance().is_phase_out() && monster.get_appearance_monrace().misc_flags.has(MonsterMiscType::ELDRITCH_HORROR)) {
-        monster.mflag.set(MonsterTemporaryFlagType::SANITY_BLAST);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::SANITY_BLAST);
     }
 
     const auto &floor = *creature.current_floor_ptr;
@@ -556,11 +556,11 @@ static void update_invisible_monster(CreatureEntity &creature, um_type *um_ptr, 
 static void update_visible_monster(CreatureEntity &creature, um_type *um_ptr, MONSTER_IDX m_idx)
 {
     auto &player = static_cast<PlayerType &>(creature);
-    if (!um_ptr->m_ptr->ml) {
+    if (!um_ptr->m_ptr->get_monster_profile().ml) {
         return;
     }
 
-    um_ptr->m_ptr->ml = false;
+    um_ptr->m_ptr->get_monster_profile().ml = false;
     lite_spot(player, um_ptr->get_position());
 
     HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
@@ -580,8 +580,8 @@ static bool update_clear_monster(CreatureEntity &creature, um_type *um_ptr)
         return false;
     }
 
-    if (um_ptr->m_ptr->mflag.has_not(MonsterTemporaryFlagType::VIEW)) {
-        um_ptr->m_ptr->mflag.set(MonsterTemporaryFlagType::VIEW);
+    if (um_ptr->m_ptr->get_monster_profile().mflag.has_not(MonsterTemporaryFlagType::VIEW)) {
+        um_ptr->m_ptr->get_monster_profile().mflag.set(MonsterTemporaryFlagType::VIEW);
         if (um_ptr->do_disturb && (disturb_pets || um_ptr->m_ptr->is_hostile())) {
             disturb(player, true, true);
         }
@@ -607,7 +607,7 @@ void update_monster(CreatureEntity &creature, MONSTER_IDX m_idx, bool full)
         }
     }
 
-    if (um_ptr->m_ptr->mflag2.has(MonsterConstantFlagType::MARK)) {
+    if (um_ptr->m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::MARK)) {
         um_ptr->flag = true;
     }
 
@@ -618,11 +618,11 @@ void update_monster(CreatureEntity &creature, MONSTER_IDX m_idx, bool full)
         update_visible_monster(creature, um_ptr, m_idx);
     }
 
-    if (update_clear_monster(creature, um_ptr) || um_ptr->m_ptr->mflag.has_not(MonsterTemporaryFlagType::VIEW)) {
+    if (update_clear_monster(creature, um_ptr) || um_ptr->m_ptr->get_monster_profile().mflag.has_not(MonsterTemporaryFlagType::VIEW)) {
         return;
     }
 
-    um_ptr->m_ptr->mflag.reset(MonsterTemporaryFlagType::VIEW);
+    um_ptr->m_ptr->get_monster_profile().mflag.reset(MonsterTemporaryFlagType::VIEW);
     if (um_ptr->do_disturb && (disturb_pets || um_ptr->m_ptr->is_hostile())) {
         disturb(player, true, true);
     }
@@ -664,151 +664,151 @@ void update_smart_learn(CreatureEntity &creature, MONSTER_IDX m_idx, int what)
     switch (what) {
     case DRS_ACID:
         if (has_resist_acid(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_ACID);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_ACID);
         }
 
         if (is_oppose_acid(player)) {
-            monster.smart.set(MonsterSmartLearnType::OPP_ACID);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::OPP_ACID);
         }
 
         if (has_immune_acid(player)) {
-            monster.smart.set(MonsterSmartLearnType::IMM_ACID);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_ACID);
         }
 
         break;
     case DRS_ELEC:
         if (has_resist_elec(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_ELEC);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_ELEC);
         }
 
         if (is_oppose_elec(player)) {
-            monster.smart.set(MonsterSmartLearnType::OPP_ELEC);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::OPP_ELEC);
         }
 
         if (has_immune_elec(player)) {
-            monster.smart.set(MonsterSmartLearnType::IMM_ELEC);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_ELEC);
         }
 
         break;
     case DRS_FIRE:
         if (has_resist_fire(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_FIRE);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_FIRE);
         }
 
         if (is_oppose_fire(player)) {
-            monster.smart.set(MonsterSmartLearnType::OPP_FIRE);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::OPP_FIRE);
         }
 
         if (has_immune_fire(player)) {
-            monster.smart.set(MonsterSmartLearnType::IMM_FIRE);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_FIRE);
         }
 
         break;
     case DRS_COLD:
         if (has_resist_cold(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_COLD);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_COLD);
         }
 
         if (is_oppose_cold(player)) {
-            monster.smart.set(MonsterSmartLearnType::OPP_COLD);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::OPP_COLD);
         }
 
         if (has_immune_cold(player)) {
-            monster.smart.set(MonsterSmartLearnType::IMM_COLD);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_COLD);
         }
 
         break;
     case DRS_POIS:
         if (has_resist_pois(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_POIS);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_POIS);
         }
 
         if (is_oppose_pois(player)) {
-            monster.smart.set(MonsterSmartLearnType::OPP_POIS);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::OPP_POIS);
         }
 
         break;
     case DRS_NETH:
         if (has_resist_neth(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_NETH);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_NETH);
         }
 
         break;
     case DRS_LITE:
         if (has_resist_lite(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_LITE);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_LITE);
         }
 
         break;
     case DRS_DARK:
         if (has_resist_dark(player) || has_immune_dark(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_DARK);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_DARK);
         }
 
         break;
     case DRS_FEAR:
         if (has_resist_fear(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_FEAR);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_FEAR);
         }
 
         break;
     case DRS_CONF:
         if (has_resist_conf(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_CONF);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_CONF);
         }
 
         break;
     case DRS_CHAOS:
         if (has_resist_chaos(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_CHAOS);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_CHAOS);
         }
 
         break;
     case DRS_DISEN:
         if (has_resist_disen(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_DISEN);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_DISEN);
         }
 
         break;
     case DRS_BLIND:
         if (has_resist_blind(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_BLIND);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_BLIND);
         }
 
         break;
     case DRS_NEXUS:
         if (has_resist_shard(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_NEXUS);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_NEXUS);
         }
 
         break;
     case DRS_SOUND:
         if (has_resist_sound(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_SOUND);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_SOUND);
         }
 
         break;
     case DRS_SHARD:
         if (has_resist_shard(player)) {
-            monster.smart.set(MonsterSmartLearnType::RES_SHARD);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_SHARD);
         }
 
         break;
     case DRS_FREE:
         if (player.free_act) {
-            monster.smart.set(MonsterSmartLearnType::IMM_FREE);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_FREE);
         }
 
         break;
     case DRS_MANA:
         if (!player.msp) {
-            monster.smart.set(MonsterSmartLearnType::IMM_MANA);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_MANA);
         }
 
         break;
     case DRS_REFLECT:
         if (has_reflect(player)) {
-            monster.smart.set(MonsterSmartLearnType::IMM_REFLECT);
+            monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_REFLECT);
         }
 
         break;

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -732,7 +732,7 @@ void mark_monsters_present(CreatureEntity &creature)
         if (!monster.is_valid()) {
             continue;
         }
-        monster.mflag.set(MonsterTemporaryFlagType::PRESENT_AT_TURN_START);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::PRESENT_AT_TURN_START);
     }
 }
 

--- a/src/mspell/improper-mspell-remover.cpp
+++ b/src/mspell/improper-mspell-remover.cpp
@@ -43,10 +43,10 @@ void remove_bad_spells(MONSTER_IDX m_idx, CreatureEntity &creature, EnumClassFla
     if (smart_learn) {
         /* 時々学習情報を忘れる */
         if (one_in_(100)) {
-            monster.smart.clear();
+            monster.get_monster_profile().smart.clear();
         }
 
-        msr_ptr->smart_flags = monster.smart;
+        msr_ptr->smart_flags = monster.get_monster_profile().smart;
     }
 
     add_cheat_remove_flags(creature, msr_ptr);

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -263,7 +263,7 @@ static bool check_thrown_mspell(CreatureEntity &creature, msa_type *msa_ptr)
 
 static void check_mspell_imitation(CreatureEntity &creature, msa_type *msa_ptr)
 {
-    const auto seen = (!creature.is_blind() && msa_ptr->m_ptr->ml);
+    const auto seen = (!creature.is_blind() && msa_ptr->m_ptr->get_monster_profile().ml);
     const auto can_imitate = creature.current_floor_ptr->has_los_at({ msa_ptr->m_ptr->y, msa_ptr->m_ptr->x });
     CreatureClass pc(creature);
     if (!seen || !can_imitate || (AngbandWorld::get_instance().timewalk_m_idx != 0) || !pc.equals(PlayerClassType::IMITATOR)) {
@@ -315,7 +315,7 @@ bool make_attack_spell(CreatureEntity &creature, MONSTER_IDX m_idx)
     }
 
     const auto &m_ref = *msa_ptr->m_ptr;
-    auto should_prevent = m_ref.mflag.has(MonsterTemporaryFlagType::PREVENT_MAGIC);
+    auto should_prevent = m_ref.get_monster_profile().mflag.has(MonsterTemporaryFlagType::PREVENT_MAGIC);
     should_prevent |= !m_ref.is_hostile();
     should_prevent |= (Grid::calc_distance(creature.get_position(), m_ref.get_position()) > AngbandSystem::get_instance().get_max_range()) && !m_ref.get_target_position().y;
     if (should_prevent) {

--- a/src/mspell/mspell-learn-checker.cpp
+++ b/src/mspell/mspell-learn-checker.cpp
@@ -17,7 +17,7 @@ bool spell_learnable(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
     const auto &floor = *creature.current_floor_ptr;
     const auto &monster = floor.m_list[m_idx];
-    const auto seen = (!creature.is_blind() && monster.ml);
+    const auto seen = (!creature.is_blind() && monster.get_monster_profile().ml);
     const auto maneable = floor.has_los_at({ monster.y, monster.x });
     return seen && maneable && (AngbandWorld::get_instance().timewalk_m_idx == 0);
 }

--- a/src/mspell/mspell-selector.cpp
+++ b/src/mspell/mspell-selector.cpp
@@ -452,7 +452,7 @@ MonsterAbilityType choose_attack_spell(CreatureEntity &creature, msa_type *msa_p
         return rand_choice(tactic);
     }
 
-    if (!invul.empty() && !monster.mtimed.at(MonsterTimedEffect::INVULNERABILITY) && one_in_(2)) {
+    if (!invul.empty() && !monster.get_monster_profile().mtimed.at(MonsterTimedEffect::INVULNERABILITY) && one_in_(2)) {
         return rand_choice(invul);
     }
 

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -172,7 +172,7 @@ MonsterSpellResult spell_RF5_DRAIN_MANA(CreatureEntity &creature, POSITION y, PO
 MonsterSpellResult spell_RF5_MIND_BLAST(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
     const auto &monster = creature.current_floor_ptr->m_list[m_idx];
-    bool seen = (!creature.is_blind() && monster.ml);
+    bool seen = (!creature.is_blind() && monster.get_monster_profile().ml);
     const auto m_name = monster_name(creature, m_idx);
     const auto t_name = monster_name(creature, t_idx);
 
@@ -210,7 +210,7 @@ MonsterSpellResult spell_RF5_MIND_BLAST(CreatureEntity &creature, POSITION y, PO
 MonsterSpellResult spell_RF5_BRAIN_SMASH(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
     const auto &monster = creature.current_floor_ptr->m_list[m_idx];
-    bool seen = (!creature.is_blind() && monster.ml);
+    bool seen = (!creature.is_blind() && monster.get_monster_profile().ml);
     const auto m_name = monster_name(creature, m_idx);
     const auto t_name = monster_name(creature, t_idx);
 
@@ -275,7 +275,7 @@ MonsterSpellResult spell_RF5_SCARE(MONSTER_IDX m_idx, CreatureEntity &creature, 
         return res;
     }
 
-    resist = (monrace_target.resistance_flags.has(MonsterResistanceType::NO_FEAR) || monster_target.mflag2.has(MonsterConstantFlagType::FRENZY));
+    resist = (monrace_target.resistance_flags.has(MonsterResistanceType::NO_FEAR) || monster_target.get_monster_profile().mflag2.has(MonsterConstantFlagType::FRENZY));
     saving_throw = (monrace_target.level > randint1((rlev - 10) < 1 ? 1 : (rlev - 10)) + 10);
 
     mspell_cast_msg_bad_status_to_monster msg(_("%s^が恐ろしげな幻覚を作り出した。", "%s^ casts a fearful illusion in front of %s."),
@@ -585,7 +585,7 @@ MonsterSpellResult spell_RF6_HEAL(CreatureEntity &creature, MONSTER_IDX m_idx, M
     auto &monster = floor.m_list[m_idx];
     DEPTH rlev = monster_level_idx(floor, m_idx);
     const auto is_blind = creature.is_blind();
-    const auto seen = (!is_blind && monster.ml);
+    const auto seen = (!is_blind && monster.get_monster_profile().ml);
     const auto m_poss = monster_desc(creature, monster, MD_PRON_VISIBLE | MD_POSSESSIVE);
 
     msg.to_player_true = _("%s^が何かをつぶやいた。", "%s^ mumbles.");
@@ -643,14 +643,14 @@ MonsterSpellResult spell_RF6_HEAL(CreatureEntity &creature, MONSTER_IDX m_idx, M
 MonsterSpellResult spell_RF6_INVULNER(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
     const auto &monster = creature.current_floor_ptr->m_list[m_idx];
-    bool seen = (!creature.is_blind() && monster.ml);
+    bool seen = (!creature.is_blind() && monster.get_monster_profile().ml);
     mspell_cast_msg msg(_("%s^が何かを力強くつぶやいた。", "%s^ mumbles powerfully."),
         _("%s^が何かを力強くつぶやいた。", "%s^ mumbles powerfully."), _("%sは無傷の球の呪文を唱えた。", "%s^ casts a Globe of Invulnerability."),
         _("%sは無傷の球の呪文を唱えた。", "%s^ casts a Globe of Invulnerability."));
 
     monspell_message_base(creature, m_idx, t_idx, msg, !seen, target_type);
 
-    if (monster.ml) {
+    if (monster.get_monster_profile().ml) {
         MonraceId r_idx = monster.r_idx;
         const auto m_name = monster_desc(creature, monster, MD_NONE);
         switch (r_idx) {

--- a/src/mspell/mspell-summon.cpp
+++ b/src/mspell/mspell-summon.cpp
@@ -1154,9 +1154,9 @@ MonsterSpellResult spell_RF6_S_UNIQUE(CreatureEntity &creature, POSITION y, POSI
     }
 
     summon_type non_unique_type = SUMMON_HI_UNDEAD;
-    if ((monster.sub_align & (SUB_ALIGN_GOOD | SUB_ALIGN_EVIL)) == (SUB_ALIGN_GOOD | SUB_ALIGN_EVIL)) {
+    if ((monster.get_monster_profile().sub_align & (SUB_ALIGN_GOOD | SUB_ALIGN_EVIL)) == (SUB_ALIGN_GOOD | SUB_ALIGN_EVIL)) {
         non_unique_type = SUMMON_NONE;
-    } else if (monster.sub_align & SUB_ALIGN_GOOD) {
+    } else if (monster.get_monster_profile().sub_align & SUB_ALIGN_GOOD) {
         non_unique_type = SUMMON_ANGEL;
     }
 

--- a/src/mutation/mutation-techniques.cpp
+++ b/src/mutation/mutation-techniques.cpp
@@ -46,7 +46,7 @@ bool eat_rock(CreatureEntity &creature)
     } else if (grid.has_monster()) {
         const auto &monster = creature.current_floor_ptr->m_list[grid.m_idx];
         msg_print(_("何かが邪魔しています！", "There's something in the way!"));
-        if (!monster.ml || !monster.is_pet()) {
+        if (!monster.get_monster_profile().ml || !monster.is_pet()) {
             do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
         }
     } else if (terrain.flags.has(TerrainCharacteristics::TREE)) {

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -454,7 +454,7 @@ void ObjectThrowEntity::attack_racial_power()
     }
 
     auto &monster = *this->hit_monster->m_ptr;
-    if (!test_hit_fire(player, this->chance - this->cur_dis, monster, monster.ml, this->o_name)) {
+    if (!test_hit_fire(player, this->chance - this->cur_dis, monster, monster.get_monster_profile().ml, this->o_name)) {
         return;
     }
 
@@ -483,7 +483,7 @@ void ObjectThrowEntity::attack_racial_power()
         anger_monster(player, monster);
     }
 
-    if (fear && monster.ml) {
+    if (fear && monster.get_monster_profile().ml) {
         sound(SoundKind::FLEE);
         msg_format(_("%s^は恐怖して逃げ出した！", "%s^ flees in terror!"), this->hit_monster->m_name.data());
     }
@@ -496,7 +496,7 @@ void ObjectThrowEntity::display_attack_racial_power()
         return;
     }
 
-    if (!this->hit_monster->m_ptr->ml) {
+    if (!this->hit_monster->m_ptr->get_monster_profile().ml) {
         msg_format(_("%sが敵を捕捉した。", "The %s finds a mark."), this->o_name.data());
         return;
     }

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -105,7 +105,7 @@ static void attack_stun(CreatureEntity &creature, player_attack_type *pa_ptr, bo
 static void attack_scare(CreatureEntity &creature, player_attack_type *pa_ptr, bool can_resist = true)
 {
     auto &monrace = *pa_ptr->r_ptr;
-    if (monrace.resistance_flags.has(MonsterResistanceType::NO_FEAR) || pa_ptr->m_ptr->mflag2.has(MonsterConstantFlagType::FRENZY)) {
+    if (monrace.resistance_flags.has(MonsterResistanceType::NO_FEAR) || pa_ptr->m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::FRENZY)) {
         if (is_original_ap_and_seen(creature, *pa_ptr->m_ptr)) {
             monrace.resistance_flags.set(MonsterResistanceType::NO_FEAR);
         }
@@ -132,13 +132,13 @@ static void attack_dispel(CreatureEntity &creature, player_attack_type *pa_ptr)
     }
 
     auto dd = 2;
-    if (pa_ptr->m_ptr->mtimed[MonsterTimedEffect::SLOW]) {
+    if (pa_ptr->m_ptr->get_monster_profile().mtimed[MonsterTimedEffect::SLOW]) {
         dd += 1;
     }
-    if (pa_ptr->m_ptr->mtimed[MonsterTimedEffect::FAST]) {
+    if (pa_ptr->m_ptr->get_monster_profile().mtimed[MonsterTimedEffect::FAST]) {
         dd += 2;
     }
-    if (pa_ptr->m_ptr->mtimed[MonsterTimedEffect::INVULNERABILITY]) {
+    if (pa_ptr->m_ptr->get_monster_profile().mtimed[MonsterTimedEffect::INVULNERABILITY]) {
         dd += 3;
     }
 
@@ -259,15 +259,15 @@ static void attack_golden_hammer(CreatureEntity &creature, player_attack_type *p
     auto &player = static_cast<PlayerType &>(creature);
     auto &floor = *creature.current_floor_ptr;
     auto &monster = floor.m_list[pa_ptr->m_idx];
-    if (monster.hold_o_idx_list.empty()) {
+    if (monster.get_monster_profile().hold_o_idx_list.empty()) {
         return;
     }
 
-    auto &item = *floor.o_list[monster.hold_o_idx_list.front()];
+    auto &item = *floor.o_list[monster.get_monster_profile().hold_o_idx_list.front()];
     const auto item_name = describe_flavor(player, item, OD_NAME_ONLY);
     item.held_m_idx = 0;
     item.marked.clear().set(OmType::TOUCHED);
-    monster.hold_o_idx_list.pop_front();
+    monster.get_monster_profile().hold_o_idx_list.pop_front();
     msg_format(_("%sを奪った。", "You snatched %s."), item_name.data());
     store_item_to_inventory(player, &item);
 }

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -612,7 +612,7 @@ void massacre(CreatureEntity &creature)
         const auto pos = creature.get_neighbor(d);
         const auto &grid = floor.get_grid(pos);
         const auto &monster = floor.m_list[grid.m_idx];
-        if (grid.has_monster() && (monster.ml || floor.has_terrain_characteristics(pos, TerrainCharacteristics::PROJECTION))) {
+        if (grid.has_monster() && (monster.get_monster_profile().ml || floor.has_terrain_characteristics(pos, TerrainCharacteristics::PROJECTION))) {
             do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
         }
     }

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -83,7 +83,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
             return;
         }
 
-        if (!monster.ml) {
+        if (!monster.get_monster_profile().ml) {
             return;
         }
 

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -433,7 +433,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
                 const auto pos_ddd = pos + d.vec();
                 const auto &grid = floor.get_grid(pos_ddd);
                 const auto &monster = floor.m_list[grid.m_idx];
-                if (!grid.has_monster() || (!monster.ml && !floor.has_terrain_characteristics(pos_ddd, TerrainCharacteristics::PROJECTION))) {
+                if (!grid.has_monster() || (!monster.get_monster_profile().ml && !floor.has_terrain_characteristics(pos_ddd, TerrainCharacteristics::PROJECTION))) {
                     continue;
                 }
 

--- a/src/room/rooms-nest.cpp
+++ b/src/room/rooms-nest.cpp
@@ -56,11 +56,11 @@ tl::optional<std::array<NestMonsterInfo, NUM_NEST_MON_TYPE>> pick_nest_monraces(
 
         const auto &monrace = monraces.get_monrace(*monrace_id);
         if (monrace.kind_flags.has(MonsterKindType::EVIL)) {
-            align.sub_align |= SUB_ALIGN_EVIL;
+            align.get_monster_profile().sub_align |= SUB_ALIGN_EVIL;
         }
 
         if (monrace.kind_flags.has(MonsterKindType::GOOD)) {
-            align.sub_align |= SUB_ALIGN_GOOD;
+            align.get_monster_profile().sub_align |= SUB_ALIGN_GOOD;
         }
 
         nest_mon_info.monrace_id = *monrace_id;
@@ -210,7 +210,7 @@ bool build_type5(CreatureEntity &creature, DungeonData *dd_ptr)
     nest.prepare_filter(creature);
     get_mon_num_prep_enum(creature, nest.monrace_hook);
     MonsterEntity align;
-    align.sub_align = SUB_ALIGN_NEUTRAL;
+    align.get_monster_profile().sub_align = SUB_ALIGN_NEUTRAL;
 
     auto nest_mon_info_list = pick_nest_monraces(creature, align);
     if (!nest_mon_info_list) {

--- a/src/room/rooms-pit.cpp
+++ b/src/room/rooms-pit.cpp
@@ -97,11 +97,11 @@ tl::optional<std::array<MonraceId, NUM_PIT_MONRACES>> pick_pit_monraces(Creature
 
         const auto &monrace = monraces.get_monrace(*monrace_id);
         if (monrace.kind_flags.has(MonsterKindType::EVIL)) {
-            align.sub_align |= SUB_ALIGN_EVIL;
+            align.get_monster_profile().sub_align |= SUB_ALIGN_EVIL;
         }
 
         if (monrace.kind_flags.has(MonsterKindType::GOOD)) {
-            align.sub_align |= SUB_ALIGN_GOOD;
+            align.get_monster_profile().sub_align |= SUB_ALIGN_GOOD;
         }
 
         what = *monrace_id;
@@ -218,7 +218,7 @@ bool build_type6(CreatureEntity &creature, DungeonData *dd_ptr)
     pit.prepare_filter(creature);
     get_mon_num_prep_enum(creature, pit.monrace_hook);
     MonsterEntity align;
-    align.sub_align = SUB_ALIGN_NEUTRAL;
+    align.get_monster_profile().sub_align = SUB_ALIGN_NEUTRAL;
 
     auto whats = pick_pit_monraces(creature, align, 11);
     if (!whats) {
@@ -359,7 +359,7 @@ bool build_type13(CreatureEntity &creature, DungeonData *dd_ptr)
     pit.prepare_filter(creature);
     get_mon_num_prep_enum(creature, pit.monrace_hook, MonraceHookTerrain::TRAPPED_PIT);
     MonsterEntity align;
-    align.sub_align = SUB_ALIGN_NEUTRAL;
+    align.get_monster_profile().sub_align = SUB_ALIGN_NEUTRAL;
     auto whats = pick_pit_monraces(creature, align);
     if (!whats) {
         return false;

--- a/src/save/monster-entity-writer.cpp
+++ b/src/save/monster-entity-writer.cpp
@@ -22,7 +22,7 @@ void MonsterEntityWriter::write_to_savedata() const
     const auto flags = this->write_monster_flags();
 
     wr_s16b(enum2i(this->monster.r_idx));
-    wr_s32b(enum2i(this->monster.alliance_idx));
+    wr_s32b(enum2i(this->monster.get_monster_profile().alliance_idx));
 
     wr_byte((byte)this->monster.y);
     wr_byte((byte)this->monster.x);
@@ -36,11 +36,11 @@ void MonsterEntityWriter::write_to_savedata() const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN)) {
-        wr_byte(this->monster.sub_align);
+        wr_byte(this->monster.get_monster_profile().sub_align);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::SLEEP)) {
-        wr_s16b(this->monster.mtimed.at(MonsterTimedEffect::SLEEP));
+        wr_s16b(this->monster.get_monster_profile().mtimed.at(MonsterTimedEffect::SLEEP));
     }
 
     wr_byte((byte)this->monster.speed);
@@ -56,7 +56,7 @@ uint32_t MonsterEntityWriter::write_monster_flags() const
         set_bits(flags, SaveDataMonsterFlagType::AP_R_IDX);
     }
 
-    if (this->monster.sub_align) {
+    if (this->monster.get_monster_profile().sub_align) {
         set_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN);
     }
 
@@ -96,7 +96,7 @@ uint32_t MonsterEntityWriter::write_monster_flags() const
         set_bits(flags, SaveDataMonsterFlagType::INVULNER);
     }
 
-    if (this->monster.smart.any()) {
+    if (this->monster.get_monster_profile().smart.any()) {
         set_bits(flags, SaveDataMonsterFlagType::SMART);
     }
 
@@ -104,7 +104,7 @@ uint32_t MonsterEntityWriter::write_monster_flags() const
         set_bits(flags, SaveDataMonsterFlagType::EXP);
     }
 
-    if (this->monster.mflag2.any()) {
+    if (this->monster.get_monster_profile().mflag2.any()) {
         set_bits(flags, SaveDataMonsterFlagType::MFLAG2);
     }
 
@@ -132,7 +132,7 @@ uint32_t MonsterEntityWriter::write_monster_flags() const
         set_bits(flags, SaveDataMonsterFlagType::CLASS);
     }
 
-    if (MonraceList::is_valid(this->monster.transform_r_idx) || this->monster.has_transformed) {
+    if (MonraceList::is_valid(this->monster.get_monster_profile().transform_r_idx) || this->monster.get_monster_profile().has_transformed) {
         set_bits(flags, SaveDataMonsterFlagType::TRANSFORM);
     }
 
@@ -156,27 +156,27 @@ void MonsterEntityWriter::write_monster_info(uint32_t flags) const
 {
     byte tmp8u;
     if (any_bits(flags, SaveDataMonsterFlagType::FAST)) {
-        tmp8u = (byte)this->monster.mtimed.at(MonsterTimedEffect::FAST);
+        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(MonsterTimedEffect::FAST);
         wr_byte(tmp8u);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::SLOW)) {
-        tmp8u = (byte)this->monster.mtimed.at(MonsterTimedEffect::SLOW);
+        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(MonsterTimedEffect::SLOW);
         wr_byte(tmp8u);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::STUNNED)) {
-        tmp8u = (byte)this->monster.mtimed.at(MonsterTimedEffect::STUN);
+        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(MonsterTimedEffect::STUN);
         wr_byte(tmp8u);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::CONFUSED)) {
-        tmp8u = (byte)this->monster.mtimed.at(MonsterTimedEffect::CONFUSION);
+        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(MonsterTimedEffect::CONFUSION);
         wr_byte(tmp8u);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::MONFEAR)) {
-        tmp8u = (byte)this->monster.mtimed.at(MonsterTimedEffect::FEAR);
+        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(MonsterTimedEffect::FEAR);
         wr_byte(tmp8u);
     }
 
@@ -189,12 +189,12 @@ void MonsterEntityWriter::write_monster_info(uint32_t flags) const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::INVULNER)) {
-        tmp8u = (byte)this->monster.mtimed.at(MonsterTimedEffect::INVULNERABILITY);
+        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(MonsterTimedEffect::INVULNERABILITY);
         wr_byte(tmp8u);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::SMART)) {
-        wr_FlagGroup(this->monster.smart, wr_byte);
+        wr_FlagGroup(this->monster.get_monster_profile().smart, wr_byte);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::EXP)) {
@@ -202,7 +202,7 @@ void MonsterEntityWriter::write_monster_info(uint32_t flags) const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::MFLAG2)) {
-        wr_FlagGroup(this->monster.mflag2, wr_byte);
+        wr_FlagGroup(this->monster.get_monster_profile().mflag2, wr_byte);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::NICKNAME)) {
@@ -210,7 +210,7 @@ void MonsterEntityWriter::write_monster_info(uint32_t flags) const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::PARENT)) {
-        wr_s16b(this->monster.parent_m_idx);
+        wr_s16b(this->monster.get_monster_profile().parent_m_idx);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::GOLD)) {
@@ -231,9 +231,9 @@ void MonsterEntityWriter::write_monster_info(uint32_t flags) const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::TRANSFORM)) {
-        wr_s16b(enum2i(this->monster.transform_r_idx));
-        wr_byte(this->monster.transform_hp_threshold);
-        wr_byte(this->monster.has_transformed ? 1 : 0);
+        wr_s16b(enum2i(this->monster.get_monster_profile().transform_r_idx));
+        wr_byte(this->monster.get_monster_profile().transform_hp_threshold);
+        wr_byte(this->monster.get_monster_profile().has_transformed ? 1 : 0);
     }
 
     // インベントリの保存（PlayerTypeと同じ形式）

--- a/src/specific-object/monster-ball.cpp
+++ b/src/specific-object/monster-ball.cpp
@@ -120,7 +120,7 @@ static bool release_monster(CreatureEntity &creature, ItemEntity &item, const Di
     if (item.captured_monster_current_hp > 0) {
         monster.hp = item.captured_monster_current_hp;
     }
-    monster.mflag2 = item.captured_monster_mflag2;
+    monster.get_monster_profile().mflag2 = item.captured_monster_mflag2;
 
     monster.maxhp = monster.max_maxhp;
     restore_monster_nickname(monster, item);

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -295,7 +295,7 @@ void SpellsMirrorMaster::project_seeker_ray(int target_x, int target_y, int dam)
             }
             const auto &grid = floor.grid_array[project_m_y][project_m_x];
             const auto &monster = floor.m_list[grid.m_idx];
-            if (project_m_n == 1 && grid.has_monster() && monster.ml) {
+            if (project_m_n == 1 && grid.has_monster() && monster.get_monster_profile().ml) {
                 if (!this->creature_ptr->effects()->hallucination().is_hallucinated()) {
                     tracker.set_trackee(monster.ap_r_idx);
                 }
@@ -395,7 +395,7 @@ static bool activate_super_ray_effect(CreatureEntity &creature, int y, int x, in
     const auto &floor = *creature.current_floor_ptr;
     const auto &grid = floor.grid_array[project_m_y][project_m_x];
     const auto &monster = floor.m_list[grid.m_idx];
-    if (project_m_n == 1 && grid.has_monster() && monster.ml) {
+    if (project_m_n == 1 && grid.has_monster() && monster.get_monster_profile().ml) {
         if (!creature.effects()->hallucination().is_hallucinated()) {
             LoreTracker::get_instance().set_trackee(monster.ap_r_idx);
         }

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -359,7 +359,7 @@ bool detect_monsters_normal(CreatureEntity &creature, POSITION range)
         }
 
         if (monrace.misc_flags.has_not(MonsterMiscType::INVISIBLE) || player.see_inv) {
-            monster.mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+            monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
             update_monster(player, i, false);
             flag = true;
         }
@@ -412,7 +412,7 @@ bool detect_monsters_invis(CreatureEntity &creature, POSITION range)
                 rfu.set_flag(SubWindowRedrawingFlag::MONSTER_LORE);
             }
 
-            monster.mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+            monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
             update_monster(player, i, false);
             flag = true;
         }
@@ -466,7 +466,7 @@ bool detect_monsters_evil(CreatureEntity &creature, POSITION range)
                 }
             }
 
-            monster.mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+            monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
             update_monster(creature, i, false);
             flag = true;
         }
@@ -512,7 +512,7 @@ bool detect_monsters_nonliving(CreatureEntity &creature, POSITION range)
                 rfu.set_flag(SubWindowRedrawingFlag::MONSTER_LORE);
             }
 
-            monster.mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+            monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
             update_monster(creature, i, false);
             flag = true;
         }
@@ -560,7 +560,7 @@ bool detect_monsters_mind(CreatureEntity &creature, POSITION range)
                 rfu.set_flag(SubWindowRedrawingFlag::MONSTER_LORE);
             }
 
-            monster.mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+            monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
             update_monster(creature, i, false);
             flag = true;
         }
@@ -610,7 +610,7 @@ bool detect_monsters_string(CreatureEntity &creature, POSITION range, concptr Ma
                 rfu.set_flag(SubWindowRedrawingFlag::MONSTER_LORE);
             }
 
-            monster.mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+            monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
             update_monster(player, i, false);
             flag = true;
         }

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -159,7 +159,7 @@ bool fetch_monster(CreatureEntity &creature)
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
     }
 
-    if (monster.ml) {
+    if (monster.get_monster_profile().ml) {
         if (!player.effects()->hallucination().is_hallucinated()) {
             LoreTracker::get_instance().set_trackee(monster.ap_r_idx);
         }

--- a/src/spell-kind/spells-genocide.cpp
+++ b/src/spell-kind/spells-genocide.cpp
@@ -61,7 +61,7 @@ bool genocide_aux(CreatureEntity &creature, MONSTER_IDX m_idx, int power, bool p
         resist = true;
     } else if (player_cast && (monrace.level > randint0(power))) {
         resist = true;
-    } else if (player_cast && monster.mflag2.has(MonsterConstantFlagType::NOGENO)) {
+    } else if (player_cast && monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::NOGENO)) {
         resist = true;
     } else {
         if (record_named_pet && monster.is_named_pet()) {
@@ -82,7 +82,7 @@ bool genocide_aux(CreatureEntity &creature, MONSTER_IDX m_idx, int power, bool p
 
         if (monster.is_asleep()) {
             (void)set_monster_csleep(*creature.current_floor_ptr, m_idx, 0);
-            if (monster.ml) {
+            if (monster.get_monster_profile().ml) {
                 msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());
             }
         }
@@ -96,7 +96,7 @@ bool genocide_aux(CreatureEntity &creature, MONSTER_IDX m_idx, int power, bool p
         }
 
         if (one_in_(13)) {
-            monster.mflag2.set(MonsterConstantFlagType::NOGENO);
+            monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::NOGENO);
         }
     }
 

--- a/src/spell-kind/spells-lite.cpp
+++ b/src/spell-kind/spells-lite.cpp
@@ -62,7 +62,7 @@ static void cave_temp_room_lite(CreatureEntity &creature, const std::vector<Pos2
 
             if (monster.is_asleep() && evaluate_percent(chance)) {
                 (void)set_monster_csleep(*creature.current_floor_ptr, grid.m_idx, 0);
-                if (monster.ml) {
+                if (monster.get_monster_profile().ml) {
                     const auto m_name = monster_desc(creature, monster, 0);
                     msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());
                 }

--- a/src/spell-kind/spells-polymorph.cpp
+++ b/src/spell-kind/spells-polymorph.cpp
@@ -86,7 +86,7 @@ bool polymorph_monster(CreatureEntity &creature, POSITION y, POSITION x)
     if (floor.inside_arena || AngbandSystem::get_instance().is_phase_out()) {
         return false;
     }
-    if (monster.is_riding() || monster.mflag2.has(MonsterConstantFlagType::KAGE)) {
+    if (monster.is_riding() || monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::KAGE)) {
         return false;
     }
 
@@ -96,7 +96,7 @@ bool polymorph_monster(CreatureEntity &creature, POSITION y, POSITION x)
         return false;
     }
 
-    bool preserve_hold_objects = !back_m.hold_o_idx_list.empty();
+    bool preserve_hold_objects = !back_m.get_monster_profile().hold_o_idx_list.empty();
 
     BIT_FLAGS mode = 0L;
     if (monster.is_friendly()) {
@@ -105,19 +105,19 @@ bool polymorph_monster(CreatureEntity &creature, POSITION y, POSITION x)
     if (monster.is_pet()) {
         mode |= PM_FORCE_PET;
     }
-    if (monster.mflag2.has(MonsterConstantFlagType::NOPET)) {
+    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::NOPET)) {
         mode |= PM_NO_PET;
     }
 
-    monster.hold_o_idx_list.clear();
+    monster.get_monster_profile().hold_o_idx_list.clear();
     delete_monster_idx(creature, grid.m_idx);
     bool polymorphed = false;
     auto m_idx = place_specific_monster(creature, y, x, new_r_idx, mode);
     if (m_idx) {
         auto &monster_polymorphed = floor.m_list[*m_idx];
         monster_polymorphed.name = back_m.name;
-        monster_polymorphed.parent_m_idx = back_m.parent_m_idx;
-        monster_polymorphed.hold_o_idx_list = back_m.hold_o_idx_list;
+        monster_polymorphed.get_monster_profile().parent_m_idx = back_m.get_monster_profile().parent_m_idx;
+        monster_polymorphed.get_monster_profile().hold_o_idx_list = back_m.get_monster_profile().hold_o_idx_list;
         polymorphed = true;
     } else {
         m_idx = place_specific_monster(creature, y, x, old_r_idx, (mode | PM_NO_KAGE | PM_IGNORE_TERRAIN));
@@ -130,12 +130,12 @@ bool polymorph_monster(CreatureEntity &creature, POSITION y, POSITION x)
     }
 
     if (preserve_hold_objects) {
-        for (const auto this_o_idx : back_m.hold_o_idx_list) {
+        for (const auto this_o_idx : back_m.get_monster_profile().hold_o_idx_list) {
             auto *o_ptr = floor.o_list[this_o_idx].get();
             o_ptr->held_m_idx = *m_idx;
         }
     } else {
-        delete_items(creature, back_m.hold_o_idx_list);
+        delete_items(creature, back_m.get_monster_profile().hold_o_idx_list);
     }
 
     if (targeted) {

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -58,18 +58,18 @@ bool project_all_los(CreatureEntity &creature, AttributeType typ, int dam)
             continue;
         }
 
-        monster.mflag.set(MonsterTemporaryFlagType::LOS);
+        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::LOS);
     }
 
     BIT_FLAGS flg = PROJECT_JUMP | PROJECT_KILL | PROJECT_HIDE;
     auto obvious = false;
     for (short i = 1; i < floor.m_max; i++) {
         auto &monster = floor.m_list[i];
-        if (monster.mflag.has_not(MonsterTemporaryFlagType::LOS)) {
+        if (monster.get_monster_profile().mflag.has_not(MonsterTemporaryFlagType::LOS)) {
             continue;
         }
 
-        monster.mflag.reset(MonsterTemporaryFlagType::LOS);
+        monster.get_monster_profile().mflag.reset(MonsterTemporaryFlagType::LOS);
         const auto m_pos = monster.get_position();
         if (project(creature, 0, 0, m_pos.y, m_pos.x, dam, typ, flg).notice) {
             obvious = true;
@@ -232,12 +232,12 @@ void aggravate_monsters(CreatureEntity &creature, MONSTER_IDX src_idx)
             }
 
             if (!monster.is_pet()) {
-                monster.mflag2.set(MonsterConstantFlagType::NOPET);
+                monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
             }
         }
 
         if (floor.has_los_at({ monster.y, monster.x }) && !monster.is_pet()) {
-            monster.mflag2.set(MonsterConstantFlagType::ANGER);
+            monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::ANGER);
             (void)set_monster_fast(floor, i, monster.get_remaining_acceleration() + 100);
             speed = true;
         }
@@ -373,8 +373,8 @@ bool deathray_monsters(CreatureEntity &creature)
 std::string probed_monster_info(CreatureEntity &creature, MonsterEntity &monster, const MonraceDefinition &monrace)
 {
     if (!monster.is_original_ap()) {
-        if (monster.mflag2.has(MonsterConstantFlagType::KAGE)) {
-            monster.mflag2.reset(MonsterConstantFlagType::KAGE);
+        if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::KAGE)) {
+            monster.get_monster_profile().mflag2.reset(MonsterConstantFlagType::KAGE);
         }
 
         monster.ap_r_idx = monster.r_idx;
@@ -390,11 +390,11 @@ std::string probed_monster_info(CreatureEntity &creature, MonsterEntity &monster
         align = _("邪悪", "evil");
     } else if (monrace.kind_flags.has(MonsterKindType::GOOD)) {
         align = _("善良", "good");
-    } else if ((monster.sub_align & (SUB_ALIGN_EVIL | SUB_ALIGN_GOOD)) == (SUB_ALIGN_EVIL | SUB_ALIGN_GOOD)) {
+    } else if ((monster.get_monster_profile().sub_align & (SUB_ALIGN_EVIL | SUB_ALIGN_GOOD)) == (SUB_ALIGN_EVIL | SUB_ALIGN_GOOD)) {
         align = _("中立(善悪)", "neutral(good&evil)");
-    } else if (monster.sub_align & SUB_ALIGN_EVIL) {
+    } else if (monster.get_monster_profile().sub_align & SUB_ALIGN_EVIL) {
         align = _("中立(邪悪)", "neutral(evil)");
-    } else if (monster.sub_align & SUB_ALIGN_GOOD) {
+    } else if (monster.get_monster_profile().sub_align & SUB_ALIGN_GOOD) {
         align = _("中立(善良)", "neutral(good)");
     } else {
         align = _("中立", "neutral");
@@ -452,7 +452,7 @@ bool probing(CreatureEntity &creature)
         if (!floor.has_los_at({ monster.y, monster.x })) {
             continue;
         }
-        if (!monster.ml) {
+        if (!monster.get_monster_profile().ml) {
             continue;
         }
 

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -519,7 +519,7 @@ void teleport_away_followable(CreatureEntity &creature, MONSTER_IDX m_idx)
     const auto &floor = *creature.current_floor_ptr;
     const auto &monster = floor.m_list[m_idx];
     const auto old_m_pos = monster.get_position();
-    bool old_ml = monster.ml;
+    bool old_ml = monster.get_monster_profile().ml;
     const auto old_cdis = Grid::calc_distance(creature.get_position(), old_m_pos);
 
     teleport_away(creature, m_idx, MAX_PLAYER_SIGHT * 2 + 5, TELEPORT_SPONTANEOUS);

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -145,7 +145,7 @@ bool vanish_dungeon(CreatureEntity &creature)
         const auto &monster = floor.m_list[grid.m_idx];
         if (grid.has_monster() && monster.is_asleep()) {
             (void)set_monster_csleep(floor, grid.m_idx, 0);
-            if (monster.ml) {
+            if (monster.get_monster_profile().ml) {
                 const auto m_name = monster_desc(creature, monster, 0);
                 msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());
             }

--- a/src/spell/spells-diceroll.cpp
+++ b/src/spell/spells-diceroll.cpp
@@ -42,7 +42,7 @@ bool common_saving_throw_charm(CreatureEntity &creature, int pow, const MonsterE
         return true;
     }
 
-    if (monrace.misc_flags.has(MonsterMiscType::QUESTOR) || monster.mflag2.has(MonsterConstantFlagType::NOPET)) {
+    if (monrace.misc_flags.has(MonsterMiscType::QUESTOR) || monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::NOPET)) {
         return true;
     }
 
@@ -75,7 +75,7 @@ bool common_saving_throw_control(CreatureEntity &creature, int pow, const Monste
         return true;
     }
 
-    if (monrace.misc_flags.has(MonsterMiscType::QUESTOR) || monster.mflag2.has(MonsterConstantFlagType::NOPET)) {
+    if (monrace.misc_flags.has(MonsterMiscType::QUESTOR) || monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::NOPET)) {
         return true;
     }
 

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -10,6 +10,7 @@
 #include "player/player-skill.h"
 #include "system/angband.h"
 #include "system/creature-timed-effect-types.h"
+#include "system/monster-profile.h"
 #include "system/system-variables.h"
 #include "util/dice.h"
 #include "util/flag-group.h"
@@ -20,6 +21,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <tl/optional.hpp>
 
 class Direction;
 class FloorType;
@@ -420,6 +422,26 @@ public:
      */
     bool is_wielding(FixedArtifactId fa_id) const;
 
+    /*!
+     * @brief モンスター固有データを取得する（非const版）
+     * @return モンスター固有データへの参照
+     * @pre has_monster_profile() == true
+     */
+    MonsterProfile &get_monster_profile() { return this->monster_profile.value(); }
+
+    /*!
+     * @brief モンスター固有データを取得する（const版）
+     * @return モンスター固有データへのconst参照
+     * @pre has_monster_profile() == true
+     */
+    const MonsterProfile &get_monster_profile() const { return this->monster_profile.value(); }
+
+    /*!
+     * @brief モンスター固有データを持っているかどうかを返す
+     * @return モンスター固有データがあればtrue
+     */
+    bool has_monster_profile() const { return this->monster_profile.has_value(); }
+
     // モンスター種族ID（プレイヤーの場合は0）
     MonraceId r_idx{}; /*!< モンスターの実種族ID (これが0の時は死亡扱いになる) / Monster race index 0 = dead. */
     MonraceId ap_r_idx{}; /*!< モンスターの外見種族ID（あやしい影、たぬき、ジュラル星人誤認などにより変化する）Monster race appearance index */
@@ -449,6 +471,8 @@ public:
     POSITION run_px{}; /*!< 走行中の目標X座標 / Target X position while running */
 
     Pos2D target{}; /*!< 攻撃目標座標 (0,0 は未設定) / Attack target position ({0,0} means none) */
+
+    tl::optional<MonsterProfile> monster_profile{}; /*!< モンスター固有データ (モンスターの場合のみ有効) */
 
     bool ambush_flag{}; /*!< 待ち伏せフラグ / Ambush flag */
 

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -537,7 +537,7 @@ void FloorType::reset_mproc()
         }
 
         for (const auto mte : MONSTER_TIMED_EFFECT_RANGE) {
-            if (monster.mtimed.at(mte) > 0) {
+            if (monster.get_monster_profile().mtimed.at(mte) > 0) {
                 this->add_mproc(i, mte);
             }
         }

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -24,8 +24,9 @@
 
 MonsterEntity::MonsterEntity()
 {
+    this->monster_profile.emplace();
     for (const auto mte : MONSTER_TIMED_EFFECT_RANGE) {
-        this->mtimed[mte] = 0;
+        this->get_monster_profile().mtimed[mte] = 0;
     }
 
     // CreatureEntityの基本メンバーを初期化
@@ -60,6 +61,10 @@ bool MonsterEntity::check_sub_alignments(const byte sub_align1, const byte sub_a
 void MonsterEntity::wipe()
 {
     *this = {};
+    this->monster_profile.emplace();
+    for (const auto mte : MONSTER_TIMED_EFFECT_RANGE) {
+        this->get_monster_profile().mtimed[mte] = 0;
+    }
 }
 
 MonsterEntity MonsterEntity::clone() const
@@ -69,12 +74,12 @@ MonsterEntity MonsterEntity::clone() const
 
 bool MonsterEntity::is_friendly() const
 {
-    return this->mflag2.has(MonsterConstantFlagType::FRIENDLY);
+    return this->get_monster_profile().mflag2.has(MonsterConstantFlagType::FRIENDLY);
 }
 
 bool MonsterEntity::is_pet() const
 {
-    return this->mflag2.has(MonsterConstantFlagType::PET);
+    return this->get_monster_profile().mflag2.has(MonsterConstantFlagType::PET);
 }
 
 bool MonsterEntity::is_hostile() const
@@ -103,10 +108,10 @@ bool MonsterEntity::is_hostile_to_melee(const MonsterEntity &other) const
         }
     }
 
-    if (this->alliance_idx != other.alliance_idx) {
+    if (this->get_monster_profile().alliance_idx != other.get_monster_profile().alliance_idx) {
         return true;
-    } else if (this->is_hostile_align(other.sub_align)) {
-        if (this->mflag2.has_not(MonsterConstantFlagType::CHAMELEON) || other.mflag2.has_not(MonsterConstantFlagType::CHAMELEON)) {
+    } else if (this->is_hostile_align(other.get_monster_profile().sub_align)) {
+        if (this->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::CHAMELEON) || other.get_monster_profile().mflag2.has_not(MonsterConstantFlagType::CHAMELEON)) {
             return true;
         }
     }
@@ -121,7 +126,7 @@ bool MonsterEntity::is_hostile_to_melee(const MonsterEntity &other) const
  */
 bool MonsterEntity::is_hostile_align(const byte other_sub_align) const
 {
-    return MonsterEntity::check_sub_alignments(this->sub_align, other_sub_align);
+    return MonsterEntity::check_sub_alignments(this->get_monster_profile().sub_align, other_sub_align);
 }
 
 bool MonsterEntity::is_named_pet() const
@@ -177,13 +182,13 @@ bool MonsterEntity::is_male() const
 bool MonsterEntity::is_female() const
 {
     const auto &monrace = this->get_monrace();
-    return monrace.is_female() || this->mflag2.has(MonsterConstantFlagType::WAIFUIZED);
+    return monrace.is_female() || this->get_monster_profile().mflag2.has(MonsterConstantFlagType::WAIFUIZED);
 }
 
 MonraceId MonsterEntity::get_real_monrace_id() const
 {
     const auto &monrace = this->get_monrace();
-    if (this->mflag2.has_not(MonsterConstantFlagType::CHAMELEON)) {
+    if (this->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::CHAMELEON)) {
         return this->r_idx;
     }
 
@@ -211,7 +216,7 @@ MonraceDefinition &MonsterEntity::get_monrace() const
 
 short MonsterEntity::get_remaining_sleep() const
 {
-    return this->mtimed.at(MonsterTimedEffect::SLEEP);
+    return this->get_monster_profile().mtimed.at(MonsterTimedEffect::SLEEP);
 }
 
 bool MonsterEntity::is_dead() const
@@ -226,7 +231,7 @@ bool MonsterEntity::is_asleep() const
 
 short MonsterEntity::get_remaining_acceleration() const
 {
-    return this->mtimed.at(MonsterTimedEffect::FAST);
+    return this->get_monster_profile().mtimed.at(MonsterTimedEffect::FAST);
 }
 
 bool MonsterEntity::is_accelerated() const
@@ -241,12 +246,12 @@ bool MonsterEntity::is_decelerated() const
 
 short MonsterEntity::get_remaining_deceleration() const
 {
-    return this->mtimed.at(MonsterTimedEffect::SLOW);
+    return this->get_monster_profile().mtimed.at(MonsterTimedEffect::SLOW);
 }
 
 short MonsterEntity::get_remaining_stun() const
 {
-    return this->mtimed.at(MonsterTimedEffect::STUN);
+    return this->get_monster_profile().mtimed.at(MonsterTimedEffect::STUN);
 }
 
 bool MonsterEntity::is_stunned() const
@@ -256,7 +261,7 @@ bool MonsterEntity::is_stunned() const
 
 short MonsterEntity::get_remaining_confusion() const
 {
-    return this->mtimed.at(MonsterTimedEffect::CONFUSION);
+    return this->get_monster_profile().mtimed.at(MonsterTimedEffect::CONFUSION);
 }
 
 bool MonsterEntity::is_confused() const
@@ -266,7 +271,7 @@ bool MonsterEntity::is_confused() const
 
 short MonsterEntity::get_remaining_fear() const
 {
-    return this->mtimed.at(MonsterTimedEffect::FEAR);
+    return this->get_monster_profile().mtimed.at(MonsterTimedEffect::FEAR);
 }
 
 bool MonsterEntity::is_fearful() const
@@ -276,7 +281,7 @@ bool MonsterEntity::is_fearful() const
 
 short MonsterEntity::get_remaining_invulnerability() const
 {
-    return this->mtimed.at(MonsterTimedEffect::INVULNERABILITY);
+    return this->get_monster_profile().mtimed.at(MonsterTimedEffect::INVULNERABILITY);
 }
 
 bool MonsterEntity::is_invulnerable() const
@@ -288,19 +293,19 @@ short MonsterEntity::get_timed_effect(CreatureTimedEffect effect) const
 {
     switch (effect) {
     case CreatureTimedEffect::STUN:
-        return this->mtimed.at(MonsterTimedEffect::STUN);
+        return this->get_monster_profile().mtimed.at(MonsterTimedEffect::STUN);
     case CreatureTimedEffect::CONFUSION:
-        return this->mtimed.at(MonsterTimedEffect::CONFUSION);
+        return this->get_monster_profile().mtimed.at(MonsterTimedEffect::CONFUSION);
     case CreatureTimedEffect::FEAR:
-        return this->mtimed.at(MonsterTimedEffect::FEAR);
+        return this->get_monster_profile().mtimed.at(MonsterTimedEffect::FEAR);
     case CreatureTimedEffect::INVULNERABILITY:
-        return this->mtimed.at(MonsterTimedEffect::INVULNERABILITY);
+        return this->get_monster_profile().mtimed.at(MonsterTimedEffect::INVULNERABILITY);
     case CreatureTimedEffect::ACCELERATION:
-        return this->mtimed.at(MonsterTimedEffect::FAST);
+        return this->get_monster_profile().mtimed.at(MonsterTimedEffect::FAST);
     case CreatureTimedEffect::DECELERATION:
-        return this->mtimed.at(MonsterTimedEffect::SLOW);
+        return this->get_monster_profile().mtimed.at(MonsterTimedEffect::SLOW);
     case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
-        return this->mtimed.at(MonsterTimedEffect::SLEEP);
+        return this->get_monster_profile().mtimed.at(MonsterTimedEffect::SLEEP);
     default:
         return 0;
     }
@@ -324,11 +329,11 @@ byte MonsterEntity::get_temporary_speed() const
         speed -= 10;
     }
 
-    if (this->mflag2.has(MonsterConstantFlagType::FAT)) {
+    if (this->get_monster_profile().mflag2.has(MonsterConstantFlagType::FAT)) {
         speed -= 5;
     }
 
-    if (this->mflag2.has(MonsterConstantFlagType::FRENZY)) {
+    if (this->get_monster_profile().mflag2.has(MonsterConstantFlagType::FRENZY)) {
         speed += 10;
     }
 
@@ -396,7 +401,7 @@ bool MonsterEntity::is_explodable() const
  */
 bool MonsterEntity::has_parent() const
 {
-    return this->parent_m_idx > 0;
+    return this->get_monster_profile().parent_m_idx > 0;
 }
 
 /*!
@@ -416,7 +421,7 @@ std::string MonsterEntity::get_died_message() const
 tl::optional<std::string> MonsterEntity::get_pain_message(std::string_view monster_name, int damage) const
 {
     auto &monrace = this->get_monrace();
-    return MonsterPainDescriber(monrace.idx, monrace.symbol_definition.character, monster_name).describe(this->hp, damage, this->ml);
+    return MonsterPainDescriber(monrace.idx, monrace.symbol_definition.character, monster_name).describe(this->hp, damage, this->get_monster_profile().ml);
 }
 
 /*!
@@ -529,12 +534,12 @@ void MonsterEntity::set_hostile()
         return;
     }
 
-    this->mflag2.reset({ MonsterConstantFlagType::PET, MonsterConstantFlagType::FRIENDLY });
+    this->get_monster_profile().mflag2.reset({ MonsterConstantFlagType::PET, MonsterConstantFlagType::FRIENDLY });
 
-    if (this->alliance_idx != AllianceType::NONE) {
+    if (this->get_monster_profile().alliance_idx != AllianceType::NONE) {
         for (auto &monster : this->current_floor_ptr->m_list) {
-            if (monster.alliance_idx == this->alliance_idx) {
-                monster.mflag2.reset({ MonsterConstantFlagType::PET, MonsterConstantFlagType::FRIENDLY });
+            if (monster.get_monster_profile().alliance_idx == this->get_monster_profile().alliance_idx) {
+                monster.get_monster_profile().mflag2.reset({ MonsterConstantFlagType::PET, MonsterConstantFlagType::FRIENDLY });
             }
         }
     }
@@ -599,7 +604,7 @@ tl::optional<bool> MonsterEntity::order_pet_hp(const MonsterEntity &other) const
  */
 void MonsterEntity::set_friendly()
 {
-    this->mflag2.set(MonsterConstantFlagType::FRIENDLY);
+    this->get_monster_profile().mflag2.set(MonsterConstantFlagType::FRIENDLY);
 }
 
 /*!
@@ -609,101 +614,101 @@ void MonsterEntity::set_friendly()
  */
 void MonsterEntity::initialize_equivalent_player_races()
 {
-    this->equivalent_player_races.clear();
+    this->get_monster_profile().equivalent_player_races.clear();
     const auto &monrace = this->get_monrace();
 
     // モンスターのフラグとプレイヤー種族の対応関係をチェック
     if (monrace.kind_flags.has(MonsterKindType::HUMAN)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::HUMAN);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::HUMAN);
     }
     if (monrace.kind_flags.has(MonsterKindType::ELF)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::ELF);
-        this->equivalent_player_races.push_back(PlayerRaceType::HALF_ELF);
-        this->equivalent_player_races.push_back(PlayerRaceType::HIGH_ELF);
-        this->equivalent_player_races.push_back(PlayerRaceType::DARK_ELF);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::ELF);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::HALF_ELF);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::HIGH_ELF);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::DARK_ELF);
     }
     if (monrace.kind_flags.has(MonsterKindType::DWARF)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::DWARF);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::DWARF);
     }
     if (monrace.kind_flags.has(MonsterKindType::HOBBIT)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::HOBBIT);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::HOBBIT);
     }
     if (monrace.kind_flags.has(MonsterKindType::GNOME)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::GNOME);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::GNOME);
     }
     if (monrace.kind_flags.has(MonsterKindType::ORC)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::HALF_ORC);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::HALF_ORC);
     }
     if (monrace.kind_flags.has(MonsterKindType::TROLL)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::HALF_TROLL);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::HALF_TROLL);
     }
     if (monrace.kind_flags.has(MonsterKindType::GIANT)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::HALF_GIANT);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::HALF_GIANT);
     }
     if (monrace.kind_flags.has(MonsterKindType::OGRE)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::HALF_OGRE);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::HALF_OGRE);
     }
     if (monrace.kind_flags.has(MonsterKindType::AMBERITE)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::AMBERITE);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::AMBERITE);
     }
     if (monrace.kind_flags.has(MonsterKindType::YEEK)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::YEEK);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::YEEK);
     }
     if (monrace.kind_flags.has(MonsterKindType::KOBOLD)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::KOBOLD);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::KOBOLD);
     }
     if (monrace.kind_flags.has(MonsterKindType::NIBELUNG)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::NIBELUNG);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::NIBELUNG);
     }
     if (monrace.kind_flags.has(MonsterKindType::DRAGON)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::DRACONIAN);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::DRACONIAN);
     }
     if (monrace.kind_flags.has(MonsterKindType::MINDFLAYER)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::MIND_FLAYER);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::MIND_FLAYER);
     }
     if (monrace.kind_flags.has(MonsterKindType::DEMON)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::IMP);
-        this->equivalent_player_races.push_back(PlayerRaceType::BALROG);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::IMP);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::BALROG);
     }
     if (monrace.kind_flags.has(MonsterKindType::GOLEM)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::GOLEM);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::GOLEM);
     }
     if (monrace.kind_flags.has(MonsterKindType::SKELETON)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::SKELETON);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::SKELETON);
     }
     if (monrace.kind_flags.has(MonsterKindType::ZOMBIE)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::ZOMBIE);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::ZOMBIE);
     }
     if (monrace.kind_flags.has(MonsterKindType::VAMPIRE)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::VAMPIRE);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::VAMPIRE);
     }
     if (monrace.kind_flags.has(MonsterKindType::UNDEAD)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::SPECTRE);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::SPECTRE);
     }
     if (monrace.kind_flags.has(MonsterKindType::FAIRY)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::SPRITE);
-        this->equivalent_player_races.push_back(PlayerRaceType::S_FAIRY);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::SPRITE);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::S_FAIRY);
     }
     if (monrace.kind_flags.has(MonsterKindType::BEAST)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::BEASTMAN);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::BEASTMAN);
     }
     if (monrace.kind_flags.has(MonsterKindType::TREEFOLK)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::ENT);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::ENT);
     }
     if (monrace.kind_flags.has(MonsterKindType::ANGEL)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::ARCHON);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::ARCHON);
     }
     if (monrace.kind_flags.has(MonsterKindType::ROBOT)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::ANDROID);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::ANDROID);
     }
     if (monrace.kind_flags.has(MonsterKindType::MERFOLK)) {
-        this->equivalent_player_races.push_back(PlayerRaceType::MERFOLK);
+        this->get_monster_profile().equivalent_player_races.push_back(PlayerRaceType::MERFOLK);
     }
 
     // equivalent_player_racesの最初の種族をraceポインタに設定
-    if (!this->equivalent_player_races.empty()) {
-        this->race = &race_info[enum2i(this->equivalent_player_races[0])];
-        this->prace = this->equivalent_player_races[0];
+    if (!this->get_monster_profile().equivalent_player_races.empty()) {
+        this->race = &race_info[enum2i(this->get_monster_profile().equivalent_player_races[0])];
+        this->prace = this->get_monster_profile().equivalent_player_races[0];
     } else {
         this->race = nullptr;
         this->prace = PlayerRaceType::HUMAN; // デフォルト
@@ -717,54 +722,54 @@ void MonsterEntity::initialize_equivalent_player_races()
  */
 void MonsterEntity::initialize_equivalent_player_classes()
 {
-    this->equivalent_player_classes.clear();
+    this->get_monster_profile().equivalent_player_classes.clear();
     const auto &monrace = this->get_monrace();
 
     // モンスターのフラグとプレイヤー職業の対応関係をチェック
     if (monrace.kind_flags.has(MonsterKindType::WARRIOR)) {
-        this->equivalent_player_classes.push_back(PlayerClassType::WARRIOR);
+        this->get_monster_profile().equivalent_player_classes.push_back(PlayerClassType::WARRIOR);
     }
     if (monrace.kind_flags.has(MonsterKindType::MAGE)) {
-        this->equivalent_player_classes.push_back(PlayerClassType::MAGE);
+        this->get_monster_profile().equivalent_player_classes.push_back(PlayerClassType::MAGE);
     }
     if (monrace.kind_flags.has(MonsterKindType::PRIEST)) {
-        this->equivalent_player_classes.push_back(PlayerClassType::PRIEST);
+        this->get_monster_profile().equivalent_player_classes.push_back(PlayerClassType::PRIEST);
     }
     if (monrace.kind_flags.has(MonsterKindType::ROGUE)) {
-        this->equivalent_player_classes.push_back(PlayerClassType::ROGUE);
+        this->get_monster_profile().equivalent_player_classes.push_back(PlayerClassType::ROGUE);
     }
     if (monrace.kind_flags.has(MonsterKindType::RANGER)) {
-        this->equivalent_player_classes.push_back(PlayerClassType::RANGER);
+        this->get_monster_profile().equivalent_player_classes.push_back(PlayerClassType::RANGER);
     }
     if (monrace.kind_flags.has(MonsterKindType::PALADIN)) {
-        this->equivalent_player_classes.push_back(PlayerClassType::PALADIN);
+        this->get_monster_profile().equivalent_player_classes.push_back(PlayerClassType::PALADIN);
     }
     if (monrace.kind_flags.has(MonsterKindType::SAMURAI)) {
-        this->equivalent_player_classes.push_back(PlayerClassType::SAMURAI);
+        this->get_monster_profile().equivalent_player_classes.push_back(PlayerClassType::SAMURAI);
     }
     if (monrace.kind_flags.has(MonsterKindType::NINJA)) {
-        this->equivalent_player_classes.push_back(PlayerClassType::NINJA);
+        this->get_monster_profile().equivalent_player_classes.push_back(PlayerClassType::NINJA);
     }
     if (monrace.kind_flags.has(MonsterKindType::MINDCRAFTER)) {
-        this->equivalent_player_classes.push_back(PlayerClassType::MINDCRAFTER);
+        this->get_monster_profile().equivalent_player_classes.push_back(PlayerClassType::MINDCRAFTER);
     }
     if (monrace.kind_flags.has(MonsterKindType::ARCHER)) {
-        this->equivalent_player_classes.push_back(PlayerClassType::ARCHER);
+        this->get_monster_profile().equivalent_player_classes.push_back(PlayerClassType::ARCHER);
     }
     if (monrace.kind_flags.has(MonsterKindType::BARD)) {
-        this->equivalent_player_classes.push_back(PlayerClassType::BARD);
+        this->get_monster_profile().equivalent_player_classes.push_back(PlayerClassType::BARD);
     }
     if (monrace.kind_flags.has(MonsterKindType::SMITH)) {
-        this->equivalent_player_classes.push_back(PlayerClassType::SMITH);
+        this->get_monster_profile().equivalent_player_classes.push_back(PlayerClassType::SMITH);
     }
     if (monrace.kind_flags.has(MonsterKindType::KARATEKA)) {
-        this->equivalent_player_classes.push_back(PlayerClassType::MONK);
+        this->get_monster_profile().equivalent_player_classes.push_back(PlayerClassType::MONK);
     }
 
     // equivalent_player_classesの最初の職業をpclass_refポインタに設定
-    if (!this->equivalent_player_classes.empty()) {
-        this->pclass_ref = &class_info.at(this->equivalent_player_classes[0]);
-        this->pclass = this->equivalent_player_classes[0];
+    if (!this->get_monster_profile().equivalent_player_classes.empty()) {
+        this->pclass_ref = &class_info.at(this->get_monster_profile().equivalent_player_classes[0]);
+        this->pclass = this->get_monster_profile().equivalent_player_classes[0];
     } else {
         this->pclass_ref = nullptr;
         this->pclass = PlayerClassType::WARRIOR; // デフォルト
@@ -773,7 +778,7 @@ void MonsterEntity::initialize_equivalent_player_classes()
 
 bool MonsterEntity::is_riding() const
 {
-    return this->mflag2.has(MonsterConstantFlagType::RIDING);
+    return this->get_monster_profile().mflag2.has(MonsterConstantFlagType::RIDING);
 }
 
 Pos2D MonsterEntity::get_position() const
@@ -795,14 +800,14 @@ std::string MonsterEntity::build_looking_description(bool needs_attitude) const
 {
     const auto description = this->build_damage_description();
     const auto attitude = needs_attitude ? this->build_attitude_description() : "";
-    const std::string clone(this->mflag2.has(MonsterConstantFlagType::CLONED) ? ", clone" : "");
+    const std::string clone(this->get_monster_profile().mflag2.has(MonsterConstantFlagType::CLONED) ? ", clone" : "");
     const auto &apparent_monrace = this->get_appearance_monrace();
 
     // ペットの場合はアライアンス表示を省略
-    const bool show_alliance = !this->is_pet() && this->alliance_idx != AllianceType::NONE;
-    const std::string alliance_part = show_alliance ? format("(%s)", alliance_list.at(this->alliance_idx)->name.data()) : "";
+    const bool show_alliance = !this->is_pet() && this->get_monster_profile().alliance_idx != AllianceType::NONE;
+    const std::string alliance_part = show_alliance ? format("(%s)", alliance_list.at(this->get_monster_profile().alliance_idx)->name.data()) : "";
 
-    if ((apparent_monrace.r_tkills > 0) && this->mflag2.has_not(MonsterConstantFlagType::KAGE)) {
+    if ((apparent_monrace.r_tkills > 0) && this->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::KAGE)) {
         constexpr auto fmt = _("レベル%d, %s%s%s%s", "Level %d, %s%s%s%s");
         return format(fmt, apparent_monrace.level, description.data(), attitude.data(), clone.data(), alliance_part.data());
     }
@@ -815,7 +820,7 @@ std::string MonsterEntity::build_damage_description() const
 {
     const auto is_living = this->has_living_flag(true);
     const auto damage_ratio = this->maxhp > 0 ? 100L * this->hp / this->maxhp : 0;
-    if (!this->ml) {
+    if (!this->get_monster_profile().ml) {
         return _("損傷具合不明", "damage unknown");
     }
 
@@ -853,7 +858,7 @@ std::string MonsterEntity::build_attitude_description() const
 
 int MonsterEntity::get_ac() const
 {
-    if (this->mflag2.has(MonsterConstantFlagType::NAKED)) {
+    if (this->get_monster_profile().mflag2.has(MonsterConstantFlagType::NAKED)) {
         return 0;
     }
     return this->ac;

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -1,17 +1,10 @@
 #pragma once
 
-#include "alliance/alliance.h"
-#include "monster/monster-flag-types.h"
-#include "monster/monster-timed-effects.h"
-#include "monster/smart-learn-types.h"
-#include "object/object-index-list.h"
 #include "system/creature-entity.h"
-#include "util/flag-group.h"
+#include "system/monster-profile.h"
 #include "util/point-2d.h"
-#include <map>
 #include <string>
 #include <string_view>
-#include <vector>
 
 /*!
  * @brief Monster information, for a specific monster.
@@ -36,30 +29,6 @@ public:
     MonsterEntity &operator=(MonsterEntity &&) = default;
     MonsterEntity(const MonsterEntity &) = default;
     MonsterEntity &operator=(const MonsterEntity &) = default;
-
-/* Sub-alignment flags for neutral monsters */
-#define SUB_ALIGN_NEUTRAL 0x0000 /*!< モンスターのサブアライメント:中立 */
-#define SUB_ALIGN_EVIL 0x0001 /*!< モンスターのサブアライメント:善 */
-#define SUB_ALIGN_GOOD 0x0002 /*!< モンスターのサブアライメント:悪 */
-    BIT_FLAGS8 sub_align{}; /*!< 中立属性のモンスターが召喚主のアライメントに従い一時的に立っている善悪陣営 / Sub-alignment for a neutral monster */
-    AllianceType alliance_idx; /*!< 現在の所属アライアンス */
-    std::vector<PlayerRaceType> equivalent_player_races{}; /*!< モンスターのフラグに基づいて対応するプレイヤー種族IDリスト */
-    std::vector<PlayerClassType> equivalent_player_classes{}; /*!< モンスターのフラグに基づいて対応するプレイヤー職業IDリスト */
-
-    int death_count{}; /*!< 自壊するまでの残りターン数 */
-    std::map<MonsterTimedEffect, short> mtimed; /*!< 与えられた時限効果の残りターン / Timed status counter */
-
-    EnumClassFlagGroup<MonsterTemporaryFlagType> mflag{}; /*!< モンスター個体に与えられた特殊フラグ1 (セーブ不要) / Extra monster flags */
-    EnumClassFlagGroup<MonsterConstantFlagType> mflag2{}; /*!< モンスター個体に与えられた特殊フラグ2 (セーブ必要) / Extra monster flags */
-    bool ml{}; /*!< モンスターがプレイヤーにとって視認できるか(処理のためのテンポラリ変数) Monster is "visible" */
-    ObjectIndexList hold_o_idx_list{}; /*!< モンスターが所持しているアイテムのリスト / Object list being held (if any) */
-
-    /* TODO: クローン、ペット、有効化は意義が異なるので別変数に切り離すこと。save/loadのバージョン更新が面倒そうだけど */
-    EnumClassFlagGroup<MonsterSmartLearnType> smart{}; /*!< モンスターのプレイヤーに対する学習状態 / Field for "smart_learn" - Some bit-flags for the "smart" field */
-    MONSTER_IDX parent_m_idx{}; /*!< 召喚主のモンスターID */
-    MonraceId transform_r_idx{}; /*!< 変身先モンスター種族ID */
-    PERCENTAGE transform_hp_threshold{}; /*!< 変身するHP閾値(最大HPの%) */
-    bool has_transformed{}; /*!< 既に変身済みかどうかのフラグ */
 
     static bool check_sub_alignments(const byte sub_align1, const byte sub_align2);
 

--- a/src/system/monster-profile.h
+++ b/src/system/monster-profile.h
@@ -1,0 +1,40 @@
+﻿#pragma once
+
+#include "alliance/alliance.h"
+#include "monster/monster-flag-types.h"
+#include "monster/monster-timed-effects.h"
+#include "monster/smart-learn-types.h"
+#include "object/object-index-list.h"
+#include "system/enums/monrace/monrace-id.h"
+#include "util/flag-group.h"
+#include <map>
+#include <vector>
+
+enum class PlayerRaceType;
+enum class PlayerClassType : short;
+
+/* Sub-alignment flags for neutral monsters */
+#define SUB_ALIGN_NEUTRAL 0x0000 /*!< モンスターのサブアライメント:中立 */
+#define SUB_ALIGN_EVIL 0x0001 /*!< モンスターのサブアライメント:善 */
+#define SUB_ALIGN_GOOD 0x0002 /*!< モンスターのサブアライメント:悪 */
+
+/*!
+ * @brief モンスターインスタンス固有データ
+ */
+struct MonsterProfile {
+    BIT_FLAGS8 sub_align{}; /*!< 中立属性のモンスターが召喚主のアライメントに従い一時的に立っている善悪陣営 / Sub-alignment for a neutral monster */
+    AllianceType alliance_idx{}; /*!< 現在の所属アライアンス */
+    std::vector<PlayerRaceType> equivalent_player_races{}; /*!< モンスターのフラグに基づいて対応するプレイヤー種族IDリスト */
+    std::vector<PlayerClassType> equivalent_player_classes{}; /*!< モンスターのフラグに基づいて対応するプレイヤー職業IDリスト */
+    int death_count{}; /*!< 自壊するまでの残りターン数 */
+    std::map<MonsterTimedEffect, short> mtimed{}; /*!< 与えられた時限効果の残りターン / Timed status counter */
+    EnumClassFlagGroup<MonsterTemporaryFlagType> mflag{}; /*!< モンスター個体に与えられた特殊フラグ1 (セーブ不要) / Extra monster flags */
+    EnumClassFlagGroup<MonsterConstantFlagType> mflag2{}; /*!< モンスター個体に与えられた特殊フラグ2 (セーブ必要) / Extra monster flags */
+    bool ml{}; /*!< モンスターがプレイヤーにとって視認できるか(処理のためのテンポラリ変数) Monster is "visible" */
+    ObjectIndexList hold_o_idx_list{}; /*!< モンスターが所持しているアイテムのリスト / Object list being held (if any) */
+    EnumClassFlagGroup<MonsterSmartLearnType> smart{}; /*!< モンスターのプレイヤーに対する学習状態 / Field for "smart_learn" */
+    MONSTER_IDX parent_m_idx{}; /*!< 召喚主のモンスターID */
+    MonraceId transform_r_idx{}; /*!< 変身先モンスター種族ID */
+    PERCENTAGE transform_hp_threshold{}; /*!< 変身するHP閾値(最大HPの%) */
+    bool has_transformed{}; /*!< 既に変身済みかどうかのフラグ */
+};

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -63,13 +63,13 @@ void PlayerType::plus_incident(INCIDENT incidentID, int num)
 void PlayerType::ride_monster(MONSTER_IDX m_idx)
 {
     if (is_monster(this->riding)) {
-        this->current_floor_ptr->m_list[this->riding].mflag2.reset(MonsterConstantFlagType::RIDING);
+        this->current_floor_ptr->m_list[this->riding].get_monster_profile().mflag2.reset(MonsterConstantFlagType::RIDING);
     }
 
     this->riding = m_idx;
 
     if (is_monster(m_idx)) {
-        this->current_floor_ptr->m_list[m_idx].mflag2.set(MonsterConstantFlagType::RIDING);
+        this->current_floor_ptr->m_list[m_idx].get_monster_profile().mflag2.set(MonsterConstantFlagType::RIDING);
     }
 }
 

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -112,7 +112,7 @@ static std::string evaluate_monster_exp(CreatureEntity &creature, const MonsterE
         return "**";
     }
 
-    if (!monrace.r_tkills || monster.mflag2.has(MonsterConstantFlagType::KAGE)) {
+    if (!monrace.r_tkills || monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::KAGE)) {
         if (!AngbandWorld::get_instance().wizard) {
             return "??";
         }
@@ -255,7 +255,7 @@ static void describe_monster_person(GridExamination *ge_ptr)
 
 static short describe_monster_item(CreatureEntity &creature, GridExamination *ge_ptr)
 {
-    for (const auto this_o_idx : ge_ptr->m_ptr->hold_o_idx_list) {
+    for (const auto this_o_idx : ge_ptr->m_ptr->get_monster_profile().hold_o_idx_list) {
         const auto &item = *creature.current_floor_ptr->o_list[this_o_idx];
         const auto item_name = describe_flavor(creature, item, 0);
 #ifdef JP
@@ -287,7 +287,7 @@ static bool within_char_util(const short input)
 
 static short describe_grid(CreatureEntity &creature, GridExamination *ge_ptr)
 {
-    if (!ge_ptr->g_ptr->has_monster() || !creature.current_floor_ptr->m_list[ge_ptr->g_ptr->m_idx].ml) {
+    if (!ge_ptr->g_ptr->has_monster() || !creature.current_floor_ptr->m_list[ge_ptr->g_ptr->m_idx].get_monster_profile().ml) {
         return CONTINUOUS_DESCRIPTION;
     }
 

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -43,7 +43,7 @@ bool target_able(CreatureEntity &creature, MONSTER_IDX m_idx)
         return false;
     }
 
-    if (!monster.ml) {
+    if (!monster.get_monster_profile().ml) {
         return false;
     }
 
@@ -80,7 +80,7 @@ static bool target_set_accept(CreatureEntity &creature, const Pos2D &pos)
     const auto &grid = floor.get_grid(pos);
     if (grid.has_monster()) {
         auto &monster = floor.m_list[grid.m_idx];
-        if (monster.ml) {
+        if (monster.get_monster_profile().ml) {
             return true;
         }
     }
@@ -181,12 +181,12 @@ void target_sensing_monsters_prepare(CreatureEntity &creature, std::vector<MONST
 
     for (MONSTER_IDX i = 1; i < creature.current_floor_ptr->m_max; i++) {
         const auto &monster = creature.current_floor_ptr->m_list[i];
-        if (!monster.is_valid() || !monster.ml || monster.is_pet()) {
+        if (!monster.is_valid() || !monster.get_monster_profile().ml || monster.is_pet()) {
             continue;
         }
 
         // 感知魔法/スキルやESPで感知していない擬態モンスターはモンスター一覧に表示しない
-        if (monster.is_mimicry() && monster.mflag2.has_none_of({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW }) && monster.mflag.has_not(MonsterTemporaryFlagType::ESP)) {
+        if (monster.is_mimicry() && monster.get_monster_profile().mflag2.has_none_of({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW }) && monster.get_monster_profile().mflag.has_not(MonsterTemporaryFlagType::ESP)) {
             continue;
         }
 
@@ -205,8 +205,8 @@ void target_sensing_monsters_prepare(CreatureEntity &creature, std::vector<MONST
         }
 
         /* Shadowers first (あやしい影) */
-        if (monster1.mflag2.has(MonsterConstantFlagType::KAGE) != monster2.mflag2.has(MonsterConstantFlagType::KAGE)) {
-            return monster1.mflag2.has(MonsterConstantFlagType::KAGE);
+        if (monster1.get_monster_profile().mflag2.has(MonsterConstantFlagType::KAGE) != monster2.get_monster_profile().mflag2.has(MonsterConstantFlagType::KAGE)) {
+            return monster1.get_monster_profile().mflag2.has(MonsterConstantFlagType::KAGE);
         }
 
         /* Unknown monsters first */

--- a/src/target/target-sorter.cpp
+++ b/src/target/target-sorter.cpp
@@ -39,8 +39,8 @@ bool TargetSorter::compare_importance(const FloorType &floor, const Pos2D &pos_a
         return false;
     }
 
-    const auto can_see_grid1 = grid1.has_monster() && monster_a.ml;
-    const auto can_see_grid2 = grid2.has_monster() && monster_b.ml;
+    const auto can_see_grid1 = grid1.has_monster() && monster_a.get_monster_profile().ml;
+    const auto can_see_grid2 = grid2.has_monster() && monster_b.get_monster_profile().ml;
     if (can_see_grid1 && !can_see_grid2) {
         return true;
     }
@@ -60,11 +60,11 @@ bool TargetSorter::compare_importance(const FloorType &floor, const Pos2D &pos_a
             return false;
         }
 
-        if (monster_a.mflag2.has(MonsterConstantFlagType::KAGE) && monster_b.mflag2.has_not(MonsterConstantFlagType::KAGE)) {
+        if (monster_a.get_monster_profile().mflag2.has(MonsterConstantFlagType::KAGE) && monster_b.get_monster_profile().mflag2.has_not(MonsterConstantFlagType::KAGE)) {
             return true;
         }
 
-        if (monster_a.mflag2.has_not(MonsterConstantFlagType::KAGE) && monster_b.mflag2.has(MonsterConstantFlagType::KAGE)) {
+        if (monster_a.get_monster_profile().mflag2.has_not(MonsterConstantFlagType::KAGE) && monster_b.get_monster_profile().mflag2.has(MonsterConstantFlagType::KAGE)) {
             return false;
         }
 

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -1125,7 +1125,7 @@ void display_lore_this(CreatureEntity &creature, lore_type *lore_ptr)
         hooked_roff("に所属している");
 #else
         hooked_roff("belonging to ");
-        hooked_roff(alliance_list.at(lore_ptr->r_ptr->alliance_idx)->name.c_str());
+        hooked_roff(alliance_list.at(lore_ptr->r_ptr->get_monster_profile().alliance_idx)->name.c_str());
 #endif
     }
 

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -257,7 +257,7 @@ DisplaySymbolPair map_info(CreatureEntity &creature, const Pos2D &pos)
     }
 
     const auto &monster = floor.m_list[grid.m_idx];
-    if (!monster.ml) {
+    if (!monster.get_monster_profile().ml) {
         symbol_pair.symbol_foreground = set_term_color(creature, pos, symbol_pair.symbol_foreground);
         return symbol_pair;
     }

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -148,7 +148,7 @@ static void print_monster_line(TERM_LEN x, TERM_LEN y, const MonsterEntity &mons
     term_addstr(-1, TERM_WHITE, " ");
     term_add_bigch(monrace.symbol_config);
 
-    if (monrace.r_tkills && monster.mflag2.has_not(MonsterConstantFlagType::KAGE)) {
+    if (monrace.r_tkills && monster.get_monster_profile().mflag2.has_not(MonsterConstantFlagType::KAGE)) {
         buf = format(" %2d", monrace.level);
     } else {
         buf = "???";
@@ -223,7 +223,7 @@ static void print_pet_list_oneline(CreatureEntity &creature, const MonsterEntity
     const auto &monrace = monster.get_appearance_monrace();
     const auto name = monster_desc(creature, monster, MD_ASSUME_VISIBLE | MD_INDEF_VISIBLE | MD_NO_OWNER);
     const auto &[bar_color, bar_len] = monster.get_hp_bar_data();
-    const auto is_visible = monster.ml && !creature.effects()->hallucination().is_hallucinated();
+    const auto is_visible = monster.get_monster_profile().ml && !creature.effects()->hallucination().is_hallucinated();
 
     term_erase(0, y);
     if (is_visible) {
@@ -540,7 +540,7 @@ static bool is_seeing_monster_on(const FloorType &floor, const Grid &grid)
     }
 
     const auto &monster = floor.m_list[grid.m_idx];
-    return monster.is_valid() && monster.ml;
+    return monster.is_valid() && monster.get_monster_profile().ml;
 }
 
 /*!

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -392,7 +392,7 @@ void print_health(CreatureEntity &creature, bool riding)
 
     const auto &monster = creature.current_floor_ptr->m_list[monster_idx.value()];
 
-    if ((!monster.ml) || (creature.effects()->hallucination().is_hallucinated()) || monster.is_dead()) {
+    if ((!monster.get_monster_profile().ml) || (creature.effects()->hallucination().is_hallucinated()) || monster.is_dead()) {
         term_putstr(col, row, max_width, TERM_WHITE, "[----------]");
         return;
     }

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -138,7 +138,7 @@ void wiz_summon_specific_monster_common(CreatureEntity &creature, MonraceId monr
         return;
     }
 
-    if (monster->mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
+    if (monster->get_monster_profile().mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
         wiz_select_chameleon_polymorph(*monster);
     }
 


### PR DESCRIPTION
…

- src/system/monster-profile.h を新規作成（MonsterProfile 構造体定義）
  - MonsterEntity のインスタンス固有フィールド（sub_align, alliance_idx, mtimed, mflag, mflag2, ml, hold_o_idx_list, smart, parent_m_idx, transform_r_idx, transform_hp_threshold, has_transformed 等）を収録
- CreatureEntity に tl::optional<MonsterProfile> monster_profile と get_monster_profile() / has_monster_profile() メソッドを追加
- MonsterEntity のコンストラクタ・wipe() で monster_profile を emplace/reset
- MonsterEntity から上記フィールドを削除し、92ファイルで monster.xxx → monster.get_monster_profile().xxx に移行