### PR TITLE
refactor: is_blessed/hero/shero/echizen/fast/invulnerable/esp/stealthを CreatureEntity に移動（Phase 8）

### DIFF
--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -7,10 +7,14 @@
 #include "monster/monster-flag-types.h"
 #include "monster/monster-pain-describer.h"
 #include "player-ability/player-ability-types.h"
+#include "player-info/bard-data-type.h"
 #include "player-info/class-info.h"
 #include "player-info/class-types.h"
 #include "player-info/race-types.h"
+#include "player-info/sniper-data-type.h"
+#include "player-info/spell-hex-data-type.h"
 #include "player/race-info-table.h"
+#include "realm/realm-song-numbers.h"
 #include "system/angband-system.h"
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
@@ -135,12 +139,28 @@ std::pair<TERM_COLOR, int> CreatureEntity::get_hp_bar_data() const
 
 bool CreatureEntity::is_time_limit_esp() const
 {
-    return this->tim_esp > 0;
+    if (this->tim_esp > 0) {
+        return true;
+    }
+
+    const auto *bard = std::get_if<std::shared_ptr<bard_data_type>>(&this->class_specific_data);
+    if (bard && *bard && (*bard)->singing_song == MUSIC_MIND) {
+        return true;
+    }
+
+    const auto *sniper = std::get_if<std::shared_ptr<SniperData>>(&this->class_specific_data);
+    const auto sniper_concent = sniper && *sniper ? (*sniper)->concent : 0;
+    return sniper_concent >= CONCENT_TELE_THRESHOLD;
 }
 
 bool CreatureEntity::is_time_limit_stealth() const
 {
-    return this->tim_stealth > 0;
+    if (this->tim_stealth > 0) {
+        return true;
+    }
+
+    const auto *bard = std::get_if<std::shared_ptr<bard_data_type>>(&this->class_specific_data);
+    return bard && *bard && (*bard)->singing_song == MUSIC_STEALTH;
 }
 
 /*!
@@ -239,12 +259,22 @@ bool CreatureEntity::is_fearful() const
 
 bool CreatureEntity::is_invulnerable() const
 {
-    return this->get_timed_effect(CreatureTimedEffect::INVULNERABILITY) > 0;
+    if (this->get_timed_effect(CreatureTimedEffect::INVULNERABILITY) > 0) {
+        return true;
+    }
+
+    const auto *bard = std::get_if<std::shared_ptr<bard_data_type>>(&this->class_specific_data);
+    return bard && *bard && (*bard)->singing_song == MUSIC_INVULN;
 }
 
 bool CreatureEntity::is_fast() const
 {
-    return this->get_timed_effect(CreatureTimedEffect::ACCELERATION) > 0;
+    if (this->get_timed_effect(CreatureTimedEffect::ACCELERATION) > 0) {
+        return true;
+    }
+
+    const auto *bard = std::get_if<std::shared_ptr<bard_data_type>>(&this->class_specific_data);
+    return bard && *bard && ((*bard)->singing_song == MUSIC_SPEED || (*bard)->singing_song == MUSIC_SHERO);
 }
 
 bool CreatureEntity::is_accelerated() const
@@ -265,6 +295,41 @@ bool CreatureEntity::is_blind() const
 bool CreatureEntity::is_paralyzed() const
 {
     return this->get_timed_effect(CreatureTimedEffect::PARALYSIS) > 0;
+}
+
+bool CreatureEntity::is_blessed() const
+{
+    if (this->blessed > 0) {
+        return true;
+    }
+
+    const auto *bard = std::get_if<std::shared_ptr<bard_data_type>>(&this->class_specific_data);
+    if (bard && *bard && (*bard)->singing_song == MUSIC_BLESS) {
+        return true;
+    }
+
+    const auto *hex = std::get_if<std::shared_ptr<spell_hex_data_type>>(&this->class_specific_data);
+    return hex && *hex && (*hex)->casting_spells.has(HEX_BLESS);
+}
+
+bool CreatureEntity::is_hero() const
+{
+    if (this->hero > 0) {
+        return true;
+    }
+
+    const auto *bard = std::get_if<std::shared_ptr<bard_data_type>>(&this->class_specific_data);
+    return bard && *bard && ((*bard)->singing_song == MUSIC_HERO || (*bard)->singing_song == MUSIC_SHERO);
+}
+
+bool CreatureEntity::is_shero() const
+{
+    return this->berserk > 0 || this->pclass == PlayerClassType::BERSERKER;
+}
+
+bool CreatureEntity::is_echizen() const
+{
+    return this->ppersonality == PERSONALITY_COMBAT || this->is_wielding(FixedArtifactId::CRIMSON);
 }
 
 short CreatureEntity::get_timed_effect(CreatureTimedEffect effect) const

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -531,35 +531,23 @@ public:
 
     /*!
      * @brief クリーチャーが祝福状態かどうかを判定
-     * @return 祝福されていればtrue、デフォルトはfalse
+     * @return 祝福されていればtrue
      */
-    virtual bool is_blessed() const
-    {
-        return false;
-    }
+    virtual bool is_blessed() const;
 
     /*!
      * @brief クリーチャーが士気高揚状態かどうかを判定
-     * @return 士気高揚ならtrue、デフォルトはfalse
+     * @return 士気高揚ならtrue
      */
-    virtual bool is_hero() const
-    {
-        return false;
-    }
+    virtual bool is_hero() const;
 
     /*!
      * @brief クリーチャーが狂戦士状態かどうかを判定
-     * @return 狂戦士ならtrue、デフォルトはfalse
+     * @return 狂戦士ならtrue
      */
-    virtual bool is_shero() const
-    {
-        return false;
-    }
+    virtual bool is_shero() const;
 
-    virtual bool is_echizen() const
-    {
-        return false;
-    }
+    virtual bool is_echizen() const;
 
     /*!
      * @brief クリーチャーがペットかどうかを判定

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -3,12 +3,6 @@
 #include "inventory/inventory-slot-types.h"
 #include "market/arena-entry.h"
 #include "monster/monster-util.h"
-#include "player-info/bard-data-type.h"
-#include "player-info/class-types.h"
-#include "player-info/sniper-data-type.h"
-#include "player-info/spell-hex-data-type.h"
-#include "realm/realm-hex-numbers.h"
-#include "realm/realm-song-numbers.h"
 #include "system/angband-exceptions.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
@@ -210,71 +204,4 @@ void PlayerType::set_timed_effect(CreatureTimedEffect effect, short value)
     default:
         break;
     }
-}
-
-bool PlayerType::is_invulnerable() const
-{
-    if (this->invuln > 0) {
-        return true;
-    }
-
-    const auto *bard = std::get_if<std::shared_ptr<bard_data_type>>(&this->class_specific_data);
-    return bard && *bard && (*bard)->singing_song == MUSIC_INVULN;
-}
-
-bool PlayerType::is_fast() const
-{
-    const auto *bard = std::get_if<std::shared_ptr<bard_data_type>>(&this->class_specific_data);
-    const auto singing_speed = bard && *bard && ((*bard)->singing_song == MUSIC_SPEED || (*bard)->singing_song == MUSIC_SHERO);
-    return this->effects()->acceleration().is_fast() || singing_speed;
-}
-
-bool PlayerType::is_blessed() const
-{
-    if (this->blessed > 0) {
-        return true;
-    }
-
-    const auto *bard = std::get_if<std::shared_ptr<bard_data_type>>(&this->class_specific_data);
-    if (bard && *bard && (*bard)->singing_song == MUSIC_BLESS) {
-        return true;
-    }
-
-    const auto *hex = std::get_if<std::shared_ptr<spell_hex_data_type>>(&this->class_specific_data);
-    return hex && *hex && (*hex)->casting_spells.has(HEX_BLESS);
-}
-
-bool PlayerType::is_hero() const
-{
-    if (this->hero > 0) {
-        return true;
-    }
-
-    const auto *bard = std::get_if<std::shared_ptr<bard_data_type>>(&this->class_specific_data);
-    return bard && *bard && ((*bard)->singing_song == MUSIC_HERO || (*bard)->singing_song == MUSIC_SHERO);
-}
-
-bool PlayerType::is_shero() const
-{
-    return this->berserk > 0 || this->pclass == PlayerClassType::BERSERKER;
-}
-
-bool PlayerType::is_echizen() const
-{
-    return this->ppersonality == PERSONALITY_COMBAT || this->is_wielding(FixedArtifactId::CRIMSON);
-}
-
-bool PlayerType::is_time_limit_esp() const
-{
-    const auto *bard = std::get_if<std::shared_ptr<bard_data_type>>(&this->class_specific_data);
-    const auto singing_mind = bard && *bard && (*bard)->singing_song == MUSIC_MIND;
-    const auto *sniper_specific = std::get_if<std::shared_ptr<SniperData>>(&this->class_specific_data);
-    const auto sniper_concent = sniper_specific && *sniper_specific ? (*sniper_specific)->concent : 0;
-    return this->tim_esp > 0 || singing_mind || (sniper_concent >= CONCENT_TELE_THRESHOLD);
-}
-
-bool PlayerType::is_time_limit_stealth() const
-{
-    const auto *bard = std::get_if<std::shared_ptr<bard_data_type>>(&this->class_specific_data);
-    return this->tim_stealth > 0 || (bard && *bard && (*bard)->singing_song == MUSIC_STEALTH);
 }

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -64,15 +64,6 @@ public:
 
     short get_timed_effect(CreatureTimedEffect effect) const override;
     void set_timed_effect(CreatureTimedEffect effect, short value) override;
-
-    bool is_invulnerable() const override;
-    bool is_fast() const override;
-    bool is_blessed() const override;
-    bool is_hero() const override;
-    bool is_shero() const override;
-    bool is_echizen() const override;
-    bool is_time_limit_esp() const override;
-    bool is_time_limit_stealth() const override;
 };
 
 extern PlayerType *p_ptr;


### PR DESCRIPTION
… 

PlayerType の 8 つのオーバーライドを CreatureEntity 基底クラスに統合。 bard/hex/sniper の class_specific_data 参照は CreatureEntity にすでに存在するフィールドを使用。