### PR TITLE
refactor: ローカル変数の MonsterEntity* を CreatureEntity* に変更（Phase 8）

### DIFF
--- a/src/melee/melee-postprocess.cpp
+++ b/src/melee/melee-postprocess.cpp
@@ -49,7 +49,7 @@
 struct mam_pp_type {
     mam_pp_type(CreatureEntity &creature, MONSTER_IDX m_idx, int dam, bool *dead, bool *fear, std::string_view note, MONSTER_IDX src_idx);
     MONSTER_IDX m_idx;
-    MonsterEntity *m_ptr;
+    CreatureEntity *m_ptr;
     int dam;
     bool *dead;
     bool *fear;

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -284,7 +284,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
 
     const auto &new_monrace = m_ptr->get_monrace();
     const auto is_summoned = summoner_m_idx.has_value();
-    const MonsterEntity &summoner = floor.m_list[summoner_m_idx.value_or(0)];
+    const CreatureEntity &summoner = floor.m_list[summoner_m_idx.value_or(0)];
 
     auto same_appearance_as_parent = m_ptr->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::CHAMELEON);
     same_appearance_as_parent &= any_bits(mode, PM_MULTIPLY);

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -45,7 +45,7 @@
 
 // Update Monster.
 struct um_type {
-    MonsterEntity *m_ptr;
+    CreatureEntity *m_ptr;
     bool do_disturb;
     POSITION fy;
     POSITION fx;
@@ -80,7 +80,7 @@ bool update_riding_monster(CreatureEntity &creature, turn_flags *turn_flags_ptr,
 
     auto &monster = player.current_floor_ptr->m_list[m_idx];
     auto &grid = player.current_floor_ptr->grid_array[ny][nx];
-    MonsterEntity *y_ptr = &player.current_floor_ptr->m_list[grid.m_idx];
+    CreatureEntity *y_ptr = &player.current_floor_ptr->m_list[grid.m_idx];
     if (turn_flags_ptr->is_riding_mon) {
         return move_player_effect(player, ny, nx, MPE_DONT_PICKUP);
     }

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -168,7 +168,7 @@ void print_monster_list(const FloorType &floor, const std::vector<MONSTER_IDX> &
 {
     TERM_LEN line = y;
     struct info {
-        const MonsterEntity *monster_entity;
+        const CreatureEntity *monster_entity;
         int visible_count; // 現在数
         int awake_count; // 起きている数
     };


### PR DESCRIPTION
- melee-postprocess.cpp: mam_pp_type::m_ptr を CreatureEntity* に変更
- monster-update.cpp: um_type::m_ptr と y_ptr を CreatureEntity* に変更
- one-monster-placer.cpp: const summoner を CreatureEntity& に変更
- display-sub-windows.cpp: info::monster_entity を const CreatureEntity* に変更

いずれも参照するメソッドはすべて CreatureEntity 上で利用可能。