### PR TITLE
refactor: Phase 3 残り — set_timed_effect() 仮想メソッドを CreatureEntity に追加

### DIFF
--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -304,6 +304,14 @@ public:
     virtual short get_timed_effect(CreatureTimedEffect effect) const = 0;
 
     /*!
+     * @brief クリーチャーの時限効果の残りターン数を直接設定する（セーブ/ロード・内部操作用）
+     * @param effect 設定する時限効果の種別
+     * @param value 設定するターン数
+     * @note メッセージや副作用は発生しない。ゲームロジックからの呼び出しには専用セッターを使うこと。
+     */
+    virtual void set_timed_effect(CreatureTimedEffect effect, short value) = 0;
+
+    /*!
      * @brief クリーチャーが朦朧状態かどうかを判定
      * @return 朦朧状態ならtrue
      */

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -311,6 +311,35 @@ short MonsterEntity::get_timed_effect(CreatureTimedEffect effect) const
     }
 }
 
+void MonsterEntity::set_timed_effect(CreatureTimedEffect effect, short value)
+{
+    switch (effect) {
+    case CreatureTimedEffect::STUN:
+        this->get_monster_profile().mtimed[MonsterTimedEffect::STUN] = value;
+        break;
+    case CreatureTimedEffect::CONFUSION:
+        this->get_monster_profile().mtimed[MonsterTimedEffect::CONFUSION] = value;
+        break;
+    case CreatureTimedEffect::FEAR:
+        this->get_monster_profile().mtimed[MonsterTimedEffect::FEAR] = value;
+        break;
+    case CreatureTimedEffect::INVULNERABILITY:
+        this->get_monster_profile().mtimed[MonsterTimedEffect::INVULNERABILITY] = value;
+        break;
+    case CreatureTimedEffect::ACCELERATION:
+        this->get_monster_profile().mtimed[MonsterTimedEffect::FAST] = value;
+        break;
+    case CreatureTimedEffect::DECELERATION:
+        this->get_monster_profile().mtimed[MonsterTimedEffect::SLOW] = value;
+        break;
+    case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
+        this->get_monster_profile().mtimed[MonsterTimedEffect::SLEEP] = value;
+        break;
+    default:
+        break;
+    }
+}
+
 /*
  * @brief 悪夢モード、一時加速、一時減速に基づくモンスターの現在速度を返す
  */

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -63,6 +63,7 @@ public:
     bool is_fearful() const override;
     bool is_invulnerable() const override;
     short get_timed_effect(CreatureTimedEffect effect) const override;
+    void set_timed_effect(CreatureTimedEffect effect, short value) override;
     byte get_temporary_speed() const;
     int get_speed() const override;
     bool has_living_flag(bool is_apperance = false) const;

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -193,6 +193,36 @@ short PlayerType::get_timed_effect(CreatureTimedEffect effect) const
     }
 }
 
+void PlayerType::set_timed_effect(CreatureTimedEffect effect, short value)
+{
+    auto &eff = *this->effects();
+    switch (effect) {
+    case CreatureTimedEffect::STUN:
+        eff.stun().set(value);
+        break;
+    case CreatureTimedEffect::CONFUSION:
+        eff.confusion().set(value);
+        break;
+    case CreatureTimedEffect::FEAR:
+        eff.fear().set(value);
+        break;
+    case CreatureTimedEffect::INVULNERABILITY:
+        this->invuln = value;
+        break;
+    case CreatureTimedEffect::ACCELERATION:
+        eff.acceleration().set(value);
+        break;
+    case CreatureTimedEffect::DECELERATION:
+        eff.deceleration().set(value);
+        break;
+    case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
+        eff.paralysis().set(value);
+        break;
+    default:
+        break;
+    }
+}
+
 bool PlayerType::is_confused() const
 {
     return this->effects()->confusion().is_confused();

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -70,6 +70,7 @@ public:
     void on_death(std::string_view cause) override;
 
     short get_timed_effect(CreatureTimedEffect effect) const override;
+    void set_timed_effect(CreatureTimedEffect effect, short value) override;
 
     bool is_confused() const override;
     bool is_stunned() const override;


### PR DESCRIPTION
- CreatureEntity に純粋仮想メソッド set_timed_effect(CreatureTimedEffect, short) を追加
  - get_timed_effect() と対になる直接セッター（メッセージ・副作用なし）
  - セーブ/ロードや内部状態操作用途を想定
- MonsterEntity: mtimed[] への直接書き込みで実装
- PlayerType: 各 effects()->xxx().set(value) および invuln フィールドへの書き込みで実装