### PR TITLE
refactor: plus_incident/set_position を PlayerType から CreatureEntity に昇格（Phase 8）

### DIFF
--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -95,6 +95,14 @@ void CreatureEntity::ride_monster(MONSTER_IDX m_idx)
     }
 }
 
+void CreatureEntity::plus_incident(INCIDENT incidentID, int num)
+{
+    if (this->incident.count(incidentID) == 0) {
+        this->incident[incidentID] = 0;
+    }
+    this->incident[incidentID] += num;
+}
+
 bool CreatureEntity::check_sub_alignments(const byte sub_align1, const byte sub_align2)
 {
     if (sub_align1 == sub_align2) {

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -303,6 +303,7 @@ public:
     bool is_true_winner() const;
     bool try_resist_eldritch_horror() const;
     void ride_monster(MONSTER_IDX m_idx);
+    void plus_incident(INCIDENT incidentID, int num);
 
     /*!
      * @brief モンスターがいない場合にのみ位置を設定する

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -1,15 +1,8 @@
 #include "system/player-type-definition.h"
-#include "floor/geometry.h"
 #include "inventory/inventory-slot-types.h"
-#include "monster/monster-util.h"
-#include "system/angband-exceptions.h"
 #include "system/creature-entity.h"
-#include "system/floor/floor-info.h"
-#include "system/grid-type-definition.h"
 #include "system/item-entity.h"
-#include "system/redrawing-flags-updater.h"
 #include "timed-effect/timed-effects.h"
-#include "world/world.h"
 #include <range/v3/algorithm.hpp>
 
 /*!
@@ -27,30 +20,6 @@ PlayerType::PlayerType()
     this->inventory.resize(INVEN_TOTAL);
     ranges::generate(this->inventory, [] { return std::make_shared<ItemEntity>(); });
     this->timed_effects = std::make_shared<TimedEffects>();
-}
-
-/*!
- * @brief インシデント数加算
- * @param incident_id 加算したいインシデント
- * @param num 加算量
- */
-void PlayerType::plus_incident(INCIDENT incidentID, int num)
-{
-    if (this->incident.count(incidentID) == 0) {
-        this->incident[incidentID] = 0;
-    }
-    this->incident[incidentID] += num;
-}
-
-/*!
- * @brief プレイヤーを指定座標に配置する
- * @param pos 配置先座標
- * @return 配置に成功したらTRUE
- */
-void PlayerType::set_position(const Pos2D &pos)
-{
-    this->y = pos.y;
-    this->x = pos.x;
 }
 
 bool PlayerType::is_valid() const

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -6,9 +6,6 @@
 class PlayerType : public CreatureEntity {
 public:
     PlayerType();
-    void plus_incident(INCIDENT incidentID, int num);
-
-    void set_position(const Pos2D &pos);
 
     bool is_valid() const override;
     bool is_dead() const override;


### PR DESCRIPTION
…

- PlayerType::plus_incident() → CreatureEntity::plus_incident() に移動
- PlayerType::set_position() を削除（CreatureEntity に同一実装が既にある）
- player-type-definition.cpp の不要インクルードを整理