### PR TITLE
refactor: MonsterEntity の冗長オーバーライド削除と PartyMonsters クラス追加（Phase 8）

### DIFF
--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
@@ -504,6 +504,7 @@
     <ClCompile Include="..\..\src\floor\floor-leaver.cpp" />
     <ClCompile Include="..\..\src\floor\floor-mode-changer.cpp" />
     <ClCompile Include="..\..\src\floor\floor-save-util.cpp" />
+    <ClCompile Include="..\..\src\floor\party-monsters.cpp" />
     <ClCompile Include="..\..\src\floor\floor-util.cpp" />
     <ClCompile Include="..\..\src\floor\line-of-sight.cpp" />
     <ClCompile Include="..\..\src\floor\object-allocator.cpp" />
@@ -1403,6 +1404,7 @@
     <ClInclude Include="..\..\src\floor\floor-base-definitions.h" />
     <ClInclude Include="..\..\src\floor\floor-generator-util.h" />
     <ClInclude Include="..\..\src\floor\floor-save-util.h" />
+    <ClInclude Include="..\..\src\floor\party-monsters.h" />
     <ClInclude Include="..\..\src\floor\floor-util.h" />
     <ClInclude Include="..\..\src\floor\line-of-sight.h" />
     <ClInclude Include="..\..\src\floor\object-allocator.h" />

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -638,6 +638,7 @@ hengband_SOURCES = \
 	floor/floor-object.cpp floor/floor-object.h \
 	floor/floor-save.cpp floor/floor-save.h \
 	floor/floor-save-util.cpp floor/floor-save-util.h \
+	floor/party-monsters.cpp floor/party-monsters.h \
 	floor/floor-streams.cpp floor/floor-streams.h \
 	floor/floor-util.cpp floor/floor-util.h \
 	floor/geometry.cpp floor/geometry.h \

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -11,6 +11,7 @@
 #include "floor/floor-save-util.h"
 #include "floor/floor-save.h"
 #include "floor/floor-util.h"
+#include "floor/party-monsters.h"
 #include "floor/wild.h"
 #include "game-option/birth-options.h"
 #include "game-option/play-record-options.h"
@@ -105,7 +106,7 @@ static std::pair<short, Pos2D> decide_pet_index(CreatureEntity &creature, const 
         int j;
         for (j = 1000; j > 0; j--) {
             pos = scatter(floor, p_pos, d, PROJECT_NONE);
-            if (monster_can_enter(player_ptr, pos.y, pos.x, party_mon[current_monster].get_monrace(), 0)) {
+            if (monster_can_enter(player_ptr, pos.y, pos.x, party_monsters[current_monster].get_monrace(), 0)) {
                 break;
             }
         }
@@ -126,7 +127,7 @@ static MonraceDefinition &set_pet_params(CreatureEntity &creature, const int cur
 
     player_ptr->current_floor_ptr->grid_array[cy][cx].m_idx = m_idx;
     auto &monster = player_ptr->current_floor_ptr->m_list[m_idx];
-    monster = party_mon[current_monster].clone();
+    monster = party_monsters[current_monster].clone();
     monster.y = cy;
     monster.x = cx;
     monster.current_floor_ptr = player_ptr->current_floor_ptr;
@@ -151,10 +152,10 @@ static void place_pet(CreatureEntity &creature)
     auto &player = static_cast<PlayerType &>(creature);
     auto *player_ptr = &player;
 
-    const auto max_num = AngbandWorld::get_instance().is_wild_mode() ? 1 : MAX_PARTY_MON;
+    const auto max_num = AngbandWorld::get_instance().is_wild_mode() ? 1 : PartyMonsters::MAX_SIZE;
     auto &floor = *player_ptr->current_floor_ptr;
     for (int current_monster = 0; current_monster < max_num; current_monster++) {
-        if (!MonraceList::is_valid(party_mon[current_monster].r_idx)) {
+        if (!MonraceList::is_valid(party_monsters[current_monster].r_idx)) {
             continue;
         }
 
@@ -167,7 +168,7 @@ static void place_pet(CreatureEntity &creature)
                 floor.num_repro++;
             }
         } else {
-            const auto &monster = party_mon[current_monster];
+            const auto &monster = party_monsters[current_monster];
             auto &monrace = monster.get_real_monrace();
             msg_format(_("%sとはぐれてしまった。", "You have lost sight of %s."), monster_desc(*player_ptr, monster, 0).data());
             if (record_named_pet && monster.is_named()) {
@@ -180,9 +181,7 @@ static void place_pet(CreatureEntity &creature)
         }
     }
 
-    for (auto &monster : party_mon) {
-        monster.wipe();
-    }
+    party_monsters.wipe_all();
 }
 
 /*!

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -4,6 +4,7 @@
 #include "floor/floor-save-util.h"
 #include "floor/floor-save.h"
 #include "floor/line-of-sight.h"
+#include "floor/party-monsters.h"
 #include "floor/wild.h"
 #include "game-option/birth-options.h"
 #include "game-option/play-record-options.h"
@@ -56,7 +57,7 @@ static void check_riding_preservation(CreatureEntity &creature)
         player_ptr->pet_extra_flags &= ~(PF_TWO_HANDS);
         player_ptr->riding_ryoute = player_ptr->old_riding_ryoute = false;
     } else {
-        party_mon[0] = monster.clone();
+        party_monsters[0] = monster.clone();
         delete_monster_idx(creature, player_ptr->riding);
     }
 }
@@ -99,13 +100,13 @@ static void sweep_preserving_pet(CreatureEntity &creature)
         return;
     }
 
-    for (MONSTER_IDX i = player_ptr->current_floor_ptr->m_max - 1, party_monster_num = 1; (i >= 1) && (party_monster_num < MAX_PARTY_MON); i--) {
+    for (MONSTER_IDX i = player_ptr->current_floor_ptr->m_max - 1, party_monster_num = 1; (i >= 1) && (party_monster_num < PartyMonsters::MAX_SIZE); i--) {
         const auto &monster = player_ptr->current_floor_ptr->m_list[i];
         if (!monster.is_valid() || !monster.is_pet() || monster.is_riding() || check_pet_preservation_conditions(creature, monster)) {
             continue;
         }
 
-        party_mon[party_monster_num] = player_ptr->current_floor_ptr->m_list[i].clone();
+        party_monsters[party_monster_num] = player_ptr->current_floor_ptr->m_list[i].clone();
         party_monster_num++;
         delete_monster_idx(creature, i);
     }
@@ -140,9 +141,7 @@ static void preserve_pet(CreatureEntity &creature)
     auto &player = static_cast<PlayerType &>(creature);
     auto *player_ptr = &player;
 
-    for (auto &mon : party_mon) {
-        mon.r_idx = MonraceList::empty_id();
-    }
+    party_monsters.invalidate_all();
 
     check_riding_preservation(creature);
     sweep_preserving_pet(creature);

--- a/src/floor/floor-save-util.cpp
+++ b/src/floor/floor-save-util.cpp
@@ -9,8 +9,6 @@ saved_floor_type saved_floors[MAX_SAVED_FLOORS];
 FLOOR_IDX max_floor_id; /*!< Number of floor_id used from birth */
 FLOOR_IDX new_floor_id; /*!<次のフロアのID / floor_id of the destination */
 uint32_t latest_visit_mark; /*!<フロアを渡った回数？(確認中) / Max number of visit_mark */
-MonsterEntity party_mon[MAX_PARTY_MON]; /*!< フロア移動に保存するペットモンスターの配列 */
-
 /*!
  * @brief フロアIDが0でないとき、すなわち保存済フロアの場合真を返す。
  * @param sf_ptr 保存フロアのポインタ

--- a/src/floor/floor-save-util.h
+++ b/src/floor/floor-save-util.h
@@ -1,10 +1,8 @@
 #pragma once
 
 #include "system/angband.h"
-#include "system/monster-entity.h"
 
 #define MAX_SAVED_FLOORS 20 /*!< 保存フロアの最大数 / Maximum number of saved floors. */
-#define MAX_PARTY_MON 21 /*!< フロア移動時に先のフロアに連れて行けるペットの最大数 Maximum number of preservable pets */
 
 struct saved_floor_type {
     FLOOR_IDX floor_id; /* No recycle until 65536 IDs are all used */
@@ -22,5 +20,4 @@ extern FLOOR_IDX max_floor_id;
 
 extern FLOOR_IDX new_floor_id;
 extern uint32_t latest_visit_mark;
-extern MonsterEntity party_mon[MAX_PARTY_MON];
 extern bool is_saved_floor(saved_floor_type *sf_ptr);

--- a/src/floor/floor-save.cpp
+++ b/src/floor/floor-save.cpp
@@ -13,6 +13,7 @@
 #include "core/asking-player.h"
 #include "floor/floor-mode-changer.h"
 #include "floor/floor-save-util.h"
+#include "floor/party-monsters.h"
 #include "io/files-util.h"
 #include "io/uid-checker.h"
 #include "monster/monster-info.h"
@@ -23,7 +24,6 @@
 #include "term/z-form.h"
 #include "util/angband-files.h"
 #include "view/display-messages.h"
-#include "world/world.h"
 #include <ctime>
 
 static std::string get_saved_floor_name(int level)
@@ -213,18 +213,9 @@ FLOOR_IDX get_unused_floor_id(CreatureEntity &creature)
 }
 
 /*!
- * @brief フロアにいるペットの数を数える
- * @todo party_mon をPartyMonsters クラスに組み上げてそのオブジェクトメソッドに繰り込む
+ * @brief フロアにいるペットの種族出現数カウンタを加算する
  */
 void precalc_cur_num_of_pet()
 {
-    const auto max_num = AngbandWorld::get_instance().is_wild_mode() ? 1 : MAX_PARTY_MON;
-    for (auto i = 0; i < max_num; i++) {
-        auto &monster = party_mon[i];
-        if (!monster.is_valid()) {
-            continue;
-        }
-
-        monster.get_real_monrace().increment_current_numbers();
-    }
+    party_monsters.precalc_cur_num_of_pet();
 }

--- a/src/floor/party-monsters.cpp
+++ b/src/floor/party-monsters.cpp
@@ -1,0 +1,45 @@
+#include "floor/party-monsters.h"
+#include "system/monrace/monrace-list.h"
+#include "world/world.h"
+
+PartyMonsters party_monsters;
+
+MonsterEntity &PartyMonsters::operator[](int i)
+{
+    return monsters_[i];
+}
+
+const MonsterEntity &PartyMonsters::operator[](int i) const
+{
+    return monsters_[i];
+}
+
+void PartyMonsters::invalidate_all()
+{
+    for (auto &monster : monsters_) {
+        monster.r_idx = MonraceList::empty_id();
+    }
+}
+
+void PartyMonsters::wipe_all()
+{
+    for (auto &monster : monsters_) {
+        monster.wipe();
+    }
+}
+
+/*!
+ * @brief フロアにいるペットの種族出現数カウンタを加算する
+ */
+void PartyMonsters::precalc_cur_num_of_pet() const
+{
+    const auto max_num = AngbandWorld::get_instance().is_wild_mode() ? 1 : MAX_SIZE;
+    for (auto i = 0; i < max_num; i++) {
+        const auto &monster = monsters_[i];
+        if (!monster.is_valid()) {
+            continue;
+        }
+
+        monster.get_real_monrace().increment_current_numbers();
+    }
+}

--- a/src/floor/party-monsters.cpp
+++ b/src/floor/party-monsters.cpp
@@ -1,4 +1,5 @@
 #include "floor/party-monsters.h"
+#include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
 #include "world/world.h"
 

--- a/src/floor/party-monsters.h
+++ b/src/floor/party-monsters.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "system/monster-entity.h"
+#include <array>
+
+/*!
+ * @brief フロア移動時にペットを保存するコンテナクラス
+ */
+class PartyMonsters {
+public:
+    static constexpr int MAX_SIZE = 21; /*!< フロア移動時に先のフロアに連れて行けるペットの最大数 */
+
+    MonsterEntity &operator[](int i);
+    const MonsterEntity &operator[](int i) const;
+
+    void invalidate_all();
+    void wipe_all();
+    void precalc_cur_num_of_pet() const;
+
+    auto begin()
+    {
+        return monsters_.begin();
+    }
+    auto end()
+    {
+        return monsters_.end();
+    }
+    auto begin() const
+    {
+        return monsters_.begin();
+    }
+    auto end() const
+    {
+        return monsters_.end();
+    }
+
+private:
+    std::array<MonsterEntity, MAX_SIZE> monsters_{};
+};
+
+extern PartyMonsters party_monsters;

--- a/src/load/old/load-v1-5-0.h
+++ b/src/load/old/load-v1-5-0.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "system/angband.h"
-#include "system/monster-entity.h"
 
 // TODO: 更に分割する可能性が中程度あるのでヘッダに置いておく
 enum old_monster_resistance_type {

--- a/src/load/old/load-v1-5-0.h
+++ b/src/load/old/load-v1-5-0.h
@@ -2,6 +2,9 @@
 
 #include "system/angband.h"
 
+class MonraceDefinition;
+enum class MonraceId : int16_t;
+
 // TODO: 更に分割する可能性が中程度あるのでヘッダに置いておく
 enum old_monster_resistance_type {
     RF3_IM_ACID = 0x00010000, /* Resist acid a lot */

--- a/src/mspell/mspell-summon.cpp
+++ b/src/mspell/mspell-summon.cpp
@@ -927,7 +927,7 @@ MonsterSpellResult spell_RF6_S_DRAGON(CreatureEntity &creature, POSITION y, POSI
 MonsterSpellResult spell_RF6_S_HI_UNDEAD(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
     auto &floor = *creature.current_floor_ptr;
-    const auto &monster = floor.get_monster(m_idx);
+    const auto &monster = floor.m_list[m_idx];
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -937,7 +937,7 @@ MonsterSpellResult spell_RF6_S_HI_UNDEAD(CreatureEntity &creature, POSITION y, P
     summon_disturb(creature, target_type, known, see_either);
 
     int count = 0;
-    if (static_cast<const MonsterEntity &>(monster).can_ring_boss_call_nazgul() && mon_to_player) {
+    if (monster.can_ring_boss_call_nazgul() && mon_to_player) {
         count += summon_NAZGUL(creature, y, x, m_idx);
     } else {
         mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -247,6 +247,67 @@ bool CreatureEntity::is_decelerated() const
     return this->get_timed_effect(CreatureTimedEffect::DECELERATION) > 0;
 }
 
+short CreatureEntity::get_timed_effect(CreatureTimedEffect effect) const
+{
+    if (!this->has_monster_profile()) {
+        return 0;
+    }
+
+    const auto &mp = this->get_monster_profile();
+    switch (effect) {
+    case CreatureTimedEffect::STUN:
+        return mp.mtimed.at(MonsterTimedEffect::STUN);
+    case CreatureTimedEffect::CONFUSION:
+        return mp.mtimed.at(MonsterTimedEffect::CONFUSION);
+    case CreatureTimedEffect::FEAR:
+        return mp.mtimed.at(MonsterTimedEffect::FEAR);
+    case CreatureTimedEffect::INVULNERABILITY:
+        return mp.mtimed.at(MonsterTimedEffect::INVULNERABILITY);
+    case CreatureTimedEffect::ACCELERATION:
+        return mp.mtimed.at(MonsterTimedEffect::FAST);
+    case CreatureTimedEffect::DECELERATION:
+        return mp.mtimed.at(MonsterTimedEffect::SLOW);
+    case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
+        return mp.mtimed.at(MonsterTimedEffect::SLEEP);
+    default:
+        return 0;
+    }
+}
+
+void CreatureEntity::set_timed_effect(CreatureTimedEffect effect, short value)
+{
+    if (!this->has_monster_profile()) {
+        return;
+    }
+
+    auto &mp = this->get_monster_profile();
+    switch (effect) {
+    case CreatureTimedEffect::STUN:
+        mp.mtimed[MonsterTimedEffect::STUN] = value;
+        break;
+    case CreatureTimedEffect::CONFUSION:
+        mp.mtimed[MonsterTimedEffect::CONFUSION] = value;
+        break;
+    case CreatureTimedEffect::FEAR:
+        mp.mtimed[MonsterTimedEffect::FEAR] = value;
+        break;
+    case CreatureTimedEffect::INVULNERABILITY:
+        mp.mtimed[MonsterTimedEffect::INVULNERABILITY] = value;
+        break;
+    case CreatureTimedEffect::ACCELERATION:
+        mp.mtimed[MonsterTimedEffect::FAST] = value;
+        break;
+    case CreatureTimedEffect::DECELERATION:
+        mp.mtimed[MonsterTimedEffect::SLOW] = value;
+        break;
+    case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
+        mp.mtimed[MonsterTimedEffect::SLEEP] = value;
+        break;
+    default:
+        break;
+    }
+}
+
 /*!
  * @brief ツリー構造インシデント数加算
  * @param incident_id 階層構造のインシデントID（例: "root/attack/critical"）

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -14,6 +14,7 @@
 #include "term/z-form.h"
 #include "term/z-rand.h"
 #include "timed-effect/timed-effects.h"
+#include "tracking/lore-tracker.h"
 #include "util/bit-flags-calculator.h"
 #include <range/v3/algorithm.hpp>
 
@@ -305,6 +306,19 @@ void CreatureEntity::set_timed_effect(CreatureTimedEffect effect, short value)
         break;
     default:
         break;
+    }
+}
+
+void CreatureEntity::make_lore_treasure(int num_item, int num_gold) const
+{
+    auto &monrace = this->get_monrace();
+    if (!this->is_original_ap()) {
+        return;
+    }
+
+    monrace.make_lore_treasure(num_item, num_gold);
+    if (LoreTracker::get_instance().is_tracking(this->r_idx)) {
+        RedrawingFlagsUpdater::get_instance().set_flag(SubWindowRedrawingFlag::MONSTER_LORE);
     }
 }
 

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -448,9 +448,13 @@ public:
         this->ap_r_idx = real_id;
     }
 
-    virtual void make_lore_treasure([[maybe_unused]] int num_item, [[maybe_unused]] int num_gold) const
-    {
-    }
+    /*!
+     * @brief ルアー記録に宝物情報を追加する
+     * @param num_item アイテム数
+     * @param num_gold 金貨数
+     * @details is_original_ap() でない場合は何もしない。
+     */
+    virtual void make_lore_treasure(int num_item, int num_gold) const;
 
     virtual std::string build_looking_description([[maybe_unused]] bool needs_attitude) const
     {

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -356,8 +356,12 @@ public:
     /*!
      * @brief クリーチャーがプレイヤーかどうかを判定
      * @return プレイヤーならtrue、モンスターならfalse
+     * @details デフォルトはfalse（モンスター）。PlayerTypeのみtrueを返す。
      */
-    virtual bool is_player() const = 0;
+    virtual bool is_player() const
+    {
+        return false;
+    }
 
     /*!
      * @brief クリーチャーの実効ACを取得
@@ -434,10 +438,14 @@ public:
     tl::optional<std::string> get_pain_message(std::string_view monster_name, int damage) const;
 
     /*!
-     * @brief カメレオンの変身を元に戻す。モンスター以外は何もしない。
+     * @brief カメレオンの変身を元に戻す。
+     * @details r_idx と ap_r_idx を実種族IDにリセットする。
      */
     virtual void reset_chameleon_polymorph()
     {
+        const auto real_id = this->get_real_monrace_id();
+        this->r_idx = real_id;
+        this->ap_r_idx = real_id;
     }
 
     virtual void make_lore_treasure([[maybe_unused]] int num_item, [[maybe_unused]] int num_gold) const
@@ -583,8 +591,15 @@ public:
     {
     }
 
+    /*!
+     * @brief クリーチャーをフレンドリー状態に設定する
+     * @details モンスターの場合は FRIENDLY フラグをセットする。
+     */
     virtual void set_friendly()
     {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().mflag2.set(MonsterConstantFlagType::FRIENDLY);
+        }
     }
 
     virtual void set_individual_speed([[maybe_unused]] bool force_fixed_speed)

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -192,13 +192,19 @@ public:
      * @brief クリーチャーの現在HPを取得
      * @return 現在HP
      */
-    virtual int get_current_hp() const = 0;
+    virtual int get_current_hp() const
+    {
+        return this->hp;
+    }
 
     /*!
      * @brief クリーチャーの最大HPを取得
      * @return 最大HP
      */
-    virtual int get_max_hp() const = 0;
+    virtual int get_max_hp() const
+    {
+        return this->maxhp;
+    }
 
     /*!
      * @brief クリーチャーの速度を取得

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -372,8 +372,15 @@ public:
     /*!
      * @brief ダメージを受けた際のフック（dealt_damage等の蓄積処理）
      * @param damage 受けたダメージ量
+     * @details dealt_damage を加算し max_maxhp * 100 を上限とする。
      */
-    virtual void on_take_hit([[maybe_unused]] int damage) {}
+    virtual void on_take_hit(int damage)
+    {
+        this->dealt_damage += damage;
+        if (this->dealt_damage > this->max_maxhp * 100) {
+            this->dealt_damage = this->max_maxhp * 100;
+        }
+    }
 
     /*!
      * @brief 死亡した際のフック（死亡処理・記録等）

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -381,16 +381,20 @@ public:
      * @brief クリーチャーの時限効果の残りターン数を取得
      * @param effect 取得する時限効果の種別
      * @return 残りターン数（0なら効果なし）
+     * @details デフォルト実装は MonsterProfile::mtimed を参照する（モンスター用）。
+     *          PlayerType はオーバーライドして TimedEffects を使う。
      */
-    virtual short get_timed_effect(CreatureTimedEffect effect) const = 0;
+    virtual short get_timed_effect(CreatureTimedEffect effect) const;
 
     /*!
      * @brief クリーチャーの時限効果の残りターン数を直接設定する（セーブ/ロード・内部操作用）
      * @param effect 設定する時限効果の種別
      * @param value 設定するターン数
      * @note メッセージや副作用は発生しない。ゲームロジックからの呼び出しには専用セッターを使うこと。
+     * @details デフォルト実装は MonsterProfile::mtimed を更新する（モンスター用）。
+     *          PlayerType はオーバーライドして TimedEffects を使う。
      */
-    virtual void set_timed_effect(CreatureTimedEffect effect, short value) = 0;
+    virtual void set_timed_effect(CreatureTimedEffect effect, short value);
 
     short get_remaining_sleep() const
     {

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -126,31 +126,6 @@ bool MonsterEntity::is_dead() const
     return this->hp < 0;
 }
 
-bool MonsterEntity::is_decelerated() const
-{
-    return this->get_remaining_deceleration() > 0;
-}
-
-bool MonsterEntity::is_stunned() const
-{
-    return this->get_remaining_stun() > 0;
-}
-
-bool MonsterEntity::is_confused() const
-{
-    return this->get_remaining_confusion() > 0;
-}
-
-bool MonsterEntity::is_fearful() const
-{
-    return this->get_remaining_fear() > 0;
-}
-
-bool MonsterEntity::is_invulnerable() const
-{
-    return this->get_remaining_invulnerability() > 0;
-}
-
 short MonsterEntity::get_timed_effect(CreatureTimedEffect effect) const
 {
     switch (effect) {
@@ -200,15 +175,6 @@ void MonsterEntity::set_timed_effect(CreatureTimedEffect effect, short value)
     default:
         break;
     }
-}
-
-/*!
- * @brief モンスターの基本速度を取得
- * @return 基本速度値
- */
-int MonsterEntity::get_speed() const
-{
-    return this->speed;
 }
 
 /*!
@@ -533,11 +499,6 @@ void MonsterEntity::initialize_equivalent_player_classes()
     }
 }
 
-Pos2D MonsterEntity::get_position() const
-{
-    return { this->y, this->x };
-}
-
 bool MonsterEntity::can_ring_boss_call_nazgul() const
 {
     auto is_boss = this->r_idx == MonraceId::MORGOTH;
@@ -617,16 +578,6 @@ int MonsterEntity::get_ac() const
 }
 
 // CreatureEntityインターフェースの実装
-POSITION MonsterEntity::get_x() const
-{
-    return this->x;
-}
-
-POSITION MonsterEntity::get_y() const
-{
-    return this->y;
-}
-
 int MonsterEntity::get_current_hp() const
 {
     return this->hp;

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -126,57 +126,6 @@ bool MonsterEntity::is_dead() const
     return this->hp < 0;
 }
 
-short MonsterEntity::get_timed_effect(CreatureTimedEffect effect) const
-{
-    switch (effect) {
-    case CreatureTimedEffect::STUN:
-        return this->get_monster_profile().mtimed.at(MonsterTimedEffect::STUN);
-    case CreatureTimedEffect::CONFUSION:
-        return this->get_monster_profile().mtimed.at(MonsterTimedEffect::CONFUSION);
-    case CreatureTimedEffect::FEAR:
-        return this->get_monster_profile().mtimed.at(MonsterTimedEffect::FEAR);
-    case CreatureTimedEffect::INVULNERABILITY:
-        return this->get_monster_profile().mtimed.at(MonsterTimedEffect::INVULNERABILITY);
-    case CreatureTimedEffect::ACCELERATION:
-        return this->get_monster_profile().mtimed.at(MonsterTimedEffect::FAST);
-    case CreatureTimedEffect::DECELERATION:
-        return this->get_monster_profile().mtimed.at(MonsterTimedEffect::SLOW);
-    case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
-        return this->get_monster_profile().mtimed.at(MonsterTimedEffect::SLEEP);
-    default:
-        return 0;
-    }
-}
-
-void MonsterEntity::set_timed_effect(CreatureTimedEffect effect, short value)
-{
-    switch (effect) {
-    case CreatureTimedEffect::STUN:
-        this->get_monster_profile().mtimed[MonsterTimedEffect::STUN] = value;
-        break;
-    case CreatureTimedEffect::CONFUSION:
-        this->get_monster_profile().mtimed[MonsterTimedEffect::CONFUSION] = value;
-        break;
-    case CreatureTimedEffect::FEAR:
-        this->get_monster_profile().mtimed[MonsterTimedEffect::FEAR] = value;
-        break;
-    case CreatureTimedEffect::INVULNERABILITY:
-        this->get_monster_profile().mtimed[MonsterTimedEffect::INVULNERABILITY] = value;
-        break;
-    case CreatureTimedEffect::ACCELERATION:
-        this->get_monster_profile().mtimed[MonsterTimedEffect::FAST] = value;
-        break;
-    case CreatureTimedEffect::DECELERATION:
-        this->get_monster_profile().mtimed[MonsterTimedEffect::SLOW] = value;
-        break;
-    case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
-        this->get_monster_profile().mtimed[MonsterTimedEffect::SLEEP] = value;
-        break;
-    default:
-        break;
-    }
-}
-
 /*!
  * @brief モンスターが生命体かどうかを返す
  * @param is_apperance たぬき、カメレオン、各種誤認ならtrue
@@ -598,4 +547,3 @@ void MonsterEntity::on_take_hit(int damage)
         this->dealt_damage = this->max_maxhp * 100;
     }
 }
-

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -577,17 +577,6 @@ int MonsterEntity::get_ac() const
     return this->ac;
 }
 
-// CreatureEntityインターフェースの実装
-int MonsterEntity::get_current_hp() const
-{
-    return this->hp;
-}
-
-int MonsterEntity::get_max_hp() const
-{
-    return this->maxhp;
-}
-
 int MonsterEntity::get_level() const
 {
     // 個体レベルが設定されていればそれを使用、未設定なら種族レベルを使用

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -503,11 +503,3 @@ int MonsterEntity::get_level() const
     }
     return this->get_monrace().level / 2;
 }
-
-void MonsterEntity::on_take_hit(int damage)
-{
-    this->dealt_damage += damage;
-    if (this->dealt_damage > this->max_maxhp * 100) {
-        this->dealt_damage = this->max_maxhp * 100;
-    }
-}

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -599,7 +599,3 @@ void MonsterEntity::on_take_hit(int damage)
     }
 }
 
-void MonsterEntity::on_death([[maybe_unused]] std::string_view cause)
-{
-    // モンスター死亡時の経験値・徳処理は MonsterDamageProcessor::process_dead_exp_virtue() で行う
-}

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -222,19 +222,6 @@ std::string MonsterEntity::get_pronoun_of_summoned_kin() const
     return this->get_monrace().get_pronoun_of_summoned_kin();
 }
 
-void MonsterEntity::make_lore_treasure(int num_item, int num_gold) const
-{
-    auto &monrace = this->get_monrace();
-    if (!this->is_original_ap()) {
-        return;
-    }
-
-    monrace.make_lore_treasure(num_item, num_gold);
-    if (LoreTracker::get_instance().is_tracking(this->r_idx)) {
-        RedrawingFlagsUpdater::get_instance().set_flag(SubWindowRedrawingFlag::MONSTER_LORE);
-    }
-}
-
 tl::optional<bool> MonsterEntity::order_pet_named(const CreatureEntity &other) const
 {
     if (this->is_named() && !other.is_named()) {

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -217,16 +217,6 @@ void MonsterEntity::set_hostile()
     }
 }
 
-/*
- * 捕獲・死亡の際にカメレオンの変身を元に戻す
- */
-void MonsterEntity::reset_chameleon_polymorph()
-{
-    auto real_monrace_id = this->get_real_monrace_id();
-    this->r_idx = real_monrace_id;
-    this->ap_r_idx = real_monrace_id;
-}
-
 std::string MonsterEntity::get_pronoun_of_summoned_kin() const
 {
     return this->get_monrace().get_pronoun_of_summoned_kin();
@@ -269,14 +259,6 @@ tl::optional<bool> MonsterEntity::order_pet_hp(const CreatureEntity &other) cons
     }
 
     return tl::nullopt;
-}
-
-/*!
- * @brief モンスターを友好的にする
- */
-void MonsterEntity::set_friendly()
-{
-    this->get_monster_profile().mflag2.set(MonsterConstantFlagType::FRIENDLY);
 }
 
 /*!
@@ -533,11 +515,6 @@ int MonsterEntity::get_level() const
         return this->level;
     }
     return this->get_monrace().level / 2;
-}
-
-bool MonsterEntity::is_player() const
-{
-    return false;
 }
 
 void MonsterEntity::on_take_hit(int damage)

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -12,10 +12,6 @@
  * The "hold_o_idx" field points to the first object of a stack
  * of objects (if any) being carried by the monster (see above).
  */
-enum class MonraceId : int16_t;
-enum class PlayerRaceType;
-enum class PlayerClassType : short;
-class FloorType;
 class MonsterEntityWriter;
 class MonsterEntity : public CreatureEntity {
 public:

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -50,10 +50,6 @@ public:
     void initialize_equivalent_player_races() override;
     void initialize_equivalent_player_classes() override;
 
-    // CreatureEntityインターフェースの実装
-    int get_current_hp() const override;
-    int get_max_hp() const override;
-
     bool is_valid() const override;
     bool is_dead() const override;
 

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -2,7 +2,6 @@
 
 #include "system/creature-entity.h"
 #include "system/monster-profile.h"
-#include "util/point-2d.h"
 #include <string>
 #include <string_view>
 
@@ -32,18 +31,11 @@ public:
     bool is_hostile_to_melee(const CreatureEntity &other) const override;
     bool is_hostile_align(const byte other_sub_align) const;
     bool is_mimicry() const;
-    bool is_decelerated() const override;
-    bool is_stunned() const override;
-    bool is_confused() const override;
-    bool is_fearful() const override;
-    bool is_invulnerable() const override;
     short get_timed_effect(CreatureTimedEffect effect) const override;
     void set_timed_effect(CreatureTimedEffect effect, short value) override;
-    int get_speed() const override;
     std::string get_pronoun_of_summoned_kin() const;
     tl::optional<bool> order_pet_whistle(const CreatureEntity &other) const;
     tl::optional<bool> order_pet_dismission(const CreatureEntity &other) const;
-    Pos2D get_position() const override;
     bool can_ring_boss_call_nazgul() const;
     std::string build_looking_description(bool needs_attitude) const override;
     int get_ac() const override;
@@ -59,8 +51,6 @@ public:
     void initialize_equivalent_player_classes() override;
 
     // CreatureEntityインターフェースの実装
-    POSITION get_x() const override;
-    POSITION get_y() const override;
     int get_current_hp() const override;
     int get_max_hp() const override;
 

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -38,8 +38,6 @@ public:
     void set_individual_speed(bool force_fixed_speed) override;
     void set_hostile() override;
     void make_lore_treasure(int num_item, int num_gold) const override;
-    void reset_chameleon_polymorph() override;
-    void set_friendly() override;
     void initialize_equivalent_player_races() override;
     void initialize_equivalent_player_classes() override;
 
@@ -47,7 +45,6 @@ public:
     bool is_dead() const override;
 
     int get_level() const override;
-    bool is_player() const override;
 
 private:
     tl::optional<bool> order_pet_named(const CreatureEntity &other) const;

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -37,7 +37,6 @@ public:
 
     void set_individual_speed(bool force_fixed_speed) override;
     void set_hostile() override;
-    void make_lore_treasure(int num_item, int num_gold) const override;
     void initialize_equivalent_player_races() override;
     void initialize_equivalent_player_classes() override;
 

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -40,7 +40,6 @@ public:
     std::string build_looking_description(bool needs_attitude) const override;
     int get_ac() const override;
     void on_take_hit(int damage) override;
-    void on_death(std::string_view cause) override;
 
     void set_individual_speed(bool force_fixed_speed) override;
     void set_hostile() override;

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -33,7 +33,6 @@ public:
     bool can_ring_boss_call_nazgul() const;
     std::string build_looking_description(bool needs_attitude) const override;
     int get_ac() const override;
-    void on_take_hit(int damage) override;
 
     void set_individual_speed(bool force_fixed_speed) override;
     void set_hostile() override;

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -27,8 +27,6 @@ public:
     bool is_hostile_to_melee(const CreatureEntity &other) const override;
     bool is_hostile_align(const byte other_sub_align) const;
     bool is_mimicry() const;
-    short get_timed_effect(CreatureTimedEffect effect) const override;
-    void set_timed_effect(CreatureTimedEffect effect, short value) override;
     std::string get_pronoun_of_summoned_kin() const;
     tl::optional<bool> order_pet_whistle(const CreatureEntity &other) const;
     tl::optional<bool> order_pet_dismission(const CreatureEntity &other) const;

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -139,17 +139,6 @@ bool PlayerType::try_resist_eldritch_horror() const
     return evaluate_percent(this->skill_sav) || one_in_(2);
 }
 
-// CreatureEntityインターフェースの実装
-int PlayerType::get_current_hp() const
-{
-    return this->hp;
-}
-
-int PlayerType::get_max_hp() const
-{
-    return this->maxhp;
-}
-
 bool PlayerType::is_valid() const
 {
     return true; // プレイヤーは常に有効

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -55,10 +55,6 @@ public:
     bool in_saved_floor() const;
     bool try_resist_eldritch_horror() const;
 
-    // CreatureEntityインターフェースの実装
-    int get_current_hp() const override;
-    int get_max_hp() const override;
-
     bool is_valid() const override;
     bool is_dead() const override;
 

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -180,13 +180,13 @@ void target_sensing_monsters_prepare(CreatureEntity &creature, std::vector<MONST
     }
 
     for (MONSTER_IDX i = 1; i < creature.current_floor_ptr->m_max; i++) {
-        const auto &monster = creature.current_floor_ptr->get_monster(i);
+        const auto &monster = creature.current_floor_ptr->m_list[i];
         if (!monster.is_valid() || !monster.get_monster_profile().ml || monster.is_pet()) {
             continue;
         }
 
         // 感知魔法/スキルやESPで感知していない擬態モンスターはモンスター一覧に表示しない
-        if (static_cast<const MonsterEntity &>(monster).is_mimicry() && monster.get_monster_profile().mflag2.has_none_of({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW }) && monster.get_monster_profile().mflag.has_not(MonsterTemporaryFlagType::ESP)) {
+        if (monster.is_mimicry() && monster.get_monster_profile().mflag2.has_none_of({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW }) && monster.get_monster_profile().mflag.has_not(MonsterTemporaryFlagType::ESP)) {
             continue;
         }
 


### PR DESCRIPTION
## Summary

Phase 8 リファクタリング: `MonsterEntity` のオーバーライドを削減し `CreatureEntity` 基底クラスに昇格。

### 変更内容

**MonsterEntity 依存の削減**
- `static_cast<MonsterEntity>` を `m_list` 直接アクセスに置換（`mspell-summon.cpp`, `target-preparation.cpp`）
- `load-v1-5-0.h` から不要な `monster-entity.h` インクルードを削除
- `monster-entity.h` から `creature-entity.h` で既に宣言済みの前方宣言を削除

**PartyMonsters クラス追加**
- `party_mon[MAX_PARTY_MON]` グローバル配列を `PartyMonsters` クラスに集約
- `floor-save-util.h` から `monster-entity.h` 依存を除去

**`CreatureEntity` に昇格したメソッド（MonsterEntity から削除）**
- `is_decelerated/is_stunned/is_confused/is_fearful/is_invulnerable`（9メソッド削除）
- `get_speed/get_x/get_y/get_position`
- `get_current_hp/get_max_hp`（純粋仮想 → 非純粋仮想）
- `get_timed_effect/set_timed_effect`（`MonsterProfile::mtimed` 経由のデフォルト実装を `CreatureEntity` に追加）
- `is_player()`（デフォルト `return false`）
- `reset_chameleon_polymorph()`（`r_idx`/`ap_r_idx` リセット）
- `set_friendly()`（`monster_profile.mflag2.set(FRIENDLY)`）
- `make_lore_treasure()`（`get_monrace()` は `CreatureEntity` メンバー）
- `on_take_hit()`（`dealt_damage`/`max_maxhp` は `CreatureEntity` フィールド）
- `on_death()`（空実装削除）

## Test plan

- [x] `sh .github/scripts/ci-build-test.sh` でビルド成功確認
- [x] clang-format-15 で整形確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)