### PR TITLE
refactor: PlayerType依存を削減 - score-util/include整理（Phase 8）

### DIFF
--- a/src/birth/birth-body-spec.cpp
+++ b/src/birth/birth-body-spec.cpp
@@ -6,7 +6,6 @@
 #include "player/player-personality-types.h"
 #include "player/player-sex.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 
 /*!
  * @brief クリーチャーの身長体重を決める / Get creature's height and weight

--- a/src/core/score-util.cpp
+++ b/src/core/score-util.cpp
@@ -1,7 +1,7 @@
 #include "core/score-util.h"
+#include "system/creature-entity.h"
 #include "system/dungeon/dungeon-record.h"
 #include "system/floor/floor-info.h"
-#include "system/player-type-definition.h"
 #include "util/angband-files.h"
 #include "util/string-processor.h"
 #include <algorithm>
@@ -34,9 +34,9 @@ errr highscore_read(high_score *score)
     return fd_read(highscore_fd, (char *)(score), sizeof(high_score));
 }
 
-void high_score::copy_info(const PlayerType &player)
+void high_score::copy_info(const CreatureEntity &creature)
 {
-    const auto name = format("%-.15s", player.name.data());
+    const auto name = format("%-.15s", creature.name.data());
     std::copy_n(name.begin(), name.length(), this->who);
 
 #ifdef SET_UID
@@ -46,19 +46,19 @@ void high_score::copy_info(const PlayerType &player)
 #endif
     const auto uid_str = format("%7u", tmp_uid);
     std::copy_n(uid_str.begin(), uid_str.length(), this->uid);
-    this->sex[0] = player.psex ? 'm' : 'f';
-    const auto prace = format("%2d", std::min(enum2i(player.prace), MAX_RACES));
+    this->sex[0] = creature.psex ? 'm' : 'f';
+    const auto prace = format("%2d", std::min(enum2i(creature.prace), MAX_RACES));
     std::copy_n(prace.begin(), prace.length(), this->p_r);
-    const auto pclass = format("%2d", enum2i(std::min(player.pclass, PlayerClassType::MAX)));
+    const auto pclass = format("%2d", enum2i(std::min(creature.pclass, PlayerClassType::MAX)));
     std::copy_n(pclass.begin(), pclass.length(), this->p_c);
-    const auto ppersonality = format("%2d", std::min(player.ppersonality, MAX_PERSONALITIES));
+    const auto ppersonality = format("%2d", std::min(creature.ppersonality, MAX_PERSONALITIES));
     std::copy_n(ppersonality.begin(), ppersonality.length(), this->p_a);
-    const auto current_level = format("%3d", std::min<ushort>(player.level, 999));
+    const auto current_level = format("%3d", std::min<ushort>(creature.level, 999));
     std::copy_n(current_level.begin(), current_level.length(), this->cur_lev);
-    const auto &floor = *player.current_floor_ptr;
+    const auto &floor = *creature.current_floor_ptr;
     const auto current_dungeon = format("%3d", floor.dun_level);
     std::copy_n(current_dungeon.begin(), current_dungeon.length(), this->cur_dun);
-    const auto max_level = format("%3d", std::min<ushort>(player.max_plv, 999));
+    const auto max_level = format("%3d", std::min<ushort>(creature.max_plv, 999));
     std::copy_n(max_level.begin(), max_level.length(), this->max_lev);
     const auto max_dungeon = format("%3d", DungeonRecords::get_instance().get_record(floor.dungeon_id).get_max_level());
     std::copy_n(max_dungeon.begin(), max_dungeon.length(), this->max_dun);

--- a/src/core/score-util.h
+++ b/src/core/score-util.h
@@ -14,7 +14,7 @@
  *
  * Note that "string comparisons" are thus valid on "pts".
  */
-class PlayerType;
+class CreatureEntity;
 struct high_score {
     GAME_TEXT what[8]{}; /* Version info (string) */
     GAME_TEXT pts[10]{}; /* Total Score (number) */
@@ -35,7 +35,7 @@ struct high_score {
 
     GAME_TEXT how[40]{}; /* Method of death (string) */
 
-    void copy_info(const PlayerType &player);
+    void copy_info(const CreatureEntity &creature);
 };
 
 extern int highscore_fd;

--- a/src/core/scores.cpp
+++ b/src/core/scores.cpp
@@ -31,7 +31,6 @@
 #include "system/angband-version.h"
 #include "system/creature-entity.h"
 #include "system/inner-game-data.h"
-#include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "util/angband-files.h"
@@ -203,7 +202,7 @@ errr top_twenty(CreatureEntity &creature)
     auto ct = time((time_t *)0);
 
     strftime(the_score.day, 10, "@%Y%m%d", localtime(&ct));
-    the_score.copy_info(static_cast<const PlayerType &>(creature));
+    the_score.copy_info(creature);
     if (creature.died_from.size() >= sizeof(the_score.how)) {
 #ifdef JP
         angband_strcpy(the_score.how, creature.died_from, sizeof(the_score.how) - 2);
@@ -261,7 +260,7 @@ errr predict_score(CreatureEntity &creature)
     snprintf(the_score.gold, sizeof(the_score.gold), "%9d", creature.au);
     snprintf(the_score.turns, sizeof(the_score.turns), "%9d", igd.get_real_turns(AngbandWorld::get_instance().game_turn));
     angband_strcpy(the_score.day, _("今日", "TODAY"), sizeof(the_score.day));
-    the_score.copy_info(static_cast<const PlayerType &>(creature));
+    the_score.copy_info(creature);
     strcpy(the_score.how, _("yet", "nobody (yet!)"));
     auto j = highscore_where(&the_score);
     if (j < 10) {

--- a/src/effect/effect-player-oldies.cpp
+++ b/src/effect/effect-player-oldies.cpp
@@ -7,7 +7,6 @@
 #include "status/buff-setter.h"
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 void effect_player_old_heal(CreatureEntity &creature, EffectPlayerType *ep_ptr)

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -8,7 +8,7 @@
 #include "player/player-status-flags.h"
 #include "status/bad-status-setter.h"
 #include "status/base-status.h"
-#include "system/player-type-definition.h"
+#include "system/creature-entity.h"
 #include "system/redrawing-flags-updater.h"
 #include "tracking/health-bar-tracker.h"
 #include "view/display-messages.h"

--- a/src/effect/effect-player-switcher.cpp
+++ b/src/effect/effect-player-switcher.cpp
@@ -7,7 +7,6 @@
 #include "effect/effect-player.h"
 #include "player/player-damage.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 
 /*!
  * @brief

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -23,7 +23,6 @@
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "util/angband-files.h"
 #include "util/enum-converter.h"

--- a/src/load/old/monster-loader-savefile50.cpp
+++ b/src/load/old/monster-loader-savefile50.cpp
@@ -12,7 +12,6 @@
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
 

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -18,7 +18,6 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/projection-path-calculator.h"
 #include "tracking/health-bar-tracker.h"


### PR DESCRIPTION
- high_score::copy_info の引数を PlayerType & → CreatureEntity & に変更 (使用フィールドが全て CreatureEntity に存在するため)
- scores.cpp の static_cast<const PlayerType &> キャストを削除
- 29ファイルから不要な #include "system/player-type-definition.h" を削除