### PR TITLE
refactor: static_cast<MonsterEntity> を m_list 直接アクセスに置換し不要インクルード削除（Phase 8）

### DIFF
--- a/src/load/old/load-v1-5-0.h
+++ b/src/load/old/load-v1-5-0.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "system/angband.h"
-#include "system/monster-entity.h"
+#include "system/enums/monrace/monrace-id.h"
+
+class MonraceDefinition;
 
 // TODO: 更に分割する可能性が中程度あるのでヘッダに置いておく
 enum old_monster_resistance_type {

--- a/src/mspell/mspell-summon.cpp
+++ b/src/mspell/mspell-summon.cpp
@@ -927,7 +927,7 @@ MonsterSpellResult spell_RF6_S_DRAGON(CreatureEntity &creature, POSITION y, POSI
 MonsterSpellResult spell_RF6_S_HI_UNDEAD(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
     auto &floor = *creature.current_floor_ptr;
-    const auto &monster = floor.get_monster(m_idx);
+    const auto &monster = floor.m_list[m_idx];
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -937,7 +937,7 @@ MonsterSpellResult spell_RF6_S_HI_UNDEAD(CreatureEntity &creature, POSITION y, P
     summon_disturb(creature, target_type, known, see_either);
 
     int count = 0;
-    if (static_cast<const MonsterEntity &>(monster).can_ring_boss_call_nazgul() && mon_to_player) {
+    if (monster.can_ring_boss_call_nazgul() && mon_to_player) {
         count += summon_NAZGUL(creature, y, x, m_idx);
     } else {
         mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -180,13 +180,13 @@ void target_sensing_monsters_prepare(CreatureEntity &creature, std::vector<MONST
     }
 
     for (MONSTER_IDX i = 1; i < creature.current_floor_ptr->m_max; i++) {
-        const auto &monster = creature.current_floor_ptr->get_monster(i);
+        const auto &monster = creature.current_floor_ptr->m_list[i];
         if (!monster.is_valid() || !monster.get_monster_profile().ml || monster.is_pet()) {
             continue;
         }
 
         // 感知魔法/スキルやESPで感知していない擬態モンスターはモンスター一覧に表示しない
-        if (static_cast<const MonsterEntity &>(monster).is_mimicry() && monster.get_monster_profile().mflag2.has_none_of({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW }) && monster.get_monster_profile().mflag.has_not(MonsterTemporaryFlagType::ESP)) {
+        if (monster.is_mimicry() && monster.get_monster_profile().mflag2.has_none_of({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW }) && monster.get_monster_profile().mflag.has_not(MonsterTemporaryFlagType::ESP)) {
             continue;
         }
 


### PR DESCRIPTION
- mspell-summon.cpp: spell_RF6_S_HI_UNDEAD の get_monster() → m_list[] に変更し cast 解消
- target-preparation.cpp: monster 一覧構築ループの get_monster() → m_list[] に変更し cast 解消
- load/old/load-v1-5-0.h: 未使用の #include "system/monster-entity.h" を削除