### PR TITLE
refactor: player-type-definition.h の不要インクルードを171ファイルから削除（Phase 8）

### DIFF
--- a/src/achievement/achievement-checker.cpp
+++ b/src/achievement/achievement-checker.cpp
@@ -11,7 +11,6 @@
 #include "system/creature-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 namespace AchievementChecker {
 

--- a/src/achievement/achievement-tracker.cpp
+++ b/src/achievement/achievement-tracker.cpp
@@ -9,7 +9,6 @@
 #include "achievement/achievement-definitions.h"
 #include "core/stuff-handler.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"

--- a/src/action/racial-execution.cpp
+++ b/src/action/racial-execution.cpp
@@ -16,7 +16,6 @@
 #include "racial/racial-util.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"

--- a/src/alliance/alliance-amber.cpp
+++ b/src/alliance/alliance-amber.cpp
@@ -4,7 +4,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 int AllianceAmber::calcImpressionPoint(const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-angartha.cpp
+++ b/src/alliance/alliance-angartha.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 int AllianceAngartha::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-anor-londo.cpp
+++ b/src/alliance/alliance-anor-londo.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 /*!
  * @brief アノール・ロンドのアライアンス印象値を計算する

--- a/src/alliance/alliance-arioch.cpp
+++ b/src/alliance/alliance-arioch.cpp
@@ -1,6 +1,5 @@
 #include "alliance/alliance-arioch.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 
 int AllianceArioch::calcImpressionPoint(const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-aryan-family.cpp
+++ b/src/alliance/alliance-aryan-family.cpp
@@ -4,7 +4,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 int AllianceAryanFamily::calcImpressionPoint(const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-ashina-clan.cpp
+++ b/src/alliance/alliance-ashina-clan.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 int AllianceAshinaClan::calcImpressionPoint(const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-avarin-lords.cpp
+++ b/src/alliance/alliance-avarin-lords.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 int AllianceAvarinLords::calcImpressionPoint(const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-basam-empire.cpp
+++ b/src/alliance/alliance-basam-empire.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 int AllianceBasamEmpire::calcImpressionPoint(const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-binzyou-buddhism.cpp
+++ b/src/alliance/alliance-binzyou-buddhism.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 int AllianceBinzyouBuddhism::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-boletaria.cpp
+++ b/src/alliance/alliance-boletaria.cpp
@@ -5,7 +5,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 /*!
  * @brief ボーレタリアのアライアンス印象値を計算する

--- a/src/alliance/alliance-chardros.cpp
+++ b/src/alliance/alliance-chardros.cpp
@@ -1,6 +1,5 @@
 #include "alliance/alliance-chardros.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 
 int AllianceChardros::calcImpressionPoint(const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-chinchintei.cpp
+++ b/src/alliance/alliance-chinchintei.cpp
@@ -3,7 +3,6 @@
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 int AllianceChinChinTei::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-cookie-grandma.cpp
+++ b/src/alliance/alliance-cookie-grandma.cpp
@@ -1,7 +1,6 @@
 #include "alliance/alliance-cookie-grandma.h"
 #include "alliance/alliance.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 /*!

--- a/src/alliance/alliance-court-of-chaos.cpp
+++ b/src/alliance/alliance-court-of-chaos.cpp
@@ -4,7 +4,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 int AllianceCourtOfChaos::calcImpressionPoint(const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-diabolique.cpp
+++ b/src/alliance/alliance-diabolique.cpp
@@ -12,7 +12,6 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 

--- a/src/alliance/alliance-dokachans.cpp
+++ b/src/alliance/alliance-dokachans.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 int AllianceDokachans::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-eldrazi.cpp
+++ b/src/alliance/alliance-eldrazi.cpp
@@ -1,7 +1,6 @@
 #include "alliance/alliance-eldrazi.h"
 #include "system/creature-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 
 int AllianceEldrazi::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-feanor-noldor.cpp
+++ b/src/alliance/alliance-feanor-noldor.cpp
@@ -4,7 +4,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 /*!

--- a/src/alliance/alliance-fingolfin-noldor.cpp
+++ b/src/alliance/alliance-fingolfin-noldor.cpp
@@ -4,7 +4,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 /*!

--- a/src/alliance/alliance-frieza-clan.cpp
+++ b/src/alliance/alliance-frieza-clan.cpp
@@ -1,7 +1,6 @@
 #include "alliance/alliance-frieza-clan.h"
 #include "alliance/alliance.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 /*!

--- a/src/alliance/alliance-gaichi.cpp
+++ b/src/alliance/alliance-gaichi.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 int AllianceGaichi::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-ge-orlic.cpp
+++ b/src/alliance/alliance-ge-orlic.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 int AllianceGEOrlic::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-getter.cpp
+++ b/src/alliance/alliance-getter.cpp
@@ -1,6 +1,5 @@
 #include "alliance/alliance-getter.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 
 int AllianceGetter::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-go.cpp
+++ b/src/alliance/alliance-go.cpp
@@ -1,6 +1,5 @@
 #include "alliance/alliance-go.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 
 int AllianceGO::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-golan.cpp
+++ b/src/alliance/alliance-golan.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 int AllianceGOLAN::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-gondor.cpp
+++ b/src/alliance/alliance-gondor.cpp
@@ -1,7 +1,6 @@
 #include "alliance/alliance-gondor.h"
 #include "alliance/alliance.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 /*!

--- a/src/alliance/alliance-hafu.cpp
+++ b/src/alliance/alliance-hafu.cpp
@@ -12,7 +12,6 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 int AllianceHafu::calcImpressionPoint(const CreatureEntity &creature) const

--- a/src/alliance/alliance-hakushin-karate.cpp
+++ b/src/alliance/alliance-hakushin-karate.cpp
@@ -1,6 +1,5 @@
 #include "alliance/alliance-hakushin-karate.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 
 int AllianceHakushinKarate::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-hide.cpp
+++ b/src/alliance/alliance-hide.cpp
@@ -1,7 +1,6 @@
 #include "alliance/alliance-hide.h"
 #include "alliance/alliance.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 /*!

--- a/src/alliance/alliance-hionhurn.cpp
+++ b/src/alliance/alliance-hionhurn.cpp
@@ -1,6 +1,5 @@
 #include "alliance/alliance-hionhurn.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 
 int AllianceHionhurn::calcImpressionPoint(const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-ide.cpp
+++ b/src/alliance/alliance-ide.cpp
@@ -5,7 +5,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 /*!
  * @brief イデのアライアンス印象値を計算する

--- a/src/alliance/alliance-incubetor.cpp
+++ b/src/alliance/alliance-incubetor.cpp
@@ -1,7 +1,6 @@
 #include "alliance/alliance-incubetor.h"
 #include "alliance/alliance.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 /*!
  * @brief インキュベーターアライアンスの印象ポイント計算

--- a/src/alliance/alliance-kenohgun.cpp
+++ b/src/alliance/alliance-kenohgun.cpp
@@ -8,7 +8,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 AllianceKenohgun::AllianceKenohgun(AllianceType id, std::string tag, std::string name, int64_t base_power)
     : Alliance(id, tag, name, base_power)
 {

--- a/src/alliance/alliance-ketholdeth.cpp
+++ b/src/alliance/alliance-ketholdeth.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 int AllianceKetholdeth::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-khaine.cpp
+++ b/src/alliance/alliance-khaine.cpp
@@ -2,7 +2,6 @@
 #include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 
 /*!
  * @brief カインのアライアンス印象値を計算する

--- a/src/alliance/alliance-king.cpp
+++ b/src/alliance/alliance-king.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 int AllianceKING::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {
     int impression = 0;

--- a/src/alliance/alliance-kogan-ryu.cpp
+++ b/src/alliance/alliance-kogan-ryu.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 int AllianceKoganRyu::calcImpressionPoint(const CreatureEntity &creature) const
 {
     int impression = 0;

--- a/src/alliance/alliance-mabelode.cpp
+++ b/src/alliance/alliance-mabelode.cpp
@@ -1,6 +1,5 @@
 #include "alliance/alliance-mabelode.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 int AllianceMabelode::calcImpressionPoint(const CreatureEntity &creature) const
 {
     int impression = 0;

--- a/src/alliance/alliance-megadeth.cpp
+++ b/src/alliance/alliance-megadeth.cpp
@@ -4,7 +4,6 @@
 #include "floor/floor-util.h"
 #include "monster-floor/monster-summon.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 int AllianceMegadeth::calcImpressionPoint(const CreatureEntity &creature) const

--- a/src/alliance/alliance-meldor.cpp
+++ b/src/alliance/alliance-meldor.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 int AllianceMeldor::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {
     int impression = 0;

--- a/src/alliance/alliance-naked-knights.cpp
+++ b/src/alliance/alliance-naked-knights.cpp
@@ -1,6 +1,5 @@
 #include "alliance/alliance-naked-knights.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 
 int AllianceNakedKnights::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-nanman.cpp
+++ b/src/alliance/alliance-nanman.cpp
@@ -1,7 +1,6 @@
 #include "alliance/alliance-nanman.h"
 #include "alliance/alliance.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 /*!

--- a/src/alliance/alliance-nanto-orthodox.cpp
+++ b/src/alliance/alliance-nanto-orthodox.cpp
@@ -9,7 +9,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 /*!
  * @brief アライアンス「南斗正統派」のコンストラクタ
  * @param id アライアンスID

--- a/src/alliance/alliance-nibelung.cpp
+++ b/src/alliance/alliance-nibelung.cpp
@@ -31,7 +31,6 @@
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 

--- a/src/alliance/alliance-none.cpp
+++ b/src/alliance/alliance-none.cpp
@@ -1,6 +1,5 @@
 #include "alliance/alliance-none.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 
 int AllianceNone::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-numenor.cpp
+++ b/src/alliance/alliance-numenor.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 int AllianceNumenor::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {
     int impression = 0;

--- a/src/alliance/alliance-odio.cpp
+++ b/src/alliance/alliance-odio.cpp
@@ -5,7 +5,6 @@
 #include "monster-floor/monster-summon.h"
 #include "system/creature-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 

--- a/src/alliance/alliance-phyrexia.cpp
+++ b/src/alliance/alliance-phyrexia.cpp
@@ -1,7 +1,6 @@
 #include "alliance/alliance-phyrexia.h"
 #include "system/creature-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 int AlliancePhyrexia::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {
     int impression = 0;

--- a/src/alliance/alliance-pure-mirrodin.cpp
+++ b/src/alliance/alliance-pure-mirrodin.cpp
@@ -1,6 +1,5 @@
 #include "alliance/alliance-pure-mirrodin.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 int AlliancePureMirrodin::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {
     int impression = 0;

--- a/src/alliance/alliance-seitei.cpp
+++ b/src/alliance/alliance-seitei.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 int AllianceSEITEI::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {
     int impression = 0;

--- a/src/alliance/alliance-sexy-commando-club.cpp
+++ b/src/alliance/alliance-sexy-commando-club.cpp
@@ -11,7 +11,6 @@
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"

--- a/src/alliance/alliance-shire.cpp
+++ b/src/alliance/alliance-shire.cpp
@@ -4,7 +4,6 @@
 #include "floor/floor-util.h"
 #include "monster-floor/monster-summon.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 int AllianceTheShire::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const

--- a/src/alliance/alliance-silvan-elf.cpp
+++ b/src/alliance/alliance-silvan-elf.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 int AllianceSilvanElf::calcImpressionPoint(const CreatureEntity &creature) const
 {
     int impression = 0;

--- a/src/alliance/alliance-soukaiya.cpp
+++ b/src/alliance/alliance-soukaiya.cpp
@@ -8,7 +8,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 

--- a/src/alliance/alliance-suren.cpp
+++ b/src/alliance/alliance-suren.cpp
@@ -3,7 +3,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 int AllianceSuren::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-tophamhatt.cpp
+++ b/src/alliance/alliance-tophamhatt.cpp
@@ -7,7 +7,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 

--- a/src/alliance/alliance-triothepunch.cpp
+++ b/src/alliance/alliance-triothepunch.cpp
@@ -7,7 +7,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 

--- a/src/alliance/alliance-ungoliant.cpp
+++ b/src/alliance/alliance-ungoliant.cpp
@@ -4,7 +4,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 AllianceUngoliant::AllianceUngoliant(AllianceType id, std::string tag, std::string name, int64_t base_power)
     : Alliance(id, tag, name, base_power)
 {

--- a/src/alliance/alliance-utumno.cpp
+++ b/src/alliance/alliance-utumno.cpp
@@ -4,7 +4,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 AllianceUtumno::AllianceUtumno(AllianceType id, std::string tag, std::string name, int64_t base_power)
     : Alliance(id, tag, name, base_power)
 {

--- a/src/alliance/alliance-valinor.cpp
+++ b/src/alliance/alliance-valinor.cpp
@@ -12,7 +12,6 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 int AllianceValinor::calcImpressionPoint(const CreatureEntity &creature) const

--- a/src/alliance/alliance-valverde.cpp
+++ b/src/alliance/alliance-valverde.cpp
@@ -1,7 +1,6 @@
 #include "alliance/alliance-valverde.h"
 #include "alliance/alliance.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 /*!

--- a/src/alliance/alliance-xiombarg.cpp
+++ b/src/alliance/alliance-xiombarg.cpp
@@ -1,6 +1,5 @@
 #include "alliance/alliance-xiombarg.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 
 int AllianceXiombarg::calcImpressionPoint(const CreatureEntity &creature) const
 {

--- a/src/alliance/alliance-yeek-kingdom.cpp
+++ b/src/alliance/alliance-yeek-kingdom.cpp
@@ -7,7 +7,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 
 /**
  * @brief イークの王国の印象値を計算する

--- a/src/alliance/alliance.cpp
+++ b/src/alliance/alliance.cpp
@@ -81,7 +81,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -20,7 +20,6 @@
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "util/string-processor.h"
 #include <sstream>
 #include <string>

--- a/src/autopick/autopick-util.cpp
+++ b/src/autopick/autopick-util.cpp
@@ -6,7 +6,6 @@
 #include "object-enchant/item-feeling.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "util/bit-flags-calculator.h"
 

--- a/src/avatar/avatar-changer.cpp
+++ b/src/avatar/avatar-changer.cpp
@@ -14,7 +14,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
 /*!

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -34,6 +34,7 @@
 #include "player/player-status.h"
 #include "player/process-name.h"
 #include "system/creature-entity.h"
+#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -28,6 +28,7 @@
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/player-type-definition.h"
 #include "util/enum-range.h"
 #include "util/string-processor.h"
 #include "world/world.h"

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -14,6 +14,7 @@
 #include "player/process-name.h"
 #include "player/race-info-table.h"
 #include "system/creature-entity.h"
+#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "util/enum-converter.h"

--- a/src/blue-magic/blue-magic-summon.cpp
+++ b/src/blue-magic/blue-magic-summon.cpp
@@ -10,7 +10,6 @@
 #include "spell/spells-summon.h"
 #include "spell/summon-types.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 bool cast_blue_summon_kin(CreatureEntity &creature, bmc_type *bmc_ptr)

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -50,7 +50,6 @@
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "target/target-getter.h"
 #include "timed-effect/timed-effects.h"
 #include "tracking/lore-tracker.h"

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -46,6 +46,7 @@
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
+#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "timed-effect/timed-effects.h"

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -60,6 +60,7 @@
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
+#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"

--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -16,7 +16,6 @@
 #include "io/write-diary.h"
 #include "main/sound-of-music.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"

--- a/src/cmd-io/cmd-knowledge.cpp
+++ b/src/cmd-io/cmd-knowledge.cpp
@@ -16,7 +16,6 @@
 #include "knowledge/knowledge-uniques.h"
 #include "main/sound-of-music.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -74,6 +74,7 @@
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
 #include "system/creature-entity.h"
+#include "system/player-type-definition.h"
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"

--- a/src/cmd-item/cmd-read.cpp
+++ b/src/cmd-item/cmd-read.cpp
@@ -20,7 +20,6 @@
 #include "status/action-setter.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "world/world.h"
 
 /*!

--- a/src/cmd-visual/cmd-map.cpp
+++ b/src/cmd-visual/cmd-map.cpp
@@ -3,7 +3,6 @@
 #include "autopick/autopick-util.h"
 #include "io/input-key-acceptor.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "view/display-map.h"
 #include "window/main-window-util.h"

--- a/src/combat/aura-counterattack.cpp
+++ b/src/combat/aura-counterattack.cpp
@@ -26,6 +26,7 @@
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
+#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 static void aura_fire_by_monster_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)

--- a/src/core/game-closer.cpp
+++ b/src/core/game-closer.cpp
@@ -25,6 +25,7 @@
 #include "save/save.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
+#include "system/player-type-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "util/angband-files.h"

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -5,7 +5,6 @@
 #include "main/sound-of-music.h"
 #include "system/angband-exceptions.h"
 #include "system/angband-system.h"
-#include "system/player-type-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -23,7 +23,6 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 

--- a/src/effect/effect-player-curse.cpp
+++ b/src/effect/effect-player-curse.cpp
@@ -7,6 +7,7 @@
 #include "status/bad-status-setter.h"
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
+#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -28,6 +28,7 @@
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "system/item-entity.h"
+#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
 #include "world/world.h"

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -25,6 +25,7 @@
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
+#include "system/player-type-definition.h"
 #include "target/projection-path-calculator.h"
 #include "view/display-messages.h"
 #include <string>

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -33,7 +33,6 @@
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "util/string-processor.h"
 #include <sstream>

--- a/src/flavor/tval-description-switcher.cpp
+++ b/src/flavor/tval-description-switcher.cpp
@@ -14,6 +14,7 @@
 #include "system/baseitem/baseitem-list.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
+#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "util/bit-flags-calculator.h"

--- a/src/floor/object-allocator.cpp
+++ b/src/floor/object-allocator.cpp
@@ -14,7 +14,6 @@
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "term/z-rand.h"

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -31,7 +31,6 @@
 #include "system/dungeon/dungeon-definition.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
-#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "target/projection-path-calculator.h"
 #include "view/display-messages.h"

--- a/src/inventory/item-getter.cpp
+++ b/src/inventory/item-getter.cpp
@@ -21,7 +21,6 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"

--- a/src/io-dump/dump-util.cpp
+++ b/src/io-dump/dump-util.cpp
@@ -2,6 +2,7 @@
 #include "floor/geometry.h"
 #include "game-option/keymap-directory-getter.h"
 #include "game-option/special-options.h"
+#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"

--- a/src/io/cursor.cpp
+++ b/src/io/cursor.cpp
@@ -10,7 +10,6 @@
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "system/terrain/terrain-definition.h"
 #include "target/projection-path-calculator.h"

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -90,6 +90,7 @@
 #include "system/dungeon/dungeon-definition.h"
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
+#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "util/int-char-converter.h"

--- a/src/load/dummy-loader.cpp
+++ b/src/load/dummy-loader.cpp
@@ -3,7 +3,6 @@
 #include "load/monster/monster-loader-factory.h"
 #include "load/old/monster-loader-savefile50.h"
 #include "system/floor/floor-info.h"
-#include "system/player-type-definition.h"
 
 /*!
  * @brief ダミーバイトを読み込む

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -43,6 +43,7 @@
 #include "system/angband-exceptions.h"
 #include "system/angband-system.h"
 #include "system/angband-version.h"
+#include "system/player-type-definition.h"
 #include "system/system-variables.h"
 #include "util/angband-files.h"
 #include "util/enum-converter.h"

--- a/src/load/old/item-loader-savefile50.cpp
+++ b/src/load/old/item-loader-savefile50.cpp
@@ -12,7 +12,6 @@
 #include "system/angband.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
 

--- a/src/load/old/load-v1-5-0.cpp
+++ b/src/load/old/load-v1-5-0.cpp
@@ -43,7 +43,6 @@
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "util/bit-flags-calculator.h"

--- a/src/load/store-loader.cpp
+++ b/src/load/store-loader.cpp
@@ -11,7 +11,6 @@
 #include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "util/object-sort.h"
 #include <cstdint>
 

--- a/src/lore/lore-store.cpp
+++ b/src/lore/lore-store.cpp
@@ -9,7 +9,6 @@
 #include "monster/monster-info.h"
 #include "system/creature-entity.h"
 #include "system/floor-type-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "tracking/lore-tracker.h"
 

--- a/src/main-cap.cpp
+++ b/src/main-cap.cpp
@@ -4,6 +4,7 @@
 
 #include "io/exit-panic.h"
 #include "system/angband.h"
+#include "system/player-type-definition.h"
 #include "term/gameterm.h"
 #include "term/z-form.h"
 

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -27,7 +27,6 @@
 #include "system/creature-entity.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/services/baseitem-monrace-service.h"
 #include "system/system-variables.h"
 #include "term/gameterm.h"

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -24,7 +24,6 @@
 #include "system/item-entity.h"
 #include "system/monrace/monrace-allocation.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/gameterm.h"
 #include "util/angband-files.h"

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -39,7 +39,6 @@
 #include "system/floor/wilderness-grid.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "system/spell-info-list.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"

--- a/src/main/scene-table-monster.cpp
+++ b/src/main/scene-table-monster.cpp
@@ -10,7 +10,6 @@
 #include "system/floor/floor-info.h"
 #include "system/inner-game-data.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "world/world.h"
 #include <ctime>

--- a/src/main/scene-table.cpp
+++ b/src/main/scene-table.cpp
@@ -8,7 +8,6 @@
 #include "main/scene-table-monster.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
-#include "system/player-type-definition.h"
 #include "term/z-term.h"
 
 int interrupt_scene_type;

--- a/src/main/sound-of-music.cpp
+++ b/src/main/sound-of-music.cpp
@@ -8,7 +8,6 @@
 #include "game-option/special-options.h"
 #include "main/scene-table.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "util/enum-converter.h"
 

--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -19,7 +19,6 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "system/terrain/terrain-definition.h"
 #include "target/target-getter.h"

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -29,7 +29,6 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/projection-path-calculator.h"
 #include "target/target-checker.h"

--- a/src/mind/mind-hobbit.cpp
+++ b/src/mind/mind-hobbit.cpp
@@ -5,7 +5,6 @@
 #include "system/baseitem/baseitem-list.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 bool create_ration(CreatureEntity &creature)

--- a/src/mind/mind-mindcrafter.cpp
+++ b/src/mind/mind-mindcrafter.cpp
@@ -33,7 +33,6 @@
 #include "status/sight-setter.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/target-getter.h"
 #include "util/bit-flags-calculator.h"

--- a/src/mind/mind-monk.cpp
+++ b/src/mind/mind-monk.cpp
@@ -8,7 +8,6 @@
 #include "player/special-defense-types.h"
 #include "status/action-setter.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -15,6 +15,7 @@
 #include "player-info/equipment-info.h"
 #include "player/player-status-table.h"
 #include "system/creature-entity.h"
+#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -30,6 +30,7 @@
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
+#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"

--- a/src/monster-attack/monster-attack-describer.cpp
+++ b/src/monster-attack/monster-attack-describer.cpp
@@ -13,6 +13,7 @@
 #include "system/angband.h"
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
+#include "system/player-type-definition.h"
 
 static void show_jaian_song(MonsterAttackPlayer *monap_ptr)
 {

--- a/src/monster-attack/monster-attack-processor.cpp
+++ b/src/monster-attack/monster-attack-processor.cpp
@@ -17,7 +17,6 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
 /*!

--- a/src/monster-floor/monster-death-util.cpp
+++ b/src/monster-floor/monster-death-util.cpp
@@ -6,7 +6,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
 MonsterDeath::MonsterDeath(FloorType &floor, short m_idx, bool drop_item)

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -18,7 +18,6 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "target/projection-path-calculator.h"
 #include "util/bit-flags-calculator.h"
 #include <range/v3/algorithm.hpp>

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -16,7 +16,6 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "system/services/dungeon-monrace-service.h"
 #include "util/bit-flags-calculator.h"
 #include "util/string-processor.h"

--- a/src/monster/monster-info.cpp
+++ b/src/monster/monster-info.cpp
@@ -24,7 +24,6 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "timed-effect/timed-effects.h"

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -24,7 +24,6 @@
 #include "system/monrace/monrace-allocation.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "system/system-variables.h"
 #include "view/display-messages.h"

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -19,7 +19,6 @@
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "timed-effect/timed-effects.h"
 #include "tracking/health-bar-tracker.h"

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -23,7 +23,6 @@
 #include "system/monrace/monrace-allocation.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "system/services/dungeon-monrace-service.h"
 #include "system/terrain/terrain-definition.h"
 #include "util/bit-flags-calculator.h"

--- a/src/mspell/mspell-summon.cpp
+++ b/src/mspell/mspell-summon.cpp
@@ -22,7 +22,6 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 

--- a/src/mutation/mutation-data.cpp
+++ b/src/mutation/mutation-data.cpp
@@ -1,6 +1,5 @@
 #include "mutation/mutation-data.h"
 #include "player-base/player-class.h"
-#include "system/player-type-definition.h"
 #include "util/rng-xoshiro.h"
 
 const MutationData MutationDataManager::mutation_table[] = {

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -46,7 +46,6 @@
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/target-checker.h"
 #include "target/target-getter.h"

--- a/src/object-enchant/enchanter-factory.cpp
+++ b/src/object-enchant/enchanter-factory.cpp
@@ -28,7 +28,6 @@
 #include "object/tval-types.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 
 std::unique_ptr<EnchanterBase> EnchanterFactory::create_enchanter(CreatureEntity &creature, ItemEntity *o_ptr, int lev, int power)
 {

--- a/src/object-enchant/item-magic-applier.cpp
+++ b/src/object-enchant/item-magic-applier.cpp
@@ -18,7 +18,6 @@
 #include "system/dungeon/dungeon-definition.h"
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "world/world.h"
 

--- a/src/object-enchant/others/apply-magic-others.cpp
+++ b/src/object-enchant/others/apply-magic-others.cpp
@@ -27,7 +27,6 @@
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include <unordered_map>

--- a/src/object-enchant/protector/apply-magic-soft-armor.cpp
+++ b/src/object-enchant/protector/apply-magic-soft-armor.cpp
@@ -13,7 +13,6 @@
 #include "system/baseitem/baseitem-list.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 
 /*
  * @brief コンストラクタ

--- a/src/object-hook/hook-expendable.cpp
+++ b/src/object-hook/hook-expendable.cpp
@@ -15,7 +15,6 @@
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "util/string-processor.h"
 

--- a/src/object-hook/hook-perception.cpp
+++ b/src/object-hook/hook-perception.cpp
@@ -2,7 +2,6 @@
 #include "object-hook/hook-weapon.h"
 #include "perception/object-perception.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 
 /*!
  * @brief アイテムが並の価値のアイテムかどうか判定する /

--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -38,7 +38,6 @@
 #include "system/angband.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"

--- a/src/object-use/quaff/quaff-execution.cpp
+++ b/src/object-use/quaff/quaff-execution.cpp
@@ -25,7 +25,6 @@
 #include "status/experience.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "view/display-messages.h"

--- a/src/object-use/read/read-execution.cpp
+++ b/src/object-use/read/read-execution.cpp
@@ -22,7 +22,6 @@
 #include "status/experience.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"

--- a/src/object-use/zapwand-execution.cpp
+++ b/src/object-use/zapwand-execution.cpp
@@ -18,7 +18,6 @@
 #include "sv-definition/sv-wand-types.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/target-getter.h"
 #include "term/screen-processor.h"

--- a/src/object/lite-processor.cpp
+++ b/src/object/lite-processor.cpp
@@ -8,7 +8,6 @@
 #include "sv-definition/sv-lite-types.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
 #include "world/world.h"

--- a/src/object/object-broken.cpp
+++ b/src/object/object-broken.cpp
@@ -15,7 +15,6 @@
 #include "system/baseitem/baseitem-list.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
 ObjectBreaker::ObjectBreaker(tr_type ignore_flg)

--- a/src/object/object-info.cpp
+++ b/src/object/object-info.cpp
@@ -22,7 +22,6 @@
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "util/int-char-converter.h"
 
 /*!

--- a/src/object/object-value-calc.cpp
+++ b/src/object/object-value-calc.cpp
@@ -6,7 +6,6 @@
 #include "system/artifact-type-definition.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
 /*!

--- a/src/object/object-value.cpp
+++ b/src/object/object-value.cpp
@@ -5,7 +5,6 @@
 #include "system/baseitem/baseitem-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 
 /*!
  * @brief オブジェクトの真の価格を算出する /

--- a/src/player-ability/player-charisma.cpp
+++ b/src/player-ability/player-charisma.cpp
@@ -10,7 +10,6 @@
 #include "realm/realm-hex-numbers.h"
 #include "spell-realm/spells-hex.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
 PlayerCharisma::PlayerCharisma(CreatureEntity &creature)

--- a/src/player-ability/player-constitution.cpp
+++ b/src/player-ability/player-constitution.cpp
@@ -12,7 +12,6 @@
 #include "realm/realm-hex-numbers.h"
 #include "spell-realm/spells-hex.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
 PlayerConstitution::PlayerConstitution(CreatureEntity &creature)

--- a/src/player-ability/player-dexterity.cpp
+++ b/src/player-ability/player-dexterity.cpp
@@ -12,7 +12,6 @@
 #include "realm/realm-hex-numbers.h"
 #include "spell-realm/spells-hex.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
 PlayerDexterity::PlayerDexterity(CreatureEntity &creature)

--- a/src/player-ability/player-intelligence.cpp
+++ b/src/player-ability/player-intelligence.cpp
@@ -11,7 +11,6 @@
 #include "realm/realm-hex-numbers.h"
 #include "spell-realm/spells-hex.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
 PlayerIntelligence::PlayerIntelligence(CreatureEntity &creature)

--- a/src/player-ability/player-strength.cpp
+++ b/src/player-ability/player-strength.cpp
@@ -12,7 +12,6 @@
 #include "realm/realm-types.h"
 #include "spell-realm/spells-hex.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
 PlayerStrength::PlayerStrength(CreatureEntity &creature)

--- a/src/player-ability/player-wisdom.cpp
+++ b/src/player-ability/player-wisdom.cpp
@@ -9,7 +9,6 @@
 #include "player/race-info-table.h"
 #include "player/special-defense-types.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
 PlayerWisdom::PlayerWisdom(CreatureEntity &creature)

--- a/src/player-base/player-class.h
+++ b/src/player-base/player-class.h
@@ -2,7 +2,6 @@
 
 #include "object-enchant/tr-flags.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include <initializer_list>
 #include <memory>
 #include <span>

--- a/src/player-info/mutation-info.cpp
+++ b/src/player-info/mutation-info.cpp
@@ -3,7 +3,6 @@
 #include "player-info/self-info-util.h"
 #include "player/player-status-flags.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
 /*!< @todo FEAELESS フラグも記述して問題ないと思われる */

--- a/src/player-status/player-basic-statistics.cpp
+++ b/src/player-status/player-basic-statistics.cpp
@@ -11,7 +11,6 @@
 #include "realm/realm-hex-numbers.h"
 #include "spell-realm/spells-hex.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"

--- a/src/player-status/player-infravision.cpp
+++ b/src/player-status/player-infravision.cpp
@@ -5,7 +5,6 @@
 #include "player-info/race-types.h"
 #include "player/race-info-table.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "util/enum-converter.h"
 
 PlayerInfravision::PlayerInfravision(CreatureEntity &creature)

--- a/src/player-status/player-status-base.cpp
+++ b/src/player-status/player-status-base.cpp
@@ -3,7 +3,6 @@
 #include "player/player-status.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
 /*!

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -63,6 +63,7 @@
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
+#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"

--- a/src/player/player-status-resist.cpp
+++ b/src/player/player-status-resist.cpp
@@ -23,7 +23,6 @@
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "util/string-processor.h"
 

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -25,7 +25,6 @@
 #include "system/floor/floor-info.h"
 #include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"

--- a/src/racial/class-racial-switcher.cpp
+++ b/src/racial/class-racial-switcher.cpp
@@ -5,7 +5,6 @@
 #include "racial/racial-util.h"
 #include "realm/realm-types.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 
 void switch_class_racial(CreatureEntity &creature, rc_type *rc_ptr)
 {

--- a/src/racial/racial-vampire.cpp
+++ b/src/racial/racial-vampire.cpp
@@ -9,7 +9,6 @@
 #include "system/dungeon/dungeon-definition.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
-#include "system/player-type-definition.h"
 #include "target/target-getter.h"
 #include "view/display-messages.h"
 

--- a/src/room/space-finder.cpp
+++ b/src/room/space-finder.cpp
@@ -5,7 +5,6 @@
 #include "system/dungeon/dungeon-definition.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
-#include "system/player-type-definition.h"
 
 /*!
  * @brief 指定のマスが床系地形であるかを返す

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -13,7 +13,6 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "util/bit-flags-calculator.h"
 #include "util/point-2d.h"

--- a/src/spell-kind/blood-curse.cpp
+++ b/src/spell-kind/blood-curse.cpp
@@ -14,7 +14,6 @@
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 void blood_curse_to_enemy(CreatureEntity &creature, MONSTER_IDX m_idx)

--- a/src/spell-kind/spells-genocide.cpp
+++ b/src/spell-kind/spells-genocide.cpp
@@ -24,7 +24,6 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"

--- a/src/spell-kind/spells-launcher.cpp
+++ b/src/spell-kind/spells-launcher.cpp
@@ -4,7 +4,6 @@
 #include "floor/geometry.h"
 #include "system/creature-entity.h"
 #include "system/grid-type-definition.h"
-#include "system/player-type-definition.h"
 #include "target/target-checker.h"
 #include "util/bit-flags-calculator.h"
 #include "util/dice.h"

--- a/src/spell-kind/spells-neighbor.cpp
+++ b/src/spell-kind/spells-neighbor.cpp
@@ -8,7 +8,6 @@
 #include "system/creature-entity.h"
 #include "system/enums/terrain/terrain-characteristics.h"
 #include "system/floor/floor-info.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "util/bit-flags-calculator.h"
 

--- a/src/spell-kind/spells-specific-bolt.cpp
+++ b/src/spell-kind/spells-specific-bolt.cpp
@@ -4,7 +4,6 @@
 #include "floor/geometry.h"
 #include "spell-kind/spells-launcher.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 
 /*!
  * @brief 衰弱ボルト処理

--- a/src/spell-realm/spells-crusade.cpp
+++ b/src/spell-realm/spells-crusade.cpp
@@ -20,7 +20,6 @@
 #include "system/enums/terrain/terrain-characteristics.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/target-checker.h"
 #include "target/target-getter.h"

--- a/src/spell-realm/spells-demon.cpp
+++ b/src/spell-realm/spells-demon.cpp
@@ -4,7 +4,6 @@
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
 

--- a/src/spell/range-calc.cpp
+++ b/src/spell/range-calc.cpp
@@ -10,7 +10,6 @@
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
-#include "system/player-type-definition.h"
 #include "target/projection-path-calculator.h"
 
 namespace {

--- a/src/spell/spells-diceroll.cpp
+++ b/src/spell/spells-diceroll.cpp
@@ -10,7 +10,6 @@
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 
 /*!
  * @brief モンスター魅了用セービングスロー共通部(汎用系)

--- a/src/spell/spells-execution.cpp
+++ b/src/spell/spells-execution.cpp
@@ -14,7 +14,6 @@
 #include "realm/realm-trump.h"
 #include "realm/realm-types.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 
 /*!
  * @brief 魔法処理のメインルーチン

--- a/src/spell/spells-staff-only.cpp
+++ b/src/spell/spells-staff-only.cpp
@@ -9,7 +9,6 @@
 #include "status/bad-status-setter.h"
 #include "status/body-improvement.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 

--- a/src/status/base-status.cpp
+++ b/src/status/base-status.cpp
@@ -10,7 +10,6 @@
 #include "spell-kind/spells-floor.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"

--- a/src/status/element-resistance.cpp
+++ b/src/status/element-resistance.cpp
@@ -11,7 +11,6 @@
 #include "realm/realm-song-numbers.h"
 #include "spell-realm/spells-song.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
 

--- a/src/store/home.cpp
+++ b/src/store/home.cpp
@@ -10,7 +10,6 @@
 #include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "util/object-sort.h"
 #include <algorithm>
 

--- a/src/target/target-checker.cpp
+++ b/src/target/target-checker.cpp
@@ -18,7 +18,6 @@
 #include "io/screen-util.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/target-preparation.h"
 #include "target/target-types.h"

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -11,7 +11,6 @@
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "timed-effect/timed-effects.h"

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -24,7 +24,6 @@
 #include "system/floor/floor-info.h"
 #include "system/inner-game-data.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "term/term-color-types.h"
 #include "term/z-form.h"
 #include "timed-effect/timed-effects.h"

--- a/src/view/display-player-stat-info.cpp
+++ b/src/view/display-player-stat-info.cpp
@@ -19,7 +19,6 @@
 #include "player/player-status.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "util/bit-flags-calculator.h"

--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -26,7 +26,6 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -16,7 +16,6 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "system/system-variables.h"
 #include "term/screen-processor.h"
 #include "util/bit-flags-calculator.h"

--- a/src/world/world-object.cpp
+++ b/src/world/world-object.cpp
@@ -5,7 +5,6 @@
 #include "system/dungeon/dungeon-definition.h"
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 #include <iterator>

--- a/src/world/world.cpp
+++ b/src/world/world.cpp
@@ -3,7 +3,6 @@
 #include "market/arena-entry.h"
 #include "player-info/race-types.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "term/term-color-types.h"
 #include "term/z-util.h"
 #include "util/bit-flags-calculator.h"


### PR DESCRIPTION
PlayerType を使用しない .cpp ファイルから不要なインクルードを除去した。
また p_ptr / PlayerType:: を使用するファイルで誤って削除してしまったものを
修正し、game-play-initializer.cpp / player-damage.cpp / main-gcu.cpp / view/display-messages.cpp 等に必要なインクルードを再追加した。