### PR TITLE
refactor: build_looking_description() を CreatureEntity に virtual 昇格し残存 MonsterEntity* を変更（Phase 8）

### DIFF
--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -432,6 +432,11 @@ public:
     {
     }
 
+    virtual std::string build_looking_description([[maybe_unused]] bool needs_attitude) const
+    {
+        return "";
+    }
+
     /*!
      * @brief クリーチャーが睡眠状態かどうかを判定
      * @return 睡眠状態ならtrue

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -49,7 +49,7 @@ public:
     tl::optional<bool> order_pet_dismission(const CreatureEntity &other) const;
     Pos2D get_position() const override;
     bool can_ring_boss_call_nazgul() const;
-    std::string build_looking_description(bool needs_attitude) const;
+    std::string build_looking_description(bool needs_attitude) const override;
     int get_ac() const override;
     void on_take_hit(int damage) override;
     void on_death(std::string_view cause) override;

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -64,7 +64,7 @@ public:
     char query = '\001';
     std::vector<short> floor_item_index;
     Grid *g_ptr;
-    MonsterEntity *m_ptr;
+    CreatureEntity *m_ptr;
     OBJECT_IDX next_o_idx = 0;
     FEAT_IDX feat = 0;
     TerrainType *terrain_ptr = nullptr;

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -127,7 +127,7 @@ void wiz_summon_specific_monster_common(CreatureEntity &creature, MonraceId monr
     }
 
     const auto p_pos = creature.get_position();
-    const auto index_to_monster = [&creature](auto index) -> MonsterEntity & {
+    const auto index_to_monster = [&creature](auto index) -> CreatureEntity & {
         return creature.current_floor_ptr->m_list[index];
     };
     auto monster =


### PR DESCRIPTION
- build_looking_description() を virtual std::string として CreatureEntity に追加（デフォルト空文字）
- MonsterEntity で override 追加
- target-describer.cpp: GridExamination::m_ptr を MonsterEntity* → CreatureEntity* に変更
- wizard-spells.cpp: index_to_monster ラムダの戻り型を MonsterEntity& → CreatureEntity& に変更