### PR TITLE
refactor: PlayerType キャスト削除・CreatureEntity へのメソッド昇格（Phase 8 継続）

### DIFF
--- a/.github/scripts/ci-build-test.sh
+++ b/.github/scripts/ci-build-test.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# autotools ビルドテストスクリプト
+# GitHub Actions の build_test_japanese ジョブ（pull-request-status-check.yml）と同等のビルドをローカルで実行する。
+#
+# 使い方:
+#   sh .github/scripts/ci-build-test.sh [オプション]
+#
+# オプション:
+#   --cxx <コンパイラ>        使用するコンパイラ (デフォルト: g++)
+#   --cxxflags <フラグ>       コンパイルフラグ (デフォルト: -pipe -O3 -Werror -Wall -Wextra)
+#   --configure-opts <オプション>  configure に渡す追加オプション (デフォルト: --disable-pch)
+#   --jobs <数>               並列ビルド数 (デフォルト: nproc の値)
+#
+# 前提:
+#   以下のパッケージがインストールされていること:
+#     sudo apt-get install libncursesw5-dev libcurl4-openssl-dev nkf libc++-15-dev libc++abi-15-dev
+
+set -eu
+
+CXX="${CXX:-g++}"
+CXXFLAGS="${CXXFLAGS:--pipe -O3 -Werror -Wall -Wextra}"
+CONFIGURE_OPTS="--disable-pch"
+JOBS=$(nproc 2>/dev/null || echo 4)
+
+# 引数パース
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --cxx)
+            CXX="$2"; shift 2 ;;
+        --cxxflags)
+            CXXFLAGS="$2"; shift 2 ;;
+        --configure-opts)
+            CONFIGURE_OPTS="$2"; shift 2 ;;
+        --jobs)
+            JOBS="$2"; shift 2 ;;
+        *)
+            echo "不明なオプション: $1"
+            exit 1 ;;
+    esac
+done
+
+echo "[ci-build-test] コンパイラ : ${CXX}"
+echo "[ci-build-test] フラグ     : ${CXXFLAGS}"
+echo "[ci-build-test] configure  : ${CONFIGURE_OPTS}"
+echo "[ci-build-test] 並列数     : ${JOBS}"
+
+# bootstrap (configure スクリプト生成)
+echo "[ci-build-test] bootstrap を実行しています..."
+./bootstrap
+
+# configure
+echo "[ci-build-test] configure を実行しています..."
+CXX="${CXX}" CXXFLAGS="${CXXFLAGS}" ./configure ${CONFIGURE_OPTS}
+
+# ビルド
+echo "[ci-build-test] make を実行しています..."
+make -j"${JOBS}" >/dev/null
+
+echo "[ci-build-test] OK: ビルドが成功しました。"
+exit 0

--- a/src/action/open-close-execution.cpp
+++ b/src/action/open-close-execution.cpp
@@ -28,7 +28,6 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "term/screen-processor.h"
@@ -45,7 +44,7 @@
  */
 bool exe_open(CreatureEntity &creature, POSITION y, POSITION x)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const Pos2D pos(y, x);
     const auto &grid = creature.current_floor_ptr->get_grid(pos);
     auto &terrain = grid.get_terrain();
@@ -110,7 +109,7 @@ bool exe_open(CreatureEntity &creature, POSITION y, POSITION x)
  */
 bool exe_close(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
     const auto &grid = floor.get_grid(pos);
     const auto terrain_id = grid.feat;
@@ -156,7 +155,7 @@ bool exe_close(CreatureEntity &creature, const Pos2D &pos)
  */
 bool easy_open_door(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
     if (!floor.has_closed_door_at(pos)) {
         return false;
@@ -220,7 +219,7 @@ bool easy_open_door(CreatureEntity &creature, const Pos2D &pos)
  */
 bool exe_disarm_chest(CreatureEntity &creature, POSITION y, POSITION x, OBJECT_IDX o_idx)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const Pos2D pos(y, x);
     auto *o_ptr = creature.current_floor_ptr->o_list[o_idx].get();
     PlayerEnergy(player).set_player_turn_energy(100);
@@ -283,7 +282,7 @@ bool exe_disarm_chest(CreatureEntity &creature, POSITION y, POSITION x, OBJECT_I
 
 bool exe_disarm(CreatureEntity &creature, POSITION y, POSITION x, const Direction &dir)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &baseitems = BaseitemList::get_instance();
     const Pos2D pos(y, x);
     const auto &grid = creature.current_floor_ptr->get_grid(pos);
@@ -349,7 +348,7 @@ bool exe_disarm(CreatureEntity &creature, POSITION y, POSITION x, const Directio
  */
 bool exe_bash(CreatureEntity &creature, POSITION y, POSITION x, const Direction &dir)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
     const Pos2D pos(y, x);
     const auto &grid = floor.get_grid(pos);

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -81,7 +81,7 @@ static bool confirm_leave_level(CreatureEntity &creature, bool down_stair)
  */
 void do_cmd_go_up(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto &quests = QuestList::get_instance();
     auto &floor = *creature.current_floor_ptr;
     const auto &grid = floor.get_grid({ creature.y, creature.x });
@@ -220,7 +220,7 @@ void do_cmd_go_up(CreatureEntity &creature)
  */
 void do_cmd_go_down(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     CreatureClass(player).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
     auto &floor = *creature.current_floor_ptr;
@@ -450,7 +450,7 @@ void do_cmd_walk(CreatureEntity &creature, bool pickup)
  */
 void do_cmd_run(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (cmd_limit_confused(player)) {
         return;
     }
@@ -479,7 +479,7 @@ void do_cmd_stay(CreatureEntity &creature, bool pickup)
         command_arg = 0;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     PlayerEnergy(player).set_player_turn_energy(100);
     if (pickup) {
         mpe_mode |= MPE_DO_PICKUP;
@@ -527,7 +527,7 @@ static bool input_rest_turns()
  */
 void do_cmd_rest(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     set_action(creature, ACTION_NONE);
     if (CreatureClass(player).equals(PlayerClassType::BARD)) {
         auto is_singing = get_singing_song_effect(player) != 0;
@@ -552,7 +552,7 @@ void do_cmd_rest(CreatureEntity &creature)
         chg_virtue(creature, Virtue::DILIGENCE, -1);
     }
 
-    if (player.is_fully_healthy()) {
+    if (static_cast<PlayerType &>(player).is_fully_healthy()) {
         chg_virtue(creature, Virtue::DILIGENCE, -1);
     }
 
@@ -572,7 +572,7 @@ void do_cmd_rest(CreatureEntity &creature)
  */
 void do_cmd_go_portal(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     const auto &grid = floor.get_grid({ creature.y, creature.x });
     const auto &terrain = grid.get_terrain();

--- a/src/cmd-item/cmd-destroy.cpp
+++ b/src/cmd-item/cmd-destroy.cpp
@@ -33,7 +33,6 @@
 #include "system/baseitem/baseitem-key.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"
@@ -46,7 +45,7 @@ using SelectionResult = std::tuple<ItemEntity *, short, int>;
 
 static bool check_destory_item(CreatureEntity &creature, const ItemEntity &destroying_item, short i_idx)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (!confirm_destroy && (destroying_item.calc_price() <= 0)) {
         return true;
     }
@@ -84,7 +83,7 @@ static bool check_destory_item(CreatureEntity &creature, const ItemEntity &destr
 
 static tl::optional<SelectionResult> select_destroying_item(CreatureEntity &creature, bool force_destroy)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     short i_idx;
     constexpr auto q = _("どのアイテムを壊しますか? ", "Destroy which item? ");
     constexpr auto s = _("壊せるアイテムを持っていない。", "You have nothing to destroy.");
@@ -117,7 +116,7 @@ static tl::optional<SelectionResult> select_destroying_item(CreatureEntity &crea
  */
 static bool decide_magic_book_exp(CreatureEntity &creature, const ItemEntity &destroyed_item)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (CreatureRace(&creature).equals(PlayerRaceType::ANDROID)) {
         return false;
     }
@@ -142,7 +141,7 @@ static bool decide_magic_book_exp(CreatureEntity &creature, const ItemEntity &de
 
 static void gain_exp_by_destroying_magic_book(CreatureEntity &creature, const ItemEntity &destroyed_item)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto gain_expr = decide_magic_book_exp(creature, destroyed_item);
     if (!gain_expr || (player.exp >= PY_MAX_EXP)) {
         return;
@@ -195,7 +194,7 @@ static void process_destroy_magic_book(CreatureEntity &creature, const ItemEntit
 
 static void exe_destroy_item(CreatureEntity &creature, ItemEntity &destroying_item, short i_idx, int amount)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto destroyed_item = destroying_item.clone();
     destroyed_item.number = amount;
     const auto item_name = describe_flavor(player, destroyed_item, 0);
@@ -219,7 +218,7 @@ static void exe_destroy_item(CreatureEntity &creature, ItemEntity &destroying_it
  */
 void do_cmd_destroy(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
     const auto selection_result = select_destroying_item(creature, (command_arg > 0));

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -53,7 +53,6 @@
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "util/dice.h"
 #include "util/string-processor.h"
@@ -68,7 +67,7 @@
  */
 static bool exe_eat_junk_type_object(CreatureEntity &creature, ItemEntity *o_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (o_ptr->bi_key.tval() != ItemKindType::JUNK) {
         return false;
     }
@@ -104,7 +103,7 @@ static bool exe_eat_junk_type_object(CreatureEntity &creature, ItemEntity *o_ptr
  */
 static bool exe_eat_soul(CreatureEntity &creature, ItemEntity *o_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (!(o_ptr->bi_key.tval() == ItemKindType::MONSTER_REMAINS && o_ptr->bi_key.sval() == SV_SOUL)) {
         return false;
     }
@@ -134,7 +133,7 @@ static bool exe_eat_soul(CreatureEntity &creature, ItemEntity *o_ptr)
  */
 static bool exe_eat_corpse_type_object(CreatureEntity &creature, ItemEntity *o_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (!(o_ptr->bi_key.tval() == ItemKindType::MONSTER_REMAINS && o_ptr->bi_key.sval() == SV_CORPSE)) {
         return false;
     }
@@ -274,7 +273,7 @@ static bool exe_eat_corpse_type_object(CreatureEntity &creature, ItemEntity *o_p
  */
 static bool exe_eat_food_type_object(CreatureEntity &creature, const BaseitemKey &bi_key)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (bi_key.tval() != ItemKindType::FOOD) {
         return false;
     }
@@ -483,7 +482,7 @@ static bool exe_eat_food_type_object(CreatureEntity &creature, const BaseitemKey
  */
 static bool exe_eat_charge_of_magic_device(CreatureEntity &creature, ItemEntity *o_ptr, short i_idx)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (!o_ptr->is_wand_staff() || (CreatureRace(&creature).food() != PlayerRaceFoodType::MANA)) {
         return false;
     }
@@ -546,7 +545,7 @@ static bool exe_eat_charge_of_magic_device(CreatureEntity &creature, ItemEntity 
  */
 void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (music_singing_any(player)) {
         stop_singing(player);
     }
@@ -711,7 +710,7 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
  */
 void do_cmd_eat_food(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU, SamuraiStanceType::KOUKIJIN });
     constexpr auto q = _("どれを食べますか? ", "Eat which item? ");
     constexpr auto s = _("食べ物がない。", "You have nothing to eat.");

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -60,7 +60,6 @@
 #include "status/action-setter.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "util/bit-flags-calculator.h"
@@ -109,7 +108,7 @@ void do_cmd_inven(CreatureEntity &creature)
  */
 void do_cmd_drop(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     int amt = 1;
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
@@ -148,7 +147,7 @@ void do_cmd_drop(CreatureEntity &creature)
  */
 void do_cmd_observe(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     constexpr auto q = _("どのアイテムを調べますか? ", "Examine which item? ");
     constexpr auto s = _("調べられるアイテムがない。", "You have nothing to examine.");
     short i_idx;
@@ -175,7 +174,7 @@ void do_cmd_observe(CreatureEntity &creature)
  */
 void do_cmd_uninscribe(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     constexpr auto q = _("どのアイテムの銘を消しますか? ", "Un-inscribe which item? ");
     constexpr auto s = _("銘を消せるアイテムがない。", "You have nothing to un-inscribe.");
     short i_idx;
@@ -212,7 +211,7 @@ void do_cmd_uninscribe(CreatureEntity &creature)
  */
 void do_cmd_inscribe(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     constexpr auto q = _("どのアイテムに銘を刻みますか? ", "Inscribe which item? ");
     constexpr auto s = _("銘を刻めるアイテムがない。", "You have nothing to inscribe.");
     short i_idx;
@@ -254,7 +253,7 @@ void do_cmd_inscribe(CreatureEntity &creature)
  */
 void do_cmd_use(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (AngbandWorld::get_instance().is_wild_mode() || cmd_limit_arena(creature)) {
         return;
     }
@@ -312,7 +311,7 @@ void do_cmd_use(CreatureEntity &creature)
  */
 void do_cmd_activate(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (AngbandWorld::get_instance().is_wild_mode() || cmd_limit_arena(creature)) {
         return;
     }

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -31,7 +31,6 @@
 #include "system/enums/terrain/terrain-tag.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
-#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "util/bit-flags-calculator.h"
@@ -175,7 +174,7 @@ static void generate_circular_waterway(CreatureEntity &creature)
 
 static bool decide_tunnel_planned_site(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon, dt_type *dt_ptr, int i)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     dd_ptr->tunn_n = 0;
     dd_ptr->wall_n = 0;
     if (dungeon.flags.has(DungeonFeatureType::NO_TUNNEL)) {
@@ -211,7 +210,7 @@ static void make_tunnels(CreatureEntity &creature, DungeonData *dd_ptr)
 
 static void make_walls(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon, dt_type *dt_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     for (size_t j = 0; j < dd_ptr->wall_n; j++) {
         dd_ptr->tunnel_pos = dd_ptr->walls[j];
         auto &grid = creature.current_floor_ptr->get_grid(dd_ptr->tunnel_pos);
@@ -243,7 +242,7 @@ static bool make_centers(CreatureEntity &creature, DungeonData *dd_ptr, const Du
 
 static void make_doors(CreatureEntity &creature, DungeonData *dd_ptr, dt_type *dt_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     for (size_t i = 0; i < dd_ptr->door_n; i++) {
         dd_ptr->tunnel_pos = dd_ptr->doors[i];
         for (const auto &d : Direction::directions_4()) {
@@ -264,7 +263,7 @@ static void make_only_tunnel_points(const FloorType &floor, DungeonData *dd_ptr)
 
 static bool make_one_floor(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     if (dungeon.flags.has(DungeonFeatureType::NO_ROOM)) {
         make_only_tunnel_points(floor, dd_ptr);
@@ -330,7 +329,7 @@ static bool make_one_floor(CreatureEntity &creature, DungeonData *dd_ptr, const 
 
 static bool switch_making_floor(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (dungeon.flags.has(DungeonFeatureType::MAZE)) {
         const auto &floor = *creature.current_floor_ptr;
         build_maze_vault(player, { floor.height / 2 - 1, floor.width / 2 - 1 }, { floor.height - 4, floor.width - 4 }, false);
@@ -418,7 +417,7 @@ static void make_perm_walls(CreatureEntity &creature)
 
 static bool check_place_necessary_objects(CreatureEntity &creature, DungeonData *dd_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto p_pos = new_player_spot(creature);
     if (!p_pos) {
         dd_ptr->why = _("プレイヤー配置に失敗", "Failed to place a player");
@@ -436,7 +435,7 @@ static bool check_place_necessary_objects(CreatureEntity &creature, DungeonData 
 
 static void decide_dungeon_data_allocation(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
     dd_ptr->alloc_object_num = floor.dun_level / 3 + 5;
     if (dd_ptr->alloc_object_num > 30) {
@@ -467,7 +466,7 @@ static void decide_dungeon_data_allocation(CreatureEntity &creature, DungeonData
 
 static bool allocate_dungeon_data(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     dd_ptr->alloc_monster_num += randint1(8);
     auto &floor = *creature.current_floor_ptr;
 
@@ -558,7 +557,7 @@ uint32_t calculate_terrain_seed(int dungeon_id, int dun_level)
  */
 tl::optional<std::string> cave_gen(CreatureEntity &creature, tl::optional<uint32_t> seed)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     // 乱数種の保存と復元用
     Xoshiro128StarStar::state_type original_state{};
     bool seed_was_fixed = false;
@@ -677,7 +676,7 @@ tl::optional<std::string> cave_gen(CreatureEntity &creature, tl::optional<uint32
  */
 void apply_vestige_terrain_replacement(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     auto &terrains = TerrainList::get_instance();
 
@@ -732,7 +731,7 @@ void apply_void_terrain_placement(CreatureEntity &creature)
         return;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     auto &terrains = TerrainList::get_instance();
 

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -42,7 +42,6 @@
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "util/bit-flags-calculator.h"
@@ -57,24 +56,23 @@
  */
 static void build_dead_end(CreatureEntity &creature, saved_floor_type *sf_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
     msg_print(_("階段は行き止まりだった。", "The staircases come to a dead end..."));
     clear_cave(creature);
-    player_ptr->x = player_ptr->y = 0;
-    player_ptr->current_floor_ptr->height = SCREEN_HGT;
-    player_ptr->current_floor_ptr->width = SCREEN_WID;
+    player.x = player.y = 0;
+    player.current_floor_ptr->height = SCREEN_HGT;
+    player.current_floor_ptr->width = SCREEN_WID;
     for (POSITION y = 0; y < MAX_HGT; y++) {
         for (POSITION x = 0; x < MAX_WID; x++) {
-            place_bold(*player_ptr, y, x, GB_SOLID_PERM);
+            place_bold(player, y, x, GB_SOLID_PERM);
         }
     }
 
-    player_ptr->y = player_ptr->current_floor_ptr->height / 2;
-    player_ptr->x = player_ptr->current_floor_ptr->width / 2;
-    place_bold(*player_ptr, player_ptr->y, player_ptr->x, GB_FLOOR);
-    wipe_generate_random_floor_flags(*player_ptr->current_floor_ptr);
+    player.y = player.current_floor_ptr->height / 2;
+    player.x = player.current_floor_ptr->width / 2;
+    place_bold(player, player.y, player.x, GB_FLOOR);
+    wipe_generate_random_floor_flags(*player.current_floor_ptr);
     const auto &fcms = FloorChangeModesStore::get_instace();
     if (fcms->has(FloorChangeMode::UP)) {
         sf_ptr->upper_floor_id = 0;
@@ -85,15 +83,14 @@ static void build_dead_end(CreatureEntity &creature, saved_floor_type *sf_ptr)
 
 static std::pair<short, Pos2D> decide_pet_index(CreatureEntity &creature, const int current_monster)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
-    auto &floor = *player_ptr->current_floor_ptr;
-    const auto p_pos = player_ptr->get_position();
+    auto &floor = *player.current_floor_ptr;
+    const auto p_pos = player.get_position();
     Pos2D pos(0, 0);
     if (current_monster == 0) {
         const auto m_idx = floor.pop_empty_index_monster();
-        player_ptr->riding = m_idx;
+        player.riding = m_idx;
         if (m_idx) {
             pos = p_pos;
         }
@@ -106,7 +103,7 @@ static std::pair<short, Pos2D> decide_pet_index(CreatureEntity &creature, const 
         int j;
         for (j = 1000; j > 0; j--) {
             pos = scatter(floor, p_pos, d, PROJECT_NONE);
-            if (monster_can_enter(player_ptr, pos.y, pos.x, party_monsters[current_monster].get_monrace(), 0)) {
+            if (monster_can_enter(&player, pos.y, pos.x, party_monsters[current_monster].get_monrace(), 0)) {
                 break;
             }
         }
@@ -122,15 +119,14 @@ static std::pair<short, Pos2D> decide_pet_index(CreatureEntity &creature, const 
 
 static MonraceDefinition &set_pet_params(CreatureEntity &creature, const int current_monster, MONSTER_IDX m_idx, const POSITION cy, const POSITION cx)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
-    player_ptr->current_floor_ptr->grid_array[cy][cx].m_idx = m_idx;
-    auto &monster = player_ptr->current_floor_ptr->m_list[m_idx];
+    player.current_floor_ptr->grid_array[cy][cx].m_idx = m_idx;
+    auto &monster = player.current_floor_ptr->m_list[m_idx];
     monster = party_monsters[current_monster].clone();
     monster.y = cy;
     monster.x = cx;
-    monster.current_floor_ptr = player_ptr->current_floor_ptr;
+    monster.current_floor_ptr = player.current_floor_ptr;
     monster.get_monster_profile().ml = true;
     monster.get_monster_profile().mtimed[MonsterTimedEffect::SLEEP] = 0;
     monster.get_monster_profile().hold_o_idx_list.clear();
@@ -149,11 +145,10 @@ static MonraceDefinition &set_pet_params(CreatureEntity &creature, const int cur
  */
 static void place_pet(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
     const auto max_num = AngbandWorld::get_instance().is_wild_mode() ? 1 : PartyMonsters::MAX_SIZE;
-    auto &floor = *player_ptr->current_floor_ptr;
+    auto &floor = *player.current_floor_ptr;
     for (int current_monster = 0; current_monster < max_num; current_monster++) {
         if (!MonraceList::is_valid(party_monsters[current_monster].r_idx)) {
             continue;
@@ -162,17 +157,17 @@ static void place_pet(CreatureEntity &creature)
         const auto &[m_idx, pos] = decide_pet_index(creature, current_monster);
         if (m_idx != 0) {
             const auto &monrace = set_pet_params(creature, current_monster, m_idx, pos.y, pos.x);
-            update_monster(*player_ptr, m_idx, true);
-            lite_spot(*player_ptr, pos);
+            update_monster(player, m_idx, true);
+            lite_spot(player, pos);
             if (monrace.misc_flags.has(MonsterMiscType::MULTIPLY)) {
                 floor.num_repro++;
             }
         } else {
             const auto &monster = party_monsters[current_monster];
             auto &monrace = monster.get_real_monrace();
-            msg_format(_("%sとはぐれてしまった。", "You have lost sight of %s."), monster_desc(*player_ptr, monster, 0).data());
+            msg_format(_("%sとはぐれてしまった。", "You have lost sight of %s."), monster_desc(player, monster, 0).data());
             if (record_named_pet && monster.is_named()) {
-                exe_write_diary(floor, DiaryKind::NAMED_PET, RECORD_NAMED_PET_LOST_SIGHT, monster_desc(*player_ptr, monster, MD_INDEF_VISIBLE));
+                exe_write_diary(floor, DiaryKind::NAMED_PET, RECORD_NAMED_PET_LOST_SIGHT, monster_desc(player, monster, MD_INDEF_VISIBLE));
             }
 
             if (monrace.has_entity()) {
@@ -225,13 +220,12 @@ static bool is_visited_floor(saved_floor_type *sf_ptr)
 
 static void update_floor_id(CreatureEntity &creature, saved_floor_type *sf_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
     const auto &fcms = FloorChangeModesStore::get_instace();
     const auto is_up = fcms->has(FloorChangeMode::UP);
     const auto is_down = fcms->has(FloorChangeMode::DOWN);
-    if (!player_ptr->in_saved_floor()) {
+    if (!player.in_saved_floor()) {
         if (is_up) {
             sf_ptr->lower_floor_id = 0;
         } else if (is_down) {
@@ -241,26 +235,25 @@ static void update_floor_id(CreatureEntity &creature, saved_floor_type *sf_ptr)
         return;
     }
 
-    saved_floor_type *cur_sf_ptr = get_sf_ptr(player_ptr->floor_id);
+    saved_floor_type *cur_sf_ptr = get_sf_ptr(player.floor_id);
     if (is_up) {
         if (cur_sf_ptr->upper_floor_id == new_floor_id) {
-            sf_ptr->lower_floor_id = player_ptr->floor_id;
+            sf_ptr->lower_floor_id = player.floor_id;
         }
 
         return;
     }
 
     if (is_down && (cur_sf_ptr->lower_floor_id == new_floor_id)) {
-        sf_ptr->upper_floor_id = player_ptr->floor_id;
+        sf_ptr->upper_floor_id = player.floor_id;
     }
 }
 
 static void reset_unique_by_floor_change(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
-    auto &floor = *player_ptr->current_floor_ptr;
+    auto &floor = *player.current_floor_ptr;
     for (short i = 1; i < floor.m_max; i++) {
         auto &monster = floor.m_list[i];
         if (!monster.is_valid()) {
@@ -283,18 +276,17 @@ static void reset_unique_by_floor_change(CreatureEntity &creature)
         }
 
         if (monrace.floor_id != new_floor_id) {
-            delete_monster_idx(*player_ptr, i);
+            delete_monster_idx(player, i);
         }
     }
 }
 
 static void new_floor_allocation(CreatureEntity &creature, saved_floor_type *sf_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
     GAME_TURN tmp_last_visit = sf_ptr->last_visit;
-    const auto &floor = *player_ptr->current_floor_ptr;
+    const auto &floor = *player.current_floor_ptr;
     auto alloc_chance = floor.get_dungeon_definition().max_m_alloc_chance;
     const auto &world = AngbandWorld::get_instance();
     while (tmp_last_visit > world.game_turn) {
@@ -316,16 +308,16 @@ static void new_floor_allocation(CreatureEntity &creature, saved_floor_type *sf_
             delete_i_idx_list.push_back(static_cast<OBJECT_IDX>(i_idx));
         }
     }
-    delete_items(*player_ptr, std::move(delete_i_idx_list));
+    delete_items(player, std::move(delete_i_idx_list));
 
-    (void)place_quest_monsters(*player_ptr);
+    (void)place_quest_monsters(player);
     GAME_TURN alloc_times = absence_ticks / alloc_chance;
     if (randint0(alloc_chance) < (absence_ticks % alloc_chance)) {
         alloc_times++;
     }
 
     for (MONSTER_IDX i = 0; i < alloc_times; i++) {
-        (void)alloc_monster(*player_ptr, 0, 0, summon_specific);
+        (void)alloc_monster(player, 0, 0, summon_specific);
     }
 }
 
@@ -335,11 +327,10 @@ static void new_floor_allocation(CreatureEntity &creature, saved_floor_type *sf_
  */
 static void set_stairs(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
-    auto &floor = *player_ptr->current_floor_ptr;
-    auto &grid = floor.grid_array[player_ptr->y][player_ptr->x];
+    auto &floor = *player.current_floor_ptr;
+    auto &grid = floor.grid_array[player.y][player.x];
     const auto &fcms = FloorChangeModesStore::get_instace();
     const auto &dungeon = floor.get_dungeon_definition();
     const auto &terrains = TerrainList::get_instance();
@@ -356,13 +347,12 @@ static void set_stairs(CreatureEntity &creature)
     }
 
     grid.mimic = 0;
-    grid.special = player_ptr->floor_id;
+    grid.special = player.floor_id;
 }
 
 static void update_new_floor_feature(CreatureEntity &creature, saved_floor_type *sf_ptr, const bool loaded)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
     if (loaded) {
         new_floor_allocation(creature, sf_ptr);
@@ -376,7 +366,7 @@ static void update_new_floor_feature(CreatureEntity &creature, saved_floor_type 
     }
 
     sf_ptr->last_visit = AngbandWorld::get_instance().game_turn;
-    auto &floor = *player_ptr->current_floor_ptr;
+    auto &floor = *player.current_floor_ptr;
     sf_ptr->dun_level = floor.dun_level;
     if (FloorChangeModesStore::get_instace()->has(FloorChangeMode::NO_RETURN)) {
         return;
@@ -387,13 +377,12 @@ static void update_new_floor_feature(CreatureEntity &creature, saved_floor_type 
 
 static void cut_off_the_upstair(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
     const auto &fcms = FloorChangeModesStore::get_instace();
     if (fcms->has(FloorChangeMode::RANDOM_PLACE)) {
-        if (const auto p_pos = new_player_spot(*player_ptr); p_pos) {
-            player_ptr->set_position(*p_pos);
+        if (const auto p_pos = new_player_spot(player); p_pos) {
+            player.set_position(*p_pos);
         }
 
         return;
@@ -403,7 +392,7 @@ static void cut_off_the_upstair(CreatureEntity &creature)
         return;
     }
 
-    const auto is_blind = player_ptr->is_blind();
+    const auto is_blind = player.is_blind();
     const auto mes = is_blind
                          ? _("ゴトゴトと何か音がした。", "You hear some noises.")
                          : _("突然階段が塞がれてしまった！", "Suddenly the stairs is blocked!");
@@ -442,12 +431,11 @@ static void update_floor(CreatureEntity &creature)
  */
 void change_floor(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
     auto &world = AngbandWorld::get_instance();
     world.character_dungeon = false;
-    player_ptr->dtrap = false;
+    player.dtrap = false;
     panel_row_min = 0;
     panel_row_max = 0;
     panel_col_min = 0;
@@ -456,11 +444,11 @@ void change_floor(CreatureEntity &creature)
     update_floor(creature);
     place_pet(creature);
     Travel::get_instance().reset_goal();
-    auto &floor = *player_ptr->current_floor_ptr;
+    auto &floor = *player.current_floor_ptr;
     update_unique_artifact(floor, new_floor_id);
-    player_ptr->floor_id = new_floor_id;
+    player.floor_id = new_floor_id;
     world.character_dungeon = true;
-    if (player_ptr->ppersonality == PERSONALITY_MUNCHKIN) {
+    if (player.ppersonality == PERSONALITY_MUNCHKIN) {
         wiz_lite(creature, CreatureClass(creature).equals(PlayerClassType::NINJA));
     }
 
@@ -470,22 +458,22 @@ void change_floor(CreatureEntity &creature)
     df.set_feeling(0);
     auto &fcms = FloorChangeModesStore::get_instace();
     fcms->clear();
-    select_floor_music(*player_ptr);
+    select_floor_music(player);
     fcms->clear();
 
     // 移動後のフロアで階段を消去する処理
-    if (player_ptr->vanish_stairs_flag) {
-        player_ptr->vanish_stairs_flag = false;
+    if (player.vanish_stairs_flag) {
+        player.vanish_stairs_flag = false;
         const auto &dungeon = floor.get_dungeon_definition();
         if (dungeon.flags.has(DungeonFeatureType::VANISH_STAIRS) && floor.is_underground()) {
-            const auto p_pos = player_ptr->get_position();
+            const auto p_pos = player.get_position();
             auto &grid = floor.grid_array[p_pos.y][p_pos.x];
             const auto &terrain = grid.get_terrain();
 
             // 階段かどうかをチェック
             if (terrain.flags.has_any_of({ TerrainCharacteristics::LESS, TerrainCharacteristics::MORE })) {
                 const auto floor_terrain_id = dungeon.select_floor_terrain_id();
-                set_terrain_id_to_grid(*player_ptr, p_pos, floor_terrain_id);
+                set_terrain_id_to_grid(player, p_pos, floor_terrain_id);
                 msg_print(_("階段が消え去った。", "The staircase vanishes."));
             }
         }

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -47,7 +47,6 @@
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "util/bit-flags-calculator.h"
@@ -66,8 +65,7 @@
  */
 static Pos2D build_arena(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
     const auto yval = SCREEN_HGT / 2;
     const auto xval = SCREEN_WID / 2;
@@ -75,11 +73,11 @@ static Pos2D build_arena(CreatureEntity &creature)
     const auto y_depth = yval + 15;
     const auto x_left = xval - 15;
     const auto x_right = xval + 15;
-    auto &floor = *player_ptr->current_floor_ptr;
+    auto &floor = *player.current_floor_ptr;
     for (auto y = y_height; y <= y_height + 5; y++) {
         for (auto x = x_left; x <= x_right; x++) {
             const Pos2D pos(y, x);
-            place_bold(*player_ptr, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -87,7 +85,7 @@ static Pos2D build_arena(CreatureEntity &creature)
     for (auto y = y_depth; y >= y_depth - 5; y--) {
         for (auto x = x_left; x <= x_right; x++) {
             const Pos2D pos(y, x);
-            place_bold(*player_ptr, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -95,7 +93,7 @@ static Pos2D build_arena(CreatureEntity &creature)
     for (auto x = x_left; x <= x_left + 5; x++) {
         for (auto y = y_height; y <= y_depth; y++) {
             const Pos2D pos(y, x);
-            place_bold(*player_ptr, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -103,28 +101,28 @@ static Pos2D build_arena(CreatureEntity &creature)
     for (auto x = x_right; x >= x_right - 5; x--) {
         for (auto y = y_height; y <= y_depth; y++) {
             const Pos2D pos(y, x);
-            place_bold(*player_ptr, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
 
     // 柱っぽいもの
-    place_bold(*player_ptr, y_height + 6, x_left + 18, GB_EXTRA_PERM);
+    place_bold(player, y_height + 6, x_left + 18, GB_EXTRA_PERM);
     floor.get_grid({ y_height + 6, x_left + 18 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(*player_ptr, y_depth - 6, x_left + 18, GB_EXTRA_PERM);
+    place_bold(player, y_depth - 6, x_left + 18, GB_EXTRA_PERM);
     floor.get_grid({ y_depth - 6, x_left + 18 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(*player_ptr, y_height + 6, x_right - 18, GB_EXTRA_PERM);
+    place_bold(player, y_height + 6, x_right - 18, GB_EXTRA_PERM);
     floor.get_grid({ y_height + 6, x_right - 18 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(*player_ptr, y_depth - 6, x_right - 18, GB_EXTRA_PERM);
+    place_bold(player, y_depth - 6, x_right - 18, GB_EXTRA_PERM);
     floor.get_grid({ y_depth - 6, x_right - 18 }).info |= CAVE_GLOW | CAVE_MARK;
 
-    place_bold(*player_ptr, y_height + 9, x_left + 21, GB_EXTRA_PERM);
+    place_bold(player, y_height + 9, x_left + 21, GB_EXTRA_PERM);
     floor.get_grid({ y_height + 9, x_left + 21 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(*player_ptr, y_depth - 9, x_left + 21, GB_EXTRA_PERM);
+    place_bold(player, y_depth - 9, x_left + 21, GB_EXTRA_PERM);
     floor.get_grid({ y_height - 9, x_left + 21 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(*player_ptr, y_height + 9, x_right - 21, GB_EXTRA_PERM);
+    place_bold(player, y_height + 9, x_right - 21, GB_EXTRA_PERM);
     floor.get_grid({ y_height + 9, x_left - 21 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(*player_ptr, y_depth - 9, x_right - 21, GB_EXTRA_PERM);
+    place_bold(player, y_depth - 9, x_right - 21, GB_EXTRA_PERM);
     floor.get_grid({ y_height - 9, x_left - 21 }).info |= CAVE_GLOW | CAVE_MARK;
 
     const Pos2D pos(y_height + 10, xval);
@@ -142,15 +140,14 @@ static Pos2D build_arena(CreatureEntity &creature)
  */
 static void generate_challenge_arena(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
-    auto &floor = *player_ptr->current_floor_ptr;
+    auto &floor = *player.current_floor_ptr;
     floor.height = SCREEN_HGT;
     floor.width = SCREEN_WID;
     for (auto y = 0; y < MAX_HGT; y++) {
         for (auto x = 0; x < MAX_WID; x++) {
-            place_bold(*player_ptr, y, x, GB_SOLID_PERM);
+            place_bold(player, y, x, GB_SOLID_PERM);
             floor.get_grid({ y, x }).add_info(CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -162,13 +159,13 @@ static void generate_challenge_arena(CreatureEntity &creature)
     }
 
     const auto pos = build_arena(creature);
-    if (!player_ptr->try_set_position(pos)) {
+    if (!player.try_set_position(pos)) {
         return;
     }
 
     auto &entries = ArenaEntryList::get_instance();
     const auto &monrace = entries.get_monrace();
-    if (place_specific_monster(*player_ptr, player_ptr->y + 5, player_ptr->x, monrace.idx, PM_NO_KAGE | PM_NO_PET)) {
+    if (place_specific_monster(player, player.y + 5, player.x, monrace.idx, PM_NO_KAGE | PM_NO_PET)) {
         return;
     }
 
@@ -183,8 +180,7 @@ static void generate_challenge_arena(CreatureEntity &creature)
  */
 static Pos2D build_battle(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
     const auto yval = ARENA_WID / 2;
     const auto xval = ARENA_HGT / 2;
@@ -192,11 +188,11 @@ static Pos2D build_battle(CreatureEntity &creature)
     const auto y_depth = yval + 15;
     const auto x_left = xval - 15;
     const auto x_right = xval + 15;
-    auto &floor = *player_ptr->current_floor_ptr;
+    auto &floor = *player.current_floor_ptr;
     for (auto y = y_height; y <= y_height + 5; y++) {
         for (auto x = x_left; x <= x_right; x++) {
             const Pos2D pos(y, x);
-            place_bold(*player_ptr, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -204,7 +200,7 @@ static Pos2D build_battle(CreatureEntity &creature)
     for (auto y = y_depth; y >= y_depth - 3; y--) {
         for (auto x = x_left; x <= x_right; x++) {
             const Pos2D pos(y, x);
-            place_bold(*player_ptr, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -212,7 +208,7 @@ static Pos2D build_battle(CreatureEntity &creature)
     for (auto x = x_left; x <= x_left + 17; x++) {
         for (auto y = y_height; y <= y_depth; y++) {
             const Pos2D pos(y, x);
-            place_bold(*player_ptr, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -220,18 +216,18 @@ static Pos2D build_battle(CreatureEntity &creature)
     for (auto x = x_right; x >= x_right - 17; x--) {
         for (auto y = y_height; y <= y_depth; y++) {
             const Pos2D pos(y, x);
-            place_bold(*player_ptr, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
 
-    place_bold(*player_ptr, y_height + 6, x_left + 18, GB_EXTRA_PERM);
+    place_bold(player, y_height + 6, x_left + 18, GB_EXTRA_PERM);
     floor.get_grid({ y_height + 6, x_left + 18 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(*player_ptr, y_depth - 4, x_left + 18, GB_EXTRA_PERM);
+    place_bold(player, y_depth - 4, x_left + 18, GB_EXTRA_PERM);
     floor.get_grid({ y_depth - 4, x_left + 18 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(*player_ptr, y_height + 6, x_right - 18, GB_EXTRA_PERM);
+    place_bold(player, y_height + 6, x_right - 18, GB_EXTRA_PERM);
     floor.get_grid({ y_height + 6, x_right - 18 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(*player_ptr, y_depth - 4, x_right - 18, GB_EXTRA_PERM);
+    place_bold(player, y_depth - 4, x_right - 18, GB_EXTRA_PERM);
     floor.get_grid({ y_depth - 4, x_right - 18 }).info |= CAVE_GLOW | CAVE_MARK;
 
     for (auto y = y_height + 1; y <= y_height + 5; y++) {
@@ -251,14 +247,13 @@ static Pos2D build_battle(CreatureEntity &creature)
  */
 static void generate_gambling_arena(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
-    auto &floor = *player_ptr->current_floor_ptr;
+    auto &floor = *player.current_floor_ptr;
     for (auto y = 0; y < MAX_HGT; y++) {
         for (auto x = 0; x < MAX_WID; x++) {
             const Pos2D pos(y, x);
-            place_bold(*player_ptr, y, x, GB_SOLID_PERM);
+            place_bold(player, y, x, GB_SOLID_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -270,16 +265,16 @@ static void generate_gambling_arena(CreatureEntity &creature)
     }
 
     const auto pos = build_battle(creature);
-    if (!player_ptr->try_set_position(pos)) {
+    if (!player.try_set_position(pos)) {
         return;
     }
 
     const auto &melee_arena = MeleeArena::get_instance();
     for (auto i = 0; i < NUM_GLADIATORS; i++) {
         const auto &gladiator = melee_arena.get_gladiator(i);
-        const Pos2D m_pos(player_ptr->y + 8 + (i / 2) * 4, player_ptr->x - 2 + (i % 2) * 4);
+        const Pos2D m_pos(player.y + 8 + (i / 2) * 4, player.x - 2 + (i % 2) * 4);
         constexpr auto mode = PM_NO_KAGE | PM_NO_PET;
-        const auto m_idx = place_specific_monster(*player_ptr, m_pos.y, m_pos.x, gladiator.monrace_id, mode);
+        const auto m_idx = place_specific_monster(player, m_pos.y, m_pos.x, gladiator.monrace_id, mode);
         if (m_idx > 0) {
             floor.get_monster(*m_idx).set_friendly();
         }
@@ -292,7 +287,7 @@ static void generate_gambling_arena(CreatureEntity &creature)
         }
 
         monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
-        update_monster(*player_ptr, i, false);
+        update_monster(player, i, false);
     }
 }
 
@@ -302,12 +297,11 @@ static void generate_gambling_arena(CreatureEntity &creature)
  */
 static void generate_fixed_floor(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
-    auto &floor = *player_ptr->current_floor_ptr;
+    auto &floor = *player.current_floor_ptr;
     for (const auto &pos : floor.get_area()) {
-        place_bold(*player_ptr, pos.y, pos.x, GB_SOLID_PERM);
+        place_bold(player, pos.y, pos.x, GB_SOLID_PERM);
     }
 
     const auto &quests = QuestList::get_instance();
@@ -316,10 +310,10 @@ static void generate_fixed_floor(CreatureEntity &creature)
     floor.object_level = floor.base_level;
     floor.monster_level = floor.base_level;
     if (record_stair) {
-        exe_write_diary_quest(*player_ptr, DiaryKind::TO_QUEST, floor.quest_number);
+        exe_write_diary_quest(player, DiaryKind::TO_QUEST, floor.quest_number);
     }
 
-    get_mon_num_prep_enum(*player_ptr, floor.get_monrace_hook());
+    get_mon_num_prep_enum(player, floor.get_monrace_hook());
     init_flags = INIT_CREATE_DUNGEON;
     parse_fixed_map(creature, QUEST_DEFINITION_LIST, 0, 0, MAX_HGT, MAX_WID);
 }
@@ -332,8 +326,7 @@ static void generate_fixed_floor(CreatureEntity &creature)
  */
 static tl::optional<std::string> level_gen(CreatureEntity &creature, tl::optional<uint32_t> seed = tl::nullopt)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
     // 乱数種の保存と復元用
     Xoshiro128StarStar::state_type original_state{};
@@ -345,13 +338,13 @@ static tl::optional<std::string> level_gen(CreatureEntity &creature, tl::optiona
         original_state = rng.get_state(); // 現在の乱数状態を保存
         rng = Xoshiro128StarStar(*seed); // 指定された種で乱数を初期化
         seed_was_fixed = true;
-        msg_format_wizard(*player_ptr, CHEAT_DUNGEON,
+        msg_format_wizard(player, CHEAT_DUNGEON,
             _("乱数種を固定してフロア生成: 0x%08X", "Generating floor with fixed seed: 0x%08X"),
             *seed);
     }
 
     constexpr auto chance_small_floor = 10;
-    auto &floor = *player_ptr->current_floor_ptr;
+    auto &floor = *player.current_floor_ptr;
     const auto &dungeon = floor.get_generated_dungeon_definition();
     int level_height, level_width;
     if (dungeon.flags.has(DungeonFeatureType::ALWAY_MAX_SIZE)) {
@@ -388,7 +381,7 @@ static tl::optional<std::string> level_gen(CreatureEntity &creature, tl::optiona
     panel_row_min = floor.height;
     panel_col_min = floor.width;
 
-    auto result = cave_gen(*player_ptr, seed);
+    auto result = cave_gen(player, seed);
 
     // 乱数状態を復元
     if (seed_was_fixed) {
@@ -447,10 +440,9 @@ void wipe_generate_random_floor_flags(FloorType &floor)
  */
 void clear_cave(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
-    auto &floor = *player_ptr->current_floor_ptr;
+    auto &floor = *player.current_floor_ptr;
     floor.o_list.clear();
     floor.o_list.push_back(std::make_shared<ItemEntity>()); // 0番にダミーアイテムを用意
 
@@ -581,15 +573,14 @@ static bool floor_is_connected(const FloorType &floor, const IsWallFunc is_wall)
  */
 void generate_floor(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
-    auto *player_ptr = &player;
+    auto &player = creature;
 
-    auto &floor = *player_ptr->current_floor_ptr;
+    auto &floor = *player.current_floor_ptr;
     const auto is_wild_mode = AngbandWorld::get_instance().is_wild_mode();
     for (int num = 0; true; num++) {
         tl::optional<std::string> why;
         clear_cave(creature);
-        player_ptr->x = player_ptr->y = 0;
+        player.x = player.y = 0;
         if (floor.inside_arena) {
             generate_challenge_arena(creature);
         } else if (AngbandSystem::get_instance().is_phase_out()) {
@@ -606,8 +597,8 @@ void generate_floor(CreatureEntity &creature)
             why = level_gen(creature);
         }
 
-        if (player_ptr->is_sushi_eater()) {
-            alloc_object(*player_ptr, ALLOC_SET_BOTH, ALLOC_TYP_SUSHI, randnor(floor.width * floor.height / 20, 3));
+        if (player.is_sushi_eater()) {
+            alloc_object(player, ALLOC_SET_BOTH, ALLOC_TYP_SUSHI, randnor(floor.width * floor.height / 20, 3));
         }
 
         if (floor.o_list.size() >= MAX_FLOOR_ITEMS) {
@@ -636,10 +627,10 @@ void generate_floor(CreatureEntity &creature)
 
         msg_format(_("生成やり直し(%s)", "Generation restarted (%s)"), why->data());
         wipe_o_list(floor);
-        wipe_monsters_list(*player_ptr);
+        wipe_monsters_list(player);
     }
 
-    glow_deep_lava_and_bldg(*player_ptr);
+    glow_deep_lava_and_bldg(player);
     floor.enter_dungeon(false);
     wipe_generate_random_floor_flags(floor);
 }

--- a/src/inventory/inventory-util.cpp
+++ b/src/inventory/inventory-util.cpp
@@ -15,7 +15,6 @@
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
@@ -100,7 +99,7 @@ tl::optional<short> get_tag(CreatureEntity &creature, char tag, BIT_FLAGS mode, 
         return tl::nullopt;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &[start, end] = *range;
     tl::optional<short> i_idx;
     for (auto i = start; i < end; i++) {
@@ -146,7 +145,7 @@ bool get_item_okay(CreatureEntity &creature, OBJECT_IDX i, const ItemTester &ite
         return is_ring_slot(i);
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     return item_tester.okay(player.inventory[i].get());
 }
 
@@ -162,7 +161,7 @@ bool get_item_allow(CreatureEntity &creature, INVENTORY_IDX i_idx)
         return true;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     ItemEntity *o_ptr;
     if (i_idx >= 0) {
         o_ptr = player.inventory[i_idx].get();
@@ -206,7 +205,7 @@ INVENTORY_IDX label_to_equipment(CreatureEntity &creature, int c)
         return is_ring_slot(i) ? i : -1;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (!player.inventory[i]->bi_id) {
         return -1;
     }
@@ -226,7 +225,7 @@ INVENTORY_IDX label_to_inventory(CreatureEntity &creature, int c)
 {
     INVENTORY_IDX i = (INVENTORY_IDX)(islower(c) ? A2I(c) : -1);
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if ((i < 0) || (i > INVEN_PACK) || !player.inventory[i]->is_valid()) {
         return -1;
     }
@@ -243,7 +242,7 @@ INVENTORY_IDX label_to_inventory(CreatureEntity &creature, int c)
  */
 bool verify(CreatureEntity &creature, concptr prompt, INVENTORY_IDX i_idx)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &item = i_idx >= 0 ? *player.inventory[i_idx] : *creature.current_floor_ptr->o_list[0 - i_idx];
     const auto item_name = describe_flavor(player, item, 0);
     std::stringstream ss;

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -28,7 +28,6 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/target-checker.h"
 #include "term/z-form.h"
@@ -50,7 +49,7 @@
  */
 bool can_get_item(CreatureEntity &creature, const ItemTester &item_tester)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     for (int j = 0; j < INVEN_TOTAL; j++) {
         if (item_tester.okay(player.inventory[j].get())) {
             return true;
@@ -81,7 +80,7 @@ static bool query_pickup(std::string_view item_name)
 
 static void py_pickup_all_golds_on_floor(CreatureEntity &creature, const Grid &grid)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     for (auto it = grid.o_idx_list.begin(); it != grid.o_idx_list.end();) {
         const auto i_idx = *it++;
         auto &item = *player.current_floor_ptr->o_list[i_idx];
@@ -106,7 +105,7 @@ static void py_pickup_all_golds_on_floor(CreatureEntity &creature, const Grid &g
 
 static void py_pickup_single_item(CreatureEntity &creature, short i_idx, bool pickup)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto &item = *player.current_floor_ptr->o_list[i_idx];
     const auto item_name = describe_flavor(player, item, 0);
 
@@ -132,7 +131,7 @@ static void py_pickup_single_item(CreatureEntity &creature, short i_idx, bool pi
 
 static void py_pickup_multiple_items(CreatureEntity &creature, bool pickup)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &floor = *player.current_floor_ptr;
     const auto &grid = floor.get_grid(player.get_position());
 
@@ -169,7 +168,7 @@ static void py_pickup_multiple_items(CreatureEntity &creature, bool pickup)
  */
 static void py_pickup_floor(CreatureEntity &creature, bool pickup)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &o_list = player.current_floor_ptr->o_list;
     const auto exclude_marked_as_skip = ranges::views::remove_if([&](auto i_idx) { return o_list.at(i_idx)->marked.has(OmType::SUPRESS_MESSAGE); });
     const auto &grid = player.current_floor_ptr->get_grid(player.get_position());
@@ -209,7 +208,7 @@ static void py_pickup_floor(CreatureEntity &creature, bool pickup)
  */
 static void print_pickup_message(CreatureEntity &creature, [[maybe_unused]] const ItemEntity &picked_item, const ItemEntity &picked_slot_item, short slot)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto item_name = describe_flavor(player, picked_slot_item, 0);
     const auto item_name_with_label = fmt::format(_("{}({})", "{} ({})"), item_name, index_to_label(slot));
 
@@ -245,7 +244,7 @@ static void print_pickup_message(CreatureEntity &creature, [[maybe_unused]] cons
  */
 void process_player_pickup_item(CreatureEntity &creature, OBJECT_IDX o_idx)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     // delete_object_idx()で配列から削除した後にも使用するためshared_ptrをコピーする
     const std::shared_ptr<ItemEntity> picked_item_ptr = player.current_floor_ptr->o_list[o_idx];
 
@@ -275,7 +274,7 @@ void process_player_pickup_item(CreatureEntity &creature, OBJECT_IDX o_idx)
  */
 void carry(CreatureEntity &creature, bool pickup)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     verify_panel(creature);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -37,7 +37,6 @@
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "system/services/dungeon-service.h"
 #include "term/gameterm.h"
 #include "term/z-form.h"
@@ -59,7 +58,7 @@
  */
 static void dump_aux_pet(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
     auto pet = false;
     auto pet_settings = false;
@@ -138,7 +137,7 @@ static void dump_aux_quest(CreatureEntity &creature, FILE *fff)
  */
 static void dump_aux_last_message(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (!creature.is_dead()) {
         return;
     }
@@ -374,7 +373,7 @@ static void dump_aux_monsters(FILE *fff)
  */
 static void dump_aux_race_history(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (!player.old_race1 && !player.old_race2) {
         return;
     }
@@ -408,7 +407,7 @@ static void dump_aux_race_history(CreatureEntity &creature, FILE *fff)
  */
 static void dump_aux_realm_history(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (player.old_realm == 0) {
         return;
     }
@@ -431,7 +430,7 @@ static void dump_aux_realm_history(CreatureEntity &creature, FILE *fff)
  */
 static void dump_aux_virtues(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     fmt::println(fff, _("\n\n  [自分に関する情報]\n", "\n\n  [HP-rate & Max stat & Virtues]\n"));
 
 #ifdef JP
@@ -470,7 +469,7 @@ static void dump_aux_virtues(CreatureEntity &creature, FILE *fff)
  */
 static void dump_aux_mutations(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (player.muta.any()) {
         fmt::println(fff, _("\n\n  [突然変異]\n", "\n\n  [Mutations]\n"));
         dump_mutations(creature, fff);
@@ -484,7 +483,7 @@ static void dump_aux_mutations(CreatureEntity &creature, FILE *fff)
  */
 static void dump_aux_equipment_inventory(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (player.equip_cnt) {
         fmt::println(fff, _("  [キャラクタの装備]\n", "  [Character Equipment]\n"));
         for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
@@ -521,7 +520,7 @@ static void dump_aux_equipment_inventory(CreatureEntity &creature, FILE *fff)
  */
 static void dump_aux_home_museum(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &home = towns_info[1].get_store(StoreSaleType::HOME);
     if (home.stock_num) {
         fmt::println(fff, _("  [我が家のアイテム]", "  [Home Inventory]"));

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -29,7 +29,6 @@
 #include "system/dungeon/dungeon-definition.h"
 #include "system/floor/floor-info.h"
 #include "system/inner-game-data.h"
-#include "system/player-type-definition.h"
 #include "timed-effect/timed-effects.h"
 #include "world/world.h"
 
@@ -39,7 +38,7 @@
  */
 static void rd_realms(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     PlayerRealm pr(player);
     pr.reset();
 
@@ -66,7 +65,7 @@ static void rd_realms(CreatureEntity &creature)
  */
 void rd_base_info(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     creature.name = rd_string();
     if (creature.name.length() > 40) {
         creature.name.resize(40);
@@ -168,7 +167,7 @@ void rd_skills(CreatureEntity &creature)
 
 static void set_race(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     InnerGameData::get_instance().set_start_race(i2enum<PlayerRaceType>(rd_byte()));
     player.old_race1 = rd_u32b();
     player.old_race2 = rd_u32b();
@@ -340,7 +339,7 @@ static void rd_bad_status(CreatureEntity &creature)
 
 static void rd_energy(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     creature.energy_need = rd_s16b();
     player.enchant_energy_need = rd_s16b();
 }
@@ -447,7 +446,7 @@ static void rd_timed_effects(CreatureEntity &creature)
 
 static void rd_player_status(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     rd_base_status(creature);
     strip_bytes(24);
     creature.au = rd_s32b();
@@ -518,7 +517,7 @@ static void rd_player_status(CreatureEntity &creature)
 
 void rd_player_info(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     rd_player_status(creature);
     rd_special_attack(creature);
     rd_special_action(creature);

--- a/src/melee/melee-spell-flags-checker.cpp
+++ b/src/melee/melee-spell-flags-checker.cpp
@@ -20,14 +20,13 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "target/projection-path-calculator.h"
 #include "util/bit-flags-calculator.h"
 #include <iterator>
 
 static void decide_melee_spell_target(CreatureEntity &creature, melee_spell_type *ms_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if ((player.pet_t_m_idx == 0) || !ms_ptr->pet) {
         return;
     }
@@ -56,7 +55,7 @@ static void decide_indirection_melee_spell(CreatureEntity &creature, melee_spell
 
     ms_ptr->t_ptr = &floor.get_monster(ms_ptr->target_idx);
     const auto &monster_to = *ms_ptr->t_ptr;
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if ((ms_ptr->m_idx == ms_ptr->target_idx) || ((ms_ptr->target_idx != player.pet_t_m_idx) && !monster_from.is_hostile_to_melee(monster_to))) {
         ms_ptr->target_idx = 0;
         return;
@@ -216,7 +215,7 @@ static void check_melee_spell_rocket(CreatureEntity &creature, melee_spell_type 
 
 static void check_melee_spell_beam(CreatureEntity &creature, melee_spell_type *ms_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (ms_ptr->ability_flags.has_none_of(RF_ABILITY_BEAM_MASK) || direct_beam(player, *ms_ptr->m_ptr, ms_ptr->t_ptr->get_position())) {
         return;
     }
@@ -230,7 +229,7 @@ static void check_melee_spell_breath(CreatureEntity &creature, melee_spell_type 
         return;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     POSITION rad = ms_ptr->r_ptr->misc_flags.has(MonsterMiscType::POWERFUL) ? 3 : 2;
     if (!breath_direct(player, ms_ptr->m_ptr->get_position(), ms_ptr->t_ptr->get_position(), rad, AttributeType::NONE, true)) {
         ms_ptr->ability_flags.reset(RF_ABILITY_BREATH_MASK);
@@ -255,7 +254,7 @@ static void check_melee_spell_special(CreatureEntity &creature, melee_spell_type
         return;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (ms_ptr->m_ptr->r_idx == MonraceId::ROLENTO) {
         if ((player.pet_extra_flags & (PF_ATTACK_SPELL | PF_SUMMON_SPELL)) != (PF_ATTACK_SPELL | PF_SUMMON_SPELL)) {
             ms_ptr->ability_flags.reset(MonsterAbilityType::SPECIAL);
@@ -290,7 +289,7 @@ static void check_pet(CreatureEntity &creature, melee_spell_type *ms_ptr)
         return;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     ms_ptr->ability_flags.reset({ MonsterAbilityType::SHRIEK, MonsterAbilityType::DARKNESS, MonsterAbilityType::TRAPS });
     if (!(player.pet_extra_flags & PF_TELEPORT)) {
         ms_ptr->ability_flags.reset({ MonsterAbilityType::BLINK, MonsterAbilityType::TPORT, MonsterAbilityType::TELE_TO, MonsterAbilityType::TELE_AWAY, MonsterAbilityType::TELE_LEVEL });
@@ -320,7 +319,7 @@ static void check_non_stupid(CreatureEntity &creature, melee_spell_type *ms_ptr)
         return;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (ms_ptr->ability_flags.has_any_of(RF_ABILITY_BOLT_MASK) && !clean_shot(player, ms_ptr->m_ptr->y, ms_ptr->m_ptr->x, ms_ptr->t_ptr->y, ms_ptr->t_ptr->x, ms_ptr->pet)) {
         ms_ptr->ability_flags.reset(RF_ABILITY_BOLT_MASK);
     }
@@ -366,7 +365,7 @@ static bool set_melee_spell_set(CreatureEntity &creature, melee_spell_type *ms_p
 
     EnumClassFlagGroup<MonsterAbilityType>::get_flags(ms_ptr->ability_flags, std::back_inserter(ms_ptr->spells));
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     return !ms_ptr->spells.empty() && player.playing && !creature.is_dead() && !player.leaving;
 }
 

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -31,7 +31,6 @@
 #include "system/dungeon/dungeon-definition.h"
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "tracking/health-bar-tracker.h"
 #include "util/string-processor.h"
@@ -81,7 +80,7 @@ static void process_blow_effect(CreatureEntity &creature, mam_type *mam_ptr)
 
 static void aura_fire_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto &monrace = mam_ptr->m_ptr->get_monrace();
     auto &monrace_target = mam_ptr->t_ptr->get_monrace();
     if (monrace_target.aura_flags.has_not(MonsterAuraType::FIRE) || !mam_ptr->m_ptr->is_valid()) {
@@ -108,7 +107,7 @@ static void aura_fire_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
 
 static void aura_cold_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &monster = *mam_ptr->m_ptr;
     auto &monrace = monster.get_monrace();
     auto &monrace_target = mam_ptr->t_ptr->get_monrace();
@@ -136,7 +135,7 @@ static void aura_cold_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
 
 static void aura_elec_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &monster = *mam_ptr->m_ptr;
     auto &monrace = monster.get_monrace();
     auto &monrace_target = mam_ptr->t_ptr->get_monrace();
@@ -262,7 +261,7 @@ static void process_melee(CreatureEntity &creature, mam_type *mam_ptr)
 static void thief_runaway_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
 {
     if (creature.is_player()) {
-        auto &player = static_cast<PlayerType &>(creature);
+        auto &player = creature;
         if (SpellHex(player).check_hex_barrier(mam_ptr->m_idx, HEX_ANTI_TELE)) {
             if (mam_ptr->see_m) {
                 msg_print(_("泥棒は笑って逃げ...ようとしたがバリアに防がれた。", "The thief flees laughing...? But a magic barrier obstructs it."));
@@ -290,7 +289,7 @@ static void explode_monster_by_melee(CreatureEntity &creature, mam_type *mam_ptr
     if (!creature.is_player()) {
         return;
     }
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
 
     sound(SoundKind::EXPLODE);
     (void)set_monster_invulner(*creature.current_floor_ptr, mam_ptr->m_idx, 0, false);
@@ -329,7 +328,7 @@ static void repeat_melee(CreatureEntity &creature, mam_type *mam_ptr)
         if (!creature.is_player() || mam_ptr->do_silly_attack) {
             continue;
         }
-        auto &player = static_cast<PlayerType &>(creature);
+        auto &player = creature;
         if (!is_original_ap_and_seen(player, *mam_ptr->m_ptr)) {
             continue;
         }
@@ -370,7 +369,7 @@ bool monst_attack_monst(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX
     }
 
     if (creature.is_player() && mam_ptr->m_ptr->is_riding()) {
-        auto &player = static_cast<PlayerType &>(creature);
+        auto &player = creature;
         disturb(player, true, true);
     }
 

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -44,7 +44,6 @@
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "system/terrain/terrain-definition.h"
 #include "target/projection-path-calculator.h"
@@ -92,7 +91,7 @@ bool kawarimi(CreatureEntity &creature, bool success)
     }
 
     const auto p_pos_orig = creature.get_position(); //!< @details 元の位置に変わり身を置く.
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     teleport_player(player, 10 + randint1(90), TELEPORT_SPONTANEOUS);
     constexpr auto sv_wooden_statue = 0;
     ItemEntity item({ ItemKindType::STATUE, sv_wooden_statue });
@@ -143,7 +142,7 @@ bool rush_attack(CreatureEntity &creature, bool *mdeath)
         return true;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto *player_ptr = &player;
     auto p_pos_new = p_pos;
     auto tmp_mdeath = false;
@@ -205,7 +204,7 @@ bool rush_attack(CreatureEntity &creature, bool *mdeath)
  */
 void process_surprise_attack(CreatureEntity &creature, player_attack_type *pa_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto *player_ptr = &player;
 
     const auto &monrace = pa_ptr->m_ptr->get_monrace();
@@ -281,7 +280,7 @@ void calc_surprise_attack_damage(CreatureEntity &creature, player_attack_type *p
  */
 bool hayagake(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto *player_ptr = &player;
     PlayerEnergy energy(creature);
     if (player_ptr->action == ACTION_HAYAGAKE) {
@@ -312,7 +311,7 @@ bool set_superstealth(CreatureEntity &creature, bool set)
 {
     bool notice = false;
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto *player_ptr = &player;
 
     auto ninja_data = CreatureClass(creature).get_specific_data<ninja_data_type>();
@@ -362,7 +361,7 @@ bool set_superstealth(CreatureEntity &creature, bool set)
  */
 bool cast_ninja_spell(CreatureEntity &creature, MindNinjaType spell)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto *player_ptr = &player;
     PLAYER_LEVEL plev = creature.level;
     auto ninja_data = CreatureClass(creature).get_specific_data<ninja_data_type>();

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -30,7 +30,6 @@
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"
@@ -272,7 +271,7 @@ static void hissatsu_lightning_eagle(CreatureEntity &creature, samurai_slaying_t
  */
 static void hissatsu_bloody_maelstroem(CreatureEntity &creature, samurai_slaying_type *samurai_slaying_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &player_cut = player.effects()->cut();
     if ((samurai_slaying_ptr->mode == HISSATSU_SEKIRYUKA) && player_cut.is_cut() && samurai_slaying_ptr->m_ptr->has_living_flag()) {
         auto tmp = std::min<short>(100, std::max<short>(10, player_cut.current() / 10));
@@ -344,7 +343,7 @@ MULTIPLY mult_hissatsu(CreatureEntity &creature, MULTIPLY mult, const TrFlags &f
 
 void concentration(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     int max_csp = std::max(player.msp * 4, player.level * 5 + 5);
 
     if (total_friends) {
@@ -374,7 +373,7 @@ void concentration(CreatureEntity &creature)
  */
 bool choose_samurai_stance(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     char choice;
 
     if (cmd_limit_confused(player)) {
@@ -465,7 +464,7 @@ bool choose_samurai_stance(CreatureEntity &creature)
  */
 int calc_attack_quality(CreatureEntity &creature, player_attack_type *pa_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto *o_ptr = player.inventory[INVEN_MAIN_HAND + pa_ptr->hand].get();
     int bonus = player.to_h[pa_ptr->hand] + o_ptr->to_h;
     int chance = (player.skill_thn + (bonus * BTH_PLUS_ADJ));
@@ -496,7 +495,7 @@ int calc_attack_quality(CreatureEntity &creature, player_attack_type *pa_ptr)
  */
 void mineuchi(CreatureEntity &creature, player_attack_type *pa_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (pa_ptr->mode != HISSATSU_MINEUCHI) {
         return;
     }
@@ -528,7 +527,7 @@ void mineuchi(CreatureEntity &creature, player_attack_type *pa_ptr)
  */
 void musou_counterattack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto is_musou = CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU);
     if ((!player.counter && !is_musou) || !monap_ptr->alive || player.is_dead() || !monap_ptr->m_ptr->get_monster_profile().ml || (player.csp <= 7)) {
         return;

--- a/src/mspell/mspell-floor.cpp
+++ b/src/mspell/mspell-floor.cpp
@@ -35,7 +35,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
@@ -51,7 +50,7 @@
  */
 MonsterSpellResult spell_RF4_SHRIEK(MONSTER_IDX m_idx, CreatureEntity &creature, MONSTER_IDX t_idx, int target_type)
 {
-    auto &player_ptr = static_cast<PlayerType &>(creature);
+    auto &player_ptr = creature;
     mspell_cast_msg_simple msg(_("%s^がかん高い金切り声をあげた。", "%s^ makes a high pitched shriek."),
         _("%s^が%sに向かって叫んだ。", "%s^ shrieks at %s."));
 
@@ -82,7 +81,7 @@ MonsterSpellResult spell_RF4_SHRIEK(MONSTER_IDX m_idx, CreatureEntity &creature,
  */
 MonsterSpellResult spell_RF6_WORLD(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    auto &player_ptr = static_cast<PlayerType &>(creature);
+    auto &player_ptr = creature;
     disturb(player_ptr, true, true);
     (void)set_monster_timewalk(player_ptr, m_idx, randint1(2) + 2, true);
 
@@ -100,7 +99,7 @@ MonsterSpellResult spell_RF6_WORLD(CreatureEntity &creature, MONSTER_IDX m_idx)
  */
 MonsterSpellResult spell_RF6_BLINK(CreatureEntity &creature, MONSTER_IDX m_idx, int target_type, bool is_quantum_effect)
 {
-    auto &player_ptr = static_cast<PlayerType &>(creature);
+    auto &player_ptr = creature;
     const auto res = MonsterSpellResult::make_valid();
     const auto m_name = monster_name(player_ptr, m_idx);
 
@@ -138,7 +137,7 @@ MonsterSpellResult spell_RF6_BLINK(CreatureEntity &creature, MONSTER_IDX m_idx, 
  */
 MonsterSpellResult spell_RF6_TPORT(CreatureEntity &creature, MONSTER_IDX m_idx, int target_type)
 {
-    auto &player_ptr = static_cast<PlayerType &>(creature);
+    auto &player_ptr = creature;
     const auto res = MonsterSpellResult::make_valid();
     const auto m_name = monster_name(player_ptr, m_idx);
 
@@ -172,7 +171,7 @@ MonsterSpellResult spell_RF6_TPORT(CreatureEntity &creature, MONSTER_IDX m_idx, 
  */
 MonsterSpellResult spell_RF6_TELE_TO(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &player_ptr = static_cast<PlayerType &>(creature);
+    auto &player_ptr = creature;
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
@@ -244,7 +243,7 @@ MonsterSpellResult spell_RF6_TELE_TO(CreatureEntity &creature, MONSTER_IDX m_idx
  */
 MonsterSpellResult spell_RF6_TELE_AWAY(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &player_ptr = static_cast<PlayerType &>(creature);
+    auto &player_ptr = creature;
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
@@ -327,7 +326,7 @@ MonsterSpellResult spell_RF6_TELE_AWAY(CreatureEntity &creature, MONSTER_IDX m_i
  */
 MonsterSpellResult spell_RF6_TELE_LEVEL(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &player_ptr = static_cast<PlayerType &>(creature);
+    auto &player_ptr = creature;
     const auto res = MonsterSpellResult::make_valid();
 
     const auto &floor = *player_ptr.current_floor_ptr;
@@ -386,7 +385,7 @@ MonsterSpellResult spell_RF6_TELE_LEVEL(CreatureEntity &creature, MONSTER_IDX m_
  */
 MonsterSpellResult spell_RF6_DARKNESS(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &player_ptr = static_cast<PlayerType &>(creature);
+    auto &player_ptr = creature;
     const Pos2D pos(y, x);
     mspell_cast_msg_blind msg;
     concptr msg_done;
@@ -463,7 +462,7 @@ MonsterSpellResult spell_RF6_DARKNESS(CreatureEntity &creature, POSITION y, POSI
  */
 MonsterSpellResult spell_RF6_TRAPS(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx)
 {
-    auto &player_ptr = static_cast<PlayerType &>(creature);
+    auto &player_ptr = creature;
     const auto m_name = monster_name(player_ptr, m_idx);
     disturb(player_ptr, true, true);
 
@@ -492,7 +491,7 @@ MonsterSpellResult spell_RF6_TRAPS(CreatureEntity &creature, POSITION y, POSITIO
  */
 MonsterSpellResult spell_RF6_RAISE_DEAD(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &player_ptr = static_cast<PlayerType &>(creature);
+    auto &player_ptr = creature;
     const auto &monster = player_ptr.current_floor_ptr->get_monster(m_idx);
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が死者復活の呪文を唱えた。", "%s^ casts a spell to revive corpses."), _("%s^が死者復活の呪文を唱えた。", "%s^ casts a spell to revive corpses."));

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -28,7 +28,6 @@
 #include "status/action-setter.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -43,7 +42,7 @@ bool CreatureClass::equals(PlayerClassType type) const
     if (!this->creature.is_player()) {
         return false;
     }
-    auto &player = static_cast<PlayerType &>(this->creature);
+    auto &player = this->creature;
     return player.pclass == type;
 }
 
@@ -55,7 +54,7 @@ TrFlags CreatureClass::tr_flags() const
     if (!this->creature.is_player()) {
         return TrFlags();
     }
-    auto &player = static_cast<PlayerType &>(this->creature);
+    auto &player = this->creature;
 
     TrFlags flags;
     const auto plev = player.level;
@@ -235,7 +234,7 @@ TrFlags CreatureClass::stance_tr_flags() const
     if (!this->creature.is_player()) {
         return TrFlags();
     }
-    auto &player = static_cast<PlayerType &>(this->creature);
+    auto &player = this->creature;
 
     TrFlags flags;
 
@@ -285,7 +284,7 @@ bool CreatureClass::has_stun_immunity() const
     if (!this->creature.is_player()) {
         return false;
     }
-    auto &player = static_cast<PlayerType &>(this->creature);
+    auto &player = this->creature;
     return this->equals(PlayerClassType::BERSERKER) && (player.level > 34);
 }
 
@@ -294,7 +293,7 @@ bool CreatureClass::has_poison_resistance() const
     if (!this->creature.is_player()) {
         return false;
     }
-    auto &player = static_cast<PlayerType &>(this->creature);
+    auto &player = this->creature;
     return this->equals(PlayerClassType::NINJA) && (player.level > 44);
 }
 
@@ -412,7 +411,7 @@ bool CreatureClass::lose_balance()
     if (!this->creature.is_player()) {
         return false;
     }
-    auto &player = static_cast<PlayerType &>(this->creature);
+    auto &player = this->creature;
     if (player.pclass != PlayerClassType::SAMURAI) {
         return false;
     }
@@ -517,7 +516,7 @@ void CreatureClass::init_specific_data()
     if (!this->creature.is_player()) {
         return;
     }
-    auto &player = static_cast<PlayerType &>(this->creature);
+    auto &player = this->creature;
 
     switch (player.pclass) {
     case PlayerClassType::SMITH:
@@ -568,7 +567,7 @@ bool CreatureClass::has_ninja_speed() const
     if (!this->creature.is_player()) {
         return false;
     }
-    auto &player = static_cast<PlayerType &>(this->creature);
+    auto &player = this->creature;
 
     auto has_ninja_speed_main = !player.inventory[INVEN_MAIN_HAND]->is_valid();
     has_ninja_speed_main |= can_attack_with_main_hand(player);

--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -30,7 +30,6 @@
 #include "system/floor/town-list.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "wizard/wizard-messages.h"
 
 /*
@@ -101,7 +100,7 @@ void set_boundaries(CreatureEntity &creature, const Pos2D &pos)
  */
 static void build_bubble_vault(CreatureEntity &creature, const Pos2D &pos0, const Pos2DVec &vec)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     msg_print_wizard(player, CHEAT_DUNGEON, _("泡型ランダムVaultを生成しました。", "Bubble-shaped Vault."));
     auto center_points = create_bubbles_center(vec);
 
@@ -172,7 +171,7 @@ static void build_bubble_vault(CreatureEntity &creature, const Pos2D &pos0, cons
 /* Create a random vault that looks like a collection of overlapping rooms */
 static void build_room_vault(CreatureEntity &creature, const Pos2D &center, const Pos2DVec &vec)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const Pos2DVec vec_half(vec.y / 2, vec.x / 2);
     msg_print_wizard(player, CHEAT_DUNGEON, _("部屋型ランダムVaultを生成しました。", "Room Vault."));
 
@@ -212,7 +211,7 @@ static void build_room_vault(CreatureEntity &creature, const Pos2D &center, cons
 /* Create a random vault out of a fractal grid */
 static void build_cave_vault(CreatureEntity &creature, const Pos2D &center, const Pos2DVec &vec)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     /* round to make sizes even */
     const Pos2DVec vec_half(vec.y / 2, vec.x / 2);
     const auto xsize = vec_half.x * 2;
@@ -302,7 +301,7 @@ static Pos2D coord_trans(const Pos2D &pos_initial, const Pos2DVec &offset, int t
  */
 void build_vault(vault_type &vault, CreatureEntity &creature, POSITION yval, POSITION xval, POSITION ymax, POSITION xmax, concptr data, POSITION xoffset, POSITION yoffset, int transno)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     /* Place dungeon features and objects */
     auto &floor = *creature.current_floor_ptr;
     auto t = data;
@@ -567,7 +566,7 @@ void build_vault(vault_type &vault, CreatureEntity &creature, POSITION yval, POS
  */
 static void build_target_vault(CreatureEntity &creature, const Pos2D &center, const Pos2DVec &vec)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     /* Make a random metric */
     const auto h1 = randint1(32) - 16;
     const auto h2 = randint1(16);
@@ -664,7 +663,7 @@ static void build_target_vault(CreatureEntity &creature, const Pos2D &center, co
  */
 static void build_elemental_vault(CreatureEntity &creature, const Pos2D &center, const Pos2DVec &vec)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     msg_print_wizard(player, CHEAT_DUNGEON, _("精霊界ランダムVaultを生成しました。", "Elemental Vault"));
 
     /* round to make sizes even */
@@ -737,7 +736,7 @@ static void build_elemental_vault(CreatureEntity &creature, const Pos2D &center,
  */
 static void build_mini_c_vault(CreatureEntity &creature, const Pos2D &center, const Pos2DVec &vec)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     msg_print_wizard(player, CHEAT_DUNGEON, _("小型チェッカーランダムVaultを生成しました。", "Mini Checker Board Vault."));
 
     /* Pick a random room size */
@@ -847,7 +846,7 @@ static void build_mini_c_vault(CreatureEntity &creature, const Pos2D &center, co
  */
 static void build_castle_vault(CreatureEntity &creature, const Pos2D &center, const Pos2DVec &vec)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     /* Pick a random room size */
     const Pos2DVec vec_half(vec.y / 2 - 1, vec.x / 2 - 1);
     const Rect2D area(center, vec_half);
@@ -874,7 +873,7 @@ static void build_castle_vault(CreatureEntity &creature, const Pos2D &center, co
  */
 bool build_type10(CreatureEntity &creature, DungeonData *dd_ptr)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
     const auto xsize = randint1(22) + 22;
     const auto ysize = randint1(11) + 11;
@@ -932,7 +931,7 @@ bool build_type10(CreatureEntity &creature, DungeonData *dd_ptr)
  */
 bool build_fixed_room(CreatureEntity &creature, DungeonData *dd_ptr, int typ, bool more_space, int id = -1)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     int result;
 
     ProbabilityTable<int> prob_table;

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -20,7 +20,6 @@
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "system/terrain/terrain-definition.h"
 #include "tracking/lore-tracker.h"
@@ -37,7 +36,7 @@
  */
 static bool detect_feat_flag(CreatureEntity &creature, POSITION range, TerrainCharacteristics flag, bool known)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto &floor = *player.current_floor_ptr;
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
@@ -86,7 +85,7 @@ static bool detect_feat_flag(CreatureEntity &creature, POSITION range, TerrainCh
  */
 bool detect_traps(CreatureEntity &creature, POSITION range, bool known)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     bool detect = detect_feat_flag(creature, range, TerrainCharacteristics::TRAP, known);
     if (!known && detect) {
         detect_feat_flag(creature, range, TerrainCharacteristics::TRAP, true);
@@ -115,7 +114,7 @@ bool detect_traps(CreatureEntity &creature, POSITION range, bool known)
  */
 bool detect_doors(CreatureEntity &creature, POSITION range)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     bool detect = detect_feat_flag(creature, range, TerrainCharacteristics::DOOR, true);
 
     if (music_singing(player, MUSIC_DETECT) && get_singing_count(player) > 0) {
@@ -136,7 +135,7 @@ bool detect_doors(CreatureEntity &creature, POSITION range)
  */
 bool detect_stairs(CreatureEntity &creature, POSITION range)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     bool detect = detect_feat_flag(creature, range, TerrainCharacteristics::STAIRS, true);
 
     if (music_singing(player, MUSIC_DETECT) && get_singing_count(player) > 0) {
@@ -157,7 +156,7 @@ bool detect_stairs(CreatureEntity &creature, POSITION range)
  */
 bool detect_treasure(CreatureEntity &creature, POSITION range)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     bool detect = detect_feat_flag(creature, range, TerrainCharacteristics::HAS_GOLD, true);
 
     if (music_singing(player, MUSIC_DETECT) && get_singing_count(player) > 6) {
@@ -177,7 +176,7 @@ bool detect_treasure(CreatureEntity &creature, POSITION range)
  */
 bool detect_objects_gold(CreatureEntity &creature, POSITION range)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     POSITION range2 = range;
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
@@ -229,7 +228,7 @@ bool detect_objects_gold(CreatureEntity &creature, POSITION range)
  */
 bool detect_objects_normal(CreatureEntity &creature, POSITION range)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     POSITION range2 = range;
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
@@ -338,7 +337,7 @@ bool detect_objects_magic(CreatureEntity &creature, POSITION range)
  */
 bool detect_monsters_normal(CreatureEntity &creature, POSITION range)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
@@ -383,7 +382,7 @@ bool detect_monsters_normal(CreatureEntity &creature, POSITION range)
  */
 bool detect_monsters_invis(CreatureEntity &creature, POSITION range)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
@@ -582,7 +581,7 @@ bool detect_monsters_mind(CreatureEntity &creature, POSITION range)
  */
 bool detect_monsters_string(CreatureEntity &creature, POSITION range, concptr Match)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -34,7 +34,6 @@
 #include "system/floor/wilderness-grid.h"
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "system/services/dungeon-service.h"
 #include "target/projection-path-calculator.h"
@@ -61,7 +60,7 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
         return;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     std::string m_name;
     auto see_m = true;
     auto &floor = *player.current_floor_ptr;
@@ -226,7 +225,7 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
 
 bool teleport_level_other(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
 
     const auto pos = target_set(creature, TARGET_KILL).get_position();
     if (!pos) {
@@ -271,7 +270,7 @@ bool tele_town(CreatureEntity &creature)
         return false;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (player.current_floor_ptr->is_underground()) {
         msg_print(_("この魔法は地上でしか使えない！", "This spell can only be used on the surface!"));
         return false;
@@ -349,7 +348,7 @@ void reserve_alter_reality(CreatureEntity &creature, TIME_EFFECT turns)
         return;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (player.current_floor_ptr->inside_arena || ironman_downward) {
         msg_print(_("何も起こらなかった。", "Nothing happens."));
         return;
@@ -433,7 +432,7 @@ bool recall_player(CreatureEntity &creature, TIME_EFFECT turns)
         return true;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &floor = *player.current_floor_ptr;
     if (floor.inside_arena || ironman_downward) {
         msg_print(_("何も起こらなかった。", "Nothing happens."));
@@ -489,7 +488,7 @@ bool free_level_recall(CreatureEntity &creature)
         return false;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto select_dungeon = choose_dungeon(_("にテレポート", "teleport"), 4, 0);
     if (!select_dungeon) {
         return false;
@@ -536,7 +535,7 @@ bool reset_recall(CreatureEntity &creature)
         return false;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto select_dungeon = choose_dungeon(_("をセット", "reset"), 2, 14);
     if (ironman_downward) {
         msg_print(_("何も起こらなかった。", "Nothing happens."));

--- a/src/status/body-improvement.cpp
+++ b/src/status/body-improvement.cpp
@@ -9,7 +9,6 @@
 #include "realm/realm-song-numbers.h"
 #include "spell-realm/spells-song.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
@@ -85,7 +84,7 @@ void BodyImprovement::set_protection(short v, bool is_decrease)
  */
 bool set_invuln(CreatureEntity &creature, short v, bool do_dec)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     bool notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
@@ -150,7 +149,7 @@ bool set_invuln(CreatureEntity &creature, short v, bool do_dec)
  */
 bool set_tim_regen(CreatureEntity &creature, short v, bool do_dec)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     bool notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
@@ -199,7 +198,7 @@ bool set_tim_regen(CreatureEntity &creature, short v, bool do_dec)
  */
 bool set_tim_reflect(CreatureEntity &creature, short v, bool do_dec)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     bool notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
@@ -248,7 +247,7 @@ bool set_tim_reflect(CreatureEntity &creature, short v, bool do_dec)
  */
 bool set_pass_wall(CreatureEntity &creature, short v, bool do_dec)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     bool notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
@@ -297,7 +296,7 @@ bool set_pass_wall(CreatureEntity &creature, short v, bool do_dec)
  */
 bool set_tim_emission(CreatureEntity &creature, short v, bool do_dec)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
@@ -346,7 +345,7 @@ bool set_tim_emission(CreatureEntity &creature, short v, bool do_dec)
  */
 bool set_tim_exorcism(CreatureEntity &creature, short v, bool do_dec)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     auto notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -17,6 +17,7 @@
 #include "realm/realm-song-numbers.h"
 #include "system/angband-system.h"
 #include "system/floor/floor-info.h"
+#include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
@@ -30,6 +31,17 @@
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
 #include <range/v3/algorithm.hpp>
+
+bool CreatureEntity::try_set_position(const Pos2D &pos)
+{
+    if (this->current_floor_ptr->get_grid(pos).has_monster()) {
+        return false;
+    }
+
+    this->y = pos.y;
+    this->x = pos.x;
+    return true;
+}
 
 bool CreatureEntity::check_sub_alignments(const byte sub_align1, const byte sub_align2)
 {

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -290,6 +290,21 @@ public:
     virtual int get_ac() const;
 
     /*!
+     * @brief セーブフロアに滞在中かどうか
+     * @return floor_id が 0 でなければ true
+     */
+    bool in_saved_floor() const
+    {
+        return this->floor_id != 0;
+    }
+
+    /*!
+     * @brief モンスターがいない場合にのみ位置を設定する
+     * @return 設定できた場合 true
+     */
+    bool try_set_position(const Pos2D &pos);
+
+    /*!
      * @brief クリーチャーが所属するフロアを取得
      * @return フロアへのポインタ
      */

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -101,26 +101,10 @@ bool PlayerType::is_located_at_running_destination() const
  * @param pos 配置先座標
  * @return 配置に成功したらTRUE
  */
-bool PlayerType::try_set_position(const Pos2D &pos)
-{
-    if (this->current_floor_ptr->get_grid(pos).has_monster()) {
-        return false;
-    }
-
-    this->y = pos.y;
-    this->x = pos.x;
-    return true;
-}
-
 void PlayerType::set_position(const Pos2D &pos)
 {
     this->y = pos.y;
     this->x = pos.x;
-}
-
-bool PlayerType::in_saved_floor() const
-{
-    return this->floor_id != 0;
 }
 
 bool PlayerType::try_resist_eldritch_horror() const

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -12,9 +12,7 @@ public:
     void ride_monster(MONSTER_IDX m_idx);
     bool is_fully_healthy() const;
     bool is_located_at_running_destination() const;
-    bool try_set_position(const Pos2D &pos);
     void set_position(const Pos2D &pos);
-    bool in_saved_floor() const;
     bool try_resist_eldritch_horror() const;
 
     bool is_valid() const override;

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -268,7 +268,7 @@ static void print_pet_list(CreatureEntity &creature, const std::vector<MONSTER_I
  */
 void fix_monster_list(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     static std::vector<MONSTER_IDX> monster_list;
     std::once_flag once;
 
@@ -290,7 +290,7 @@ void fix_monster_list(CreatureEntity &creature)
  */
 void fix_pet_list(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     display_sub_windows(SubWindowRedrawingFlag::PETS,
         [&player, &creature] {
             const auto &[wid, hgt] = term_get_size();
@@ -309,7 +309,7 @@ static void display_equipment(CreatureEntity &creature, const ItemTester &item_t
         return;
     }
 
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &[wid, hgt] = term_get_size();
     byte attr = TERM_WHITE;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
@@ -501,7 +501,7 @@ void fix_dungeon(CreatureEntity &creature)
  */
 void fix_monster(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     if (!LoreTracker::get_instance().is_tracking()) {
         return;
     }
@@ -551,7 +551,7 @@ static bool is_seeing_monster_on(const FloorType &floor, const Grid &grid)
  */
 static void display_floor_item_list(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &[wid, hgt] = term_get_size();
     if (hgt <= 0) {
         return;
@@ -637,7 +637,7 @@ void fix_floor_item_list(CreatureEntity &creature, const Pos2D &pos)
  */
 static void display_found_item_list(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     const auto &[wid, hgt] = term_get_size();
     if (hgt <= 0) {
         return;
@@ -720,7 +720,7 @@ void fix_found_item_list(CreatureEntity &creature)
  */
 static void display_spell_list(CreatureEntity &creature)
 {
-    auto &player = static_cast<PlayerType &>(creature);
+    auto &player = creature;
     TERM_LEN y, x;
     int m[9]{};
 


### PR DESCRIPTION
floor-changer.cpp, floor-generator.cpp, cave-generator.cpp, spells-detection.cpp, mspell-floor.cpp, rooms-vault.cpp, player-class.cpp, melee-spell-flags-checker.cpp, character-dump.cpp, player-inventory.cpp, display-sub-windows.cpp, spells-world.cpp, monster-attack-monster.cpp, cmd-eat.cpp, body-improvement.cpp, mind-samurai.cpp, mind-ninja.cpp, cmd-item.cpp, cmd-destroy.cpp, cmd-move.cpp, open-close-execution.cpp, player-info-loader.cpp, inventory-util.cpp などの不要な static_cast<PlayerType> を削除。

in_saved_floor(), try_set_position() を CreatureEntity に昇格。