### PR TITLE
refactor: party_mon グローバル配列を PartyMonsters クラスに集約（Phase 8）

### DIFF
--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
@@ -504,6 +504,7 @@
     <ClCompile Include="..\..\src\floor\floor-leaver.cpp" />
     <ClCompile Include="..\..\src\floor\floor-mode-changer.cpp" />
     <ClCompile Include="..\..\src\floor\floor-save-util.cpp" />
+    <ClCompile Include="..\..\src\floor\party-monsters.cpp" />
     <ClCompile Include="..\..\src\floor\floor-util.cpp" />
     <ClCompile Include="..\..\src\floor\line-of-sight.cpp" />
     <ClCompile Include="..\..\src\floor\object-allocator.cpp" />
@@ -1403,6 +1404,7 @@
     <ClInclude Include="..\..\src\floor\floor-base-definitions.h" />
     <ClInclude Include="..\..\src\floor\floor-generator-util.h" />
     <ClInclude Include="..\..\src\floor\floor-save-util.h" />
+    <ClInclude Include="..\..\src\floor\party-monsters.h" />
     <ClInclude Include="..\..\src\floor\floor-util.h" />
     <ClInclude Include="..\..\src\floor\line-of-sight.h" />
     <ClInclude Include="..\..\src\floor\object-allocator.h" />

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -638,6 +638,7 @@ hengband_SOURCES = \
 	floor/floor-object.cpp floor/floor-object.h \
 	floor/floor-save.cpp floor/floor-save.h \
 	floor/floor-save-util.cpp floor/floor-save-util.h \
+	floor/party-monsters.cpp floor/party-monsters.h \
 	floor/floor-streams.cpp floor/floor-streams.h \
 	floor/floor-util.cpp floor/floor-util.h \
 	floor/geometry.cpp floor/geometry.h \

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -11,6 +11,7 @@
 #include "floor/floor-save-util.h"
 #include "floor/floor-save.h"
 #include "floor/floor-util.h"
+#include "floor/party-monsters.h"
 #include "floor/wild.h"
 #include "game-option/birth-options.h"
 #include "game-option/play-record-options.h"
@@ -105,7 +106,7 @@ static std::pair<short, Pos2D> decide_pet_index(CreatureEntity &creature, const 
         int j;
         for (j = 1000; j > 0; j--) {
             pos = scatter(floor, p_pos, d, PROJECT_NONE);
-            if (monster_can_enter(player_ptr, pos.y, pos.x, party_mon[current_monster].get_monrace(), 0)) {
+            if (monster_can_enter(player_ptr, pos.y, pos.x, party_monsters[current_monster].get_monrace(), 0)) {
                 break;
             }
         }
@@ -126,7 +127,7 @@ static MonraceDefinition &set_pet_params(CreatureEntity &creature, const int cur
 
     player_ptr->current_floor_ptr->grid_array[cy][cx].m_idx = m_idx;
     auto &monster = player_ptr->current_floor_ptr->m_list[m_idx];
-    monster = party_mon[current_monster].clone();
+    monster = party_monsters[current_monster].clone();
     monster.y = cy;
     monster.x = cx;
     monster.current_floor_ptr = player_ptr->current_floor_ptr;
@@ -151,10 +152,10 @@ static void place_pet(CreatureEntity &creature)
     auto &player = static_cast<PlayerType &>(creature);
     auto *player_ptr = &player;
 
-    const auto max_num = AngbandWorld::get_instance().is_wild_mode() ? 1 : MAX_PARTY_MON;
+    const auto max_num = AngbandWorld::get_instance().is_wild_mode() ? 1 : PartyMonsters::MAX_SIZE;
     auto &floor = *player_ptr->current_floor_ptr;
     for (int current_monster = 0; current_monster < max_num; current_monster++) {
-        if (!MonraceList::is_valid(party_mon[current_monster].r_idx)) {
+        if (!MonraceList::is_valid(party_monsters[current_monster].r_idx)) {
             continue;
         }
 
@@ -167,7 +168,7 @@ static void place_pet(CreatureEntity &creature)
                 floor.num_repro++;
             }
         } else {
-            const auto &monster = party_mon[current_monster];
+            const auto &monster = party_monsters[current_monster];
             auto &monrace = monster.get_real_monrace();
             msg_format(_("%sとはぐれてしまった。", "You have lost sight of %s."), monster_desc(*player_ptr, monster, 0).data());
             if (record_named_pet && monster.is_named()) {
@@ -180,9 +181,7 @@ static void place_pet(CreatureEntity &creature)
         }
     }
 
-    for (auto &monster : party_mon) {
-        monster.wipe();
-    }
+    party_monsters.wipe_all();
 }
 
 /*!

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -4,6 +4,7 @@
 #include "floor/floor-save-util.h"
 #include "floor/floor-save.h"
 #include "floor/line-of-sight.h"
+#include "floor/party-monsters.h"
 #include "floor/wild.h"
 #include "game-option/birth-options.h"
 #include "game-option/play-record-options.h"
@@ -56,7 +57,7 @@ static void check_riding_preservation(CreatureEntity &creature)
         player_ptr->pet_extra_flags &= ~(PF_TWO_HANDS);
         player_ptr->riding_ryoute = player_ptr->old_riding_ryoute = false;
     } else {
-        party_mon[0] = monster.clone();
+        party_monsters[0] = monster.clone();
         delete_monster_idx(creature, player_ptr->riding);
     }
 }
@@ -99,13 +100,13 @@ static void sweep_preserving_pet(CreatureEntity &creature)
         return;
     }
 
-    for (MONSTER_IDX i = player_ptr->current_floor_ptr->m_max - 1, party_monster_num = 1; (i >= 1) && (party_monster_num < MAX_PARTY_MON); i--) {
+    for (MONSTER_IDX i = player_ptr->current_floor_ptr->m_max - 1, party_monster_num = 1; (i >= 1) && (party_monster_num < PartyMonsters::MAX_SIZE); i--) {
         const auto &monster = player_ptr->current_floor_ptr->m_list[i];
         if (!monster.is_valid() || !monster.is_pet() || monster.is_riding() || check_pet_preservation_conditions(creature, monster)) {
             continue;
         }
 
-        party_mon[party_monster_num] = player_ptr->current_floor_ptr->m_list[i].clone();
+        party_monsters[party_monster_num] = player_ptr->current_floor_ptr->m_list[i].clone();
         party_monster_num++;
         delete_monster_idx(creature, i);
     }
@@ -140,9 +141,7 @@ static void preserve_pet(CreatureEntity &creature)
     auto &player = static_cast<PlayerType &>(creature);
     auto *player_ptr = &player;
 
-    for (auto &mon : party_mon) {
-        mon.r_idx = MonraceList::empty_id();
-    }
+    party_monsters.invalidate_all();
 
     check_riding_preservation(creature);
     sweep_preserving_pet(creature);

--- a/src/floor/floor-save-util.cpp
+++ b/src/floor/floor-save-util.cpp
@@ -9,8 +9,6 @@ saved_floor_type saved_floors[MAX_SAVED_FLOORS];
 FLOOR_IDX max_floor_id; /*!< Number of floor_id used from birth */
 FLOOR_IDX new_floor_id; /*!<次のフロアのID / floor_id of the destination */
 uint32_t latest_visit_mark; /*!<フロアを渡った回数？(確認中) / Max number of visit_mark */
-MonsterEntity party_mon[MAX_PARTY_MON]; /*!< フロア移動に保存するペットモンスターの配列 */
-
 /*!
  * @brief フロアIDが0でないとき、すなわち保存済フロアの場合真を返す。
  * @param sf_ptr 保存フロアのポインタ

--- a/src/floor/floor-save-util.h
+++ b/src/floor/floor-save-util.h
@@ -1,10 +1,8 @@
 #pragma once
 
 #include "system/angband.h"
-#include "system/monster-entity.h"
 
 #define MAX_SAVED_FLOORS 20 /*!< 保存フロアの最大数 / Maximum number of saved floors. */
-#define MAX_PARTY_MON 21 /*!< フロア移動時に先のフロアに連れて行けるペットの最大数 Maximum number of preservable pets */
 
 struct saved_floor_type {
     FLOOR_IDX floor_id; /* No recycle until 65536 IDs are all used */
@@ -22,5 +20,4 @@ extern FLOOR_IDX max_floor_id;
 
 extern FLOOR_IDX new_floor_id;
 extern uint32_t latest_visit_mark;
-extern MonsterEntity party_mon[MAX_PARTY_MON];
 extern bool is_saved_floor(saved_floor_type *sf_ptr);

--- a/src/floor/floor-save.cpp
+++ b/src/floor/floor-save.cpp
@@ -13,6 +13,7 @@
 #include "core/asking-player.h"
 #include "floor/floor-mode-changer.h"
 #include "floor/floor-save-util.h"
+#include "floor/party-monsters.h"
 #include "io/files-util.h"
 #include "io/uid-checker.h"
 #include "monster/monster-info.h"
@@ -23,7 +24,6 @@
 #include "term/z-form.h"
 #include "util/angband-files.h"
 #include "view/display-messages.h"
-#include "world/world.h"
 #include <ctime>
 
 static std::string get_saved_floor_name(int level)
@@ -213,18 +213,9 @@ FLOOR_IDX get_unused_floor_id(CreatureEntity &creature)
 }
 
 /*!
- * @brief フロアにいるペットの数を数える
- * @todo party_mon をPartyMonsters クラスに組み上げてそのオブジェクトメソッドに繰り込む
+ * @brief フロアにいるペットの種族出現数カウンタを加算する
  */
 void precalc_cur_num_of_pet()
 {
-    const auto max_num = AngbandWorld::get_instance().is_wild_mode() ? 1 : MAX_PARTY_MON;
-    for (auto i = 0; i < max_num; i++) {
-        auto &monster = party_mon[i];
-        if (!monster.is_valid()) {
-            continue;
-        }
-
-        monster.get_real_monrace().increment_current_numbers();
-    }
+    party_monsters.precalc_cur_num_of_pet();
 }

--- a/src/floor/party-monsters.cpp
+++ b/src/floor/party-monsters.cpp
@@ -1,0 +1,47 @@
+#include "floor/party-monsters.h"
+#include "system/monrace/monrace-definition.h"
+#include "system/monrace/monrace-list.h"
+#include "system/monster-entity.h"
+#include "world/world.h"
+
+PartyMonsters party_monsters;
+
+MonsterEntity &PartyMonsters::operator[](int i)
+{
+    return monsters_[i];
+}
+
+const MonsterEntity &PartyMonsters::operator[](int i) const
+{
+    return monsters_[i];
+}
+
+void PartyMonsters::invalidate_all()
+{
+    for (auto &monster : monsters_) {
+        monster.r_idx = MonraceList::empty_id();
+    }
+}
+
+void PartyMonsters::wipe_all()
+{
+    for (auto &monster : monsters_) {
+        monster.wipe();
+    }
+}
+
+/*!
+ * @brief フロアにいるペットの種族出現数カウンタを加算する
+ */
+void PartyMonsters::precalc_cur_num_of_pet() const
+{
+    const auto max_num = AngbandWorld::get_instance().is_wild_mode() ? 1 : MAX_SIZE;
+    for (auto i = 0; i < max_num; i++) {
+        const auto &monster = monsters_[i];
+        if (!monster.is_valid()) {
+            continue;
+        }
+
+        monster.get_real_monrace().increment_current_numbers();
+    }
+}

--- a/src/floor/party-monsters.h
+++ b/src/floor/party-monsters.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "system/monster-entity.h"
+#include <array>
+
+/*!
+ * @brief フロア移動時にペットを保存するコンテナクラス
+ */
+class PartyMonsters {
+public:
+    static constexpr int MAX_SIZE = 21; /*!< フロア移動時に先のフロアに連れて行けるペットの最大数 */
+
+    MonsterEntity &operator[](int i);
+    const MonsterEntity &operator[](int i) const;
+
+    void invalidate_all();
+    void wipe_all();
+    void precalc_cur_num_of_pet() const;
+
+    auto begin()
+    {
+        return monsters_.begin();
+    }
+    auto end()
+    {
+        return monsters_.end();
+    }
+    auto begin() const
+    {
+        return monsters_.begin();
+    }
+    auto end() const
+    {
+        return monsters_.end();
+    }
+
+private:
+    std::array<MonsterEntity, MAX_SIZE> monsters_{};
+};
+
+extern PartyMonsters party_monsters;


### PR DESCRIPTION
- floor/party-monsters.h/cpp: PartyMonsters クラスを新規作成
  - operator[] でインデックスアクセスを提供
  - invalidate_all() / wipe_all() で一括操作
  - precalc_cur_num_of_pet() を floor-save.cpp から移動
- floor-save-util.h から #include "system/monster-entity.h" と extern party_mon / #define MAX_PARTY_MON を削除
- floor-save.cpp / floor-changer.cpp / floor-leaver.cpp を party_monsters に移行
- Makefile.am / Bakabakaband.vcxproj に party-monsters を追加