### PR TITLE
refactor: auto &player = creature エイリアスを一括削除（Phase 8）

### DIFF
--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -314,22 +314,21 @@ static bool activate_raygun(CreatureEntity &creature, ae_type *ae_ptr)
  */
 void exe_activate(CreatureEntity &creature, INVENTORY_IDX i_idx)
 {
-    auto &player = creature;
     bool activated = false;
-    if (i_idx <= INVEN_PACK && BaseitemList::get_instance().get_baseitem(player.inventory[i_idx]->bi_id).flags.has_not(TR_INVEN_ACTIVATE)) {
+    if (i_idx <= INVEN_PACK && BaseitemList::get_instance().get_baseitem(creature.inventory[i_idx]->bi_id).flags.has_not(TR_INVEN_ACTIVATE)) {
         msg_print(_("このアイテムは装備しないと始動できない。", "That object must be activated by equipment."));
         return;
     }
 
     ae_type tmp_ae;
-    ae_type *ae_ptr = initialize_ae_type(player, &tmp_ae, i_idx);
+    ae_type *ae_ptr = initialize_ae_type(creature, &tmp_ae, i_idx);
 
     if (ae_ptr->o_ptr->ego_idx == EgoType::SHATTERED || ae_ptr->o_ptr->ego_idx == EgoType::BLASTED) {
         msg_print(_("このアイテムはもう壊れていて始動できない。", "That broken object can't be activated."));
         return;
     }
 
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
     decide_activation_level(ae_ptr);
     decide_chance_fail(creature, ae_ptr);
     if (cmd_limit_time_walk(creature)) {
@@ -357,7 +356,7 @@ void exe_activate(CreatureEntity &creature, INVENTORY_IDX i_idx)
         activated = true;
     } else if (scouter_probing(creature, ae_ptr)) {
         activated = true;
-    } else if (exe_monster_capture(player, *ae_ptr->o_ptr)) {
+    } else if (exe_monster_capture(creature, *ae_ptr->o_ptr)) {
         activated = true;
     } else if (activate_firethrowing(creature, ae_ptr)) {
         activated = true;
@@ -375,8 +374,8 @@ void exe_activate(CreatureEntity &creature, INVENTORY_IDX i_idx)
     }
 
     if (randint1(100) <= ae_ptr->broken) {
-        std::string o_name = describe_flavor(player, *ae_ptr->o_ptr, OD_OMIT_PREFIX);
+        std::string o_name = describe_flavor(creature, *ae_ptr->o_ptr, OD_OMIT_PREFIX);
         msg_format(_("%sは壊れた！", "%s is destroyed!"), o_name.data());
-        curse_weapon_object(player, true, ae_ptr->o_ptr);
+        curse_weapon_object(creature, true, ae_ptr->o_ptr);
     }
 }

--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -66,7 +66,7 @@ static bool boundary_floor(const Grid &grid, const TerrainType &terrain, const T
 
 /*!
  * @brief 該当地形のトラップがプレイヤーにとって無効かどうかを判定して返す /
- * Move player in the given direction, with the given "pickup" flag.
+ * Move creature in the given direction, with the given "pickup" flag.
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param dir 移動方向
  * @param do_pickup 罠解除を試みながらの移動ならばTRUE
@@ -81,14 +81,13 @@ static bool boundary_floor(const Grid &grid, const TerrainType &terrain, const T
  */
 void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup, bool break_trap)
 {
-    auto &player = creature;
     const auto pos = creature.get_neighbor(dir);
     auto &floor = *creature.current_floor_ptr;
     auto &grid = floor.get_grid(pos);
-    bool p_can_enter = player_can_enter(player, grid.feat, CEM_P_CAN_ENTER_PATTERN);
+    bool p_can_enter = player_can_enter(creature, grid.feat, CEM_P_CAN_ENTER_PATTERN);
     const auto &world = AngbandWorld::get_instance();
     if (!floor.is_underground() && !world.is_wild_mode() && ((pos.x == 0) || (pos.x == MAX_WID - 1) || (pos.y == 0) || (pos.y == MAX_HGT - 1))) {
-        if (grid.mimic && player_can_enter(player, grid.mimic, 0)) {
+        if (grid.mimic && player_can_enter(creature, grid.mimic, 0)) {
             auto &wilderness = WildernessGrids::get_instance();
             if ((pos.y == 0) && (pos.x == 0)) {
                 wilderness.move_player_to(Direction(7));
@@ -132,8 +131,8 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
                 creature.ambush_flag = false;
             }
 
-            player.leaving = true;
-            PlayerEnergy(player).set_player_turn_energy(100);
+            creature.leaving = true;
+            PlayerEnergy(creature).set_player_turn_energy(100);
             return;
         }
 
@@ -152,58 +151,58 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
     bool do_past = false;
     if (grid.has_monster() && (monster.get_monster_profile().ml || p_can_enter || p_can_kill_walls)) {
         const auto &monrace = monster.get_monrace();
-        const auto effects = player.effects();
+        const auto effects = creature.effects();
         const auto is_stunned = effects->stun().is_stunned();
         auto can_cast = !effects->confusion().is_confused();
         const auto is_hallucinated = effects->hallucination().is_hallucinated();
         can_cast &= !is_hallucinated;
         can_cast &= monster.get_monster_profile().ml;
         can_cast &= !is_stunned;
-        can_cast &= player.muta.has_not(PlayerMutationType::BERS_RAGE) || !player.is_shero();
-        if (!monster.is_hostile() && can_cast && pattern_seq(player, pos) && (p_can_enter || p_can_kill_walls)) {
-            (void)set_monster_csleep(*player.current_floor_ptr, grid.m_idx, 0);
-            m_name = monster_desc(player, monster, 0);
+        can_cast &= creature.muta.has_not(PlayerMutationType::BERS_RAGE) || !creature.is_shero();
+        if (!monster.is_hostile() && can_cast && pattern_seq(creature, pos) && (p_can_enter || p_can_kill_walls)) {
+            (void)set_monster_csleep(*creature.current_floor_ptr, grid.m_idx, 0);
+            m_name = monster_desc(creature, monster, 0);
             if (monster.get_monster_profile().ml) {
                 if (!is_hallucinated) {
                     LoreTracker::get_instance().set_trackee(monster.ap_r_idx);
                 }
 
-                health_track(player, grid.m_idx);
+                health_track(creature, grid.m_idx);
             }
 
-            if ((player.is_wielding(FixedArtifactId::STORMBRINGER) && (randint1(1000) > 666)) || CreatureClass(player).equals(PlayerClassType::BERSERKER)) {
-                do_cmd_attack(player, pos.y, pos.x, HISSATSU_NONE);
+            if ((creature.is_wielding(FixedArtifactId::STORMBRINGER) && (randint1(1000) > 666)) || CreatureClass(creature).equals(PlayerClassType::BERSERKER)) {
+                do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
                 can_move = false;
             } else if (monster_can_cross_terrain(&creature, floor.get_grid(creature.get_position()).feat, monrace, 0)) {
                 do_past = true;
             } else {
                 msg_format(_("%s^が邪魔だ！", "%s^ is in your way!"), m_name.data());
-                PlayerEnergy(player).reset_player_turn();
+                PlayerEnergy(creature).reset_player_turn();
                 can_move = false;
             }
         } else {
-            do_cmd_attack(player, pos.y, pos.x, HISSATSU_NONE);
+            do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
             can_move = false;
         }
     }
 
-    const auto &riding_monster = floor.get_monster(player.riding);
+    const auto &riding_monster = floor.get_monster(creature.riding);
     const auto &riding_monrace = riding_monster.get_monrace();
     PlayerEnergy energy(creature);
-    if (can_move && player.riding) {
+    if (can_move && creature.riding) {
         if (riding_monrace.behavior_flags.has(MonsterBehaviorType::NEVER_MOVE)) {
             msg_print(_("動けない！", "Can't move!"));
             energy.reset_player_turn();
             can_move = false;
-            disturb(player, false, true);
+            disturb(creature, false, true);
         } else if (riding_monster.is_fearful()) {
-            const auto steed_name = monster_desc(player, riding_monster, 0);
+            const auto steed_name = monster_desc(creature, riding_monster, 0);
             msg_format(_("%sが恐怖していて制御できない。", "%s^ is too scared to control."), steed_name.data());
             can_move = false;
-            disturb(player, false, true);
-        } else if (player.riding_ryoute) {
+            disturb(creature, false, true);
+        } else if (creature.riding_ryoute) {
             can_move = false;
-            disturb(player, false, true);
+            disturb(creature, false, true);
         } else if (terrain.flags.has(TerrainCharacteristics::CAN_FLY) && (riding_monrace.feature_flags.has(MonsterFeatureType::CAN_FLY))) {
             /* Allow moving */
         } else if (terrain.flags.has(TerrainCharacteristics::CAN_SWIM) && (riding_monrace.feature_flags.has(MonsterFeatureType::CAN_SWIM))) {
@@ -212,50 +211,50 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
             msg_print(_(format("%sの上に行けない。", grid.get_terrain(TerrainKind::MIMIC).name.data()), "Can't swim."));
             energy.reset_player_turn();
             can_move = false;
-            disturb(player, false, true);
+            disturb(creature, false, true);
         } else if (terrain.flags.has_not(TerrainCharacteristics::WATER) && riding_monrace.feature_flags.has(MonsterFeatureType::AQUATIC)) {
             constexpr auto fmt = _("%sから上がれない。", "Can't land from %s.");
             const auto p_pos = creature.get_position();
             msg_format(fmt, floor.get_grid(p_pos).get_terrain(TerrainKind::MIMIC).name.data());
             energy.reset_player_turn();
             can_move = false;
-            disturb(player, false, true);
+            disturb(creature, false, true);
         } else if (terrain.flags.has(TerrainCharacteristics::LAVA) && riding_monrace.resistance_flags.has_none_of(RFR_EFF_IM_FIRE_MASK)) {
             msg_print(_(format("%sの上に行けない。", grid.get_terrain(TerrainKind::MIMIC).name.data()), "Too hot to go through."));
             energy.reset_player_turn();
             can_move = false;
-            disturb(player, false, true);
+            disturb(creature, false, true);
         }
 
         if (can_move && riding_monster.is_stunned() && one_in_(2)) {
-            const auto steed_name = monster_desc(player, riding_monster, 0);
+            const auto steed_name = monster_desc(creature, riding_monster, 0);
             msg_format(_("%sが朦朧としていてうまく動けない！", "You cannot control stunned %s!"), steed_name.data());
             can_move = false;
-            disturb(player, false, true);
+            disturb(creature, false, true);
         }
     }
 
     if (!can_move) {
-    } else if (terrain.flags.has_not(TerrainCharacteristics::MOVE) && terrain.flags.has(TerrainCharacteristics::CAN_FLY) && !player.levitation) {
+    } else if (terrain.flags.has_not(TerrainCharacteristics::MOVE) && terrain.flags.has(TerrainCharacteristics::CAN_FLY) && !creature.levitation) {
         msg_format(_("空を飛ばないと%sの上には行けない。", "You need to fly to go through the %s."), grid.get_terrain(TerrainKind::MIMIC).name.data());
         energy.reset_player_turn();
-        player.running = 0;
+        creature.running = 0;
         can_move = false;
     } else if (terrain.flags.has(TerrainCharacteristics::TREE) && !p_can_kill_walls) {
-        const auto riding_wild_wood = player.riding && riding_monrace.wilderness_flags.has(MonsterWildernessType::WILD_WOOD);
-        if (!CreatureClass(player).equals(PlayerClassType::RANGER) && !player.levitation && !riding_wild_wood) {
+        const auto riding_wild_wood = creature.riding && riding_monrace.wilderness_flags.has(MonsterWildernessType::WILD_WOOD);
+        if (!CreatureClass(creature).equals(PlayerClassType::RANGER) && !creature.levitation && !riding_wild_wood) {
             energy.mul_player_turn_energy(2);
         }
     } else if ((do_pickup != easy_disarm) && terrain.flags.has(TerrainCharacteristics::DISARM) && !grid.mimic) {
-        if (!trap_can_be_ignored(player, grid.feat)) {
-            (void)exe_disarm(player, pos.y, pos.x, dir);
+        if (!trap_can_be_ignored(creature, grid.feat)) {
+            (void)exe_disarm(creature, pos.y, pos.x, dir);
             return;
         }
     } else if (!p_can_enter && !p_can_kill_walls) {
         const auto &terrain_mimic = grid.get_terrain(TerrainKind::MIMIC);
         const auto &name = terrain_mimic.name;
         can_move = false;
-        if (!grid.is_mark() && !player_can_see_bold(player, pos.y, pos.x)) {
+        if (!grid.is_mark() && !player_can_see_bold(creature, pos.y, pos.x)) {
             if (boundary_floor(grid, terrain, terrain_mimic)) {
                 msg_print(_("それ以上先には進めないようだ。", "You feel you cannot go any more."));
             } else {
@@ -265,10 +264,10 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
                 msg_format("You feel %s %s blocking your way.", is_a_vowel(name[0]) ? "an" : "a", name.data());
 #endif
                 grid.info |= (CAVE_MARK);
-                lite_spot(player, pos);
+                lite_spot(creature, pos);
             }
         } else {
-            const auto effects = player.effects();
+            const auto effects = creature.effects();
             const auto is_confused = effects->confusion().is_confused();
             const auto is_stunned = effects->stun().is_stunned();
             const auto is_hallucinated = effects->hallucination().is_hallucinated();
@@ -278,7 +277,7 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
                     energy.reset_player_turn();
                 }
             } else {
-                if (easy_open && floor.has_closed_door_at(pos, true) && easy_open_door(player, pos)) {
+                if (easy_open && floor.has_closed_door_at(pos, true) && easy_open_door(creature, pos)) {
                     return;
                 }
 
@@ -293,14 +292,14 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
             }
         }
 
-        disturb(player, false, true);
+        disturb(creature, false, true);
         if (!boundary_floor(grid, terrain, terrain_mimic)) {
             sound(SoundKind::HITWALL);
         }
     }
 
-    if (can_move && !pattern_seq(player, pos)) {
-        const auto effects = player.effects();
+    if (can_move && !pattern_seq(creature, pos)) {
+        const auto effects = creature.effects();
         const auto is_confused = effects->confusion().is_confused();
         const auto is_stunned = effects->stun().is_stunned();
         const auto is_hallucinated = effects->hallucination().is_hallucinated();
@@ -308,7 +307,7 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
             energy.reset_player_turn();
         }
 
-        disturb(player, false, true);
+        disturb(creature, false, true);
         can_move = false;
     }
 
@@ -316,7 +315,7 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
         return;
     }
 
-    if (player.warning && (!process_warning(player, pos.x, pos.y))) {
+    if (creature.warning && (!process_warning(creature, pos.x, pos.y))) {
         energy.set_player_turn_energy(25);
         return;
     }
@@ -348,7 +347,7 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
     }
 
     if (p_can_kill_walls) {
-        cave_alter_feat(player, pos.y, pos.x, TerrainCharacteristics::HURT_DISI);
+        cave_alter_feat(creature, pos.y, pos.x, TerrainCharacteristics::HURT_DISI);
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::FLOW);
     }
 
@@ -361,7 +360,7 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
         mpe_mode |= MPE_BREAK_TRAP;
     }
 
-    player.plus_incident_tree("WALK", 1);
+    creature.plus_incident_tree("WALK", 1);
 
     static constexpr const char *dir_names[10] = {
         nullptr, "SW", "S", "SE", "W", "C", "E", "NW", "N", "NE"
@@ -370,8 +369,8 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
     const auto dir_id = dir.dir();
     if (dir_id >= 1 && dir_id <= 9 && dir_names[dir_id] != nullptr) {
         const auto walk_dir = format("WALK/%s", dir_names[dir_id]);
-        player.plus_incident_tree(walk_dir.data(), 1);
+        creature.plus_incident_tree(walk_dir.data(), 1);
     }
 
-    (void)move_player_effect(player, pos.y, pos.x, mpe_mode);
+    (void)move_player_effect(creature, pos.y, pos.x, mpe_mode);
 }

--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -63,7 +63,6 @@ bool exe_mutation_power(CreatureEntity &creature, PlayerMutationType power)
 {
     PLAYER_LEVEL lvl = creature.level;
     auto &floor = *creature.current_floor_ptr;
-    auto &player = creature;
     switch (power) {
     case PlayerMutationType::SPIT_ACID: {
         const auto dir = get_aim_dir(creature);
@@ -163,7 +162,7 @@ bool exe_mutation_power(CreatureEntity &creature, PlayerMutationType power)
         return true;
     case PlayerMutationType::DET_CURSE:
         for (int i = 0; i < INVEN_TOTAL; i++) {
-            auto *o_ptr = player.inventory[i].get();
+            auto *o_ptr = creature.inventory[i].get();
             if (!o_ptr->is_valid() || !o_ptr->is_cursed()) {
                 continue;
             }
@@ -310,7 +309,7 @@ bool exe_mutation_power(CreatureEntity &creature, PlayerMutationType power)
     case PlayerMutationType::LAUNCHER:
         return ThrowCommand(creature).do_cmd_throw(2 + lvl / 40, false, -1);
     default:
-        PlayerEnergy(player).reset_player_turn();
+        PlayerEnergy(creature).reset_player_turn();
         msg_format(_("能力 %s は実装されていません。", "Power %s not implemented. Oops."), power);
         return true;
     }

--- a/src/action/open-close-execution.cpp
+++ b/src/action/open-close-execution.cpp
@@ -44,11 +44,10 @@
  */
 bool exe_open(CreatureEntity &creature, POSITION y, POSITION x)
 {
-    auto &player = creature;
     const Pos2D pos(y, x);
     const auto &grid = creature.current_floor_ptr->get_grid(pos);
     auto &terrain = grid.get_terrain();
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
     if (terrain.flags.has_not(TerrainCharacteristics::OPEN)) {
         constexpr auto fmt = _("%sはがっちりと閉じられているようだ。", "The %s appears to be stuck.");
         msg_format(fmt, grid.get_terrain(TerrainKind::MIMIC).name.data());
@@ -58,12 +57,12 @@ bool exe_open(CreatureEntity &creature, POSITION y, POSITION x)
     if (!terrain.power) {
         cave_alter_feat(creature, y, x, TerrainCharacteristics::OPEN);
         sound(SoundKind::OPENDOOR);
-        player.plus_incident_tree("OPEN_DOOR", 1);
+        creature.plus_incident_tree("OPEN_DOOR", 1);
         return false;
     }
 
-    int i = player.skill_dis;
-    const auto effects = player.effects();
+    int i = creature.skill_dis;
+    const auto effects = creature.effects();
     if (effects->blindness().is_blind() || no_lite(creature)) {
         i = i / 10;
     }
@@ -90,7 +89,7 @@ bool exe_open(CreatureEntity &creature, POSITION y, POSITION x)
     msg_print(_("鍵をはずした。", "You have picked the lock."));
     cave_alter_feat(creature, y, x, TerrainCharacteristics::OPEN);
     sound(SoundKind::OPENDOOR);
-    player.plus_incident_tree("OPEN_DOOR", 1);
+    creature.plus_incident_tree("OPEN_DOOR", 1);
     gain_exp(creature, 1);
     return false;
 }
@@ -109,12 +108,11 @@ bool exe_open(CreatureEntity &creature, POSITION y, POSITION x)
  */
 bool exe_close(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
     const auto &grid = floor.get_grid(pos);
     const auto terrain_id = grid.feat;
     auto more = false;
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
     if (grid.get_terrain().flags.has_not(TerrainCharacteristics::CLOSE)) {
         return more;
     }
@@ -133,7 +131,7 @@ bool exe_close(CreatureEntity &creature, const Pos2D &pos)
         msg_print(_("ドアは壊れてしまっている。", "The door appears to be broken."));
     } else {
         sound(SoundKind::SHUTDOOR);
-        player.plus_incident_tree("CLOSE_DOOR", 1);
+        creature.plus_incident_tree("CLOSE_DOOR", 1);
     }
 
     return more;
@@ -155,7 +153,6 @@ bool exe_close(CreatureEntity &creature, const Pos2D &pos)
  */
 bool easy_open_door(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
     if (!floor.has_closed_door_at(pos)) {
         return false;
@@ -167,8 +164,8 @@ bool easy_open_door(CreatureEntity &creature, const Pos2D &pos)
         constexpr auto fmt = _("%sはがっちりと閉じられているようだ。", "The %s appears to be stuck.");
         msg_format(fmt, grid.get_terrain(TerrainKind::MIMIC).name.data());
     } else if (terrain.power) {
-        auto power_disarm = player.skill_dis;
-        const auto effects = player.effects();
+        auto power_disarm = creature.skill_dis;
+        const auto effects = creature.effects();
         if (effects->blindness().is_blind() || no_lite(creature)) {
             power_disarm = power_disarm / 10;
         }
@@ -219,12 +216,11 @@ bool easy_open_door(CreatureEntity &creature, const Pos2D &pos)
  */
 bool exe_disarm_chest(CreatureEntity &creature, POSITION y, POSITION x, OBJECT_IDX o_idx)
 {
-    auto &player = creature;
     const Pos2D pos(y, x);
     auto *o_ptr = creature.current_floor_ptr->o_list[o_idx].get();
-    PlayerEnergy(player).set_player_turn_energy(100);
-    int i = player.skill_dis;
-    const auto effects = player.effects();
+    PlayerEnergy(creature).set_player_turn_energy(100);
+    int i = creature.skill_dis;
+    const auto effects = creature.effects();
     if (effects->blindness().is_blind() || no_lite(creature)) {
         i = i / 10;
     }
@@ -282,16 +278,15 @@ bool exe_disarm_chest(CreatureEntity &creature, POSITION y, POSITION x, OBJECT_I
 
 bool exe_disarm(CreatureEntity &creature, POSITION y, POSITION x, const Direction &dir)
 {
-    auto &player = creature;
     const auto &baseitems = BaseitemList::get_instance();
     const Pos2D pos(y, x);
     const auto &grid = creature.current_floor_ptr->get_grid(pos);
     const auto &terrain = grid.get_terrain();
     const auto &name = terrain.name;
     int power = terrain.power;
-    int i = player.skill_dis;
-    PlayerEnergy(player).set_player_turn_energy(100);
-    auto effects = player.effects();
+    int i = creature.skill_dis;
+    PlayerEnergy(creature).set_player_turn_energy(100);
+    auto effects = creature.effects();
     if (effects->blindness().is_blind() || no_lite(creature)) {
         i = i / 10;
     }
@@ -313,9 +308,9 @@ bool exe_disarm(CreatureEntity &creature, POSITION y, POSITION x, const Directio
         msg_format(_("%sを解除した。", "You have disarmed the %s."), name.data());
         gain_exp(creature, power);
         cave_alter_feat(creature, y, x, TerrainCharacteristics::DISARM);
-        exe_movement(player, dir, easy_disarm, false);
+        exe_movement(creature, dir, easy_disarm, false);
 
-        (void)drop_near(player, item, pos);
+        (void)drop_near(creature, item, pos);
 
     } else if ((i > 5) && (randint1(i) > 5)) {
         if (flush_failure) {
@@ -326,7 +321,7 @@ bool exe_disarm(CreatureEntity &creature, POSITION y, POSITION x, const Directio
         more = true;
     } else {
         msg_format(_("%sを作動させてしまった！", "You set off the %s!"), name.data());
-        exe_movement(player, dir, easy_disarm, false);
+        exe_movement(creature, dir, easy_disarm, false);
     }
 
     return more;
@@ -348,18 +343,17 @@ bool exe_disarm(CreatureEntity &creature, POSITION y, POSITION x, const Directio
  */
 bool exe_bash(CreatureEntity &creature, POSITION y, POSITION x, const Direction &dir)
 {
-    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
     const Pos2D pos(y, x);
     const auto &grid = floor.get_grid(pos);
     const auto &terrain = grid.get_terrain();
-    int bash = adj_str_blow[player.stat_index[A_STR]];
+    int bash = adj_str_blow[creature.stat_index[A_STR]];
     int power = terrain.power;
     const auto &name = grid.get_terrain(TerrainKind::MIMIC).name;
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
     msg_format(_("%sに体当たりをした！", "You smash into the %s!"), name.data());
     power = (bash - (power * 10));
-    if (CreatureClass(player).equals(PlayerClassType::BERSERKER)) {
+    if (CreatureClass(creature).equals(PlayerClassType::BERSERKER)) {
         power *= 2;
     }
 
@@ -378,13 +372,13 @@ bool exe_bash(CreatureEntity &creature, POSITION y, POSITION x, const Direction 
             cave_alter_feat(creature, y, x, TerrainCharacteristics::OPEN);
         }
 
-        exe_movement(player, dir, false, false);
-    } else if (evaluate_percent(adj_dex_safe[player.stat_index[A_DEX]] + player.level)) {
+        exe_movement(creature, dir, false, false);
+    } else if (evaluate_percent(adj_dex_safe[creature.stat_index[A_DEX]] + creature.level)) {
         msg_format(_("この%sは頑丈だ。", "The %s holds firm."), name.data());
         more = true;
     } else {
         msg_print(_("体のバランスをくずしてしまった。", "You are off-balance."));
-        (void)BadStatusSetter(player).mod_paralysis(2 + randint0(2));
+        (void)BadStatusSetter(creature).mod_paralysis(2 + randint0(2));
     }
 
     return more;

--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -185,13 +185,12 @@ static bool see_nothing(CreatureEntity &creature, const Direction &dir, const Po
  */
 static bool run_test(CreatureEntity &creature)
 {
-    auto &player = creature;
     const auto prev_dir = find_prevdir;
     const auto &floor = *creature.current_floor_ptr;
     const auto p_pos = creature.get_position();
     const auto &p_grid = floor.get_grid(p_pos);
-    if ((disturb_trap_detect || alert_trap_detect) && player.dtrap && !(p_grid.info & CAVE_IN_DETECT)) {
-        player.dtrap = false;
+    if ((disturb_trap_detect || alert_trap_detect) && creature.dtrap && !(p_grid.info & CAVE_IN_DETECT)) {
+        creature.dtrap = false;
         if (!(p_grid.info & CAVE_UNSAFE)) {
             if (alert_trap_detect) {
                 msg_print(_("* 注意:この先はトラップの感知範囲外です！ *", "*Leaving trap detect region!*"));
@@ -363,7 +362,6 @@ static bool run_test(CreatureEntity &creature)
  */
 void run_step(CreatureEntity &creature, const Direction &dir)
 {
-    auto &player = creature;
     if (dir) {
         ignore_avoid_run = true;
         if (see_wall(creature, dir, creature.get_position())) {
@@ -385,9 +383,9 @@ void run_step(CreatureEntity &creature, const Direction &dir)
         return;
     }
 
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
     exe_movement(creature, find_current, false, false);
-    if (player.is_located_at_running_destination()) {
+    if (creature.is_located_at_running_destination()) {
         creature.run_py = 0;
         creature.run_px = 0;
         disturb(creature, false, false);

--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -139,9 +139,8 @@ Direction decide_travel_step_dir(CreatureEntity &creature, const Direction &prev
     auto &floor = *creature.current_floor_ptr;
     const auto &p_grid = floor.get_grid(p_pos);
     if (creature.is_player()) {
-        auto &player = creature;
-        if ((disturb_trap_detect || alert_trap_detect) && player.dtrap && none_bits(p_grid.info, CAVE_IN_DETECT)) {
-            player.dtrap = false;
+        if ((disturb_trap_detect || alert_trap_detect) && creature.dtrap && none_bits(p_grid.info, CAVE_IN_DETECT)) {
+            creature.dtrap = false;
             if (none_bits(p_grid.info, CAVE_UNSAFE)) {
                 if (alert_trap_detect) {
                     msg_print(_("* 注意:この先はトラップの感知範囲外です！ *", "*Leaving trap detect region!*"));
@@ -279,8 +278,7 @@ void Travel::step(CreatureEntity &creature)
         return;
     }
 
-    auto &player = creature;
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
     exe_movement(creature, this->dir, always_pickup, false);
 
     if (creature.get_position() == this->get_goal()) {

--- a/src/action/tunnel-execution.cpp
+++ b/src/action/tunnel-execution.cpp
@@ -61,8 +61,7 @@ bool exe_tunnel(CreatureEntity &creature, POSITION y, POSITION x)
         return false;
     }
 
-    auto &player = creature;
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
     const auto &terrain = grid.get_terrain();
     const auto power = terrain.power;
     const auto &terrain_mimic = grid.get_terrain(TerrainKind::MIMIC);
@@ -78,11 +77,11 @@ bool exe_tunnel(CreatureEntity &creature, POSITION y, POSITION x)
             msg_print(_("そこは掘れない!", "You can't tunnel through that!"));
         }
     } else if (terrain.flags.has(TerrainCharacteristics::CAN_DIG)) {
-        if (player.skill_dig > randint0(20 * power)) {
+        if (creature.skill_dig > randint0(20 * power)) {
             sound(SoundKind::DIG_THROUGH);
             msg_format(_("%sをくずした。", "You have removed the %s."), name.data());
             cave_alter_feat(creature, y, x, TerrainCharacteristics::TUNNEL);
-            player.plus_incident_tree("TUNNEL", 1);
+            creature.plus_incident_tree("TUNNEL", 1);
             RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::FLOW);
         } else {
             msg_format(_("%sをくずしている。", "You dig into the %s."), name.data());
@@ -90,7 +89,7 @@ bool exe_tunnel(CreatureEntity &creature, POSITION y, POSITION x)
         }
     } else {
         bool tree = terrain_mimic.flags.has(TerrainCharacteristics::TREE);
-        if (player.skill_dig > power + randint0(40 * power)) {
+        if (creature.skill_dig > power + randint0(40 * power)) {
             sound(SoundKind::DIG_THROUGH);
             if (tree) {
                 msg_format(_("%sを切り払った。", "You have cleared away the %s."), name.data());
@@ -104,7 +103,7 @@ bool exe_tunnel(CreatureEntity &creature, POSITION y, POSITION x)
             }
 
             cave_alter_feat(creature, y, x, TerrainCharacteristics::TUNNEL);
-            player.plus_incident_tree("TUNNEL", 1);
+            creature.plus_incident_tree("TUNNEL", 1);
             chg_virtue(creature, Virtue::DILIGENCE, 1);
             chg_virtue(creature, Virtue::NATURE, -1);
         } else {

--- a/src/alliance/alliance-fangfamily.cpp
+++ b/src/alliance/alliance-fangfamily.cpp
@@ -42,17 +42,16 @@ void AllianceFangFamily::panishment(CreatureEntity &creature)
     if (!creature.is_player()) {
         return;
     }
-    auto &player = creature;
     if (one_in_(25)) {
         Pos2D m_pos(creature.get_position());
-        m_pos = scatter(*player.current_floor_ptr, m_pos, 10, PROJECT_NONE);
+        m_pos = scatter(*creature.current_floor_ptr, m_pos, 10, PROJECT_NONE);
         MonraceId avenger_id;
         if (impression < -200) {
             avenger_id = MonraceId::KING_FANG_FAMILY;
         } else {
             avenger_id = MonraceId::FANG_FAMILY;
         }
-        const auto m_idx = place_monster_one(player, m_pos.y, m_pos.x, avenger_id, PM_ALLOW_GROUP);
+        const auto m_idx = place_monster_one(creature, m_pos.y, m_pos.x, avenger_id, PM_ALLOW_GROUP);
         if (m_idx) {
             if (avenger_id == MonraceId::KING_FANG_FAMILY) {
                 msg_print(_("「一族の復讐を受けよ！」族長があなたを始末しに現れた！",
@@ -62,9 +61,9 @@ void AllianceFangFamily::panishment(CreatureEntity &creature)
                     "\"For the honor of Fang Family!\" A Fang family member is chasing you for revenge!"));
             }
 
-            disturb(player, true, true);
+            disturb(creature, true, true);
             for (int k = 0; k < 4; k++) {
-                summon_specific(player, m_pos.y, m_pos.x, std::max(player.current_floor_ptr->monster_level, 5), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
+                summon_specific(creature, m_pos.y, m_pos.x, std::max(creature.current_floor_ptr->monster_level, 5), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
             }
         }
     }

--- a/src/alliance/alliance-jural.cpp
+++ b/src/alliance/alliance-jural.cpp
@@ -46,16 +46,15 @@ void AllianceJural::panishment(CreatureEntity &creature)
     if (!creature.is_player()) {
         return;
     }
-    auto &player = creature;
     if (one_in_(20)) {
         Pos2D m_pos(creature.get_position());
-        m_pos = scatter(*player.current_floor_ptr, m_pos, 12, PROJECT_NONE);
-        const auto m_idx = place_monster_one(player, m_pos.y, m_pos.x, MonraceId::ALIEN_JURAL, PM_ALLOW_GROUP | PM_JURAL);
+        m_pos = scatter(*creature.current_floor_ptr, m_pos, 12, PROJECT_NONE);
+        const auto m_idx = place_monster_one(creature, m_pos.y, m_pos.x, MonraceId::ALIEN_JURAL, PM_ALLOW_GROUP | PM_JURAL);
         if (m_idx) {
             msg_print(_("「おーい、行ってみよう！」ジュラル星人があなたに報復すべく追跡してきた！", "\"Hey, let's go!\" Alien Jurals is chasing you for revenge!"));
             disturb(creature, true, true);
             for (int k = 0; k < 4; k++) {
-                summon_specific(player, m_pos.y, m_pos.x, std::max(player.current_floor_ptr->monster_level, 5), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
+                summon_specific(creature, m_pos.y, m_pos.x, std::max(creature.current_floor_ptr->monster_level, 5), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
             }
         }
     }

--- a/src/alliance/alliance-khorne.cpp
+++ b/src/alliance/alliance-khorne.cpp
@@ -39,7 +39,7 @@ int AllianceKhorne::calcImpressionPoint(const CreatureEntity &creature) const
     }
 
     // 魔法使用による減点（コーンは魔法を嫌う）
-    if (player.realm1 != REALM_NONE || player.realm2 != REALM_NONE) {
+    if (creature.realm1 != REALM_NONE || creature.realm2 != REALM_NONE) {
         impression -= 100;
     }
     */
@@ -54,7 +54,6 @@ bool AllianceKhorne::isAnnihilated()
 
 void AllianceKhorne::panishment(CreatureEntity &creature)
 {
-    auto &player = creature;
     auto impression = calcImpressionPoint(creature);
     if (isAnnihilated() || impression > -60) {
         return;
@@ -104,12 +103,12 @@ void AllianceKhorne::panishment(CreatureEntity &creature)
     if (one_in_(20)) {
         Pos2D m_pos(creature.get_position());
         m_pos = scatter(*creature.current_floor_ptr, m_pos, 12, PROJECT_NONE);
-        const auto m_idx = place_monster_one(player, m_pos.y, m_pos.x, MonraceId::KHORNE_CHOSEN, PM_ALLOW_GROUP);
+        const auto m_idx = place_monster_one(creature, m_pos.y, m_pos.x, MonraceId::KHORNE_CHOSEN, PM_ALLOW_GROUP);
         if (m_idx) {
             msg_print(_("コーンの選ばれし者があなたを誅すべく追跡してきた！", "Khorne's Chosen is chasing you for revenge!"));
             disturb(creature, true, true);
             for (int k = 0; k < 3; k++) {
-                summon_specific(player, m_pos.y, m_pos.x, std::max(creature.current_floor_ptr->monster_level, 5), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
+                summon_specific(creature, m_pos.y, m_pos.x, std::max(creature.current_floor_ptr->monster_level, 5), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
             }
         }
     }

--- a/src/alliance/alliance-legendofsavior.cpp
+++ b/src/alliance/alliance-legendofsavior.cpp
@@ -39,11 +39,10 @@ void AllianceLegendOfSavior::panishment(CreatureEntity &creature)
     if (!creature.is_player()) {
         return;
     }
-    auto &player = creature;
     if (one_in_(30)) {
-        Pos2D m_pos(player.get_position());
-        m_pos = scatter(*player.current_floor_ptr, m_pos, 6, PROJECT_NONE);
-        if (summon_named_creature(player, 0, m_pos.y, m_pos.x, MonraceId::KENSHIROU, 0)) {
+        Pos2D m_pos(creature.get_position());
+        m_pos = scatter(*creature.current_floor_ptr, m_pos, 6, PROJECT_NONE);
+        if (summon_named_creature(creature, 0, m_pos.y, m_pos.x, MonraceId::KENSHIROU, 0)) {
             msg_print(_("「てめえに今日を生きる資格はねえ！」", "You don't deserve to live today!"));
             msg_print(_("ケンシロウはあなたがミスミ老人を殺したことに義憤を覚えて襲ってきた！", "Kenshiro attacked you because you killed old man Misumi!"));
         }

--- a/src/alliance/alliance-nurgle.cpp
+++ b/src/alliance/alliance-nurgle.cpp
@@ -104,7 +104,7 @@ int AllianceNurgle::calcImpressionPoint(const CreatureEntity &creature) const
 
     // 現在のHP状況（傷ついているほど好まれる）
     /*
-    int hp_ratio = (player.hp * 100) / player.maxhp;
+    int hp_ratio = (creature.hp * 100) / creature.maxhp;
     if (hp_ratio <= 25)
         impression += 60;
     else if (hp_ratio <= 50)
@@ -138,7 +138,6 @@ void AllianceNurgle::panishment(CreatureEntity &creature)
     if (!creature.is_player()) {
         return;
     }
-    auto &player = creature;
 
     // 印象に応じて段階的な制裁
     if (this->calcImpressionPoint(creature) <= -50) {
@@ -191,8 +190,8 @@ void AllianceNurgle::panishment(CreatureEntity &creature)
 
         if (one_in_(2)) {
             msg_print("あなたの体が腐敗し始めた...");
-            project(player, 0, 3, player.y, player.x,
-                player.level * 2, AttributeType::POIS,
+            project(creature, 0, 3, creature.y, creature.x,
+                creature.level * 2, AttributeType::POIS,
                 PROJECT_KILL | PROJECT_ITEM);
         }
 
@@ -227,8 +226,8 @@ void AllianceNurgle::panishment(CreatureEntity &creature)
         (void)BadStatusSetter(creature).set_stun(randint1(100) + 50);
 
         // 大ダメージ（腐敗エリア放撃）
-        project(player, 0, 5, player.y, player.x,
-            player.level * 4, AttributeType::POIS,
+        project(creature, 0, 5, creature.y, creature.x,
+            creature.level * 4, AttributeType::POIS,
             PROJECT_KILL | PROJECT_ITEM | PROJECT_GRID);
 
         if (one_in_(2)) {

--- a/src/alliance/alliance-shittodan.cpp
+++ b/src/alliance/alliance-shittodan.cpp
@@ -35,18 +35,17 @@ void AllianceShittoDan::panishment(CreatureEntity &creature)
     if (!creature.is_player()) {
         return;
     }
-    auto &player = creature;
     if (one_in_(20)) {
         Pos2D m_pos(creature.get_position());
-        m_pos = scatter(*player.current_floor_ptr, m_pos, 8, PROJECT_NONE);
+        m_pos = scatter(*creature.current_floor_ptr, m_pos, 8, PROJECT_NONE);
 
-        const auto m_idx = place_monster_one(player, m_pos.y, m_pos.x, MonraceId::SHITTO_MASK, PM_ALLOW_GROUP);
+        const auto m_idx = place_monster_one(creature, m_pos.y, m_pos.x, MonraceId::SHITTO_MASK, PM_ALLOW_GROUP);
         if (m_idx) {
             msg_print(_("「アベックもリア充も死にさらせええ！」しっと団の襲撃だ！",
                 "\"Death to couples and people with fulfilling social lives!\" It's an attack by the Shitto Dan!"));
             disturb(creature, true, true);
             for (int k = 0; k < 3; k++) {
-                summon_specific(player, m_pos.y, m_pos.x, 5, SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
+                summon_specific(creature, m_pos.y, m_pos.x, 5, SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
             }
         }
     }

--- a/src/alliance/alliance-slaanesh.cpp
+++ b/src/alliance/alliance-slaanesh.cpp
@@ -26,7 +26,7 @@ int AllianceSlaanesh::calcImpressionPoint(const CreatureEntity &creature) const
     impression += (creature.stat_use[A_CHR] - 10) * 5;
 
     // 魔法使用による好感度向上（コーンとは逆）
-    // if (player.realm1 != REALM_NONE || player.realm2 != REALM_NONE) {
+    // if (creature.realm1 != REALM_NONE || creature.realm2 != REALM_NONE) {
     //     impression += 50;
     // }
 
@@ -57,7 +57,6 @@ bool AllianceSlaanesh::isAnnihilated()
 
 void AllianceSlaanesh::panishment(CreatureEntity &creature)
 {
-    auto &player = creature;
     auto impression = calcImpressionPoint(creature);
     if (isAnnihilated() || impression > -40) {
         return;
@@ -106,13 +105,13 @@ void AllianceSlaanesh::panishment(CreatureEntity &creature)
 
     if (one_in_(25)) {
         Pos2D m_pos(creature.get_position());
-        m_pos = scatter(*player.current_floor_ptr, m_pos, 10, PROJECT_NONE);
-        const auto m_idx = place_monster_one(player, m_pos.y, m_pos.x, MonraceId::SLAANESH_CHOSEN, PM_ALLOW_GROUP);
+        m_pos = scatter(*creature.current_floor_ptr, m_pos, 10, PROJECT_NONE);
+        const auto m_idx = place_monster_one(creature, m_pos.y, m_pos.x, MonraceId::SLAANESH_CHOSEN, PM_ALLOW_GROUP);
         if (m_idx) {
             msg_print(_("スラーネッシュの選ばれし者があなたを誘惑すべく現れた！", "Slaanesh's Chosen appears to seduce you!"));
             disturb(creature, true, true);
             for (int k = 0; k < 2; k++) {
-                summon_specific(player, m_pos.y, m_pos.x, std::max(player.current_floor_ptr->monster_level, 3), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
+                summon_specific(creature, m_pos.y, m_pos.x, std::max(creature.current_floor_ptr->monster_level, 3), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
             }
         }
     }

--- a/src/alliance/alliance-turban-kids.cpp
+++ b/src/alliance/alliance-turban-kids.cpp
@@ -21,9 +21,8 @@ void AllianceTurbanKids::panishment(CreatureEntity &creature)
     if (!creature.is_player()) {
         return;
     }
-    auto &player = creature;
     if (one_in_(19)) {
-        summon_specific(player, player.y, player.x, 100, SUMMON_TURBAN_KID, PM_AMBUSH);
+        summon_specific(creature, creature.y, creature.x, 100, SUMMON_TURBAN_KID, PM_AMBUSH);
     }
     return;
 }

--- a/src/alliance/alliance-tzeentch.cpp
+++ b/src/alliance/alliance-tzeentch.cpp
@@ -76,10 +76,9 @@ void AllianceTzeentch::panishment(CreatureEntity &creature)
     if (!creature.is_player()) {
         return;
     }
-    auto &player = creature;
     if (one_in_(22)) {
-        Pos2D m_pos(player.get_position());
-        m_pos = scatter(*player.current_floor_ptr, m_pos, 15, PROJECT_NONE);
+        Pos2D m_pos(creature.get_position());
+        m_pos = scatter(*creature.current_floor_ptr, m_pos, 15, PROJECT_NONE);
 
         // ティーンチの知識と変幻レベルに応じて異なる復讐者を派遣
         /*

--- a/src/artifact/fixed-art-generator.cpp
+++ b/src/artifact/fixed-art-generator.cpp
@@ -41,8 +41,7 @@ static bool invest_terror_mask(CreatureEntity &creature, ItemEntity *o_ptr)
     if (!creature.is_player()) {
         return false;
     }
-    auto &player = creature;
-    switch (player.pclass) {
+    switch (creature.pclass) {
     case PlayerClassType::WARRIOR:
     case PlayerClassType::ARCHER:
     case PlayerClassType::CAVALRY:
@@ -67,8 +66,7 @@ static void milim_swimsuit(CreatureEntity &creature, ItemEntity *o_ptr)
     if (!o_ptr->is_specific_artifact(FixedArtifactId::MILIM) || !creature.is_player()) {
         return;
     }
-    auto &player = creature;
-    if (player.ppersonality != PERSONALITY_SEXY) {
+    if (creature.ppersonality != PERSONALITY_SEXY) {
         return;
     }
 
@@ -116,8 +114,7 @@ static void invest_special_artifact_abilities(CreatureEntity &creature, ItemEnti
         return;
     case FixedArtifactId::HEAVENLY_MAIDEN:
         if (creature.is_player()) {
-            auto &player = creature;
-            if (player.psex != SEX_FEMALE) {
+            if (creature.psex != SEX_FEMALE) {
                 o_ptr->art_flags.set(TR_AGGRAVATE);
             }
         }

--- a/src/avatar/avatar.cpp
+++ b/src/avatar/avatar.cpp
@@ -177,7 +177,6 @@ void initialize_virtues(CreatureEntity &creature)
     if (!creature.is_player()) {
         return;
     }
-    auto &player = creature;
 
     auto add_virtue = [&](Virtue v) {
         if (v != Virtue::NONE && creature.virtues.find(v) == creature.virtues.end()) {
@@ -186,7 +185,7 @@ void initialize_virtues(CreatureEntity &creature)
     };
 
     /* Get pre-defined types based on class */
-    switch (player.pclass) {
+    switch (creature.pclass) {
     case PlayerClassType::WARRIOR:
     case PlayerClassType::SAMURAI:
         add_virtue(Virtue::VALOUR);
@@ -293,7 +292,7 @@ void initialize_virtues(CreatureEntity &creature)
     };
 
     /* Get one virtue based on race */
-    switch (player.prace) {
+    switch (creature.prace) {
     case PlayerRaceType::HUMAN:
     case PlayerRaceType::HALF_ELF:
     case PlayerRaceType::DUNADAN:

--- a/src/birth/auto-roller.cpp
+++ b/src/birth/auto-roller.cpp
@@ -119,9 +119,8 @@ static int32_t get_autoroller_prob(int *minval)
  */
 static void decide_initial_stat(CreatureEntity &creature, int *cval)
 {
-    auto &player = creature;
-    auto &player_class = class_info.at(player.pclass);
-    auto &class_magic = class_magics_info[enum2i(player.pclass)];
+    auto &player_class = class_info.at(creature.pclass);
+    auto &class_magic = class_magics_info[enum2i(creature.pclass)];
     auto is_magic_user = class_magic.spell_stat == A_INT || class_magic.spell_stat == A_WIS || class_magic.spell_stat == A_CHR;
     auto is_attacker = player_class.num > 3;
 
@@ -172,15 +171,14 @@ static void decide_initial_stat(CreatureEntity &creature, int *cval)
  */
 static std::string cursor_of_adjusted_stat(CreatureEntity &creature, const int *cval, int cs)
 {
-    auto &player = creature;
-    auto j = player.race->r_adj[cs] + (*player.pclass_ref).c_adj[cs] + (*player.personality).a_adj[cs];
+    auto j = creature.race->r_adj[cs] + (*creature.pclass_ref).c_adj[cs] + (*creature.personality).a_adj[cs];
     auto m = adjust_stat(170, j); // 17.0 の新形式
     auto maxv = format("%4.1f", m / 10.0);
 
     m = adjust_stat(cval[cs], j);
     auto inp = format("%4.1f", m / 10.0);
 
-    return format("%6s     %4.1f   %+3d  %+3d  %+3d  =  %6s  %6s", stat_names[cs], cval[cs] / 10.0, player.race->r_adj[cs], (*player.pclass_ref).c_adj[cs], (*player.personality).a_adj[cs], inp.data(), maxv.data());
+    return format("%6s     %4.1f   %+3d  %+3d  %+3d  =  %6s  %6s", stat_names[cs], cval[cs] / 10.0, creature.race->r_adj[cs], (*creature.pclass_ref).c_adj[cs], (*creature.personality).a_adj[cs], inp.data(), maxv.data());
 }
 
 /*!
@@ -207,7 +205,6 @@ static void display_autoroller_chance(int *cval)
  */
 bool get_stat_limits(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     clear_from(10);
     put_str(_("能力値を抽選します。最低限得たい能力値を設定して下さい。", "Set minimum stats for picking up your charactor."), 10, 10);
@@ -325,7 +322,7 @@ bool get_stat_limits(CreatureEntity &creature)
             break;
         case '=':
             screen_save();
-            do_cmd_options_aux(player, GameOptionPage::BIRTH, _("初期オプション((*)はスコアに影響)", "Birth Options ((*)) affect score"));
+            do_cmd_options_aux(creature, GameOptionPage::BIRTH, _("初期オプション((*)はスコアに影響)", "Birth Options ((*)) affect score"));
             screen_load();
             break;
         default:
@@ -362,7 +359,6 @@ void initialize_chara_limit(chara_limit_type *chara_limit_ptr)
  */
 bool get_chara_limits(CreatureEntity &creature, chara_limit_type *chara_limit_ptr)
 {
-    auto &player = creature;
 
     static const std::vector<std::string> item_names = { _("年齢", "age"), _("身長(cm)", "height"), _("体重(kg)", "weight"), _("威信", "prestige") };
     clear_from(10);
@@ -371,12 +367,12 @@ bool get_chara_limits(CreatureEntity &creature, chara_limit_type *chara_limit_pt
         _("注意：身長と体重の最大値/最小値ぎりぎりの値は非常に出現確率が低くなります。", "Caution: Values near minimum or maximum are extremely rare."), 23, 2);
 
     int max_percent, min_percent;
-    if (player.psex == SEX_MALE) {
-        max_percent = (int)(player.race->m_b_ht + player.race->m_m_ht * 4 - 1) * 100 / (int)(player.race->m_b_ht);
-        min_percent = (int)(player.race->m_b_ht - player.race->m_m_ht * 4 + 1) * 100 / (int)(player.race->m_b_ht);
+    if (creature.psex == SEX_MALE) {
+        max_percent = (int)(creature.race->m_b_ht + creature.race->m_m_ht * 4 - 1) * 100 / (int)(creature.race->m_b_ht);
+        min_percent = (int)(creature.race->m_b_ht - creature.race->m_m_ht * 4 + 1) * 100 / (int)(creature.race->m_b_ht);
     } else {
-        max_percent = (int)(player.race->f_b_ht + player.race->f_m_ht * 4 - 1) * 100 / (int)(player.race->f_b_ht);
-        min_percent = (int)(player.race->f_b_ht - player.race->f_m_ht * 4 + 1) * 100 / (int)(player.race->f_b_ht);
+        max_percent = (int)(creature.race->f_b_ht + creature.race->f_m_ht * 4 - 1) * 100 / (int)(creature.race->f_b_ht);
+        min_percent = (int)(creature.race->f_b_ht - creature.race->f_m_ht * 4 + 1) * 100 / (int)(creature.race->f_b_ht);
     }
 
     put_str(_("体格/地位の最小値/最大値を設定して下さい。", "Set minimum/maximum attribute."), 10, 10);
@@ -388,38 +384,38 @@ bool get_chara_limits(CreatureEntity &creature, chara_limit_type *chara_limit_pt
         int m;
         switch (i) {
         case 0: /* Minimum age */
-            m = player.race->b_age + 1;
+            m = creature.race->b_age + 1;
             break;
         case 1: /* Maximum age */
-            m = player.race->b_age + player.race->m_age;
+            m = creature.race->b_age + creature.race->m_age;
             break;
 
         case 2: /* Minimum height */
-            if (player.psex == SEX_MALE) {
-                m = player.race->m_b_ht - player.race->m_m_ht * 4 + 1;
+            if (creature.psex == SEX_MALE) {
+                m = creature.race->m_b_ht - creature.race->m_m_ht * 4 + 1;
             } else {
-                m = player.race->f_b_ht - player.race->f_m_ht * 4 + 1;
+                m = creature.race->f_b_ht - creature.race->f_m_ht * 4 + 1;
             }
             break;
         case 3: /* Maximum height */
-            if (player.psex == SEX_MALE) {
-                m = player.race->m_b_ht + player.race->m_m_ht * 4 - 1;
+            if (creature.psex == SEX_MALE) {
+                m = creature.race->m_b_ht + creature.race->m_m_ht * 4 - 1;
             } else {
-                m = player.race->f_b_ht + player.race->f_m_ht * 4 - 1;
+                m = creature.race->f_b_ht + creature.race->f_m_ht * 4 - 1;
             }
             break;
         case 4: /* Minimum weight */
-            if (player.psex == SEX_MALE) {
-                m = (player.race->m_b_wt * min_percent / 100) - (player.race->m_m_wt * min_percent / 75) + 1;
+            if (creature.psex == SEX_MALE) {
+                m = (creature.race->m_b_wt * min_percent / 100) - (creature.race->m_m_wt * min_percent / 75) + 1;
             } else {
-                m = (player.race->f_b_wt * min_percent / 100) - (player.race->f_m_wt * min_percent / 75) + 1;
+                m = (creature.race->f_b_wt * min_percent / 100) - (creature.race->f_m_wt * min_percent / 75) + 1;
             }
             break;
         case 5: /* Maximum weight */
-            if (player.psex == SEX_MALE) {
-                m = (player.race->m_b_wt * max_percent / 100) + (player.race->m_m_wt * max_percent / 75) - 1;
+            if (creature.psex == SEX_MALE) {
+                m = (creature.race->m_b_wt * max_percent / 100) + (creature.race->m_m_wt * max_percent / 75) - 1;
             } else {
-                m = (player.race->f_b_wt * max_percent / 100) + (player.race->f_m_wt * max_percent / 75) - 1;
+                m = (creature.race->f_b_wt * max_percent / 100) + (creature.race->f_m_wt * max_percent / 75) - 1;
             }
             break;
         case 6: /* Minimum prestige */
@@ -597,7 +593,7 @@ bool get_chara_limits(CreatureEntity &creature, chara_limit_type *chara_limit_pt
             break;
         case '=':
             screen_save();
-            do_cmd_options_aux(player, GameOptionPage::BIRTH, _("初期オプション((*)はスコアに影響)", "Birth Options ((*)) affect score"));
+            do_cmd_options_aux(creature, GameOptionPage::BIRTH, _("初期オプション((*)はスコアに影響)", "Birth Options ((*)) affect score"));
             screen_load();
             break;
         default:

--- a/src/birth/birth-select-patron.cpp
+++ b/src/birth/birth-select-patron.cpp
@@ -91,8 +91,7 @@ static int interpret_patron_select_key_move(char key, int initial_patron)
 
 static bool select_patron(CreatureEntity &creature, int *k, concptr sym)
 {
-    auto &player = creature;
-    int cs = player.patron;
+    int cs = creature.patron;
     int os = MAX_PATRON;
     std::string cur = birth_patron_label(os, sym);
     while (true) {
@@ -151,11 +150,10 @@ static bool select_patron(CreatureEntity &creature, int *k, concptr sym)
 }
 
 /*!
- * @brief プレイヤーのパトロン選択を行う / Select player's patron
+ * @brief プレイヤーのパトロン選択を行う / Select creature's patron
  */
 bool get_player_patron(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     clear_from(10);
     put_str(_("注意：《パトロン》によってキャラクターが得る加護が変化します。", "Note: Your patron determines the divine protection you receive."),
@@ -169,7 +167,7 @@ bool get_player_patron(CreatureEntity &creature)
         return false;
     }
 
-    player.patron = k;
+    creature.patron = k;
     display_player_name(creature);
     return true;
 }

--- a/src/birth/birth-select-personality.cpp
+++ b/src/birth/birth-select-personality.cpp
@@ -25,9 +25,8 @@ static std::string birth_personality_label(int cs, concptr sym)
 
 static void enumerate_personality_list(CreatureEntity &creature, char *sym)
 {
-    auto &player = creature;
     for (int n = 0; n < MAX_PERSONALITIES; n++) {
-        if (personality_info[n].sex && (personality_info[n].sex != (player.psex + 1))) {
+        if (personality_info[n].sex && (personality_info[n].sex != (creature.psex + 1))) {
             continue;
         }
 
@@ -84,7 +83,6 @@ static bool check_selected_sex(int pp_idx, player_sex psex)
 
 static int interpret_personality_select_key_move(CreatureEntity &creature, char key, int initial_personality)
 {
-    auto &player = creature;
     auto pp_idx = initial_personality;
     switch (key) {
     case '8':
@@ -92,7 +90,7 @@ static int interpret_personality_select_key_move(CreatureEntity &creature, char 
             pp_idx -= 4;
         }
 
-        if ((pp_idx >= MAX_PERSONALITIES) || !check_selected_sex(pp_idx, player.psex)) {
+        if ((pp_idx >= MAX_PERSONALITIES) || !check_selected_sex(pp_idx, creature.psex)) {
             return pp_idx;
         }
 
@@ -108,7 +106,7 @@ static int interpret_personality_select_key_move(CreatureEntity &creature, char 
             (pp_idx)--;
         }
 
-        if ((pp_idx >= MAX_PERSONALITIES) || !check_selected_sex(pp_idx, player.psex)) {
+        if ((pp_idx >= MAX_PERSONALITIES) || !check_selected_sex(pp_idx, creature.psex)) {
             return pp_idx;
         }
 
@@ -124,7 +122,7 @@ static int interpret_personality_select_key_move(CreatureEntity &creature, char 
             (pp_idx)++;
         }
 
-        if ((pp_idx >= MAX_PERSONALITIES) || !check_selected_sex(pp_idx, player.psex)) {
+        if ((pp_idx >= MAX_PERSONALITIES) || !check_selected_sex(pp_idx, creature.psex)) {
             return pp_idx;
         }
 
@@ -140,7 +138,7 @@ static int interpret_personality_select_key_move(CreatureEntity &creature, char 
             pp_idx += 4;
         }
 
-        if ((pp_idx >= MAX_PERSONALITIES) || !check_selected_sex(pp_idx, player.psex)) {
+        if ((pp_idx >= MAX_PERSONALITIES) || !check_selected_sex(pp_idx, creature.psex)) {
             return pp_idx;
         }
 
@@ -158,8 +156,7 @@ static int interpret_personality_select_key_move(CreatureEntity &creature, char 
 
 static bool select_personality(CreatureEntity &creature, int *k, concptr sym)
 {
-    auto &player = creature;
-    int cs = player.ppersonality;
+    int cs = creature.ppersonality;
     int os = MAX_PERSONALITIES;
     std::string cur = birth_personality_label(os, sym);
     while (true) {
@@ -183,7 +180,7 @@ static bool select_personality(CreatureEntity &creature, int *k, concptr sym)
             if (cs == MAX_PERSONALITIES) {
                 do {
                     *k = randint0(MAX_PERSONALITIES);
-                } while (personality_info[*k].sex && (personality_info[*k].sex != (player.psex + 1)));
+                } while (personality_info[*k].sex && (personality_info[*k].sex != (creature.psex + 1)));
 
                 cs = *k;
                 continue;
@@ -203,7 +200,7 @@ static bool select_personality(CreatureEntity &creature, int *k, concptr sym)
                 }
 
                 ppersonality = personality_info[*k];
-            } while (ppersonality.sex && (ppersonality.sex != (player.psex + 1)));
+            } while (ppersonality.sex && (ppersonality.sex != (creature.psex + 1)));
 
             cs = *k;
             continue;
@@ -211,7 +208,7 @@ static bool select_personality(CreatureEntity &creature, int *k, concptr sym)
 
         *k = (islower(c) ? A2I(c) : -1);
         if ((*k >= 0) && (*k < MAX_PERSONALITIES)) {
-            if ((personality_info[*k].sex == 0) || (personality_info[*k].sex == (player.psex + 1))) {
+            if ((personality_info[*k].sex == 0) || (personality_info[*k].sex == (creature.psex + 1))) {
                 cs = *k;
                 continue;
             }
@@ -219,7 +216,7 @@ static bool select_personality(CreatureEntity &creature, int *k, concptr sym)
 
         *k = (isupper(c) ? (26 + c - 'A') : -1);
         if ((*k >= 26) && (*k < MAX_PERSONALITIES)) {
-            if ((personality_info[*k].sex == 0) || (personality_info[*k].sex == (player.psex + 1))) {
+            if ((personality_info[*k].sex == 0) || (personality_info[*k].sex == (creature.psex + 1))) {
                 cs = *k;
                 continue;
             }
@@ -234,11 +231,10 @@ static bool select_personality(CreatureEntity &creature, int *k, concptr sym)
 }
 
 /*!
- * @brief プレイヤーの性格選択を行う / Select player's personality
+ * @brief プレイヤーの性格選択を行う / Select creature's personality
  */
 bool get_player_personality(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     clear_from(10);
     put_str(_("注意：《性格》によってキャラクターの能力やボーナスが変化します。", "Note: Your personality determines various intrinsic abilities and bonuses."),
@@ -252,8 +248,8 @@ bool get_player_personality(CreatureEntity &creature)
         return false;
     }
 
-    player.ppersonality = (player_personality_type)k;
-    player.personality = &personality_info[player.ppersonality];
+    creature.ppersonality = (player_personality_type)k;
+    creature.personality = &personality_info[creature.ppersonality];
     display_player_name(creature);
     return true;
 }

--- a/src/birth/birth-select-race.cpp
+++ b/src/birth/birth-select-race.cpp
@@ -125,7 +125,6 @@ static void interpret_race_select_key_move(char c, int *cs)
 
 static bool select_race(CreatureEntity &creature, char *sym, int *k)
 {
-    auto &player = creature;
     auto cs = enum2i(creature.prace);
     int os = MAX_RACES;
     std::string cur = birth_race_label(os, sym);
@@ -178,7 +177,7 @@ static bool select_race(CreatureEntity &creature, char *sym, int *k)
             *k = -1;
         }
 
-        birth_help_option(player, c, BirthKind::RACE);
+        birth_help_option(creature, c, BirthKind::RACE);
     }
 
     return true;

--- a/src/birth/birth-select-realm.cpp
+++ b/src/birth/birth-select-realm.cpp
@@ -227,13 +227,12 @@ static void cleanup_realm_selection_window(void)
  */
 static bool check_realm_selection(CreatureEntity &creature, int count)
 {
-    auto &player = creature;
     if (count < 2) {
         prt(_("何かキーを押してください", "Hit any key."), 0, 0);
         (void)inkey();
         prt("", 0, 0);
         return true;
-    } else if (input_check_strict(player, _("よろしいですか？", "Are you sure? "), UserCheck::DEFAULT_Y)) {
+    } else if (input_check_strict(creature, _("よろしいですか？", "Are you sure? "), UserCheck::DEFAULT_Y)) {
         return true;
     }
 
@@ -263,8 +262,7 @@ static void print_choosed_realms(CreatureEntity &creature)
 {
     put_str(_("魔法        :", "Magic       :"), 6, 1);
 
-    auto &player = creature;
-    PlayerRealm pr(player);
+    PlayerRealm pr(creature);
     std::string choosed_realms;
     if (pr.realm2().is_available()) {
         choosed_realms = format("%s, %s", pr.realm1().get_name().data(), pr.realm2().get_name().data());
@@ -287,8 +285,7 @@ bool get_player_realms(CreatureEntity &creature)
     put_str("                                   ", 5, 40);
     put_str("                                   ", 6, 40);
 
-    auto &player = creature;
-    PlayerRealm pr(player);
+    PlayerRealm pr(creature);
     pr.reset();
 
     if (CreatureClass(creature).equals(PlayerClassType::ELEMENTALIST)) {
@@ -296,10 +293,10 @@ bool get_player_realms(CreatureEntity &creature)
         if (!realm) {
             return false;
         }
-        player.element_realm = *realm;
+        creature.element_realm = *realm;
 
         put_str(_("魔法        :", "Magic       :"), 6, 1);
-        c_put_str(TERM_L_BLUE, get_element_title(player.element_realm), 6, 15);
+        c_put_str(TERM_L_BLUE, get_element_title(creature.element_realm), 6, 15);
         return true;
     }
 

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -1,6 +1,6 @@
 /*!
  * @file birth.c
- * @brief プレイヤーの作成を行う / Create a player character
+ * @brief プレイヤーの作成を行う / Create a creature character
  * @date 2013/12/28
  * @author
  * Copyright (c) 1997 Ben Harrison, James E. Wilson, Robert A. Koeneke\n
@@ -57,7 +57,6 @@
  */
 static void write_birth_diary(CreatureEntity &creature)
 {
-    auto &player = creature;
     concptr indent = "                            ";
 
     message_add(" ");
@@ -65,32 +64,32 @@ static void write_birth_diary(CreatureEntity &creature)
     message_add("====================");
     message_add(" ");
     message_add("  ");
-    const auto &floor = *player.current_floor_ptr;
+    const auto &floor = *creature.current_floor_ptr;
     exe_write_diary(floor, DiaryKind::GAMESTART, 1, _("-------- 新規ゲーム開始 --------", "------- Started New Game -------"));
     exe_write_diary(floor, DiaryKind::DIALY, 0);
-    const auto mes_sex = format(_("%s性別に%sを選択した。", "%schose %s gender."), indent, sex_info[player.psex].title.data());
+    const auto mes_sex = format(_("%s性別に%sを選択した。", "%schose %s gender."), indent, sex_info[creature.psex].title.data());
     exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_sex);
-    const auto mes_race = format(_("%s種族に%sを選択した。", "%schose %s race."), indent, race_info[enum2i(player.prace)].title.data());
+    const auto mes_race = format(_("%s種族に%sを選択した。", "%schose %s race."), indent, race_info[enum2i(creature.prace)].title.data());
     exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_race);
-    const auto mes_class = format(_("%s職業に%sを選択した。", "%schose %s class."), indent, class_info.at(player.pclass).title.data());
+    const auto mes_class = format(_("%s職業に%sを選択した。", "%schose %s class."), indent, class_info.at(creature.pclass).title.data());
     exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_class);
-    PlayerRealm pr(player);
+    PlayerRealm pr(creature);
     if (pr.realm1().is_available()) {
         const auto mes_realm2 = pr.realm2().is_available() ? format(_("と%s", " and %s realms"), pr.realm2().get_name().data()) : _("", " realm");
         const auto mes_realm = format(_("%s魔法の領域に%s%sを選択した。", "%schose %s%s."), indent, pr.realm1().get_name().data(), mes_realm2.data());
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_realm);
     }
 
-    if (player.element_realm != ElementRealmType::NONE) {
-        const auto mes_element = format(_("%s元素系統に%sを選択した。", "%schose %s system."), indent, get_element_title(player.element_realm).data());
+    if (creature.element_realm != ElementRealmType::NONE) {
+        const auto mes_element = format(_("%s元素系統に%sを選択した。", "%schose %s system."), indent, get_element_title(creature.element_realm).data());
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_element);
     }
 
-    const auto mes_personality = format(_("%s性格に%sを選択した。", "%schose %s personality."), indent, personality_info[player.ppersonality].title.data());
+    const auto mes_personality = format(_("%s性格に%sを選択した。", "%schose %s personality."), indent, personality_info[creature.ppersonality].title.data());
     exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_personality);
     if (CreatureClass(creature).equals(PlayerClassType::CHAOS_WARRIOR)) {
         const auto fmt_patron = _("%s守護神%sと契約を交わした。", "%smade a contract with patron %s.");
-        const auto mes_patron = format(fmt_patron, indent, patron_list[player.patron].name.data());
+        const auto mes_patron = format(fmt_patron, indent, patron_list[creature.patron].name.data());
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_patron);
     }
 }
@@ -105,7 +104,6 @@ static void write_birth_diary(CreatureEntity &creature)
  */
 void player_birth(CreatureEntity &creature, std::optional<QuestId> initial_quest_id)
 {
-    auto &player = creature;
 
     TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
 
@@ -132,9 +130,9 @@ void player_birth(CreatureEntity &creature, std::optional<QuestId> initial_quest
 
     WildernessGrids::get_instance().initialize_seeds();
     if (CreatureRace(&creature).equals(PlayerRaceType::BEASTMAN)) {
-        player.hack_mutation = true;
+        creature.hack_mutation = true;
     } else {
-        player.hack_mutation = false;
+        creature.hack_mutation = false;
     }
 
     if (g_window_flags[1].none()) {
@@ -152,13 +150,13 @@ void player_birth(CreatureEntity &creature, std::optional<QuestId> initial_quest
 
         // クエストの初期化処理（ウィザードモードのwiz_enter_quest関数を参考）
         init_flags = i2enum<init_flags_type>(INIT_SHOW_TEXT | INIT_ASSIGN);
-        player.current_floor_ptr->quest_number = *initial_quest_id;
+        creature.current_floor_ptr->quest_number = *initial_quest_id;
         parse_fixed_map(creature, QUEST_DEFINITION_LIST, 0, 0, 0, 0);
         quest.status = QuestStatusType::TAKEN;
 
         // クエストに突入
         if (quest.dungeon == DungeonId::WILDERNESS) {
-            exe_enter_quest(player, *initial_quest_id);
+            exe_enter_quest(creature, *initial_quest_id);
         }
     }
 }

--- a/src/birth/history-generator.cpp
+++ b/src/birth/history-generator.cpp
@@ -13,9 +13,8 @@ static int get_history_chart(CreatureEntity &creature)
     if (!creature.is_player()) {
         return 0;
     }
-    auto &player = creature;
 
-    switch (player.prace) {
+    switch (creature.prace) {
     case PlayerRaceType::AMBERITE:
         return 67;
     case PlayerRaceType::HUMAN:
@@ -103,7 +102,6 @@ static std::string decide_social_class(CreatureEntity &creature)
     if (!creature.is_player()) {
         return "";
     }
-    auto &player = creature;
 
     auto social_class = randnum1<short>(4);
     auto chart = get_history_chart(creature);
@@ -126,7 +124,7 @@ static std::string decide_social_class(CreatureEntity &creature)
         social_class = 1;
     }
 
-    player.prestige = social_class;
+    creature.prestige = social_class;
     return ss.str();
 }
 
@@ -139,18 +137,17 @@ void get_history(CreatureEntity &creature)
     if (!creature.is_player()) {
         return;
     }
-    auto &player = creature;
 
     constexpr auto lines = 4;
     for (int i = 0; i < lines; i++) {
-        player.history[i][0] = '\0';
+        creature.history[i][0] = '\0';
     }
 
     auto social_class = decide_social_class(creature);
-    constexpr auto max_line_len = sizeof(player.history[0]);
+    constexpr auto max_line_len = sizeof(creature.history[0]);
     const auto history_lines = shape_buffer(social_class.data(), max_line_len);
     const auto max_lines = std::min<int>(lines, history_lines.size());
     for (auto i = 0; i < max_lines; ++i) {
-        angband_strcpy(player.history[i], history_lines[i], max_line_len);
+        angband_strcpy(creature.history[i], history_lines[i], max_line_len);
     }
 }

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -41,12 +41,11 @@
  */
 void wield_all(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     ItemEntity ObjectType_body;
     for (INVENTORY_IDX i_idx = INVEN_PACK - 1; i_idx >= 0; i_idx--) {
         ItemEntity *o_ptr;
-        o_ptr = player.inventory[i_idx].get();
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -59,7 +58,7 @@ void wield_all(CreatureEntity &creature)
             continue;
         }
 
-        auto &wield_slot_item = *player.inventory[slot];
+        auto &wield_slot_item = *creature.inventory[slot];
         if (wield_slot_item.is_valid()) {
             continue;
         }
@@ -68,14 +67,14 @@ void wield_all(CreatureEntity &creature)
         wield_slot_item.number = 1;
 
         if (i_idx >= 0) {
-            inven_item_increase(player, i_idx, -1);
-            inven_item_optimize(player, i_idx);
+            inven_item_increase(creature, i_idx, -1);
+            inven_item_optimize(creature, i_idx);
         } else {
             floor_item_increase(creature, 0 - i_idx, -1);
             floor_item_optimize(creature, 0 - i_idx);
         }
 
-        player.equip_cnt++;
+        creature.equip_cnt++;
     }
 }
 
@@ -86,18 +85,16 @@ void wield_all(CreatureEntity &creature)
  */
 static void add_outfit(CreatureEntity &creature, ItemEntity &item)
 {
-    auto &player = creature;
     object_aware(creature, item);
     item.mark_as_known();
-    const auto slot = store_item_to_inventory(player, &item);
-    autopick_alter_item(player, slot, false);
+    const auto slot = store_item_to_inventory(creature, &item);
+    autopick_alter_item(creature, slot, false);
     wield_all(creature);
 }
 
 static void decide_initial_items(CreatureEntity &creature)
 {
-    auto &player = creature;
-    switch (player.prace) {
+    switch (creature.prace) {
     case PlayerRaceType::VAMPIRE:
         /* Nothing! */
         /* Vampires can drain blood of creatures */
@@ -152,11 +149,10 @@ static void decide_initial_items(CreatureEntity &creature)
 
 /*!
  * @brief 種族/職業/性格などに基づき初期所持アイテムを設定するメインセット関数。 / Init players with some belongings
- * @details Having an item makes the player "aware" of its purpose.
+ * @details Having an item makes the creature "aware" of its purpose.
  */
 void player_outfit(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     const auto &baseitems = BaseitemList::get_instance();
     ItemEntity item;
@@ -216,7 +212,7 @@ void player_outfit(CreatureEntity &creature)
             add_outfit(creature, item);
         }
     } else if (pc.equals(PlayerClassType::TOURIST)) {
-        if (player.ppersonality != PERSONALITY_SEXY) {
+        if (creature.ppersonality != PERSONALITY_SEXY) {
             ItemEntity item({ ItemKindType::SHOT, SV_AMMO_LIGHT });
             item.number = rand_range(15, 20);
             add_outfit(creature, item);
@@ -254,8 +250,8 @@ void player_outfit(CreatureEntity &creature)
     // @todo 本来read-onlyであるべきプリセットテーブルを書き換えている. 良くないパターン.
     // 「状況によって特別に持たせたいアイテム」は別途定義すべき.
     if (!pc.equals(PlayerClassType::SORCERER)) {
-        auto short_pclass = enum2i(player.pclass);
-        if (player.ppersonality == PERSONALITY_SEXY) {
+        auto short_pclass = enum2i(creature.pclass);
+        if (creature.ppersonality == PERSONALITY_SEXY) {
             player_init[short_pclass][2] = std::make_tuple(ItemKindType::HAFTED, SV_WHIP);
         } else if (pr.equals(PlayerRaceType::MERFOLK)) {
             player_init[short_pclass][2] = std::make_tuple(ItemKindType::POLEARM, SV_TRIDENT);
@@ -263,12 +259,12 @@ void player_outfit(CreatureEntity &creature)
     }
 
     for (auto i = 0; i < 3; i++) {
-        auto &[tval, sval] = player_init[enum2i(player.pclass)][i];
+        auto &[tval, sval] = player_init[enum2i(creature.pclass)][i];
         if (pr.equals(PlayerRaceType::ANDROID) && ((tval == ItemKindType::SOFT_ARMOR) || (tval == ItemKindType::HARD_ARMOR))) {
             continue;
         }
 
-        PlayerRealm prealm(player);
+        PlayerRealm prealm(creature);
         if (tval == ItemKindType::SORCERY_BOOK) {
             tval = prealm.realm1().get_book();
         } else if (tval == ItemKindType::DEATH_BOOK) {

--- a/src/blue-magic/blue-magic-caster.cpp
+++ b/src/blue-magic/blue-magic-caster.cpp
@@ -190,7 +190,6 @@ static bool cast_blue_make_trap(CreatureEntity &creature)
 
 static bool switch_cast_blue_magic(CreatureEntity &creature, bmc_type *bmc_ptr)
 {
-    auto &player = creature;
     switch (bmc_ptr->spell) {
     case MonsterAbilityType::SHRIEK:
         msg_print(_("かん高い金切り声をあげた。", "You make a high pitched shriek."));
@@ -291,7 +290,7 @@ static bool switch_cast_blue_magic(CreatureEntity &creature, bmc_type *bmc_ptr)
         return cast_blue_hand_doom(creature, bmc_ptr);
     case MonsterAbilityType::HEAL: {
         msg_print(_("自分の傷に念を集中した。", "You concentrate on your wounds!"));
-        (void)hp_player(player, bmc_ptr->plev * 4);
+        (void)hp_player(creature, bmc_ptr->plev * 4);
         BadStatusSetter bss(creature);
         (void)bss.set_stun(0);
         (void)bss.set_cut(0);
@@ -401,7 +400,7 @@ static bool switch_cast_blue_magic(CreatureEntity &creature, bmc_type *bmc_ptr)
 
 /*!
  * @brief 青魔法の発動 /
- * do_cmd_cast calls this function if the player's class is 'blue-mage'.
+ * do_cmd_cast calls this function if the creature's class is 'blue-mage'.
  * @param spell 発動するモンスター攻撃のID
  * @param success TRUEは成功時、FALSEは失敗時の処理を行う
  * @return 処理を実行したらTRUE、キャンセルした場合FALSEを返す。

--- a/src/blue-magic/blue-magic-checker.cpp
+++ b/src/blue-magic/blue-magic-checker.cpp
@@ -31,17 +31,16 @@
  */
 void learn_spell(CreatureEntity &creature, MonsterAbilityType monspell)
 {
-    auto &player = creature;
-    if (player.action != ACTION_LEARN) {
+    if (creature.action != ACTION_LEARN) {
         return;
     }
 
-    auto bluemage_data = CreatureClass(player).get_specific_data<bluemage_data_type>();
+    auto bluemage_data = CreatureClass(creature).get_specific_data<bluemage_data_type>();
     if (!bluemage_data || bluemage_data->learnt_blue_magics.has(monspell)) {
         return;
     }
 
-    const auto effects = player.effects();
+    const auto effects = creature.effects();
     const auto is_confused = effects->confusion().is_confused();
     const auto is_blind = effects->blindness().is_blind();
     const auto is_stunned = effects->stun().is_stunned();
@@ -52,10 +51,10 @@ void learn_spell(CreatureEntity &creature, MonsterAbilityType monspell)
     }
 
     const auto &monster_power = monster_powers.at(monspell);
-    if (randint1(player.level + 70) > monster_power.level + 40) {
+    if (randint1(creature.level + 70) > monster_power.level + 40) {
         bluemage_data->learnt_blue_magics.set(monspell);
         msg_format(_("%sを学習した！", "You have learned %s!"), monster_power.name);
-        gain_exp(static_cast<CreatureEntity &>(player), monster_power.level * monster_power.smana);
+        gain_exp(static_cast<CreatureEntity &>(creature), monster_power.level * monster_power.smana);
         sound(SoundKind::STUDY);
         bluemage_data->new_magic_learned = true;
         RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::ACTION);

--- a/src/blue-magic/blue-magic-status.cpp
+++ b/src/blue-magic/blue-magic-status.cpp
@@ -17,9 +17,8 @@ bool cast_blue_scare(CreatureEntity &creature, bmc_type *bmc_ptr)
         return false;
     }
 
-    auto &player = creature;
     msg_print(_("恐ろしげな幻覚を作り出した。", "You cast a fearful illusion."));
-    fear_monster(player, dir, bmc_ptr->plev + 10);
+    fear_monster(creature, dir, bmc_ptr->plev + 10);
     return true;
 }
 
@@ -30,8 +29,7 @@ bool cast_blue_blind(CreatureEntity &creature, bmc_type *bmc_ptr)
         return false;
     }
 
-    auto &player = creature;
-    confuse_monster(player, dir, bmc_ptr->plev * 2);
+    confuse_monster(creature, dir, bmc_ptr->plev * 2);
     return true;
 }
 
@@ -42,9 +40,8 @@ bool cast_blue_confusion(CreatureEntity &creature, bmc_type *bmc_ptr)
         return false;
     }
 
-    auto &player = creature;
     msg_print(_("誘惑的な幻覚をつくり出した。", "You cast a mesmerizing illusion."));
-    confuse_monster(player, dir, bmc_ptr->plev * 2);
+    confuse_monster(creature, dir, bmc_ptr->plev * 2);
     return true;
 }
 
@@ -55,8 +52,7 @@ bool cast_blue_slow(CreatureEntity &creature, bmc_type *bmc_ptr)
         return false;
     }
 
-    auto &player = creature;
-    slow_monster(player, dir, bmc_ptr->plev);
+    slow_monster(creature, dir, bmc_ptr->plev);
     return true;
 }
 
@@ -67,7 +63,6 @@ bool cast_blue_sleep(CreatureEntity &creature, bmc_type *bmc_ptr)
         return false;
     }
 
-    auto &player = creature;
-    sleep_monster(player, dir, bmc_ptr->plev);
+    sleep_monster(creature, dir, bmc_ptr->plev);
     return true;
 }

--- a/src/blue-magic/blue-magic-util.cpp
+++ b/src/blue-magic/blue-magic-util.cpp
@@ -10,10 +10,9 @@
 bmc_type *initialize_blue_magic_type(
     CreatureEntity &creature, bmc_type *bmc_ptr, MonsterAbilityType spell, const bool success, get_pseudo_monstetr_level_pf get_pseudo_monstetr_level)
 {
-    auto &player = creature;
     bmc_ptr->spell = spell;
     bmc_ptr->plev = (*get_pseudo_monstetr_level)(creature);
-    bmc_ptr->summon_lev = player.level * 2 / 3 + randint1(player.level / 2);
+    bmc_ptr->summon_lev = creature.level * 2 / 3 + randint1(creature.level / 2);
     bmc_ptr->pet = success; // read-only.
     bmc_ptr->no_trump = false;
     bmc_ptr->p_mode = bmc_ptr->pet ? PM_FORCE_PET : PM_NO_PET;

--- a/src/blue-magic/learnt-info.cpp
+++ b/src/blue-magic/learnt-info.cpp
@@ -18,8 +18,7 @@
  */
 PLAYER_LEVEL get_pseudo_monstetr_level(CreatureEntity &creature)
 {
-    auto &player = creature;
-    PLAYER_LEVEL monster_level = player.level + 40;
+    PLAYER_LEVEL monster_level = creature.level + 40;
     return (monster_level * monster_level - 1550) / 130;
 }
 

--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -251,26 +251,25 @@ static bool switch_blue_magic_choice(const char key, int &menu_line, const bluem
  */
 int calculate_blue_magic_failure_probability(CreatureEntity &creature, const monster_power &mp, int need_mana)
 {
-    auto &player = creature;
     auto chance = mp.fail;
-    if (player.level > mp.level) {
-        chance -= 3 * (player.level - mp.level);
+    if (creature.level > mp.level) {
+        chance -= 3 * (creature.level - mp.level);
     } else {
-        chance += (mp.level - player.level);
+        chance += (mp.level - creature.level);
     }
 
-    chance -= 3 * (adj_mag_stat[player.stat_index[A_INT]] - 1);
+    chance -= 3 * (adj_mag_stat[creature.stat_index[A_INT]] - 1);
     chance = mod_spell_chance_1(creature, chance);
-    if (need_mana > player.csp) {
-        chance += 5 * (need_mana - player.csp);
+    if (need_mana > creature.csp) {
+        chance += 5 * (need_mana - creature.csp);
     }
 
-    PERCENTAGE minfail = adj_mag_fail[player.stat_index[A_INT]];
+    PERCENTAGE minfail = adj_mag_fail[creature.stat_index[A_INT]];
     if (chance < minfail) {
         chance = minfail;
     }
 
-    chance += player.effects()->stun().get_magic_chance_penalty();
+    chance += creature.effects()->stun().get_magic_chance_penalty();
     if (chance > 95) {
         chance = 95;
     }
@@ -480,8 +479,7 @@ static tl::optional<MonsterAbilityType> select_learnt_spells_by_menu(CreatureEnt
  */
 tl::optional<MonsterAbilityType> get_learned_power(CreatureEntity &creature)
 {
-    auto &player = creature;
-    auto bluemage_data = CreatureClass(player).get_specific_data<bluemage_data_type>();
+    auto bluemage_data = CreatureClass(creature).get_specific_data<bluemage_data_type>();
     if (!bluemage_data) {
         return tl::nullopt;
     }

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -358,15 +358,14 @@ static int get_mane_power(CreatureEntity &creature, int *sn, bool baigaesi)
 
 /*!
  * @brief ものまね処理の発動 /
- * do_cmd_cast calls this function if the player's class is 'imitator'.
+ * do_cmd_cast calls this function if the creature's class is 'imitator'.
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 発動するモンスター攻撃のID
  * @return 処理を実行したらTRUE、キャンセルした場合FALSEを返す。
  */
 static bool use_mane(CreatureEntity &creature, MonsterAbilityType spell)
 {
-    auto &player = creature;
-    auto *player_ptr = &player;
+    auto *player_ptr = &creature;
     PLAYER_LEVEL plev = creature.get_level();
     BIT_FLAGS mode = (PM_ALLOW_GROUP | PM_FORCE_PET);
     BIT_FLAGS u_mode = 0L;
@@ -1175,7 +1174,7 @@ static bool use_mane(CreatureEntity &creature, MonsterAbilityType spell)
 
 /*!
  * @brief ものまねコマンドのメインルーチン /
- * do_cmd_cast calls this function if the player's class is 'imitator'.
+ * do_cmd_cast calls this function if the creature's class is 'imitator'.
  * @param baigaesi TRUEならば倍返し上の処理として行う
  * @return 処理を実行したらTRUE、キャンセルした場合FALSEを返す。
  * @details

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -125,25 +125,24 @@ static void decide_mind_ki_chance(CreatureEntity &creature, cm_type *cm_ptr)
         return;
     }
 
-    auto &player = creature;
     if (heavy_armor(creature)) {
         cm_ptr->chance += 20;
     }
 
-    if (player.is_icky_wield[0]) {
+    if (creature.is_icky_wield[0]) {
         cm_ptr->chance += 20;
     } else if (has_melee_weapon(creature, INVEN_MAIN_HAND)) {
         cm_ptr->chance += 10;
     }
 
-    if (player.is_icky_wield[1]) {
+    if (creature.is_icky_wield[1]) {
         cm_ptr->chance += 20;
     } else if (has_melee_weapon(creature, INVEN_SUB_HAND)) {
         cm_ptr->chance += 10;
     }
 
     if (cm_ptr->n == 5) {
-        for (int j = 0; j < get_current_ki(player) / 50; j++) {
+        for (int j = 0; j < get_current_ki(creature) / 50; j++) {
             cm_ptr->mana_cost += (j + 1) * 3 / 2;
         }
     }
@@ -195,16 +194,15 @@ static void decide_mind_chance(CreatureEntity &creature, cm_type *cm_ptr)
         return;
     }
 
-    auto &player = creature;
     if (heavy_armor(creature)) {
         cm_ptr->chance += 5;
     }
 
-    if (player.is_icky_wield[0]) {
+    if (creature.is_icky_wield[0]) {
         cm_ptr->chance += 5;
     }
 
-    if (player.is_icky_wield[1]) {
+    if (creature.is_icky_wield[1]) {
         cm_ptr->chance += 5;
     }
 }
@@ -295,26 +293,25 @@ static void check_mind_class(CreatureEntity &creature, cm_type *cm_ptr)
 
 static bool switch_mind_class(CreatureEntity &creature, cm_type *cm_ptr)
 {
-    auto &player = creature;
     switch (cm_ptr->use_mind) {
     case MindKindType::MINDCRAFTER:
         cm_ptr->cast = cast_mindcrafter_spell(creature, i2enum<MindMindcrafterType>(cm_ptr->n));
         return true;
     case MindKindType::KI:
-        cm_ptr->cast = cast_force_spell(player, i2enum<MindForceTrainerType>(cm_ptr->n));
+        cm_ptr->cast = cast_force_spell(creature, i2enum<MindForceTrainerType>(cm_ptr->n));
         return true;
     case MindKindType::BERSERKER:
-        cm_ptr->cast = cast_berserk_spell(player, i2enum<MindBerserkerType>(cm_ptr->n));
+        cm_ptr->cast = cast_berserk_spell(creature, i2enum<MindBerserkerType>(cm_ptr->n));
         return true;
     case MindKindType::MIRROR_MASTER:
-        if (player.current_floor_ptr->grid_array[player.y][player.x].is_mirror()) {
+        if (creature.current_floor_ptr->grid_array[creature.y][creature.x].is_mirror()) {
             cm_ptr->on_mirror = true;
         }
 
-        cm_ptr->cast = cast_mirror_spell(player, i2enum<MindMirrorMasterType>(cm_ptr->n));
+        cm_ptr->cast = cast_mirror_spell(creature, i2enum<MindMirrorMasterType>(cm_ptr->n));
         return true;
     case MindKindType::NINJUTSU:
-        cm_ptr->cast = cast_ninja_spell(player, i2enum<MindNinjaType>(cm_ptr->n));
+        cm_ptr->cast = cast_ninja_spell(creature, i2enum<MindNinjaType>(cm_ptr->n));
         return true;
     default:
         msg_format(_("謎の能力:%d, %d", "Mystery power:%d, %d"), cm_ptr->use_mind, cm_ptr->n);
@@ -401,9 +398,8 @@ static void process_hard_concentration(CreatureEntity &creature, cm_type *cm_ptr
 void do_cmd_mind(CreatureEntity &creature)
 {
     cm_type tmp_cm;
-    auto &player = creature;
     cm_type *cm_ptr = initialize_cm_type(creature, &tmp_cm);
-    if (cmd_limit_confused(player) || !MindPowerGetter(player).get_mind_power(&cm_ptr->n, false)) {
+    if (cmd_limit_confused(creature) || !MindPowerGetter(creature).get_mind_power(&cm_ptr->n, false)) {
         return;
     }
 
@@ -461,11 +457,10 @@ static MindKindType decide_use_mind_browse(CreatureEntity &creature)
 void do_cmd_mind_browse(CreatureEntity &creature)
 {
     SPELL_IDX n = 0;
-    auto &player = creature;
     MindKindType use_mind = decide_use_mind_browse(creature);
     screen_save();
     while (true) {
-        if (!MindPowerGetter(player).get_mind_power(&n, true)) {
+        if (!MindPowerGetter(creature).get_mind_power(&n, true)) {
             screen_load();
             return;
         }

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -81,12 +81,11 @@ static bool confirm_leave_level(CreatureEntity &creature, bool down_stair)
  */
 void do_cmd_go_up(CreatureEntity &creature)
 {
-    auto &player = creature;
     auto &quests = QuestList::get_instance();
     auto &floor = *creature.current_floor_ptr;
     const auto &grid = floor.get_grid({ creature.y, creature.x });
     const auto &terrain = grid.get_terrain();
-    CreatureClass(player).break_samurai_stance({ SamuraiStanceType::MUSOU });
+    CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
     if (terrain.flags.has(TerrainCharacteristics::PORTAL)) {
         do_cmd_go_portal(creature);
@@ -103,7 +102,7 @@ void do_cmd_go_up(CreatureEntity &creature)
             return;
         }
 
-        if (player.is_echizen()) {
+        if (creature.is_echizen()) {
             msg_print(_("なんだこの階段は！", "What's this STAIRWAY!"));
         } else {
             msg_print(_("上の階に登った。", "You enter the up staircase."));
@@ -111,14 +110,14 @@ void do_cmd_go_up(CreatureEntity &creature)
 
         sound(SoundKind::STAIRWAY);
 
-        leave_quest_check(player);
+        leave_quest_check(creature);
         floor.quest_number = i2enum<QuestId>(grid.special);
         const auto quest_id = floor.quest_number;
         auto &quest = quests.get_quest(quest_id);
         if (quest.status == QuestStatusType::UNTAKEN) {
             if (quest.type != QuestKindType::RANDOM) {
                 init_flags = INIT_ASSIGN;
-                parse_fixed_map(player, QUEST_DEFINITION_LIST, 0, 0, 0, 0);
+                parse_fixed_map(creature, QUEST_DEFINITION_LIST, 0, 0, 0, 0);
             }
 
             quest.status = QuestStatusType::TAKEN;
@@ -126,13 +125,13 @@ void do_cmd_go_up(CreatureEntity &creature)
 
         if (!inside_quest(quest_id)) {
             floor.dun_level = 0;
-            player.word_recall = 0;
+            creature.word_recall = 0;
         }
 
-        player.leaving = true;
+        creature.leaving = true;
         creature.oldpx = 0;
         creature.oldpy = 0;
-        PlayerEnergy(player).set_player_turn_energy(100);
+        PlayerEnergy(creature).set_player_turn_energy(100);
         return;
     }
 
@@ -147,23 +146,23 @@ void do_cmd_go_up(CreatureEntity &creature)
         return;
     }
 
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
 
     if (autosave_l) {
-        do_cmd_save_game(player, true);
+        do_cmd_save_game(creature, true);
     }
 
     const auto quest_number = floor.quest_number;
     auto &quest = quests.get_quest(quest_number);
 
     if (inside_quest(quest_number) && quest.type == QuestKindType::RANDOM) {
-        leave_quest_check(player);
+        leave_quest_check(creature);
         floor.quest_number = QuestId::NONE;
     }
 
     auto up_num = 0;
     if (inside_quest(quest_number) && quest.type != QuestKindType::RANDOM) {
-        leave_quest_check(player);
+        leave_quest_check(creature);
         floor.quest_number = i2enum<QuestId>(grid.special);
         floor.dun_level = 0;
         up_num = 0;
@@ -191,18 +190,18 @@ void do_cmd_go_up(CreatureEntity &creature)
         const auto p_pos = creature.get_position();
         const auto floor_terrain_id = dungeon.select_floor_terrain_id();
         set_terrain_id_to_grid(creature, p_pos, floor_terrain_id);
-        player.vanish_stairs_flag = true; // 移動後のフロアでも階段を消す
+        creature.vanish_stairs_flag = true; // 移動後のフロアでも階段を消す
     }
 
     if (up_num == floor.dun_level) {
-        if (player.is_echizen()) {
+        if (creature.is_echizen()) {
             msg_print(_("なんだこの階段は！", "What's this STAIRWAY!"));
         } else {
             msg_print(_("地上に戻った。", "You go back to the surface."));
         }
-        player.word_recall = 0;
+        creature.word_recall = 0;
     } else {
-        if (player.is_echizen()) {
+        if (creature.is_echizen()) {
             msg_print(_("なんだこの階段は！", "What's this STAIRWAY!"));
         } else {
             msg_print(_("階段を上って新たなる迷宮へと足を踏み入れた。", "You enter a maze of up staircases."));
@@ -211,7 +210,7 @@ void do_cmd_go_up(CreatureEntity &creature)
 
     sound(SoundKind::STAIRWAY);
 
-    player.leaving = true;
+    creature.leaving = true;
 }
 
 /*!
@@ -220,8 +219,7 @@ void do_cmd_go_up(CreatureEntity &creature)
  */
 void do_cmd_go_down(CreatureEntity &creature)
 {
-    auto &player = creature;
-    CreatureClass(player).break_samurai_stance({ SamuraiStanceType::MUSOU });
+    CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
     auto &floor = *creature.current_floor_ptr;
     auto &grid = floor.grid_array[creature.y][creature.x];
@@ -239,7 +237,7 @@ void do_cmd_go_down(CreatureEntity &creature)
 
     const auto is_fall_trap = terrain.flags.has(TerrainCharacteristics::TRAP);
     if (terrain.flags.has(TerrainCharacteristics::QUEST_ENTER)) {
-        do_cmd_quest(player);
+        do_cmd_quest(creature);
         return;
     }
 
@@ -248,7 +246,7 @@ void do_cmd_go_down(CreatureEntity &creature)
             return;
         }
 
-        if (player.is_echizen()) {
+        if (creature.is_echizen()) {
             msg_print(_("なんだこの階段は！", "What's this STAIRWAY!"));
         } else {
             msg_print(_("下の階に降りた。", "You enter the down staircase."));
@@ -256,8 +254,8 @@ void do_cmd_go_down(CreatureEntity &creature)
 
         sound(SoundKind::STAIRWAY);
 
-        leave_quest_check(player);
-        leave_tower_check(player);
+        leave_quest_check(creature);
+        leave_tower_check(creature);
         floor.quest_number = i2enum<QuestId>(grid.special);
 
         auto &quests = QuestList::get_instance();
@@ -265,7 +263,7 @@ void do_cmd_go_down(CreatureEntity &creature)
         if (quest.status == QuestStatusType::UNTAKEN) {
             if (quest.type != QuestKindType::RANDOM) {
                 init_flags = INIT_ASSIGN;
-                parse_fixed_map(player, QUEST_DEFINITION_LIST, 0, 0, 0, 0);
+                parse_fixed_map(creature, QUEST_DEFINITION_LIST, 0, 0, 0, 0);
             }
 
             quest.status = QuestStatusType::TAKEN;
@@ -273,13 +271,13 @@ void do_cmd_go_down(CreatureEntity &creature)
 
         if (!floor.is_in_quest()) {
             floor.dun_level = 0;
-            player.word_recall = 0;
+            creature.word_recall = 0;
         }
 
-        player.leaving = true;
+        creature.leaving = true;
         creature.oldpx = 0;
         creature.oldpy = 0;
-        PlayerEnergy(player).set_player_turn_energy(100);
+        PlayerEnergy(creature).set_player_turn_energy(100);
         return;
     }
 
@@ -312,9 +310,9 @@ void do_cmd_go_down(CreatureEntity &creature)
         fcms->set(FloorChangeMode::FIRST_FLOOR);
     }
 
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
     if (autosave_l) {
-        do_cmd_save_game(player, true);
+        do_cmd_save_game(creature, true);
     }
 
     auto down_num = 0;
@@ -347,7 +345,7 @@ void do_cmd_go_down(CreatureEntity &creature)
         const auto p_pos = creature.get_position();
         const auto floor_terrain_id = dungeon.select_floor_terrain_id();
         set_terrain_id_to_grid(creature, p_pos, floor_terrain_id);
-        player.vanish_stairs_flag = true; // 移動後のフロアでも階段を消す
+        creature.vanish_stairs_flag = true; // 移動後のフロアでも階段を消す
     }
 
     if (is_fall_trap) {
@@ -360,7 +358,7 @@ void do_cmd_go_down(CreatureEntity &creature)
         if (dungeon_id > DungeonId::WILDERNESS) {
             msg_format(_("%sへ入った。", "You entered %s."), dungeon.text.data());
         } else {
-            if (player.is_echizen()) {
+            if (creature.is_echizen()) {
                 msg_print(_("なんだこの階段は！", "What's this STAIRWAY!"));
             } else {
                 msg_print(_("階段を下りて新たなる迷宮へと足を踏み入れた。", "You enter a maze of down staircases."));
@@ -370,7 +368,7 @@ void do_cmd_go_down(CreatureEntity &creature)
         sound(SoundKind::STAIRWAY);
     }
 
-    player.leaving = true;
+    creature.leaving = true;
     if (is_fall_trap) {
         fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::DOWN, FloorChangeMode::RANDOM_PLACE, FloorChangeMode::RANDOM_CONNECT });
         return;
@@ -450,16 +448,15 @@ void do_cmd_walk(CreatureEntity &creature, bool pickup)
  */
 void do_cmd_run(CreatureEntity &creature)
 {
-    auto &player = creature;
-    if (cmd_limit_confused(player)) {
+    if (cmd_limit_confused(creature)) {
         return;
     }
 
-    CreatureClass(player).break_samurai_stance({ SamuraiStanceType::MUSOU });
+    CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
-    if (const auto dir = get_rep_dir(player)) {
+    if (const auto dir = get_rep_dir(creature)) {
         creature.running = (command_arg ? command_arg : 1000);
-        run_step(player, dir);
+        run_step(creature, dir);
     }
 }
 
@@ -479,8 +476,7 @@ void do_cmd_stay(CreatureEntity &creature, bool pickup)
         command_arg = 0;
     }
 
-    auto &player = creature;
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
     if (pickup) {
         mpe_mode |= MPE_DO_PICKUP;
     }
@@ -522,18 +518,17 @@ static bool input_rest_turns()
 
 /*!
  * @brief 「休む」動作コマンドのメインルーチン /
- * Resting allows a player to safely restore his hp	-RAK-
+ * Resting allows a creature to safely restore his hp	-RAK-
  * @param creature クリーチャーへの参照
  */
 void do_cmd_rest(CreatureEntity &creature)
 {
-    auto &player = creature;
     set_action(creature, ACTION_NONE);
-    if (CreatureClass(player).equals(PlayerClassType::BARD)) {
-        auto is_singing = get_singing_song_effect(player) != 0;
-        is_singing |= get_interrupting_song_effect(player) != 0;
+    if (CreatureClass(creature).equals(PlayerClassType::BARD)) {
+        auto is_singing = get_singing_song_effect(creature) != 0;
+        is_singing |= get_interrupting_song_effect(creature) != 0;
         if (is_singing) {
-            stop_singing(player);
+            stop_singing(creature);
         }
     }
 
@@ -546,23 +541,23 @@ void do_cmd_rest(CreatureEntity &creature)
         return;
     }
 
-    set_superstealth(player, false);
-    PlayerEnergy(player).set_player_turn_energy(100);
+    set_superstealth(creature, false);
+    PlayerEnergy(creature).set_player_turn_energy(100);
     if (command_arg > 100) {
         chg_virtue(creature, Virtue::DILIGENCE, -1);
     }
 
-    if (static_cast<PlayerType &>(player).is_fully_healthy()) {
+    if (creature.is_fully_healthy()) {
         chg_virtue(creature, Virtue::DILIGENCE, -1);
     }
 
     creature.plus_incident_tree("REST", 1);
-    player.resting = command_arg;
-    player.action = ACTION_REST;
+    creature.resting = command_arg;
+    creature.action = ACTION_REST;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
     rfu.set_flag(MainWindowRedrawingFlag::ACTION);
-    handle_stuff(player);
+    handle_stuff(creature);
     term_fresh();
 }
 
@@ -572,7 +567,6 @@ void do_cmd_rest(CreatureEntity &creature)
  */
 void do_cmd_go_portal(CreatureEntity &creature)
 {
-    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     const auto &grid = floor.get_grid({ creature.y, creature.x });
     const auto &terrain = grid.get_terrain();
@@ -582,7 +576,7 @@ void do_cmd_go_portal(CreatureEntity &creature)
         return;
     }
 
-    CreatureClass(player).break_samurai_stance({ SamuraiStanceType::MUSOU });
+    CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
     if (!confirm_leave_level(creature, false)) {
         return;
@@ -620,15 +614,15 @@ void do_cmd_go_portal(CreatureEntity &creature)
     const auto target_dungeon = available_dungeons[randint0(available_dungeons.size())];
 
     // エネルギー消費
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
 
     // オートセーブ
     if (autosave_l) {
-        do_cmd_save_game(player, true);
+        do_cmd_save_game(creature, true);
     }
 
     // 階層移動処理
-    player.leaving = true;
+    creature.leaving = true;
     floor.set_dungeon_index(target_dungeon);
 
     const auto &target_dungeon_info = dungeons.get_dungeon(target_dungeon);

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -185,47 +185,46 @@ bool do_cmd_riding(CreatureEntity &creature, bool force)
     if (!creature.is_player()) {
         return false;
     }
-    auto &player = creature;
 
-    const auto dir = get_direction(player);
+    const auto dir = get_direction(creature);
     if (!dir) {
         return false;
     }
 
-    const auto pos = player.get_neighbor(dir);
-    auto &grid = player.current_floor_ptr->get_grid(pos);
+    const auto pos = creature.get_neighbor(dir);
+    auto &grid = creature.current_floor_ptr->get_grid(pos);
 
-    CreatureClass(player).break_samurai_stance({ SamuraiStanceType::MUSOU });
+    CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
     if (creature.riding) {
         /* Skip non-empty grids */
-        if (!can_player_ride_pet(player, grid, false)) {
+        if (!can_player_ride_pet(creature, grid, false)) {
             msg_print(_("そちらには降りられません。", "You cannot go that direction."));
             return false;
         }
 
-        if (!pattern_seq(player, pos)) {
+        if (!pattern_seq(creature, pos)) {
             return false;
         }
 
         if (grid.has_monster()) {
-            PlayerEnergy(player).set_player_turn_energy(100);
+            PlayerEnergy(creature).set_player_turn_energy(100);
 
             msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
 
-            do_cmd_attack(player, pos.y, pos.x, HISSATSU_NONE);
+            do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
             return false;
         }
 
-        player.ride_monster(0);
-        player.pet_extra_flags &= ~(PF_TWO_HANDS);
-        player.riding_ryoute = player.old_riding_ryoute = false;
+        creature.ride_monster(0);
+        creature.pet_extra_flags &= ~(PF_TWO_HANDS);
+        creature.riding_ryoute = creature.old_riding_ryoute = false;
     } else {
-        if (cmd_limit_confused(player)) {
+        if (cmd_limit_confused(creature)) {
             return false;
         }
 
-        const auto &monster = player.current_floor_ptr->get_monster(grid.m_idx);
+        const auto &monster = creature.current_floor_ptr->get_monster(grid.m_idx);
 
         if (!grid.has_monster() || !monster.get_monster_profile().ml) {
             msg_print(_("その場所にはモンスターはいません。", "There is no monster here."));
@@ -240,11 +239,11 @@ bool do_cmd_riding(CreatureEntity &creature, bool force)
             return false;
         }
 
-        if (!pattern_seq(player, pos)) {
+        if (!pattern_seq(creature, pos)) {
             return false;
         }
 
-        if (!can_player_ride_pet(player, grid, true)) {
+        if (!can_player_ride_pet(creature, grid, true)) {
             /* Feature code (applying "mimic" field) */
             const auto &terrain = grid.get_terrain(TerrainKind::MIMIC);
             using Tc = TerrainCharacteristics;
@@ -258,29 +257,29 @@ bool do_cmd_riding(CreatureEntity &creature, bool force)
 
             return false;
         }
-        if (monster.get_monrace().level > randint1((player.skill_exp[PlayerSkillKindType::RIDING] / 50 + player.level / 2 + 20))) {
+        if (monster.get_monrace().level > randint1((creature.skill_exp[PlayerSkillKindType::RIDING] / 50 + creature.level / 2 + 20))) {
             msg_print(_("うまく乗れなかった。", "You failed to ride."));
-            PlayerEnergy(player).set_player_turn_energy(100);
+            PlayerEnergy(creature).set_player_turn_energy(100);
             return false;
         }
 
         if (monster.is_asleep()) {
-            const auto m_name = monster_desc(player, monster, 0);
-            (void)set_monster_csleep(*player.current_floor_ptr, grid.m_idx, 0);
+            const auto m_name = monster_desc(creature, monster, 0);
+            (void)set_monster_csleep(*creature.current_floor_ptr, grid.m_idx, 0);
             msg_format(_("%sを起こした。", "You have woken %s up."), m_name.data());
         }
 
-        if (player.action == ACTION_MONK_STANCE) {
+        if (creature.action == ACTION_MONK_STANCE) {
             set_action(creature, ACTION_NONE);
         }
 
-        player.ride_monster(grid.m_idx);
-        if (HealthBarTracker::get_instance().is_tracking(player.riding)) {
-            health_track(player, 0);
+        creature.ride_monster(grid.m_idx);
+        if (HealthBarTracker::get_instance().is_tracking(creature.riding)) {
+            health_track(creature, 0);
         }
     }
 
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
@@ -295,7 +294,7 @@ bool do_cmd_riding(CreatureEntity &creature, bool force)
         MainWindowRedrawingFlag::UHEALTH,
     };
     rfu.set_flags(flags_mwrf);
-    (void)move_player_effect(player, pos.y, pos.x, MPE_HANDLE_STUFF | MPE_ENERGY_USE | MPE_DONT_PICKUP | MPE_DONT_SWAP_MON);
+    (void)move_player_effect(creature, pos.y, pos.x, MPE_HANDLE_STUFF | MPE_ENERGY_USE | MPE_DONT_PICKUP | MPE_DONT_SWAP_MON);
     return true;
 }
 
@@ -457,9 +456,9 @@ void do_cmd_pet(CreatureEntity &creature)
     powers[num++] = PET_SUMMON_SPELL;
 
     if (creature.pet_extra_flags & PF_BALL_SPELL) {
-        power_desc[num] = _("プレイヤーを巻き込む範囲魔法を使う (現在:ON)", "allow involve player in area spell (now On)");
+        power_desc[num] = _("プレイヤーを巻き込む範囲魔法を使う (現在:ON)", "allow involve creature in area spell (now On)");
     } else {
-        power_desc[num] = _("プレイヤーを巻き込む範囲魔法を使う (現在:OFF)", "allow involve player in area spell (now Off)");
+        power_desc[num] = _("プレイヤーを巻き込む範囲魔法を使う (現在:OFF)", "allow involve creature in area spell (now Off)");
     }
     powers[num++] = PET_BALL_SPELL;
 

--- a/src/cmd-item/cmd-destroy.cpp
+++ b/src/cmd-item/cmd-destroy.cpp
@@ -45,18 +45,17 @@ using SelectionResult = std::tuple<ItemEntity *, short, int>;
 
 static bool check_destory_item(CreatureEntity &creature, const ItemEntity &destroying_item, short i_idx)
 {
-    auto &player = creature;
     if (!confirm_destroy && (destroying_item.calc_price() <= 0)) {
         return true;
     }
 
-    const auto item_name = describe_flavor(player, destroying_item, OD_OMIT_PREFIX);
+    const auto item_name = describe_flavor(creature, destroying_item, OD_OMIT_PREFIX);
     constexpr auto fmt = _("本当に%sを壊しますか? [y/n/Auto]", "Really destroy %s? [y/n/Auto]");
     const auto msg = format(fmt, item_name.data());
     msg_erase();
     message_add(msg);
     RedrawingFlagsUpdater::get_instance().set_flag(SubWindowRedrawingFlag::MESSAGE);
-    window_stuff(player);
+    window_stuff(creature);
     while (true) {
         prt(msg, 0, 0);
         char i = inkey();
@@ -73,8 +72,8 @@ static bool check_destory_item(CreatureEntity &creature, const ItemEntity &destr
             continue;
         }
 
-        if (autopick_autoregister(player, &destroying_item)) {
-            autopick_alter_item(player, i_idx, true);
+        if (autopick_autoregister(creature, &destroying_item)) {
+            autopick_alter_item(creature, i_idx, true);
         }
 
         return false;
@@ -83,11 +82,10 @@ static bool check_destory_item(CreatureEntity &creature, const ItemEntity &destr
 
 static tl::optional<SelectionResult> select_destroying_item(CreatureEntity &creature, bool force_destroy)
 {
-    auto &player = creature;
     short i_idx;
     constexpr auto q = _("どのアイテムを壊しますか? ", "Destroy which item? ");
     constexpr auto s = _("壊せるアイテムを持っていない。", "You have nothing to destroy.");
-    auto *o_ptr = choose_object(player, &i_idx, q, s, USE_INVEN | USE_FLOOR);
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, USE_INVEN | USE_FLOOR);
     if (o_ptr == nullptr) {
         return tl::nullopt;
     }
@@ -116,7 +114,6 @@ static tl::optional<SelectionResult> select_destroying_item(CreatureEntity &crea
  */
 static bool decide_magic_book_exp(CreatureEntity &creature, const ItemEntity &destroyed_item)
 {
-    auto &player = creature;
     if (CreatureRace(&creature).equals(PlayerRaceType::ANDROID)) {
         return false;
     }
@@ -132,7 +129,7 @@ static bool decide_magic_book_exp(CreatureEntity &creature, const ItemEntity &de
     }
 
     auto is_good_magic_realm = (tval == ItemKindType::LIFE_BOOK) || (tval == ItemKindType::CRUSADE_BOOK);
-    if (PlayerRealm(player).realm1().is_good_attribute()) {
+    if (PlayerRealm(creature).realm1().is_good_attribute()) {
         return !is_good_magic_realm;
     } else {
         return is_good_magic_realm;
@@ -141,13 +138,12 @@ static bool decide_magic_book_exp(CreatureEntity &creature, const ItemEntity &de
 
 static void gain_exp_by_destroying_magic_book(CreatureEntity &creature, const ItemEntity &destroyed_item)
 {
-    auto &player = creature;
     const auto gain_expr = decide_magic_book_exp(creature, destroyed_item);
-    if (!gain_expr || (player.exp >= PY_MAX_EXP)) {
+    if (!gain_expr || (creature.exp >= PY_MAX_EXP)) {
         return;
     }
 
-    auto tester_exp = player.max_exp / 20;
+    auto tester_exp = creature.max_exp / 20;
     if (tester_exp > 10000) {
         tester_exp = 10000;
     }
@@ -194,14 +190,13 @@ static void process_destroy_magic_book(CreatureEntity &creature, const ItemEntit
 
 static void exe_destroy_item(CreatureEntity &creature, ItemEntity &destroying_item, short i_idx, int amount)
 {
-    auto &player = creature;
     auto destroyed_item = destroying_item.clone();
     destroyed_item.number = amount;
-    const auto item_name = describe_flavor(player, destroyed_item, 0);
+    const auto item_name = describe_flavor(creature, destroyed_item, 0);
     msg_format(_("%sを壊した。", "You destroy %s."), item_name.data());
     sound(SoundKind::DESTITEM);
     reduce_charges(&destroying_item, amount);
-    vary_item(player, i_idx, -amount);
+    vary_item(creature, i_idx, -amount);
     process_destroy_magic_book(creature, destroyed_item);
     if ((destroyed_item.to_a != 0) || (destroyed_item.to_d != 0) || (destroyed_item.to_h != 0)) {
         chg_virtue(creature, Virtue::HARMONY, 1);
@@ -218,7 +213,6 @@ static void exe_destroy_item(CreatureEntity &creature, ItemEntity &destroying_it
  */
 void do_cmd_destroy(CreatureEntity &creature)
 {
-    auto &player = creature;
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
     const auto selection_result = select_destroying_item(creature, (command_arg > 0));
@@ -231,7 +225,7 @@ void do_cmd_destroy(CreatureEntity &creature)
     energy.set_player_turn_energy(100);
     if (!can_player_destroy_object(o_ptr)) {
         energy.reset_player_turn();
-        const auto item_name = describe_flavor(player, *o_ptr, 0);
+        const auto item_name = describe_flavor(creature, *o_ptr, 0);
         msg_format(_("%sは破壊不可能だ。", "You cannot destroy %s."), item_name.data());
         return;
     }

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -67,7 +67,6 @@
  */
 static bool exe_eat_junk_type_object(CreatureEntity &creature, ItemEntity *o_ptr)
 {
-    auto &player = creature;
     if (o_ptr->bi_key.tval() != ItemKindType::JUNK) {
         return false;
     }
@@ -75,21 +74,21 @@ static bool exe_eat_junk_type_object(CreatureEntity &creature, ItemEntity *o_ptr
     if (o_ptr->bi_key.sval() == SV_JUNK_FECES || o_ptr->bi_key.sval() == SV_KMR_CURRY) {
         msg_print("ワーォ！貴方は糞を喰った！");
         msg_print("『涙が出るほどうめぇ……』");
-        if (!(has_resist_pois(player) || is_oppose_pois(player))) {
-            (void)BadStatusSetter(player).mod_poison(10 + randint1(10));
+        if (!(has_resist_pois(creature) || is_oppose_pois(creature))) {
+            (void)BadStatusSetter(creature).mod_poison(10 + randint1(10));
         }
-        player.plus_incident_tree("EAT_FECES", 1);
-        PlayerSkill(player).gain_riding_skill_exp_on_gross_eating();
+        creature.plus_incident_tree("EAT_FECES", 1);
+        PlayerSkill(creature).gain_riding_skill_exp_on_gross_eating();
         return true;
     }
     if (o_ptr->bi_key.sval() == SV_JUNK_VOMITTING) {
         msg_print("ワーォ！貴方はゲロを喰った！");
         msg_print("『涙が出るほどうめぇ……』");
-        if (!(has_resist_pois(player) || is_oppose_pois(player))) {
-            (void)BadStatusSetter(player).mod_poison(10 + randint1(10));
+        if (!(has_resist_pois(creature) || is_oppose_pois(creature))) {
+            (void)BadStatusSetter(creature).mod_poison(10 + randint1(10));
         }
-        player.plus_incident_tree("EAT_FECES", 1);
-        PlayerSkill(player).gain_riding_skill_exp_on_gross_eating();
+        creature.plus_incident_tree("EAT_FECES", 1);
+        PlayerSkill(creature).gain_riding_skill_exp_on_gross_eating();
         return true;
     }
     return false;
@@ -103,12 +102,11 @@ static bool exe_eat_junk_type_object(CreatureEntity &creature, ItemEntity *o_ptr
  */
 static bool exe_eat_soul(CreatureEntity &creature, ItemEntity *o_ptr)
 {
-    auto &player = creature;
     if (!(o_ptr->bi_key.tval() == ItemKindType::MONSTER_REMAINS && o_ptr->bi_key.sval() == SV_SOUL)) {
         return false;
     }
 
-    if (player.prace == PlayerRaceType::ANDROID) {
+    if (creature.prace == PlayerRaceType::ANDROID) {
         return false;
     }
 
@@ -116,8 +114,8 @@ static bool exe_eat_soul(CreatureEntity &creature, ItemEntity *o_ptr)
     EXP max_exp = monrace.level * monrace.level * 5;
 
     chg_virtue(creature, Virtue::ENLIGHTEN, 1);
-    if (player.exp < PY_MAX_EXP) {
-        EXP ee = (player.exp / 2) + 10;
+    if (creature.exp < PY_MAX_EXP) {
+        EXP ee = (creature.exp / 2) + 10;
         ee = std::min(ee, max_exp);
         msg_print(_("更に経験を積んだような気がする。", "You feel more experienced."));
         gain_exp(creature, ee);
@@ -133,7 +131,6 @@ static bool exe_eat_soul(CreatureEntity &creature, ItemEntity *o_ptr)
  */
 static bool exe_eat_corpse_type_object(CreatureEntity &creature, ItemEntity *o_ptr)
 {
-    auto &player = creature;
     if (!(o_ptr->bi_key.tval() == ItemKindType::MONSTER_REMAINS && o_ptr->bi_key.sval() == SV_CORPSE)) {
         return false;
     }
@@ -141,124 +138,124 @@ static bool exe_eat_corpse_type_object(CreatureEntity &creature, ItemEntity *o_p
     const auto &monrace = MonraceList::get_instance().get_monrace(i2enum<MonraceId, int>(o_ptr->pval));
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::BLIND)) {
-        BadStatusSetter(player).mod_blindness(200 + randint1(200));
+        BadStatusSetter(creature).mod_blindness(200 + randint1(200));
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::CONF)) {
-        BadStatusSetter(player).mod_confusion(200 + randint1(200));
+        BadStatusSetter(creature).mod_confusion(200 + randint1(200));
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::MANA)) {
-        restore_mana(player, false);
+        restore_mana(creature, false);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::NEXUS)) {
-        do_poly_self(player);
+        do_poly_self(creature);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::SLEEP)) {
-        if (!player.free_act) {
-            BadStatusSetter(player).set_paralysis(10 + randint1(10));
+        if (!creature.free_act) {
+            BadStatusSetter(creature).set_paralysis(10 + randint1(10));
         }
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::BERSERKER)) {
-        set_berserk(player, player.berserk + randint1(10) + 10, false);
+        set_berserk(creature, creature.berserk + randint1(10) + 10, false);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::ACIDIC)) {
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::SPEED)) {
-        (void)set_acceleration(player, randint1(20) + 20, false);
+        (void)set_acceleration(creature, randint1(20) + 20, false);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::CURE)) {
-        true_healing(player, 50);
+        true_healing(creature, 50);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::FIRE_RES)) {
-        set_oppose_fire(player, randint1(20) + 20, false);
+        set_oppose_fire(creature, randint1(20) + 20, false);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::COLD_RES)) {
-        set_oppose_cold(player, randint1(20) + 20, false);
+        set_oppose_cold(creature, randint1(20) + 20, false);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::ELEC_RES)) {
-        set_oppose_elec(player, randint1(20) + 20, false);
+        set_oppose_elec(creature, randint1(20) + 20, false);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::POIS_RES)) {
-        set_oppose_pois(player, randint1(20) + 20, false);
+        set_oppose_pois(creature, randint1(20) + 20, false);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::INSANITY)) {
-        sanity_blast(player, tl::nullopt, false);
+        sanity_blast(creature, tl::nullopt, false);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::DRAIN_EXP)) {
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::POISONOUS)) {
-        if (!(has_resist_pois(player) || is_oppose_pois(player))) {
-            (void)BadStatusSetter(player).mod_poison(10 + randint1(15));
+        if (!(has_resist_pois(creature) || is_oppose_pois(creature))) {
+            (void)BadStatusSetter(creature).mod_poison(10 + randint1(15));
         }
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::GIVE_STR)) {
-        do_inc_stat(player, A_STR);
+        do_inc_stat(creature, A_STR);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::GIVE_INT)) {
-        do_inc_stat(player, A_INT);
+        do_inc_stat(creature, A_INT);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::GIVE_WIS)) {
-        do_inc_stat(player, A_WIS);
+        do_inc_stat(creature, A_WIS);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::GIVE_DEX)) {
-        do_inc_stat(player, A_DEX);
+        do_inc_stat(creature, A_DEX);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::GIVE_CON)) {
-        do_inc_stat(player, A_CON);
+        do_inc_stat(creature, A_CON);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::GIVE_CHR)) {
-        do_inc_stat(player, A_CHR);
+        do_inc_stat(creature, A_CHR);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::LOSE_STR)) {
-        do_dec_stat(player, A_STR);
+        do_dec_stat(creature, A_STR);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::LOSE_INT)) {
-        do_dec_stat(player, A_INT);
+        do_dec_stat(creature, A_INT);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::LOSE_WIS)) {
-        do_dec_stat(player, A_WIS);
+        do_dec_stat(creature, A_WIS);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::LOSE_DEX)) {
-        do_dec_stat(player, A_DEX);
+        do_dec_stat(creature, A_DEX);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::LOSE_CON)) {
-        do_dec_stat(player, A_CON);
+        do_dec_stat(creature, A_CON);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::LOSE_CHR)) {
-        do_dec_stat(player, A_CHR);
+        do_dec_stat(creature, A_CHR);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::DRAIN_MANA)) {
-        player.csp -= 30;
-        if (player.csp < 0) {
-            player.csp = 0;
-            player.csp_frac = 0;
+        creature.csp -= 30;
+        if (creature.csp < 0) {
+            creature.csp = 0;
+            creature.csp_frac = 0;
         }
     }
 
@@ -273,84 +270,83 @@ static bool exe_eat_corpse_type_object(CreatureEntity &creature, ItemEntity *o_p
  */
 static bool exe_eat_food_type_object(CreatureEntity &creature, const BaseitemKey &bi_key)
 {
-    auto &player = creature;
     if (bi_key.tval() != ItemKindType::FOOD) {
         return false;
     }
 
-    BadStatusSetter bss(player);
+    BadStatusSetter bss(creature);
     switch (bi_key.sval().value()) {
     case SV_FOOD_POISON:
-        if (!(has_resist_pois(player) || is_oppose_pois(player))) {
+        if (!(has_resist_pois(creature) || is_oppose_pois(creature))) {
             if (bss.mod_poison(randint0(10) + 10)) {
-                player.plus_incident_tree("EAT_POISON", 1);
+                creature.plus_incident_tree("EAT_POISON", 1);
                 return true;
             }
         }
         break;
     case SV_FOOD_BLINDNESS:
-        if (!has_resist_blind(player)) {
+        if (!has_resist_blind(creature)) {
             if (bss.mod_blindness(randint0(200) + 200)) {
-                player.plus_incident_tree("EAT_POISON", 1);
+                creature.plus_incident_tree("EAT_POISON", 1);
                 return true;
             }
         }
         break;
     case SV_FOOD_PARANOIA:
-        if (!has_resist_fear(player)) {
+        if (!has_resist_fear(creature)) {
             if (bss.mod_fear(randint0(10) + 10)) {
-                player.plus_incident_tree("EAT_POISON", 1);
+                creature.plus_incident_tree("EAT_POISON", 1);
                 return true;
             }
         }
         break;
     case SV_FOOD_CONFUSION:
-        if (!has_resist_conf(player)) {
+        if (!has_resist_conf(creature)) {
             if (bss.mod_confusion(randint0(10) + 10)) {
-                player.plus_incident_tree("EAT_POISON", 1);
+                creature.plus_incident_tree("EAT_POISON", 1);
                 return true;
             }
         }
         break;
     case SV_FOOD_HALLUCINATION:
-        if (!has_resist_chaos(player)) {
+        if (!has_resist_chaos(creature)) {
             if (bss.mod_hallucination(randint0(250) + 250)) {
-                player.plus_incident_tree("EAT_POISON", 1);
+                creature.plus_incident_tree("EAT_POISON", 1);
                 return true;
             }
         }
         break;
     case SV_FOOD_PARALYSIS:
-        if (!player.free_act) {
+        if (!creature.free_act) {
             if (bss.set_paralysis(10 + randint1(10))) {
-                player.plus_incident_tree("EAT_POISON", 1);
+                creature.plus_incident_tree("EAT_POISON", 1);
                 return true;
             }
         }
         break;
     case SV_FOOD_WEAKNESS:
-        take_hit(player, DAMAGE_NOESCAPE, Dice::roll(6, 6), _("毒入り食料", "poisonous food"));
-        (void)do_dec_stat(player, A_STR);
+        take_hit(creature, DAMAGE_NOESCAPE, Dice::roll(6, 6), _("毒入り食料", "poisonous food"));
+        (void)do_dec_stat(creature, A_STR);
         return true;
     case SV_FOOD_SICKNESS:
-        take_hit(player, DAMAGE_NOESCAPE, Dice::roll(6, 6), _("毒入り食料", "poisonous food"));
-        (void)do_dec_stat(player, A_CON);
+        take_hit(creature, DAMAGE_NOESCAPE, Dice::roll(6, 6), _("毒入り食料", "poisonous food"));
+        (void)do_dec_stat(creature, A_CON);
         return true;
     case SV_FOOD_STUPIDITY:
-        take_hit(player, DAMAGE_NOESCAPE, Dice::roll(8, 8), _("毒入り食料", "poisonous food"));
-        (void)do_dec_stat(player, A_INT);
+        take_hit(creature, DAMAGE_NOESCAPE, Dice::roll(8, 8), _("毒入り食料", "poisonous food"));
+        (void)do_dec_stat(creature, A_INT);
         return true;
     case SV_FOOD_NAIVETY:
-        take_hit(player, DAMAGE_NOESCAPE, Dice::roll(8, 8), _("毒入り食料", "poisonous food"));
-        (void)do_dec_stat(player, A_WIS);
+        take_hit(creature, DAMAGE_NOESCAPE, Dice::roll(8, 8), _("毒入り食料", "poisonous food"));
+        (void)do_dec_stat(creature, A_WIS);
         return true;
     case SV_FOOD_UNHEALTH:
-        take_hit(player, DAMAGE_NOESCAPE, Dice::roll(10, 10), _("毒入り食料", "poisonous food"));
-        (void)do_dec_stat(player, A_CON);
+        take_hit(creature, DAMAGE_NOESCAPE, Dice::roll(10, 10), _("毒入り食料", "poisonous food"));
+        (void)do_dec_stat(creature, A_CON);
         return true;
     case SV_FOOD_DISEASE:
-        take_hit(player, DAMAGE_NOESCAPE, Dice::roll(10, 10), _("毒入り食料", "poisonous food"));
-        (void)do_dec_stat(player, A_STR);
+        take_hit(creature, DAMAGE_NOESCAPE, Dice::roll(10, 10), _("毒入り食料", "poisonous food"));
+        (void)do_dec_stat(creature, A_STR);
         return true;
     case SV_FOOD_CURE_POISON:
         return bss.set_poison(0);
@@ -361,13 +357,13 @@ static bool exe_eat_food_type_object(CreatureEntity &creature, const BaseitemKey
     case SV_FOOD_CURE_CONFUSION:
         return bss.set_confusion(0);
     case SV_FOOD_CURE_SERIOUS:
-        return cure_serious_wounds(player, Dice::roll(4, 8));
+        return cure_serious_wounds(creature, Dice::roll(4, 8));
     case SV_FOOD_RESTORE_STR:
-        return do_res_stat(player, A_STR);
+        return do_res_stat(creature, A_STR);
     case SV_FOOD_RESTORE_CON:
-        return do_res_stat(player, A_CON);
+        return do_res_stat(creature, A_CON);
     case SV_FOOD_RESTORING:
-        return restore_all_status(player);
+        return restore_all_status(creature);
     case SV_FOOD_BISCUIT:
         msg_print(_("甘くてサクサクしてとてもおいしい。", "That is sweet, crispy, and very delicious."));
         return true;
@@ -386,7 +382,7 @@ static bool exe_eat_food_type_object(CreatureEntity &creature, const BaseitemKey
     case SV_FOOD_WAYBREAD:
         msg_print(_("これはひじょうに美味だ。", "That tastes very good."));
         (void)bss.set_poison(0);
-        (void)hp_player(player, Dice::roll(4, 8));
+        (void)hp_player(creature, Dice::roll(4, 8));
         return true;
     case SV_FOOD_PINT_OF_ALE:
     case SV_FOOD_PINT_OF_WINE:
@@ -394,77 +390,77 @@ static bool exe_eat_food_type_object(CreatureEntity &creature, const BaseitemKey
         return true;
     case SV_FOOD_WELCOME_DRINK_OF_ARE:
     case SV_FOOD_ABA_TEA:
-        player.plus_incident_tree("EAT_POISON", 1);
-        (void)BadStatusSetter(player).mod_poison(10);
+        creature.plus_incident_tree("EAT_POISON", 1);
+        (void)BadStatusSetter(creature).mod_poison(10);
         msg_print("「非常に新鮮で……非常においしい……」");
-        player.plus_incident_tree("EAT_FECES", 1);
+        creature.plus_incident_tree("EAT_FECES", 1);
         return true;
     case SV_FOOD_SEED_FEA:
         msg_print("脱穀して炊いた方が良かったかもしれないが、多少空腹は収まった。");
         return true;
     case SV_FOOD_HIP:
-        player.plus_incident_tree("EAT_POISON", 1);
+        creature.plus_incident_tree("EAT_POISON", 1);
         msg_print("ヴォエ！食ったら尻の肉だった！");
         msg_erase();
-        (void)BadStatusSetter(player).mod_poison(10);
+        (void)BadStatusSetter(creature).mod_poison(10);
         msg_print("「作者は広告で収入得てないけど、こんな卑猥なアイテム放置するなよ」");
         msg_erase();
-        player.plus_incident_tree("EAT_FECES", 1);
+        creature.plus_incident_tree("EAT_FECES", 1);
         return true;
     case SV_FOOD_SURSTROMMING:
         msg_print("悪臭が周囲を取り巻いた！");
         msg_erase();
-        fire_ball(player, AttributeType::POIS, Direction::self(), 30, 4);
-        (void)BadStatusSetter(player).mod_poison(10);
+        fire_ball(creature, AttributeType::POIS, Direction::self(), 30, 4);
+        (void)BadStatusSetter(creature).mod_poison(10);
         return true;
     case SV_FOOD_HOMOTEA:
-        (void)BadStatusSetter(player).mod_stun(200);
+        (void)BadStatusSetter(creature).mod_stun(200);
         msg_print("「お、大丈夫か？大丈夫か？……」");
         return true;
     case SV_FOOD_GOLDEN_EGG:
-        (void)do_inc_stat(player, randint0(6));
+        (void)do_inc_stat(creature, randint0(6));
         return true;
     case SV_FOOD_ABESHI:
-        gain_exp(creature, player.level * 50);
-        (void)set_hero(player, randint1(10) + 10, false);
+        gain_exp(creature, creature.level * 50);
+        (void)set_hero(creature, randint1(10) + 10, false);
         if (one_in_(300)) {
-            (void)do_inc_stat(player, A_STR);
+            (void)do_inc_stat(creature, A_STR);
         }
         if (one_in_(300)) {
-            (void)do_inc_stat(player, A_DEX);
+            (void)do_inc_stat(creature, A_DEX);
         }
         if (one_in_(300)) {
-            (void)do_inc_stat(player, A_CON);
+            (void)do_inc_stat(creature, A_CON);
         }
         return true;
     case SV_FOOD_HIDEBU:
-        gain_exp(creature, player.level * 100);
-        (void)set_hero(player, randint1(25) + 25, false);
+        gain_exp(creature, creature.level * 100);
+        (void)set_hero(creature, randint1(25) + 25, false);
         if (one_in_(100)) {
-            (void)do_inc_stat(player, A_STR);
+            (void)do_inc_stat(creature, A_STR);
         }
         if (one_in_(100)) {
-            (void)do_inc_stat(player, A_DEX);
+            (void)do_inc_stat(creature, A_DEX);
         }
         if (one_in_(100)) {
-            (void)do_inc_stat(player, A_CON);
+            (void)do_inc_stat(creature, A_CON);
         }
         return true;
     case SV_FOOD_BASILISK_TIME:
-        gain_exp(creature, player.level * 100);
+        gain_exp(creature, creature.level * 100);
         msg_print("あなたは突如狂ったように踊り始めた！");
         msg_print("「みずのよーうにのようにやさしく！はなのよーうにはげしく！ふーるえ……」");
-        (void)BadStatusSetter(player).mod_stun(25 + randint1(25));
-        (void)set_hero(player, randint1(25) + 25, false);
-        (void)set_berserk(player, randint1(25) + 25, false);
+        (void)BadStatusSetter(creature).mod_stun(25 + randint1(25));
+        (void)set_hero(creature, randint1(25) + 25, false);
+        (void)set_berserk(creature, randint1(25) + 25, false);
         if (one_in_(100)) {
-            (void)do_inc_stat(player, A_STR);
+            (void)do_inc_stat(creature, A_STR);
         }
         if (one_in_(100)) {
-            (void)do_inc_stat(player, A_DEX);
+            (void)do_inc_stat(creature, A_DEX);
         }
         if (one_in_(100)) {
-            (void)do_inc_stat(player, A_CON);
+            (void)do_inc_stat(creature, A_CON);
         }
         return true;
     default:
@@ -482,7 +478,6 @@ static bool exe_eat_food_type_object(CreatureEntity &creature, const BaseitemKey
  */
 static bool exe_eat_charge_of_magic_device(CreatureEntity &creature, ItemEntity *o_ptr, short i_idx)
 {
-    auto &player = creature;
     if (!o_ptr->is_wand_staff() || (CreatureRace(&creature).food() != PlayerRaceFoodType::MANA)) {
         return false;
     }
@@ -509,7 +504,7 @@ static bool exe_eat_charge_of_magic_device(CreatureEntity &creature, ItemEntity 
     o_ptr->pval--;
 
     /* Eat a charge */
-    set_food(player, player.food + 5000);
+    set_food(creature, creature.food + 5000);
 
     /* XXX Hack -- unstack if necessary */
     if (is_staff && (i_idx >= 0) && (o_ptr->number > 1)) {
@@ -521,14 +516,14 @@ static bool exe_eat_charge_of_magic_device(CreatureEntity &creature, ItemEntity 
 
         /* Unstack the used item */
         o_ptr->number--;
-        i_idx = store_item_to_inventory(player, &item);
+        i_idx = store_item_to_inventory(creature, &item);
         msg_format(_("杖をまとめなおした。", "You unstack your staff."));
     }
 
     if (i_idx >= 0) {
-        inven_item_charges(*player.inventory[i_idx]);
+        inven_item_charges(*creature.inventory[i_idx]);
     } else {
-        floor_item_charges(*player.current_floor_ptr, 0 - i_idx);
+        floor_item_charges(*creature.current_floor_ptr, 0 - i_idx);
     }
 
     static constexpr auto flags = {
@@ -545,9 +540,8 @@ static bool exe_eat_charge_of_magic_device(CreatureEntity &creature, ItemEntity 
  */
 void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
 {
-    auto &player = creature;
-    if (music_singing_any(player)) {
-        stop_singing(player);
+    if (music_singing_any(creature)) {
+        stop_singing(creature);
     }
 
     SpellHex spell_hex(creature);
@@ -555,11 +549,11 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
         (void)spell_hex.stop_all_spells();
     }
 
-    auto *o_ptr = ref_item(player, i_idx);
+    auto *o_ptr = ref_item(creature, i_idx);
 
     sound(SoundKind::EAT);
 
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
     const auto level = o_ptr->get_baseitem_level();
 
     /* 基本食い物でないものを喰う判定 */
@@ -606,10 +600,10 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
         o_ptr->mark_as_tried();
     }
 
-    /* The player is now aware of the object */
+    /* The creature is now aware of the object */
     if (ident && !o_ptr->is_aware()) {
         object_aware(creature, *o_ptr);
-        gain_exp(creature, (level + (player.level >> 1)) / player.level);
+        gain_exp(creature, (level + (creature.level >> 1)) / creature.level);
     }
 
     static constexpr auto flags_swrf = {
@@ -630,12 +624,12 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
     /* Balrogs change humanoid corpses to energy */
     if (food_type == PlayerRaceFoodType::CORPSE) {
         if (o_ptr->is_corpse() && o_ptr->get_monrace().is_human()) {
-            const auto item_name = describe_flavor(player, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+            const auto item_name = describe_flavor(creature, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
             msg_format(_("%sは燃え上り灰になった。精力を吸収した気がする。", "%s^ is burnt to ashes.  You absorb its vitality!"), item_name.data());
-            (void)set_food(player, PY_FOOD_MAX - 1);
+            (void)set_food(creature, PY_FOOD_MAX - 1);
 
             rfu.set_flags(flags_srf);
-            vary_item(player, i_idx, -1);
+            vary_item(creature, i_idx, -1);
             return;
         }
     }
@@ -647,7 +641,7 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
             msg_print(_("食べ物がアゴを素通りして落ちた！", "The food falls through your jaws!"));
 
             /* Drop the object from heaven */
-            (void)drop_near(player, item, player.get_position());
+            (void)drop_near(creature, item, creature.get_position());
             ate = true;
         } else {
             msg_print(_("食べ物がアゴを素通りして落ち、消えた！", "The food falls through your jaws and vanishes!"));
@@ -655,10 +649,10 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
         }
     } else if (food_type == PlayerRaceFoodType::BLOOD) {
         /* Vampires are filled only by bloods, so reduced nutritional benefit */
-        (void)set_food(player, player.food + (o_ptr->pval / 10));
+        (void)set_food(creature, creature.food + (o_ptr->pval / 10));
         msg_print(_("あなたのような者にとって食糧など僅かな栄養にしかならない。", "Mere victuals hold scant sustenance for a being such as yourself."));
 
-        if (player.food < PY_FOOD_ALERT) {
+        if (creature.food < PY_FOOD_ALERT) {
             /* Hungry */
             msg_print(_("あなたの飢えは新鮮な血によってのみ満たされる！", "Your hunger can only be satisfied with fresh blood!"));
         }
@@ -666,20 +660,20 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
 
     } else if (food_type == PlayerRaceFoodType::WATER) {
         msg_print(_("動物の食物はあなたにとってほとんど栄養にならない。", "The food of animals is poor sustenance for you."));
-        set_food(player, player.food + ((o_ptr->pval) / 20));
+        set_food(creature, creature.food + ((o_ptr->pval) / 20));
         ate = true;
     } else if (food_type != PlayerRaceFoodType::RATION) {
         msg_print(_("生者の食物はあなたにとってほとんど栄養にならない。", "The food of mortals is poor sustenance for you."));
-        set_food(player, player.food + ((o_ptr->pval) / 20));
+        set_food(creature, creature.food + ((o_ptr->pval) / 20));
         ate = true;
     } else {
         if (bi_key == BaseitemKey(ItemKindType::FOOD, SV_FOOD_WAYBREAD)) {
             /* Waybread is always fully satisfying. */
-            set_food(player, std::max<short>(player.food, PY_FOOD_MAX - 1));
+            set_food(creature, std::max<short>(creature.food, PY_FOOD_MAX - 1));
             ate = true;
         } else if (bi_key.tval() == ItemKindType::FOOD) {
-            /* Food can feed the player */
-            (void)set_food(player, player.food + o_ptr->pval);
+            /* Food can feed the creature */
+            (void)set_food(creature, creature.food + o_ptr->pval);
             ate = true;
         }
     }
@@ -689,7 +683,7 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
         return;
     }
 
-    player.plus_incident_tree("EAT", 1);
+    creature.plus_incident_tree("EAT", 1);
 
     // 死体を食べた場合は詳細情報を記録
     if (o_ptr->bi_key.tval() == ItemKindType::MONSTER_REMAINS && o_ptr->bi_key.sval() == SV_CORPSE) {
@@ -697,11 +691,11 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
             static_cast<int>(o_ptr->bi_key.tval()),
             o_ptr->bi_key.sval().value_or(0),
             o_ptr->pval);
-        player.plus_incident_tree(incident_key, 1);
+        creature.plus_incident_tree(incident_key, 1);
     }
 
     rfu.set_flags(flags_srf);
-    vary_item(player, i_idx, -1);
+    vary_item(creature, i_idx, -1);
 }
 
 /*!
@@ -710,12 +704,11 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
  */
 void do_cmd_eat_food(CreatureEntity &creature)
 {
-    auto &player = creature;
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU, SamuraiStanceType::KOUKIJIN });
     constexpr auto q = _("どれを食べますか? ", "Eat which item? ");
     constexpr auto s = _("食べ物がない。", "You have nothing to eat.");
     short i_idx;
-    if (!choose_object(player, &i_idx, q, s, (USE_INVEN | USE_FLOOR), FuncItemTester(item_tester_hook_eatable, creature))) {
+    if (!choose_object(creature, &i_idx, q, s, (USE_INVEN | USE_FLOOR), FuncItemTester(item_tester_hook_eatable, creature))) {
         return;
     }
 

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -58,12 +58,11 @@
  */
 static void do_curse_on_equip(OBJECT_IDX slot, ItemEntity &item, CreatureEntity &creature)
 {
-    auto &player = creature;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (set_anubis_and_chariot(player) && ((slot == INVEN_MAIN_HAND) || (slot == INVEN_SUB_HAND))) {
+    if (set_anubis_and_chariot(creature) && ((slot == INVEN_MAIN_HAND) || (slot == INVEN_SUB_HAND))) {
 
-        ItemEntity *anubis = player.inventory[INVEN_MAIN_HAND].get();
-        ItemEntity *chariot = player.inventory[INVEN_SUB_HAND].get();
+        ItemEntity *anubis = creature.inventory[INVEN_MAIN_HAND].get();
+        ItemEntity *chariot = creature.inventory[INVEN_SUB_HAND].get();
 
         anubis->curse_flags.set(CurseTraitType::PERSISTENT_CURSE);
         anubis->curse_flags.set(CurseTraitType::HEAVY_CURSE);
@@ -83,7 +82,7 @@ static void do_curse_on_equip(OBJECT_IDX slot, ItemEntity &item, CreatureEntity 
         return;
     }
 
-    const auto item_name = describe_flavor(player, item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(creature, item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     item.curse_flags.set(CurseTraitType::HEAVY_CURSE);
     msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), item_name.data());
     item.feeling = FEEL_NONE;
@@ -131,7 +130,6 @@ void do_cmd_equip(CreatureEntity &creature)
  */
 void do_cmd_wield(CreatureEntity &creature)
 {
-    auto &player = creature;
     concptr act;
     OBJECT_IDX need_switch_wielding = 0;
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
@@ -139,7 +137,7 @@ void do_cmd_wield(CreatureEntity &creature)
     constexpr auto selection_q = _("どれを装備しますか? ", "Wear/Wield which item? ");
     constexpr auto selection_s = _("装備可能なアイテムがない。", "You have nothing you can wear or wield.");
     short i_idx;
-    auto *o_ptr = choose_object(player, &i_idx, selection_q, selection_s, (USE_INVEN | USE_FLOOR), FuncItemTester(item_tester_hook_wear, creature));
+    auto *o_ptr = choose_object(creature, &i_idx, selection_q, selection_s, (USE_INVEN | USE_FLOOR), FuncItemTester(item_tester_hook_wear, creature));
     if (!o_ptr) {
         return;
     }
@@ -147,18 +145,18 @@ void do_cmd_wield(CreatureEntity &creature)
     auto slot = wield_slot(creature, o_ptr);
 
     // 肛門破壊チェック
-    if (slot == INVEN_ASSHOLE && player.muta.has(PlayerMutationType::DESTROYED_ASSHOLE)) {
+    if (slot == INVEN_ASSHOLE && creature.muta.has(PlayerMutationType::DESTROYED_ASSHOLE)) {
         msg_print(_("あなたの肛門は完全に破壊されており、何も装備できない！", "Your asshole is completely destroyed and cannot equip anything!"));
         return;
     }
 
     // 頭部失失チェック
-    if (slot == INVEN_HEAD && player.muta.has(PlayerMutationType::LOST_HEAD)) {
+    if (slot == INVEN_HEAD && creature.muta.has(PlayerMutationType::LOST_HEAD)) {
         msg_print(_("あなたは頭がないので、頭に何も装備できない！", "You have no head and cannot equip anything on your head!"));
         return;
     }
-    const auto o_ptr_mh = player.inventory[INVEN_MAIN_HAND].get();
-    const auto o_ptr_sh = player.inventory[INVEN_SUB_HAND].get();
+    const auto o_ptr_mh = creature.inventory[INVEN_MAIN_HAND].get();
+    const auto o_ptr_sh = creature.inventory[INVEN_SUB_HAND].get();
     const auto tval = o_ptr->bi_key.tval();
     switch (tval) {
     case ItemKindType::CAPTURE:
@@ -167,7 +165,7 @@ void do_cmd_wield(CreatureEntity &creature)
         if (has_melee_weapon(creature, INVEN_MAIN_HAND) && has_melee_weapon(creature, INVEN_SUB_HAND)) {
             constexpr auto q = _("どちらの武器と取り替えますか?", "Replace which weapon? ");
             constexpr auto s = _("おっと。", "Oops.");
-            if (!choose_object(player, &slot, q, s, (USE_EQUIP | IGNORE_BOTHHAND_SLOT), FuncItemTester(&ItemEntity::is_melee_weapon))) {
+            if (!choose_object(creature, &slot, q, s, (USE_EQUIP | IGNORE_BOTHHAND_SLOT), FuncItemTester(&ItemEntity::is_melee_weapon))) {
                 return;
             }
 
@@ -180,7 +178,7 @@ void do_cmd_wield(CreatureEntity &creature)
                    ((tval == ItemKindType::CAPTURE) || (!o_ptr_mh->is_melee_weapon() && !o_ptr_sh->is_melee_weapon()))) {
             constexpr auto q = _("どちらの手に装備しますか?", "Equip which hand? ");
             constexpr auto s = _("おっと。", "Oops.");
-            if (!choose_object(player, &slot, q, s, (USE_EQUIP), FuncItemTester(&ItemEntity::is_wieldable_in_etheir_hand))) {
+            if (!choose_object(creature, &slot, q, s, (USE_EQUIP), FuncItemTester(&ItemEntity::is_wieldable_in_etheir_hand))) {
                 return;
             }
         }
@@ -201,7 +199,7 @@ void do_cmd_wield(CreatureEntity &creature)
         } else if (o_ptr_mh->is_valid() && o_ptr_sh->is_valid()) {
             constexpr auto q = _("どちらの手に装備しますか?", "Equip which hand? ");
             constexpr auto s = _("おっと。", "Oops.");
-            if (!choose_object(player, &slot, q, s, (USE_EQUIP), FuncItemTester(&ItemEntity::is_wieldable_in_etheir_hand))) {
+            if (!choose_object(creature, &slot, q, s, (USE_EQUIP), FuncItemTester(&ItemEntity::is_wieldable_in_etheir_hand))) {
                 return;
             }
 
@@ -213,32 +211,32 @@ void do_cmd_wield(CreatureEntity &creature)
         break;
     case ItemKindType::RING: {
         std::string q;
-        if (player.inventory[INVEN_SUB_RING]->is_valid() && player.inventory[INVEN_MAIN_RING]->is_valid()) {
+        if (creature.inventory[INVEN_SUB_RING]->is_valid() && creature.inventory[INVEN_MAIN_RING]->is_valid()) {
             q = _("どちらの指輪と取り替えますか?", "Replace which ring? ");
         } else {
             q = _("どちらの手に装備しますか?", "Equip which hand? ");
         }
 
         constexpr auto s = _("おっと。", "Oops.");
-        player.select_ring_slot = true;
-        if (!choose_object(player, &slot, q.data(), s, (USE_EQUIP | IGNORE_BOTHHAND_SLOT))) {
-            player.select_ring_slot = false;
+        creature.select_ring_slot = true;
+        if (!choose_object(creature, &slot, q.data(), s, (USE_EQUIP | IGNORE_BOTHHAND_SLOT))) {
+            creature.select_ring_slot = false;
             return;
         }
 
-        player.select_ring_slot = false;
+        creature.select_ring_slot = false;
         break;
     }
     default:
         break;
     }
 
-    if (player.inventory[slot]->is_cursed()) {
-        const auto item_name = describe_flavor(player, *player.inventory[slot], OD_OMIT_PREFIX | OD_NAME_ONLY);
+    if (creature.inventory[slot]->is_cursed()) {
+        const auto item_name = describe_flavor(creature, *creature.inventory[slot], OD_OMIT_PREFIX | OD_NAME_ONLY);
 #ifdef JP
-        msg_format("%s%sは呪われているようだ。", describe_use(player, slot), item_name.data());
+        msg_format("%s%sは呪われているようだ。", describe_use(creature, slot), item_name.data());
 #else
-        msg_format("The %s you are %s appears to be cursed.", item_name.data(), describe_use(player, slot));
+        msg_format("The %s you are %s appears to be cursed.", item_name.data(), describe_use(creature, slot));
 #endif
         return;
     }
@@ -247,7 +245,7 @@ void do_cmd_wield(CreatureEntity &creature)
     should_equip_cursed |= any_bits(o_ptr->ident, IDENT_SENSE) && (FEEL_BROKEN <= o_ptr->feeling) && (o_ptr->feeling <= FEEL_CURSED);
     should_equip_cursed &= confirm_wear;
     if (should_equip_cursed) {
-        const auto item_name = describe_flavor(player, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        const auto item_name = describe_flavor(creature, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         if (!input_check(format(_("本当に%s{呪われている}を使いますか？", "Really use the %s {cursed}? "), item_name.data()))) {
             return;
         }
@@ -259,7 +257,7 @@ void do_cmd_wield(CreatureEntity &creature)
     should_change_vampire &= !pr.equals(PlayerRaceType::VAMPIRE);
     should_change_vampire &= !pr.equals(PlayerRaceType::ANDROID);
     if (should_change_vampire) {
-        const auto item_name = describe_flavor(player, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        const auto item_name = describe_flavor(creature, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         constexpr auto mes = _("%sを装備すると吸血鬼になります。よろしいですか？",
             "%s will transform you into a vampire permanently when equipped. Do you become a vampire? ");
         if (!input_check(format(mes, item_name.data()))) {
@@ -268,41 +266,41 @@ void do_cmd_wield(CreatureEntity &creature)
     }
 
     sound(SoundKind::WIELD);
-    if (need_switch_wielding && !player.inventory[need_switch_wielding]->is_cursed()) {
-        auto &slot_item = *player.inventory[slot];
-        auto &switch_item = *player.inventory[need_switch_wielding];
-        const auto item_name = describe_flavor(player, switch_item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    if (need_switch_wielding && !creature.inventory[need_switch_wielding]->is_cursed()) {
+        auto &slot_item = *creature.inventory[slot];
+        auto &switch_item = *creature.inventory[need_switch_wielding];
+        const auto item_name = describe_flavor(creature, switch_item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         std::swap(switch_item, slot_item);
         msg_format(_("%sを%sに構えなおした。", "You wield %s at %s hand."), item_name.data(),
             (slot == INVEN_MAIN_HAND) ? (left_hander ? _("左手", "left") : _("右手", "right")) : (left_hander ? _("右手", "right") : _("左手", "left")));
         slot = need_switch_wielding;
     }
 
-    check_find_art_quest_completion(player, o_ptr);
-    if (player.ppersonality == PERSONALITY_MUNCHKIN) {
+    check_find_art_quest_completion(creature, o_ptr);
+    if (creature.ppersonality == PERSONALITY_MUNCHKIN) {
         identify_item(creature, o_ptr);
-        autopick_alter_item(player, i_idx, false);
+        autopick_alter_item(creature, i_idx, false);
     }
 
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
     auto item = o_ptr->clone();
     item.number = 1;
     if (i_idx >= 0) {
-        inven_item_increase(player, i_idx, -1);
-        inven_item_optimize(player, i_idx);
+        inven_item_increase(creature, i_idx, -1);
+        inven_item_optimize(creature, i_idx);
     } else {
         floor_item_increase(creature, 0 - i_idx, -1);
         floor_item_optimize(creature, 0 - i_idx);
     }
 
-    auto &wield_slot_item = *player.inventory[slot];
+    auto &wield_slot_item = *creature.inventory[slot];
     if (wield_slot_item.is_valid()) {
-        (void)inven_takeoff(player, slot, 255);
+        (void)inven_takeoff(creature, slot, 255);
     }
 
     wield_slot_item = std::move(item);
     wield_slot_item.marked.set(OmType::TOUCHED);
-    player.equip_cnt++;
+    creature.equip_cnt++;
 
 #define STR_WIELD_HAND_RIGHT _("%s(%c)を右手に装備した。", "You are wielding %s (%c) in your right hand.")
 #define STR_WIELD_HAND_LEFT _("%s(%c)を左手に装備した。", "You are wielding %s (%c) in your left hand.")
@@ -336,7 +334,7 @@ void do_cmd_wield(CreatureEntity &creature)
         break;
     }
 
-    const auto item_name = describe_flavor(player, wield_slot_item, 0);
+    const auto item_name = describe_flavor(creature, wield_slot_item, 0);
     msg_format(act, item_name.data(), index_to_label(slot));
     if (wield_slot_item.is_cursed()) {
         msg_print(_("うわ！ すさまじく冷たい！", "Oops! It feels deathly cold!"));
@@ -349,7 +347,7 @@ void do_cmd_wield(CreatureEntity &creature)
         auto is_specific_race = pr.equals(PlayerRaceType::VAMPIRE);
         is_specific_race |= pr.equals(PlayerRaceType::ANDROID);
         if (!is_specific_race) {
-            change_race(player, PlayerRaceType::VAMPIRE, "");
+            change_race(creature, PlayerRaceType::VAMPIRE, "");
         }
     }
 
@@ -375,14 +373,13 @@ void do_cmd_wield(CreatureEntity &creature)
  */
 void do_cmd_takeoff(CreatureEntity &creature)
 {
-    auto &player = creature;
     CreatureClass pc(creature);
     pc.break_samurai_stance({ SamuraiStanceType::MUSOU });
 
     constexpr auto q = _("どれを装備からはずしますか? ", "Take off which item? ");
     constexpr auto s = _("はずせる装備がない。", "You are not wearing anything to take off.");
     short i_idx;
-    auto *o_ptr = choose_object(player, &i_idx, q, s, (USE_EQUIP | IGNORE_BOTHHAND_SLOT));
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, (USE_EQUIP | IGNORE_BOTHHAND_SLOT));
     if (!o_ptr) {
         return;
     }
@@ -412,7 +409,7 @@ void do_cmd_takeoff(CreatureEntity &creature)
 
     sound(SoundKind::TAKE_OFF);
     energy.set_player_turn_energy(50);
-    (void)inven_takeoff(player, i_idx, 255);
+    (void)inven_takeoff(creature, i_idx, 255);
     verify_equip_slot(creature, i_idx);
     calc_android_exp(creature);
     static constexpr auto flags_srf = {

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -108,14 +108,13 @@ void do_cmd_inven(CreatureEntity &creature)
  */
 void do_cmd_drop(CreatureEntity &creature)
 {
-    auto &player = creature;
     int amt = 1;
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
     constexpr auto q = _("どのアイテムを落としますか? ", "Drop which item? ");
     constexpr auto s = _("落とせるアイテムを持っていない。", "You have nothing to drop.");
     short i_idx;
-    auto *o_ptr = choose_object(player, &i_idx, q, s, (USE_EQUIP | USE_INVEN | IGNORE_BOTHHAND_SLOT));
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, (USE_EQUIP | USE_INVEN | IGNORE_BOTHHAND_SLOT));
     if (!o_ptr) {
         return;
     }
@@ -132,8 +131,8 @@ void do_cmd_drop(CreatureEntity &creature)
         }
     }
 
-    PlayerEnergy(player).set_player_turn_energy(50);
-    drop_from_inventory(player, i_idx, amt);
+    PlayerEnergy(creature).set_player_turn_energy(50);
+    drop_from_inventory(creature, i_idx, amt);
     if (i_idx >= INVEN_MAIN_HAND) {
         verify_equip_slot(creature, i_idx);
         calc_android_exp(creature);
@@ -147,11 +146,10 @@ void do_cmd_drop(CreatureEntity &creature)
  */
 void do_cmd_observe(CreatureEntity &creature)
 {
-    auto &player = creature;
     constexpr auto q = _("どのアイテムを調べますか? ", "Examine which item? ");
     constexpr auto s = _("調べられるアイテムがない。", "You have nothing to examine.");
     short i_idx;
-    auto *o_ptr = choose_object(player, &i_idx, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT));
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT));
     if (!o_ptr) {
         return;
     }
@@ -174,11 +172,10 @@ void do_cmd_observe(CreatureEntity &creature)
  */
 void do_cmd_uninscribe(CreatureEntity &creature)
 {
-    auto &player = creature;
     constexpr auto q = _("どのアイテムの銘を消しますか? ", "Un-inscribe which item? ");
     constexpr auto s = _("銘を消せるアイテムがない。", "You have nothing to un-inscribe.");
     short i_idx;
-    auto *o_ptr = choose_object(player, &i_idx, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT));
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT));
     if (!o_ptr) {
         return;
     }
@@ -211,16 +208,15 @@ void do_cmd_uninscribe(CreatureEntity &creature)
  */
 void do_cmd_inscribe(CreatureEntity &creature)
 {
-    auto &player = creature;
     constexpr auto q = _("どのアイテムに銘を刻みますか? ", "Inscribe which item? ");
     constexpr auto s = _("銘を刻めるアイテムがない。", "You have nothing to inscribe.");
     short i_idx;
-    auto *o_ptr = choose_object(player, &i_idx, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT));
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT));
     if (!o_ptr) {
         return;
     }
 
-    const auto item_name = describe_flavor(player, *o_ptr, OD_OMIT_INSCRIPTION);
+    const auto item_name = describe_flavor(creature, *o_ptr, OD_OMIT_INSCRIPTION);
     msg_format(_("%sに銘を刻む。", "Inscribing %s."), item_name.data());
     msg_erase();
     const auto initial_inscription = o_ptr->is_inscribed() ? *o_ptr->inscription : "";
@@ -253,7 +249,6 @@ void do_cmd_inscribe(CreatureEntity &creature)
  */
 void do_cmd_use(CreatureEntity &creature)
 {
-    auto &player = creature;
     if (AngbandWorld::get_instance().is_wild_mode() || cmd_limit_arena(creature)) {
         return;
     }
@@ -263,7 +258,7 @@ void do_cmd_use(CreatureEntity &creature)
     constexpr auto s = _("使えるものがありません。", "You have nothing to use.");
     const auto options = USE_INVEN | USE_EQUIP | USE_FLOOR | IGNORE_BOTHHAND_SLOT;
     short i_idx;
-    const auto *o_ptr = choose_object(player, &i_idx, q, s, options, FuncItemTester(item_tester_hook_use, creature));
+    const auto *o_ptr = choose_object(creature, &i_idx, q, s, options, FuncItemTester(item_tester_hook_use, creature));
     if (o_ptr == nullptr) {
         return;
     }
@@ -279,16 +274,16 @@ void do_cmd_use(CreatureEntity &creature)
         ObjectZapWandEntity(creature).execute(i_idx);
         break;
     case ItemKindType::STAFF:
-        ObjectUseEntity(player, i_idx).execute();
+        ObjectUseEntity(creature, i_idx).execute();
         break;
     case ItemKindType::ROD:
-        ObjectZapRodEntity(player).execute(i_idx);
+        ObjectZapRodEntity(creature).execute(i_idx);
         break;
     case ItemKindType::POTION:
         ObjectQuaffEntity(creature).execute(i_idx);
         break;
     case ItemKindType::SCROLL:
-        if (cmd_limit_blind(creature) || cmd_limit_confused(player)) {
+        if (cmd_limit_blind(creature) || cmd_limit_confused(creature)) {
             return;
         }
 
@@ -297,7 +292,7 @@ void do_cmd_use(CreatureEntity &creature)
     case ItemKindType::SHOT:
     case ItemKindType::ARROW:
     case ItemKindType::BOLT:
-        exe_fire(player, i_idx, player.inventory[INVEN_BOW].get(), SP_NONE);
+        exe_fire(creature, i_idx, creature.inventory[INVEN_BOW].get(), SP_NONE);
         break;
     default:
         exe_activate(creature, i_idx);
@@ -311,7 +306,6 @@ void do_cmd_use(CreatureEntity &creature)
  */
 void do_cmd_activate(CreatureEntity &creature)
 {
-    auto &player = creature;
     if (AngbandWorld::get_instance().is_wild_mode() || cmd_limit_arena(creature)) {
         return;
     }
@@ -320,7 +314,7 @@ void do_cmd_activate(CreatureEntity &creature)
     constexpr auto q = _("どのアイテムを始動させますか? ", "Activate which item? ");
     constexpr auto s = _("始動できるアイテムを装備していない。", "You have nothing to activate.");
     short i_idx;
-    if (!choose_object(player, &i_idx, q, s, (USE_EQUIP | IGNORE_BOTHHAND_SLOT), FuncItemTester(&ItemEntity::is_activatable))) {
+    if (!choose_object(creature, &i_idx, q, s, (USE_EQUIP | IGNORE_BOTHHAND_SLOT), FuncItemTester(&ItemEntity::is_activatable))) {
         return;
     }
 

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -15,17 +15,17 @@
  * reading scrolls, aiming wands, using staffs, zapping rods,
  * and activating artifacts.
  *
- * In all cases, if the player becomes "aware" of the item's use
+ * In all cases, if the creature becomes "aware" of the item's use
  * by testing it, mark it as "aware" and reward some experience
- * based on the object's level, always rounding up.  If the player
+ * based on the object's level, always rounding up.  If the creature
  * remains "unaware", mark that object "kind" as "tried".
  *
  * This code now correctly handles the unstacking of wands, staffs,
  * and rods.  Note the overly paranoid warning about potential pack
- * overflow, which allows the player to use and drop a stacked item.
+ * overflow, which allows the creature to use and drop a stacked item.
  *
  * In all "unstacking" scenarios, the "used" object is "carried" as if
- * the player had just picked it up.  In particular, this means that if
+ * the creature had just picked it up.  In particular, this means that if
  * the use of an item induces pack overflow, that item will be dropped.
  *
  * For simplicity, these routines induce a full "pack reorganization"
@@ -93,7 +93,6 @@
  */
 static tl::optional<BaseitemKey> select_magic_eater(CreatureEntity &creature, bool only_browse)
 {
-    auto &player = creature;
     bool flag, request_list;
     auto tval = ItemKindType::NONE;
     int menu_line = (use_menu ? 1 : 0);
@@ -267,14 +266,14 @@ static tl::optional<BaseitemKey> select_magic_eater(CreatureEntity &creature, bo
                 const auto &baseitem = baseitems.lookup_baseitem({ tval, sval_ctr });
                 level = (tval == ItemKindType::ROD ? baseitem.level * 5 / 6 - 5 : baseitem.level);
                 chance = level * 4 / 5 + 20;
-                chance -= 3 * (adj_mag_stat[player.stat_index[mp_ptr->spell_stat]] - 1);
+                chance -= 3 * (adj_mag_stat[creature.stat_index[mp_ptr->spell_stat]] - 1);
                 level /= 2;
-                if (player.level > level) {
-                    chance -= 3 * (player.level - level);
+                if (creature.level > level) {
+                    chance -= 3 * (creature.level - level);
                 }
                 chance = mod_spell_chance_1(creature, chance);
-                chance = std::max<int>(chance, adj_mag_fail[player.stat_index[mp_ptr->spell_stat]]);
-                chance += player.effects()->stun().get_magic_chance_penalty();
+                chance = std::max<int>(chance, adj_mag_fail[creature.stat_index[mp_ptr->spell_stat]]);
+                chance += creature.effects()->stun().get_magic_chance_penalty();
                 if (chance > 95) {
                     chance = 95;
                 }
@@ -491,7 +490,6 @@ static tl::optional<BaseitemKey> select_magic_eater(CreatureEntity &creature, bo
  */
 bool do_cmd_magic_eater(CreatureEntity &creature, bool only_browse, bool powerful)
 {
-    auto &player = creature;
     bool use_charge = true;
 
     if (cmd_limit_confused(creature)) {
@@ -509,14 +507,14 @@ bool do_cmd_magic_eater(CreatureEntity &creature, bool only_browse, bool powerfu
     const auto &baseitem = baseitems.lookup_baseitem(*bi_key);
     auto level = (bi_key->tval() == ItemKindType::ROD ? baseitem.level * 5 / 6 - 5 : baseitem.level);
     auto chance = level * 4 / 5 + 20;
-    chance -= 3 * (adj_mag_stat[player.stat_index[mp_ptr->spell_stat]] - 1);
+    chance -= 3 * (adj_mag_stat[creature.stat_index[mp_ptr->spell_stat]] - 1);
     level /= 2;
-    if (player.level > level) {
-        chance -= 3 * (player.level - level);
+    if (creature.level > level) {
+        chance -= 3 * (creature.level - level);
     }
     chance = mod_spell_chance_1(creature, chance);
-    chance = std::max<int>(chance, adj_mag_fail[player.stat_index[mp_ptr->spell_stat]]);
-    chance += player.effects()->stun().get_magic_chance_penalty();
+    chance = std::max<int>(chance, adj_mag_fail[creature.stat_index[mp_ptr->spell_stat]]);
+    chance += creature.effects()->stun().get_magic_chance_penalty();
     if (chance > 95) {
         chance = 95;
     }
@@ -546,13 +544,13 @@ bool do_cmd_magic_eater(CreatureEntity &creature, bool only_browse, bool powerfu
 
             auto dir = Direction::none();
             if (bi_key->is_aiming_rod()) {
-                dir = get_aim_dir(player);
+                dir = get_aim_dir(creature);
                 if (!dir) {
                     return false;
                 }
             }
 
-            (void)rod_effect(player, sval.value(), dir, &use_charge, powerful);
+            (void)rod_effect(creature, sval.value(), dir, &use_charge, powerful);
             if (!use_charge) {
                 return false;
             }
@@ -565,12 +563,12 @@ bool do_cmd_magic_eater(CreatureEntity &creature, bool only_browse, bool powerfu
                 return false;
             }
 
-            const auto dir = get_aim_dir(player);
+            const auto dir = get_aim_dir(creature);
             if (!dir) {
                 return false;
             }
 
-            (void)wand_effect(player, sval.value(), dir, powerful, true);
+            (void)wand_effect(creature, sval.value(), dir, powerful, true);
             break;
         }
         default:
@@ -579,7 +577,7 @@ bool do_cmd_magic_eater(CreatureEntity &creature, bool only_browse, bool powerfu
                 return false;
             }
 
-            (void)staff_effect(player, sval.value(), &use_charge, powerful, true, true);
+            (void)staff_effect(creature, sval.value(), &use_charge, powerful, true, true);
             if (!use_charge) {
                 return false;
             }

--- a/src/cmd-item/cmd-refill.cpp
+++ b/src/cmd-item/cmd-refill.cpp
@@ -26,19 +26,18 @@
  */
 static void do_cmd_refill_lamp(CreatureEntity &creature)
 {
-    auto &player = creature;
     constexpr auto q = _("どの油つぼから注ぎますか? ", "Refill with which flask? ");
     constexpr auto s = _("油つぼがない。", "You have no flasks of oil.");
     short i_idx;
-    const auto *o_ptr = choose_object(player, &i_idx, q, s, USE_INVEN | USE_FLOOR, FuncItemTester(&ItemEntity::can_refill_lantern));
+    const auto *o_ptr = choose_object(creature, &i_idx, q, s, USE_INVEN | USE_FLOOR, FuncItemTester(&ItemEntity::can_refill_lantern));
     if (!o_ptr) {
         return;
     }
 
     const auto flags = o_ptr->get_flags();
 
-    PlayerEnergy(player).set_player_turn_energy(50);
-    auto *j_ptr = player.inventory[INVEN_LITE].get();
+    PlayerEnergy(creature).set_player_turn_energy(50);
+    auto *j_ptr = creature.inventory[INVEN_LITE].get();
     const auto flags2 = j_ptr->get_flags();
     j_ptr->fuel += o_ptr->fuel;
     msg_print(_("ランプに油を注いだ。", "You fuel your lamp."));
@@ -53,7 +52,7 @@ static void do_cmd_refill_lamp(CreatureEntity &creature)
         msg_print(_("ランプの油は一杯だ。", "Your lamp is full."));
     }
 
-    vary_item(player, i_idx, -1);
+    vary_item(creature, i_idx, -1);
     RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::TORCH);
 }
 
@@ -63,19 +62,18 @@ static void do_cmd_refill_lamp(CreatureEntity &creature)
  */
 static void do_cmd_refill_torch(CreatureEntity &creature)
 {
-    auto &player = creature;
     constexpr auto q = _("どの松明で明かりを強めますか? ", "Refuel with which torch? ");
     constexpr auto s = _("他に松明がない。", "You have no extra torches.");
     short i_idx;
-    const auto *o_ptr = choose_object(player, &i_idx, q, s, USE_INVEN | USE_FLOOR, FuncItemTester(&ItemEntity::can_refill_torch));
+    const auto *o_ptr = choose_object(creature, &i_idx, q, s, USE_INVEN | USE_FLOOR, FuncItemTester(&ItemEntity::can_refill_torch));
     if (!o_ptr) {
         return;
     }
 
     const auto flags = o_ptr->get_flags();
 
-    PlayerEnergy(player).set_player_turn_energy(50);
-    auto *j_ptr = player.inventory[INVEN_LITE].get();
+    PlayerEnergy(creature).set_player_turn_energy(50);
+    auto *j_ptr = creature.inventory[INVEN_LITE].get();
     const auto flags2 = j_ptr->get_flags();
     j_ptr->fuel += o_ptr->fuel + 5;
     msg_print(_("松明を結合した。", "You combine the torches."));
@@ -92,7 +90,7 @@ static void do_cmd_refill_torch(CreatureEntity &creature)
         msg_print(_("松明はいっそう明るく輝いた。", "Your torch glows more brightly."));
     }
 
-    vary_item(player, i_idx, -1);
+    vary_item(creature, i_idx, -1);
     RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::TORCH);
 }
 
@@ -102,9 +100,8 @@ static void do_cmd_refill_torch(CreatureEntity &creature)
  */
 void do_cmd_refill(CreatureEntity &creature)
 {
-    auto &player = creature;
-    CreatureClass(player).break_samurai_stance({ SamuraiStanceType::MUSOU });
-    const auto *o_ptr = player.inventory[INVEN_LITE].get();
+    CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
+    const auto *o_ptr = creature.inventory[INVEN_LITE].get();
     const auto &bi_key = o_ptr->bi_key;
     if (bi_key.tval() != ItemKindType::LITE) {
         msg_print(_("光源を装備していない。", "You are not wielding a light."));

--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -54,25 +54,24 @@
  */
 int staff_effect(CreatureEntity &creature, int sval, bool *use_charge, bool powerful, bool magic, bool known)
 {
-    auto &player = creature;
     int k;
     bool ident = false;
-    PLAYER_LEVEL lev = powerful ? player.level * 2 : player.level;
+    PLAYER_LEVEL lev = powerful ? creature.level * 2 : creature.level;
     POSITION detect_rad = powerful ? DETECT_RAD_DEFAULT * 3 / 2 : DETECT_RAD_DEFAULT;
 
-    player.plus_incident_tree("ZAP_STAFF", 1);
+    creature.plus_incident_tree("ZAP_STAFF", 1);
 
     /* Analyze the staff */
-    BadStatusSetter bss(player);
+    BadStatusSetter bss(creature);
     switch (sval) {
     case SV_STAFF_DARKNESS:
-        if (!has_resist_blind(player) && !has_resist_dark(player)) {
+        if (!has_resist_blind(creature) && !has_resist_dark(creature)) {
             if (bss.mod_blindness(3 + randint1(5))) {
                 ident = true;
             }
         }
 
-        if (unlite_area(player, 10, (powerful ? 6 : 3))) {
+        if (unlite_area(creature, 10, (powerful ? 6 : 3))) {
             ident = true;
         }
 
@@ -85,7 +84,7 @@ int staff_effect(CreatureEntity &creature, int sval, bool *use_charge, bool powe
     }
 
     case SV_STAFF_HASTE_MONSTERS: {
-        if (speed_monsters(player)) {
+        if (speed_monsters(creature)) {
             ident = true;
         }
         break;
@@ -94,7 +93,7 @@ int staff_effect(CreatureEntity &creature, int sval, bool *use_charge, bool powe
     case SV_STAFF_SUMMONING: {
         const int times = randint1(powerful ? 8 : 4);
         for (k = 0; k < times; k++) {
-            if (summon_specific(creature, creature.y, creature.x, player.current_floor_ptr->dun_level, SUMMON_NONE,
+            if (summon_specific(creature, creature.y, creature.x, creature.current_floor_ptr->dun_level, SUMMON_NONE,
                     (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET))) {
                 ident = true;
             }
@@ -110,11 +109,11 @@ int staff_effect(CreatureEntity &creature, int sval, bool *use_charge, bool powe
 
     case SV_STAFF_IDENTIFY: {
         if (powerful) {
-            if (!identify_fully(player, false)) {
+            if (!identify_fully(creature, false)) {
                 *use_charge = false;
             }
         } else {
-            if (!ident_spell(player, false)) {
+            if (!ident_spell(creature, false)) {
                 *use_charge = false;
             }
         }
@@ -131,134 +130,134 @@ int staff_effect(CreatureEntity &creature, int sval, bool *use_charge, bool powe
     }
 
     case SV_STAFF_STARLITE:
-        ident = starlight(player, magic);
+        ident = starlight(creature, magic);
         break;
 
     case SV_STAFF_LITE: {
-        if (lite_area(player, Dice::roll(2, 8), (powerful ? 4 : 2))) {
+        if (lite_area(creature, Dice::roll(2, 8), (powerful ? 4 : 2))) {
             ident = true;
         }
         break;
     }
 
     case SV_STAFF_MAPPING: {
-        map_area(player, powerful ? DETECT_RAD_MAP * 3 / 2 : DETECT_RAD_MAP);
+        map_area(creature, powerful ? DETECT_RAD_MAP * 3 / 2 : DETECT_RAD_MAP);
         ident = true;
         break;
     }
 
     case SV_STAFF_DETECT_GOLD: {
-        if (detect_treasure(player, detect_rad)) {
+        if (detect_treasure(creature, detect_rad)) {
             ident = true;
         }
-        if (detect_objects_gold(player, detect_rad)) {
+        if (detect_objects_gold(creature, detect_rad)) {
             ident = true;
         }
         break;
     }
 
     case SV_STAFF_DETECT_ITEM: {
-        if (detect_objects_normal(player, detect_rad)) {
+        if (detect_objects_normal(creature, detect_rad)) {
             ident = true;
         }
         break;
     }
 
     case SV_STAFF_DETECT_TRAP: {
-        if (detect_traps(player, detect_rad, known)) {
+        if (detect_traps(creature, detect_rad, known)) {
             ident = true;
         }
         break;
     }
 
     case SV_STAFF_DETECT_DOOR: {
-        if (detect_doors(player, detect_rad)) {
+        if (detect_doors(creature, detect_rad)) {
             ident = true;
         }
-        if (detect_stairs(player, detect_rad)) {
+        if (detect_stairs(creature, detect_rad)) {
             ident = true;
         }
         break;
     }
 
     case SV_STAFF_DETECT_INVIS: {
-        if (set_tim_invis(player, player.tim_invis + 12 + randint1(12), false)) {
+        if (set_tim_invis(creature, creature.tim_invis + 12 + randint1(12), false)) {
             ident = true;
         }
         break;
     }
 
     case SV_STAFF_DETECT_EVIL: {
-        if (detect_monsters_evil(player, detect_rad)) {
+        if (detect_monsters_evil(creature, detect_rad)) {
             ident = true;
         }
         break;
     }
 
     case SV_STAFF_CURE_LIGHT: {
-        ident = cure_light_wounds(player, Dice::roll(powerful ? 4 : 2, 8));
+        ident = cure_light_wounds(creature, Dice::roll(powerful ? 4 : 2, 8));
         break;
     }
 
     case SV_STAFF_CURING: {
-        ident = true_healing(player, 0);
-        if (set_berserk(player, 0, true)) {
+        ident = true_healing(creature, 0);
+        if (set_berserk(creature, 0, true)) {
             ident = true;
         }
         break;
     }
 
     case SV_STAFF_HEALING: {
-        if (cure_critical_wounds(player, powerful ? 500 : 300)) {
+        if (cure_critical_wounds(creature, powerful ? 500 : 300)) {
             ident = true;
         }
         break;
     }
 
     case SV_STAFF_THE_MAGI: {
-        if (do_res_stat(player, A_INT)) {
+        if (do_res_stat(creature, A_INT)) {
             ident = true;
         }
-        ident |= restore_mana(player, false);
-        if (set_berserk(player, 0, true)) {
+        ident |= restore_mana(creature, false);
+        if (set_berserk(creature, 0, true)) {
             ident = true;
         }
         break;
     }
 
     case SV_STAFF_SLEEP_MONSTERS: {
-        if (sleep_monsters(player, lev)) {
+        if (sleep_monsters(creature, lev)) {
             ident = true;
         }
         break;
     }
 
     case SV_STAFF_SLOW_MONSTERS: {
-        if (slow_monsters(player, lev)) {
+        if (slow_monsters(creature, lev)) {
             ident = true;
         }
         break;
     }
 
     case SV_STAFF_SPEED: {
-        if (set_acceleration(player, randint1(30) + (powerful ? 30 : 15), false)) {
+        if (set_acceleration(creature, randint1(30) + (powerful ? 30 : 15), false)) {
             ident = true;
         }
         break;
     }
 
     case SV_STAFF_PROBING: {
-        ident = probing(player);
+        ident = probing(creature);
         break;
     }
 
     case SV_STAFF_DISPEL_EVIL: {
-        ident = dispel_evil(player, powerful ? 120 : 80);
+        ident = dispel_evil(creature, powerful ? 120 : 80);
         break;
     }
 
     case SV_STAFF_POWER: {
-        ident = dispel_monsters(player, powerful ? 225 : 150);
+        ident = dispel_monsters(creature, powerful ? 225 : 150);
         break;
     }
 
@@ -268,7 +267,7 @@ int staff_effect(CreatureEntity &creature, int sval, bool *use_charge, bool powe
     }
 
     case SV_STAFF_GENOCIDE: {
-        ident = symbol_genocide(player, (magic ? lev + 50 : 200), true);
+        ident = symbol_genocide(creature, (magic ? lev + 50 : 200), true);
         break;
     }
 
@@ -313,7 +312,6 @@ int staff_effect(CreatureEntity &creature, int sval, bool *use_charge, bool powe
  */
 void do_cmd_use_staff(CreatureEntity &creature)
 {
-    auto &player = creature;
     if (AngbandWorld::get_instance().is_wild_mode()) {
         return;
     }
@@ -326,9 +324,9 @@ void do_cmd_use_staff(CreatureEntity &creature)
     constexpr auto q = _("どの杖を使いますか? ", "Use which staff? ");
     constexpr auto s = _("使える杖がない。", "You have no staff to use.");
     short i_idx;
-    if (!choose_object(player, &i_idx, q, s, (USE_INVEN | USE_FLOOR), TvalItemTester(ItemKindType::STAFF))) {
+    if (!choose_object(creature, &i_idx, q, s, (USE_INVEN | USE_FLOOR), TvalItemTester(ItemKindType::STAFF))) {
         return;
     }
 
-    ObjectUseEntity(player, i_idx).execute();
+    ObjectUseEntity(creature, i_idx).execute();
 }

--- a/src/cmd-item/cmd-zaprod.cpp
+++ b/src/cmd-item/cmd-zaprod.cpp
@@ -46,27 +46,26 @@
  */
 int rod_effect(CreatureEntity &creature, int sval, const Direction &dir, bool *use_charge, bool powerful)
 {
-    auto &player = creature;
     int ident = false;
-    PLAYER_LEVEL lev = powerful ? player.level * 2 : player.level;
+    PLAYER_LEVEL lev = powerful ? creature.level * 2 : creature.level;
     POSITION detect_rad = powerful ? DETECT_RAD_DEFAULT * 3 / 2 : DETECT_RAD_DEFAULT;
     POSITION rad = powerful ? 3 : 2;
 
-    player.plus_incident_tree("ZAP_ROD", 1);
+    creature.plus_incident_tree("ZAP_ROD", 1);
 
     switch (sval) {
     case SV_ROD_DETECT_TRAP: {
-        if (detect_traps(player, detect_rad, !dir)) {
+        if (detect_traps(creature, detect_rad, !dir)) {
             ident = true;
         }
         break;
     }
 
     case SV_ROD_DETECT_DOOR: {
-        if (detect_doors(player, detect_rad)) {
+        if (detect_doors(creature, detect_rad)) {
             ident = true;
         }
-        if (detect_stairs(player, detect_rad)) {
+        if (detect_stairs(creature, detect_rad)) {
             ident = true;
         }
         break;
@@ -74,11 +73,11 @@ int rod_effect(CreatureEntity &creature, int sval, const Direction &dir, bool *u
 
     case SV_ROD_IDENTIFY: {
         if (powerful) {
-            if (!identify_fully(player, false)) {
+            if (!identify_fully(creature, false)) {
                 *use_charge = false;
             }
         } else {
-            if (!ident_spell(player, false)) {
+            if (!ident_spell(creature, false)) {
                 *use_charge = false;
             }
         }
@@ -87,7 +86,7 @@ int rod_effect(CreatureEntity &creature, int sval, const Direction &dir, bool *u
     }
 
     case SV_ROD_RECALL: {
-        if (!recall_player(player, randint0(21) + 15)) {
+        if (!recall_player(creature, randint0(21) + 15)) {
             *use_charge = false;
         }
         ident = true;
@@ -95,42 +94,42 @@ int rod_effect(CreatureEntity &creature, int sval, const Direction &dir, bool *u
     }
 
     case SV_ROD_ILLUMINATION: {
-        if (lite_area(player, Dice::roll(2, 8), (powerful ? 4 : 2))) {
+        if (lite_area(creature, Dice::roll(2, 8), (powerful ? 4 : 2))) {
             ident = true;
         }
         break;
     }
 
     case SV_ROD_MAPPING: {
-        map_area(player, powerful ? DETECT_RAD_MAP * 3 / 2 : DETECT_RAD_MAP);
+        map_area(creature, powerful ? DETECT_RAD_MAP * 3 / 2 : DETECT_RAD_MAP);
         ident = true;
         break;
     }
 
     case SV_ROD_DETECTION: {
-        detect_all(player, detect_rad);
+        detect_all(creature, detect_rad);
         ident = true;
         break;
     }
 
     case SV_ROD_PROBING: {
-        probing(player);
+        probing(creature);
         ident = true;
         break;
     }
 
     case SV_ROD_CURING: {
-        if (true_healing(player, 0)) {
+        if (true_healing(creature, 0)) {
             ident = true;
         }
-        if (set_berserk(player, 0, true)) {
+        if (set_berserk(creature, 0, true)) {
             ident = true;
         }
         break;
     }
 
     case SV_ROD_HEALING: {
-        if (cure_critical_wounds(player, powerful ? 750 : 500)) {
+        if (cure_critical_wounds(creature, powerful ? 750 : 500)) {
             ident = true;
         }
         break;
@@ -140,21 +139,21 @@ int rod_effect(CreatureEntity &creature, int sval, const Direction &dir, bool *u
         if (restore_level(creature)) {
             ident = true;
         }
-        if (restore_all_status(player)) {
+        if (restore_all_status(creature)) {
             ident = true;
         }
         break;
     }
 
     case SV_ROD_SPEED: {
-        if (set_acceleration(player, randint1(30) + (powerful ? 30 : 15), false)) {
+        if (set_acceleration(creature, randint1(30) + (powerful ? 30 : 15), false)) {
             ident = true;
         }
         break;
     }
 
     case SV_ROD_PESTICIDE: {
-        if (dispel_monsters(player, powerful ? 8 : 4)) {
+        if (dispel_monsters(creature, powerful ? 8 : 4)) {
             ident = true;
         }
         break;
@@ -162,17 +161,17 @@ int rod_effect(CreatureEntity &creature, int sval, const Direction &dir, bool *u
 
     case SV_ROD_TELEPORT_AWAY: {
         int distance = MAX_PLAYER_SIGHT * (powerful ? 8 : 5);
-        if (teleport_monster(player, dir, distance)) {
+        if (teleport_monster(creature, dir, distance)) {
             ident = true;
         }
         break;
     }
 
     case SV_ROD_DISARMING: {
-        if (disarm_trap(player, dir)) {
+        if (disarm_trap(creature, dir)) {
             ident = true;
         }
-        if (powerful && disarm_traps_touch(player)) {
+        if (powerful && disarm_traps_touch(creature)) {
             ident = true;
         }
         break;
@@ -181,103 +180,103 @@ int rod_effect(CreatureEntity &creature, int sval, const Direction &dir, bool *u
     case SV_ROD_LITE: {
         int dam = Dice::roll((powerful ? 12 : 6), 8);
         msg_print(_("青く輝く光線が放たれた。", "A line of blue shimmering light appears."));
-        (void)lite_line(player, dir, dam);
+        (void)lite_line(creature, dir, dam);
         ident = true;
         break;
     }
 
     case SV_ROD_SLEEP_MONSTER: {
-        if (sleep_monster(player, dir, lev)) {
+        if (sleep_monster(creature, dir, lev)) {
             ident = true;
         }
         break;
     }
 
     case SV_ROD_SLOW_MONSTER: {
-        if (slow_monster(player, dir, lev)) {
+        if (slow_monster(creature, dir, lev)) {
             ident = true;
         }
         break;
     }
 
     case SV_ROD_HYPODYNAMIA: {
-        if (hypodynamic_bolt(player, dir, 70 + 3 * lev / 2)) {
+        if (hypodynamic_bolt(creature, dir, 70 + 3 * lev / 2)) {
             ident = true;
         }
         break;
     }
 
     case SV_ROD_POLYMORPH: {
-        if (poly_monster(player, dir, lev)) {
+        if (poly_monster(creature, dir, lev)) {
             ident = true;
         }
         break;
     }
 
     case SV_ROD_ACID_BOLT: {
-        fire_bolt_or_beam(player, 10, AttributeType::ACID, dir, Dice::roll(6 + lev / 7, 8));
+        fire_bolt_or_beam(creature, 10, AttributeType::ACID, dir, Dice::roll(6 + lev / 7, 8));
         ident = true;
         break;
     }
 
     case SV_ROD_ELEC_BOLT: {
-        fire_bolt_or_beam(player, 10, AttributeType::ELEC, dir, Dice::roll(4 + lev / 9, 8));
+        fire_bolt_or_beam(creature, 10, AttributeType::ELEC, dir, Dice::roll(4 + lev / 9, 8));
         ident = true;
         break;
     }
 
     case SV_ROD_FIRE_BOLT: {
-        fire_bolt_or_beam(player, 10, AttributeType::FIRE, dir, Dice::roll(7 + lev / 6, 8));
+        fire_bolt_or_beam(creature, 10, AttributeType::FIRE, dir, Dice::roll(7 + lev / 6, 8));
         ident = true;
         break;
     }
 
     case SV_ROD_COLD_BOLT: {
-        fire_bolt_or_beam(player, 10, AttributeType::COLD, dir, Dice::roll(5 + lev / 8, 8));
+        fire_bolt_or_beam(creature, 10, AttributeType::COLD, dir, Dice::roll(5 + lev / 8, 8));
         ident = true;
         break;
     }
 
     case SV_ROD_ACID_BALL: {
-        fire_ball(player, AttributeType::ACID, dir, 60 + lev, rad);
+        fire_ball(creature, AttributeType::ACID, dir, 60 + lev, rad);
         ident = true;
         break;
     }
 
     case SV_ROD_ELEC_BALL: {
-        fire_ball(player, AttributeType::ELEC, dir, 40 + lev, rad);
+        fire_ball(creature, AttributeType::ELEC, dir, 40 + lev, rad);
         ident = true;
         break;
     }
 
     case SV_ROD_FIRE_BALL: {
-        fire_ball(player, AttributeType::FIRE, dir, 70 + lev, rad);
+        fire_ball(creature, AttributeType::FIRE, dir, 70 + lev, rad);
         ident = true;
         break;
     }
 
     case SV_ROD_COLD_BALL: {
-        fire_ball(player, AttributeType::COLD, dir, 50 + lev, rad);
+        fire_ball(creature, AttributeType::COLD, dir, 50 + lev, rad);
         ident = true;
         break;
     }
 
     case SV_ROD_HAVOC: {
-        call_chaos(player);
+        call_chaos(creature);
         ident = true;
         break;
     }
 
     case SV_ROD_STONE_TO_MUD: {
         int dam = powerful ? 40 + randint1(60) : 20 + randint1(30);
-        if (wall_to_mud(player, dir, dam)) {
+        if (wall_to_mud(creature, dir, dam)) {
             ident = true;
         }
         break;
     }
 
     case SV_ROD_AGGRAVATE: {
-        aggravate_monsters(player, 0);
+        aggravate_monsters(creature, 0);
         ident = true;
         break;
     }
@@ -291,7 +290,6 @@ int rod_effect(CreatureEntity &creature, int sval, const Direction &dir, bool *u
  */
 void do_cmd_zap_rod(CreatureEntity &creature)
 {
-    auto &player = creature;
     if (AngbandWorld::get_instance().is_wild_mode()) {
         return;
     }
@@ -305,9 +303,9 @@ void do_cmd_zap_rod(CreatureEntity &creature)
     constexpr auto q = _("どのロッドを振りますか? ", "Zap which rod? ");
     constexpr auto s = _("使えるロッドがない。", "You have no rod to zap.");
     short i_idx;
-    if (!choose_object(player, &i_idx, q, s, (USE_INVEN | USE_FLOOR), TvalItemTester(ItemKindType::ROD))) {
+    if (!choose_object(creature, &i_idx, q, s, (USE_INVEN | USE_FLOOR), TvalItemTester(ItemKindType::ROD))) {
         return;
     }
 
-    ObjectZapRodEntity(player).execute(i_idx);
+    ObjectZapRodEntity(creature).execute(i_idx);
 }

--- a/src/cmd-item/cmd-zapwand.cpp
+++ b/src/cmd-item/cmd-zapwand.cpp
@@ -53,12 +53,11 @@
  */
 bool wand_effect(CreatureEntity &creature, int sval, const Direction &dir, bool powerful, bool magic)
 {
-    auto &player = creature;
     bool ident = false;
-    PLAYER_LEVEL lev = powerful ? player.level * 2 : player.level;
+    PLAYER_LEVEL lev = powerful ? creature.level * 2 : creature.level;
     POSITION rad = powerful ? 3 : 2;
 
-    player.plus_incident_tree("ZAP_WAND", 1);
+    creature.plus_incident_tree("ZAP_WAND", 1);
 
     /* XXX Hack -- Wand of wonder can do anything before it */
     if (sval == SV_WAND_WONDER) {
@@ -66,8 +65,8 @@ bool wand_effect(CreatureEntity &creature, int sval, const Direction &dir, bool 
         sval = randint0(SV_WAND_WONDER);
 
         if (vir) {
-            auto it = player.virtues.find(Virtue::CHANCE);
-            if (it != player.virtues.end()) {
+            auto it = creature.virtues.find(Virtue::CHANCE);
+            if (it != creature.virtues.end()) {
                 if (it->second > 0) {
                     while (randint1(300) < it->second) {
                         sval++;
@@ -94,21 +93,21 @@ bool wand_effect(CreatureEntity &creature, int sval, const Direction &dir, bool 
     switch (sval) {
     case SV_WAND_HEAL_MONSTER: {
         int dam = Dice::roll((powerful ? 20 : 10), 10);
-        if (heal_monster(player, dir, dam)) {
+        if (heal_monster(creature, dir, dam)) {
             ident = true;
         }
         break;
     }
 
     case SV_WAND_HASTE_MONSTER: {
-        if (speed_monster(player, dir, lev)) {
+        if (speed_monster(creature, dir, lev)) {
             ident = true;
         }
         break;
     }
 
     case SV_WAND_CLONE_MONSTER: {
-        if (clone_monster(player, dir)) {
+        if (clone_monster(creature, dir)) {
             ident = true;
         }
         break;
@@ -116,27 +115,27 @@ bool wand_effect(CreatureEntity &creature, int sval, const Direction &dir, bool 
 
     case SV_WAND_TELEPORT_AWAY: {
         int distance = MAX_PLAYER_SIGHT * (powerful ? 8 : 5);
-        if (teleport_monster(player, dir, distance)) {
+        if (teleport_monster(creature, dir, distance)) {
             ident = true;
         }
         break;
     }
 
     case SV_WAND_DISARMING: {
-        if (disarm_trap(player, dir)) {
+        if (disarm_trap(creature, dir)) {
             ident = true;
         }
-        if (powerful && disarm_traps_touch(player)) {
+        if (powerful && disarm_traps_touch(creature)) {
             ident = true;
         }
         break;
     }
 
     case SV_WAND_TRAP_DOOR_DEST: {
-        if (destroy_door(player, dir)) {
+        if (destroy_door(creature, dir)) {
             ident = true;
         }
-        if (powerful && destroy_doors_touch(player)) {
+        if (powerful && destroy_doors_touch(creature)) {
             ident = true;
         }
         break;
@@ -144,7 +143,7 @@ bool wand_effect(CreatureEntity &creature, int sval, const Direction &dir, bool 
 
     case SV_WAND_STONE_TO_MUD: {
         int dam = powerful ? 40 + randint1(60) : 20 + randint1(30);
-        if (wall_to_mud(player, dir, dam)) {
+        if (wall_to_mud(creature, dir, dam)) {
             ident = true;
         }
         break;
@@ -153,67 +152,67 @@ bool wand_effect(CreatureEntity &creature, int sval, const Direction &dir, bool 
     case SV_WAND_LITE: {
         int dam = Dice::roll((powerful ? 12 : 6), 8);
         msg_print(_("青く輝く光線が放たれた。", "A line of blue shimmering light appears."));
-        (void)lite_line(player, dir, dam);
+        (void)lite_line(creature, dir, dam);
         ident = true;
         break;
     }
 
     case SV_WAND_SLEEP_MONSTER: {
-        if (sleep_monster(player, dir, lev)) {
+        if (sleep_monster(creature, dir, lev)) {
             ident = true;
         }
         break;
     }
 
     case SV_WAND_SLOW_MONSTER: {
-        if (slow_monster(player, dir, lev)) {
+        if (slow_monster(creature, dir, lev)) {
             ident = true;
         }
         break;
     }
 
     case SV_WAND_CONFUSE_MONSTER: {
-        if (confuse_monster(player, dir, lev)) {
+        if (confuse_monster(creature, dir, lev)) {
             ident = true;
         }
         break;
     }
 
     case SV_WAND_FEAR_MONSTER: {
-        if (fear_monster(player, dir, lev)) {
+        if (fear_monster(creature, dir, lev)) {
             ident = true;
         }
         break;
     }
 
     case SV_WAND_HYPODYNAMIA: {
-        if (hypodynamic_bolt(player, dir, 80 + lev)) {
+        if (hypodynamic_bolt(creature, dir, 80 + lev)) {
             ident = true;
         }
         break;
     }
 
     case SV_WAND_POLYMORPH: {
-        if (poly_monster(player, dir, lev)) {
+        if (poly_monster(creature, dir, lev)) {
             ident = true;
         }
         break;
     }
 
     case SV_WAND_STINKING_CLOUD: {
-        fire_ball(player, AttributeType::POIS, dir, 12 + lev / 4, rad);
+        fire_ball(creature, AttributeType::POIS, dir, 12 + lev / 4, rad);
         ident = true;
         break;
     }
 
     case SV_WAND_MAGIC_MISSILE: {
-        fire_bolt_or_beam(player, 20, AttributeType::MISSILE, dir, Dice::roll(2 + lev / 10, 6));
+        fire_bolt_or_beam(creature, 20, AttributeType::MISSILE, dir, Dice::roll(2 + lev / 10, 6));
         ident = true;
         break;
     }
 
     case SV_WAND_ACID_BOLT: {
-        fire_bolt_or_beam(player, 20, AttributeType::ACID, dir, Dice::roll(6 + lev / 7, 8));
+        fire_bolt_or_beam(creature, 20, AttributeType::ACID, dir, Dice::roll(6 + lev / 7, 8));
         ident = true;
         break;
     }
@@ -226,37 +225,37 @@ bool wand_effect(CreatureEntity &creature, int sval, const Direction &dir, bool 
     }
 
     case SV_WAND_FIRE_BOLT: {
-        fire_bolt_or_beam(player, 20, AttributeType::FIRE, dir, Dice::roll(7 + lev / 6, 8));
+        fire_bolt_or_beam(creature, 20, AttributeType::FIRE, dir, Dice::roll(7 + lev / 6, 8));
         ident = true;
         break;
     }
 
     case SV_WAND_COLD_BOLT: {
-        fire_bolt_or_beam(player, 20, AttributeType::COLD, dir, Dice::roll(5 + lev / 8, 8));
+        fire_bolt_or_beam(creature, 20, AttributeType::COLD, dir, Dice::roll(5 + lev / 8, 8));
         ident = true;
         break;
     }
 
     case SV_WAND_ACID_BALL: {
-        fire_ball(player, AttributeType::ACID, dir, 60 + 3 * lev / 4, rad);
+        fire_ball(creature, AttributeType::ACID, dir, 60 + 3 * lev / 4, rad);
         ident = true;
         break;
     }
 
     case SV_WAND_ELEC_BALL: {
-        fire_ball(player, AttributeType::ELEC, dir, 40 + 3 * lev / 4, rad);
+        fire_ball(creature, AttributeType::ELEC, dir, 40 + 3 * lev / 4, rad);
         ident = true;
         break;
     }
 
     case SV_WAND_FIRE_BALL: {
-        fire_ball(player, AttributeType::FIRE, dir, 70 + 3 * lev / 4, rad);
+        fire_ball(creature, AttributeType::FIRE, dir, 70 + 3 * lev / 4, rad);
         ident = true;
         break;
     }
 
     case SV_WAND_COLD_BALL: {
-        fire_ball(player, AttributeType::COLD, dir, 50 + 3 * lev / 4, rad);
+        fire_ball(creature, AttributeType::COLD, dir, 50 + 3 * lev / 4, rad);
         ident = true;
         break;
     }
@@ -267,13 +266,13 @@ bool wand_effect(CreatureEntity &creature, int sval, const Direction &dir, bool 
     }
 
     case SV_WAND_DRAGON_FIRE: {
-        fire_breath(player, AttributeType::FIRE, dir, (powerful ? 300 : 200), 3);
+        fire_breath(creature, AttributeType::FIRE, dir, (powerful ? 300 : 200), 3);
         ident = true;
         break;
     }
 
     case SV_WAND_DRAGON_COLD: {
-        fire_breath(player, AttributeType::COLD, dir, (powerful ? 270 : 180), 3);
+        fire_breath(creature, AttributeType::COLD, dir, (powerful ? 270 : 180), 3);
         ident = true;
         break;
     }
@@ -293,33 +292,33 @@ bool wand_effect(CreatureEntity &creature, int sval, const Direction &dir, bool 
             dam = (dam * 3) / 2;
         }
 
-        fire_breath(player, type, dir, dam, 3);
+        fire_breath(creature, type, dir, dam, 3);
 
         ident = true;
         break;
     }
 
     case SV_WAND_DISINTEGRATE: {
-        fire_ball(player, AttributeType::DISINTEGRATE, dir, 200 + randint1(lev * 2), rad);
+        fire_ball(creature, AttributeType::DISINTEGRATE, dir, 200 + randint1(lev * 2), rad);
         ident = true;
         break;
     }
 
     case SV_WAND_ROCKETS: {
         msg_print(_("ロケットを発射した！", "You launch a rocket!"));
-        fire_rocket(player, AttributeType::ROCKET, dir, 250 + lev * 3, rad);
+        fire_rocket(creature, AttributeType::ROCKET, dir, 250 + lev * 3, rad);
         ident = true;
         break;
     }
 
     case SV_WAND_STRIKING: {
-        fire_bolt(player, AttributeType::METEOR, dir, Dice::roll(15 + lev / 3, 13));
+        fire_bolt(creature, AttributeType::METEOR, dir, Dice::roll(15 + lev / 3, 13));
         ident = true;
         break;
     }
 
     case SV_WAND_GENOCIDE: {
-        fire_ball_hide(player, AttributeType::GENOCIDE, dir, magic ? lev + 50 : 250, 0);
+        fire_ball_hide(creature, AttributeType::GENOCIDE, dir, magic ? lev + 50 : 250, 0);
         ident = true;
         break;
     }
@@ -332,7 +331,6 @@ bool wand_effect(CreatureEntity &creature, int sval, const Direction &dir, bool 
  */
 void do_cmd_aim_wand(CreatureEntity &creature)
 {
-    auto &player = creature;
     if (AngbandWorld::get_instance().is_wild_mode()) {
         return;
     }
@@ -344,7 +342,7 @@ void do_cmd_aim_wand(CreatureEntity &creature)
     constexpr auto q = _("どの魔法棒で狙いますか? ", "Aim which wand? ");
     constexpr auto s = _("使える魔法棒がない。", "You have no wand to aim.");
     short i_idx;
-    if (!choose_object(player, &i_idx, q, s, (USE_INVEN | USE_FLOOR), TvalItemTester(ItemKindType::WAND))) {
+    if (!choose_object(creature, &i_idx, q, s, (USE_INVEN | USE_FLOOR), TvalItemTester(ItemKindType::WAND))) {
         return;
     }
 

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -222,12 +222,11 @@ static void restore_world_floor_info(CreatureEntity &creature)
         return;
     }
 
-    auto &player = creature;
-    player.ride_monster(0);
+    creature.ride_monster(0);
     for (short i = floor.m_max; i > 0; i--) {
         const auto &monster = floor.get_monster(i);
         if (creature.is_located_at({ monster.y, monster.x })) {
-            player.ride_monster(i);
+            creature.ride_monster(i);
             break;
         }
     }
@@ -267,7 +266,7 @@ static void change_floor_if_error(CreatureEntity &creature)
     }
 
     if (!creature.y || !creature.x) {
-        msg_print(_("プレイヤーの位置がおかしい。フロアを再生成します。", "What a strange player location, regenerate the dungeon floor."));
+        msg_print(_("プレイヤーの位置がおかしい。フロアを再生成します。", "What a strange creature location, regenerate the dungeon floor."));
         change_floor(creature);
     }
 
@@ -424,7 +423,7 @@ static void process_game_turn(CreatureEntity &creature)
  * @note
  * If the "new_game" parameter is true, then, after loading the
  * savefile, we will commit suicide, if necessary, to allow the
- * player to start a new game.
+ * creature to start a new game.
  */
 void play_game(CreatureEntity &creature, bool new_game, bool browsing_movie, std::optional<QuestId> initial_quest_id)
 {

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -47,13 +47,13 @@ Pos2D decide_source_position(CreatureEntity &creature, MONSTER_IDX src_idx, cons
  * @brief 汎用的なビーム/ボルト/ボール系処理のルーチン Generic
  * "beam"/"bolt"/"ball" projection routine.
  * @param src_idx 魔法を発動したモンスター(0ならばプレイヤー) / Index of "source"
- * monster (zero for "player")
+ * monster (zero for "creature")
  * @param rad 効果半径(ビーム/ボルト = 0 / ボール = 1以上) / Radius of explosion
  * (0 = beam/bolt, 1 to 9 = ball)
  * @param target_y 目標Y座標 / Target y location (or location to travel "towards")
  * @param target_x 目標X座標 / Target x location (or location to travel "towards")
  * @param dam 基本威力 / Base damage roll to apply to affected monsters (or
- * player)
+ * creature)
  * @param typ 効果属性 / Type of damage to apply to monsters (and objects)
  * @param flag 効果フラグ / Extra bit flags (see PROJECT_xxxx)
  * @param monspell 効果元のモンスター魔法ID
@@ -63,13 +63,12 @@ Pos2D decide_source_position(CreatureEntity &creature, MONSTER_IDX src_idx, cons
 ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSITION rad, const POSITION target_y, const POSITION target_x, const int dam,
     const AttributeType typ, BIT_FLAGS flag, tl::optional<CapturedMonsterType *> cap_mon_ptr)
 {
-    auto &player = creature;
-    monster_target_y = player.y;
-    monster_target_x = player.x;
+    monster_target_y = creature.y;
+    monster_target_x = creature.x;
 
     ProjectResult res;
     const Pos2D pos_target(target_y, target_x);
-    const auto pos_source = decide_source_position(player, src_idx, pos_target, flag);
+    const auto pos_source = decide_source_position(creature, src_idx, pos_target, flag);
 
     if (flag & (PROJECT_THRU)) {
         if (pos_source == pos_target) {
@@ -112,15 +111,15 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
     /* Calculate the projection path */
     const auto &system = AngbandSystem::get_instance();
     const auto range = project_length != 0 ? project_length : AngbandSystem::get_instance().get_max_range();
-    auto &floor = *player.current_floor_ptr;
-    ProjectionPath path_g(floor, range, player.get_position(), pos_source, pos_target, flag);
-    handle_stuff(player);
+    auto &floor = *creature.current_floor_ptr;
+    ProjectionPath path_g(floor, range, creature.get_position(), pos_source, pos_target, flag);
+    handle_stuff(creature);
 
     auto k = 0;
     Pos2D pos_path = pos_source;
     auto visual = false;
     auto see_s_msg = true;
-    const auto is_blind = player.is_blind();
+    const auto is_blind = creature.is_blind();
     for (const auto &pos : path_g) {
         if (flag & PROJECT_DISI) {
             if (floor.can_block_disintegration_at(pos) && (rad > 0)) {
@@ -146,7 +145,7 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
                     move_cursor_relative(pos.y, pos.x);
                     term_fresh();
                     term_xtra(TERM_XTRA_DELAY, delay_factor);
-                    lite_spot(player, pos);
+                    lite_spot(creature, pos);
                     term_fresh();
                     if (flag & (PROJECT_BEAM)) {
                         print_bolt_pict(creature, pos, pos, typ);
@@ -227,7 +226,7 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
         if (drawn) {
             for (const auto &[_, pos] : positions) {
                 if (panel_contains(pos) && floor.has_los_at(pos)) {
-                    lite_spot(player, pos);
+                    lite_spot(creature, pos);
                 }
             }
 
@@ -236,12 +235,12 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
         }
     }
 
-    update_creature(player);
+    update_creature(creature);
 
-    const auto p_pos = player.get_position();
+    const auto p_pos = creature.get_position();
     if (flag & PROJECT_KILL) {
-        see_s_msg = is_monster(src_idx) ? is_seen(player, floor.get_monster(src_idx))
-                                        : (is_player(src_idx) ? true : (player_can_see_bold(player, pos_source.y, pos_source.x) && projectable(floor, p_pos, pos_source)));
+        see_s_msg = is_monster(src_idx) ? is_seen(creature, floor.get_monster(src_idx))
+                                        : (is_player(src_idx) ? true : (player_can_see_bold(creature, pos_source.y, pos_source.x) && projectable(floor, p_pos, pos_source)));
     }
 
     if (flag & (PROJECT_GRID)) {
@@ -253,7 +252,7 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
         }
     }
 
-    update_creature(player);
+    update_creature(creature);
     if (flag & (PROJECT_ITEM)) {
         for (const auto &[dist, pos] : positions) {
             const auto effective_dist = breath ? dist_to_line(pos, pos_source, pos_impact) : dist;
@@ -288,8 +287,8 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
                         pos_reflection = pos_source;
                     }
 
-                    if (is_seen(player, monster)) {
-                        const auto m_name = monster.get_monster_profile().ml ? monster_desc(player, monster, 0) : std::string(_("それ", "It"));
+                    if (is_seen(creature, monster)) {
+                        const auto m_name = monster.get_monster_profile().ml ? monster_desc(creature, monster, 0) : std::string(_("それ", "It"));
                         sound(SoundKind::REFLECT);
                         const auto reflect_message = monrace.get_message(m_name, MonsterMessageType::MESSAGE_REFLECT);
                         if (reflect_message) {
@@ -299,11 +298,11 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
                         sound(SoundKind::REFLECT);
                     }
 
-                    if (is_original_ap_and_seen(player, monster)) {
+                    if (is_original_ap_and_seen(creature, monster)) {
                         monrace.r_misc_flags.set(MonsterMiscType::REFLECTING);
                     }
 
-                    if (player.is_located_at(pos) || one_in_(2)) {
+                    if (creature.is_located_at(pos) || one_in_(2)) {
                         flag &= ~(PROJECT_PLAYER);
                     } else {
                         flag |= PROJECT_PLAYER;
@@ -317,7 +316,7 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
             /* Find the closest point in the blast */
             auto effective_dist = breath ? dist_to_line(pos, pos_source, pos_impact) : dist;
 
-            if (player.riding && player.is_located_at(pos)) {
+            if (creature.riding && creature.is_located_at(pos)) {
                 if (flag & PROJECT_PLAYER) {
                     if (flag & (PROJECT_BEAM | PROJECT_REFLECTABLE | PROJECT_AIMED)) {
                         /*
@@ -351,7 +350,7 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
                  */
                 /*
                  * A beam or bolt will hit either
-                 * player or mount.  Choose randomly.
+                 * creature or mount.  Choose randomly.
                  */
                 else if (flag & (PROJECT_BEAM | PROJECT_REFLECTABLE)) {
                     if (one_in_(2)) {
@@ -364,7 +363,7 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
 
                 /*
                  * The spell is not well aimed, so
-                 * partly affect both player and
+                 * partly affect both creature and
                  * mount.
                  */
                 else {
@@ -383,11 +382,11 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
             if (grid.has_monster()) {
                 auto &monster = floor.get_monster(grid.m_idx);
                 if (monster.get_monster_profile().ml) {
-                    if (!player.effects()->hallucination().is_hallucinated()) {
+                    if (!creature.effects()->hallucination().is_hallucinated()) {
                         tracker.set_trackee(monster.ap_r_idx);
                     }
 
-                    health_track(player, grid.m_idx);
+                    health_track(creature, grid.m_idx);
                 }
             }
         }
@@ -395,22 +394,22 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
 
     if (flag & (PROJECT_KILL)) {
         for (const auto &[dist, pos] : positions) {
-            if (!player.is_located_at(pos)) {
+            if (!creature.is_located_at(pos)) {
                 continue;
             }
 
             /* Find the closest point in the blast */
             auto effective_dist = breath ? dist_to_line(pos, pos_source, pos_impact) : dist;
 
-            if (player.riding) {
+            if (creature.riding) {
                 if (flag & PROJECT_PLAYER) {
-                    /* Hit the player with full damage */
+                    /* Hit the creature with full damage */
                 }
 
                 /*
                  * Hack -- When this grid was not the
                  * original target, a beam or bolt
-                 * would hit either player or mount,
+                 * would hit either creature or mount,
                  * and should be choosen randomly.
                  *
                  * But already choosen to hit the
@@ -422,13 +421,13 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
                     /*
                      * A beam or bolt is well aimed
                      * at the mount!
-                     * So don't affects the player.
+                     * So don't affects the creature.
                      */
                     continue;
                 } else {
                     /*
                      * The spell is not well aimed,
-                     * So partly affect the player too.
+                     * So partly affect the creature too.
                      */
                     effective_dist++;
                 }
@@ -436,10 +435,10 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
 
             std::string who_name;
             if (is_monster(src_idx)) {
-                who_name = monster_desc(player, floor.get_monster(src_idx), MD_WRONGDOER_NAME);
+                who_name = monster_desc(creature, floor.get_monster(src_idx), MD_WRONGDOER_NAME);
             }
 
-            if (affect_player(src_idx, player, who_name.data(), effective_dist, pos.y, pos.x, dam, typ, flag, fall_off_horse_effect, project)) {
+            if (affect_player(src_idx, creature, who_name.data(), effective_dist, pos.y, pos.x, dam, typ, flag, fall_off_horse_effect, project)) {
                 res.notice = true;
                 res.affected_player = true;
             }

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -174,7 +174,6 @@ static void generate_circular_waterway(CreatureEntity &creature)
 
 static bool decide_tunnel_planned_site(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon, dt_type *dt_ptr, int i)
 {
-    auto &player = creature;
     dd_ptr->tunn_n = 0;
     dd_ptr->wall_n = 0;
     if (dungeon.flags.has(DungeonFeatureType::NO_TUNNEL)) {
@@ -189,7 +188,7 @@ static bool decide_tunnel_planned_site(CreatureEntity &creature, DungeonData *dd
         dd_ptr->why = _("トンネル接続に失敗", "Failed to generate tunnels");
         return false;
     } else {
-        msg_format_wizard(player, CHEAT_DUNGEON, _("トンネル失敗回数:%d ", "Failure Tunnels:%d "), dd_ptr->tunnel_fail_count);
+        msg_format_wizard(creature, CHEAT_DUNGEON, _("トンネル失敗回数:%d ", "Failure Tunnels:%d "), dd_ptr->tunnel_fail_count);
     }
 
     return true;
@@ -210,14 +209,13 @@ static void make_tunnels(CreatureEntity &creature, DungeonData *dd_ptr)
 
 static void make_walls(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon, dt_type *dt_ptr)
 {
-    auto &player = creature;
     for (size_t j = 0; j < dd_ptr->wall_n; j++) {
         dd_ptr->tunnel_pos = dd_ptr->walls[j];
         auto &grid = creature.current_floor_ptr->get_grid(dd_ptr->tunnel_pos);
         grid.mimic = 0;
         place_grid(creature, grid, GB_FLOOR);
         if (evaluate_percent(dt_ptr->dun_tun_pen) && dungeon.flags.has_not(DungeonFeatureType::NO_DOORS)) {
-            place_random_door(player, dd_ptr->tunnel_pos, true);
+            place_random_door(creature, dd_ptr->tunnel_pos, true);
         }
     }
 }
@@ -242,11 +240,10 @@ static bool make_centers(CreatureEntity &creature, DungeonData *dd_ptr, const Du
 
 static void make_doors(CreatureEntity &creature, DungeonData *dd_ptr, dt_type *dt_ptr)
 {
-    auto &player = creature;
     for (size_t i = 0; i < dd_ptr->door_n; i++) {
         dd_ptr->tunnel_pos = dd_ptr->doors[i];
         for (const auto &d : Direction::directions_4()) {
-            try_door(player, dt_ptr, dd_ptr->tunnel_pos + d.vec());
+            try_door(creature, dt_ptr, dd_ptr->tunnel_pos + d.vec());
         }
     }
 }
@@ -263,12 +260,11 @@ static void make_only_tunnel_points(const FloorType &floor, DungeonData *dd_ptr)
 
 static bool make_one_floor(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon)
 {
-    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     if (dungeon.flags.has(DungeonFeatureType::NO_ROOM)) {
         make_only_tunnel_points(floor, dd_ptr);
     } else {
-        if (!generate_rooms(player, dd_ptr)) {
+        if (!generate_rooms(creature, dd_ptr)) {
             dd_ptr->why = _("部屋群の生成に失敗", "Failed to generate rooms");
             return false;
         }
@@ -320,7 +316,7 @@ static bool make_one_floor(CreatureEntity &creature, DungeonData *dd_ptr, const 
         const auto portal_num = randint1(2);
         if (!alloc_stairs(creature, terrains.get_terrain_id(TerrainTag::PORTAL), portal_num, 3)) {
             // ポータル配置失敗は警告のみで処理継続
-            msg_print_wizard(player, CHEAT_DUNGEON, _("ポータル生成に失敗", "Failed to generate portals."));
+            msg_print_wizard(creature, CHEAT_DUNGEON, _("ポータル生成に失敗", "Failed to generate portals."));
         }
     }
 
@@ -329,10 +325,9 @@ static bool make_one_floor(CreatureEntity &creature, DungeonData *dd_ptr, const 
 
 static bool switch_making_floor(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon)
 {
-    auto &player = creature;
     if (dungeon.flags.has(DungeonFeatureType::MAZE)) {
         const auto &floor = *creature.current_floor_ptr;
-        build_maze_vault(player, { floor.height / 2 - 1, floor.width / 2 - 1 }, { floor.height - 4, floor.width - 4 }, false);
+        build_maze_vault(creature, { floor.height / 2 - 1, floor.width / 2 - 1 }, { floor.height - 4, floor.width - 4 }, false);
         const auto &terrains = TerrainList::get_instance();
         if (!alloc_stairs(creature, terrains.get_terrain_id(TerrainTag::DOWN_STAIR), rand_range(2, 3), 3)) {
             dd_ptr->why = _("迷宮ダンジョンの下り階段生成に失敗", "Failed to alloc up stairs in maze dungeon.");
@@ -349,7 +344,7 @@ static bool switch_making_floor(CreatureEntity &creature, DungeonData *dd_ptr, c
             const auto portal_num = randint1(2);
             if (!alloc_stairs(creature, terrains.get_terrain_id(TerrainTag::PORTAL), portal_num, 3)) {
                 // ポータル配置失敗は警告のみで処理継続
-                msg_print_wizard(player, CHEAT_DUNGEON, _("迷宮ダンジョンのポータル生成に失敗", "Failed to generate portals in maze dungeon."));
+                msg_print_wizard(creature, CHEAT_DUNGEON, _("迷宮ダンジョンのポータル生成に失敗", "Failed to generate portals in maze dungeon."));
             }
         }
 
@@ -417,15 +412,14 @@ static void make_perm_walls(CreatureEntity &creature)
 
 static bool check_place_necessary_objects(CreatureEntity &creature, DungeonData *dd_ptr)
 {
-    auto &player = creature;
     const auto p_pos = new_player_spot(creature);
     if (!p_pos) {
-        dd_ptr->why = _("プレイヤー配置に失敗", "Failed to place a player");
+        dd_ptr->why = _("プレイヤー配置に失敗", "Failed to place a creature");
         return false;
     }
 
-    player.set_position(*p_pos);
-    if (!place_quest_monsters(player)) {
+    creature.set_position(*p_pos);
+    if (!place_quest_monsters(creature)) {
         dd_ptr->why = _("クエストモンスター配置に失敗", "Failed to place a quest monster");
         return false;
     }
@@ -435,7 +429,6 @@ static bool check_place_necessary_objects(CreatureEntity &creature, DungeonData 
 
 static void decide_dungeon_data_allocation(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon)
 {
-    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
     dd_ptr->alloc_object_num = floor.dun_level / 3 + 5;
     if (dd_ptr->alloc_object_num > 30) {
@@ -459,14 +452,13 @@ static void decide_dungeon_data_allocation(CreatureEntity &creature, DungeonData
     if (dd_ptr->alloc_monster_num > small_tester) {
         dd_ptr->alloc_monster_num = small_tester;
     } else {
-        msg_format_wizard(player, CHEAT_DUNGEON, _("モンスター数基本値を %d から %d に減らします", "Reduced monsters base from %d to %d"), small_tester,
+        msg_format_wizard(creature, CHEAT_DUNGEON, _("モンスター数基本値を %d から %d に減らします", "Reduced monsters base from %d to %d"), small_tester,
             dd_ptr->alloc_monster_num);
     }
 }
 
 static bool allocate_dungeon_data(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon)
 {
-    auto &player = creature;
     dd_ptr->alloc_monster_num += randint1(8);
     auto &floor = *creature.current_floor_ptr;
 
@@ -474,14 +466,14 @@ static bool allocate_dungeon_data(CreatureEntity &creature, DungeonData *dd_ptr,
         if (one_in_(30)) {
             // ランダムな位置を決定
             Pos2D pos(randint0(floor.height), randint0(floor.width));
-            if (alloc_creature_party(player, pos)) {
+            if (alloc_creature_party(creature, pos)) {
                 // パーティ生成に成功した場合、このイテレーションをスキップ
                 continue;
             }
         }
 
         // 通常のモンスター生成
-        (void)alloc_monster(player, 0, PM_ALLOW_SLEEP, summon_specific);
+        (void)alloc_monster(creature, 0, PM_ALLOW_SLEEP, summon_specific);
     }
 
     alloc_object(creature, ALLOC_SET_BOTH, ALLOC_TYP_TRAP, randint1(dd_ptr->alloc_object_num * dungeon.trap_rate / 100));
@@ -504,7 +496,7 @@ static bool allocate_dungeon_data(CreatureEntity &creature, DungeonData *dd_ptr,
     alloc_specific_floor_items(creature);
 
     floor.object_level = floor.base_level;
-    if (alloc_guardian(player, true)) {
+    if (alloc_guardian(creature, true)) {
         return true;
     }
 
@@ -557,7 +549,6 @@ uint32_t calculate_terrain_seed(int dungeon_id, int dun_level)
  */
 tl::optional<std::string> cave_gen(CreatureEntity &creature, tl::optional<uint32_t> seed)
 {
-    auto &player = creature;
     // 乱数種の保存と復元用
     Xoshiro128StarStar::state_type original_state{};
     bool seed_was_fixed = false;
@@ -568,21 +559,21 @@ tl::optional<std::string> cave_gen(CreatureEntity &creature, tl::optional<uint32
         original_state = rng.get_state(); // 現在の乱数状態を保存
         rng = Xoshiro128StarStar(*seed); // 指定された種で乱数を初期化
         seed_was_fixed = true;
-        msg_format_wizard(player, CHEAT_DUNGEON,
+        msg_format_wizard(creature, CHEAT_DUNGEON,
             _("乱数種を固定してダンジョンを生成: 0x%08X", "Generating dungeon with fixed seed: 0x%08X"),
             *seed);
     }
 
     auto &floor = *creature.current_floor_ptr;
     floor.reset_lite_area();
-    get_mon_num_prep_enum(player, floor.get_monrace_hook());
+    get_mon_num_prep_enum(creature, floor.get_monrace_hook());
 
     // 鉄獄（ANGBAND）では一定確率で他のダンジョンの生成処理を使用
     constexpr auto chance_random_dungeon = 10; // 10%の確率
     if (floor.dungeon_id == DungeonId::ANGBAND && one_in_(chance_random_dungeon)) {
         if (auto random_dungeon_id = select_random_non_beginner_dungeon()) {
             floor.dungeon_generated_id = *random_dungeon_id;
-            msg_print_wizard(player, CHEAT_DUNGEON,
+            msg_print_wizard(creature, CHEAT_DUNGEON,
                 format(_("鉄獄で他ダンジョンの生成処理を使用: %s", "Using random dungeon generation in Angband: %s"),
                     floor.get_generated_dungeon_definition().name.data()));
         } else {
@@ -599,17 +590,17 @@ tl::optional<std::string> cave_gen(CreatureEntity &creature, tl::optional<uint32
     constexpr auto chance_empty_floor = 24;
     if (ironman_empty_levels || (dungeon.flags.has(DungeonFeatureType::ARENA) && (empty_levels && one_in_(chance_empty_floor)))) {
         dd.empty_level = true;
-        msg_print_wizard(player, CHEAT_DUNGEON, _("アリーナレベルを生成。", "Arena level."));
+        msg_print_wizard(creature, CHEAT_DUNGEON, _("アリーナレベルを生成。", "Arena level."));
     }
 
     // ALWAY_ARENAフラグがある場合は常にアリーナ地形にする
     if (dungeon.flags.has(DungeonFeatureType::ALWAY_ARENA)) {
         dd.empty_level = true;
-        msg_print_wizard(player, CHEAT_DUNGEON, _("常時アリーナレベルを生成。", "Always arena level."));
+        msg_print_wizard(creature, CHEAT_DUNGEON, _("常時アリーナレベルを生成。", "Always arena level."));
     }
 
     check_arena_floor(creature, &dd);
-    gen_caverns_and_lakes(player, dungeon, &dd);
+    gen_caverns_and_lakes(creature, dungeon, &dd);
     if (!switch_making_floor(creature, &dd, dungeon)) {
         // 乱数状態を復元
         if (seed_was_fixed) {
@@ -625,14 +616,14 @@ tl::optional<std::string> cave_gen(CreatureEntity &creature, tl::optional<uint32
     constexpr int waterway_chance = 8;
     if (dungeon.flags.has(DungeonFeatureType::WATERWAY) && one_in_(waterway_chance) && !dd.empty_level) {
         generate_circular_waterway(creature);
-        msg_print_wizard(player, CHEAT_DUNGEON, _("環状水路を生成。", "Circular waterway generated."));
+        msg_print_wizard(creature, CHEAT_DUNGEON, _("環状水路を生成。", "Circular waterway generated."));
     }
 
     // 地形生成完了後、モンスター・アイテム配置前に左右対称化
     constexpr int symmetric_chance = 25;
     if (one_in_(symmetric_chance)) {
         make_symmetric_floor(floor);
-        msg_print_wizard(player, CHEAT_DUNGEON, _("シンメトリックなフロアを生成。", "Symmetric floor generated."));
+        msg_print_wizard(creature, CHEAT_DUNGEON, _("シンメトリックなフロアを生成。", "Symmetric floor generated."));
     }
 
     if (!check_place_necessary_objects(creature, &dd)) {
@@ -654,7 +645,7 @@ tl::optional<std::string> cave_gen(CreatureEntity &creature, tl::optional<uint32
     // ★地形生成完了：ここで乱数状態を復元し、以降のモンスター/アイテム配置は元の乱数で実行★
     if (seed_was_fixed) {
         AngbandSystem::get_instance().get_rng().set_state(original_state);
-        msg_print_wizard(player, CHEAT_DUNGEON,
+        msg_print_wizard(creature, CHEAT_DUNGEON,
             _("地形生成完了、乱数状態を復元してモンスター/アイテム配置へ",
                 "Terrain generation complete, restoring RNG for monster/item placement"));
     }
@@ -676,7 +667,6 @@ tl::optional<std::string> cave_gen(CreatureEntity &creature, tl::optional<uint32
  */
 void apply_vestige_terrain_replacement(CreatureEntity &creature)
 {
-    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     auto &terrains = TerrainList::get_instance();
 
@@ -713,7 +703,7 @@ void apply_vestige_terrain_replacement(CreatureEntity &creature)
         }
     }
 
-    msg_print_wizard(player, CHEAT_DUNGEON,
+    msg_print_wizard(creature, CHEAT_DUNGEON,
         format(_("VESTIGE効果: %d箇所の地形を差し替えました", "VESTIGE effect: Replaced %d terrain features"),
             replacement_count));
 }
@@ -731,7 +721,6 @@ void apply_void_terrain_placement(CreatureEntity &creature)
         return;
     }
 
-    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     auto &terrains = TerrainList::get_instance();
 
@@ -777,7 +766,7 @@ void apply_void_terrain_placement(CreatureEntity &creature)
         }
     }
 
-    msg_print_wizard(player, CHEAT_DUNGEON,
+    msg_print_wizard(creature, CHEAT_DUNGEON,
         format(_("時空崩壊効果: %d箇所を虚空地形に置き換えました（崩壊度: %d.%06d%%、配置率: %d%%）",
                    "World collapse effect: Replaced %d terrain features with void (collapse: %d.%06d%%, rate: %d%%)"),
             placement_count,

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -66,18 +66,17 @@ static void drop_here(FloorType &floor, ItemEntity &&item, POSITION y, POSITION 
 
 static void generate_artifact(CreatureEntity &creature, qtwg_type *qtwg_ptr, const FixedArtifactId a_idx)
 {
-    auto &player = creature;
     if (a_idx == FixedArtifactId::NONE) {
         return;
     }
 
     const auto &artifact = ArtifactList::get_instance().get_artifact(a_idx);
-    if (!artifact.is_generated && create_named_art(player, a_idx, *qtwg_ptr->y, *qtwg_ptr->x)) {
+    if (!artifact.is_generated && create_named_art(creature, a_idx, *qtwg_ptr->y, *qtwg_ptr->x)) {
         return;
     }
 
     ItemEntity item({ ItemKindType::SCROLL, SV_SCROLL_ACQUIREMENT });
-    drop_here(*player.current_floor_ptr, std::move(item), *qtwg_ptr->y, *qtwg_ptr->x);
+    drop_here(*creature.current_floor_ptr, std::move(item), *qtwg_ptr->y, *qtwg_ptr->x);
 }
 
 /**
@@ -85,9 +84,8 @@ static void generate_artifact(CreatureEntity &creature, qtwg_type *qtwg_ptr, con
  */
 static void parse_qtw_D(CreatureEntity &creature, qtwg_type *qtwg_ptr, char *s)
 {
-    auto &player = creature;
     *qtwg_ptr->x = qtwg_ptr->xmin;
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     int len = strlen(s);
     auto &monraces = MonraceList::get_instance();
     const auto &dungeon = floor.get_dungeon_definition();
@@ -105,7 +103,7 @@ static void parse_qtw_D(CreatureEntity &creature, qtwg_type *qtwg_ptr, char *s)
         grid.info = letter[idx].cave_info;
         if (random & RANDOM_MONSTER) {
             floor.monster_level = floor.base_level + monster_index;
-            place_random_monster(player, *qtwg_ptr->y, *qtwg_ptr->x, (PM_ALLOW_SLEEP | PM_ALLOW_GROUP | PM_NO_QUEST));
+            place_random_monster(creature, *qtwg_ptr->y, *qtwg_ptr->x, (PM_ALLOW_SLEEP | PM_ALLOW_GROUP | PM_NO_QUEST));
             floor.monster_level = floor.base_level;
         } else if (monster_index) {
             auto clone = false;
@@ -130,7 +128,7 @@ static void parse_qtw_D(CreatureEntity &creature, qtwg_type *qtwg_ptr, char *s)
                 monrace.max_num = monrace.mob_num;
             }
 
-            const auto m_idx = place_specific_monster(player, *qtwg_ptr->y, *qtwg_ptr->x, monrace_id, (PM_ALLOW_SLEEP | PM_NO_KAGE));
+            const auto m_idx = place_specific_monster(creature, *qtwg_ptr->y, *qtwg_ptr->x, monrace_id, (PM_ALLOW_SLEEP | PM_NO_KAGE));
             if (clone && m_idx) {
                 floor.get_monster(*m_idx).get_monster_profile().mflag2.set(MonsterConstantFlagType::CLONED);
                 monrace.cur_num = old_cur_num;
@@ -148,7 +146,7 @@ static void parse_qtw_D(CreatureEntity &creature, qtwg_type *qtwg_ptr, char *s)
              */
             const Pos2D pos(*qtwg_ptr->y, *qtwg_ptr->x);
             if (evaluate_percent(75)) {
-                place_object(player, pos, 0);
+                place_object(creature, pos, 0);
             } else {
                 floor.place_trap_at(pos);
             }
@@ -158,11 +156,11 @@ static void parse_qtw_D(CreatureEntity &creature, qtwg_type *qtwg_ptr, char *s)
             floor.object_level = floor.base_level + item_index;
             const Pos2D pos(*qtwg_ptr->y, *qtwg_ptr->x);
             if (evaluate_percent(75)) {
-                place_object(player, pos, 0);
+                place_object(creature, pos, 0);
             } else if (evaluate_percent(80)) {
-                place_object(player, pos, AM_GOOD);
+                place_object(creature, pos, AM_GOOD);
             } else {
-                place_object(player, pos, AM_GOOD | AM_GREAT);
+                place_object(creature, pos, AM_GOOD | AM_GREAT);
             }
 
             floor.object_level = floor.base_level;
@@ -178,7 +176,7 @@ static void parse_qtw_D(CreatureEntity &creature, qtwg_type *qtwg_ptr, char *s)
                 item = floor.make_gold(item.bi_key);
             }
 
-            ItemMagicApplier(player, &item, floor.base_level, AM_NO_FIXED_ART | AM_GOOD).execute();
+            ItemMagicApplier(creature, &item, floor.base_level, AM_NO_FIXED_ART | AM_GOOD).execute();
             drop_here(floor, std::move(item), *qtwg_ptr->y, *qtwg_ptr->x);
         }
 
@@ -329,7 +327,6 @@ static int parse_qtw_Q(qtwg_type *qtwg_ptr, char **zz)
 
 static bool parse_qtw_P(CreatureEntity &creature, qtwg_type *qtwg_ptr, char **zz)
 {
-    auto &player = creature;
     if (qtwg_ptr->buf[0] != 'P') {
         return false;
     }
@@ -348,7 +345,7 @@ static bool parse_qtw_P(CreatureEntity &creature, qtwg_type *qtwg_ptr, char **zz
         panels_y++;
     }
 
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     floor.height = panels_y * SCREEN_HGT;
     int panels_x = (*qtwg_ptr->x / SCREEN_WID);
     if (*qtwg_ptr->x % SCREEN_WID) {
@@ -367,15 +364,15 @@ static bool parse_qtw_P(CreatureEntity &creature, qtwg_type *qtwg_ptr, char **zz
     if (floor.is_in_quest()) {
         POSITION py = atoi(zz[0]);
         POSITION px = atoi(zz[1]);
-        player.y = py;
-        player.x = px;
-        delete_monster(player, player.get_position());
+        creature.y = py;
+        creature.x = px;
+        delete_monster(creature, creature.get_position());
         return true;
     }
 
-    if (!player.oldpx && !player.oldpy) {
-        player.oldpy = atoi(zz[0]);
-        player.oldpx = atoi(zz[1]);
+    if (!creature.oldpx && !creature.oldpy) {
+        creature.oldpy = atoi(zz[0]);
+        creature.oldpx = atoi(zz[1]);
     }
 
     return true;
@@ -397,7 +394,6 @@ static bool parse_qtw_P(CreatureEntity &creature, qtwg_type *qtwg_ptr, char **zz
  */
 parse_error_type generate_fixed_map_floor(CreatureEntity &creature, qtwg_type *qtwg_ptr, process_dungeon_file_pf parse_fixed_map)
 {
-    auto &player = creature;
     char *zz[33];
     if (!qtwg_ptr->buf[0]) {
         return PARSE_ERROR_NONE;
@@ -421,7 +417,7 @@ parse_error_type generate_fixed_map_floor(CreatureEntity &creature, qtwg_type *q
 
     /* Process "F:<letter>:<terrain>:<cave_info>:<monster>:<object>:<ego>:<artifact>:<trap>:<special>" -- info for dungeon grid */
     if (qtwg_ptr->buf[0] == 'F') {
-        return parse_line_feature(*player.current_floor_ptr, qtwg_ptr->buf);
+        return parse_line_feature(*creature.current_floor_ptr, qtwg_ptr->buf);
     }
 
     if (qtwg_ptr->buf[0] == 'D') {
@@ -463,11 +459,11 @@ parse_error_type generate_fixed_map_floor(CreatureEntity &creature, qtwg_type *q
         if (init_flags & INIT_ONLY_FEATURES) {
             return PARSE_ERROR_NONE;
         }
-        return parse_line_vault(player.current_floor_ptr, qtwg_ptr->buf);
+        return parse_line_vault(creature.current_floor_ptr, qtwg_ptr->buf);
     }
 
     if (qtwg_ptr->buf[0] == 'A') {
-        return parse_line_alliance(player.current_floor_ptr, qtwg_ptr->buf);
+        return parse_line_alliance(creature.current_floor_ptr, qtwg_ptr->buf);
     }
 
     if (qtwg_ptr->buf[0] == 'M') {

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -56,23 +56,22 @@
  */
 static void build_dead_end(CreatureEntity &creature, saved_floor_type *sf_ptr)
 {
-    auto &player = creature;
 
     msg_print(_("階段は行き止まりだった。", "The staircases come to a dead end..."));
     clear_cave(creature);
-    player.x = player.y = 0;
-    player.current_floor_ptr->height = SCREEN_HGT;
-    player.current_floor_ptr->width = SCREEN_WID;
+    creature.x = creature.y = 0;
+    creature.current_floor_ptr->height = SCREEN_HGT;
+    creature.current_floor_ptr->width = SCREEN_WID;
     for (POSITION y = 0; y < MAX_HGT; y++) {
         for (POSITION x = 0; x < MAX_WID; x++) {
-            place_bold(player, y, x, GB_SOLID_PERM);
+            place_bold(creature, y, x, GB_SOLID_PERM);
         }
     }
 
-    player.y = player.current_floor_ptr->height / 2;
-    player.x = player.current_floor_ptr->width / 2;
-    place_bold(player, player.y, player.x, GB_FLOOR);
-    wipe_generate_random_floor_flags(*player.current_floor_ptr);
+    creature.y = creature.current_floor_ptr->height / 2;
+    creature.x = creature.current_floor_ptr->width / 2;
+    place_bold(creature, creature.y, creature.x, GB_FLOOR);
+    wipe_generate_random_floor_flags(*creature.current_floor_ptr);
     const auto &fcms = FloorChangeModesStore::get_instace();
     if (fcms->has(FloorChangeMode::UP)) {
         sf_ptr->upper_floor_id = 0;
@@ -83,14 +82,13 @@ static void build_dead_end(CreatureEntity &creature, saved_floor_type *sf_ptr)
 
 static std::pair<short, Pos2D> decide_pet_index(CreatureEntity &creature, const int current_monster)
 {
-    auto &player = creature;
 
-    auto &floor = *player.current_floor_ptr;
-    const auto p_pos = player.get_position();
+    auto &floor = *creature.current_floor_ptr;
+    const auto p_pos = creature.get_position();
     Pos2D pos(0, 0);
     if (current_monster == 0) {
         const auto m_idx = floor.pop_empty_index_monster();
-        player.riding = m_idx;
+        creature.riding = m_idx;
         if (m_idx) {
             pos = p_pos;
         }
@@ -103,7 +101,7 @@ static std::pair<short, Pos2D> decide_pet_index(CreatureEntity &creature, const 
         int j;
         for (j = 1000; j > 0; j--) {
             pos = scatter(floor, p_pos, d, PROJECT_NONE);
-            if (monster_can_enter(&player, pos.y, pos.x, party_monsters[current_monster].get_monrace(), 0)) {
+            if (monster_can_enter(&creature, pos.y, pos.x, party_monsters[current_monster].get_monrace(), 0)) {
                 break;
             }
         }
@@ -119,14 +117,13 @@ static std::pair<short, Pos2D> decide_pet_index(CreatureEntity &creature, const 
 
 static MonraceDefinition &set_pet_params(CreatureEntity &creature, const int current_monster, MONSTER_IDX m_idx, const POSITION cy, const POSITION cx)
 {
-    auto &player = creature;
 
-    player.current_floor_ptr->grid_array[cy][cx].m_idx = m_idx;
-    auto &monster = player.current_floor_ptr->m_list[m_idx];
+    creature.current_floor_ptr->grid_array[cy][cx].m_idx = m_idx;
+    auto &monster = creature.current_floor_ptr->m_list[m_idx];
     monster = party_monsters[current_monster].clone();
     monster.y = cy;
     monster.x = cx;
-    monster.current_floor_ptr = player.current_floor_ptr;
+    monster.current_floor_ptr = creature.current_floor_ptr;
     monster.get_monster_profile().ml = true;
     monster.get_monster_profile().mtimed[MonsterTimedEffect::SLEEP] = 0;
     monster.get_monster_profile().hold_o_idx_list.clear();
@@ -145,10 +142,9 @@ static MonraceDefinition &set_pet_params(CreatureEntity &creature, const int cur
  */
 static void place_pet(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     const auto max_num = AngbandWorld::get_instance().is_wild_mode() ? 1 : PartyMonsters::MAX_SIZE;
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     for (int current_monster = 0; current_monster < max_num; current_monster++) {
         if (!MonraceList::is_valid(party_monsters[current_monster].r_idx)) {
             continue;
@@ -157,17 +153,17 @@ static void place_pet(CreatureEntity &creature)
         const auto &[m_idx, pos] = decide_pet_index(creature, current_monster);
         if (m_idx != 0) {
             const auto &monrace = set_pet_params(creature, current_monster, m_idx, pos.y, pos.x);
-            update_monster(player, m_idx, true);
-            lite_spot(player, pos);
+            update_monster(creature, m_idx, true);
+            lite_spot(creature, pos);
             if (monrace.misc_flags.has(MonsterMiscType::MULTIPLY)) {
                 floor.num_repro++;
             }
         } else {
             const auto &monster = party_monsters[current_monster];
             auto &monrace = monster.get_real_monrace();
-            msg_format(_("%sとはぐれてしまった。", "You have lost sight of %s."), monster_desc(player, monster, 0).data());
+            msg_format(_("%sとはぐれてしまった。", "You have lost sight of %s."), monster_desc(creature, monster, 0).data());
             if (record_named_pet && monster.is_named()) {
-                exe_write_diary(floor, DiaryKind::NAMED_PET, RECORD_NAMED_PET_LOST_SIGHT, monster_desc(player, monster, MD_INDEF_VISIBLE));
+                exe_write_diary(floor, DiaryKind::NAMED_PET, RECORD_NAMED_PET_LOST_SIGHT, monster_desc(creature, monster, MD_INDEF_VISIBLE));
             }
 
             if (monrace.has_entity()) {
@@ -220,12 +216,11 @@ static bool is_visited_floor(saved_floor_type *sf_ptr)
 
 static void update_floor_id(CreatureEntity &creature, saved_floor_type *sf_ptr)
 {
-    auto &player = creature;
 
     const auto &fcms = FloorChangeModesStore::get_instace();
     const auto is_up = fcms->has(FloorChangeMode::UP);
     const auto is_down = fcms->has(FloorChangeMode::DOWN);
-    if (!player.in_saved_floor()) {
+    if (!creature.in_saved_floor()) {
         if (is_up) {
             sf_ptr->lower_floor_id = 0;
         } else if (is_down) {
@@ -235,25 +230,24 @@ static void update_floor_id(CreatureEntity &creature, saved_floor_type *sf_ptr)
         return;
     }
 
-    saved_floor_type *cur_sf_ptr = get_sf_ptr(player.floor_id);
+    saved_floor_type *cur_sf_ptr = get_sf_ptr(creature.floor_id);
     if (is_up) {
         if (cur_sf_ptr->upper_floor_id == new_floor_id) {
-            sf_ptr->lower_floor_id = player.floor_id;
+            sf_ptr->lower_floor_id = creature.floor_id;
         }
 
         return;
     }
 
     if (is_down && (cur_sf_ptr->lower_floor_id == new_floor_id)) {
-        sf_ptr->upper_floor_id = player.floor_id;
+        sf_ptr->upper_floor_id = creature.floor_id;
     }
 }
 
 static void reset_unique_by_floor_change(CreatureEntity &creature)
 {
-    auto &player = creature;
 
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     for (short i = 1; i < floor.m_max; i++) {
         auto &monster = floor.m_list[i];
         if (!monster.is_valid()) {
@@ -276,17 +270,16 @@ static void reset_unique_by_floor_change(CreatureEntity &creature)
         }
 
         if (monrace.floor_id != new_floor_id) {
-            delete_monster_idx(player, i);
+            delete_monster_idx(creature, i);
         }
     }
 }
 
 static void new_floor_allocation(CreatureEntity &creature, saved_floor_type *sf_ptr)
 {
-    auto &player = creature;
 
     GAME_TURN tmp_last_visit = sf_ptr->last_visit;
-    const auto &floor = *player.current_floor_ptr;
+    const auto &floor = *creature.current_floor_ptr;
     auto alloc_chance = floor.get_dungeon_definition().max_m_alloc_chance;
     const auto &world = AngbandWorld::get_instance();
     while (tmp_last_visit > world.game_turn) {
@@ -308,16 +301,16 @@ static void new_floor_allocation(CreatureEntity &creature, saved_floor_type *sf_
             delete_i_idx_list.push_back(static_cast<OBJECT_IDX>(i_idx));
         }
     }
-    delete_items(player, std::move(delete_i_idx_list));
+    delete_items(creature, std::move(delete_i_idx_list));
 
-    (void)place_quest_monsters(player);
+    (void)place_quest_monsters(creature);
     GAME_TURN alloc_times = absence_ticks / alloc_chance;
     if (randint0(alloc_chance) < (absence_ticks % alloc_chance)) {
         alloc_times++;
     }
 
     for (MONSTER_IDX i = 0; i < alloc_times; i++) {
-        (void)alloc_monster(player, 0, 0, summon_specific);
+        (void)alloc_monster(creature, 0, 0, summon_specific);
     }
 }
 
@@ -327,10 +320,9 @@ static void new_floor_allocation(CreatureEntity &creature, saved_floor_type *sf_
  */
 static void set_stairs(CreatureEntity &creature)
 {
-    auto &player = creature;
 
-    auto &floor = *player.current_floor_ptr;
-    auto &grid = floor.grid_array[player.y][player.x];
+    auto &floor = *creature.current_floor_ptr;
+    auto &grid = floor.grid_array[creature.y][creature.x];
     const auto &fcms = FloorChangeModesStore::get_instace();
     const auto &dungeon = floor.get_dungeon_definition();
     const auto &terrains = TerrainList::get_instance();
@@ -347,12 +339,11 @@ static void set_stairs(CreatureEntity &creature)
     }
 
     grid.mimic = 0;
-    grid.special = player.floor_id;
+    grid.special = creature.floor_id;
 }
 
 static void update_new_floor_feature(CreatureEntity &creature, saved_floor_type *sf_ptr, const bool loaded)
 {
-    auto &player = creature;
 
     if (loaded) {
         new_floor_allocation(creature, sf_ptr);
@@ -366,7 +357,7 @@ static void update_new_floor_feature(CreatureEntity &creature, saved_floor_type 
     }
 
     sf_ptr->last_visit = AngbandWorld::get_instance().game_turn;
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     sf_ptr->dun_level = floor.dun_level;
     if (FloorChangeModesStore::get_instace()->has(FloorChangeMode::NO_RETURN)) {
         return;
@@ -377,12 +368,11 @@ static void update_new_floor_feature(CreatureEntity &creature, saved_floor_type 
 
 static void cut_off_the_upstair(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     const auto &fcms = FloorChangeModesStore::get_instace();
     if (fcms->has(FloorChangeMode::RANDOM_PLACE)) {
-        if (const auto p_pos = new_player_spot(player); p_pos) {
-            player.set_position(*p_pos);
+        if (const auto p_pos = new_player_spot(creature); p_pos) {
+            creature.set_position(*p_pos);
         }
 
         return;
@@ -392,7 +382,7 @@ static void cut_off_the_upstair(CreatureEntity &creature)
         return;
     }
 
-    const auto is_blind = player.is_blind();
+    const auto is_blind = creature.is_blind();
     const auto mes = is_blind
                          ? _("ゴトゴトと何か音がした。", "You hear some noises.")
                          : _("突然階段が塞がれてしまった！", "Suddenly the stairs is blocked!");
@@ -431,11 +421,10 @@ static void update_floor(CreatureEntity &creature)
  */
 void change_floor(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     auto &world = AngbandWorld::get_instance();
     world.character_dungeon = false;
-    player.dtrap = false;
+    creature.dtrap = false;
     panel_row_min = 0;
     panel_row_max = 0;
     panel_col_min = 0;
@@ -444,11 +433,11 @@ void change_floor(CreatureEntity &creature)
     update_floor(creature);
     place_pet(creature);
     Travel::get_instance().reset_goal();
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     update_unique_artifact(floor, new_floor_id);
-    player.floor_id = new_floor_id;
+    creature.floor_id = new_floor_id;
     world.character_dungeon = true;
-    if (player.ppersonality == PERSONALITY_MUNCHKIN) {
+    if (creature.ppersonality == PERSONALITY_MUNCHKIN) {
         wiz_lite(creature, CreatureClass(creature).equals(PlayerClassType::NINJA));
     }
 
@@ -458,22 +447,22 @@ void change_floor(CreatureEntity &creature)
     df.set_feeling(0);
     auto &fcms = FloorChangeModesStore::get_instace();
     fcms->clear();
-    select_floor_music(player);
+    select_floor_music(creature);
     fcms->clear();
 
     // 移動後のフロアで階段を消去する処理
-    if (player.vanish_stairs_flag) {
-        player.vanish_stairs_flag = false;
+    if (creature.vanish_stairs_flag) {
+        creature.vanish_stairs_flag = false;
         const auto &dungeon = floor.get_dungeon_definition();
         if (dungeon.flags.has(DungeonFeatureType::VANISH_STAIRS) && floor.is_underground()) {
-            const auto p_pos = player.get_position();
+            const auto p_pos = creature.get_position();
             auto &grid = floor.grid_array[p_pos.y][p_pos.x];
             const auto &terrain = grid.get_terrain();
 
             // 階段かどうかをチェック
             if (terrain.flags.has_any_of({ TerrainCharacteristics::LESS, TerrainCharacteristics::MORE })) {
                 const auto floor_terrain_id = dungeon.select_floor_terrain_id();
-                set_terrain_id_to_grid(player, p_pos, floor_terrain_id);
+                set_terrain_id_to_grid(creature, p_pos, floor_terrain_id);
                 msg_print(_("階段が消え去った。", "The staircase vanishes."));
             }
         }

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -308,9 +308,8 @@ void update_dungeon_feeling(CreatureEntity &creature)
     }
 
     df.set_feeling(new_feeling);
-    auto &player = creature;
-    do_cmd_feeling(player);
-    select_floor_music(player);
+    do_cmd_feeling(creature);
+    select_floor_music(creature);
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::DEPTH);
     if (disturb_minor) {
         disturb(creature, false, false);

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -65,7 +65,6 @@
  */
 static Pos2D build_arena(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     const auto yval = SCREEN_HGT / 2;
     const auto xval = SCREEN_WID / 2;
@@ -73,11 +72,11 @@ static Pos2D build_arena(CreatureEntity &creature)
     const auto y_depth = yval + 15;
     const auto x_left = xval - 15;
     const auto x_right = xval + 15;
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     for (auto y = y_height; y <= y_height + 5; y++) {
         for (auto x = x_left; x <= x_right; x++) {
             const Pos2D pos(y, x);
-            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(creature, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -85,7 +84,7 @@ static Pos2D build_arena(CreatureEntity &creature)
     for (auto y = y_depth; y >= y_depth - 5; y--) {
         for (auto x = x_left; x <= x_right; x++) {
             const Pos2D pos(y, x);
-            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(creature, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -93,7 +92,7 @@ static Pos2D build_arena(CreatureEntity &creature)
     for (auto x = x_left; x <= x_left + 5; x++) {
         for (auto y = y_height; y <= y_depth; y++) {
             const Pos2D pos(y, x);
-            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(creature, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -101,28 +100,28 @@ static Pos2D build_arena(CreatureEntity &creature)
     for (auto x = x_right; x >= x_right - 5; x--) {
         for (auto y = y_height; y <= y_depth; y++) {
             const Pos2D pos(y, x);
-            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(creature, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
 
     // 柱っぽいもの
-    place_bold(player, y_height + 6, x_left + 18, GB_EXTRA_PERM);
+    place_bold(creature, y_height + 6, x_left + 18, GB_EXTRA_PERM);
     floor.get_grid({ y_height + 6, x_left + 18 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(player, y_depth - 6, x_left + 18, GB_EXTRA_PERM);
+    place_bold(creature, y_depth - 6, x_left + 18, GB_EXTRA_PERM);
     floor.get_grid({ y_depth - 6, x_left + 18 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(player, y_height + 6, x_right - 18, GB_EXTRA_PERM);
+    place_bold(creature, y_height + 6, x_right - 18, GB_EXTRA_PERM);
     floor.get_grid({ y_height + 6, x_right - 18 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(player, y_depth - 6, x_right - 18, GB_EXTRA_PERM);
+    place_bold(creature, y_depth - 6, x_right - 18, GB_EXTRA_PERM);
     floor.get_grid({ y_depth - 6, x_right - 18 }).info |= CAVE_GLOW | CAVE_MARK;
 
-    place_bold(player, y_height + 9, x_left + 21, GB_EXTRA_PERM);
+    place_bold(creature, y_height + 9, x_left + 21, GB_EXTRA_PERM);
     floor.get_grid({ y_height + 9, x_left + 21 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(player, y_depth - 9, x_left + 21, GB_EXTRA_PERM);
+    place_bold(creature, y_depth - 9, x_left + 21, GB_EXTRA_PERM);
     floor.get_grid({ y_height - 9, x_left + 21 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(player, y_height + 9, x_right - 21, GB_EXTRA_PERM);
+    place_bold(creature, y_height + 9, x_right - 21, GB_EXTRA_PERM);
     floor.get_grid({ y_height + 9, x_left - 21 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(player, y_depth - 9, x_right - 21, GB_EXTRA_PERM);
+    place_bold(creature, y_depth - 9, x_right - 21, GB_EXTRA_PERM);
     floor.get_grid({ y_height - 9, x_left - 21 }).info |= CAVE_GLOW | CAVE_MARK;
 
     const Pos2D pos(y_height + 10, xval);
@@ -140,14 +139,13 @@ static Pos2D build_arena(CreatureEntity &creature)
  */
 static void generate_challenge_arena(CreatureEntity &creature)
 {
-    auto &player = creature;
 
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     floor.height = SCREEN_HGT;
     floor.width = SCREEN_WID;
     for (auto y = 0; y < MAX_HGT; y++) {
         for (auto x = 0; x < MAX_WID; x++) {
-            place_bold(player, y, x, GB_SOLID_PERM);
+            place_bold(creature, y, x, GB_SOLID_PERM);
             floor.get_grid({ y, x }).add_info(CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -159,13 +157,13 @@ static void generate_challenge_arena(CreatureEntity &creature)
     }
 
     const auto pos = build_arena(creature);
-    if (!player.try_set_position(pos)) {
+    if (!creature.try_set_position(pos)) {
         return;
     }
 
     auto &entries = ArenaEntryList::get_instance();
     const auto &monrace = entries.get_monrace();
-    if (place_specific_monster(player, player.y + 5, player.x, monrace.idx, PM_NO_KAGE | PM_NO_PET)) {
+    if (place_specific_monster(creature, creature.y + 5, creature.x, monrace.idx, PM_NO_KAGE | PM_NO_PET)) {
         return;
     }
 
@@ -180,7 +178,6 @@ static void generate_challenge_arena(CreatureEntity &creature)
  */
 static Pos2D build_battle(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     const auto yval = ARENA_WID / 2;
     const auto xval = ARENA_HGT / 2;
@@ -188,11 +185,11 @@ static Pos2D build_battle(CreatureEntity &creature)
     const auto y_depth = yval + 15;
     const auto x_left = xval - 15;
     const auto x_right = xval + 15;
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     for (auto y = y_height; y <= y_height + 5; y++) {
         for (auto x = x_left; x <= x_right; x++) {
             const Pos2D pos(y, x);
-            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(creature, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -200,7 +197,7 @@ static Pos2D build_battle(CreatureEntity &creature)
     for (auto y = y_depth; y >= y_depth - 3; y--) {
         for (auto x = x_left; x <= x_right; x++) {
             const Pos2D pos(y, x);
-            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(creature, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -208,7 +205,7 @@ static Pos2D build_battle(CreatureEntity &creature)
     for (auto x = x_left; x <= x_left + 17; x++) {
         for (auto y = y_height; y <= y_depth; y++) {
             const Pos2D pos(y, x);
-            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(creature, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -216,18 +213,18 @@ static Pos2D build_battle(CreatureEntity &creature)
     for (auto x = x_right; x >= x_right - 17; x--) {
         for (auto y = y_height; y <= y_depth; y++) {
             const Pos2D pos(y, x);
-            place_bold(player, pos.y, pos.x, GB_EXTRA_PERM);
+            place_bold(creature, pos.y, pos.x, GB_EXTRA_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
 
-    place_bold(player, y_height + 6, x_left + 18, GB_EXTRA_PERM);
+    place_bold(creature, y_height + 6, x_left + 18, GB_EXTRA_PERM);
     floor.get_grid({ y_height + 6, x_left + 18 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(player, y_depth - 4, x_left + 18, GB_EXTRA_PERM);
+    place_bold(creature, y_depth - 4, x_left + 18, GB_EXTRA_PERM);
     floor.get_grid({ y_depth - 4, x_left + 18 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(player, y_height + 6, x_right - 18, GB_EXTRA_PERM);
+    place_bold(creature, y_height + 6, x_right - 18, GB_EXTRA_PERM);
     floor.get_grid({ y_height + 6, x_right - 18 }).info |= CAVE_GLOW | CAVE_MARK;
-    place_bold(player, y_depth - 4, x_right - 18, GB_EXTRA_PERM);
+    place_bold(creature, y_depth - 4, x_right - 18, GB_EXTRA_PERM);
     floor.get_grid({ y_depth - 4, x_right - 18 }).info |= CAVE_GLOW | CAVE_MARK;
 
     for (auto y = y_height + 1; y <= y_height + 5; y++) {
@@ -247,13 +244,12 @@ static Pos2D build_battle(CreatureEntity &creature)
  */
 static void generate_gambling_arena(CreatureEntity &creature)
 {
-    auto &player = creature;
 
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     for (auto y = 0; y < MAX_HGT; y++) {
         for (auto x = 0; x < MAX_WID; x++) {
             const Pos2D pos(y, x);
-            place_bold(player, y, x, GB_SOLID_PERM);
+            place_bold(creature, y, x, GB_SOLID_PERM);
             floor.get_grid(pos).info |= (CAVE_GLOW | CAVE_MARK);
         }
     }
@@ -265,16 +261,16 @@ static void generate_gambling_arena(CreatureEntity &creature)
     }
 
     const auto pos = build_battle(creature);
-    if (!player.try_set_position(pos)) {
+    if (!creature.try_set_position(pos)) {
         return;
     }
 
     const auto &melee_arena = MeleeArena::get_instance();
     for (auto i = 0; i < NUM_GLADIATORS; i++) {
         const auto &gladiator = melee_arena.get_gladiator(i);
-        const Pos2D m_pos(player.y + 8 + (i / 2) * 4, player.x - 2 + (i % 2) * 4);
+        const Pos2D m_pos(creature.y + 8 + (i / 2) * 4, creature.x - 2 + (i % 2) * 4);
         constexpr auto mode = PM_NO_KAGE | PM_NO_PET;
-        const auto m_idx = place_specific_monster(player, m_pos.y, m_pos.x, gladiator.monrace_id, mode);
+        const auto m_idx = place_specific_monster(creature, m_pos.y, m_pos.x, gladiator.monrace_id, mode);
         if (m_idx > 0) {
             floor.get_monster(*m_idx).set_friendly();
         }
@@ -287,7 +283,7 @@ static void generate_gambling_arena(CreatureEntity &creature)
         }
 
         monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
-        update_monster(player, i, false);
+        update_monster(creature, i, false);
     }
 }
 
@@ -297,11 +293,10 @@ static void generate_gambling_arena(CreatureEntity &creature)
  */
 static void generate_fixed_floor(CreatureEntity &creature)
 {
-    auto &player = creature;
 
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     for (const auto &pos : floor.get_area()) {
-        place_bold(player, pos.y, pos.x, GB_SOLID_PERM);
+        place_bold(creature, pos.y, pos.x, GB_SOLID_PERM);
     }
 
     const auto &quests = QuestList::get_instance();
@@ -310,10 +305,10 @@ static void generate_fixed_floor(CreatureEntity &creature)
     floor.object_level = floor.base_level;
     floor.monster_level = floor.base_level;
     if (record_stair) {
-        exe_write_diary_quest(player, DiaryKind::TO_QUEST, floor.quest_number);
+        exe_write_diary_quest(creature, DiaryKind::TO_QUEST, floor.quest_number);
     }
 
-    get_mon_num_prep_enum(player, floor.get_monrace_hook());
+    get_mon_num_prep_enum(creature, floor.get_monrace_hook());
     init_flags = INIT_CREATE_DUNGEON;
     parse_fixed_map(creature, QUEST_DEFINITION_LIST, 0, 0, MAX_HGT, MAX_WID);
 }
@@ -326,7 +321,6 @@ static void generate_fixed_floor(CreatureEntity &creature)
  */
 static tl::optional<std::string> level_gen(CreatureEntity &creature, tl::optional<uint32_t> seed = tl::nullopt)
 {
-    auto &player = creature;
 
     // 乱数種の保存と復元用
     Xoshiro128StarStar::state_type original_state{};
@@ -338,13 +332,13 @@ static tl::optional<std::string> level_gen(CreatureEntity &creature, tl::optiona
         original_state = rng.get_state(); // 現在の乱数状態を保存
         rng = Xoshiro128StarStar(*seed); // 指定された種で乱数を初期化
         seed_was_fixed = true;
-        msg_format_wizard(player, CHEAT_DUNGEON,
+        msg_format_wizard(creature, CHEAT_DUNGEON,
             _("乱数種を固定してフロア生成: 0x%08X", "Generating floor with fixed seed: 0x%08X"),
             *seed);
     }
 
     constexpr auto chance_small_floor = 10;
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     const auto &dungeon = floor.get_generated_dungeon_definition();
     int level_height, level_width;
     if (dungeon.flags.has(DungeonFeatureType::ALWAY_MAX_SIZE)) {
@@ -381,7 +375,7 @@ static tl::optional<std::string> level_gen(CreatureEntity &creature, tl::optiona
     panel_row_min = floor.height;
     panel_col_min = floor.width;
 
-    auto result = cave_gen(player, seed);
+    auto result = cave_gen(creature, seed);
 
     // 乱数状態を復元
     if (seed_was_fixed) {
@@ -440,9 +434,8 @@ void wipe_generate_random_floor_flags(FloorType &floor)
  */
 void clear_cave(CreatureEntity &creature)
 {
-    auto &player = creature;
 
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     floor.o_list.clear();
     floor.o_list.push_back(std::make_shared<ItemEntity>()); // 0番にダミーアイテムを用意
 
@@ -573,14 +566,12 @@ static bool floor_is_connected(const FloorType &floor, const IsWallFunc is_wall)
  */
 void generate_floor(CreatureEntity &creature)
 {
-    auto &player = creature;
-
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     const auto is_wild_mode = AngbandWorld::get_instance().is_wild_mode();
     for (int num = 0; true; num++) {
         tl::optional<std::string> why;
         clear_cave(creature);
-        player.x = player.y = 0;
+        creature.x = creature.y = 0;
         if (floor.inside_arena) {
             generate_challenge_arena(creature);
         } else if (AngbandSystem::get_instance().is_phase_out()) {
@@ -597,8 +588,8 @@ void generate_floor(CreatureEntity &creature)
             why = level_gen(creature);
         }
 
-        if (player.is_sushi_eater()) {
-            alloc_object(player, ALLOC_SET_BOTH, ALLOC_TYP_SUSHI, randnor(floor.width * floor.height / 20, 3));
+        if (creature.is_sushi_eater()) {
+            alloc_object(creature, ALLOC_SET_BOTH, ALLOC_TYP_SUSHI, randnor(floor.width * floor.height / 20, 3));
         }
 
         if (floor.o_list.size() >= MAX_FLOOR_ITEMS) {
@@ -627,10 +618,10 @@ void generate_floor(CreatureEntity &creature)
 
         msg_format(_("生成やり直し(%s)", "Generation restarted (%s)"), why->data());
         wipe_o_list(floor);
-        wipe_monsters_list(player);
+        wipe_monsters_list(creature);
     }
 
-    glow_deep_lava_and_bldg(player);
+    glow_deep_lava_and_bldg(creature);
     floor.enter_dungeon(false);
     wipe_generate_random_floor_flags(floor);
 }

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -49,8 +49,7 @@ static void check_riding_preservation(CreatureEntity &creature)
 
     const auto &monster = creature.current_floor_ptr->m_list[creature.riding];
     if (monster.has_parent()) {
-        auto &player = creature;
-        player.ride_monster(0);
+        creature.ride_monster(0);
         creature.pet_extra_flags &= ~(PF_TWO_HANDS);
         creature.riding_ryoute = creature.old_riding_ryoute = false;
     } else {
@@ -61,13 +60,12 @@ static void check_riding_preservation(CreatureEntity &creature)
 
 static bool check_pet_preservation_conditions(CreatureEntity &creature, const CreatureEntity &monster)
 {
-    auto &player = creature;
 
     if (reinit_wilderness) {
         return false;
     }
 
-    const auto p_pos = player.get_position();
+    const auto p_pos = creature.get_position();
     const auto m_pos = monster.get_position();
     const auto dis = Grid::calc_distance(p_pos, m_pos);
     if (monster.is_confused() || monster.is_stunned() || monster.is_asleep() || monster.has_parent()) {
@@ -75,7 +73,7 @@ static bool check_pet_preservation_conditions(CreatureEntity &creature, const Cr
     }
 
     const auto should_preserve = monster.is_named();
-    const auto &floor = *player.current_floor_ptr;
+    const auto &floor = *creature.current_floor_ptr;
     auto sight_from_player = floor.has_los_at(m_pos);
     sight_from_player &= projectable(floor, p_pos, m_pos);
     auto sight_from_monster = los(floor, m_pos, p_pos);
@@ -89,19 +87,18 @@ static bool check_pet_preservation_conditions(CreatureEntity &creature, const Cr
 
 static void sweep_preserving_pet(CreatureEntity &creature)
 {
-    auto &player = creature;
 
-    if (AngbandWorld::get_instance().is_wild_mode() || player.current_floor_ptr->inside_arena || AngbandSystem::get_instance().is_phase_out()) {
+    if (AngbandWorld::get_instance().is_wild_mode() || creature.current_floor_ptr->inside_arena || AngbandSystem::get_instance().is_phase_out()) {
         return;
     }
 
-    for (MONSTER_IDX i = player.current_floor_ptr->m_max - 1, party_monster_num = 1; (i >= 1) && (party_monster_num < PartyMonsters::MAX_SIZE); i--) {
-        const auto &monster = player.current_floor_ptr->m_list[i];
+    for (MONSTER_IDX i = creature.current_floor_ptr->m_max - 1, party_monster_num = 1; (i >= 1) && (party_monster_num < PartyMonsters::MAX_SIZE); i--) {
+        const auto &monster = creature.current_floor_ptr->m_list[i];
         if (!monster.is_valid() || !monster.is_pet() || monster.is_riding() || check_pet_preservation_conditions(creature, monster)) {
             continue;
         }
 
-        party_monsters[party_monster_num] = player.current_floor_ptr->m_list[i].clone();
+        party_monsters[party_monster_num] = creature.current_floor_ptr->m_list[i].clone();
         party_monster_num++;
         delete_monster_idx(creature, i);
     }
@@ -109,13 +106,12 @@ static void sweep_preserving_pet(CreatureEntity &creature)
 
 static void record_pet_diary(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     if (!record_named_pet) {
         return;
     }
 
-    const auto &floor = *player.current_floor_ptr;
+    const auto &floor = *creature.current_floor_ptr;
     for (MONSTER_IDX i = floor.m_max - 1; i >= 1; i--) {
         const auto &monster = floor.m_list[i];
         if (!monster.is_valid() || !monster.is_named_pet() || monster.is_riding()) {
@@ -132,16 +128,15 @@ static void record_pet_diary(CreatureEntity &creature)
  */
 static void preserve_pet(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     party_monsters.invalidate_all();
 
     check_riding_preservation(creature);
     sweep_preserving_pet(creature);
     record_pet_diary(creature);
-    for (MONSTER_IDX i = player.current_floor_ptr->m_max - 1; i >= 1; i--) {
-        const auto &monster = player.current_floor_ptr->m_list[i];
-        const auto parent_r_idx = player.current_floor_ptr->m_list[monster.get_monster_profile().parent_m_idx].r_idx;
+    for (MONSTER_IDX i = creature.current_floor_ptr->m_max - 1; i >= 1; i--) {
+        const auto &monster = creature.current_floor_ptr->m_list[i];
+        const auto parent_r_idx = creature.current_floor_ptr->m_list[monster.get_monster_profile().parent_m_idx].r_idx;
         if (!monster.has_parent() || MonraceList::is_valid(parent_r_idx)) {
             continue;
         }
@@ -161,7 +156,6 @@ static void preserve_pet(CreatureEntity &creature)
  */
 static void locate_connected_stairs(CreatureEntity &creature, FloorType &floor, saved_floor_type *sf_ptr)
 {
-    auto &player = creature;
 
     auto sx = 0;
     auto sy = 0;
@@ -203,14 +197,14 @@ static void locate_connected_stairs(CreatureEntity &creature, FloorType &floor, 
     }
 
     if (sx) {
-        player.y = sy;
-        player.x = sx;
+        creature.y = sy;
+        creature.x = sx;
         return;
     }
 
     if (num == 0) {
         FloorChangeModesStore::get_instace()->set({ FloorChangeMode::RANDOM_PLACE, FloorChangeMode::NO_RETURN });
-        auto &grid = floor.get_grid(player.get_position());
+        auto &grid = floor.get_grid(creature.get_position());
         if (!grid.has_special_terrain()) {
             grid.special = 0;
         }
@@ -219,21 +213,20 @@ static void locate_connected_stairs(CreatureEntity &creature, FloorType &floor, 
     }
 
     int i = randint0(num);
-    player.y = y_table[i];
-    player.x = x_table[i];
+    creature.y = y_table[i];
+    creature.x = x_table[i];
 }
 
 /*!
- * @brief フロア移動時、プレイヤーの移動先モンスターが既にいた場合ランダムな近隣に移動させる / When a monster is at a place where player will return,
+ * @brief フロア移動時、プレイヤーの移動先モンスターが既にいた場合ランダムな近隣に移動させる / When a monster is at a place where creature will return,
  */
 static void get_out_monster(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     auto tries = 0;
     auto dis = 1;
-    const auto p_pos = player.get_position();
-    auto &floor = *player.current_floor_ptr;
+    const auto p_pos = creature.get_position();
+    auto &floor = *creature.current_floor_ptr;
     auto &p_grid = floor.get_grid(p_pos);
     const auto m_idx = p_grid.m_idx;
     if (m_idx == 0) {
@@ -272,11 +265,10 @@ static void get_out_monster(CreatureEntity &creature)
  */
 static void preserve_info(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     auto quest_monrace_id = MonraceList::empty_id();
     const auto &quests = QuestList::get_instance();
-    const auto &floor = *player.current_floor_ptr;
+    const auto &floor = *creature.current_floor_ptr;
     for (const auto &[quest_id, quest] : quests) {
         auto quest_relating_monster = (quest.status == QuestStatusType::TAKEN);
         quest_relating_monster &= ((quest.type == QuestKindType::KILL_LEVEL) || (quest.type == QuestKindType::RANDOM));
@@ -303,7 +295,7 @@ static void preserve_info(CreatureEntity &creature)
     }
 
     for (short i = 0; i < INVEN_PACK; i++) {
-        auto *o_ptr = player.inventory[i].get();
+        auto *o_ptr = creature.inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -316,13 +308,12 @@ static void preserve_info(CreatureEntity &creature)
 
 static Grid *set_grid_by_leaving_floor(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     if (FloorChangeModesStore::get_instace()->has_not(FloorChangeMode::SAVE_FLOORS)) {
         return nullptr;
     }
-    auto &floor = *player.current_floor_ptr;
-    auto &grid = floor.get_grid(player.get_position());
+    auto &floor = *creature.current_floor_ptr;
+    auto &grid = floor.get_grid(creature.get_position());
     const auto &terrain = grid.get_terrain();
     if (grid.special && terrain.flags.has_not(TerrainCharacteristics::SPECIAL) && get_sf_ptr(grid.special)) {
         new_floor_id = grid.special;
@@ -337,7 +328,6 @@ static Grid *set_grid_by_leaving_floor(CreatureEntity &creature)
 
 static void jump_floors(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     const auto &fcms = FloorChangeModesStore::get_instace();
     if (fcms->has_none_of({ FloorChangeMode::DOWN, FloorChangeMode::UP })) {
@@ -355,7 +345,7 @@ static void jump_floors(CreatureEntity &creature)
         move_num *= 2;
     }
 
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     const auto &dungeon = floor.get_dungeon_definition();
     if (fcms->has(FloorChangeMode::DOWN)) {
         if (!floor.is_underground()) {
@@ -373,9 +363,8 @@ static void jump_floors(CreatureEntity &creature)
 //!< @details SAVE_FLOORS フラグを抜く箇所に「TODO」のコメントがあった、何をするかは書いておらず詳細不明
 static void exit_to_wilderness(CreatureEntity &creature)
 {
-    auto &player = creature;
 
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     if (floor.is_underground() || (floor.dungeon_id == DungeonId::WILDERNESS)) {
         return;
     }
@@ -386,8 +375,8 @@ static void exit_to_wilderness(CreatureEntity &creature)
         WildernessGrids::get_instance().set_player_position(dungeon.get_position());
     }
 
-    player.recall_dungeon = floor.dungeon_id;
-    player.word_recall = 0;
+    creature.recall_dungeon = floor.dungeon_id;
+    creature.word_recall = 0;
     floor.reset_dungeon_index();
     FloorChangeModesStore::get_instace()->reset(FloorChangeMode::SAVE_FLOORS);
 }
@@ -472,7 +461,6 @@ static void exe_leave_floor(CreatureEntity &creature, saved_floor_type *sf_ptr)
  */
 void leave_floor(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     preserve_pet(creature);
     SpellsMirrorMaster(creature).remove_all_mirrors(false);
@@ -481,9 +469,9 @@ void leave_floor(CreatureEntity &creature)
     new_floor_id = 0;
 
     preserve_info(creature);
-    saved_floor_type *sf_ptr = get_sf_ptr(player.floor_id);
+    saved_floor_type *sf_ptr = get_sf_ptr(creature.floor_id);
     if (FloorChangeModesStore::get_instace()->has(FloorChangeMode::RANDOM_CONNECT)) {
-        locate_connected_stairs(creature, *player.current_floor_ptr, sf_ptr);
+        locate_connected_stairs(creature, *creature.current_floor_ptr, sf_ptr);
     }
 
     exe_leave_floor(creature, sf_ptr);
@@ -495,9 +483,8 @@ void leave_floor(CreatureEntity &creature)
  */
 void jump_floor(CreatureEntity &creature, DungeonId dun_idx, DEPTH depth)
 {
-    auto &player = creature;
 
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     floor.set_dungeon_index(dun_idx);
     floor.dun_level = depth;
     auto &fcms = FloorChangeModesStore::get_instace();
@@ -515,7 +502,7 @@ void jump_floor(CreatureEntity &creature, DungeonId dun_idx, DEPTH depth)
     msg_print_wizard(creature, 2, format(mes, to.data()));
     floor.quest_number = QuestId::NONE;
     PlayerEnergy(creature).reset_player_turn();
-    player.energy_need = 0;
+    creature.energy_need = 0;
     fcms->set(FloorChangeMode::FIRST_FLOOR);
-    player.leaving = true;
+    creature.leaving = true;
 }

--- a/src/floor/floor-save.cpp
+++ b/src/floor/floor-save.cpp
@@ -89,10 +89,9 @@ void init_saved_floors(bool force)
  */
 void clear_saved_floor_files(CreatureEntity &creature)
 {
-    auto &player = creature;
     for (int i = 0; i < MAX_SAVED_FLOORS; i++) {
         saved_floor_type *sf_ptr = &saved_floors[i];
-        if (!is_saved_floor(sf_ptr) || (sf_ptr->floor_id == player.floor_id)) {
+        if (!is_saved_floor(sf_ptr) || (sf_ptr->floor_id == creature.floor_id)) {
             continue;
         }
 
@@ -130,13 +129,12 @@ saved_floor_type *get_sf_ptr(FLOOR_IDX floor_id)
  */
 void kill_saved_floor(CreatureEntity &creature, saved_floor_type *sf_ptr)
 {
-    auto &player = creature;
     if (!sf_ptr || !is_saved_floor(sf_ptr)) {
         return;
     }
 
-    if (sf_ptr->floor_id == player.floor_id) {
-        player.floor_id = 0;
+    if (sf_ptr->floor_id == creature.floor_id) {
+        creature.floor_id = 0;
         sf_ptr->floor_id = 0;
         return;
     }
@@ -149,13 +147,12 @@ void kill_saved_floor(CreatureEntity &creature, saved_floor_type *sf_ptr)
 
 static FLOOR_IDX find_oldest_floor_idx(CreatureEntity &creature)
 {
-    auto &player = creature;
     FLOOR_IDX oldest_floor_idx = 0;
     uint32_t oldest_visit = 0xffffffffL;
 
     for (FLOOR_IDX fl_idx = 0; fl_idx < MAX_SAVED_FLOORS; fl_idx++) {
         const saved_floor_type *sf_ptr = &saved_floors[fl_idx];
-        if ((sf_ptr->floor_id == player.floor_id) || (sf_ptr->visit_mark > oldest_visit)) {
+        if ((sf_ptr->floor_id == creature.floor_id) || (sf_ptr->visit_mark > oldest_visit)) {
             continue;
         }
 
@@ -175,7 +172,6 @@ static FLOOR_IDX find_oldest_floor_idx(CreatureEntity &creature)
  */
 FLOOR_IDX get_unused_floor_id(CreatureEntity &creature)
 {
-    auto &player = creature;
     saved_floor_type *sf_ptr = nullptr;
     FLOOR_IDX fl_idx;
     for (fl_idx = 0; fl_idx < MAX_SAVED_FLOORS; fl_idx++) {
@@ -197,7 +193,7 @@ FLOOR_IDX get_unused_floor_id(CreatureEntity &creature)
     sf_ptr->upper_floor_id = 0;
     sf_ptr->lower_floor_id = 0;
     sf_ptr->visit_mark = latest_visit_mark++;
-    sf_ptr->dun_level = player.current_floor_ptr->dun_level;
+    sf_ptr->dun_level = creature.current_floor_ptr->dun_level;
     if (max_floor_id < MAX_SHORT) {
         max_floor_id++;
     } else {

--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -237,7 +237,6 @@ void add_river(FloorType &floor, DungeonData *dd_ptr)
  */
 void build_streamer(CreatureEntity &creature, FEAT_IDX feat, int chance)
 {
-    auto &player = creature;
     const auto &streamer = TerrainList::get_instance().get_terrain(feat);
     bool streamer_is_wall = streamer.flags.has(TerrainCharacteristics::WALL) && streamer.flags.has_not(TerrainCharacteristics::PERMANENT);
     bool streamer_may_have_gold = streamer.flags.has(TerrainCharacteristics::MAY_HAVE_GOLD);
@@ -295,7 +294,7 @@ void build_streamer(CreatureEntity &creature, FEAT_IDX feat, int chance)
             const auto &monrace = floor.get_monster(grid.m_idx).get_monrace();
             if (grid.has_monster() && !(streamer.flags.has(TerrainCharacteristics::PLACE) && monster_can_cross_terrain(&creature, feat, monrace, 0))) {
                 /* Delete the monster (if any) */
-                delete_monster(player, pos);
+                delete_monster(creature, pos);
             }
 
             if (!grid.o_idx_list.empty() && streamer.flags.has_not(TerrainCharacteristics::DROP)) {
@@ -308,7 +307,7 @@ void build_streamer(CreatureEntity &creature, FEAT_IDX feat, int chance)
                     if (item.is_fixed_artifact()) {
                         item.get_fixed_artifact().is_generated = false;
                         if (cheat_peek) {
-                            const auto item_name = describe_flavor(player, item, (OD_NAME_ONLY | OD_STORE));
+                            const auto item_name = describe_flavor(creature, item, (OD_NAME_ONLY | OD_STORE));
                             msg_format(_("伝説のアイテム (%s) はストリーマーにより削除された。", "Artifact (%s) was deleted by streamer."), item_name.data());
                         }
                     } else if (cheat_peek && item.is_random_artifact()) {
@@ -316,7 +315,7 @@ void build_streamer(CreatureEntity &creature, FEAT_IDX feat, int chance)
                     }
                 }
 
-                delete_all_items_from_floor(player, pos);
+                delete_all_items_from_floor(creature, pos);
             }
 
             /* Clear previous contents, add proper vein type */
@@ -340,7 +339,7 @@ void build_streamer(CreatureEntity &creature, FEAT_IDX feat, int chance)
         }
 
         if (dummy >= SAFE_MAX_ATTEMPTS) {
-            msg_print_wizard(player, CHEAT_DUNGEON, _("地形のストリーマー処理に失敗しました。", "Failed to place streamer."));
+            msg_print_wizard(creature, CHEAT_DUNGEON, _("地形のストリーマー処理に失敗しました。", "Failed to place streamer."));
             return;
         }
 
@@ -417,8 +416,7 @@ void place_trees(CreatureEntity &creature, const Pos2D &pos)
  */
 void destroy_level(CreatureEntity &creature)
 {
-    auto &player = creature;
-    msg_print_wizard(player, CHEAT_DUNGEON, _("階に*破壊*の痕跡を生成しました。", "Destroyed Level."));
+    msg_print_wizard(creature, CHEAT_DUNGEON, _("階に*破壊*の痕跡を生成しました。", "Destroyed Level."));
 
     /* Drop a few epi-centers (usually about two) */
     POSITION y1, x1;
@@ -428,6 +426,6 @@ void destroy_level(CreatureEntity &creature)
         x1 = rand_range(5, floor.width - 1 - 5);
         y1 = rand_range(5, floor.height - 1 - 5);
 
-        (void)destroy_area(player, y1, x1, 15, true);
+        (void)destroy_area(creature, y1, x1, 15, true);
     }
 }

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -37,8 +37,7 @@
  */
 void pattern_teleport(CreatureEntity &creature)
 {
-    auto &player = creature;
-    auto *player_ptr = &player;
+    auto *player_ptr = &creature;
     auto min_level = 0;
     auto max_level = 99;
     auto &floor = *player_ptr->current_floor_ptr;
@@ -105,8 +104,7 @@ void pattern_teleport(CreatureEntity &creature)
  */
 bool pattern_effect(CreatureEntity &creature)
 {
-    auto &player = creature;
-    auto *player_ptr = &player;
+    auto *player_ptr = &creature;
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto p_pos = player_ptr->get_position();
     const auto &grid = floor.get_grid(p_pos);
@@ -171,8 +169,7 @@ bool pattern_effect(CreatureEntity &creature)
  */
 bool pattern_seq(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto &player = creature;
-    auto *player_ptr = &player;
+    auto *player_ptr = &creature;
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto &grid_current = floor.get_grid(player_ptr->get_position());
     const auto &grid_new = floor.get_grid(pos);

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -280,17 +280,16 @@ static void generate_wilderness_area(FloorType &floor, const WildernessGrid &wg,
  */
 static void generate_area(CreatureEntity &creature, const Pos2D &pos, bool is_border, bool is_corner)
 {
-    auto &player = creature;
 
     const auto &wilderness = WildernessGrids::get_instance();
     const auto &wg = wilderness.get_grid(pos);
-    player.town_num = wg.get_town();
-    auto &floor = *player.current_floor_ptr;
+    creature.town_num = wg.get_town();
+    auto &floor = *creature.current_floor_ptr;
     floor.base_level = wg.get_level();
     floor.dun_level = 0;
     floor.monster_level = floor.base_level;
     floor.object_level = floor.base_level;
-    if (player.town_num) {
+    if (creature.town_num) {
         init_buildings();
         if (is_border || is_corner) {
             init_flags = i2enum<init_flags_type>(INIT_CREATE_DUNGEON | INIT_ONLY_FEATURES);
@@ -305,11 +304,11 @@ static void generate_area(CreatureEntity &creature, const Pos2D &pos, bool is_bo
 
         for (auto tv : floor.vault_list) {
             const auto vault = &vaults_info[static_cast<int>(tv.id)];
-            build_vault(*vault, player, tv.y, tv.x, vault->hgt, vault->wid, vault->text.data(), tv.yoffset, tv.xoffset, tv.transno);
+            build_vault(*vault, creature, tv.y, tv.x, vault->hgt, vault->wid, vault->text.data(), tv.yoffset, tv.xoffset, tv.transno);
         }
 
         if (!is_corner && !is_border) {
-            player.visit |= (1UL << (player.town_num - 1));
+            creature.visit |= (1UL << (creature.town_num - 1));
         }
     } else {
         generate_wilderness_area(floor, wg, is_corner);
@@ -377,7 +376,6 @@ static void generate_area(CreatureEntity &creature, const Pos2D &pos, bool is_bo
  */
 static void generate_wild_monsters(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     constexpr auto num_ambush_monsters = 100;
     constexpr auto num_normal_monsters = 25;
@@ -401,16 +399,16 @@ static void generate_wild_monsters(CreatureEntity &creature)
 
         if (alliance_it != alliance_list.end()) {
             const auto &alliance = alliance_it->second;
-            int impression = alliance->calcImpressionPoint(player);
-            auto ambush_monsters = alliance->get_ambush_monsters(player, impression);
+            int impression = alliance->calcImpressionPoint(creature);
+            auto ambush_monsters = alliance->get_ambush_monsters(creature, impression);
 
             // アライアンス固有のモンスターを配置
             if (!ambush_monsters.empty()) {
                 for (const auto &monster_id : ambush_monsters) {
                     for (int i = 0; i < 3; i++) { // 各モンスターを3体ずつ配置
-                        auto y = randint0(player.current_floor_ptr->height);
-                        auto x = randint0(player.current_floor_ptr->width);
-                        (void)place_monster_one(player, y, x, monster_id, PM_ALLOW_GROUP);
+                        auto y = randint0(creature.current_floor_ptr->height);
+                        auto x = randint0(creature.current_floor_ptr->width);
+                        (void)place_monster_one(creature, y, x, monster_id, PM_ALLOW_GROUP);
                     }
                 }
             }
@@ -420,11 +418,11 @@ static void generate_wild_monsters(CreatureEntity &creature)
     // 通常のランダムモンスター生成（襲撃時も追加で生成）
     for (auto i = 0; i < lim; i++) {
         BIT_FLAGS mode = 0;
-        if (!(generate_encounter || (one_in_(2) && (!player.town_num)))) {
+        if (!(generate_encounter || (one_in_(2) && (!creature.town_num)))) {
             mode |= PM_ALLOW_SLEEP;
         }
 
-        (void)alloc_monster(player, generate_encounter ? 0 : 3, mode, summon_specific);
+        (void)alloc_monster(creature, generate_encounter ? 0 : 3, mode, summon_specific);
     }
 }
 
@@ -436,9 +434,8 @@ static void generate_wild_monsters(CreatureEntity &creature)
  */
 void wilderness_gen(CreatureEntity &creature)
 {
-    auto &player = creature;
 
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     floor.height = MAX_HGT;
     floor.width = MAX_WID;
     panel_row_min = floor.height;
@@ -551,7 +548,7 @@ void wilderness_gen(CreatureEntity &creature)
         }
     }
 
-    if (player.teleport_town) {
+    if (creature.teleport_town) {
         for (const auto &pos : floor.get_area()) {
             auto &grid = floor.get_grid(pos);
             const auto &terrain = grid.get_terrain();
@@ -559,7 +556,7 @@ void wilderness_gen(CreatureEntity &creature)
                 continue;
             }
 
-            if ((terrain.subtype != 4) && !((player.town_num == 1) && (terrain.subtype == 0))) {
+            if ((terrain.subtype != 4) && !((creature.town_num == 1) && (terrain.subtype == 0))) {
                 continue;
             }
 
@@ -567,11 +564,11 @@ void wilderness_gen(CreatureEntity &creature)
                 delete_monster_idx(creature, grid.m_idx);
             }
 
-            player.oldpy = pos.y;
-            player.oldpx = pos.x;
+            creature.oldpy = pos.y;
+            creature.oldpx = pos.x;
         }
 
-        player.teleport_town = false;
+        creature.teleport_town = false;
     } else if (floor.is_leaving_dungeon()) {
         for (const auto &pos : floor.get_area()) {
             auto &grid = floor.get_grid(pos);
@@ -583,14 +580,14 @@ void wilderness_gen(CreatureEntity &creature)
                 delete_monster_idx(creature, grid.m_idx);
             }
 
-            player.oldpy = pos.y;
-            player.oldpx = pos.x;
+            creature.oldpy = pos.y;
+            creature.oldpx = pos.x;
         }
 
-        player.teleport_town = false;
+        creature.teleport_town = false;
     }
 
-    if (!player.try_set_position(player.get_old_position())) {
+    if (!creature.try_set_position(creature.get_old_position())) {
         return;
     }
 
@@ -614,9 +611,8 @@ void wilderness_gen(CreatureEntity &creature)
  */
 void wilderness_gen_small(CreatureEntity &creature)
 {
-    auto &player = creature;
 
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     for (auto x = 0; x < MAX_WID; x++) {
         for (auto y = 0; y < MAX_HGT; y++) {
             floor.get_grid({ y, x }).set_terrain_id(TerrainTag::PERMANENT_WALL);
@@ -668,8 +664,8 @@ void wilderness_gen_small(CreatureEntity &creature)
 
     panel_row_min = floor.height;
     panel_col_min = floor.width;
-    player.set_position(wilderness.get_player_position());
-    player.town_num = 0;
+    creature.set_position(wilderness.get_player_position());
+    creature.town_num = 0;
 }
 
 /*!
@@ -842,10 +838,9 @@ void init_wilderness_encounter()
  */
 bool change_wild_mode(CreatureEntity &creature, bool encount)
 {
-    auto &player = creature;
 
     generate_encounter = encount;
-    if (player.leaving) {
+    if (creature.leaving) {
         return false;
     }
 
@@ -857,17 +852,17 @@ bool change_wild_mode(CreatureEntity &creature, bool encount)
     auto &world = AngbandWorld::get_instance();
     auto &wilderness = WildernessGrids::get_instance();
     if (world.is_wild_mode()) {
-        wilderness.set_player_position(player.get_position());
-        player.energy_need = 0;
+        wilderness.set_player_position(creature.get_position());
+        creature.energy_need = 0;
         world.set_wild_mode(false);
-        player.leaving = true;
+        creature.leaving = true;
         return true;
     }
 
     bool has_pet = false;
     PlayerEnergy energy(creature);
-    for (int i = 1; i < player.current_floor_ptr->m_max; i++) {
-        const auto &monster = player.current_floor_ptr->get_monster(i);
+    for (int i = 1; i < creature.current_floor_ptr->m_max; i++) {
+        const auto &monster = creature.current_floor_ptr->get_monster(i);
         if (!monster.is_valid()) {
             continue;
         }
@@ -894,8 +889,8 @@ bool change_wild_mode(CreatureEntity &creature, bool encount)
     }
 
     energy.set_player_turn_energy(1000);
-    player.oldpx = player.x;
-    player.oldpy = player.y;
+    creature.oldpx = creature.x;
+    creature.oldpy = creature.y;
     SpellHex spell_hex(creature);
     if (spell_hex.is_spelling_any()) {
         spell_hex.stop_all_spells();
@@ -903,6 +898,6 @@ bool change_wild_mode(CreatureEntity &creature, bool encount)
 
     set_action(creature, ACTION_NONE);
     world.set_wild_mode(true);
-    player.leaving = true;
+    creature.leaving = true;
     return true;
 }

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -83,7 +83,7 @@ void regenmana(CreatureEntity &creature, MANA_POINT upkeep_factor, MANA_POINT re
         }
     }
 
-    /* Regenerating mana (unless the player has excess mana) */
+    /* Regenerating mana (unless the creature has excess mana) */
     else if (regen_rate > 0) {
         MANA_POINT new_mana = 0;
         uint32_t new_mana_frac = (creature.msp * regen_rate / 100 + PY_REGEN_MNBASE);
@@ -95,7 +95,7 @@ void regenmana(CreatureEntity &creature, MANA_POINT upkeep_factor, MANA_POINT re
         }
     }
 
-    /* Reduce mana (even when the player has excess mana) */
+    /* Reduce mana (even when the creature has excess mana) */
     if (regen_rate < 0) {
         int32_t reduce_mana = 0;
         uint32_t reduce_mana_frac = (creature.msp * (-1) * regen_rate / 100 + PY_REGEN_MNBASE);
@@ -224,10 +224,9 @@ void regenerate_monsters(CreatureEntity &creature)
  */
 void regenerate_captured_monsters(CreatureEntity &creature)
 {
-    auto &player = creature;
     bool heal = false;
     for (int i = 0; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = player.inventory[i].get();
+        auto *o_ptr = creature.inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -252,8 +251,8 @@ void regenerate_captured_monsters(CreatureEntity &creature)
                 frac *= 2;
             }
 
-            // Apply hygiene-based regeneration modifier (based on player's current terrain)
-            const auto &grid = player.current_floor_ptr->get_grid(player.get_position());
+            // Apply hygiene-based regeneration modifier (based on creature's current terrain)
+            const auto &grid = creature.current_floor_ptr->get_grid(creature.get_position());
             const auto &terrain = grid.get_terrain();
             if (terrain.hygiene != 0) {
                 const int hygiene_modifier = 100 + terrain.hygiene;

--- a/src/info-reader/fixed-map-parser.cpp
+++ b/src/info-reader/fixed-map-parser.cpp
@@ -42,7 +42,6 @@ static concptr variant = "ZANGBAND";
  */
 static std::string parse_fixed_map_expression(CreatureEntity &creature, char **sp, char *fp)
 {
-    auto &player = creature;
     constexpr char b1 = '[';
     constexpr char b2 = ']';
 
@@ -174,16 +173,16 @@ static std::string parse_fixed_map_expression(CreatureEntity &creature, char **s
             v = "OFF";
         }
     } else if (streq(b + 1, "RACE")) {
-        v = player.race->title.en_string();
+        v = creature.race->title.en_string();
     } else if (streq(b + 1, "CLASS")) {
-        v = (*player.pclass_ref).title.en_string();
+        v = (*creature.pclass_ref).title.en_string();
     } else if (streq(b + 1, "REALM1")) {
-        v = PlayerRealm(player).realm1().get_name().en_string();
+        v = PlayerRealm(creature).realm1().get_name().en_string();
     } else if (streq(b + 1, "REALM2")) {
-        v = PlayerRealm(player).realm2().get_name().en_string();
+        v = PlayerRealm(creature).realm2().get_name().en_string();
     } else if (streq(b + 1, "PLAYER")) {
         char tmp_player_name[64]{};
-        const char *pn = player.name.c_str();
+        const char *pn = creature.name.c_str();
         char *tpn = tmp_player_name;
         for (; *pn; pn++, tpn++) {
 #ifdef JP
@@ -199,11 +198,11 @@ static std::string parse_fixed_map_expression(CreatureEntity &creature, char **s
         *tpn = '\0';
         v = tmp_player_name;
     } else if (streq(b + 1, "TOWN")) {
-        v = std::to_string(player.town_num);
+        v = std::to_string(creature.town_num);
     } else if (streq(b + 1, "LEVEL")) {
-        v = std::to_string(player.level);
+        v = std::to_string(creature.level);
     } else if (streq(b + 1, "QUEST_NUMBER")) {
-        v = std::to_string(enum2i(player.current_floor_ptr->quest_number));
+        v = std::to_string(enum2i(creature.current_floor_ptr->quest_number));
     } else if (streq(b + 1, "LEAVING_QUEST")) {
         v = std::to_string(enum2i(leaving_quest));
     } else if (prefix(b + 1, "QUEST_TYPE")) {

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -139,7 +139,6 @@ static std::pair<tl::optional<short>, char> check_floor_item_tag_inventory(Creat
  */
 static std::pair<tl::optional<short>, char> check_floor_item_tag(CreatureEntity &creature, FloorItemSelection &fis, char prev_tag, const ItemTester &item_tester)
 {
-    auto &player = creature;
     const auto code = repeat_pull();
     if (!code) {
         return { tl::nullopt, prev_tag };
@@ -150,8 +149,8 @@ static std::pair<tl::optional<short>, char> check_floor_item_tag(CreatureEntity 
         return { *code, prev_tag };
     }
 
-    const auto &floor = *player.current_floor_ptr;
-    const auto p_pos = player.get_position();
+    const auto &floor = *creature.current_floor_ptr;
+    const auto p_pos = creature.get_position();
     const auto &[floor_item_indice, tag_floor] = check_floor_item_tag_aux(floor, p_pos, fis, *code, prev_tag, item_tester);
     if (floor_item_indice) {
         return { *floor_item_indice, tag_floor };
@@ -167,7 +166,6 @@ static std::pair<tl::optional<short>, char> check_floor_item_tag(CreatureEntity 
  */
 static void test_inventory_floor(CreatureEntity &creature, FloorItemSelection *fis_ptr, const ItemTester &item_tester)
 {
-    auto &player = creature;
     if (!fis_ptr->inven) {
         fis_ptr->i2 = -1;
         return;
@@ -178,7 +176,7 @@ static void test_inventory_floor(CreatureEntity &creature, FloorItemSelection *f
     }
 
     for (int i = 0; i < INVEN_PACK; i++) {
-        if (item_tester.okay(player.inventory[i].get()) || (fis_ptr->mode & USE_FULL)) {
+        if (item_tester.okay(creature.inventory[i].get()) || (fis_ptr->mode & USE_FULL)) {
             fis_ptr->max_inven++;
         }
     }
@@ -191,7 +189,6 @@ static void test_inventory_floor(CreatureEntity &creature, FloorItemSelection *f
  */
 static void test_equipment_floor(CreatureEntity &creature, FloorItemSelection *fis_ptr, const ItemTester &item_tester)
 {
-    auto &player = creature;
     if (!fis_ptr->equip) {
         fis_ptr->e2 = -1;
         return;
@@ -202,8 +199,8 @@ static void test_equipment_floor(CreatureEntity &creature, FloorItemSelection *f
     }
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        if (player.select_ring_slot ? is_ring_slot(i)
-                                    : item_tester.okay(player.inventory[i].get()) || (fis_ptr->mode & USE_FULL)) {
+        if (creature.select_ring_slot ? is_ring_slot(i)
+                                      : item_tester.okay(creature.inventory[i].get()) || (fis_ptr->mode & USE_FULL)) {
             fis_ptr->max_equip++;
         }
     }
@@ -220,7 +217,6 @@ static void test_equipment_floor(CreatureEntity &creature, FloorItemSelection *f
  */
 tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pmt, std::string_view str, BIT_FLAGS mode, const ItemTester &item_tester)
 {
-    auto &player = creature;
     FloorItemSelection fis(mode);
     static char prev_tag = '\0';
     const auto &[i_idx, tag] = check_floor_item_tag(creature, fis, prev_tag, item_tester);
@@ -270,8 +266,8 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
     }
 
     if (fis.floor) {
-        const auto &floor = *player.current_floor_ptr;
-        fis.floor_item_index = scan_floor_items(floor, player.get_position(), { ScanFloorMode::ITEM_TESTER, ScanFloorMode::ONLY_MARKED }, item_tester);
+        const auto &floor = *creature.current_floor_ptr;
+        fis.floor_item_index = scan_floor_items(floor, creature.get_position(), { ScanFloorMode::ITEM_TESTER, ScanFloorMode::ONLY_MARKED }, item_tester);
     }
 
     if ((mode & USE_INVEN) && (fis.i1 <= fis.i2)) {
@@ -364,7 +360,7 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
             fis.n1 = I2A(j - fis.floor_top); // TODO: 常に'0'になる。どんな意図でこのようなコードになっているのか不明.
             fis.n2 = I2A(fis.k - fis.floor_top);
             if (command_see) {
-                get_item_label = show_floor_items(player, fis.menu_line, player.y, player.x, &fis.min_width, item_tester);
+                get_item_label = show_floor_items(creature, fis.menu_line, creature.y, creature.x, &fis.min_width, item_tester);
             }
         }
 
@@ -662,7 +658,7 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
         case '\n':
         case '\r':
         case '+': {
-            auto &grid = player.current_floor_ptr->grid_array[player.y][player.x];
+            auto &grid = creature.current_floor_ptr->grid_array[creature.y][creature.x];
             if (command_wrk != (USE_FLOOR)) {
                 break;
             }
@@ -673,13 +669,13 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
 
             const auto next_o_idx = fis.floor_item_index[1];
             while (grid.o_idx_list.front() != next_o_idx) {
-                grid.o_idx_list.rotate(*player.current_floor_ptr);
+                grid.o_idx_list.rotate(*creature.current_floor_ptr);
             }
 
             rfu.set_flag(SubWindowRedrawingFlag::FLOOR_ITEMS);
-            window_stuff(player);
-            const auto &floor = *player.current_floor_ptr;
-            fis.floor_item_index = scan_floor_items(floor, player.get_position(), { ScanFloorMode::ITEM_TESTER, ScanFloorMode::ONLY_MARKED }, item_tester);
+            window_stuff(creature);
+            const auto &floor = *creature.current_floor_ptr;
+            fis.floor_item_index = scan_floor_items(floor, creature.get_position(), { ScanFloorMode::ITEM_TESTER, ScanFloorMode::ONLY_MARKED }, item_tester);
             if (command_see) {
                 screen_load();
                 screen_save();
@@ -775,7 +771,7 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
                     break;
                 }
             } else {
-                const auto floor_item_idx = get_tag_floor(*player.current_floor_ptr, fis.which, fis.floor_item_index);
+                const auto floor_item_idx = get_tag_floor(*creature.current_floor_ptr, fis.which, fis.floor_item_index);
                 if (floor_item_idx) {
                     fis.k = -fis.floor_item_index[*floor_item_idx];
                 } else {
@@ -822,7 +818,7 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
                     fis.cur_tag = fis.which;
                 }
             } else {
-                const auto floor_item_idx = get_tag_floor(*player.current_floor_ptr, fis.which, fis.floor_item_index);
+                const auto floor_item_idx = get_tag_floor(*creature.current_floor_ptr, fis.which, fis.floor_item_index);
                 if (floor_item_idx) {
                     fis.k = -fis.floor_item_index[*floor_item_idx];
                     fis.cur_tag = fis.which;
@@ -840,7 +836,7 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
                     } else if (which == ')') {
                         fis.k = fis.i2;
                     } else {
-                        fis.k = label_to_inventory(player, which);
+                        fis.k = label_to_inventory(creature, which);
                     }
                 } else if (command_wrk == (USE_EQUIP)) {
                     if (which == '(') {
@@ -848,7 +844,7 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
                     } else if (which == ')') {
                         fis.k = fis.e2;
                     } else {
-                        fis.k = label_to_equipment(player, which);
+                        fis.k = label_to_equipment(creature, which);
                     }
                 } else if (command_wrk == USE_FLOOR) {
                     if (which == '(') {

--- a/src/inventory/inventory-damage.cpp
+++ b/src/inventory/inventory-damage.cpp
@@ -27,7 +27,6 @@
  */
 void inventory_damage(CreatureEntity &creature, const ObjectBreaker &breaker, int perc)
 {
-    auto &player = creature;
     int j, amt;
     if (check_multishadow(creature) || creature.current_floor_ptr->inside_arena) {
         return;
@@ -35,7 +34,7 @@ void inventory_damage(CreatureEntity &creature, const ObjectBreaker &breaker, in
 
     /* Scan through the slots backwards */
     for (short i = 0; i < INVEN_PACK; i++) {
-        auto &item = *player.inventory[i];
+        auto &item = *creature.inventory[i];
         if (!item.is_valid()) {
             continue;
         }
@@ -62,7 +61,7 @@ void inventory_damage(CreatureEntity &creature, const ObjectBreaker &breaker, in
             continue;
         }
 
-        const auto item_name = describe_flavor(player, item, OD_OMIT_PREFIX);
+        const auto item_name = describe_flavor(creature, item, OD_OMIT_PREFIX);
 
         msg_format(_("%s(%c)が%s壊れてしまった！", "%sour %s (%c) %s destroyed!"),
 #ifdef JP
@@ -73,15 +72,15 @@ void inventory_damage(CreatureEntity &creature, const ObjectBreaker &breaker, in
 #endif
 
 #ifdef JP
-        if (player.is_echizen()) {
+        if (creature.is_echizen()) {
             msg_print("やりやがったな！");
-        } else if (player.is_chargeman()) {
+        } else if (creature.is_chargeman()) {
             if (randint0(2) == 0) {
                 msg_print(_("ジュラル星人め！", ""));
             } else {
                 msg_print(_("弱い者いじめは止めるんだ！", ""));
             }
-        } else if (player.is_tough()) {
+        } else if (creature.is_tough()) {
             msg_print(_("う わ あ あ あ あ あ あ あ あ", ""));
         }
 
@@ -89,7 +88,7 @@ void inventory_damage(CreatureEntity &creature, const ObjectBreaker &breaker, in
 
         /* Potions smash open */
         if (item.is_potion()) {
-            (void)potion_smash_effect(player, 0, creature.y, creature.x, item.bi_id);
+            (void)potion_smash_effect(creature, 0, creature.y, creature.x, item.bi_id);
         }
 
         /* Reduce the charges of rods/wands */

--- a/src/inventory/inventory-describer.cpp
+++ b/src/inventory/inventory-describer.cpp
@@ -15,37 +15,36 @@
  */
 concptr mention_use(CreatureEntity &creature, int i)
 {
-    auto &player = creature;
     concptr p;
 
     /* Examine the location */
     switch (i) {
 #ifdef JP
     case INVEN_MAIN_HAND:
-        p = player.heavy_wield[0]
+        p = creature.heavy_wield[0]
                 ? "運搬中"
-                : ((has_two_handed_weapons(player) && can_attack_with_main_hand(player)) ? " 両手" : (left_hander ? " 左手" : " 右手"));
+                : ((has_two_handed_weapons(creature) && can_attack_with_main_hand(creature)) ? " 両手" : (left_hander ? " 左手" : " 右手"));
         break;
 #else
     case INVEN_MAIN_HAND:
-        p = player.heavy_wield[0] ? "Just lifting" : (can_attack_with_main_hand(player) ? "Wielding" : "On arm");
+        p = creature.heavy_wield[0] ? "Just lifting" : (can_attack_with_main_hand(creature) ? "Wielding" : "On arm");
         break;
 #endif
 
 #ifdef JP
     case INVEN_SUB_HAND:
-        p = player.heavy_wield[1]
+        p = creature.heavy_wield[1]
                 ? "運搬中"
-                : ((has_two_handed_weapons(player) && can_attack_with_sub_hand(player)) ? " 両手" : (left_hander ? " 右手" : " 左手"));
+                : ((has_two_handed_weapons(creature) && can_attack_with_sub_hand(creature)) ? " 両手" : (left_hander ? " 右手" : " 左手"));
         break;
 #else
     case INVEN_SUB_HAND:
-        p = player.heavy_wield[1] ? "Just lifting" : (can_attack_with_sub_hand(player) ? "Wielding" : "On arm");
+        p = creature.heavy_wield[1] ? "Just lifting" : (can_attack_with_sub_hand(creature) ? "Wielding" : "On arm");
         break;
 #endif
 
     case INVEN_BOW:
-        p = (adj_str_hold[player.stat_index[A_STR]] < player.inventory[i]->weight / 10) ? _("運搬中", "Just holding") : _("射撃用", "Shooting");
+        p = (adj_str_hold[creature.stat_index[A_STR]] < creature.inventory[i]->weight / 10) ? _("運搬中", "Just holding") : _("射撃用", "Shooting");
         break;
     case INVEN_MAIN_RING:
         p = (left_hander ? _("左手指", "On left hand") : _("右手指", "On right hand"));
@@ -95,38 +94,37 @@ concptr mention_use(CreatureEntity &creature, int i)
  */
 concptr describe_use(CreatureEntity &creature, int i)
 {
-    auto &player = creature;
     concptr p;
     switch (i) {
 #ifdef JP
     case INVEN_MAIN_HAND:
-        p = player.heavy_wield[0]
+        p = creature.heavy_wield[0]
                 ? "運搬中の"
-                : ((has_two_handed_weapons(player) && can_attack_with_main_hand(player)) ? "両手に装備している"
-                                                                                         : (left_hander ? "左手に装備している" : "右手に装備している"));
+                : ((has_two_handed_weapons(creature) && can_attack_with_main_hand(creature)) ? "両手に装備している"
+                                                                                             : (left_hander ? "左手に装備している" : "右手に装備している"));
         break;
 #else
     case INVEN_MAIN_HAND:
-        p = player.heavy_wield[0] ? "just lifting" : (can_attack_with_main_hand(player) ? "attacking monsters with" : "wearing on your arm");
+        p = creature.heavy_wield[0] ? "just lifting" : (can_attack_with_main_hand(creature) ? "attacking monsters with" : "wearing on your arm");
         break;
 #endif
 
 #ifdef JP
     case INVEN_SUB_HAND:
-        p = player.heavy_wield[1]
+        p = creature.heavy_wield[1]
                 ? "運搬中の"
-                : ((has_two_handed_weapons(player) && can_attack_with_sub_hand(player)) ? "両手に装備している"
-                                                                                        : (left_hander ? "右手に装備している" : "左手に装備している"));
+                : ((has_two_handed_weapons(creature) && can_attack_with_sub_hand(creature)) ? "両手に装備している"
+                                                                                            : (left_hander ? "右手に装備している" : "左手に装備している"));
         break;
 #else
     case INVEN_SUB_HAND:
-        p = player.heavy_wield[1] ? "just lifting" : (can_attack_with_sub_hand(player) ? "attacking monsters with" : "wearing on your arm");
+        p = creature.heavy_wield[1] ? "just lifting" : (can_attack_with_sub_hand(creature) ? "attacking monsters with" : "wearing on your arm");
         break;
 #endif
 
     case INVEN_BOW:
-        p = (adj_str_hold[player.stat_index[A_STR]] < player.inventory[i]->weight / 10) ? _("持つだけで精一杯の", "just holding")
-                                                                                        : _("射撃用に装備している", "shooting missiles with");
+        p = (adj_str_hold[creature.stat_index[A_STR]] < creature.inventory[i]->weight / 10) ? _("持つだけで精一杯の", "just holding")
+                                                                                            : _("射撃用に装備している", "shooting missiles with");
         break;
     case INVEN_MAIN_RING:
         p = (left_hander ? _("左手の指にはめている", "wearing on your left hand") : _("右手の指にはめている", "wearing on your right hand"));

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -138,7 +138,6 @@ void inven_item_optimize(CreatureEntity &creature, INVENTORY_IDX i_idx)
  */
 void drop_from_inventory(CreatureEntity &creature, INVENTORY_IDX i_idx, ITEM_NUMBER amt)
 {
-    auto &player = creature;
     auto *o_ptr = creature.inventory[i_idx].get();
     if (amt <= 0) {
         return;
@@ -157,7 +156,7 @@ void drop_from_inventory(CreatureEntity &creature, INVENTORY_IDX i_idx, ITEM_NUM
     distribute_charges(o_ptr, &item, amt);
 
     item.number = amt;
-    const auto item_name = describe_flavor(player, item, 0);
+    const auto item_name = describe_flavor(creature, item, 0);
     msg_format(_("%s(%c)を落とした。", "You drop %s (%c)."), item_name.data(), index_to_label(i_idx));
     (void)drop_near(creature, item, creature.get_position(), false);
     vary_item(creature, i_idx, -amt);
@@ -378,7 +377,6 @@ bool check_store_item_to_inventory(CreatureEntity &creature, const ItemEntity *o
  */
 INVENTORY_IDX inven_takeoff(CreatureEntity &creature, INVENTORY_IDX i_idx, ITEM_NUMBER amt)
 {
-    auto &player = creature;
     const auto &item_inventory = *creature.inventory[i_idx];
     if (amt <= 0) {
         return -1;
@@ -390,7 +388,7 @@ INVENTORY_IDX inven_takeoff(CreatureEntity &creature, INVENTORY_IDX i_idx, ITEM_
 
     auto item = item_inventory.clone();
     item.number = amt;
-    const auto item_name = describe_flavor(player, item, 0);
+    const auto item_name = describe_flavor(creature, item, 0);
     std::string act;
     if (((i_idx == INVEN_MAIN_HAND) || (i_idx == INVEN_SUB_HAND)) && item_inventory.is_melee_weapon()) {
         act = _("を装備からはずした", "You were wielding");

--- a/src/inventory/inventory-util.cpp
+++ b/src/inventory/inventory-util.cpp
@@ -99,11 +99,10 @@ tl::optional<short> get_tag(CreatureEntity &creature, char tag, BIT_FLAGS mode, 
         return tl::nullopt;
     }
 
-    auto &player = creature;
     const auto &[start, end] = *range;
     tl::optional<short> i_idx;
     for (auto i = start; i < end; i++) {
-        const auto &item = *player.inventory[i];
+        const auto &item = *creature.inventory[i];
         if (!item.is_valid() || !item.is_inscribed()) {
             continue;
         }
@@ -145,8 +144,7 @@ bool get_item_okay(CreatureEntity &creature, OBJECT_IDX i, const ItemTester &ite
         return is_ring_slot(i);
     }
 
-    auto &player = creature;
-    return item_tester.okay(player.inventory[i].get());
+    return item_tester.okay(creature.inventory[i].get());
 }
 
 /*!
@@ -161,10 +159,9 @@ bool get_item_allow(CreatureEntity &creature, INVENTORY_IDX i_idx)
         return true;
     }
 
-    auto &player = creature;
     ItemEntity *o_ptr;
     if (i_idx >= 0) {
-        o_ptr = player.inventory[i_idx].get();
+        o_ptr = creature.inventory[i_idx].get();
     } else {
         o_ptr = creature.current_floor_ptr->o_list[0 - i_idx].get();
     }
@@ -205,8 +202,7 @@ INVENTORY_IDX label_to_equipment(CreatureEntity &creature, int c)
         return is_ring_slot(i) ? i : -1;
     }
 
-    auto &player = creature;
-    if (!player.inventory[i]->bi_id) {
+    if (!creature.inventory[i]->bi_id) {
         return -1;
     }
 
@@ -225,8 +221,7 @@ INVENTORY_IDX label_to_inventory(CreatureEntity &creature, int c)
 {
     INVENTORY_IDX i = (INVENTORY_IDX)(islower(c) ? A2I(c) : -1);
 
-    auto &player = creature;
-    if ((i < 0) || (i > INVEN_PACK) || !player.inventory[i]->is_valid()) {
+    if ((i < 0) || (i > INVEN_PACK) || !creature.inventory[i]->is_valid()) {
         return -1;
     }
 
@@ -242,9 +237,8 @@ INVENTORY_IDX label_to_inventory(CreatureEntity &creature, int c)
  */
 bool verify(CreatureEntity &creature, concptr prompt, INVENTORY_IDX i_idx)
 {
-    auto &player = creature;
-    const auto &item = i_idx >= 0 ? *player.inventory[i_idx] : *creature.current_floor_ptr->o_list[0 - i_idx];
-    const auto item_name = describe_flavor(player, item, 0);
+    const auto &item = i_idx >= 0 ? *creature.inventory[i_idx] : *creature.current_floor_ptr->o_list[0 - i_idx];
+    const auto item_name = describe_flavor(creature, item, 0);
     std::stringstream ss;
     ss << prompt;
 #ifndef JP

--- a/src/inventory/pack-overflow.cpp
+++ b/src/inventory/pack-overflow.cpp
@@ -16,21 +16,20 @@
  */
 void pack_overflow(CreatureEntity &creature)
 {
-    auto &player = creature;
-    if (!player.inventory[INVEN_PACK]->is_valid()) {
+    if (!creature.inventory[INVEN_PACK]->is_valid()) {
         return;
     }
 
     update_creature(creature);
-    if (!player.inventory[INVEN_PACK]->is_valid()) {
+    if (!creature.inventory[INVEN_PACK]->is_valid()) {
         return;
     }
 
-    auto &item = *player.inventory[INVEN_PACK];
+    auto &item = *creature.inventory[INVEN_PACK];
     disturb(creature, false, true);
     msg_print(_("ザックからアイテムがあふれた！", "Your pack overflows!"));
 
-    const auto item_name = describe_flavor(player, item, 0);
+    const auto item_name = describe_flavor(creature, item, 0);
     msg_format(_("%s(%c)を落とした。", "You drop %s (%c)."), item_name.data(), index_to_label(INVEN_PACK));
     (void)drop_near(creature, item, creature.get_position(), false);
 

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -49,15 +49,14 @@
  */
 bool can_get_item(CreatureEntity &creature, const ItemTester &item_tester)
 {
-    auto &player = creature;
     for (int j = 0; j < INVEN_TOTAL; j++) {
-        if (item_tester.okay(player.inventory[j].get())) {
+        if (item_tester.okay(creature.inventory[j].get())) {
             return true;
         }
     }
 
-    const auto &floor = *player.current_floor_ptr;
-    const auto floor_item_index = scan_floor_items(floor, player.get_position(), { ScanFloorMode::ITEM_TESTER, ScanFloorMode::ONLY_MARKED }, item_tester);
+    const auto &floor = *creature.current_floor_ptr;
+    const auto floor_item_index = scan_floor_items(floor, creature.get_position(), { ScanFloorMode::ITEM_TESTER, ScanFloorMode::ONLY_MARKED }, item_tester);
     return !floor_item_index.empty();
 }
 
@@ -80,17 +79,16 @@ static bool query_pickup(std::string_view item_name)
 
 static void py_pickup_all_golds_on_floor(CreatureEntity &creature, const Grid &grid)
 {
-    auto &player = creature;
     for (auto it = grid.o_idx_list.begin(); it != grid.o_idx_list.end();) {
         const auto i_idx = *it++;
-        auto &item = *player.current_floor_ptr->o_list[i_idx];
+        auto &item = *creature.current_floor_ptr->o_list[i_idx];
         if (item.bi_key.tval() != ItemKindType::GOLD) {
             continue;
         }
 
         const auto value = item.pval;
-        const auto item_name = describe_flavor(player, item, 0);
-        player.au += value;
+        const auto item_name = describe_flavor(creature, item, 0);
+        creature.au += value;
 
         msg_print(_(" ${} の価値がある{}を見つけた。", "You have found {} gold pieces worth of {}."), value, item_name);
         sound(SoundKind::SELL);
@@ -105,9 +103,8 @@ static void py_pickup_all_golds_on_floor(CreatureEntity &creature, const Grid &g
 
 static void py_pickup_single_item(CreatureEntity &creature, short i_idx, bool pickup)
 {
-    auto &player = creature;
-    auto &item = *player.current_floor_ptr->o_list[i_idx];
-    const auto item_name = describe_flavor(player, item, 0);
+    auto &item = *creature.current_floor_ptr->o_list[i_idx];
+    const auto item_name = describe_flavor(creature, item, 0);
 
     if (!pickup) {
         msg_print(_("{}がある。", "You see {}."), item_name);
@@ -131,9 +128,8 @@ static void py_pickup_single_item(CreatureEntity &creature, short i_idx, bool pi
 
 static void py_pickup_multiple_items(CreatureEntity &creature, bool pickup)
 {
-    auto &player = creature;
-    const auto &floor = *player.current_floor_ptr;
-    const auto &grid = floor.get_grid(player.get_position());
+    const auto &floor = *creature.current_floor_ptr;
+    const auto &grid = floor.get_grid(creature.get_position());
 
     if (!pickup) {
         const auto count_of_items = grid.o_idx_list.size();
@@ -153,7 +149,7 @@ static void py_pickup_multiple_items(CreatureEntity &creature, bool pickup)
         constexpr auto q = _("どれを拾いますか？", "Get which item? ");
         constexpr auto s = _("もうザックには床にあるどのアイテムも入らない。", "You no longer have any room for the objects on the floor.");
         short i_idx;
-        if (!choose_object(player, &i_idx, q, s, (USE_FLOOR), tester)) {
+        if (!choose_object(creature, &i_idx, q, s, (USE_FLOOR), tester)) {
             break;
         }
         process_player_pickup_item(creature, -i_idx);
@@ -168,10 +164,9 @@ static void py_pickup_multiple_items(CreatureEntity &creature, bool pickup)
  */
 static void py_pickup_floor(CreatureEntity &creature, bool pickup)
 {
-    auto &player = creature;
-    const auto &o_list = player.current_floor_ptr->o_list;
+    const auto &o_list = creature.current_floor_ptr->o_list;
     const auto exclude_marked_as_skip = ranges::views::remove_if([&](auto i_idx) { return o_list.at(i_idx)->marked.has(OmType::SUPRESS_MESSAGE); });
-    const auto &grid = player.current_floor_ptr->get_grid(player.get_position());
+    const auto &grid = creature.current_floor_ptr->get_grid(creature.get_position());
 
     const auto i_idx_list = grid.o_idx_list | exclude_marked_as_skip | ranges::to_vector;
     const auto count_of_items = i_idx_list.size();
@@ -208,15 +203,14 @@ static void py_pickup_floor(CreatureEntity &creature, bool pickup)
  */
 static void print_pickup_message(CreatureEntity &creature, [[maybe_unused]] const ItemEntity &picked_item, const ItemEntity &picked_slot_item, short slot)
 {
-    auto &player = creature;
-    const auto item_name = describe_flavor(player, picked_slot_item, 0);
+    const auto item_name = describe_flavor(creature, picked_slot_item, 0);
     const auto item_name_with_label = fmt::format(_("{}({})", "{} ({})"), item_name, index_to_label(slot));
 
 #ifdef JP
-    if (picked_slot_item.is_specific_artifact(FixedArtifactId::CRIMSON) && (player.ppersonality == PERSONALITY_COMBAT)) {
-        msg_print("こうして、{}は『クリムゾン』を手に入れた。", player.name.data());
+    if (picked_slot_item.is_specific_artifact(FixedArtifactId::CRIMSON) && (creature.ppersonality == PERSONALITY_COMBAT)) {
+        msg_print("こうして、{}は『クリムゾン』を手に入れた。", creature.name.data());
         msg_print("しかし今、『混沌のサーペント』の放ったモンスターが、");
-        msg_print("{}に襲いかかる．．．", player.name.data());
+        msg_print("{}に襲いかかる．．．", creature.name.data());
         return;
     }
 
@@ -244,17 +238,16 @@ static void print_pickup_message(CreatureEntity &creature, [[maybe_unused]] cons
  */
 void process_player_pickup_item(CreatureEntity &creature, OBJECT_IDX o_idx)
 {
-    auto &player = creature;
     // delete_object_idx()で配列から削除した後にも使用するためshared_ptrをコピーする
-    const std::shared_ptr<ItemEntity> picked_item_ptr = player.current_floor_ptr->o_list[o_idx];
+    const std::shared_ptr<ItemEntity> picked_item_ptr = creature.current_floor_ptr->o_list[o_idx];
 
     const auto slot = store_item_to_inventory(creature, picked_item_ptr.get());
     delete_object_idx(creature, o_idx);
 
-    auto &picked_slot_item = *player.inventory[slot];
-    if (player.ppersonality == PERSONALITY_MUNCHKIN) {
+    auto &picked_slot_item = *creature.inventory[slot];
+    if (creature.ppersonality == PERSONALITY_MUNCHKIN) {
         const auto old_known = identify_item(creature, &picked_slot_item);
-        autopick_alter_item(player, slot, destroy_identify && !old_known);
+        autopick_alter_item(creature, slot, destroy_identify && !old_known);
         if (picked_slot_item.marked.has(OmType::AUTODESTROY)) {
             return;
         }
@@ -262,9 +255,9 @@ void process_player_pickup_item(CreatureEntity &creature, OBJECT_IDX o_idx)
 
     print_pickup_message(creature, *picked_item_ptr, picked_slot_item, slot);
 
-    record_item_name = describe_flavor(player, *picked_item_ptr, OD_NAME_ONLY);
+    record_item_name = describe_flavor(creature, *picked_item_ptr, OD_NAME_ONLY);
     record_turn = AngbandWorld::get_instance().game_turn;
-    check_find_art_quest_completion(player, &picked_slot_item);
+    check_find_art_quest_completion(creature, &picked_slot_item);
 }
 
 /*!
@@ -274,15 +267,14 @@ void process_player_pickup_item(CreatureEntity &creature, OBJECT_IDX o_idx)
  */
 void carry(CreatureEntity &creature, bool pickup)
 {
-    auto &player = creature;
     verify_panel(creature);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     rfu.set_flag(SubWindowRedrawingFlag::OVERHEAD);
     handle_stuff(creature);
-    const auto &grid = player.current_floor_ptr->grid_array[player.y][player.x];
-    autopick_pickup_items(player, grid);
+    const auto &grid = creature.current_floor_ptr->grid_array[creature.y][creature.x];
+    autopick_pickup_items(creature, grid);
 
     if (!grid.o_idx_list.empty()) {
         disturb(creature, false, false);
@@ -297,8 +289,8 @@ void carry(CreatureEntity &creature, bool pickup)
 
     for (auto it = grid.o_idx_list.begin(); it != grid.o_idx_list.end();) {
         const auto this_o_idx = *it++;
-        auto &item = *player.current_floor_ptr->o_list[this_o_idx];
-        const auto item_name = describe_flavor(player, item, 0);
+        auto &item = *creature.current_floor_ptr->o_list[this_o_idx];
+        const auto item_name = describe_flavor(creature, item, 0);
 
         if (item.marked.has(OmType::SUPRESS_MESSAGE)) {
             item.marked.reset(OmType::SUPRESS_MESSAGE);

--- a/src/inventory/recharge-processor.cpp
+++ b/src/inventory/recharge-processor.cpp
@@ -16,12 +16,11 @@
 /*!
  * @brief
  * !!を刻んだ魔道具の時間経過による再充填を知らせる処理 /
- * If player has inscribed the object with "!!", let him know when it's recharged. -LM-
+ * If creature has inscribed the object with "!!", let him know when it's recharged. -LM-
  * @param o_ptr 対象オブジェクトの構造体参照ポインタ
  */
 static void recharged_notice(CreatureEntity &creature, const ItemEntity &item)
 {
-    auto &player = creature;
     if (!item.is_inscribed()) {
         return;
     }
@@ -29,7 +28,7 @@ static void recharged_notice(CreatureEntity &creature, const ItemEntity &item)
     auto s = angband_strchr(item.inscription->data(), '!');
     while (s) {
         if (s[1] == '!') {
-            const auto item_name = describe_flavor(player, item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+            const auto item_name = describe_flavor(creature, item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 #ifdef JP
             msg_format("%sは再充填された。", item_name.data());
 #else
@@ -53,12 +52,11 @@ static void recharged_notice(CreatureEntity &creature, const ItemEntity &item)
  */
 void recharge_magic_items(CreatureEntity &creature)
 {
-    auto &player = creature;
     int i;
     bool changed;
 
     for (changed = false, i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        auto &item = *player.inventory[i];
+        auto &item = *creature.inventory[i];
         if (!item.is_valid()) {
             continue;
         }
@@ -84,7 +82,7 @@ void recharge_magic_items(CreatureEntity &creature)
      * one per turn. -LM-
      */
     for (changed = false, i = 0; i < INVEN_PACK; i++) {
-        auto &item = *player.inventory[i];
+        auto &item = *creature.inventory[i];
         if (!item.is_valid()) {
             continue;
         }
@@ -117,7 +115,7 @@ void recharge_magic_items(CreatureEntity &creature)
         wild_regen = 20;
     }
 
-    for (const auto &item_ptr : player.current_floor_ptr->o_list) {
+    for (const auto &item_ptr : creature.current_floor_ptr->o_list) {
         if (!item_ptr->is_valid()) {
             continue;
         }

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -58,7 +58,6 @@
  */
 static void dump_aux_pet(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
     auto pet = false;
     auto pet_settings = false;
@@ -93,22 +92,22 @@ static void dump_aux_pet(CreatureEntity &creature, FILE *fff)
     fmt::println(fff, _("\n\n  [ペットへの命令]", "\n\n  [Command for Pets]"));
 
     fmt::print(fff, _("\n ドアを開ける:                       {}", "\n Pets open doors:                    {}"),
-        (player.pet_extra_flags & PF_OPEN_DOORS) ? "ON" : "OFF");
+        (creature.pet_extra_flags & PF_OPEN_DOORS) ? "ON" : "OFF");
 
     fmt::print(fff, _("\n アイテムを拾う:                     {}", "\n Pets pick up items:                 {}"),
-        (player.pet_extra_flags & PF_PICKUP_ITEMS) ? "ON" : "OFF");
+        (creature.pet_extra_flags & PF_PICKUP_ITEMS) ? "ON" : "OFF");
 
     fmt::print(fff, _("\n テレポート系魔法を使う:             {}", "\n Allow teleport:                     {}"),
-        (player.pet_extra_flags & PF_TELEPORT) ? "ON" : "OFF");
+        (creature.pet_extra_flags & PF_TELEPORT) ? "ON" : "OFF");
 
     fmt::print(fff, _("\n 攻撃魔法を使う:                     {}", "\n Allow cast attack spell:            {}"),
-        (player.pet_extra_flags & PF_ATTACK_SPELL) ? "ON" : "OFF");
+        (creature.pet_extra_flags & PF_ATTACK_SPELL) ? "ON" : "OFF");
 
     fmt::print(fff, _("\n 召喚魔法を使う:                     {}", "\n Allow cast summon spell:            {}"),
-        (player.pet_extra_flags & PF_SUMMON_SPELL) ? "ON" : "OFF");
+        (creature.pet_extra_flags & PF_SUMMON_SPELL) ? "ON" : "OFF");
 
-    fmt::print(fff, _("\n プレイヤーを巻き込む範囲魔法を使う: {}", "\n Allow involve player in area spell: {}"),
-        (player.pet_extra_flags & PF_BALL_SPELL) ? "ON" : "OFF");
+    fmt::print(fff, _("\n プレイヤーを巻き込む範囲魔法を使う: {}", "\n Allow involve creature in area spell: {}"),
+        (creature.pet_extra_flags & PF_BALL_SPELL) ? "ON" : "OFF");
 
     fmt::print(fff, "\n");
 }
@@ -137,7 +136,6 @@ static void dump_aux_quest(CreatureEntity &creature, FILE *fff)
  */
 static void dump_aux_last_message(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = creature;
     if (!creature.is_dead()) {
         return;
     }
@@ -164,12 +162,12 @@ static void dump_aux_last_message(CreatureEntity &creature, FILE *fff)
         return;
     }
 
-    if (player.last_message.empty()) {
+    if (creature.last_message.empty()) {
         return;
     }
 
     fmt::println(fff, _("\n  [*勝利*メッセージ]\n", "\n  [*Winning* Message]\n"));
-    fmt::println(fff, "  {}\n", player.last_message);
+    fmt::println(fff, "  {}\n", creature.last_message);
 }
 
 /*!
@@ -373,8 +371,7 @@ static void dump_aux_monsters(FILE *fff)
  */
 static void dump_aux_race_history(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = creature;
-    if (!player.old_race1 && !player.old_race2) {
+    if (!creature.old_race1 && !creature.old_race2) {
         return;
     }
 
@@ -385,11 +382,11 @@ static void dump_aux_race_history(CreatureEntity &creature, FILE *fff)
             continue;
         }
         if (i < 32) {
-            if (!(player.old_race1 & 1UL << i)) {
+            if (!(creature.old_race1 & 1UL << i)) {
                 continue;
             }
         } else {
-            if (!(player.old_race2 & 1UL << (i - 32))) {
+            if (!(creature.old_race2 & 1UL << (i - 32))) {
                 continue;
             }
         }
@@ -407,14 +404,13 @@ static void dump_aux_race_history(CreatureEntity &creature, FILE *fff)
  */
 static void dump_aux_realm_history(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = creature;
-    if (player.old_realm == 0) {
+    if (creature.old_realm == 0) {
         return;
     }
 
     fmt::print(fff, "\n");
     for (auto realm : MAGIC_REALM_RANGE) {
-        if (!(player.old_realm & (1UL << (enum2i(realm) - 1)))) {
+        if (!(creature.old_realm & (1UL << (enum2i(realm) - 1)))) {
             continue;
         }
         fmt::print(fff, _("\n あなたはかつて{}魔法を使えた。", "\n You were able to use {} magic before."), PlayerRealm::get_name(realm));
@@ -430,33 +426,32 @@ static void dump_aux_realm_history(CreatureEntity &creature, FILE *fff)
  */
 static void dump_aux_virtues(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = creature;
     fmt::println(fff, _("\n\n  [自分に関する情報]\n", "\n\n  [HP-rate & Max stat & Virtues]\n"));
 
 #ifdef JP
-    if (player.knowledge & KNOW_HPRATE) {
-        fmt::println(fff, "現在の体力ランク : {}/100\n", player.calc_life_rating());
+    if (creature.knowledge & KNOW_HPRATE) {
+        fmt::println(fff, "現在の体力ランク : {}/100\n", creature.calc_life_rating());
     } else {
         fmt::println(fff, "現在の体力ランク : ???\n");
     }
     fmt::println(fff, "能力の最大値");
 #else
-    if (player.knowledge & KNOW_HPRATE) {
-        fmt::println(fff, "Your current Life Rating is {}/100.\n", player.calc_life_rating());
+    if (creature.knowledge & KNOW_HPRATE) {
+        fmt::println(fff, "Your current Life Rating is {}/100.\n", creature.calc_life_rating());
     } else {
         fmt::println(fff, "Your current Life Rating is ???.\n");
     }
     fmt::println(fff, "Limits of maximum stats");
 #endif
     for (auto v_nr = 0; v_nr < A_MAX; v_nr++) {
-        if ((player.knowledge & KNOW_STAT) || player.stat_max[v_nr] == player.stat_max_max[v_nr]) {
-            fmt::println(fff, "{} 18/{}", stat_names[v_nr], player.stat_max_max[v_nr] - 18);
+        if ((creature.knowledge & KNOW_STAT) || creature.stat_max[v_nr] == creature.stat_max_max[v_nr]) {
+            fmt::println(fff, "{} 18/{}", stat_names[v_nr], creature.stat_max_max[v_nr] - 18);
         } else {
             fmt::println(fff, "{} ???", stat_names[v_nr]);
         }
     }
 
-    std::string alg = PlayerAlignment(player).get_alignment_description();
+    std::string alg = PlayerAlignment(creature).get_alignment_description();
     fmt::println(fff, _("\n属性 : {}", "\nYour alignment : {}"), alg);
     fmt::print(fff, "\n");
     dump_virtues(creature, fff);
@@ -469,8 +464,7 @@ static void dump_aux_virtues(CreatureEntity &creature, FILE *fff)
  */
 static void dump_aux_mutations(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = creature;
-    if (player.muta.any()) {
+    if (creature.muta.any()) {
         fmt::println(fff, _("\n\n  [突然変異]\n", "\n\n  [Mutations]\n"));
         dump_mutations(creature, fff);
     }
@@ -483,11 +477,10 @@ static void dump_aux_mutations(CreatureEntity &creature, FILE *fff)
  */
 static void dump_aux_equipment_inventory(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = creature;
-    if (player.equip_cnt) {
+    if (creature.equip_cnt) {
         fmt::println(fff, _("  [キャラクタの装備]\n", "  [Character Equipment]\n"));
         for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-            auto item_name = describe_flavor(player, *player.inventory[i], 0);
+            auto item_name = describe_flavor(creature, *creature.inventory[i], 0);
             auto is_two_handed = ((i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(creature));
             is_two_handed |= ((i == INVEN_SUB_HAND) && can_attack_with_main_hand(creature));
             if (is_two_handed && has_two_handed_weapons(creature)) {
@@ -502,11 +495,11 @@ static void dump_aux_equipment_inventory(CreatureEntity &creature, FILE *fff)
 
     fmt::println(fff, _("  [キャラクタの持ち物]\n", "  [Character Inventory]\n"));
     for (auto i = 0; i < INVEN_PACK; i++) {
-        if (!player.inventory[i]->is_valid()) {
+        if (!creature.inventory[i]->is_valid()) {
             break;
         }
 
-        const auto item_name = describe_flavor(player, *player.inventory[i], 0);
+        const auto item_name = describe_flavor(creature, *creature.inventory[i], 0);
         fmt::println(fff, "{}) {}", index_to_label(i), item_name);
     }
 
@@ -520,7 +513,6 @@ static void dump_aux_equipment_inventory(CreatureEntity &creature, FILE *fff)
  */
 static void dump_aux_home_museum(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = creature;
     const auto &home = towns_info[1].get_store(StoreSaleType::HOME);
     if (home.stock_num) {
         fmt::println(fff, _("  [我が家のアイテム]", "  [Home Inventory]"));
@@ -530,7 +522,7 @@ static void dump_aux_home_museum(CreatureEntity &creature, FILE *fff)
                 fmt::println(fff, _("\n ( {} ページ )", "\n ( page {} )"), page++);
             }
 
-            const auto item_name = describe_flavor(player, *home.stock[i], 0);
+            const auto item_name = describe_flavor(creature, *home.stock[i], 0);
             fmt::println(fff, "{}) {}", I2A(i % 12), item_name);
         }
 
@@ -549,7 +541,7 @@ static void dump_aux_home_museum(CreatureEntity &creature, FILE *fff)
             fmt::println(fff, _("\n ( {} ページ )", "\n ( page {} )"), page++);
         }
 
-        const auto item_name = describe_flavor(player, *museum.stock[i], 0);
+        const auto item_name = describe_flavor(creature, *museum.stock[i], 0);
         fmt::println(fff, "{}) {}", I2A(i % 12), item_name);
     }
 

--- a/src/io-dump/player-status-dump-json.cpp
+++ b/src/io-dump/player-status-dump-json.cpp
@@ -48,36 +48,36 @@ static std::string localized_to_utf8_safe(const LocalizedString &ls)
  * @param j JSON オブジェクト
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-static void add_basic_info_to_json(nlohmann::json &j, CreatureEntity &player)
+static void add_basic_info_to_json(nlohmann::json &j, CreatureEntity &creature)
 {
-    j["basic"]["name"] = to_utf8_safe(player.name);
-    j["basic"]["sex"] = localized_to_utf8_safe(sex_info[player.psex].title);
-    j["basic"]["race"] = localized_to_utf8_safe(player.race->title);
-    j["basic"]["class"] = localized_to_utf8_safe(class_info.at(player.pclass).title);
-    j["basic"]["level"] = player.level;
-    j["basic"]["experience"] = player.exp;
-    j["basic"]["max_experience"] = player.max_exp;
+    j["basic"]["name"] = to_utf8_safe(creature.name);
+    j["basic"]["sex"] = localized_to_utf8_safe(sex_info[creature.psex].title);
+    j["basic"]["race"] = localized_to_utf8_safe(creature.race->title);
+    j["basic"]["class"] = localized_to_utf8_safe(class_info.at(creature.pclass).title);
+    j["basic"]["level"] = creature.level;
+    j["basic"]["experience"] = creature.exp;
+    j["basic"]["max_experience"] = creature.max_exp;
 
-    if (player.mimic_form != MimicKindType::NONE) {
-        j["basic"]["mimic_form"] = localized_to_utf8_safe(mimic_info.at(player.mimic_form).title);
+    if (creature.mimic_form != MimicKindType::NONE) {
+        j["basic"]["mimic_form"] = localized_to_utf8_safe(mimic_info.at(creature.mimic_form).title);
     }
 
     // 性格
-    j["basic"]["personality"] = localized_to_utf8_safe(personality_info[player.ppersonality].title);
+    j["basic"]["personality"] = localized_to_utf8_safe(personality_info[creature.ppersonality].title);
 
     // 領域
-    if (player.realm1 != RealmType::NONE) {
-        j["basic"]["realm1"] = localized_to_utf8_safe(PlayerRealm::get_name(player.realm1));
+    if (creature.realm1 != RealmType::NONE) {
+        j["basic"]["realm1"] = localized_to_utf8_safe(PlayerRealm::get_name(creature.realm1));
     }
-    if (player.realm2 != RealmType::NONE) {
-        j["basic"]["realm2"] = localized_to_utf8_safe(PlayerRealm::get_name(player.realm2));
+    if (creature.realm2 != RealmType::NONE) {
+        j["basic"]["realm2"] = localized_to_utf8_safe(PlayerRealm::get_name(creature.realm2));
     }
 
     // 年齢、身長、体重
-    j["basic"]["age"] = player.age;
-    j["basic"]["height"] = player.ht;
-    j["basic"]["weight"] = player.wt;
-    j["basic"]["prestige"] = player.prestige;
+    j["basic"]["age"] = creature.age;
+    j["basic"]["height"] = creature.ht;
+    j["basic"]["weight"] = creature.wt;
+    j["basic"]["prestige"] = creature.prestige;
 }
 
 /*!
@@ -85,7 +85,7 @@ static void add_basic_info_to_json(nlohmann::json &j, CreatureEntity &player)
  * @param j JSON オブジェクト
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-static void add_stats_to_json(nlohmann::json &j, CreatureEntity &player)
+static void add_stats_to_json(nlohmann::json &j, CreatureEntity &creature)
 {
     nlohmann::json stats = nlohmann::json::array();
 
@@ -93,10 +93,10 @@ static void add_stats_to_json(nlohmann::json &j, CreatureEntity &player)
     for (int i = 0; i < A_MAX; i++) {
         nlohmann::json stat;
         stat["name"] = stat_names[i];
-        stat["current"] = player.stat_cur[i];
-        stat["max"] = player.stat_max[i];
-        stat["use"] = player.stat_use[i];
-        stat["top"] = player.stat_top[i];
+        stat["current"] = creature.stat_cur[i];
+        stat["max"] = creature.stat_max[i];
+        stat["use"] = creature.stat_use[i];
+        stat["top"] = creature.stat_top[i];
         stats.push_back(stat);
     }
 
@@ -108,21 +108,21 @@ static void add_stats_to_json(nlohmann::json &j, CreatureEntity &player)
  * @param j JSON オブジェクト
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-static void add_status_to_json(nlohmann::json &j, CreatureEntity &player)
+static void add_status_to_json(nlohmann::json &j, CreatureEntity &creature)
 {
-    j["status"]["hitpoints"] = player.hp;
-    j["status"]["max_hitpoints"] = player.maxhp;
-    j["status"]["mana"] = player.csp;
-    j["status"]["max_mana"] = player.msp;
-    j["status"]["armor_class"] = player.ac;
-    j["status"]["display_armor_class"] = player.dis_ac;
+    j["status"]["hitpoints"] = creature.hp;
+    j["status"]["max_hitpoints"] = creature.maxhp;
+    j["status"]["mana"] = creature.csp;
+    j["status"]["max_mana"] = creature.msp;
+    j["status"]["armor_class"] = creature.ac;
+    j["status"]["display_armor_class"] = creature.dis_ac;
 
     // 所持金とアイテム
-    j["status"]["gold"] = player.au;
+    j["status"]["gold"] = creature.au;
 
     // ダンジョン情報
-    j["status"]["dungeon_level"] = player.current_floor_ptr->dun_level;
-    const auto &dungeon_record = DungeonRecords::get_instance().get_record(player.recall_dungeon);
+    j["status"]["dungeon_level"] = creature.current_floor_ptr->dun_level;
+    const auto &dungeon_record = DungeonRecords::get_instance().get_record(creature.recall_dungeon);
     j["status"]["max_dungeon_level"] = dungeon_record.get_max_level();
 
     // ターン数
@@ -135,16 +135,16 @@ static void add_status_to_json(nlohmann::json &j, CreatureEntity &player)
  * @param j JSON オブジェクト
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-static void add_combat_to_json(nlohmann::json &j, CreatureEntity &player)
+static void add_combat_to_json(nlohmann::json &j, CreatureEntity &creature)
 {
-    j["combat"]["base_to_hit"] = player.to_h_b;
-    j["combat"]["melee_to_hit"] = player.to_h_m;
-    j["combat"]["melee_to_damage"] = player.to_d_m;
-    j["combat"]["ranged_to_hit"] = player.to_h_b;
+    j["combat"]["base_to_hit"] = creature.to_h_b;
+    j["combat"]["melee_to_hit"] = creature.to_h_m;
+    j["combat"]["melee_to_damage"] = creature.to_d_m;
+    j["combat"]["ranged_to_hit"] = creature.to_h_b;
 
     // 攻撃回数
-    j["combat"]["num_blow"] = player.num_blow[0];
-    j["combat"]["num_fire"] = player.num_fire;
+    j["combat"]["num_blow"] = creature.num_blow[0];
+    j["combat"]["num_fire"] = creature.num_fire;
 }
 
 /*!
@@ -152,18 +152,18 @@ static void add_combat_to_json(nlohmann::json &j, CreatureEntity &player)
  * @param j JSON オブジェクト
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-static void add_skills_to_json(nlohmann::json &j, CreatureEntity &player)
+static void add_skills_to_json(nlohmann::json &j, CreatureEntity &creature)
 {
-    j["skills"]["fighting"] = player.skill_thn;
-    j["skills"]["shooting"] = player.skill_thb;
-    j["skills"]["saving_throw"] = player.skill_sav;
-    j["skills"]["stealth"] = player.skill_stl;
-    j["skills"]["perception"] = player.skill_fos;
-    j["skills"]["searching"] = player.skill_srh;
-    j["skills"]["disarming"] = player.skill_dis;
-    j["skills"]["magic_device"] = player.skill_dev;
-    j["skills"]["infravision"] = player.see_infra;
-    j["skills"]["speed"] = player.speed - 110;
+    j["skills"]["fighting"] = creature.skill_thn;
+    j["skills"]["shooting"] = creature.skill_thb;
+    j["skills"]["saving_throw"] = creature.skill_sav;
+    j["skills"]["stealth"] = creature.skill_stl;
+    j["skills"]["perception"] = creature.skill_fos;
+    j["skills"]["searching"] = creature.skill_srh;
+    j["skills"]["disarming"] = creature.skill_dis;
+    j["skills"]["magic_device"] = creature.skill_dev;
+    j["skills"]["infravision"] = creature.see_infra;
+    j["skills"]["speed"] = creature.speed - 110;
 }
 
 /*!
@@ -171,20 +171,20 @@ static void add_skills_to_json(nlohmann::json &j, CreatureEntity &player)
  * @param j JSON オブジェクト
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-static void add_death_info_to_json(nlohmann::json &j, CreatureEntity &player)
+static void add_death_info_to_json(nlohmann::json &j, CreatureEntity &creature)
 {
-    if (player.is_dead()) {
+    if (creature.is_dead()) {
         j["death"]["is_dead"] = true;
-        j["death"]["cause"] = to_utf8_safe(player.died_from);
-        if (player.killer_monrace_id != MonraceId::PLAYER) {
-            j["death"]["killer_id"] = enum2i(player.killer_monrace_id);
+        j["death"]["cause"] = to_utf8_safe(creature.died_from);
+        if (creature.killer_monrace_id != MonraceId::PLAYER) {
+            j["death"]["killer_id"] = enum2i(creature.killer_monrace_id);
         }
-        if (!player.last_message.empty()) {
-            j["death"]["last_message"] = to_utf8_safe(player.last_message);
+        if (!creature.last_message.empty()) {
+            j["death"]["last_message"] = to_utf8_safe(creature.last_message);
         }
     }
 
-    if (player.is_true_winner()) {
+    if (creature.is_true_winner()) {
         j["death"]["is_winner"] = true;
     }
 }
@@ -194,12 +194,12 @@ static void add_death_info_to_json(nlohmann::json &j, CreatureEntity &player)
  * @param j JSON オブジェクト
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-static void add_history_to_json(nlohmann::json &j, CreatureEntity &player)
+static void add_history_to_json(nlohmann::json &j, CreatureEntity &creature)
 {
     nlohmann::json history = nlohmann::json::array();
     for (int i = 0; i < 4; i++) {
-        if (player.history[i][0] != '\0') {
-            history.push_back(to_utf8_safe(player.history[i]));
+        if (creature.history[i][0] != '\0') {
+            history.push_back(to_utf8_safe(creature.history[i]));
         }
     }
     j["history"] = history;
@@ -212,35 +212,34 @@ static void add_history_to_json(nlohmann::json &j, CreatureEntity &player)
  */
 std::string dump_player_status_json(CreatureEntity &creature)
 {
-    auto &player = creature;
     nlohmann::json j;
 
     // バージョン情報
     j["version"] = {
-        { "format", "bakabakaband-player-status" },
+        { "format", "bakabakaband-creature-status" },
         { "version", 1 }
     };
 
     // 基本情報
-    add_basic_info_to_json(j, player);
+    add_basic_info_to_json(j, creature);
 
     // 能力値
-    add_stats_to_json(j, player);
+    add_stats_to_json(j, creature);
 
     // 状態
-    add_status_to_json(j, player);
+    add_status_to_json(j, creature);
 
     // 戦闘能力
-    add_combat_to_json(j, player);
+    add_combat_to_json(j, creature);
 
     // スキル
-    add_skills_to_json(j, player);
+    add_skills_to_json(j, creature);
 
     // 死亡/勝利情報
-    add_death_info_to_json(j, player);
+    add_death_info_to_json(j, creature);
 
     // 履歴
-    add_history_to_json(j, player);
+    add_history_to_json(j, creature);
 
     // 整形して返す
     return j.dump(2);

--- a/src/io-dump/random-art-info-dumper.cpp
+++ b/src/io-dump/random-art-info-dumper.cpp
@@ -72,7 +72,6 @@ static void spoil_random_artifact_aux(CreatureEntity &creature, const ItemEntity
  */
 void spoil_random_artifact(CreatureEntity &creature)
 {
-    auto &player = creature;
     const auto path = path_build(ANGBAND_DIR_USER, "randifact.txt");
     std::ofstream ofs(path);
     if (!ofs) {
@@ -84,12 +83,12 @@ void spoil_random_artifact(CreatureEntity &creature)
     for (const auto &[tval_list, name] : group_artifact_list) {
         for (auto tval : tval_list) {
             for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-                auto &item = *player.inventory[i];
+                auto &item = *creature.inventory[i];
                 spoil_random_artifact_aux(creature, item, tval, ofs);
             }
 
             for (int i = 0; i < INVEN_PACK; i++) {
-                auto &item = *player.inventory[i];
+                auto &item = *creature.inventory[i];
                 spoil_random_artifact_aux(creature, item, tval, ofs);
             }
 

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -31,7 +31,7 @@
 
 std::filesystem::path ANGBAND_DIR; //!< Path name: The main "lib" directory This variable is not actually used anywhere in the code
 std::filesystem::path ANGBAND_DIR_APEX; //!< High score files (binary) These files may be portable between platforms
-std::filesystem::path ANGBAND_DIR_BONE; //!< Bone files for player ghosts (ascii) These files are portable between platforms
+std::filesystem::path ANGBAND_DIR_BONE; //!< Bone files for creature ghosts (ascii) These files are portable between platforms
 std::filesystem::path ANGBAND_DIR_DATA; //!< Binary image files for the "*_info" arrays (binary) These files are not portable between platforms
 std::filesystem::path ANGBAND_DIR_EDIT; //!< Textual template files for the "*_info" arrays (ascii) These files are portable between platforms
 std::filesystem::path ANGBAND_DIR_SCRIPT; //!< Script files These files are portable between platforms.
@@ -230,14 +230,13 @@ tl::optional<std::string> get_random_line_ja_only(concptr file_name, int entry, 
  */
 static errr counts_seek(CreatureEntity &creature, int fd, uint32_t where, bool flag)
 {
-    auto &player = creature;
     char temp1[128]{}, temp2[128]{};
-    auto short_pclass = enum2i(player.pclass);
+    auto short_pclass = enum2i(creature.pclass);
 #ifdef SAVEFILE_USE_UID
     const auto user_id = UnixUserIds::get_instance().get_user_id();
-    const auto header = format("%d.%s.%d%d%d", user_id, savefile_base.string().data(), short_pclass, player.ppersonality, player.age);
+    const auto header = format("%d.%s.%d%d%d", user_id, savefile_base.string().data(), short_pclass, creature.ppersonality, creature.age);
 #else
-    const auto header = format("%s.%d%d%d", savefile_base.string().data(), short_pclass, player.ppersonality, player.age);
+    const auto header = format("%s.%d%d%d", savefile_base.string().data(), short_pclass, creature.ppersonality, creature.age);
 #endif
     angband_strcpy(temp1, header, sizeof(temp1));
     for (int i = 0; temp1[i]; i++) {

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -169,7 +169,6 @@ static bool enter_debug_mode(const FloorType &floor)
  */
 void process_command(CreatureEntity &creature)
 {
-    auto &player = creature;
     COMMAND_CODE old_now_message = now_message;
     repeat_check();
     now_message = 0;
@@ -180,7 +179,7 @@ void process_command(CreatureEntity &creature)
 
     auto &world = AngbandWorld::get_instance();
     const auto is_wild_mode = world.is_wild_mode();
-    const auto &floor = *player.current_floor_ptr;
+    const auto &floor = *creature.current_floor_ptr;
     switch (command_cmd) {
     case ESCAPE:
     case ' ':
@@ -205,53 +204,53 @@ void process_command(CreatureEntity &creature)
     }
     case KTRL('A'): {
         if (enter_debug_mode(floor)) {
-            do_cmd_debug(player);
+            do_cmd_debug(creature);
         }
 
         break;
     }
     case KTRL('Y'): {
         if (enter_debug_mode(floor)) {
-            wiz_mutation_menu(player);
+            wiz_mutation_menu(creature);
         }
 
         break;
     }
     case 'w': {
         if (!is_wild_mode) {
-            do_cmd_wield(player);
+            do_cmd_wield(creature);
         }
 
         break;
     }
     case 't': {
         if (!is_wild_mode) {
-            do_cmd_takeoff(player);
+            do_cmd_takeoff(creature);
         }
 
         break;
     }
     case 'd': {
         if (!is_wild_mode) {
-            do_cmd_drop(player);
+            do_cmd_drop(creature);
         }
 
         break;
     }
     case 'k': {
-        do_cmd_destroy(player);
+        do_cmd_destroy(creature);
         break;
     }
     case 'e': {
-        do_cmd_equip(player);
+        do_cmd_equip(creature);
         break;
     }
     case 'i': {
-        do_cmd_inven(player);
+        do_cmd_inven(creature);
         break;
     }
     case 'I': {
-        do_cmd_observe(player);
+        do_cmd_observe(creature);
         break;
     }
 
@@ -261,68 +260,68 @@ void process_command(CreatureEntity &creature)
     }
     case '+': {
         if (!is_wild_mode) {
-            do_cmd_alter(player);
+            do_cmd_alter(creature);
         }
 
         break;
     }
     case 'T': {
         if (!is_wild_mode) {
-            do_cmd_tunnel(player);
+            do_cmd_tunnel(creature);
         }
 
         break;
     }
     case ';': {
-        do_cmd_walk(player, false);
+        do_cmd_walk(creature, false);
         break;
     }
     case '-': {
-        do_cmd_walk(player, true);
+        do_cmd_walk(creature, true);
         break;
     }
     case '.': {
         if (!is_wild_mode) {
-            do_cmd_run(player);
+            do_cmd_run(creature);
         }
 
         break;
     }
     case ',': {
-        do_cmd_stay(player, always_pickup);
+        do_cmd_stay(creature, always_pickup);
         break;
     }
     case 'g': {
-        do_cmd_stay(player, !always_pickup);
+        do_cmd_stay(creature, !always_pickup);
         break;
     }
     case 'R': {
-        do_cmd_rest(player);
+        do_cmd_rest(creature);
         break;
     }
     case 's': {
-        do_cmd_search(player);
+        do_cmd_search(creature);
         break;
     }
     case 'S': {
-        if (player.action == ACTION_SEARCH) {
-            set_action(player, ACTION_NONE);
+        if (creature.action == ACTION_SEARCH) {
+            set_action(creature, ACTION_NONE);
         } else {
-            set_action(player, ACTION_SEARCH);
+            set_action(creature, ACTION_SEARCH);
         }
 
         break;
     }
     case SPECIAL_KEY_STORE: {
-        do_cmd_store(player);
+        do_cmd_store(creature);
         break;
     }
     case SPECIAL_KEY_BUILDING: {
-        do_cmd_building(player);
+        do_cmd_building(creature);
         break;
     }
     case SPECIAL_KEY_QUEST: {
-        do_cmd_quest(player);
+        do_cmd_quest(creature);
         break;
     }
     case '<': {
@@ -336,79 +335,79 @@ void process_command(CreatureEntity &creature)
                 break;
             }
 
-            if (player.food < PY_FOOD_WEAK) {
+            if (creature.food < PY_FOOD_WEAK) {
                 msg_print(_("その前に食事をとらないと。", "You must eat something here."));
                 break;
             }
 
-            change_wild_mode(player, false);
+            change_wild_mode(creature, false);
         } else {
-            do_cmd_go_up(player);
+            do_cmd_go_up(creature);
         }
 
         break;
     }
     case '>': {
         if (is_wild_mode) {
-            change_wild_mode(player, false);
+            change_wild_mode(creature, false);
         } else {
-            do_cmd_go_down(player);
+            do_cmd_go_down(creature);
         }
 
         break;
     }
     case 'o': {
-        do_cmd_open(player);
+        do_cmd_open(creature);
         break;
     }
     case 'c': {
-        do_cmd_close(player);
+        do_cmd_close(creature);
         break;
     }
     case 'j': {
-        do_cmd_spike(player);
+        do_cmd_spike(creature);
         break;
     }
     case 'B': {
-        do_cmd_bash(player);
+        do_cmd_bash(creature);
         break;
     }
     case 'D': {
-        do_cmd_disarm(player);
+        do_cmd_disarm(creature);
         break;
     }
     case 'G': {
-        CreatureClass pc(player);
+        CreatureClass pc(creature);
         if (pc.is_every_magic() || pc.equals(PlayerClassType::ELEMENTALIST)) {
             msg_print(_("呪文を学習する必要はない！", "You don't have to learn spells!"));
         } else if (pc.equals(PlayerClassType::SAMURAI)) {
-            do_cmd_gain_hissatsu(player);
+            do_cmd_gain_hissatsu(creature);
         } else if (pc.equals(PlayerClassType::MAGIC_EATER)) {
             import_magic_device(creature);
         } else {
-            do_cmd_study(player);
+            do_cmd_study(creature);
         }
 
         break;
     }
     case 'X': {
-        do_cmd_martial_arts_style(player);
+        do_cmd_martial_arts_style(creature);
         break;
     }
     case 'b': {
-        CreatureClass pc(player);
+        CreatureClass pc(creature);
         if (pc.can_browse()) {
-            do_cmd_mind_browse(player);
+            do_cmd_mind_browse(creature);
         } else if (pc.equals(PlayerClassType::ELEMENTALIST)) {
-            do_cmd_element_browse(player);
+            do_cmd_element_browse(creature);
         } else if (pc.equals(PlayerClassType::SMITH)) {
             do_cmd_kaji(creature, true);
         } else if (pc.equals(PlayerClassType::MAGIC_EATER)) {
-            do_cmd_magic_eater(player, true, false);
+            do_cmd_magic_eater(creature, true, false);
         } else if (pc.equals(PlayerClassType::SNIPER)) {
-            do_cmd_snipe_browse(player);
+            do_cmd_snipe_browse(creature);
         } else {
-            do_cmd_browse(player);
+            do_cmd_browse(creature);
         }
 
         break;
@@ -418,7 +417,7 @@ void process_command(CreatureEntity &creature)
             break;
         }
 
-        CreatureClass pc(player);
+        CreatureClass pc(creature);
         if (pc.equals(PlayerClassType::WARRIOR) || pc.equals(PlayerClassType::ARCHER) || pc.equals(PlayerClassType::CAVALRY)) {
             msg_print(_("呪文を唱えられない！", "You cannot cast spells!"));
             break;
@@ -433,9 +432,9 @@ void process_command(CreatureEntity &creature)
             break;
         }
 
-        if (player.anti_magic && !non_magic_class) {
+        if (creature.anti_magic && !non_magic_class) {
             concptr which_power = _("魔法", "magic");
-            switch (player.pclass) {
+            switch (creature.pclass) {
             case PlayerClassType::MINDCRAFTER:
                 which_power = _("超能力", "psionic powers");
                 break;
@@ -462,130 +461,130 @@ void process_command(CreatureEntity &creature)
             }
 
             msg_format(_("反魔法バリアが%sを邪魔した！", "An anti-magic shell disrupts your %s!"), which_power);
-            PlayerEnergy(player).reset_player_turn();
+            PlayerEnergy(creature).reset_player_turn();
             break;
         }
 
-        if (player.is_shero() && !pc.equals(PlayerClassType::BERSERKER)) {
+        if (creature.is_shero() && !pc.equals(PlayerClassType::BERSERKER)) {
             msg_format(_("狂戦士化していて頭が回らない！", "You cannot think directly!"));
-            PlayerEnergy(player).reset_player_turn();
+            PlayerEnergy(creature).reset_player_turn();
             break;
         }
 
         if (pc.can_browse()) {
-            do_cmd_mind(player);
+            do_cmd_mind(creature);
         } else if (pc.equals(PlayerClassType::ELEMENTALIST)) {
-            do_cmd_element(player);
+            do_cmd_element(creature);
         } else if (pc.equals(PlayerClassType::IMITATOR)) {
-            do_cmd_mane(player, false);
+            do_cmd_mane(creature, false);
         } else if (pc.equals(PlayerClassType::MAGIC_EATER)) {
-            do_cmd_magic_eater(player, false, false);
+            do_cmd_magic_eater(creature, false, false);
         } else if (pc.equals(PlayerClassType::SAMURAI)) {
-            do_cmd_hissatsu(player);
+            do_cmd_hissatsu(creature);
         } else if (pc.equals(PlayerClassType::BLUE_MAGE)) {
             do_cmd_cast_learned(creature);
         } else if (pc.equals(PlayerClassType::SMITH)) {
             do_cmd_kaji(creature, false);
         } else if (pc.equals(PlayerClassType::SNIPER)) {
-            do_cmd_snipe(player);
+            do_cmd_snipe(creature);
         } else {
-            (void)do_cmd_cast(player);
+            (void)do_cmd_cast(creature);
         }
 
         break;
     }
     case 'p': {
-        do_cmd_pet(player);
+        do_cmd_pet(creature);
         break;
     }
     case '{': {
-        do_cmd_inscribe(player);
+        do_cmd_inscribe(creature);
         break;
     }
     case '}': {
-        do_cmd_uninscribe(player);
+        do_cmd_uninscribe(creature);
         break;
     }
     case 'A': {
-        do_cmd_activate(player);
+        do_cmd_activate(creature);
         break;
     }
     case 'E': {
-        do_cmd_eat_food(player);
+        do_cmd_eat_food(creature);
         break;
     }
     case 'F': {
-        do_cmd_refill(player);
+        do_cmd_refill(creature);
         break;
     }
     case 'f': {
-        do_cmd_fire(player, SP_NONE);
+        do_cmd_fire(creature, SP_NONE);
         break;
     }
     case 'v': {
-        (void)ThrowCommand(player).do_cmd_throw(1, false, -1);
+        (void)ThrowCommand(creature).do_cmd_throw(1, false, -1);
         break;
     }
     case 'a': {
-        do_cmd_aim_wand(player);
+        do_cmd_aim_wand(creature);
         break;
     }
     case 'z': {
         if (use_command && rogue_like_commands) {
-            do_cmd_use(player);
+            do_cmd_use(creature);
         } else {
-            do_cmd_zap_rod(player);
+            do_cmd_zap_rod(creature);
         }
 
         break;
     }
     case 'q': {
-        do_cmd_quaff_potion(player);
+        do_cmd_quaff_potion(creature);
         break;
     }
     case KTRL('Z'): {
-        do_cmd_rectal_absorption(player);
+        do_cmd_rectal_absorption(creature);
         break;
     }
     case 'r': {
-        do_cmd_read_scroll(player);
+        do_cmd_read_scroll(creature);
         break;
     }
     case 'u': {
         if (use_command && !rogue_like_commands) {
-            do_cmd_use(player);
+            do_cmd_use(creature);
         } else {
-            do_cmd_use_staff(player);
+            do_cmd_use_staff(creature);
         }
 
         break;
     }
     case 'U': {
-        do_cmd_racial_power(player);
+        do_cmd_racial_power(creature);
         break;
     }
     case 'M': {
-        do_cmd_view_map(player);
+        do_cmd_view_map(creature);
         break;
     }
     case 'L': {
-        do_cmd_locate(player);
+        do_cmd_locate(creature);
         break;
     }
     case 'l': {
-        do_cmd_look(player);
+        do_cmd_look(creature);
         break;
     }
     case '*': {
-        do_cmd_target(player);
+        do_cmd_target(creature);
         break;
     }
     case '?': {
-        do_cmd_help(player);
+        do_cmd_help(creature);
         break;
     }
     case '/': {
-        do_cmd_query_symbol(player);
+        do_cmd_query_symbol(creature);
         break;
     }
     case 'C': {
@@ -596,34 +595,34 @@ void process_command(CreatureEntity &creature)
         term_user();
         break;
     case '"': {
-        do_cmd_pref(player);
+        do_cmd_pref(creature);
         break;
     }
     case '$': {
-        do_cmd_reload_autopick(player);
+        do_cmd_reload_autopick(creature);
         break;
     }
     case '_': {
-        do_cmd_edit_autopick(player);
+        do_cmd_edit_autopick(creature);
         break;
     }
     case '@': {
-        do_cmd_macros(player);
+        do_cmd_macros(creature);
         break;
     }
     case '%': {
-        do_cmd_visuals(player);
+        do_cmd_visuals(creature);
         do_cmd_redraw(creature);
         break;
     }
     case '&': {
-        do_cmd_colors(player);
+        do_cmd_colors(creature);
         do_cmd_redraw(creature);
         break;
     }
     case '=': {
-        do_cmd_options(player);
-        (void)combine_and_reorder_home(player, StoreSaleType::HOME);
+        do_cmd_options(creature);
+        (void)combine_and_reorder_home(creature, StoreSaleType::HOME);
         do_cmd_redraw(creature);
         break;
     }
@@ -636,7 +635,7 @@ void process_command(CreatureEntity &creature)
         break;
     }
     case KTRL('F'): {
-        do_cmd_feeling(player);
+        do_cmd_feeling(creature);
         break;
     }
     case KTRL('O'): {
@@ -648,7 +647,7 @@ void process_command(CreatureEntity &creature)
         break;
     }
     case KTRL('Q'): {
-        do_cmd_checkquest(player);
+        do_cmd_checkquest(creature);
         break;
     }
     case KTRL('R'): {
@@ -657,28 +656,28 @@ void process_command(CreatureEntity &creature)
         break;
     }
     case KTRL('S'): {
-        do_cmd_save_game(player, false);
+        do_cmd_save_game(creature, false);
         break;
     }
     case KTRL('T'): {
-        do_cmd_time(player);
+        do_cmd_time(creature);
         break;
     }
     case KTRL('X'):
     case SPECIAL_KEY_QUIT: {
-        do_cmd_save_and_exit(player);
+        do_cmd_save_and_exit(creature);
         break;
     }
     case 'Q': {
-        do_cmd_suicide(player);
+        do_cmd_suicide(creature);
         break;
     }
     case '|': {
-        do_cmd_diary(player);
+        do_cmd_diary(creature);
         break;
     }
     case '~': {
-        do_cmd_knowledge(player);
+        do_cmd_knowledge(creature);
         break;
     }
     case '(': {
@@ -686,7 +685,7 @@ void process_command(CreatureEntity &creature)
         break;
     }
     case ')': {
-        do_cmd_save_screen(player);
+        do_cmd_save_screen(creature);
         break;
     }
     case ']': {
@@ -694,22 +693,22 @@ void process_command(CreatureEntity &creature)
         break;
     }
     case KTRL('V'): {
-        spoil_random_artifact(player);
+        spoil_random_artifact(creature);
         break;
     }
     case KTRL('C'): {
-        do_cmd_inscribe_terrain(player);
+        do_cmd_inscribe_terrain(creature);
         break;
     }
     case KTRL('E'): {
-        do_cmd_text_command(player);
+        do_cmd_text_command(creature);
         break;
     }
     case '`': {
         if (!is_wild_mode) {
-            do_cmd_travel(player);
+            do_cmd_travel(creature);
         }
-        CreatureClass(player).break_samurai_stance({ SamuraiStanceType::MUSOU });
+        CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
         break;
     }
@@ -723,7 +722,7 @@ void process_command(CreatureEntity &creature)
     }
     }
 
-    if (!player.energy_use && !now_message) {
+    if (!creature.energy_use && !now_message) {
         now_message = old_now_message;
     }
 }

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -337,7 +337,6 @@ static bool interpret_v_token(char *buf)
  */
 static void interpret_xy_token(CreatureEntity &creature, char *buf)
 {
-    auto &player = creature;
     const auto &world = AngbandWorld::get_instance();
     for (auto &option : option_info) {
         if (option.text != buf + 2) {
@@ -346,7 +345,7 @@ static void interpret_xy_token(CreatureEntity &creature, char *buf)
 
         int os = option.flag_position;
         int ob = option.offset;
-        if ((player.playing || world.character_xtra) && (GameOptionPage::BIRTH == option.page) && !world.wizard) {
+        if ((creature.playing || world.character_xtra) && (GameOptionPage::BIRTH == option.page) && !world.wizard) {
             msg_format(_("初期オプションは変更できません! '%s'", "Birth options can not be changed! '%s'"), buf);
             msg_erase();
             return;
@@ -510,7 +509,7 @@ static bool interpret_t_token(char *buf)
  * may contain any characters including "delimiters".
  * Note the use of "strtol()" to allow all "integers" to be encoded
  * in decimal, hexidecimal, or octal form.
- * Note that "monster zero" is used for the "player" attr/char, "object
+ * Note that "monster zero" is used for the "creature" attr/char, "object
  * zero" will be used for the "stack" attr/char, and "feature zero" is
  * used for the "nothing" attr/char.
  * </pre>

--- a/src/io/mutations-dump.cpp
+++ b/src/io/mutations-dump.cpp
@@ -19,165 +19,164 @@ void dump_mutations(CreatureEntity &creature, FILE *out_file)
         return;
     }
 
-    auto &player = creature;
-    if (player.muta.any() || has_good_luck(creature) || has_pervert_attraction(creature)) {
-        if (player.muta.has(PlayerMutationType::SPIT_ACID)) {
+    if (creature.muta.any() || has_good_luck(creature) || has_pervert_attraction(creature)) {
+        if (creature.muta.has(PlayerMutationType::SPIT_ACID)) {
             fprintf(out_file, _(" あなたは酸を吹きかけることができる。(ダメージ レベルX1)\n", " You can spit acid (dam lvl).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::BR_FIRE)) {
+        if (creature.muta.has(PlayerMutationType::BR_FIRE)) {
             fprintf(out_file, _(" あなたは炎のブレスを吐くことができる。(ダメージ レベルX2)\n", " You can breathe fire (dam lvl * 2).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::HYPN_GAZE)) {
+        if (creature.muta.has(PlayerMutationType::HYPN_GAZE)) {
             fprintf(out_file, _(" あなたの睨みは催眠効果をもつ。\n", " Your gaze is hypnotic.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::TELEKINES)) {
+        if (creature.muta.has(PlayerMutationType::TELEKINES)) {
             fprintf(out_file, _(" あなたは念動力をもっている。\n", " You are telekinetic.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::VTELEPORT)) {
+        if (creature.muta.has(PlayerMutationType::VTELEPORT)) {
             fprintf(out_file, _(" あなたは自分の意思でテレポートできる。\n", " You can teleport at will.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::MIND_BLST)) {
+        if (creature.muta.has(PlayerMutationType::MIND_BLST)) {
             fprintf(out_file, _(" あなたは敵を精神攻撃できる。\n", " You can Mind Blast your enemies.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::RADIATION)) {
+        if (creature.muta.has(PlayerMutationType::RADIATION)) {
             fprintf(out_file, _(" あなたは自分の意思で放射能を発生することができる。\n", " You can emit hard radiation at will.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::VAMPIRISM)) {
+        if (creature.muta.has(PlayerMutationType::VAMPIRISM)) {
             fprintf(out_file, _(" あなたは吸血鬼のように敵から生命力を吸収することができる。\n", " You can drain life from a foe like a vampire.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::SMELL_MET)) {
+        if (creature.muta.has(PlayerMutationType::SMELL_MET)) {
             fprintf(out_file, _(" あなたは近くにある貴金属をかぎ分けることができる。\n", " You can smell nearby precious metal.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::SMELL_MON)) {
+        if (creature.muta.has(PlayerMutationType::SMELL_MON)) {
             fprintf(out_file, _(" あなたは近くのモンスターの存在をかぎ分けることができる。\n", " You can smell nearby monsters.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::BLINK)) {
+        if (creature.muta.has(PlayerMutationType::BLINK)) {
             fprintf(out_file, _(" あなたは短い距離をテレポートできる。\n", " You can teleport yourself short distances.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::EAT_ROCK)) {
+        if (creature.muta.has(PlayerMutationType::EAT_ROCK)) {
             fprintf(out_file, _(" あなたは硬い岩を食べることができる。\n", " You can consume solid rock.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::SWAP_POS)) {
+        if (creature.muta.has(PlayerMutationType::SWAP_POS)) {
             fprintf(out_file, _(" あなたは他の者と場所を入れ替わることができる。\n", " You can switch locations with another being.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::SHRIEK)) {
+        if (creature.muta.has(PlayerMutationType::SHRIEK)) {
             fprintf(out_file, _(" あなたは身の毛もよだつ叫び声を発することができる。\n", " You can emit a horrible shriek.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::ILLUMINE)) {
+        if (creature.muta.has(PlayerMutationType::ILLUMINE)) {
             fprintf(out_file, _(" あなたは明るい光を放つことができる。\n", " You can emit bright light.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::DET_CURSE)) {
+        if (creature.muta.has(PlayerMutationType::DET_CURSE)) {
             fprintf(out_file, _(" あなたは邪悪な魔法の危険を感じとることができる。\n", " You can feel the danger of evil magic.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::BERSERK)) {
+        if (creature.muta.has(PlayerMutationType::BERSERK)) {
             fprintf(out_file, _(" あなたは自分の意思で狂乱戦闘状態になることができる。\n", " You can drive yourself into a berserk frenzy.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::POLYMORPH)) {
+        if (creature.muta.has(PlayerMutationType::POLYMORPH)) {
             fprintf(out_file, _(" あなたは自分の意志で変化できる。\n", " You can polymorph yourself at will.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::MIDAS_TCH)) {
+        if (creature.muta.has(PlayerMutationType::MIDAS_TCH)) {
             fprintf(out_file, _(" あなたは通常アイテムを金に変えることができる。\n", " You can turn ordinary items to gold.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::GROW_MOLD)) {
+        if (creature.muta.has(PlayerMutationType::GROW_MOLD)) {
             fprintf(out_file, _(" あなたは周囲にキノコを生やすことができる。\n", " You can cause mold to grow near you.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::RESIST)) {
+        if (creature.muta.has(PlayerMutationType::RESIST)) {
             fprintf(out_file, _(" あなたは元素の攻撃に対して身を硬くすることができる。\n", " You can harden yourself to the ravages of the elements.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::EARTHQUAKE)) {
+        if (creature.muta.has(PlayerMutationType::EARTHQUAKE)) {
             fprintf(out_file, _(" あなたは周囲のダンジョンを崩壊させることができる。\n", " You can bring down the dungeon around your ears.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::EAT_MAGIC)) {
+        if (creature.muta.has(PlayerMutationType::EAT_MAGIC)) {
             fprintf(out_file, _(" あなたは魔法のエネルギーを自分の物として使用できる。\n", " You can consume magic energy for your own use.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::WEIGH_MAG)) {
+        if (creature.muta.has(PlayerMutationType::WEIGH_MAG)) {
             fprintf(out_file, _(" あなたは自分に影響を与える魔法の力を感じることができる。\n", " You can feel the strength of the magics affecting you.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::STERILITY)) {
+        if (creature.muta.has(PlayerMutationType::STERILITY)) {
             fprintf(out_file, _(" あなたは集団的生殖不能を起こすことができる。\n", " You can cause mass impotence.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::HIT_AND_AWAY)) {
+        if (creature.muta.has(PlayerMutationType::HIT_AND_AWAY)) {
             fprintf(out_file, _(" あなたは攻撃した後身を守るため逃げることができる。\n", " You can run for your life after hitting something.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::DAZZLE)) {
+        if (creature.muta.has(PlayerMutationType::DAZZLE)) {
             fprintf(out_file, _(" あなたは混乱と盲目を引き起こす放射能を発生することができる。 \n", " You can emit confusing, blinding radiation.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::LASER_EYE)) {
+        if (creature.muta.has(PlayerMutationType::LASER_EYE)) {
             fprintf(out_file, _(" あなたは目からレーザー光線を発射することができる。\n", " Your eyes can fire laser beams.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::RECALL)) {
+        if (creature.muta.has(PlayerMutationType::RECALL)) {
             fprintf(out_file, _(" あなたは街とダンジョンの間を行き来することができる。\n", " You can travel between town and the depths.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::BANISH)) {
+        if (creature.muta.has(PlayerMutationType::BANISH)) {
             fprintf(out_file, _(" あなたは邪悪なモンスターを地獄に落とすことができる。\n", " You can send evil creatures directly to Hell.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::COLD_TOUCH)) {
+        if (creature.muta.has(PlayerMutationType::COLD_TOUCH)) {
             fprintf(out_file, _(" あなたは物を触って凍らせることができる。\n", " You can freeze things with a touch.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::LAUNCHER)) {
+        if (creature.muta.has(PlayerMutationType::LAUNCHER)) {
             fprintf(out_file, _(" あなたはアイテムを力強く投げることができる。\n", " You can hurl objects with great force.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::BERS_RAGE)) {
+        if (creature.muta.has(PlayerMutationType::BERS_RAGE)) {
             fprintf(out_file, _(" あなたは狂戦士化の発作を起こす。\n", " You are subject to berserker fits.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::COWARDICE)) {
+        if (creature.muta.has(PlayerMutationType::COWARDICE)) {
             fprintf(out_file, _(" あなたは時々臆病になる。\n", " You are subject to cowardice.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::RTELEPORT)) {
+        if (creature.muta.has(PlayerMutationType::RTELEPORT)) {
             fprintf(out_file, _(" あなたはランダムにテレポートする。\n", " You sometimes randomly teleport.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::ALCOHOL)) {
+        if (creature.muta.has(PlayerMutationType::ALCOHOL)) {
             fprintf(out_file, _(" あなたの体はアルコールを分泌する。\n", " Your body produces alcohol.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::HALLU)) {
+        if (creature.muta.has(PlayerMutationType::HALLU)) {
             fprintf(out_file, _(" あなたは幻覚を引き起こす精神錯乱に侵されている。\n", " You have a hallucinatory insanity.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::FLATULENT)) {
+        if (creature.muta.has(PlayerMutationType::FLATULENT)) {
             fprintf(out_file, _(" あなたは制御できない強烈な屁をこく。\n", " You are subject to uncontrollable flatulence.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::IKISUGI)) {
+        if (creature.muta.has(PlayerMutationType::IKISUGI)) {
             fprintf(out_file, _(" あなたは時々イキすぎる。\n", " You sometimes climax too much.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::ATT_NASTY)) {
+        if (creature.muta.has(PlayerMutationType::ATT_NASTY)) {
             fprintf(out_file, _(" あなたはクッソ汚い輩を引きつける。\n", " You attract nasty creatures.\n"));
         }
 
@@ -185,231 +184,231 @@ void dump_mutations(CreatureEntity &creature, FILE *out_file)
             fprintf(out_file, _(" あなたは変質者を引きつける。\n", " You attract perverts.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::PROD_MANA)) {
+        if (creature.muta.has(PlayerMutationType::PROD_MANA)) {
             fprintf(out_file, _(" あなたは制御不能な魔法のエネルギーを発している。\n", " You produce magical energy uncontrollably.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::ATT_DEMON)) {
+        if (creature.muta.has(PlayerMutationType::ATT_DEMON)) {
             fprintf(out_file, _(" あなたはデーモンを引きつける。\n", " You attract demons.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::SCOR_TAIL)) {
+        if (creature.muta.has(PlayerMutationType::SCOR_TAIL)) {
             fprintf(out_file, _(" あなたはサソリの尻尾が生えている。(毒、ダメージ 3d7)\n", " You have a scorpion tail (poison, 3d7).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::HORNS)) {
+        if (creature.muta.has(PlayerMutationType::HORNS)) {
             fprintf(out_file, _(" あなたは角が生えている。(ダメージ 2d6)\n", " You have horns (dam. 2d6).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::BEAK)) {
+        if (creature.muta.has(PlayerMutationType::BEAK)) {
             fprintf(out_file, _(" あなたはクチバシが生えている。(ダメージ 2d4)\n", " You have a beak (dam. 2d4).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::SPEED_FLUX)) {
+        if (creature.muta.has(PlayerMutationType::SPEED_FLUX)) {
             fprintf(out_file, _(" あなたはランダムに早く動いたり遅く動いたりする。\n", " You move faster or slower randomly.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::BANISH_ALL)) {
+        if (creature.muta.has(PlayerMutationType::BANISH_ALL)) {
             fprintf(out_file, _(" あなたは時々近くのモンスターを消滅させる。\n", " You sometimes cause nearby creatures to vanish.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::EAT_LIGHT)) {
+        if (creature.muta.has(PlayerMutationType::EAT_LIGHT)) {
             fprintf(out_file, _(" あなたは時々周囲の光を吸収して栄養にする。\n", " You sometimes feed off of the light around you.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::TRUNK)) {
+        if (creature.muta.has(PlayerMutationType::TRUNK)) {
             fprintf(out_file, _(" あなたは象のような鼻を持っている。(ダメージ 1d4)\n", " You have an elephantine trunk (dam 1d4).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::ATT_ANIMAL)) {
+        if (creature.muta.has(PlayerMutationType::ATT_ANIMAL)) {
             fprintf(out_file, _(" あなたは動物を引きつける。\n", " You attract animals.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::TENTACLES)) {
+        if (creature.muta.has(PlayerMutationType::TENTACLES)) {
             fprintf(out_file, _(" あなたは邪悪な触手を持っている。(ダメージ 2d5)\n", " You have evil looking tentacles (dam 2d5).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::RAW_CHAOS)) {
+        if (creature.muta.has(PlayerMutationType::RAW_CHAOS)) {
             fprintf(out_file, _(" あなたはしばしば純カオスに包まれる。\n", " You occasionally are surrounded with raw chaos.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::NORMALITY)) {
+        if (creature.muta.has(PlayerMutationType::NORMALITY)) {
             fprintf(out_file, _(" あなたは変異していたが、回復してきている。\n", " You may be mutated, but you're recovering.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::WRAITH)) {
+        if (creature.muta.has(PlayerMutationType::WRAITH)) {
             fprintf(out_file, _(" あなたの肉体は幽体化したり実体化したりする。\n", " You fade in and out of physical reality.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::POLY_WOUND)) {
+        if (creature.muta.has(PlayerMutationType::POLY_WOUND)) {
             fprintf(out_file, _(" あなたの健康はカオスの力に影響を受ける。\n", " Your health is subject to chaotic forces.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::WASTING)) {
+        if (creature.muta.has(PlayerMutationType::WASTING)) {
             fprintf(out_file, _(" あなたは衰弱する恐ろしい病気にかかっている。\n", " You have a horrible wasting disease.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::ATT_DRAGON)) {
+        if (creature.muta.has(PlayerMutationType::ATT_DRAGON)) {
             fprintf(out_file, _(" あなたはドラゴンを引きつける。\n", " You attract dragons.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::WEIRD_MIND)) {
+        if (creature.muta.has(PlayerMutationType::WEIRD_MIND)) {
             fprintf(out_file, _(" あなたの精神はランダムに拡大したり縮小したりしている。\n", " Your mind randomly expands and contracts.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::NAUSEA)) {
+        if (creature.muta.has(PlayerMutationType::NAUSEA)) {
             fprintf(out_file, _(" あなたの胃は非常に落ち着きがない。\n", " You have a seriously upset stomach.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::CHAOS_GIFT)) {
+        if (creature.muta.has(PlayerMutationType::CHAOS_GIFT)) {
             fprintf(out_file, _(" あなたはカオスの守護悪魔から褒美をうけとる。\n", " Chaos deities give you gifts.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::WALK_SHAD)) {
+        if (creature.muta.has(PlayerMutationType::WALK_SHAD)) {
             fprintf(out_file, _(" あなたはしばしば他の「影」に迷い込む。\n", " You occasionally stumble into other shadows.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::WARNING)) {
+        if (creature.muta.has(PlayerMutationType::WARNING)) {
             fprintf(out_file, _(" あなたは敵に関する警告を感じる。\n", " You receive warnings about your foes.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::INVULN)) {
+        if (creature.muta.has(PlayerMutationType::INVULN)) {
             fprintf(out_file, _(" あなたは時々負け知らずな気分になる。\n", " You occasionally feel invincible.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::SP_TO_HP)) {
+        if (creature.muta.has(PlayerMutationType::SP_TO_HP)) {
             fprintf(out_file, _(" あなたは時々血が筋肉にどっと流れる。\n", " Your blood sometimes rushes to your muscles.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::HP_TO_SP)) {
+        if (creature.muta.has(PlayerMutationType::HP_TO_SP)) {
             fprintf(out_file, _(" あなたは時々頭に血がどっと流れる。\n", " Your blood sometimes rushes to your head.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::DISARM)) {
+        if (creature.muta.has(PlayerMutationType::DISARM)) {
             fprintf(out_file, _(" あなたはよくつまづいて物を落とす。\n", " You occasionally stumble and drop things.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::HYPER_STR)) {
+        if (creature.muta.has(PlayerMutationType::HYPER_STR)) {
             fprintf(out_file, _(" あなたは超人的に強い。(腕力+4)\n", " You are superhumanly strong (+4 STR).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::PUNY)) {
+        if (creature.muta.has(PlayerMutationType::PUNY)) {
             fprintf(out_file, _(" あなたは虚弱だ。(腕力-4)\n", " You are puny (-4 STR).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::HYPER_INT)) {
+        if (creature.muta.has(PlayerMutationType::HYPER_INT)) {
             fprintf(out_file, _(" あなたの脳は生体コンピュータだ。(知能＆賢さ+4)\n", " Your brain is a living computer (+4 INT/WIS).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::MORONIC)) {
+        if (creature.muta.has(PlayerMutationType::MORONIC)) {
             fprintf(out_file, _(" あなたは精神薄弱だ。(知能＆賢さ-4)\n", " You are moronic (-4 INT/WIS).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::RESILIENT)) {
+        if (creature.muta.has(PlayerMutationType::RESILIENT)) {
             fprintf(out_file, _(" あなたの体は弾力性に富んでいる。(耐久+4)\n", " You are very resilient (+4 CON).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::XTRA_FAT)) {
+        if (creature.muta.has(PlayerMutationType::XTRA_FAT)) {
             fprintf(out_file, _(" あなたは極端に太っている。(耐久+2,スピード-2)\n", " You are extremely fat (+2 CON, -2 speed).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::ALBINO)) {
+        if (creature.muta.has(PlayerMutationType::ALBINO)) {
             fprintf(out_file, _(" あなたはアルビノだ。(耐久-4)\n", " You are albino (-4 CON).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::FLESH_ROT)) {
+        if (creature.muta.has(PlayerMutationType::FLESH_ROT)) {
             fprintf(out_file, _(" あなたの肉体は腐敗している。(耐久-2,魅力-1)\n", " Your flesh is rotting (-2 CON, -1 CHR).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::SILLY_VOI)) {
+        if (creature.muta.has(PlayerMutationType::SILLY_VOI)) {
             fprintf(out_file, _(" あなたの声は間抜けなキーキー声だ。(魅力-4)\n", " Your voice is a silly squeak (-4 CHR).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::BLANK_FAC)) {
+        if (creature.muta.has(PlayerMutationType::BLANK_FAC)) {
             fprintf(out_file, _(" あなたはのっぺらぼうだ。(魅力-1)\n", " Your face is featureless (-1 CHR).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::ILL_NORM)) {
+        if (creature.muta.has(PlayerMutationType::ILL_NORM)) {
             fprintf(out_file, _(" あなたは幻影に覆われている。\n", " Your appearance is masked with illusion.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::XTRA_EYES)) {
+        if (creature.muta.has(PlayerMutationType::XTRA_EYES)) {
             fprintf(out_file, _(" あなたは余分に二つの目を持っている。(探索+15)\n", " You have an extra pair of eyes (+15 search).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::MAGIC_RES)) {
+        if (creature.muta.has(PlayerMutationType::MAGIC_RES)) {
             fprintf(out_file, _(" あなたは魔法への耐性をもっている。\n", " You are resistant to magic.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::XTRA_NOIS)) {
+        if (creature.muta.has(PlayerMutationType::XTRA_NOIS)) {
             fprintf(out_file, _(" あなたは変な音を発している。(隠密-3)\n", " You make a lot of strange noise (-3 stealth).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::INFRAVIS)) {
+        if (creature.muta.has(PlayerMutationType::INFRAVIS)) {
             fprintf(out_file, _(" あなたは素晴らしい赤外線視力を持っている。(+3)\n", " You have remarkable infravision (+3).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::XTRA_LEGS)) {
+        if (creature.muta.has(PlayerMutationType::XTRA_LEGS)) {
             fprintf(out_file, _(" あなたは余分に二本の足が生えている。(加速+3)\n", " You have an extra pair of legs (+3 speed).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::SHORT_LEG)) {
+        if (creature.muta.has(PlayerMutationType::SHORT_LEG)) {
             fprintf(out_file, _(" あなたの足は短い突起だ。(加速-3)\n", " Your legs are short stubs (-3 speed).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::WEAK_LOWER_BODY)) {
+        if (creature.muta.has(PlayerMutationType::WEAK_LOWER_BODY)) {
             fprintf(out_file, _(" あなたは上半身に比べて下半身が貧弱すぎる。(腕力+2, 加速-2)\n", " Your lower body is too weak compared to your upper body (+2 STR, -2 speed).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::ELEC_TOUC)) {
+        if (creature.muta.has(PlayerMutationType::ELEC_TOUC)) {
             fprintf(out_file, _(" あなたの血管には電流が流れている。\n", " Electricity runs through your veins.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::FIRE_BODY)) {
+        if (creature.muta.has(PlayerMutationType::FIRE_BODY)) {
             fprintf(out_file, _(" あなたの体は炎につつまれている。\n", " Your body is enveloped in flames.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::WART_SKIN)) {
+        if (creature.muta.has(PlayerMutationType::WART_SKIN)) {
             fprintf(out_file, _(" あなたの肌はイボに被われている。(魅力-2, AC+5)\n", " Your skin is covered with warts (-2 CHR, +5 AC).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::SCALES)) {
+        if (creature.muta.has(PlayerMutationType::SCALES)) {
             fprintf(out_file, _(" あなたの肌は鱗になっている。(魅力-1, AC+10)\n", " Your skin has turned into scales (-1 CHR, +10 AC).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::IRON_SKIN)) {
+        if (creature.muta.has(PlayerMutationType::IRON_SKIN)) {
             fprintf(out_file, _(" あなたの肌は鉄でできている。(器用-1, AC+25)\n", " Your skin is made of steel (-1 DEX, +25 AC).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::WINGS)) {
+        if (creature.muta.has(PlayerMutationType::WINGS)) {
             fprintf(out_file, _(" あなたは羽を持っている。\n", " You have wings.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::FEARLESS)) {
+        if (creature.muta.has(PlayerMutationType::FEARLESS)) {
             fprintf(out_file, _(" あなたは全く恐怖を感じない。\n", " You are completely fearless.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::REGEN)) {
+        if (creature.muta.has(PlayerMutationType::REGEN)) {
             fprintf(out_file, _(" あなたは急速に回復する。\n", " You are regenerating.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::ESP)) {
+        if (creature.muta.has(PlayerMutationType::ESP)) {
             fprintf(out_file, _(" あなたはテレパシーを持っている。\n", " You are telepathic.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::LIMBER)) {
+        if (creature.muta.has(PlayerMutationType::LIMBER)) {
             fprintf(out_file, _(" あなたの体は非常にしなやかだ。(器用+3)\n", " Your body is very limber (+3 DEX).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::ARTHRITIS)) {
+        if (creature.muta.has(PlayerMutationType::ARTHRITIS)) {
             fprintf(out_file, _(" あなたはいつも関節に痛みを感じている。(器用-3)\n", " Your joints ache constantly (-3 DEX).\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::VULN_ELEM)) {
+        if (creature.muta.has(PlayerMutationType::VULN_ELEM)) {
             fprintf(out_file, _(" あなたは元素の攻撃に弱い。\n", " You are susceptible to damage from the elements.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::MOTION)) {
+        if (creature.muta.has(PlayerMutationType::MOTION)) {
             fprintf(out_file, _(" あなたの動作は正確で力強い。(隠密+1)\n", " Your movements are precise and forceful (+1 STL).\n"));
         }
 
@@ -417,23 +416,23 @@ void dump_mutations(CreatureEntity &creature, FILE *out_file)
             fprintf(out_file, _(" あなたは白いオーラにつつまれている。\n", " There is a white aura surrounding you.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::BAD_LUCK)) {
+        if (creature.muta.has(PlayerMutationType::BAD_LUCK)) {
             fprintf(out_file, _(" あなたは黒いオーラにつつまれている。\n", " There is a black aura surrounding you.\n"));
         }
 
-        if (player.muta.has(PlayerMutationType::DEFECATION)) {
+        if (creature.muta.has(PlayerMutationType::DEFECATION)) {
             fprintf(out_file, _("あなたは脱糞を制御できない。", "You are subject to uncontrollable defecation."));
         }
 
-        if (player.muta.has(PlayerMutationType::ZEERO_VIRUS)) {
+        if (creature.muta.has(PlayerMutationType::ZEERO_VIRUS)) {
             fprintf(out_file, _("あなたはゼEROウイルスに感染している。SEXDA!", "You are infected with ZEERO virus. Let's SEX!"));
         }
 
-        if (player.muta.has(PlayerMutationType::HOMO_SEXUAL)) {
+        if (creature.muta.has(PlayerMutationType::HOMO_SEXUAL)) {
             fprintf(out_file, _("あなたは同性愛者だ。", "You are Homosexual."));
         }
 
-        if (player.muta.has(PlayerMutationType::BI_SEXUAL)) {
+        if (creature.muta.has(PlayerMutationType::BI_SEXUAL)) {
             fprintf(out_file, _("あなたは両性愛者だ。", "You are Homosexual."));
         }
     }

--- a/src/io/pref-file-expressor.cpp
+++ b/src/io/pref-file-expressor.cpp
@@ -27,7 +27,6 @@
  */
 std::string process_pref_file_expr(CreatureEntity &creature, char **sp, char *fp)
 {
-    auto &player = creature;
     char *s = (*sp);
     while (iswspace(*s)) {
         s++;
@@ -164,12 +163,12 @@ std::string process_pref_file_expr(CreatureEntity &creature, char **sp, char *fp
             v = "OFF";
         }
     } else if (streq(b + 1, "RACE")) {
-        v = player.race->title.en_string();
+        v = creature.race->title.en_string();
     } else if (streq(b + 1, "CLASS")) {
-        v = (*player.pclass_ref).title.en_string();
+        v = (*creature.pclass_ref).title.en_string();
     } else if (streq(b + 1, "PLAYER")) {
         static char tmp_player_name[64];
-        const char *pn = player.name.c_str();
+        const char *pn = creature.name.c_str();
         char *tpn = tmp_player_name;
         for (; *pn; pn++, tpn++) {
 #ifdef JP
@@ -185,19 +184,19 @@ std::string process_pref_file_expr(CreatureEntity &creature, char **sp, char *fp
         *tpn = '\0';
         v = tmp_player_name;
     } else if (streq(b + 1, "REALM1")) {
-        v = PlayerRealm(player).realm1().get_name().en_string();
+        v = PlayerRealm(creature).realm1().get_name().en_string();
     } else if (streq(b + 1, "REALM2")) {
-        v = PlayerRealm(player).realm2().get_name().en_string();
+        v = PlayerRealm(creature).realm2().get_name().en_string();
     } else if (streq(b + 1, "LEVEL")) {
-        v = format("%02d", player.level);
+        v = format("%02d", creature.level);
     } else if (streq(b + 1, "AUTOREGISTER")) {
-        if (player.autopick_autoregister) {
+        if (creature.autopick_autoregister) {
             v = "1";
         } else {
             v = "0";
         }
     } else if (streq(b + 1, "MONEY")) {
-        v = format("%09ld", (long int)player.au);
+        v = format("%09ld", (long int)creature.au);
     }
 
     *fp = f;

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -192,7 +192,7 @@ errr process_autopick_file(CreatureEntity &creature, std::string_view name)
 
 /*!
  * @brief プレイヤーの生い立ちファイルを読み込む /
- * Process file for player's history editor.
+ * Process file for creature's history editor.
  * @param creature クリーチャーへの参照
  * @param name ファイル名
  * @return エラーコード
@@ -276,15 +276,14 @@ void close_auto_dump(FILE **fpp, std::string_view mark)
  */
 void load_all_pref_files(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     process_pref_file(creature, "user.prf");
     process_pref_file(creature, format("user-%s.prf", ANGBAND_SYS));
     constexpr auto fmt = "%s.prf";
-    process_pref_file(creature, format(fmt, player.race->title.data()));
-    process_pref_file(creature, format(fmt, (*player.pclass_ref).title.data()));
-    process_pref_file(creature, format(fmt, player.base_name.data()));
-    PlayerRealm pr(player);
+    process_pref_file(creature, format(fmt, creature.race->title.data()));
+    process_pref_file(creature, format(fmt, (*creature.pclass_ref).title.data()));
+    process_pref_file(creature, format(fmt, creature.base_name.data()));
+    PlayerRealm pr(creature);
     if (pr.realm1().is_available()) {
         process_pref_file(creature, format(fmt, pr.realm1().get_name().data()));
     }
@@ -305,11 +304,9 @@ bool read_histpref(CreatureEntity &creature)
         return false;
     }
 
-    auto &player = creature;
-
     histpref_buf = "";
     std::stringstream ss;
-    ss << _("histedit-", "histpref-") << player.base_name << ".prf";
+    ss << _("histedit-", "histpref-") << creature.base_name << ".prf";
     auto err = process_histpref_file(creature, ss.str());
     if (0 > err) {
         err = process_histpref_file(creature, _("histedit.prf", "histpref.prf"));
@@ -329,28 +326,28 @@ bool read_histpref(CreatureEntity &creature)
     }
 
     for (auto i = 0; i < 4; i++) {
-        player.history[i][0] = '\0';
+        creature.history[i][0] = '\0';
     }
 
     histpref_buf = str_trim(*histpref_buf);
-    constexpr auto max_line_len = sizeof(player.history[0]);
+    constexpr auto max_line_len = sizeof(creature.history[0]);
     const auto history_lines = shape_buffer(*histpref_buf, max_line_len);
     const auto max_lines = std::min<int>(4, history_lines.size());
     for (auto l = 0; l < max_lines; ++l) {
-        angband_strcpy(player.history[l], history_lines[l], max_line_len);
+        angband_strcpy(creature.history[l], history_lines[l], max_line_len);
     }
 
     for (auto i = 0; i < 4; i++) {
         /* loop */
         int j;
-        for (j = 0; player.history[i][j]; j++) {
+        for (j = 0; creature.history[i][j]; j++) {
             ;
         }
 
         for (; j < 59; j++) {
-            player.history[i][j] = ' ';
+            creature.history[i][j] = ' ';
         }
-        player.history[i][59] = '\0';
+        creature.history[i][59] = '\0';
     }
 
     return true;

--- a/src/io/record-play-movie.cpp
+++ b/src/io/record-play-movie.cpp
@@ -330,7 +330,6 @@ void prepare_chuukei_hooks(void)
  */
 void prepare_movie_hooks(CreatureEntity &creature)
 {
-    auto &player = creature;
     TermCenteredOffsetSetter tcos(tl::nullopt, tl::nullopt);
 
     if (movie_mode) {
@@ -342,7 +341,7 @@ void prepare_movie_hooks(CreatureEntity &creature)
     }
 
     std::stringstream ss;
-    ss << player.base_name << ".amv";
+    ss << creature.base_name << ".amv";
     auto initial_movie_filename = ss.str();
     constexpr auto prompt = _("ムービー記録ファイル: ", "Movie file name: ");
     const auto movie_filename = input_string(prompt, 80, initial_movie_filename.data());

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -236,30 +236,29 @@ std::string make_screen_dump(CreatureEntity &creature)
  */
 bool report_score(CreatureEntity &creature)
 {
-    auto &player = creature;
     std::stringstream score_ss;
-    std::string personality_desc = (*player.personality).title.string();
-    personality_desc.append(_((*player.personality).no ? "の" : "", " "));
+    std::string personality_desc = (*creature.personality).title.string();
+    personality_desc.append(_((*creature.personality).no ? "の" : "", " "));
 
     PlayerRealm pr(creature);
-    const auto &realm1_name = CreatureClass(creature).equals(PlayerClassType::ELEMENTALIST) ? get_element_title(player.element_realm) : pr.realm1().get_name().string();
-    score_ss << fmt::format("name: {}\n", player.name)
+    const auto &realm1_name = CreatureClass(creature).equals(PlayerClassType::ELEMENTALIST) ? get_element_title(creature.element_realm) : pr.realm1().get_name().string();
+    score_ss << fmt::format("name: {}\n", creature.name)
              << fmt::format("version: {}\n", AngbandSystem::get_instance().build_version_expression(VersionExpression::FULL))
              << fmt::format("score: {}\n", calc_score(creature))
-             << fmt::format("level: {}\n", player.level)
-             << fmt::format("depth: {}\n", player.current_floor_ptr->dun_level)
-             << fmt::format("maxlv: {}\n", player.max_plv)
+             << fmt::format("level: {}\n", creature.level)
+             << fmt::format("depth: {}\n", creature.current_floor_ptr->dun_level)
+             << fmt::format("maxlv: {}\n", creature.max_plv)
              << fmt::format("maxdp: {}\n", DungeonRecords::get_instance().get_record(DungeonId::ANGBAND).get_max_level())
-             << fmt::format("au: {}\n", player.au);
+             << fmt::format("au: {}\n", creature.au);
     const auto &igd = InnerGameData::get_instance();
     score_ss << fmt::format("turns: {}\n", igd.get_real_turns(AngbandWorld::get_instance().game_turn))
-             << fmt::format("sex: {}\n", enum2i(player.psex))
-             << fmt::format("race: {}\n", player.race->title)
-             << fmt::format("class: {}\n", (*player.pclass_ref).title)
+             << fmt::format("sex: {}\n", enum2i(creature.psex))
+             << fmt::format("race: {}\n", creature.race->title)
+             << fmt::format("class: {}\n", (*creature.pclass_ref).title)
              << fmt::format("seikaku: {}\n", personality_desc)
              << fmt::format("realm1: {}\n", realm1_name)
              << fmt::format("realm2: {}\n", pr.realm2().get_name())
-             << fmt::format("killer: {}\n", player.died_from)
+             << fmt::format("killer: {}\n", creature.died_from)
              << "-----charcter dump-----\n";
 
     make_dump(creature, score_ss);

--- a/src/io/write-diary.cpp
+++ b/src/io/write-diary.cpp
@@ -152,14 +152,13 @@ static void write_diary_pet(FILE *fff, int num, std::string_view note)
  */
 int exe_write_diary_quest(CreatureEntity &creature, DiaryKind dk, QuestId quest_id)
 {
-    auto &player = creature;
     static auto disable_diary = false;
     const auto &[day, hour, min] = AngbandWorld::get_instance().extract_date_time(InnerGameData::get_instance().get_start_race());
     if (disable_diary) {
         return -1;
     }
 
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     const auto old_quest = floor.quest_number;
     const auto &quests = QuestList::get_instance();
     const auto &quest = quests.get_quest(quest_id);
@@ -378,7 +377,7 @@ void exe_write_diary(const FloorType &floor, DiaryKind dk, int num, std::string_
         break;
     }
     case DiaryKind::LEVELUP: {
-        constexpr auto fmt = _(" %2d:%02d %20s レベルが%dに上がった。\n", " %2d:%02d %20s reached player level %d.\n");
+        constexpr auto fmt = _(" %2d:%02d %20s レベルが%dに上がった。\n", " %2d:%02d %20s reached creature level %d.\n");
         fprintf(fff, fmt, hour, min, note_level.data(), num);
         break;
     }

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -26,7 +26,6 @@
  */
 void do_cmd_knowledge_weapon_exp(CreatureEntity &creature)
 {
-    auto &player = creature;
     FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name)) {
@@ -46,8 +45,8 @@ void do_cmd_knowledge_weapon_exp(CreatureEntity &creature)
                     continue;
                 }
 
-                SUB_EXP weapon_exp = player.weapon_exp[tval][num];
-                SUB_EXP weapon_max = player.weapon_exp_max[tval][num];
+                SUB_EXP weapon_exp = creature.weapon_exp[tval][num];
+                SUB_EXP weapon_max = creature.weapon_exp_max[tval][num];
                 fprintf(fff, "%-25s ", baseitem.stripped_name().data());
                 if (show_actual_value) {
                     fprintf(fff, "%4d/%4d ", weapon_exp, weapon_max);
@@ -79,14 +78,13 @@ void do_cmd_knowledge_weapon_exp(CreatureEntity &creature)
  */
 void do_cmd_knowledge_spell_exp(CreatureEntity &creature)
 {
-    auto &player = creature;
     FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name)) {
         return;
     }
 
-    PlayerRealm pr(player);
+    PlayerRealm pr(creature);
 
     if (pr.realm1().is_available()) {
         fprintf(fff, _("%sの魔法書\n", "%s Spellbook\n"), pr.realm1().get_name().data());
@@ -96,7 +94,7 @@ void do_cmd_knowledge_spell_exp(CreatureEntity &creature)
             if (spell.slevel >= 99) {
                 continue;
             }
-            SUB_EXP spell_exp = player.spell_exp[i];
+            SUB_EXP spell_exp = creature.spell_exp[i];
             auto skill_rank = PlayerSkill::spell_skill_rank(spell_exp);
             const auto &spell_name = pr.realm1().get_spell_name(i);
             fprintf(fff, "%-25s ", spell_name.data());
@@ -133,7 +131,7 @@ void do_cmd_knowledge_spell_exp(CreatureEntity &creature)
                 continue;
             }
 
-            SUB_EXP spell_exp = player.spell_exp[i + 32];
+            SUB_EXP spell_exp = creature.spell_exp[i + 32];
             auto skill_rank = PlayerSkill::spell_skill_rank(spell_exp);
             const auto spell_name = pr.realm2().get_spell_name(i);
             fprintf(fff, "%-25s ", spell_name.data());
@@ -164,7 +162,6 @@ void do_cmd_knowledge_spell_exp(CreatureEntity &creature)
  */
 void do_cmd_knowledge_skill_exp(CreatureEntity &creature)
 {
-    auto &player = creature;
     FILE *fff = nullptr;
     char file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name)) {
@@ -172,8 +169,8 @@ void do_cmd_knowledge_skill_exp(CreatureEntity &creature)
     }
 
     for (auto i : PLAYER_SKILL_KIND_TYPE_RANGE) {
-        SUB_EXP skill_exp = player.skill_exp[i];
-        SUB_EXP skill_max = class_skills_info[enum2i(player.pclass)].s_max[i];
+        SUB_EXP skill_exp = creature.skill_exp[i];
+        SUB_EXP skill_max = class_skills_info[enum2i(creature.pclass)].s_max[i];
         fprintf(fff, "%-20s ", PlayerSkill::skill_name(i));
         if (show_actual_value) {
             fprintf(fff, "%4d/%4d ", std::min(skill_exp, skill_max), skill_max);

--- a/src/knowledge/knowledge-incident.cpp
+++ b/src/knowledge/knowledge-incident.cpp
@@ -29,7 +29,6 @@
 
 void do_cmd_knowledge_incident(CreatureEntity &creature)
 {
-    auto &player = creature;
     FILE *fff = NULL;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name)) {
@@ -241,7 +240,7 @@ void do_cmd_knowledge_incident(CreatureEntity &creature)
                     item.pval = pval;
                     item.mark_as_known();
 
-                    auto item_name = describe_flavor(player, item, 0);
+                    auto item_name = describe_flavor(creature, item, 0);
                     fprintf(fff, _("        %s を %d 回\n", "        %s %d times\n"),
                         item_name.data(), entry.second);
                 }

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -176,10 +176,9 @@ static void pad_and_print_header(int label_number, FILE *fff)
  */
 static int show_wearing_equipment_resistances(CreatureEntity &creature, ItemKindType tval, int label_number_initial, FILE *fff)
 {
-    auto &player = creature;
     auto label_number = label_number_initial;
     for (short i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto &item = *player.inventory[i];
+        const auto &item = *creature.inventory[i];
         if (!item.has_knowledge(tval)) {
             continue;
         }
@@ -201,10 +200,9 @@ static int show_wearing_equipment_resistances(CreatureEntity &creature, ItemKind
  */
 static int show_holding_equipment_resistances(CreatureEntity &creature, ItemKindType tval, int label_number_initial, FILE *fff)
 {
-    auto &player = creature;
     auto label_number = label_number_initial;
     for (short i = 0; i < INVEN_PACK; i++) {
-        const auto &item = *player.inventory[i];
+        const auto &item = *creature.inventory[i];
         if (!item.has_knowledge(tval)) {
             continue;
         }

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -40,7 +40,6 @@
 namespace {
 auto collect_known_fixed_artifacts(CreatureEntity &creature)
 {
-    auto &player = creature;
     const auto &artifacts = ArtifactList::get_instance();
     const auto comparer = [&artifacts](auto id1, auto id2) { return artifacts.order(id1, id2); };
     std::set<FixedArtifactId, decltype(comparer)> fa_ids(comparer);
@@ -66,7 +65,7 @@ auto collect_known_fixed_artifacts(CreatureEntity &creature)
     }
 
     for (auto i = 0; i < INVEN_TOTAL; i++) {
-        const auto &item = *player.inventory[i];
+        const auto &item = *creature.inventory[i];
         if (!item.is_valid()) {
             continue;
         }
@@ -92,7 +91,6 @@ auto collect_known_fixed_artifacts(CreatureEntity &creature)
  */
 void do_cmd_knowledge_artifacts(CreatureEntity &creature)
 {
-    auto &player = creature;
     FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name)) {
@@ -107,7 +105,7 @@ void do_cmd_knowledge_artifacts(CreatureEntity &creature)
         ItemEntity item(artifact.bi_key);
         item.fa_id = fa_id;
         item.ident |= IDENT_STORE;
-        const auto item_name = describe_flavor(player, item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        const auto item_name = describe_flavor(creature, item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         fprintf(fff, template_basename, item_name.data());
     }
 

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -153,7 +153,6 @@ static std::vector<MonraceId> collect_monsters(short grp_cur, monster_lore_mode 
  */
 void do_cmd_knowledge_pets(CreatureEntity &creature)
 {
-    auto &player = creature;
     FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name)) {
@@ -172,7 +171,7 @@ void do_cmd_knowledge_pets(CreatureEntity &creature)
         fprintf(fff, "%s (%s)\n", pet_name.data(), monster.build_looking_description(false).data());
     }
 
-    int show_upkeep = calculate_upkeep(player);
+    int show_upkeep = calculate_upkeep(creature);
 
     fprintf(fff, "----------------------------------------------\n");
 #ifdef JP
@@ -191,7 +190,7 @@ void do_cmd_knowledge_pets(CreatureEntity &creature)
  * @brief 現在までに倒したモンスターを表示するコマンドのメインルーチン /
  * @param player_ptr プレイヤーへの参照ポインタ
  * Total kill count
- * @note the player ghosts are ignored.
+ * @note the creature ghosts are ignored.
  */
 void do_cmd_knowledge_kill_count(CreatureEntity &creature)
 {

--- a/src/knowledge/knowledge-self.cpp
+++ b/src/knowledge/knowledge-self.cpp
@@ -65,26 +65,25 @@ static void dump_explanation(std::string_view explanation, FILE *fff)
  */
 static void dump_yourself(CreatureEntity &creature, FILE *fff)
 {
-    auto &player = creature;
     if (!fff) {
         return;
     }
 
     fprintf(fff, "\n\n");
-    fprintf(fff, _("種族: %s\n", "Race: %s\n"), race_info[enum2i(player.prace)].title.data());
-    dump_explanation(race_explanations[enum2i(player.prace)], fff);
+    fprintf(fff, _("種族: %s\n", "Race: %s\n"), race_info[enum2i(creature.prace)].title.data());
+    dump_explanation(race_explanations[enum2i(creature.prace)], fff);
 
     fprintf(fff, "\n");
-    fprintf(fff, _("職業: %s\n", "Class: %s\n"), class_info.at(player.pclass).title.data());
-    auto short_pclass = enum2i(player.pclass);
+    fprintf(fff, _("職業: %s\n", "Class: %s\n"), class_info.at(creature.pclass).title.data());
+    auto short_pclass = enum2i(creature.pclass);
     dump_explanation(class_explanations[short_pclass].data(), fff);
 
     fprintf(fff, "\n");
-    fprintf(fff, _("性格: %s\n", "Pesonality: %s\n"), personality_info[player.ppersonality].title.data());
-    dump_explanation(personality_explanations[player.ppersonality], fff);
+    fprintf(fff, _("性格: %s\n", "Pesonality: %s\n"), personality_info[creature.ppersonality].title.data());
+    dump_explanation(personality_explanations[creature.ppersonality], fff);
 
     fprintf(fff, "\n");
-    PlayerRealm pr(player);
+    PlayerRealm pr(creature);
     if (pr.realm1().is_available()) {
         fprintf(fff, _("魔法: %s\n", "Realm: %s\n"), pr.realm1().get_name().data());
         dump_explanation(pr.realm1().get_explanation(), fff);
@@ -147,7 +146,6 @@ static void dump_winner_classes(FILE *fff)
  */
 void do_cmd_knowledge_stat(CreatureEntity &creature)
 {
-    auto &player = creature;
     FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name)) {
@@ -162,16 +160,16 @@ void do_cmd_knowledge_stat(CreatureEntity &creature)
     fprintf(fff, _("合計のプレイ時間 : %d:%02d:%02d\n", "  Total play Time is %d:%02d:%02d\n"), all_time / (60 * 60), (all_time / 60) % 60, all_time % 60);
     fputs("\n", fff);
 
-    if (player.knowledge & KNOW_HPRATE) {
-        fprintf(fff, _("現在の体力ランク : %d/100\n\n", "Your current Life Rating is %d/100.\n\n"), player.calc_life_rating());
+    if (creature.knowledge & KNOW_HPRATE) {
+        fprintf(fff, _("現在の体力ランク : %d/100\n\n", "Your current Life Rating is %d/100.\n\n"), creature.calc_life_rating());
     } else {
         fprintf(fff, _("現在の体力ランク : ???\n\n", "Your current Life Rating is ???.\n\n"));
     }
 
     fprintf(fff, _("能力の最大値\n\n", "Limits of maximum stats\n\n"));
     for (int v_nr = 0; v_nr < A_MAX; v_nr++) {
-        if ((player.knowledge & KNOW_STAT) || player.stat_max[v_nr] == player.stat_max_max[v_nr]) {
-            fprintf(fff, "%s 18/%d\n", stat_names[v_nr], player.stat_max_max[v_nr] - 18);
+        if ((creature.knowledge & KNOW_STAT) || creature.stat_max[v_nr] == creature.stat_max_max[v_nr]) {
+            fprintf(fff, "%s 18/%d\n", stat_names[v_nr], creature.stat_max_max[v_nr] - 18);
         } else {
             fprintf(fff, "%s ???\n", stat_names[v_nr]);
         }
@@ -191,7 +189,6 @@ void do_cmd_knowledge_stat(CreatureEntity &creature)
  */
 void do_cmd_knowledge_home(CreatureEntity &creature)
 {
-    auto &player = creature;
     const auto &area = WildernessGrids::get_instance().get_area();
     parse_fixed_map(creature, WILDERNESS_DEFINITION, 0, 0, area.height(), area.width());
 
@@ -221,7 +218,7 @@ void do_cmd_knowledge_home(CreatureEntity &creature)
             fprintf(fff, "\n ( %d ページ )\n", x++);
         }
 
-        const auto item_name = describe_flavor(player, *store.stock[i], 0);
+        const auto item_name = describe_flavor(creature, *store.stock[i], 0);
         const int item_length = item_name.length();
         if (item_length <= 80 - 3) {
             fprintf(fff, "%c%s %s\n", I2A(i % 12), close_bracket, item_name.data());
@@ -234,7 +231,7 @@ void do_cmd_knowledge_home(CreatureEntity &creature)
         fprintf(fff, "%c%s %.*s\n", I2A(i % 12), close_bracket, n, item_name.substr(0, n).data());
         fprintf(fff, "   %.77s\n", item_name.substr(n).data());
 #else
-        const auto item_name = describe_flavor(player, *store.stock[i], 0);
+        const auto item_name = describe_flavor(creature, *store.stock[i], 0);
         fprintf(fff, "%c%s %s\n", I2A(i % 12), close_bracket, item_name.data());
 #endif
     }

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -33,17 +33,16 @@
 #include "world/world.h"
 
 /*!
- * @brief セーブデータから領域情報を読み込む / Read player realms
+ * @brief セーブデータから領域情報を読み込む / Read creature realms
  * @param creature クリーチャーへの参照
  */
 static void rd_realms(CreatureEntity &creature)
 {
-    auto &player = creature;
-    PlayerRealm pr(player);
+    PlayerRealm pr(creature);
     pr.reset();
 
     if (CreatureClass(creature).equals(PlayerClassType::ELEMENTALIST)) {
-        player.element_realm = i2enum<ElementRealmType>(rd_byte());
+        creature.element_realm = i2enum<ElementRealmType>(rd_byte());
         (void)rd_byte();
         return;
     }
@@ -60,25 +59,24 @@ static void rd_realms(CreatureEntity &creature)
 }
 
 /*!
- * @brief セーブデータからプレイヤー基本情報を読み込む / Read player's basic info
+ * @brief セーブデータからプレイヤー基本情報を読み込む / Read creature's basic info
  * @param creature クリーチャーへの参照
  */
 void rd_base_info(CreatureEntity &creature)
 {
-    auto &player = creature;
     creature.name = rd_string();
     if (creature.name.length() > 40) {
         creature.name.resize(40);
     }
     creature.died_from = rd_string();
-    player.last_message = rd_string();
+    creature.last_message = rd_string();
 
     load_quick_start();
     const int max_history_lines = 4;
     for (int i = 0; i < max_history_lines; i++) {
         const auto history = rd_string();
-        const auto history_len = history.copy(player.history[i], sizeof(player.history[i]) - 1);
-        player.history[i][history_len] = '\0';
+        const auto history_len = history.copy(creature.history[i], sizeof(creature.history[i]) - 1);
+        creature.history[i][history_len] = '\0';
     }
 
     creature.prace = i2enum<PlayerRaceType>(rd_byte());
@@ -90,8 +88,8 @@ void rd_base_info(CreatureEntity &creature)
 
     strip_bytes(1);
 
-    player.hit_dice = Dice(1, rd_byte());
-    player.expfact = rd_u16b();
+    creature.hit_dice = Dice(1, rd_byte());
+    creature.expfact = rd_u16b();
 
     creature.death_count = rd_s32b();
     creature.age = rd_s16b();
@@ -167,11 +165,10 @@ void rd_skills(CreatureEntity &creature)
 
 static void set_race(CreatureEntity &creature)
 {
-    auto &player = creature;
     InnerGameData::get_instance().set_start_race(i2enum<PlayerRaceType>(rd_byte()));
-    player.old_race1 = rd_u32b();
-    player.old_race2 = rd_u32b();
-    player.old_realm = rd_s16b();
+    creature.old_race1 = rd_u32b();
+    creature.old_race2 = rd_u32b();
+    creature.old_realm = rd_s16b();
 }
 
 void rd_bounty_uniques()
@@ -339,9 +336,8 @@ static void rd_bad_status(CreatureEntity &creature)
 
 static void rd_energy(CreatureEntity &creature)
 {
-    auto &player = creature;
     creature.energy_need = rd_s16b();
-    player.enchant_energy_need = rd_s16b();
+    creature.enchant_energy_need = rd_s16b();
 }
 
 /*!
@@ -446,7 +442,6 @@ static void rd_timed_effects(CreatureEntity &creature)
 
 static void rd_player_status(CreatureEntity &creature)
 {
-    auto &player = creature;
     rd_base_status(creature);
     strip_bytes(24);
     creature.au = rd_s32b();
@@ -459,7 +454,7 @@ static void rd_player_status(CreatureEntity &creature)
     rd_dummy1();
     rd_hp(creature);
     rd_mana(creature);
-    player.max_plv = rd_s16b();
+    creature.max_plv = rd_s16b();
     rd_dungeons(creature);
     strip_bytes(8);
     creature.prestige = rd_s16b();
@@ -480,9 +475,9 @@ static void rd_player_status(CreatureEntity &creature)
     creature.shield = rd_s16b();
     creature.blessed = rd_s16b();
     creature.tim_invis = rd_s16b();
-    player.word_recall = rd_s16b();
-    player.recall_dungeon = i2enum<DungeonId>(rd_s16b());
-    player.alter_reality = rd_s16b();
+    creature.word_recall = rd_s16b();
+    creature.recall_dungeon = i2enum<DungeonId>(rd_s16b());
+    creature.alter_reality = rd_s16b();
     creature.see_infra = rd_s16b();
     creature.tim_infra = rd_s16b();
     creature.oppose_fire = rd_s16b();
@@ -492,7 +487,7 @@ static void rd_player_status(CreatureEntity &creature)
     creature.oppose_pois = rd_s16b();
     creature.tsuyoshi = rd_s16b();
     rd_timed_effects(creature);
-    player.mutant_regenerate_mod = calc_mutant_regenerate_mod(creature);
+    creature.mutant_regenerate_mod = calc_mutant_regenerate_mod(creature);
 
     if (!loading_savefile_version_is_older_than(6)) {
         int32_t num = rd_s32b();
@@ -500,7 +495,7 @@ static void rd_player_status(CreatureEntity &creature)
             int32_t id, count;
             id = rd_s32b();
             count = rd_s32b();
-            player.incident[(INCIDENT)id] = count;
+            creature.incident[(INCIDENT)id] = count;
         }
     }
 
@@ -517,12 +512,11 @@ static void rd_player_status(CreatureEntity &creature)
 
 void rd_player_info(CreatureEntity &creature)
 {
-    auto &player = creature;
     rd_player_status(creature);
     rd_special_attack(creature);
     rd_special_action(creature);
     rd_special_defense(creature);
-    player.knowledge = rd_byte();
+    creature.knowledge = rd_byte();
     rd_autopick(creature);
     rd_action(creature);
 }

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -52,7 +52,6 @@ static tl::optional<int> process_ostensible_arena_victory()
 
 static bool check_battle_metal_babble(CreatureEntity &creature)
 {
-    auto &player = creature;
     msg_print(_("最強の挑戦者が君に決闘を申し込んできた。", "The strongest challenger throws down the gauntlet to your feet."));
     msg_erase();
     if (!input_check(_("受けて立つかね？", "Do you take up the gauntlet? "))) {
@@ -64,10 +63,10 @@ static bool check_battle_metal_babble(CreatureEntity &creature)
     msg_erase();
 
     AngbandWorld::get_instance().set_arena(false);
-    reset_tim_flags(player);
+    reset_tim_flags(creature);
     FloorChangeModesStore::get_instace()->set(FloorChangeMode::SAVE_FLOORS);
-    player.current_floor_ptr->inside_arena = true;
-    player.leaving = true;
+    creature.current_floor_ptr->inside_arena = true;
+    creature.leaving = true;
     return true;
 }
 
@@ -78,10 +77,9 @@ static bool check_battle_metal_babble(CreatureEntity &creature)
  */
 static bool go_to_arena(CreatureEntity &creature)
 {
-    auto &player = creature;
     const auto prize_money = process_ostensible_arena_victory();
     if (prize_money) {
-        player.au += *prize_money;
+        creature.au += *prize_money;
         return false;
     }
 
@@ -96,17 +94,17 @@ static bool go_to_arena(CreatureEntity &creature)
         return false;
     }
 
-    if (player.riding && !CreatureClass(player).is_tamer()) {
+    if (creature.riding && !CreatureClass(creature).is_tamer()) {
         msg_print(_("ペットに乗ったままではアリーナへ入れさせてもらえなかった。", "You don't have permission to enter with pet."));
         msg_erase();
         return false;
     }
 
     AngbandWorld::get_instance().set_arena(false);
-    reset_tim_flags(player);
+    reset_tim_flags(creature);
     FloorChangeModesStore::get_instace()->set(FloorChangeMode::SAVE_FLOORS);
-    player.current_floor_ptr->inside_arena = true;
-    player.leaving = true;
+    creature.current_floor_ptr->inside_arena = true;
+    creature.leaving = true;
     return true;
 }
 
@@ -117,7 +115,6 @@ static bool go_to_arena(CreatureEntity &creature)
  */
 bool arena_comm(CreatureEntity &creature, int cmd)
 {
-    auto &player = creature;
     switch (cmd) {
     case BACT_ARENA:
         return go_to_arena(creature);
@@ -130,12 +127,12 @@ bool arena_comm(CreatureEntity &creature, int cmd)
 
         const auto &monrace = entries.get_monrace();
         LoreTracker::get_instance().set_trackee(monrace.idx);
-        handle_stuff(player);
+        handle_stuff(creature);
         return false;
     }
     case BACT_ARENA_RULES:
         screen_save();
-        FileDisplayer(player.name).display(true, _("arena_j.txt", "arena.txt"), 0, 0);
+        FileDisplayer(creature.name).display(true, _("arena_j.txt", "arena.txt"), 0, 0);
         screen_load();
         return false;
     default:

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -42,13 +42,12 @@
  */
 bool exchange_cash(CreatureEntity &creature)
 {
-    auto &player = creature;
     auto change = false;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     constexpr auto fmt_convert = _("%s を換金しますか？", "Convert %s into money? ");
     constexpr auto fmt_reward = _("賞金 %d＄を手に入れた。", "You get %dgp.");
     for (INVENTORY_IDX i = 0; i <= INVEN_SUB_HAND; i++) {
-        const auto &item = *player.inventory[i];
+        const auto &item = *creature.inventory[i];
         if (item.bi_key.tval() != ItemKindType::CAPTURE) {
             continue;
         }
@@ -58,20 +57,20 @@ bool exchange_cash(CreatureEntity &creature)
         }
 
         change = true;
-        const auto item_name = describe_flavor(player, item, 0);
+        const auto item_name = describe_flavor(creature, item, 0);
         if (!input_check(format(fmt_convert, item_name.data()))) {
             continue;
         }
 
         const auto reward_money = 1000000 * item.number;
         msg_format(fmt_reward, reward_money);
-        player.au += reward_money;
+        creature.au += reward_money;
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(player, i, -item.number);
+        vary_item(creature, i, -item.number);
     }
 
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto &item = *player.inventory[i];
+        const auto &item = *creature.inventory[i];
         if (!item.is_corpse()) {
             continue;
         }
@@ -81,20 +80,20 @@ bool exchange_cash(CreatureEntity &creature)
         }
 
         change = true;
-        const auto item_name = describe_flavor(player, item, 0);
+        const auto item_name = describe_flavor(creature, item, 0);
         if (!input_check(format(fmt_convert, item_name.data()))) {
             continue;
         }
 
         const auto reward_money = 200000 * item.number;
         msg_format(fmt_reward, reward_money);
-        player.au += reward_money;
+        creature.au += reward_money;
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(player, i, -item.number);
+        vary_item(creature, i, -item.number);
     }
 
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto &item = *player.inventory[i];
+        const auto &item = *creature.inventory[i];
         if (item.bi_key != BaseitemKey(ItemKindType::MONSTER_REMAINS, SV_SKELETON)) {
             continue;
         }
@@ -104,57 +103,57 @@ bool exchange_cash(CreatureEntity &creature)
         }
 
         change = true;
-        const auto item_name = describe_flavor(player, item, 0);
+        const auto item_name = describe_flavor(creature, item, 0);
         if (!input_check(format(fmt_convert, item_name.data()))) {
             continue;
         }
 
         const auto reward_money = 100000 * item.number;
         msg_format(fmt_reward, reward_money);
-        player.au += reward_money;
+        creature.au += reward_money;
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(player, i, -item.number);
+        vary_item(creature, i, -item.number);
     }
 
     auto &world = AngbandWorld::get_instance();
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto &item = *player.inventory[i];
+        const auto &item = *creature.inventory[i];
         const auto &monrace = world.get_today_bounty();
         if (!item.is_corpse() || (item.get_monrace().name != monrace.name)) {
             continue;
         }
 
         change = true;
-        const auto item_name = describe_flavor(player, item, 0);
+        const auto item_name = describe_flavor(creature, item, 0);
         if (!input_check(format(fmt_convert, item_name.data()))) {
             continue;
         }
 
         const auto reward_money = (monrace.level * 50 + 100) * item.number;
         msg_format(fmt_reward, reward_money);
-        player.au += reward_money;
+        creature.au += reward_money;
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(player, i, -item.number);
+        vary_item(creature, i, -item.number);
     }
 
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto &item = *player.inventory[i];
+        const auto &item = *creature.inventory[i];
         const auto &monrace = world.get_today_bounty();
         if ((item.bi_key != BaseitemKey(ItemKindType::MONSTER_REMAINS, SV_SKELETON)) || (item.get_monrace().name != monrace.name)) {
             continue;
         }
 
         change = true;
-        const auto item_name = describe_flavor(player, item, 0);
+        const auto item_name = describe_flavor(creature, item, 0);
         if (!input_check(format(fmt_convert, item_name.data()))) {
             continue;
         }
 
         const auto reward_money = (monrace.level * 30 + 60) * item.number;
         msg_format(fmt_reward, reward_money);
-        player.au += reward_money;
+        creature.au += reward_money;
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(player, i, -item.number);
+        vary_item(creature, i, -item.number);
     }
 
     for (auto &[monrace_id, is_achieved] : world.bounties) {
@@ -163,7 +162,7 @@ bool exchange_cash(CreatureEntity &creature)
         }
 
         for (INVENTORY_IDX i = INVEN_PACK - 1; i >= 0; i--) {
-            auto &item = *player.inventory[i];
+            auto &item = *creature.inventory[i];
             if ((item.bi_key.tval() != ItemKindType::MONSTER_REMAINS) || (item.get_monrace().idx != monrace_id)) {
                 continue;
             }
@@ -173,12 +172,12 @@ bool exchange_cash(CreatureEntity &creature)
             }
 
             INVENTORY_IDX inventory_new;
-            const auto item_name = describe_flavor(player, item, 0);
+            const auto item_name = describe_flavor(creature, item, 0);
             if (!input_check(format(_("%sを渡しますか？", "Hand %s over? "), item_name.data()))) {
                 continue;
             }
 
-            vary_item(player, i, -item.number);
+            vary_item(creature, i, -item.number);
             chg_virtue(creature, Virtue::JUSTICE, 5);
             is_achieved = true;
 
@@ -188,7 +187,7 @@ bool exchange_cash(CreatureEntity &creature)
             msg_format(_("これで合計 %d ポイント獲得しました。", "You earned %d point%s total."), num, (num > 1 ? "s" : ""));
 
             ItemEntity prize_item(prize_list[num - 1]);
-            ItemMagicApplier(player, &prize_item, player.current_floor_ptr->object_level, AM_NO_FIXED_ART).execute();
+            ItemMagicApplier(creature, &prize_item, creature.current_floor_ptr->object_level, AM_NO_FIXED_ART).execute();
             object_aware(creature, prize_item);
             prize_item.mark_as_known();
 
@@ -197,11 +196,11 @@ bool exchange_cash(CreatureEntity &creature)
              * Since a corpse is handed at first,
              * there is at least one empty slot.
              */
-            inventory_new = store_item_to_inventory(player, &prize_item);
-            const auto got_item_name = describe_flavor(player, prize_item, 0);
+            inventory_new = store_item_to_inventory(creature, &prize_item);
+            const auto got_item_name = describe_flavor(creature, prize_item, 0);
             msg_format(_("%s(%c)を貰った。", "You get %s (%c). "), got_item_name.data(), index_to_label(inventory_new));
 
-            autopick_alter_item(player, inventory_new, false);
+            autopick_alter_item(creature, inventory_new, false);
             handle_stuff(creature);
             change = true;
         }

--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -87,13 +87,12 @@ static void give_one_ability_of_object(ItemEntity *to_ptr, ItemEntity *from_ptr)
 
 static std::pair<short, ItemEntity *> select_repairing_broken_weapon(CreatureEntity &creature, const int row)
 {
-    auto &player = creature;
     prt(_("修復には材料となるもう1つの武器が必要です。", "Hand one material weapon to repair a broken weapon."), row, 2);
     prt(_("材料に使用した武器はなくなります！", "The material weapon will disappear after repairing!!"), row + 1, 2);
     constexpr auto q = _("どの折れた武器を修復しますか？", "Repair which broken weapon? ");
     constexpr auto s = _("修復できる折れた武器がありません。", "You have no broken weapon to repair.");
     short i_idx;
-    auto *o_ptr = choose_object(player, &i_idx, q, s, (USE_INVEN | USE_EQUIP), FuncItemTester(&ItemEntity::is_broken_weapon));
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, (USE_INVEN | USE_EQUIP), FuncItemTester(&ItemEntity::is_broken_weapon));
     if (o_ptr == nullptr) {
         return { i_idx, nullptr };
     }
@@ -113,15 +112,13 @@ static std::pair<short, ItemEntity *> select_repairing_broken_weapon(CreatureEnt
 
 static void display_reparing_weapon(CreatureEntity &creature, const ItemEntity &item, const int row)
 {
-    auto &player = creature;
-    const auto item_name = describe_flavor(player, item, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(creature, item, OD_NAME_ONLY);
     prt(format(_("修復する武器　： %s", "Repairing: %s"), item_name.data()), row + 3, 2);
 }
 
 static void display_repair_success_message(CreatureEntity &creature, const ItemEntity &item, const int cost)
 {
-    auto &player = creature;
-    const auto item_name = describe_flavor(player, item, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(creature, item, OD_NAME_ONLY);
 #ifdef JP
     msg_format("＄%dで%sに修復しました。", cost, item_name.data());
 #else
@@ -138,7 +135,6 @@ static void display_repair_success_message(CreatureEntity &creature, const ItemE
  */
 static PRICE repair_broken_weapon_aux(CreatureEntity &creature, PRICE bcost)
 {
-    auto &player = creature;
     clear_bldg(0, 22);
     auto row = 7;
     const auto &[i_idx, o_ptr] = select_repairing_broken_weapon(creature, row);
@@ -150,7 +146,7 @@ static PRICE repair_broken_weapon_aux(CreatureEntity &creature, PRICE bcost)
     constexpr auto q = _("材料となる武器は？", "Which weapon for material? ");
     constexpr auto s = _("材料となる武器がありません。", "You have no material for the repair.");
     short mater;
-    auto *mo_ptr = choose_object(player, &mater, q, s, (USE_INVEN | USE_EQUIP), FuncItemTester(&ItemEntity::is_orthodox_melee_weapons));
+    auto *mo_ptr = choose_object(creature, &mater, q, s, (USE_INVEN | USE_EQUIP), FuncItemTester(&ItemEntity::is_orthodox_melee_weapons));
     if (!mo_ptr) {
         return 0;
     }
@@ -160,14 +156,14 @@ static PRICE repair_broken_weapon_aux(CreatureEntity &creature, PRICE bcost)
         return 0;
     }
 
-    const auto item_name = describe_flavor(player, *mo_ptr, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(creature, *mo_ptr, OD_NAME_ONLY);
     prt(format(_("材料とする武器： %s", "Material : %s"), item_name.data()), row + 4, 2);
     const auto cost = bcost + object_value_real(o_ptr) * 2;
     if (!input_check(format(_("＄%dかかりますがよろしいですか？ ", "Costs %d gold, okay? "), cost))) {
         return 0;
     }
 
-    if (player.au < cost) {
+    if (creature.au < cost) {
         msg_format(_("%sを修復するだけのゴールドがありません！", "You do not have the gold to repair %s!"), item_name.data());
         msg_erase();
         return 0;
@@ -300,8 +296,8 @@ static PRICE repair_broken_weapon_aux(CreatureEntity &creature, PRICE bcost)
     o_ptr->discount = 99;
 
     calc_android_exp(creature);
-    inven_item_increase(player, mater, -1);
-    inven_item_optimize(player, mater);
+    inven_item_increase(creature, mater, -1);
+    inven_item_optimize(creature, mater);
 
     RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(creature);

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -41,7 +41,7 @@
  * (used by compare_weapon_aux)\n
  * \n
  * Only accurate for the current weapon, because it includes\n
- * the current +dam of the player.\n
+ * the current +dam of the creature.\n
  */
 static void show_weapon_dmg(int r, int c, int mindice, int maxdice, int blows, int dam_bonus, concptr attr, byte color)
 {
@@ -63,17 +63,16 @@ static void show_weapon_dmg(int r, int c, int mindice, int maxdice, int blows, i
  * Show the damage figures for the various monster types\n
  * \n
  * Only accurate for the current weapon, because it includes\n
- * the current number of blows for the player.\n
+ * the current number of blows for the creature.\n
  */
 static void compare_weapon_aux(CreatureEntity &creature, ItemEntity *o_ptr, int col, int r)
 {
-    auto &player = creature;
-    int blow = player.num_blow[0];
+    int blow = creature.num_blow[0];
     bool force = false;
     bool dokubari = false;
 
-    int eff_dd = o_ptr->damage_dice.num + player.damage_dice_bonus[0].num;
-    int eff_ds = o_ptr->damage_dice.sides + player.damage_dice_bonus[0].sides;
+    int eff_dd = o_ptr->damage_dice.num + creature.damage_dice_bonus[0].num;
+    int eff_ds = o_ptr->damage_dice.sides + creature.damage_dice_bonus[0].sides;
 
     int mindice = eff_dd;
     int maxdice = eff_ds * eff_dd;
@@ -81,18 +80,18 @@ static void compare_weapon_aux(CreatureEntity &creature, ItemEntity *o_ptr, int 
     int maxdam = 0;
     int vorpal_mult = 1;
     int vorpal_div = 1;
-    int dmg_bonus = o_ptr->to_d + player.to_d[0];
+    int dmg_bonus = o_ptr->to_d + creature.to_d[0];
 
     const auto flags = o_ptr->get_flags();
     if (o_ptr->bi_key == BaseitemKey(ItemKindType::SWORD, SV_POISON_NEEDLE)) {
         dokubari = true;
     }
 
-    bool impact = flags.has(TR_IMPACT) || (player.impact != 0);
-    mindam = calc_expect_crit(player, o_ptr->weight, o_ptr->to_h, mindice, player.to_h[0], dokubari, impact);
-    maxdam = calc_expect_crit(player, o_ptr->weight, o_ptr->to_h, maxdice, player.to_h[0], dokubari, impact);
+    bool impact = flags.has(TR_IMPACT) || (creature.impact != 0);
+    mindam = calc_expect_crit(creature, o_ptr->weight, o_ptr->to_h, mindice, creature.to_h[0], dokubari, impact);
+    maxdam = calc_expect_crit(creature, o_ptr->weight, o_ptr->to_h, maxdice, creature.to_h[0], dokubari, impact);
     show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("会心:", "Critical:"), TERM_L_RED);
-    if ((flags.has(TR_VORPAL) || SpellHex(player).is_spelling_specific(HEX_RUNESWORD))) {
+    if ((flags.has(TR_VORPAL) || SpellHex(creature).is_spelling_specific(HEX_RUNESWORD))) {
         // @todo status-first-page::strengthen_basedam() と多重実装.
         if (o_ptr->is_specific_artifact(FixedArtifactId::VORPAL_BLADE) || o_ptr->is_specific_artifact(FixedArtifactId::CHAINSWORD)) {
             vorpal_mult = 5;
@@ -102,146 +101,146 @@ static void compare_weapon_aux(CreatureEntity &creature, ItemEntity *o_ptr, int 
             vorpal_div = 9;
         }
 
-        mindam = calc_expect_dice(player, mindice, 1, 1, false, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 1, 1, false, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 1, 1, false, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 1, 1, false, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("切れ味:", "Vorpal:"), TERM_L_RED);
     }
 
-    if (!CreatureClass(player).equals(PlayerClassType::SAMURAI) && flags.has(TR_FORCE_WEAPON) && (player.csp > (o_ptr->damage_dice.maxroll() / 5))) {
+    if (!CreatureClass(creature).equals(PlayerClassType::SAMURAI) && flags.has(TR_FORCE_WEAPON) && (creature.csp > (o_ptr->damage_dice.maxroll() / 5))) {
         force = true;
 
-        mindam = calc_expect_dice(player, mindice, 1, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 1, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 1, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 1, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("理力:", "Force  :"), TERM_L_BLUE);
     }
 
     if (flags.has(TR_KILL_ANIMAL)) {
-        mindam = calc_expect_dice(player, mindice, 4, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 4, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 4, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 4, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("動物:", "Animals:"), TERM_YELLOW);
     } else if (flags.has(TR_SLAY_ANIMAL)) {
-        mindam = calc_expect_dice(player, mindice, 5, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 5, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 5, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 5, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("動物:", "Animals:"), TERM_YELLOW);
     }
 
     if (flags.has(TR_KILL_EVIL)) {
-        mindam = calc_expect_dice(player, mindice, 7, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 7, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 7, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 7, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("邪悪:", "Evil:"), TERM_YELLOW);
     } else if (flags.has(TR_SLAY_EVIL)) {
-        mindam = calc_expect_dice(player, mindice, 2, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 2, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 2, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 2, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("邪悪:", "Evil:"), TERM_YELLOW);
     }
 
     if (flags.has(TR_KILL_GOOD)) {
-        mindam = calc_expect_dice(player, mindice, 7, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 7, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 7, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 7, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("善良:", "Good:"), TERM_YELLOW);
     } else if (flags.has(TR_SLAY_GOOD)) {
-        mindam = calc_expect_dice(player, mindice, 2, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 2, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 2, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 2, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("善良:", "Good:"), TERM_YELLOW);
     }
 
     if (flags.has(TR_KILL_HUMAN)) {
-        mindam = calc_expect_dice(player, mindice, 4, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 4, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 4, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 4, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("人間:", "Human:"), TERM_YELLOW);
     } else if (flags.has(TR_SLAY_HUMAN)) {
-        mindam = calc_expect_dice(player, mindice, 5, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 5, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 5, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 5, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("人間:", "Human:"), TERM_YELLOW);
     }
 
     if (flags.has(TR_KILL_UNDEAD)) {
-        mindam = calc_expect_dice(player, mindice, 5, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 5, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 5, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 5, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("不死:", "Undead:"), TERM_YELLOW);
     } else if (flags.has(TR_SLAY_UNDEAD)) {
-        mindam = calc_expect_dice(player, mindice, 3, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 3, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 3, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 3, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("不死:", "Undead:"), TERM_YELLOW);
     }
 
     if (flags.has(TR_KILL_DEMON)) {
-        mindam = calc_expect_dice(player, mindice, 5, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 5, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 5, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 5, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("悪魔:", "Demons:"), TERM_YELLOW);
     } else if (flags.has(TR_SLAY_DEMON)) {
-        mindam = calc_expect_dice(player, mindice, 3, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 3, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 3, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 3, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("悪魔:", "Demons:"), TERM_YELLOW);
     }
 
     if (flags.has(TR_KILL_ORC)) {
-        mindam = calc_expect_dice(player, mindice, 5, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 5, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 5, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 5, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("オーク:", "Orcs:"), TERM_YELLOW);
     } else if (flags.has(TR_SLAY_ORC)) {
-        mindam = calc_expect_dice(player, mindice, 3, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 3, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 3, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 3, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("オーク:", "Orcs:"), TERM_YELLOW);
     }
 
     if (flags.has(TR_KILL_TROLL)) {
-        mindam = calc_expect_dice(player, mindice, 5, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 5, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 5, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 5, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("トロル:", "Trolls:"), TERM_YELLOW);
     } else if (flags.has(TR_SLAY_TROLL)) {
-        mindam = calc_expect_dice(player, mindice, 3, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 3, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 3, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 3, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("トロル:", "Trolls:"), TERM_YELLOW);
     }
 
     if (flags.has(TR_KILL_GIANT)) {
-        mindam = calc_expect_dice(player, mindice, 5, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 5, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 5, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 5, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("巨人:", "Giants:"), TERM_YELLOW);
     } else if (flags.has(TR_SLAY_GIANT)) {
-        mindam = calc_expect_dice(player, mindice, 3, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 3, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 3, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 3, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("巨人:", "Giants:"), TERM_YELLOW);
     }
 
     if (flags.has(TR_KILL_DRAGON)) {
-        mindam = calc_expect_dice(player, mindice, 5, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 5, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 5, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 5, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("竜:", "Dragons:"), TERM_YELLOW);
     } else if (flags.has(TR_SLAY_DRAGON)) {
-        mindam = calc_expect_dice(player, mindice, 3, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 3, 1, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 3, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 3, 1, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("竜:", "Dragons:"), TERM_YELLOW);
     }
 
     if (flags.has(TR_BRAND_ACID)) {
-        mindam = calc_expect_dice(player, mindice, 5, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 5, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 5, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 5, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("酸属性:", "Acid:"), TERM_RED);
     }
 
     if (flags.has(TR_BRAND_ELEC)) {
-        mindam = calc_expect_dice(player, mindice, 5, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 5, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 5, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 5, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("電属性:", "Elec:"), TERM_RED);
     }
 
     if (flags.has(TR_BRAND_FIRE)) {
-        mindam = calc_expect_dice(player, mindice, 5, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 5, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 5, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 5, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("炎属性:", "Fire:"), TERM_RED);
     }
 
     if (flags.has(TR_BRAND_COLD)) {
-        mindam = calc_expect_dice(player, mindice, 5, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 5, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 5, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 5, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("冷属性:", "Cold:"), TERM_RED);
     }
 
     if (flags.has(TR_BRAND_POIS)) {
-        mindam = calc_expect_dice(player, mindice, 5, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
-        maxdam = calc_expect_dice(player, maxdice, 5, 2, force, o_ptr->weight, o_ptr->to_h, player.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        mindam = calc_expect_dice(creature, mindice, 5, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
+        maxdam = calc_expect_dice(creature, maxdice, 5, 2, force, o_ptr->weight, o_ptr->to_h, creature.to_h[0], dokubari, impact, vorpal_mult, vorpal_div);
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("毒属性:", "Poison:"), TERM_RED);
     }
 }
@@ -256,36 +255,35 @@ static void compare_weapon_aux(CreatureEntity &creature, ItemEntity *o_ptr, int 
  * Displays all info about a weapon
  *
  * Only accurate for the current weapon, because it includes
- * various info about the player's +to_dam and number of blows.
+ * various info about the creature's +to_dam and number of blows.
  */
 static void list_weapon(CreatureEntity &creature, const ItemEntity &item, TERM_LEN row, TERM_LEN col)
 {
-    auto &player = creature;
-    const auto eff_dd = item.damage_dice.num + player.damage_dice_bonus[0].num;
-    const auto eff_ds = item.damage_dice.sides + player.damage_dice_bonus[0].sides;
-    const auto hit_reliability = player.skill_thn + (player.to_h[0] + item.to_h) * BTH_PLUS_ADJ;
-    const auto item_name = describe_flavor(player, item, OD_NAME_ONLY);
+    const auto eff_dd = item.damage_dice.num + creature.damage_dice_bonus[0].num;
+    const auto eff_ds = item.damage_dice.sides + creature.damage_dice_bonus[0].sides;
+    const auto hit_reliability = creature.skill_thn + (creature.to_h[0] + item.to_h) * BTH_PLUS_ADJ;
+    const auto item_name = describe_flavor(creature, item, OD_NAME_ONLY);
     c_put_str(TERM_YELLOW, item_name, row, col);
-    put_str(format(_("攻撃回数: %d", "Number of Blows: %d"), player.num_blow[0]), row + 1, col);
+    put_str(format(_("攻撃回数: %d", "Number of Blows: %d"), creature.num_blow[0]), row + 1, col);
 
     put_str(_("命中率:  0  50 100 150 200 (敵のAC)", "To Hit:  0  50 100 150 200 (AC)"), row + 2, col);
     put_str(format("        %2d  %2d  %2d  %2d  %2d (%%)",
-                (int)hit_chance(player, hit_reliability, 0),
-                (int)hit_chance(player, hit_reliability, 50),
-                (int)hit_chance(player, hit_reliability, 100),
-                (int)hit_chance(player, hit_reliability, 150),
-                (int)hit_chance(player, hit_reliability, 200)),
+                (int)hit_chance(creature, hit_reliability, 0),
+                (int)hit_chance(creature, hit_reliability, 50),
+                (int)hit_chance(creature, hit_reliability, 100),
+                (int)hit_chance(creature, hit_reliability, 150),
+                (int)hit_chance(creature, hit_reliability, 200)),
         row + 3, col);
     c_put_str(TERM_YELLOW, _("可能なダメージ:", "Possible Damage:"), row + 5, col);
 
     put_str(format(_("攻撃一回につき %d-%d", "One Strike: %d-%d damage"),
-                (int)(eff_dd + item.to_d + player.to_d[0]),
-                (int)(eff_ds * eff_dd + item.to_d + player.to_d[0])),
+                (int)(eff_dd + item.to_d + creature.to_d[0]),
+                (int)(eff_ds * eff_dd + item.to_d + creature.to_d[0])),
         row + 6, col + 1);
 
     put_str(format(_("１ターンにつき %d-%d", "One Attack: %d-%d damage"),
-                (int)(player.num_blow[0] * (eff_dd + item.to_d + player.to_d[0])),
-                (int)(player.num_blow[0] * (eff_ds * eff_dd + item.to_d + player.to_d[0]))),
+                (int)(creature.num_blow[0] * (eff_dd + item.to_d + creature.to_d[0])),
+                (int)(creature.num_blow[0] * (eff_ds * eff_dd + item.to_d + creature.to_d[0]))),
         row + 7, col + 1);
 }
 
@@ -300,7 +298,6 @@ static void list_weapon(CreatureEntity &creature, const ItemEntity &item, TERM_L
  */
 PRICE compare_weapons(CreatureEntity &creature, PRICE bcost)
 {
-    auto &player = creature;
     ItemEntity *o_ptr[2]{};
     TERM_LEN row = 2;
     TERM_LEN wid = 38, mgn = 2;
@@ -312,7 +309,7 @@ PRICE compare_weapons(CreatureEntity &creature, PRICE bcost)
 
     screen_save();
     clear_bldg(0, 22);
-    auto *i_ptr = player.inventory[INVEN_MAIN_HAND].get();
+    auto *i_ptr = creature.inventory[INVEN_MAIN_HAND].get();
     auto orig_weapon = i_ptr->clone();
 
     constexpr auto first_q = _("第一の武器は？", "What is your first weapon? ");
@@ -320,7 +317,7 @@ PRICE compare_weapons(CreatureEntity &creature, PRICE bcost)
 
     short i_idx_first;
     constexpr auto options = USE_EQUIP | USE_INVEN | IGNORE_BOTHHAND_SLOT;
-    o_ptr[0] = choose_object(player, &i_idx_first, first_q, first_s, options, FuncItemTester(&ItemEntity::is_orthodox_melee_weapons));
+    o_ptr[0] = choose_object(creature, &i_idx_first, first_q, first_s, options, FuncItemTester(&ItemEntity::is_orthodox_melee_weapons));
     if (!o_ptr[0]) {
         screen_load();
         return 0;
@@ -339,7 +336,7 @@ PRICE compare_weapons(CreatureEntity &creature, PRICE bcost)
             }
 
             rfu.set_flag(StatusRecalculatingFlag::BONUS);
-            handle_stuff(player);
+            handle_stuff(creature);
 
             list_weapon(creature, *o_ptr[i], row, col);
             compare_weapon_aux(creature, o_ptr[i], col, row + 8);
@@ -347,7 +344,7 @@ PRICE compare_weapons(CreatureEntity &creature, PRICE bcost)
         }
 
         rfu.set_flag(StatusRecalculatingFlag::BONUS);
-        handle_stuff(player);
+        handle_stuff(creature);
 
         world.character_xtra = old_character_xtra;
 #ifdef JP
@@ -366,7 +363,7 @@ PRICE compare_weapons(CreatureEntity &creature, PRICE bcost)
             break;
         }
 
-        if (total + cost > player.au) {
+        if (total + cost > creature.au) {
             msg_print(_("お金が足りません！", "You don't have enough money!"));
             msg_erase();
             continue;
@@ -375,7 +372,7 @@ PRICE compare_weapons(CreatureEntity &creature, PRICE bcost)
         constexpr auto q = _("第二の武器は？", "What is your second weapon? ");
         constexpr auto s = _("比べるものがありません。", "You have nothing to compare.");
         short i_idx_second;
-        auto *i2_ptr = choose_object(player, &i_idx_second, q, s, (USE_EQUIP | USE_INVEN | IGNORE_BOTHHAND_SLOT), FuncItemTester(&ItemEntity::is_orthodox_melee_weapons));
+        auto *i2_ptr = choose_object(creature, &i_idx_second, q, s, (USE_EQUIP | USE_INVEN | IGNORE_BOTHHAND_SLOT), FuncItemTester(&ItemEntity::is_orthodox_melee_weapons));
         if (!i2_ptr) {
             continue;
         }

--- a/src/market/building-enchanter.cpp
+++ b/src/market/building-enchanter.cpp
@@ -24,9 +24,8 @@
  */
 bool enchant_item(CreatureEntity &creature, PRICE cost, HIT_PROB to_hit, int to_dam, ARMOUR_CLASS to_ac, const ItemTester &item_tester)
 {
-    auto &player = creature;
     clear_bldg(4, 18);
-    int maxenchant = (player.level / 5);
+    int maxenchant = (creature.level / 5);
     prt(format(_("現在のあなたの技量だと、+%d まで改良できます。", "  Based on your skill, we can improve up to +%d."), maxenchant), 5, 0);
     prt(format(_(" 改良の料金は一個につき＄%d です。", "  The price for the service is %d gold per item."), cost), 7, 0);
 
@@ -34,14 +33,14 @@ bool enchant_item(CreatureEntity &creature, PRICE cost, HIT_PROB to_hit, int to_
     constexpr auto s = _("改良できるものがありません。", "You have nothing to improve.");
 
     short i_idx;
-    auto *o_ptr = choose_object(player, &i_idx, q, s, (USE_INVEN | USE_EQUIP | IGNORE_BOTHHAND_SLOT), item_tester);
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, (USE_INVEN | USE_EQUIP | IGNORE_BOTHHAND_SLOT), item_tester);
     if (!o_ptr) {
         return false;
     }
 
     const PRICE total_cost = cost * o_ptr->number;
-    if (player.au < total_cost) {
-        const auto item_name = describe_flavor(player, *o_ptr, OD_NAME_ONLY);
+    if (creature.au < total_cost) {
+        const auto item_name = describe_flavor(creature, *o_ptr, OD_NAME_ONLY);
         msg_format(_("%sを改良するだけのゴールドがありません！", "You do not have the gold to improve %s!"), item_name.data());
         return false;
     }
@@ -76,14 +75,14 @@ bool enchant_item(CreatureEntity &creature, PRICE cost, HIT_PROB to_hit, int to_
         return false;
     }
 
-    const auto item_name = describe_flavor(player, *o_ptr, OD_NAME_AND_ENCHANT);
+    const auto item_name = describe_flavor(creature, *o_ptr, OD_NAME_AND_ENCHANT);
 #ifdef JP
     msg_format("＄%dで%sに改良しました。", total_cost, item_name.data());
 #else
     msg_format("Improved into %s for %d gold.", item_name.data(), total_cost);
 #endif
 
-    player.au -= total_cost;
+    creature.au -= total_cost;
     if (i_idx >= INVEN_MAIN_HAND) {
         calc_android_exp(creature);
     }

--- a/src/market/building-monster.cpp
+++ b/src/market/building-monster.cpp
@@ -26,7 +26,6 @@
  */
 bool research_mon(CreatureEntity &creature)
 {
-    auto &player = creature;
     bool recall = false;
     bool all = false;
     bool uniq = false;
@@ -157,7 +156,7 @@ bool research_mon(CreatureEntity &creature)
 
                 tracker.set_trackee(monrace_id);
                 handle_stuff(creature);
-                screen_roff(player, monrace_id, MONSTER_LORE_RESEARCH);
+                screen_roff(creature, monrace_id, MONSTER_LORE_RESEARCH);
                 notpicked = false;
                 old_sym = *sym;
                 old_i = i;

--- a/src/market/building-quest.cpp
+++ b/src/market/building-quest.cpp
@@ -24,10 +24,9 @@
  */
 static void get_questinfo(CreatureEntity &creature, QuestId quest_id, bool do_init)
 {
-    auto &player = creature;
     quest_text_lines.clear();
 
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     const auto old_quest = floor.quest_number;
     floor.quest_number = quest_id;
 
@@ -66,10 +65,9 @@ static void print_questinfo(CreatureEntity &creature, QuestId quest_id, bool do_
  */
 void castle_quest(CreatureEntity &creature)
 {
-    auto &player = creature;
     clear_bldg(4, 18);
-    const auto &floor = *player.current_floor_ptr;
-    const auto quest_id = i2enum<QuestId>(floor.get_grid(player.get_position()).special);
+    const auto &floor = *creature.current_floor_ptr;
+    const auto quest_id = i2enum<QuestId>(floor.get_grid(creature.get_position()).special);
     if (!inside_quest(quest_id)) {
         put_str(_("今のところクエストはありません。", "I don't have a quest for you at the moment."), 8, 0);
         prt(_("何かキーを押して下さい。", "Hit any key."), 0, 0);
@@ -91,7 +89,7 @@ void castle_quest(CreatureEntity &creature)
         put_str(_("あなたは現在のクエストを終了させていません！", "You have not completed your current quest yet!"), 8, 0);
         put_str(_("CTRL-Qを使えばクエストの状態がチェックできます。", "Use CTRL-Q to check the status of your quest."), 9, 0);
 
-        get_questinfo(player, quest_id, false);
+        get_questinfo(creature, quest_id, false);
         put_str(format(_("現在のクエスト「%s」", "Current quest is '%s'."), quest.name.data()), 11, 0);
 
         if (quest.type != QuestKindType::KILL_LEVEL || quest.dungeon == DungeonId::WILDERNESS) {

--- a/src/market/building-recharger.cpp
+++ b/src/market/building-recharger.cpp
@@ -18,7 +18,7 @@
 /*!
  * @brief 魔道具の使用回数を回復させる施設のメインルーチン / Recharge rods, wands and staffs
  * @details
- * The player can select the number of charges to add\n
+ * The creature can select the number of charges to add\n
  * (up to a limit), and the recharge never fails.\n
  *\n
  * The cost for rods depends on the level of the rod. The prices\n
@@ -28,7 +28,6 @@
  */
 void building_recharge(CreatureEntity &creature)
 {
-    auto &player = creature;
     msg_flag = false;
     clear_bldg(4, 18);
     prt(_("  再充填の費用はアイテムの種類によります。", "  The prices of recharge depend on the type."), 6, 0);
@@ -41,19 +40,19 @@ void building_recharge(CreatureEntity &creature)
     }
 
     /*
-     * We don't want to give the player free info about
+     * We don't want to give the creature free info about
      * the level of the item or the number of charges.
      */
     if (!o_ptr->is_known()) {
         msg_format(_("充填する前に鑑定されている必要があります！", "The item must be identified first!"));
         msg_erase();
-        if ((player.au >= 50) && input_check(_("＄50で鑑定しますか？ ", "Identify for 50 gold? "))) {
-            player.au -= 50;
+        if ((creature.au >= 50) && input_check(_("＄50で鑑定しますか？ ", "Identify for 50 gold? "))) {
+            creature.au -= 50;
             identify_item(creature, o_ptr);
-            const auto item_name = describe_flavor(player, *o_ptr, 0);
+            const auto item_name = describe_flavor(creature, *o_ptr, 0);
             msg_format(_("%s です。", "You have: %s."), item_name.data());
-            autopick_alter_item(player, i_idx, false);
-            building_prt_gold(player.au);
+            autopick_alter_item(creature, i_idx, false);
+            building_prt_gold(creature.au);
         }
 
         return;
@@ -102,8 +101,8 @@ void building_recharge(CreatureEntity &creature)
         return;
     }
 
-    if (player.au < price) {
-        const auto item_name = describe_flavor(player, *o_ptr, OD_NAME_ONLY);
+    if (creature.au < price) {
+        const auto item_name = describe_flavor(creature, *o_ptr, OD_NAME_ONLY);
 #ifdef JP
         msg_format("%sを再充填するには＄%d 必要です！", item_name.data(), price);
 #else
@@ -133,7 +132,7 @@ void building_recharge(CreatureEntity &creature)
         }
 
         const auto mes = _("一回分＄%d で何回分充填しますか？", "Add how many charges for %d gold apiece? ");
-        const auto charges = input_quantity(std::min(player.au / price, max_charges), format(mes, price));
+        const auto charges = input_quantity(std::min(creature.au / price, max_charges), format(mes, price));
         if (charges < 1) {
             return;
         }
@@ -143,7 +142,7 @@ void building_recharge(CreatureEntity &creature)
         o_ptr->ident &= ~(IDENT_EMPTY);
     }
 
-    const auto item_name = describe_flavor(player, *o_ptr, 0);
+    const auto item_name = describe_flavor(creature, *o_ptr, 0);
 #ifdef JP
     msg_format("%sを＄%d で再充填しました。", item_name.data(), price);
 #else
@@ -156,13 +155,13 @@ void building_recharge(CreatureEntity &creature)
     };
     rfu.set_flags(flags);
     rfu.set_flag(SubWindowRedrawingFlag::INVENTORY);
-    player.au -= price;
+    creature.au -= price;
 }
 
 /*!
  * @brief 魔道具の使用回数を回復させる施設の一括処理向けサブルーチン / Recharge rods, wands and staffs
  * @details
- * The player can select the number of charges to add\n
+ * The creature can select the number of charges to add\n
  * (up to a limit), and the recharge never fails.\n
  *\n
  * The cost for rods depends on the level of the rod. The prices\n
@@ -172,7 +171,6 @@ void building_recharge(CreatureEntity &creature)
  */
 void building_recharge_all(CreatureEntity &creature)
 {
-    auto &player = creature;
     msg_flag = false;
     clear_bldg(4, 18);
     prt(_("  再充填の費用はアイテムの種類によります。", "  The prices of recharge depend on the type."), 6, 0);
@@ -180,7 +178,7 @@ void building_recharge_all(CreatureEntity &creature)
     auto price = 0;
     auto total_cost = 0;
     for (short i = 0; i < INVEN_PACK; i++) {
-        const auto &item = *player.inventory[i];
+        const auto &item = *creature.inventory[i];
         if (!item.can_recharge()) {
             continue;
         }
@@ -221,7 +219,7 @@ void building_recharge_all(CreatureEntity &creature)
         return;
     }
 
-    if (player.au < total_cost) {
+    if (creature.au < total_cost) {
         msg_format(_("すべてのアイテムを再充填するには＄%d 必要です！", "You need %d gold to recharge all items!"), total_cost);
         msg_erase();
         return;
@@ -232,14 +230,14 @@ void building_recharge_all(CreatureEntity &creature)
     }
 
     for (short i = 0; i < INVEN_PACK; i++) {
-        auto *o_ptr = player.inventory[i].get();
+        auto *o_ptr = creature.inventory[i].get();
         if (!o_ptr->can_recharge()) {
             continue;
         }
 
         if (!o_ptr->is_known()) {
             identify_item(creature, o_ptr);
-            autopick_alter_item(player, i, false);
+            autopick_alter_item(creature, i, false);
         }
 
         const auto base_pval = o_ptr->get_baseitem_pval();
@@ -275,5 +273,5 @@ void building_recharge_all(CreatureEntity &creature)
     };
     rfu.set_flags(flags);
     rfu.set_flag(SubWindowRedrawingFlag::INVENTORY);
-    player.au -= total_cost;
+    creature.au -= total_cost;
 }

--- a/src/market/building-service.cpp
+++ b/src/market/building-service.cpp
@@ -17,17 +17,16 @@
  */
 bool is_owner(CreatureEntity &creature, const building_type &bldg)
 {
-    auto &player = creature;
     constexpr auto building_owner = 2;
-    if (bldg.member_class[enum2i(player.pclass)] == building_owner) {
+    if (bldg.member_class[enum2i(creature.pclass)] == building_owner) {
         return true;
     }
 
-    if (bldg.member_race[enum2i(player.prace)] == building_owner) {
+    if (bldg.member_race[enum2i(creature.prace)] == building_owner) {
         return true;
     }
 
-    PlayerRealm pr(player);
+    PlayerRealm pr(creature);
     const auto realm1 = pr.realm1().to_enum();
     const auto realm2 = pr.realm2().to_enum();
     if ((PlayerRealm::is_magic(realm1) && (bldg.member_realm[enum2i(realm1)] == building_owner)) || (PlayerRealm::is_magic(realm2) && (bldg.member_realm[enum2i(realm2)] == building_owner))) {
@@ -49,16 +48,15 @@ bool is_owner(CreatureEntity &creature, const building_type &bldg)
  */
 bool is_member(CreatureEntity &creature, const building_type &bldg)
 {
-    auto &player = creature;
-    if (static_cast<bool>(bldg.member_class[enum2i(player.pclass)])) {
+    if (static_cast<bool>(bldg.member_class[enum2i(creature.pclass)])) {
         return true;
     }
 
-    if (static_cast<bool>(bldg.member_race[enum2i(player.prace)])) {
+    if (static_cast<bool>(bldg.member_race[enum2i(creature.prace)])) {
         return true;
     }
 
-    PlayerRealm pr(player);
+    PlayerRealm pr(creature);
     const auto realm1 = pr.realm1().to_enum();
     const auto realm2 = pr.realm2().to_enum();
     if ((PlayerRealm::is_magic(realm1) && bldg.member_realm[enum2i(realm1)]) || (PlayerRealm::is_magic(realm2) && bldg.member_realm[enum2i(realm2)])) {

--- a/src/market/melee-arena.cpp
+++ b/src/market/melee-arena.cpp
@@ -44,7 +44,6 @@ void display_gladiators()
  */
 bool melee_arena_comm(CreatureEntity &creature)
 {
-    auto &player = creature;
     auto &world = AngbandWorld::get_instance();
     if ((world.game_turn - world.arena_start_turn) > TURNS_PER_TICK * 250) {
         auto &melee_arena = MeleeArena::get_instance();
@@ -55,7 +54,7 @@ bool melee_arena_comm(CreatureEntity &creature)
     screen_save();
 
     /* No money */
-    if (player.au <= 1) {
+    if (creature.au <= 1) {
         msg_print(_("おい！おまえ一文なしじゃないか！こっから出ていけ！", "Hey! You don't have gold - get out of here!"));
         msg_erase();
         screen_load();
@@ -87,8 +86,8 @@ bool melee_arena_comm(CreatureEntity &creature)
         }
     }
 
-    auto maxbet = player.level * 200;
-    maxbet = std::min(maxbet, player.au);
+    auto maxbet = creature.level * 200;
+    maxbet = std::min(maxbet, creature.au);
     constexpr auto prompt = _("賭け金？", "Your wager? ");
     const auto wager = input_integer(prompt, 1, maxbet, 1);
     if (!wager) {
@@ -96,7 +95,7 @@ bool melee_arena_comm(CreatureEntity &creature)
         return false;
     }
 
-    if (wager > player.au) {
+    if (wager > creature.au) {
         msg_print(_("おい！金が足りないじゃないか！出ていけ！", "Hey! You don't have the gold - get out of here!"));
         msg_erase();
         screen_load();
@@ -105,12 +104,12 @@ bool melee_arena_comm(CreatureEntity &creature)
 
     msg_erase();
     melee_arena.set_wager(*wager);
-    player.au -= *wager;
-    reset_tim_flags(player);
+    creature.au -= *wager;
+    reset_tim_flags(creature);
 
     FloorChangeModesStore::get_instace()->set(FloorChangeMode::SAVE_FLOORS);
     AngbandSystem::get_instance().set_phase_out(true);
-    player.leaving = true;
+    creature.leaving = true;
     screen_load();
     return true;
 }

--- a/src/market/play-gamble.cpp
+++ b/src/market/play-gamble.cpp
@@ -19,15 +19,14 @@
  */
 void gamble_comm(CreatureEntity &creature, int cmd)
 {
-    auto &player = creature;
     screen_save();
     if (cmd == BACT_GAMBLE_RULES) {
-        FileDisplayer(player.name).display(true, _("jgambling.txt", "gambling.txt"), 0, 0);
+        FileDisplayer(creature.name).display(true, _("jgambling.txt", "gambling.txt"), 0, 0);
         screen_load();
         return;
     }
 
-    if (player.au < 1) {
+    if (creature.au < 1) {
         msg_print(_("おい！おまえ一文なしじゃないか！こっから出ていけ！", "Hey! You don't have gold - get out of here!"));
         msg_erase();
         screen_load();
@@ -35,8 +34,8 @@ void gamble_comm(CreatureEntity &creature, int cmd)
     }
 
     clear_bldg(5, 23);
-    auto maxbet = player.level * 200;
-    maxbet = std::min(maxbet, player.au);
+    auto maxbet = creature.level * 200;
+    maxbet = std::min(maxbet, creature.au);
     constexpr auto prompt = _("賭け金？", "Your wager ?");
     const auto wager = input_integer(prompt, 1, maxbet, 1);
     if (!wager) {
@@ -45,7 +44,7 @@ void gamble_comm(CreatureEntity &creature, int cmd)
         return;
     }
 
-    if (wager > player.au) {
+    if (wager > creature.au) {
         msg_print(_("おい！金が足りないじゃないか！出ていけ！", "Hey! You don't have the gold - get out of here!"));
         msg_erase();
         screen_load();
@@ -55,11 +54,11 @@ void gamble_comm(CreatureEntity &creature, int cmd)
     msg_erase();
     auto win = 0;
     auto odds = 0;
-    auto oldgold = player.au;
+    auto oldgold = creature.au;
     prt(format(_("ゲーム前の所持金: %9d", "Gold before game: %9d"), oldgold), 20, 2);
     prt(format(_("現在の掛け金:     %9d", "Current Wager:    %9d"), *wager), 21, 2);
     while (true) {
-        player.au -= *wager;
+        creature.au -= *wager;
         switch (cmd) {
         case BACT_IN_BETWEEN: {
             c_put_str(TERM_GREEN, _("イン・ビトイーン", "In Between"), 5, 2);
@@ -225,21 +224,21 @@ void gamble_comm(CreatureEntity &creature, int cmd)
 
         if (win) {
             prt(_("あなたの勝ち", "YOU WON"), 16, 37);
-            player.au += odds * *wager;
+            creature.au += odds * *wager;
             prt(format(_("倍率: %d", "Payoff: %d"), odds), 17, 37);
         } else {
             prt(_("あなたの負け", "You Lost"), 16, 37);
             prt("", 17, 37);
         }
 
-        prt(format(_("現在の所持金:     %9d", "Current Gold:     %9d"), player.au), 22, 2);
+        prt(format(_("現在の所持金:     %9d", "Current Gold:     %9d"), creature.au), 22, 2);
         prt(_("もう一度(Y/N)？", "Again(Y/N)?"), 18, 37);
         move_cursor(18, 52);
         auto again = inkey();
         prt("", 16, 37);
         prt("", 17, 37);
         prt("", 18, 37);
-        if (wager > player.au) {
+        if (wager > creature.au) {
             msg_print(_("おい！金が足りないじゃないか！ここから出て行け！", "Hey! You don't have the gold - get out of here!"));
             msg_erase();
             break;
@@ -253,12 +252,12 @@ void gamble_comm(CreatureEntity &creature, int cmd)
     }
 
     prt("", 18, 37);
-    if (player.au >= oldgold) {
+    if (creature.au >= oldgold) {
         msg_print(_("「今回は儲けたな！でも次はこっちが勝ってやるからな、絶対に！」", "You came out a winner! We'll win next time, I'm sure."));
-        chg_virtue(static_cast<CreatureEntity &>(player), Virtue::CHANCE, 3);
+        chg_virtue(static_cast<CreatureEntity &>(creature), Virtue::CHANCE, 3);
     } else {
         msg_print(_("「金をスッてしまったな、わはは！うちに帰った方がいいぜ。」", "You lost gold! Haha, better head home."));
-        chg_virtue(static_cast<CreatureEntity &>(player), Virtue::CHANCE, -3);
+        chg_virtue(static_cast<CreatureEntity &>(creature), Virtue::CHANCE, -3);
     }
 
     msg_erase();

--- a/src/melee/melee-spell-flags-checker.cpp
+++ b/src/melee/melee-spell-flags-checker.cpp
@@ -26,12 +26,11 @@
 
 static void decide_melee_spell_target(CreatureEntity &creature, melee_spell_type *ms_ptr)
 {
-    auto &player = creature;
-    if ((player.pet_t_m_idx == 0) || !ms_ptr->pet) {
+    if ((creature.pet_t_m_idx == 0) || !ms_ptr->pet) {
         return;
     }
 
-    ms_ptr->target_idx = player.pet_t_m_idx;
+    ms_ptr->target_idx = creature.pet_t_m_idx;
     const auto &floor = *creature.current_floor_ptr;
     ms_ptr->t_ptr = &floor.get_monster(ms_ptr->target_idx);
     if ((ms_ptr->m_idx == ms_ptr->target_idx) || !projectable(floor, ms_ptr->m_ptr->get_position(), ms_ptr->t_ptr->get_position())) {
@@ -55,8 +54,7 @@ static void decide_indirection_melee_spell(CreatureEntity &creature, melee_spell
 
     ms_ptr->t_ptr = &floor.get_monster(ms_ptr->target_idx);
     const auto &monster_to = *ms_ptr->t_ptr;
-    auto &player = creature;
-    if ((ms_ptr->m_idx == ms_ptr->target_idx) || ((ms_ptr->target_idx != player.pet_t_m_idx) && !monster_from.is_hostile_to_melee(monster_to))) {
+    if ((ms_ptr->m_idx == ms_ptr->target_idx) || ((ms_ptr->target_idx != creature.pet_t_m_idx) && !monster_from.is_hostile_to_melee(monster_to))) {
         ms_ptr->target_idx = 0;
         return;
     }
@@ -215,8 +213,7 @@ static void check_melee_spell_rocket(CreatureEntity &creature, melee_spell_type 
 
 static void check_melee_spell_beam(CreatureEntity &creature, melee_spell_type *ms_ptr)
 {
-    auto &player = creature;
-    if (ms_ptr->ability_flags.has_none_of(RF_ABILITY_BEAM_MASK) || direct_beam(player, *ms_ptr->m_ptr, ms_ptr->t_ptr->get_position())) {
+    if (ms_ptr->ability_flags.has_none_of(RF_ABILITY_BEAM_MASK) || direct_beam(creature, *ms_ptr->m_ptr, ms_ptr->t_ptr->get_position())) {
         return;
     }
 
@@ -229,20 +226,19 @@ static void check_melee_spell_breath(CreatureEntity &creature, melee_spell_type 
         return;
     }
 
-    auto &player = creature;
     POSITION rad = ms_ptr->r_ptr->misc_flags.has(MonsterMiscType::POWERFUL) ? 3 : 2;
-    if (!breath_direct(player, ms_ptr->m_ptr->get_position(), ms_ptr->t_ptr->get_position(), rad, AttributeType::NONE, true)) {
+    if (!breath_direct(creature, ms_ptr->m_ptr->get_position(), ms_ptr->t_ptr->get_position(), rad, AttributeType::NONE, true)) {
         ms_ptr->ability_flags.reset(RF_ABILITY_BREATH_MASK);
         return;
     }
 
-    if (ms_ptr->ability_flags.has(MonsterAbilityType::BR_LITE) && !breath_direct(player, ms_ptr->m_ptr->get_position(),
+    if (ms_ptr->ability_flags.has(MonsterAbilityType::BR_LITE) && !breath_direct(creature, ms_ptr->m_ptr->get_position(),
                                                                       ms_ptr->t_ptr->get_position(), rad, AttributeType::LITE, true)) {
         ms_ptr->ability_flags.reset(MonsterAbilityType::BR_LITE);
         return;
     }
 
-    if (ms_ptr->ability_flags.has(MonsterAbilityType::BR_DISI) && !breath_direct(player, ms_ptr->m_ptr->get_position(),
+    if (ms_ptr->ability_flags.has(MonsterAbilityType::BR_DISI) && !breath_direct(creature, ms_ptr->m_ptr->get_position(),
                                                                       ms_ptr->t_ptr->get_position(), rad, AttributeType::DISINTEGRATE, true)) {
         ms_ptr->ability_flags.reset(MonsterAbilityType::BR_DISI);
     }
@@ -254,9 +250,8 @@ static void check_melee_spell_special(CreatureEntity &creature, melee_spell_type
         return;
     }
 
-    auto &player = creature;
     if (ms_ptr->m_ptr->r_idx == MonraceId::ROLENTO) {
-        if ((player.pet_extra_flags & (PF_ATTACK_SPELL | PF_SUMMON_SPELL)) != (PF_ATTACK_SPELL | PF_SUMMON_SPELL)) {
+        if ((creature.pet_extra_flags & (PF_ATTACK_SPELL | PF_SUMMON_SPELL)) != (PF_ATTACK_SPELL | PF_SUMMON_SPELL)) {
             ms_ptr->ability_flags.reset(MonsterAbilityType::SPECIAL);
         }
 
@@ -264,7 +259,7 @@ static void check_melee_spell_special(CreatureEntity &creature, melee_spell_type
     }
 
     if (ms_ptr->r_ptr->symbol_char_is_any_of("B")) {
-        if ((player.pet_extra_flags & (PF_ATTACK_SPELL | PF_TELEPORT)) != (PF_ATTACK_SPELL | PF_TELEPORT)) {
+        if ((creature.pet_extra_flags & (PF_ATTACK_SPELL | PF_TELEPORT)) != (PF_ATTACK_SPELL | PF_TELEPORT)) {
             ms_ptr->ability_flags.reset(MonsterAbilityType::SPECIAL);
         }
 
@@ -289,21 +284,20 @@ static void check_pet(CreatureEntity &creature, melee_spell_type *ms_ptr)
         return;
     }
 
-    auto &player = creature;
     ms_ptr->ability_flags.reset({ MonsterAbilityType::SHRIEK, MonsterAbilityType::DARKNESS, MonsterAbilityType::TRAPS });
-    if (!(player.pet_extra_flags & PF_TELEPORT)) {
+    if (!(creature.pet_extra_flags & PF_TELEPORT)) {
         ms_ptr->ability_flags.reset({ MonsterAbilityType::BLINK, MonsterAbilityType::TPORT, MonsterAbilityType::TELE_TO, MonsterAbilityType::TELE_AWAY, MonsterAbilityType::TELE_LEVEL });
     }
 
-    if (!(player.pet_extra_flags & PF_ATTACK_SPELL)) {
+    if (!(creature.pet_extra_flags & PF_ATTACK_SPELL)) {
         ms_ptr->ability_flags.reset(RF_ABILITY_ATTACK_MASK);
     }
 
-    if (!(player.pet_extra_flags & PF_SUMMON_SPELL)) {
+    if (!(creature.pet_extra_flags & PF_SUMMON_SPELL)) {
         ms_ptr->ability_flags.reset(RF_ABILITY_SUMMON_MASK);
     }
 
-    if (!(player.pet_extra_flags & PF_BALL_SPELL) && !ms_ptr->m_ptr->is_riding()) {
+    if (!(creature.pet_extra_flags & PF_BALL_SPELL) && !ms_ptr->m_ptr->is_riding()) {
         check_melee_spell_distance(creature, ms_ptr);
         check_melee_spell_rocket(creature, ms_ptr);
         check_melee_spell_beam(creature, ms_ptr);
@@ -319,24 +313,23 @@ static void check_non_stupid(CreatureEntity &creature, melee_spell_type *ms_ptr)
         return;
     }
 
-    auto &player = creature;
-    if (ms_ptr->ability_flags.has_any_of(RF_ABILITY_BOLT_MASK) && !clean_shot(player, ms_ptr->m_ptr->y, ms_ptr->m_ptr->x, ms_ptr->t_ptr->y, ms_ptr->t_ptr->x, ms_ptr->pet)) {
+    if (ms_ptr->ability_flags.has_any_of(RF_ABILITY_BOLT_MASK) && !clean_shot(creature, ms_ptr->m_ptr->y, ms_ptr->m_ptr->x, ms_ptr->t_ptr->y, ms_ptr->t_ptr->x, ms_ptr->pet)) {
         ms_ptr->ability_flags.reset(RF_ABILITY_BOLT_MASK);
     }
 
-    if (ms_ptr->ability_flags.has_any_of(RF_ABILITY_SUMMON_MASK) && !(summon_possible(player, ms_ptr->t_ptr->y, ms_ptr->t_ptr->x))) {
+    if (ms_ptr->ability_flags.has_any_of(RF_ABILITY_SUMMON_MASK) && !(summon_possible(creature, ms_ptr->t_ptr->y, ms_ptr->t_ptr->x))) {
         ms_ptr->ability_flags.reset(RF_ABILITY_SUMMON_MASK);
     }
 
-    if (ms_ptr->ability_flags.has(MonsterAbilityType::DISPEL) && !dispel_check_monster(player, ms_ptr->m_idx, ms_ptr->target_idx)) {
+    if (ms_ptr->ability_flags.has(MonsterAbilityType::DISPEL) && !dispel_check_monster(creature, ms_ptr->m_idx, ms_ptr->target_idx)) {
         ms_ptr->ability_flags.reset(MonsterAbilityType::DISPEL);
     }
 
-    if (ms_ptr->ability_flags.has(MonsterAbilityType::RAISE_DEAD) && !raise_possible(player, *ms_ptr->m_ptr)) {
+    if (ms_ptr->ability_flags.has(MonsterAbilityType::RAISE_DEAD) && !raise_possible(creature, *ms_ptr->m_ptr)) {
         ms_ptr->ability_flags.reset(MonsterAbilityType::RAISE_DEAD);
     }
 
-    if (ms_ptr->ability_flags.has(MonsterAbilityType::SPECIAL) && (ms_ptr->m_ptr->r_idx == MonraceId::ROLENTO) && !summon_possible(player, ms_ptr->t_ptr->y, ms_ptr->t_ptr->x)) {
+    if (ms_ptr->ability_flags.has(MonsterAbilityType::SPECIAL) && (ms_ptr->m_ptr->r_idx == MonraceId::ROLENTO) && !summon_possible(creature, ms_ptr->t_ptr->y, ms_ptr->t_ptr->x)) {
         ms_ptr->ability_flags.reset(MonsterAbilityType::SPECIAL);
     }
 }
@@ -365,8 +358,7 @@ static bool set_melee_spell_set(CreatureEntity &creature, melee_spell_type *ms_p
 
     EnumClassFlagGroup<MonsterAbilityType>::get_flags(ms_ptr->ability_flags, std::back_inserter(ms_ptr->spells));
 
-    auto &player = creature;
-    return !ms_ptr->spells.empty() && player.playing && !creature.is_dead() && !player.leaving;
+    return !ms_ptr->spells.empty() && creature.playing && !creature.is_dead() && !creature.leaving;
 }
 
 bool check_melee_spell_set(CreatureEntity &creature, melee_spell_type *ms_ptr)

--- a/src/melee/melee-spell-util.cpp
+++ b/src/melee/melee-spell-util.cpp
@@ -16,8 +16,7 @@ melee_spell_type::melee_spell_type(CreatureEntity &creature, MONSTER_IDX m_idx)
     this->m_ptr = &floor.get_monster(m_idx);
     this->t_ptr = nullptr;
     this->r_ptr = &this->m_ptr->get_monrace();
-    auto &player = creature;
-    this->see_m = is_seen(player, *this->m_ptr);
+    this->see_m = is_seen(creature, *this->m_ptr);
     this->maneable = floor.has_los_at(this->m_ptr->get_position());
     this->pet = this->m_ptr->is_pet();
     const auto &dungeon = floor.get_dungeon_definition();

--- a/src/melee/melee-spell.cpp
+++ b/src/melee/melee-spell.cpp
@@ -44,8 +44,7 @@ static bool try_melee_spell(CreatureEntity &creature, melee_spell_type *ms_ptr)
 
 static bool disturb_melee_spell(CreatureEntity &creature, melee_spell_type *ms_ptr)
 {
-    auto &player = creature;
-    if (spell_is_inate(ms_ptr->thrown_spell) || !SpellHex(player).check_hex_barrier(ms_ptr->m_idx, HEX_ANTI_MAGIC)) {
+    if (spell_is_inate(ms_ptr->thrown_spell) || !SpellHex(creature).check_hex_barrier(ms_ptr->m_idx, HEX_ANTI_MAGIC)) {
         return false;
     }
 
@@ -58,12 +57,11 @@ static bool disturb_melee_spell(CreatureEntity &creature, melee_spell_type *ms_p
 
 static void process_special_melee_spell(CreatureEntity &creature, melee_spell_type *ms_ptr)
 {
-    auto &player = creature;
-    CreatureClass pc(player);
+    CreatureClass pc(creature);
     bool is_special_magic = ms_ptr->m_ptr->get_monster_profile().ml;
     is_special_magic &= ms_ptr->maneable;
     is_special_magic &= AngbandWorld::get_instance().timewalk_m_idx == 0;
-    is_special_magic &= !player.is_blind();
+    is_special_magic &= !creature.is_blind();
     is_special_magic &= pc.equals(PlayerClassType::IMITATOR);
     is_special_magic &= ms_ptr->thrown_spell != MonsterAbilityType::SPECIAL;
     if (!is_special_magic) {
@@ -101,7 +99,7 @@ static void process_rememberance(melee_spell_type *ms_ptr)
  * @param m_idx 術者のモンスターID
  * @return 実際に特殊能力を使った場合TRUEを返す
  * @details
- * The player is only disturbed if able to be affected by the spell.
+ * The creature is only disturbed if able to be affected by the spell.
  */
 bool monst_spell_monst(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
@@ -121,8 +119,7 @@ bool monst_spell_monst(CreatureEntity &creature, MONSTER_IDX m_idx)
         return true;
     }
 
-    auto &player = creature;
-    ms_ptr->can_remember = is_original_ap_and_seen(player, *ms_ptr->m_ptr);
+    ms_ptr->can_remember = is_original_ap_and_seen(creature, *ms_ptr->m_ptr);
     const auto res = monspell_to_monster(creature, ms_ptr->thrown_spell, ms_ptr->y, ms_ptr->x, m_idx, ms_ptr->target_idx, false);
     if (!res.valid) {
         return false;
@@ -131,7 +128,7 @@ bool monst_spell_monst(CreatureEntity &creature, MONSTER_IDX m_idx)
     ms_ptr->dam = res.dam;
     process_special_melee_spell(creature, ms_ptr);
     process_rememberance(ms_ptr);
-    if (player.is_dead() && (ms_ptr->r_ptr->r_deaths < MAX_SHORT) && !creature.current_floor_ptr->inside_arena) {
+    if (creature.is_dead() && (ms_ptr->r_ptr->r_deaths < MAX_SHORT) && !creature.current_floor_ptr->inside_arena) {
         ms_ptr->r_ptr->r_deaths++;
     }
 

--- a/src/melee/melee-switcher.cpp
+++ b/src/melee/melee-switcher.cpp
@@ -33,16 +33,14 @@ static bool monster_has_chaos_resist(CreatureEntity &creature, const CreatureEnt
     auto &monrace = monster.get_monrace();
     if (monrace.resistance_flags.has(MonsterResistanceType::RESIST_CHAOS)) {
         if (creature.is_player()) {
-            auto &player = creature;
-            if (is_original_ap_and_seen(player, monster)) {
+            if (is_original_ap_and_seen(creature, monster)) {
                 monrace.r_resistance_flags.set(MonsterResistanceType::RESIST_CHAOS);
             }
         }
         return true;
     } else if (monrace.kind_flags.has(MonsterKindType::DEMON) && one_in_(3)) {
         if (creature.is_player()) {
-            auto &player = creature;
-            if (is_original_ap_and_seen(player, monster)) {
+            if (is_original_ap_and_seen(creature, monster)) {
                 monrace.r_kind_flags.set(MonsterKindType::DEMON);
             }
         }

--- a/src/melee/melee-util.cpp
+++ b/src/melee/melee-util.cpp
@@ -17,10 +17,9 @@ mam_type *initialize_mam_type(CreatureEntity &creature, mam_type *mam_ptr, MONST
     mam_ptr->t_ptr = &creature.current_floor_ptr->get_monster(t_idx);
     mam_ptr->damage = 0;
     if (creature.is_player()) {
-        auto &player = creature;
-        mam_ptr->see_m = is_seen(player, *mam_ptr->m_ptr);
-        mam_ptr->see_t = is_seen(player, *mam_ptr->t_ptr);
-        mam_ptr->do_silly_attack = one_in_(2) && player.effects()->hallucination().is_hallucinated();
+        mam_ptr->see_m = is_seen(creature, *mam_ptr->m_ptr);
+        mam_ptr->see_t = is_seen(creature, *mam_ptr->t_ptr);
+        mam_ptr->do_silly_attack = one_in_(2) && creature.effects()->hallucination().is_hallucinated();
     } else {
         mam_ptr->see_m = false;
         mam_ptr->see_t = false;

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -80,14 +80,13 @@ static void process_blow_effect(CreatureEntity &creature, mam_type *mam_ptr)
 
 static void aura_fire_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
 {
-    auto &player = creature;
     auto &monrace = mam_ptr->m_ptr->get_monrace();
     auto &monrace_target = mam_ptr->t_ptr->get_monrace();
     if (monrace_target.aura_flags.has_not(MonsterAuraType::FIRE) || !mam_ptr->m_ptr->is_valid()) {
         return;
     }
 
-    if (monrace.resistance_flags.has_any_of(RFR_EFF_IM_FIRE_MASK) && is_original_ap_and_seen(player, *mam_ptr->m_ptr)) {
+    if (monrace.resistance_flags.has_any_of(RFR_EFF_IM_FIRE_MASK) && is_original_ap_and_seen(creature, *mam_ptr->m_ptr)) {
         monrace.r_resistance_flags.set(monrace.resistance_flags & RFR_EFF_IM_FIRE_MASK);
         return;
     }
@@ -96,7 +95,7 @@ static void aura_fire_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
         msg_format(_("%s^は突然熱くなった！", "%s^ is suddenly very hot!"), mam_ptr->m_name);
     }
 
-    if (mam_ptr->m_ptr->get_monster_profile().ml && is_original_ap_and_seen(player, *mam_ptr->t_ptr)) {
+    if (mam_ptr->m_ptr->get_monster_profile().ml && is_original_ap_and_seen(creature, *mam_ptr->t_ptr)) {
         monrace_target.aura_flags.set(MonsterAuraType::FIRE);
     }
 
@@ -107,7 +106,6 @@ static void aura_fire_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
 
 static void aura_cold_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
 {
-    auto &player = creature;
     const auto &monster = *mam_ptr->m_ptr;
     auto &monrace = monster.get_monrace();
     auto &monrace_target = mam_ptr->t_ptr->get_monrace();
@@ -115,7 +113,7 @@ static void aura_cold_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
         return;
     }
 
-    if (monrace.resistance_flags.has_any_of(RFR_EFF_IM_COLD_MASK) && is_original_ap_and_seen(player, monster)) {
+    if (monrace.resistance_flags.has_any_of(RFR_EFF_IM_COLD_MASK) && is_original_ap_and_seen(creature, monster)) {
         monrace.r_resistance_flags.set(monrace.resistance_flags & RFR_EFF_IM_COLD_MASK);
         return;
     }
@@ -124,7 +122,7 @@ static void aura_cold_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
         msg_format(_("%s^は突然寒くなった！", "%s^ is suddenly very cold!"), mam_ptr->m_name);
     }
 
-    if (monster.get_monster_profile().ml && is_original_ap_and_seen(player, *mam_ptr->t_ptr)) {
+    if (monster.get_monster_profile().ml && is_original_ap_and_seen(creature, *mam_ptr->t_ptr)) {
         monrace_target.aura_flags.set(MonsterAuraType::COLD);
     }
 
@@ -135,7 +133,6 @@ static void aura_cold_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
 
 static void aura_elec_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
 {
-    auto &player = creature;
     const auto &monster = *mam_ptr->m_ptr;
     auto &monrace = monster.get_monrace();
     auto &monrace_target = mam_ptr->t_ptr->get_monrace();
@@ -143,7 +140,7 @@ static void aura_elec_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
         return;
     }
 
-    if (monrace.resistance_flags.has_any_of(RFR_EFF_IM_ELEC_MASK) && is_original_ap_and_seen(player, monster)) {
+    if (monrace.resistance_flags.has_any_of(RFR_EFF_IM_ELEC_MASK) && is_original_ap_and_seen(creature, monster)) {
         monrace.r_resistance_flags.set(monrace.resistance_flags & RFR_EFF_IM_ELEC_MASK);
         return;
     }
@@ -152,7 +149,7 @@ static void aura_elec_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
         msg_format(_("%s^は電撃を食らった！", "%s^ gets zapped!"), mam_ptr->m_name);
     }
 
-    if (monster.get_monster_profile().ml && is_original_ap_and_seen(player, *mam_ptr->t_ptr)) {
+    if (monster.get_monster_profile().ml && is_original_ap_and_seen(creature, *mam_ptr->t_ptr)) {
         monrace_target.aura_flags.set(MonsterAuraType::ELEC);
     }
 
@@ -261,8 +258,7 @@ static void process_melee(CreatureEntity &creature, mam_type *mam_ptr)
 static void thief_runaway_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
 {
     if (creature.is_player()) {
-        auto &player = creature;
-        if (SpellHex(player).check_hex_barrier(mam_ptr->m_idx, HEX_ANTI_TELE)) {
+        if (SpellHex(creature).check_hex_barrier(mam_ptr->m_idx, HEX_ANTI_TELE)) {
             if (mam_ptr->see_m) {
                 msg_print(_("泥棒は笑って逃げ...ようとしたがバリアに防がれた。", "The thief flees laughing...? But a magic barrier obstructs it."));
             } else if (mam_ptr->known) {
@@ -289,11 +285,10 @@ static void explode_monster_by_melee(CreatureEntity &creature, mam_type *mam_ptr
     if (!creature.is_player()) {
         return;
     }
-    auto &player = creature;
 
     sound(SoundKind::EXPLODE);
     (void)set_monster_invulner(*creature.current_floor_ptr, mam_ptr->m_idx, 0, false);
-    mon_take_hit_mon(player, mam_ptr->m_idx, mam_ptr->m_ptr->hp + 1, &mam_ptr->dead, &mam_ptr->fear,
+    mon_take_hit_mon(creature, mam_ptr->m_idx, mam_ptr->m_ptr->hp + 1, &mam_ptr->dead, &mam_ptr->fear,
         _("は爆発して粉々になった。", " explodes into tiny shreds."), mam_ptr->m_idx);
     mam_ptr->blinked = false;
 }
@@ -328,8 +323,7 @@ static void repeat_melee(CreatureEntity &creature, mam_type *mam_ptr)
         if (!creature.is_player() || mam_ptr->do_silly_attack) {
             continue;
         }
-        auto &player = creature;
-        if (!is_original_ap_and_seen(player, *mam_ptr->m_ptr)) {
+        if (!is_original_ap_and_seen(creature, *mam_ptr->m_ptr)) {
             continue;
         }
 
@@ -369,8 +363,7 @@ bool monst_attack_monst(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX
     }
 
     if (creature.is_player() && mam_ptr->m_ptr->is_riding()) {
-        auto &player = creature;
-        disturb(player, true, true);
+        disturb(creature, true, true);
     }
 
     repeat_melee(creature, mam_ptr);

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -313,11 +313,10 @@ AttributeType get_element_type(ElementRealmType realm, int n)
  */
 static AttributeType get_element_spells_type(CreatureEntity &creature, int n)
 {
-    auto &player = creature;
-    const auto &realm = element_types.at(player.element_realm);
+    const auto &realm = element_types.at(creature.element_realm);
     const auto t = realm.type.at(n);
     if (realm.extra.find(t) != realm.extra.end()) {
-        if (evaluate_percent(player.level * 2)) {
+        if (evaluate_percent(creature.level * 2)) {
             return realm.extra.at(t);
         }
     }
@@ -353,8 +352,7 @@ const std::string &get_element_name(ElementRealmType realm, int n)
  */
 static std::string get_element_tip(CreatureEntity &creature, int spell_idx)
 {
-    auto &player = creature;
-    auto realm = player.element_realm;
+    auto realm = creature.element_realm;
     auto spell = i2enum<ElementSpells>(spell_idx);
     auto elem = element_powers.at(spell).elem;
     return format(element_tips.at(spell).data(), element_types.at(realm).name[elem].data());
@@ -394,8 +392,7 @@ static mind_type get_elemental_info(CreatureEntity &creature, int spell_idx)
  */
 static std::string get_element_effect_info(CreatureEntity &creature, int spell_idx)
 {
-    auto &player = creature;
-    PLAYER_LEVEL plev = player.level;
+    PLAYER_LEVEL plev = creature.level;
     auto spell = i2enum<ElementSpells>(spell_idx);
     int dam = 0;
 
@@ -411,7 +408,7 @@ static std::string get_element_effect_info(CreatureEntity &creature, int spell_i
     case ElementSpells::BALL_1ST:
         return format(" %s%d", KWD_DAM, 55 + plev);
     case ElementSpells::BREATH_2ND:
-        dam = player.hp / 2;
+        dam = creature.hp / 2;
         return format(" %s%d", KWD_DAM, (dam > 150) ? 150 : dam);
     case ElementSpells::ANNIHILATE:
         return format(" %s%d", _("効力:", "pow "), 50 + plev);
@@ -426,7 +423,7 @@ static std::string get_element_effect_info(CreatureEntity &creature, int spell_i
     case ElementSpells::STORM_2ND:
         return format(" %s%d", KWD_DAM, 115 + plev * 5 / 2);
     case ElementSpells::BREATH_1ST:
-        return format(" %s%d", KWD_DAM, player.hp * 2 / 3);
+        return format(" %s%d", KWD_DAM, creature.hp * 2 / 3);
     case ElementSpells::STORM_3ND:
         return format(" %s%d", KWD_DAM, 300 + plev * 5);
     default:
@@ -442,11 +439,10 @@ static std::string get_element_effect_info(CreatureEntity &creature, int spell_i
  */
 static bool cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx)
 {
-    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
     const auto spell = i2enum<ElementSpells>(spell_idx);
     const auto &power = element_powers.at(spell);
-    const auto plev = player.level;
+    const auto plev = creature.level;
     switch (spell) {
     case ElementSpells::BOLT_1ST: {
         const auto dir = get_aim_dir(creature);
@@ -464,9 +460,9 @@ static bool cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx)
         (void)detect_monsters_invis(creature, DETECT_RAD_DEFAULT);
         return true;
     case ElementSpells::PERCEPT:
-        return psychometry(player);
+        return psychometry(creature);
     case ElementSpells::CURE:
-        (void)hp_player(player, Dice::roll(2, 8));
+        (void)hp_player(creature, Dice::roll(2, 8));
         (void)BadStatusSetter(creature).mod_cut(-10);
         return true;
     case ElementSpells::BOLT_2ND: {
@@ -479,7 +475,7 @@ static bool cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx)
         const auto typ = get_element_spells_type(creature, power.elem);
         if (fire_bolt_or_beam(creature, plev, typ, dir, dam)) {
             if (typ == AttributeType::HYPODYNAMIA) {
-                (void)hp_player(player, dam / 2);
+                (void)hp_player(creature, dam / 2);
             }
         }
 
@@ -518,11 +514,11 @@ static bool cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx)
             return false;
         }
 
-        const auto dam = std::min(150, player.hp / 2);
+        const auto dam = std::min(150, creature.hp / 2);
         const auto typ = get_element_spells_type(creature, power.elem);
         if (fire_breath(creature, typ, dir, dam, 3)) {
             if (typ == AttributeType::HYPODYNAMIA) {
-                (void)hp_player(player, dam / 2);
+                (void)hp_player(creature, dam / 2);
             }
         }
 
@@ -564,7 +560,7 @@ static bool cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx)
         const auto typ = get_element_spells_type(creature, power.elem);
         if (fire_ball(creature, typ, dir, dam, 3)) {
             if (typ == AttributeType::HYPODYNAMIA) {
-                (void)hp_player(player, dam / 2);
+                (void)hp_player(creature, dam / 2);
             }
         }
 
@@ -604,7 +600,7 @@ static bool cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx)
         const auto typ = get_element_spells_type(creature, power.elem);
         if (fire_ball(creature, typ, dir, dam, 4)) {
             if (typ == AttributeType::HYPODYNAMIA) {
-                (void)hp_player(player, dam / 2);
+                (void)hp_player(creature, dam / 2);
             }
         }
 
@@ -616,7 +612,7 @@ static bool cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx)
             return false;
         }
 
-        const auto dam = player.hp * 2 / 3;
+        const auto dam = creature.hp * 2 / 3;
         const auto typ = get_element_spells_type(creature, power.elem);
         (void)fire_breath(creature, typ, dir, dam, 3);
         return true;
@@ -645,28 +641,27 @@ static bool cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx)
  */
 static PERCENTAGE decide_element_chance(CreatureEntity &creature, mind_type spell)
 {
-    auto &player = creature;
     PERCENTAGE chance = spell.fail;
 
-    chance -= 3 * (player.level - spell.min_lev);
-    chance += player.to_m_chance;
-    chance -= 3 * (adj_mag_stat[player.stat_index[A_WIS]] - 1);
+    chance -= 3 * (creature.level - spell.min_lev);
+    chance += creature.to_m_chance;
+    chance -= 3 * (adj_mag_stat[creature.stat_index[A_WIS]] - 1);
 
-    PERCENTAGE minfail = adj_mag_fail[player.stat_index[A_WIS]];
+    PERCENTAGE minfail = adj_mag_fail[creature.stat_index[A_WIS]];
     if (chance < minfail) {
         chance = minfail;
     }
 
-    chance += player.effects()->stun().get_magic_chance_penalty();
+    chance += creature.effects()->stun().get_magic_chance_penalty();
     if (heavy_armor(creature)) {
         chance += 5;
     }
 
-    if (player.is_icky_wield[0]) {
+    if (creature.is_icky_wield[0]) {
         chance += 5;
     }
 
-    if (player.is_icky_wield[1]) {
+    if (creature.is_icky_wield[1]) {
         chance += 5;
     }
 
@@ -698,12 +693,11 @@ static MANA_POINT decide_element_mana_cost(CreatureEntity &creature, mind_type s
  */
 bool get_element_power(CreatureEntity &creature, SPELL_IDX *sn, bool only_browse)
 {
-    auto &player = creature;
     SPELL_IDX i;
     int num = 0;
     TERM_LEN y = 1;
     TERM_LEN x = 10;
-    PLAYER_LEVEL plev = player.level;
+    PLAYER_LEVEL plev = creature.level;
     bool flag, redraw;
     int menu_line = (use_menu ? 1 : 0);
 
@@ -825,7 +819,7 @@ bool get_element_power(CreatureEntity &creature, SPELL_IDX *sn, bool only_browse
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(SubWindowRedrawingFlag::SPELL);
-    handle_stuff(player);
+    handle_stuff(creature);
     if (!flag) {
         return false;
     }
@@ -843,8 +837,7 @@ bool get_element_power(CreatureEntity &creature, SPELL_IDX *sn, bool only_browse
  */
 static bool check_element_mp_sufficiency(CreatureEntity &creature, int mana_cost)
 {
-    auto &player = creature;
-    if (mana_cost <= player.csp) {
+    if (mana_cost <= creature.csp) {
         return true;
     }
 
@@ -865,7 +858,6 @@ static bool check_element_mp_sufficiency(CreatureEntity &creature, int mana_cost
  */
 static bool try_cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx, PERCENTAGE chance)
 {
-    auto &player = creature;
     if (!evaluate_percent(chance)) {
         sound(SoundKind::ZAP);
         return cast_element_spell(creature, spell_idx);
@@ -879,14 +871,14 @@ static bool try_cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx
     sound(SoundKind::FAIL);
 
     if (randint1(100) < chance / 2) {
-        int plev = player.level;
+        int plev = creature.level;
         msg_print(_("元素の力が制御できない氾流となって解放された！", "The elemental power surges from you in an uncontrollable torrent!"));
-        const auto element = get_element_types(player.element_realm)[0];
+        const auto element = get_element_types(creature.element_realm)[0];
         constexpr auto flags = PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM;
         project(creature, PROJECT_WHO_UNCTRL_POWER, 2 + plev / 10, creature.y, creature.x, plev * 2, element, flags);
-        player.csp = std::max(0, player.csp - player.msp * 10 / (20 + randint1(10)));
+        creature.csp = std::max(0, creature.csp - creature.msp * 10 / (20 + randint1(10)));
 
-        PlayerEnergy(player).set_player_turn_energy(100);
+        PlayerEnergy(creature).set_player_turn_energy(100);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         rfu.set_flag(MainWindowRedrawingFlag::MP);
         static constexpr auto flags_swrf = {
@@ -906,9 +898,8 @@ static bool try_cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx
  */
 void do_cmd_element(CreatureEntity &creature)
 {
-    auto &player = creature;
     SPELL_IDX i;
-    if (cmd_limit_confused(player) || !get_element_power(creature, &i, false)) {
+    if (cmd_limit_confused(creature) || !get_element_power(creature, &i, false)) {
         return;
     }
 
@@ -924,23 +915,23 @@ void do_cmd_element(CreatureEntity &creature)
         return;
     }
 
-    if (mana_cost <= player.csp) {
-        player.csp -= mana_cost;
+    if (mana_cost <= creature.csp) {
+        creature.csp -= mana_cost;
     } else {
         int oops = mana_cost;
-        player.csp = 0;
-        player.csp_frac = 0;
+        creature.csp = 0;
+        creature.csp_frac = 0;
         msg_print(_("精神を集中しすぎて気を失ってしまった！", "You faint from the effort!"));
         (void)BadStatusSetter(creature).mod_paralysis(randnum1<short>(5 * oops + 1));
         chg_virtue(creature, Virtue::KNOWLEDGE, -10);
         if (one_in_(2)) {
             const auto perm = one_in_(4);
             msg_print(_("体を悪くしてしまった！", "You have damaged your health!"));
-            (void)dec_stat(player, A_CON, 15 + randint1(10), perm);
+            (void)dec_stat(creature, A_CON, 15 + randint1(10), perm);
         }
     }
 
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MP);
     static constexpr auto flags_swrf = {
@@ -983,7 +974,6 @@ void do_cmd_element_browse(CreatureEntity &creature)
  */
 void display_element_spell_list(CreatureEntity &creature, int y, int x)
 {
-    auto &player = creature;
     prt("", y, x);
     put_str(_("名前", "Name"), y, x + 5);
     put_str(_("Lv   MP 失率 効果", "Lv Mana Fail Info"), y, x + 35);
@@ -992,12 +982,12 @@ void display_element_spell_list(CreatureEntity &creature, int y, int x)
     int i;
     for (i = 0; i < spell_max; i++) {
         const auto spell = get_elemental_info(creature, i);
-        if (spell.min_lev > player.level) {
+        if (spell.min_lev > creature.level) {
             break;
         }
 
         const auto elem = get_elemental_elem(creature, i);
-        const auto name = format(spell.name, get_element_name(player.element_realm, elem).data());
+        const auto name = format(spell.name, get_element_name(creature.element_realm, elem).data());
 
         const auto mana_cost = decide_element_mana_cost(creature, spell);
         const auto chance = decide_element_chance(creature, spell);
@@ -1005,7 +995,7 @@ void display_element_spell_list(CreatureEntity &creature, int y, int x)
 
         constexpr auto fmt = "  %c) %-30s%2d %4d %3d%%%s";
         const auto info_str = format(fmt, I2A(i), name.data(), spell.min_lev, mana_cost, chance, comment.data());
-        const auto color = mana_cost > player.csp ? TERM_ORANGE : TERM_WHITE;
+        const auto color = mana_cost > creature.csp ? TERM_ORANGE : TERM_WHITE;
         c_prt(color, info_str, y + i + 1, x);
     }
     prt("", y + i + 1, x);
@@ -1075,8 +1065,7 @@ static bool is_elemental_genocide_effective(const MonraceDefinition &monrace, At
  */
 ProcessResult effect_monster_elemental_genocide(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    auto &player = creature;
-    const auto &name = get_element_name(player.element_realm, 0);
+    const auto &name = get_element_name(creature.element_realm, 0);
     if (em_ptr->seen_msg) {
         msg_format(_("%sが%sを包み込んだ。", "The %s surrounds %s."), name.data(), em_ptr->m_name);
     }
@@ -1085,7 +1074,7 @@ ProcessResult effect_monster_elemental_genocide(CreatureEntity &creature, Effect
         em_ptr->obvious = true;
     }
 
-    const auto type = get_element_type(player.element_realm, 0);
+    const auto type = get_element_type(creature.element_realm, 0);
     const auto is_effective = is_elemental_genocide_effective(*em_ptr->r_ptr, type);
     if (!is_effective) {
         if (em_ptr->seen_msg) {
@@ -1095,7 +1084,7 @@ ProcessResult effect_monster_elemental_genocide(CreatureEntity &creature, Effect
         return ProcessResult::PROCESS_TRUE;
     }
 
-    if (genocide_aux(player, em_ptr->g_ptr->m_idx, em_ptr->dam, em_ptr->is_player(), (em_ptr->r_ptr->level + 1) / 2, _("モンスター消滅", "Genocide One"))) {
+    if (genocide_aux(creature, em_ptr->g_ptr->m_idx, em_ptr->dam, em_ptr->is_player(), (em_ptr->r_ptr->level + 1) / 2, _("モンスター消滅", "Genocide One"))) {
         if (em_ptr->seen_msg) {
             msg_format(_("%sは消滅した！", "%s^ disappeared!"), em_ptr->m_name);
         }
@@ -1119,12 +1108,11 @@ ProcessResult effect_monster_elemental_genocide(CreatureEntity &creature, Effect
  */
 bool has_element_resist(CreatureEntity &creature, ElementRealmType realm, PLAYER_LEVEL lev)
 {
-    auto &player = creature;
     if (!CreatureClass(creature).equals(PlayerClassType::ELEMENTALIST)) {
         return false;
     }
 
-    return (player.element_realm == realm) && (player.level >= lev);
+    return (creature.element_realm == realm) && (creature.level >= lev);
 }
 
 /*!
@@ -1197,7 +1185,6 @@ static int interpret_realm_select_key(int cs, int n, char c)
  */
 static tl::optional<ElementRealmType> get_element_realm(CreatureEntity &creature, ElementRealmType realm, int n)
 {
-    auto &player = creature;
     int cs = std::max(0, enum2i(realm) - 1);
     int os = cs;
     int k;
@@ -1247,7 +1234,7 @@ static tl::optional<ElementRealmType> get_element_realm(CreatureEntity &creature
 
         if (c == '=') {
             screen_save();
-            do_cmd_options_aux(player, GameOptionPage::BIRTH, _("初期オプション((*)はスコアに影響)", "Birth Options ((*)) affect score"));
+            do_cmd_options_aux(creature, GameOptionPage::BIRTH, _("初期オプション((*)はスコアに影響)", "Birth Options ((*)) affect score"));
             screen_load();
         } else if (c != '2' && c != '4' && c != '6' && c != '8') {
             bell();
@@ -1265,7 +1252,6 @@ static tl::optional<ElementRealmType> get_element_realm(CreatureEntity &creature
  */
 tl::optional<ElementRealmType> select_element_realm(CreatureEntity &creature)
 {
-    auto &player = creature;
     clear_from(10);
 
     constexpr auto realm_max = enum2i(ElementRealmType::MAX);
@@ -1287,7 +1273,7 @@ tl::optional<ElementRealmType> select_element_realm(CreatureEntity &creature)
 
         display_wrap_around(element_texts.at(*realm), 74, row, 3);
 
-        if (input_check_strict(player, _("よろしいですか？", "Are you sure? "), UserCheck::DEFAULT_Y)) {
+        if (input_check_strict(creature, _("よろしいですか？", "Are you sure? "), UserCheck::DEFAULT_Y)) {
             break;
         }
 
@@ -1305,10 +1291,9 @@ tl::optional<ElementRealmType> select_element_realm(CreatureEntity &creature)
  */
 void switch_element_racial(CreatureEntity &creature, rc_type *rc_ptr)
 {
-    auto &player = creature;
-    auto plev = player.level;
+    auto plev = creature.level;
     rpi_type rpi;
-    switch (player.element_realm) {
+    switch (creature.element_realm) {
     case ElementRealmType::FIRE:
         rpi = rpi_type(_("ライト・エリア", "Light area"));
         rpi.text = _("光源が照らしている範囲か部屋全体を永久に明るくする。", "Lights up nearby area and the inside of a room permanently.");
@@ -1448,7 +1433,6 @@ static bool is_target_grid_dark(const FloorType &floor, const Pos2D &pos)
  */
 static bool door_to_darkness(CreatureEntity &creature, int distance)
 {
-    auto &player = creature;
     const auto p_pos_orig = creature.get_position();
     auto p_pos = tl::make_optional(creature.get_position());
     const auto &floor = *creature.current_floor_ptr;
@@ -1473,7 +1457,7 @@ static bool door_to_darkness(CreatureEntity &creature, int distance)
 
     const auto flag = cave_player_teleportable_bold(creature, p_pos->y, p_pos->x, TELEPORT_SPONTANEOUS) && is_target_grid_dark(floor, *p_pos);
     if (flag) {
-        teleport_player_to(player, p_pos->y, p_pos->x, TELEPORT_SPONTANEOUS);
+        teleport_player_to(creature, p_pos->y, p_pos->x, TELEPORT_SPONTANEOUS);
     } else {
         msg_print(_("闇の扉は開かなかった！", "The door to darkness does not open!"));
     }
@@ -1488,10 +1472,9 @@ static bool door_to_darkness(CreatureEntity &creature, int distance)
  */
 bool switch_element_execution(CreatureEntity &creature)
 {
-    auto &player = creature;
-    PLAYER_LEVEL plev = player.level;
+    PLAYER_LEVEL plev = creature.level;
 
-    switch (player.element_realm) {
+    switch (creature.element_realm) {
     case ElementRealmType::FIRE:
         (void)lite_area(creature, Dice::roll(2, plev / 2), plev / 10);
         return true;
@@ -1508,7 +1491,7 @@ bool switch_element_execution(CreatureEntity &creature)
             return false;
         }
 
-        (void)wall_to_mud(player, dir, plev * 3 / 2);
+        (void)wall_to_mud(creature, dir, plev * 3 / 2);
         return true;
     }
     case ElementRealmType::DARKNESS:

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -74,7 +74,7 @@ bool binding_field(CreatureEntity &creature, int dam)
     int point_x[3]{};
     int point_y[3]{};
 
-    /* Default target of monsterspell is player */
+    /* Default target of monsterspell is creature */
     monster_target_y = creature.y;
     monster_target_x = creature.x;
 
@@ -299,32 +299,31 @@ bool set_multishadow(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
  */
 bool set_dustrobe(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
 {
-    auto &player = creature;
     bool notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
 
-    if (player.is_dead()) {
+    if (creature.is_dead()) {
         return false;
     }
 
     if (v) {
-        if (player.dustrobe && !do_dec) {
-            if (player.dustrobe > v) {
+        if (creature.dustrobe && !do_dec) {
+            if (creature.dustrobe > v) {
                 return false;
             }
-        } else if (!player.dustrobe) {
+        } else if (!creature.dustrobe) {
             msg_print(_("体が鏡のオーラで覆われた。", "You are enveloped by mirror shards."));
             notice = true;
         }
     } else {
-        if (player.dustrobe) {
+        if (creature.dustrobe) {
             msg_print(_("鏡のオーラが消えた。", "The mirror shards disappear."));
             notice = true;
         }
     }
 
-    player.dustrobe = v;
+    creature.dustrobe = v;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -336,7 +335,7 @@ bool set_dustrobe(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(player);
+    handle_stuff(creature);
     return true;
 }
 
@@ -352,14 +351,13 @@ static int number_of_mirrors(const FloorType &floor)
 
 /*!
  * @brief 鏡魔法の発動 /
- * do_cmd_cast calls this function if the player's class is 'Mirror magic'.
+ * do_cmd_cast calls this function if the creature's class is 'Mirror magic'.
  * @param spell 発動する特殊技能のID
  * @return 処理を実行したらTRUE、キャンセルした場合FALSEを返す。
  */
 bool cast_mirror_spell(CreatureEntity &creature, MindMirrorMasterType spell)
 {
-    auto &player = creature;
-    PLAYER_LEVEL plev = player.level;
+    PLAYER_LEVEL plev = creature.level;
     int tmp;
     TIME_EFFECT t;
     const auto &grid = creature.current_floor_ptr->grid_array[creature.y][creature.x];
@@ -373,7 +371,7 @@ bool cast_mirror_spell(CreatureEntity &creature, MindMirrorMasterType spell)
             detect_monsters_invis(creature, DETECT_RAD_DEFAULT);
         }
         if (plev + tmp > 28) {
-            set_tim_esp(player, (TIME_EFFECT)plev, false);
+            set_tim_esp(creature, (TIME_EFFECT)plev, false);
         }
         if (plev + tmp > 38) {
             map_area(creature, DETECT_RAD_MAP);
@@ -408,13 +406,13 @@ bool cast_mirror_spell(CreatureEntity &creature, MindMirrorMasterType spell)
         break;
     }
     case MindMirrorMasterType::WRAPPED_MIRROR:
-        teleport_player(player, 10, TELEPORT_SPONTANEOUS);
+        teleport_player(creature, 10, TELEPORT_SPONTANEOUS);
         break;
     case MindMirrorMasterType::MIRROR_LIGHT:
         (void)lite_area(creature, Dice::roll(2, (plev / 2)), (plev / 10) + 1);
         break;
     case MindMirrorMasterType::WANDERING_MIRROR:
-        teleport_player(player, plev * 5, TELEPORT_SPONTANEOUS);
+        teleport_player(creature, plev * 5, TELEPORT_SPONTANEOUS);
         break;
     case MindMirrorMasterType::ROBE_DUST:
         set_dustrobe(creature, 20 + randint1(20), false);
@@ -460,13 +458,13 @@ bool cast_mirror_spell(CreatureEntity &creature, MindMirrorMasterType spell)
         break;
     case MindMirrorMasterType::WATER_SHIELD:
         t = 20 + randint1(20);
-        set_shield(player, t, false);
+        set_shield(creature, t, false);
         if (plev > 31) {
-            set_tim_reflect(player, t, false);
+            set_tim_reflect(creature, t, false);
         }
 
         if (plev > 39) {
-            set_resist_magic(player, t, false);
+            set_resist_magic(creature, t, false);
         }
 
         break;
@@ -499,7 +497,7 @@ bool cast_mirror_spell(CreatureEntity &creature, MindMirrorMasterType spell)
         msg_print(_("鏡の世界を通り抜け…  ", "You try to enter the mirror..."));
         return SpellsMirrorMaster(creature).mirror_tunnel();
     case MindMirrorMasterType::RECALL_MIRROR:
-        return recall_player(player, randint0(21) + 15);
+        return recall_player(creature, randint0(21) + 15);
     case MindMirrorMasterType::MULTI_SHADOW:
         set_multishadow(creature, 6 + randint1(6), false);
         break;
@@ -510,7 +508,7 @@ bool cast_mirror_spell(CreatureEntity &creature, MindMirrorMasterType spell)
 
         break;
     case MindMirrorMasterType::RUFFNOR_MIRROR:
-        (void)set_invuln(player, randint1(4) + 4, false);
+        (void)set_invuln(creature, randint1(4) + 4, false);
         break;
     default:
         msg_print(_("なに？", "Zap?"));

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -91,8 +91,7 @@ bool kawarimi(CreatureEntity &creature, bool success)
     }
 
     const auto p_pos_orig = creature.get_position(); //!< @details 元の位置に変わり身を置く.
-    auto &player = creature;
-    teleport_player(player, 10 + randint1(90), TELEPORT_SPONTANEOUS);
+    teleport_player(creature, 10 + randint1(90), TELEPORT_SPONTANEOUS);
     constexpr auto sv_wooden_statue = 0;
     ItemEntity item({ ItemKindType::STATUE, sv_wooden_statue });
     item.pval = enum2i(MonraceId::NINJA);
@@ -142,8 +141,7 @@ bool rush_attack(CreatureEntity &creature, bool *mdeath)
         return true;
     }
 
-    auto &player = creature;
-    auto *player_ptr = &player;
+    auto *player_ptr = &creature;
     auto p_pos_new = p_pos;
     auto tmp_mdeath = false;
     auto moved = false;
@@ -204,8 +202,7 @@ bool rush_attack(CreatureEntity &creature, bool *mdeath)
  */
 void process_surprise_attack(CreatureEntity &creature, player_attack_type *pa_ptr)
 {
-    auto &player = creature;
-    auto *player_ptr = &player;
+    auto *player_ptr = &creature;
 
     const auto &monrace = pa_ptr->m_ptr->get_monrace();
     if (!has_melee_weapon(creature, enum2i(INVEN_MAIN_HAND) + pa_ptr->hand) || player_ptr->is_icky_wield[pa_ptr->hand]) {
@@ -280,8 +277,7 @@ void calc_surprise_attack_damage(CreatureEntity &creature, player_attack_type *p
  */
 bool hayagake(CreatureEntity &creature)
 {
-    auto &player = creature;
-    auto *player_ptr = &player;
+    auto *player_ptr = &creature;
     PlayerEnergy energy(creature);
     if (player_ptr->action == ACTION_HAYAGAKE) {
         set_action(creature, ACTION_NONE);
@@ -311,8 +307,7 @@ bool set_superstealth(CreatureEntity &creature, bool set)
 {
     bool notice = false;
 
-    auto &player = creature;
-    auto *player_ptr = &player;
+    auto *player_ptr = &creature;
 
     auto ninja_data = CreatureClass(creature).get_specific_data<ninja_data_type>();
     if (!ninja_data || creature.is_dead()) {
@@ -354,15 +349,14 @@ bool set_superstealth(CreatureEntity &creature, bool set)
 
 /*!
  * @brief 忍術の発動 /
- * do_cmd_cast calls this function if the player's class is 'ninja'.
+ * do_cmd_cast calls this function if the creature's class is 'ninja'.
  * @param creature クリーチャーへの参照
  * @param spell 発動する特殊技能のID
  * @return 処理を実行したらTRUE、キャンセルした場合FALSEを返す。
  */
 bool cast_ninja_spell(CreatureEntity &creature, MindNinjaType spell)
 {
-    auto &player = creature;
-    auto *player_ptr = &player;
+    auto *player_ptr = &creature;
     PLAYER_LEVEL plev = creature.level;
     auto ninja_data = CreatureClass(creature).get_specific_data<ninja_data_type>();
     switch (spell) {

--- a/src/mind/mind-priest.cpp
+++ b/src/mind/mind-priest.cpp
@@ -25,7 +25,6 @@
  */
 bool bless_weapon(CreatureEntity &creature)
 {
-    auto &player = creature;
     constexpr auto q = _("どのアイテムを祝福しますか？", "Bless which weapon? ");
     constexpr auto s = _("祝福できる武器がありません。", "You have no weapon to bless.");
 
@@ -36,7 +35,7 @@ bool bless_weapon(CreatureEntity &creature)
         return false;
     }
 
-    const auto item_name = describe_flavor(player, *o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
+    const auto item_name = describe_flavor(creature, *o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
     const auto item_flags = o_ptr->get_flags();
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     if (o_ptr->is_cursed()) {
@@ -150,6 +149,6 @@ bool bless_weapon(CreatureEntity &creature)
         SubWindowRedrawingFlag::FOUND_ITEMS,
     };
     rfu.set_flags(flags_swrf);
-    calc_android_exp(player);
+    calc_android_exp(creature);
     return true;
 }

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -272,8 +272,7 @@ static void hissatsu_lightning_eagle(CreatureEntity &creature, samurai_slaying_t
  */
 static void hissatsu_bloody_maelstroem(CreatureEntity &creature, samurai_slaying_type *samurai_slaying_ptr)
 {
-    auto &player = creature;
-    const auto &player_cut = player.effects()->cut();
+    const auto &player_cut = creature.effects()->cut();
     if ((samurai_slaying_ptr->mode == HISSATSU_SEKIRYUKA) && player_cut.is_cut() && samurai_slaying_ptr->m_ptr->has_living_flag()) {
         auto tmp = std::min<short>(100, std::max<short>(10, player_cut.current() / 10));
         if (samurai_slaying_ptr->mult < tmp) {
@@ -344,8 +343,7 @@ MULTIPLY mult_hissatsu(CreatureEntity &creature, MULTIPLY mult, const TrFlags &f
 
 void concentration(CreatureEntity &creature)
 {
-    auto &player = creature;
-    int max_csp = std::max(player.msp * 4, player.level * 5 + 5);
+    int max_csp = std::max(creature.msp * 4, creature.level * 5 + 5);
 
     if (total_friends) {
         msg_print(_("今はペットを操ることに集中していないと。", "Your pets demand all of your attention."));
@@ -359,10 +357,10 @@ void concentration(CreatureEntity &creature)
 
     msg_print(_("精神を集中して気合いを溜めた。", "You concentrate to charge your power."));
 
-    player.csp += player.msp / 2;
-    if (player.csp >= max_csp) {
-        player.csp = max_csp;
-        player.csp_frac = 0;
+    creature.csp += creature.msp / 2;
+    if (creature.csp >= max_csp) {
+        creature.csp = max_csp;
+        creature.csp_frac = 0;
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);
@@ -374,14 +372,13 @@ void concentration(CreatureEntity &creature)
  */
 bool choose_samurai_stance(CreatureEntity &creature)
 {
-    auto &player = creature;
     char choice;
 
-    if (cmd_limit_confused(player)) {
+    if (cmd_limit_confused(creature)) {
         return false;
     }
 
-    const auto effects = player.effects();
+    const auto effects = creature.effects();
     if (effects->stun().is_stunned()) {
         msg_print(_("意識がはっきりとしない。", "You are not clear-headed"));
         return false;
@@ -395,7 +392,7 @@ bool choose_samurai_stance(CreatureEntity &creature)
     screen_save();
     prt(_(" a) 型を崩す", " a) No Form"), 2, 20);
     for (auto i = 0U; i < samurai_stances.size(); i++) {
-        if (player.level >= samurai_stances[i].min_level) {
+        if (creature.level >= samurai_stances[i].min_level) {
             const auto buf = format(_(" %c) %sの型    %s", " %c) Stance of %-12s  %s"), I2A(i + 1), samurai_stances[i].desc, samurai_stances[i].info);
             prt(buf, 3 + i, 20);
         }
@@ -412,8 +409,8 @@ bool choose_samurai_stance(CreatureEntity &creature)
             screen_load();
             return false;
         } else if ((choice == 'a') || (choice == 'A')) {
-            if (player.action == ACTION_SAMURAI_STANCE) {
-                set_action(player, ACTION_NONE);
+            if (creature.action == ACTION_SAMURAI_STANCE) {
+                set_action(creature, ACTION_NONE);
             } else {
                 msg_print(_("もともと構えていない。", "You are not in a special stance."));
             }
@@ -422,19 +419,19 @@ bool choose_samurai_stance(CreatureEntity &creature)
         } else if ((choice == 'b') || (choice == 'B')) {
             new_stance = SamuraiStanceType::IAI;
             break;
-        } else if (((choice == 'c') || (choice == 'C')) && (player.level > 29)) {
+        } else if (((choice == 'c') || (choice == 'C')) && (creature.level > 29)) {
             new_stance = SamuraiStanceType::FUUJIN;
             break;
-        } else if (((choice == 'd') || (choice == 'D')) && (player.level > 34)) {
+        } else if (((choice == 'd') || (choice == 'D')) && (creature.level > 34)) {
             new_stance = SamuraiStanceType::KOUKIJIN;
             break;
-        } else if (((choice == 'e') || (choice == 'E')) && (player.level > 39)) {
+        } else if (((choice == 'e') || (choice == 'E')) && (creature.level > 39)) {
             new_stance = SamuraiStanceType::MUSOU;
             break;
         }
     }
 
-    set_action(player, ACTION_SAMURAI_STANCE);
+    set_action(creature, ACTION_SAMURAI_STANCE);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     if (CreatureClass(creature).samurai_stance_is(new_stance)) {
         msg_print(_("構え直した。", "You reassume a stance."));
@@ -465,10 +462,9 @@ bool choose_samurai_stance(CreatureEntity &creature)
  */
 int calc_attack_quality(CreatureEntity &creature, player_attack_type *pa_ptr)
 {
-    auto &player = creature;
-    auto *o_ptr = player.inventory[INVEN_MAIN_HAND + pa_ptr->hand].get();
-    int bonus = player.to_h[pa_ptr->hand] + o_ptr->to_h;
-    int chance = (player.skill_thn + (bonus * BTH_PLUS_ADJ));
+    auto *o_ptr = creature.inventory[INVEN_MAIN_HAND + pa_ptr->hand].get();
+    int bonus = creature.to_h[pa_ptr->hand] + o_ptr->to_h;
+    int chance = (creature.skill_thn + (bonus * BTH_PLUS_ADJ));
     if (pa_ptr->mode == HISSATSU_IAI) {
         chance += 60;
     }
@@ -477,12 +473,12 @@ int calc_attack_quality(CreatureEntity &creature, player_attack_type *pa_ptr)
         chance += 150;
     }
 
-    if (player.sutemi) {
+    if (creature.sutemi) {
         chance = std::max(chance * 3 / 2, chance + 60);
     }
 
-    auto it = player.virtues.find(Virtue::VALOUR);
-    if (it != player.virtues.end()) {
+    auto it = creature.virtues.find(Virtue::VALOUR);
+    if (it != creature.virtues.end()) {
         chance += (it->second / 10);
     }
 
@@ -496,13 +492,12 @@ int calc_attack_quality(CreatureEntity &creature, player_attack_type *pa_ptr)
  */
 void mineuchi(CreatureEntity &creature, player_attack_type *pa_ptr)
 {
-    auto &player = creature;
     if (pa_ptr->mode != HISSATSU_MINEUCHI) {
         return;
     }
 
     pa_ptr->attack_damage = 0;
-    anger_monster(player, *pa_ptr->m_ptr);
+    anger_monster(creature, *pa_ptr->m_ptr);
 
     const auto &monrace = pa_ptr->m_ptr->get_monrace();
     if (monrace.resistance_flags.has(MonsterResistanceType::NO_STUN)) {
@@ -528,16 +523,15 @@ void mineuchi(CreatureEntity &creature, player_attack_type *pa_ptr)
  */
 void musou_counterattack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    auto &player = creature;
     const auto is_musou = CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU);
-    if ((!player.counter && !is_musou) || !monap_ptr->alive || player.is_dead() || !monap_ptr->m_ptr->get_monster_profile().ml || (player.csp <= 7)) {
+    if ((!creature.counter && !is_musou) || !monap_ptr->alive || creature.is_dead() || !monap_ptr->m_ptr->get_monster_profile().ml || (creature.csp <= 7)) {
         return;
     }
 
     const auto m_target_name = monster_desc(creature, *monap_ptr->m_ptr, 0);
-    player.csp -= 7;
+    creature.csp -= 7;
     msg_format(_("%s^に反撃した！", "You counterattacked %s!"), m_target_name.data());
-    do_cmd_attack(player, monap_ptr->m_ptr->y, monap_ptr->m_ptr->x, HISSATSU_COUNTER);
+    do_cmd_attack(creature, monap_ptr->m_ptr->y, monap_ptr->m_ptr->x, HISSATSU_COUNTER);
     monap_ptr->fear = false;
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);
 }

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -246,7 +246,6 @@ void display_snipe_list(CreatureEntity &creature)
  */
 static int get_snipe_power(CreatureEntity &creature, COMMAND_CODE *sn, bool only_browse)
 {
-    auto &player = creature;
     COMMAND_CODE i;
     int num = 0;
     TERM_LEN y = 1;
@@ -383,7 +382,7 @@ static int get_snipe_power(CreatureEntity &creature, COMMAND_CODE *sn, bool only
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(SubWindowRedrawingFlag::SPELL);
-    handle_stuff(player);
+    handle_stuff(creature);
 
     /* Abort if needed */
     if (!flag) {
@@ -409,8 +408,7 @@ static int get_snipe_power(CreatureEntity &creature, COMMAND_CODE *sn, bool only
 MULTIPLY calc_snipe_damage_with_slay(CreatureEntity &creature, MULTIPLY mult, const CreatureEntity &target, SPELL_IDX snipe_type)
 {
     auto &monrace = target.get_monrace();
-    auto &player = creature;
-    bool seen = is_seen(player, target);
+    bool seen = is_seen(creature, target);
 
     auto sniper_data = CreatureClass(creature).get_specific_data<SniperData>();
     const auto sniper_concent = sniper_data ? sniper_data->concent : 0;
@@ -536,14 +534,13 @@ MULTIPLY calc_snipe_damage_with_slay(CreatureEntity &creature, MULTIPLY mult, co
 
 /*!
  * @brief スナイパー技能の発動 /
- * do_cmd_cast calls this function if the player's class is 'snipe'.
+ * do_cmd_cast calls this function if the creature's class is 'snipe'.
  * @param spell 発動する特殊技能のID
  * @return 処理を実行したらTRUE、キャンセルした場合FALSEを返す。
  */
 static bool cast_sniper_spell(CreatureEntity &creature, int spell)
 {
-    auto &player = creature;
-    auto *o_ptr = player.inventory[INVEN_BOW].get();
+    auto *o_ptr = creature.inventory[INVEN_BOW].get();
     if (o_ptr->bi_key.tval() != ItemKindType::BOW) {
         msg_print(_("弓を装備していない！", "You wield no bow!"));
         return false;
@@ -556,7 +553,7 @@ static bool cast_sniper_spell(CreatureEntity &creature, int spell)
         if (!snipe_concentrate(creature)) {
             return false;
         }
-        PlayerEnergy(player).set_player_turn_energy(100);
+        PlayerEnergy(creature).set_player_turn_energy(100);
         return true;
     case 1:
         snipe_type = SP_LITE;
@@ -608,9 +605,9 @@ static bool cast_sniper_spell(CreatureEntity &creature, int spell)
     }
 
     command_cmd = 'f';
-    do_cmd_fire(player, snipe_type);
+    do_cmd_fire(creature, snipe_type);
 
-    return player.is_fired;
+    return creature.is_fired;
 }
 
 /*!
@@ -618,16 +615,15 @@ static bool cast_sniper_spell(CreatureEntity &creature, int spell)
  */
 void do_cmd_snipe(CreatureEntity &creature)
 {
-    auto &player = creature;
-    if (cmd_limit_confused(player)) {
+    if (cmd_limit_confused(creature)) {
         return;
     }
 
-    if (cmd_limit_image(player)) {
+    if (cmd_limit_image(creature)) {
         return;
     }
 
-    if (cmd_limit_stun(player)) {
+    if (cmd_limit_stun(creature)) {
         return;
     }
 

--- a/src/mind/mind-warrior-mage.cpp
+++ b/src/mind/mind-warrior-mage.cpp
@@ -7,9 +7,8 @@
 
 bool comvert_hp_to_mp(CreatureEntity &creature)
 {
-    auto &player = creature;
     constexpr auto mes = _("ＨＰからＭＰへの無謀な変換", "thoughtless conversion from HP to SP");
-    auto gain_sp = take_hit(player, DAMAGE_USELIFE, player.level, mes) / 5;
+    auto gain_sp = take_hit(creature, DAMAGE_USELIFE, creature.level, mes) / 5;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags = {
         MainWindowRedrawingFlag::HP,
@@ -21,10 +20,10 @@ bool comvert_hp_to_mp(CreatureEntity &creature)
         return true;
     }
 
-    player.csp += gain_sp;
-    if (player.csp > player.msp) {
-        player.csp = player.msp;
-        player.csp_frac = 0;
+    creature.csp += gain_sp;
+    if (creature.csp > creature.msp) {
+        creature.csp = creature.msp;
+        creature.csp_frac = 0;
     }
 
     rfu.set_flags(flags);
@@ -33,10 +32,9 @@ bool comvert_hp_to_mp(CreatureEntity &creature)
 
 bool comvert_mp_to_hp(CreatureEntity &creature)
 {
-    auto &player = creature;
-    if (player.csp >= player.level / 5) {
-        player.csp -= player.level / 5;
-        hp_player(player, player.level);
+    if (creature.csp >= creature.level / 5) {
+        creature.csp -= creature.level / 5;
+        hp_player(creature, creature.level);
     } else {
         msg_print(_("変換に失敗した。", "You failed to convert."));
     }

--- a/src/mind/mind-warrior.cpp
+++ b/src/mind/mind-warrior.cpp
@@ -15,8 +15,7 @@
  */
 bool hit_and_away(CreatureEntity &creature)
 {
-    auto &player = creature;
-    const auto dir = get_direction(player);
+    const auto dir = get_direction(creature);
     if (!dir) {
         return false;
     }
@@ -24,7 +23,7 @@ bool hit_and_away(CreatureEntity &creature)
     const auto pos = creature.get_neighbor(dir);
     if (creature.current_floor_ptr->get_grid(pos).has_monster()) {
         do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
-        if (randint0(player.skill_dis) < 7) {
+        if (randint0(creature.skill_dis) < 7) {
             msg_print(_("うまく逃げられなかった。", "You failed to run away."));
         } else {
             teleport_player(creature, 30, TELEPORT_SPONTANEOUS);

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -120,7 +120,6 @@ static void set_smith_redrawing_flags()
  */
 static void drain_essence(CreatureEntity &creature)
 {
-    auto &player = creature;
     auto q = _("どのアイテムから抽出しますか？", "Extract from which item? ");
     auto s = _("抽出できるアイテムがありません。", "You have nothing you can extract from.");
 
@@ -132,13 +131,13 @@ static void drain_essence(CreatureEntity &creature)
     }
 
     if (o_ptr->is_known() && !o_ptr->is_nameless()) {
-        const auto item_name = describe_flavor(player, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        const auto item_name = describe_flavor(creature, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         if (!input_check(format(_("本当に%sから抽出してよろしいですか？", "Really extract from %s? "), item_name.data()))) {
             return;
         }
     }
 
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
 
     auto drain_result = Smith(creature).drain_essence(o_ptr);
 
@@ -155,7 +154,7 @@ static void drain_essence(CreatureEntity &creature)
     }
 
     /* Apply autodestroy/inscription to the drained item */
-    autopick_alter_item(player, i_idx, true);
+    autopick_alter_item(creature, i_idx, true);
     set_smith_redrawing_flags();
 }
 
@@ -316,7 +315,6 @@ static void add_essence(CreatureEntity &creature, SmithCategoryType mode)
 {
     int menu_line = (use_menu ? 1 : 0);
 
-    auto &player = creature;
     Smith smith(creature);
 
     auto smith_effect_list = Smith::get_effect_list(mode);
@@ -450,7 +448,7 @@ static void add_essence(CreatureEntity &creature, SmithCategoryType mode)
         return;
     }
 
-    const auto item_name = describe_flavor(player, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(creature, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     const auto use_essence = Smith::get_essence_consumption(effect, o_ptr);
     if (o_ptr->number > 1) {
         msg_format(_("%d個あるのでエッセンスは%d必要です。", "For %d items, it will take %d essences."), o_ptr->number, use_essence);
@@ -485,7 +483,7 @@ static void add_essence(CreatureEntity &creature, SmithCategoryType mode)
 
         add_essence_count = o_ptr->pval;
     } else if (effect == SmithEffectType::SLAY_GLOVE) {
-        const auto max_val = player.level / 7 + 3;
+        const auto max_val = creature.level / 7 + 3;
         const auto num_enchants = input_numerics(prompt, 1, max_val, 1);
         if (!num_enchants.has_value()) {
             return;
@@ -501,7 +499,7 @@ static void add_essence(CreatureEntity &creature, SmithCategoryType mode)
         return;
     }
 
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
 
     if (!smith.add_essence(effect, o_ptr, add_essence_count)) {
         msg_print(_("改良に失敗した。", "You failed to enchant."));
@@ -519,7 +517,6 @@ static void add_essence(CreatureEntity &creature, SmithCategoryType mode)
  */
 static void erase_essence(CreatureEntity &creature)
 {
-    auto &player = creature;
     constexpr auto q = _("どのアイテムのエッセンスを消去しますか？", "Remove from which item? ");
     constexpr auto s = _("エッセンスを付加したアイテムがありません。", "You have nothing with added essence to remove.");
     short i_idx;
@@ -528,12 +525,12 @@ static void erase_essence(CreatureEntity &creature)
         return;
     }
 
-    const auto item_name = describe_flavor(player, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(creature, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     if (!input_check(format(_("よろしいですか？ [%s]", "Are you sure? [%s]"), item_name.data()))) {
         return;
     }
 
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
 
     Smith(creature).erase_essence(o_ptr);
 
@@ -547,10 +544,9 @@ static void erase_essence(CreatureEntity &creature)
  */
 void do_cmd_kaji(CreatureEntity &creature, bool only_browse)
 {
-    auto &player = creature;
     COMMAND_CODE menu_line = (use_menu ? 1 : 0);
     if (!only_browse) {
-        if (cmd_limit_confused(player)) {
+        if (cmd_limit_confused(creature)) {
             return;
         }
 
@@ -558,7 +554,7 @@ void do_cmd_kaji(CreatureEntity &creature, bool only_browse)
             return;
         }
 
-        if (cmd_limit_image(player)) {
+        if (cmd_limit_image(creature)) {
             return;
         }
     }

--- a/src/mspell/mspell-damage-calculator.cpp
+++ b/src/mspell/mspell-damage-calculator.cpp
@@ -482,13 +482,12 @@ int monspell_race_damage(CreatureEntity &creature, MonsterAbilityType ms_type, M
  */
 int monspell_bluemage_damage(CreatureEntity &creature, MonsterAbilityType ms_type, PLAYER_LEVEL plev, int TYPE)
 {
-    auto &player = creature;
     ItemEntity *weapon_ptr = nullptr;
 
     if (has_melee_weapon(creature, INVEN_MAIN_HAND)) {
-        weapon_ptr = player.inventory[INVEN_MAIN_HAND].get();
+        weapon_ptr = creature.inventory[INVEN_MAIN_HAND].get();
     } else if (has_melee_weapon(creature, INVEN_SUB_HAND)) {
-        weapon_ptr = player.inventory[INVEN_SUB_HAND].get();
+        weapon_ptr = creature.inventory[INVEN_SUB_HAND].get();
     }
 
     const auto shoot_base = weapon_ptr ? weapon_ptr->to_d : 0;

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -35,7 +35,6 @@
  */
 static void dispel_player(CreatureEntity &creature)
 {
-    auto &player = creature;
     (void)set_acceleration(creature, 0, true);
     set_lightspeed(creature, 0, true);
     (void)BadStatusSetter(creature).set_deceleration(0, true);
@@ -82,8 +81,8 @@ static void dispel_player(CreatureEntity &creature)
     (void)set_tim_exorcism(creature, 0, true);
     (void)set_tim_imm_dark(creature, 0, true);
 
-    if (player.special_attack & ATTACK_CONFUSE) {
-        player.special_attack &= ~(ATTACK_CONFUSE);
+    if (creature.special_attack & ATTACK_CONFUSE) {
+        creature.special_attack &= ~(ATTACK_CONFUSE);
         msg_print(_("手の輝きがなくなった。", "Your hands stop glowing."));
     }
 
@@ -101,7 +100,7 @@ static void dispel_player(CreatureEntity &creature)
             msg_print(_("呪文が途切れた。", "Your casting is interrupted."));
         }
 
-        player.action = ACTION_NONE;
+        creature.action = ACTION_NONE;
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         static constexpr auto flags_srf = {
             StatusRecalculatingFlag::BONUS,
@@ -120,7 +119,7 @@ static void dispel_player(CreatureEntity &creature)
             SubWindowRedrawingFlag::DUNGEON,
         };
         rfu.set_flags(flags_swrf);
-        player.energy_need += ENERGY_NEED();
+        creature.energy_need += ENERGY_NEED();
     }
 }
 
@@ -135,7 +134,6 @@ static void dispel_player(CreatureEntity &creature)
  */
 MonsterSpellResult spell_RF4_DISPEL(MONSTER_IDX m_idx, CreatureEntity &creature, MONSTER_IDX t_idx, int target_type)
 {
-    auto &player = creature;
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
@@ -146,8 +144,8 @@ MonsterSpellResult spell_RF4_DISPEL(MONSTER_IDX m_idx, CreatureEntity &creature,
 
     if (target_type == MONSTER_TO_PLAYER) {
         dispel_player(creature);
-        if (player.riding) {
-            dispel_monster_status(creature, player.riding);
+        if (creature.riding) {
+            dispel_monster_status(creature, creature.riding);
         }
 
         if (creature.is_echizen()) {

--- a/src/mspell/mspell-util.cpp
+++ b/src/mspell/mspell-util.cpp
@@ -61,18 +61,17 @@ bool monster_near_player(const CreatureEntity &creature, MONSTER_IDX m_idx, MONS
  */
 bool monspell_message_base(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, const mspell_cast_msg &msgs, bool msg_flag_aux, int target_type)
 {
-    auto &player = creature;
     bool notice = false;
     auto &floor = *creature.current_floor_ptr;
     bool known = monster_near_player(creature, m_idx, t_idx);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
-    const auto m_name = monster_name(player, m_idx);
-    const auto t_name = monster_name(player, t_idx);
+    const auto m_name = monster_name(creature, m_idx);
+    const auto t_name = monster_name(creature, t_idx);
 
     if (mon_to_player || (mon_to_mon && known && see_either)) {
-        disturb(player, true, true);
+        disturb(creature, true, true);
     }
 
     if (msg_flag_aux) {
@@ -111,9 +110,8 @@ bool monspell_message_base(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_
  */
 bool monspell_message(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, const mspell_cast_msg_blind &msgs, int target_type)
 {
-    auto &player = creature;
     mspell_cast_msg mcm(msgs.blind, msgs.blind, msgs.to_player, msgs.to_mons);
-    const auto is_blind = player.is_blind();
+    const auto is_blind = creature.is_blind();
     return monspell_message_base(creature, m_idx, t_idx, mcm, is_blind, target_type);
 }
 
@@ -127,8 +125,7 @@ bool monspell_message(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t
  */
 void simple_monspell_message(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, const mspell_cast_msg_simple &msgs, int target_type)
 {
-    auto &player = creature;
     mspell_cast_msg mcm(msgs.to_player, msgs.to_mons, msgs.to_player, msgs.to_mons);
-    const auto is_blind = player.is_blind();
+    const auto is_blind = creature.is_blind();
     monspell_message_base(creature, m_idx, t_idx, mcm, is_blind, target_type);
 }

--- a/src/mutation/gain-mutation-switcher.cpp
+++ b/src/mutation/gain-mutation-switcher.cpp
@@ -7,7 +7,6 @@
 
 void switch_gain_mutation(CreatureEntity &creature, glm_type *glm_ptr)
 {
-    auto &player = creature;
     CreatureClass pc(creature);
 
     // 変異の決定
@@ -40,14 +39,14 @@ void switch_gain_mutation(CreatureEntity &creature, glm_type *glm_ptr)
 
     case PlayerMutationType::BAD_LUCK:
         // 幸運な性格の場合、このミュテーションは無効
-        if (player.ppersonality == PERSONALITY_LUCKY) {
+        if (creature.ppersonality == PERSONALITY_LUCKY) {
             glm_ptr->muta_which = PlayerMutationType::MAX;
         }
         break;
 
     case PlayerMutationType::ATT_PERVERT:
         // メスガキ性格の場合、このミュテーションは無効
-        if (player.ppersonality == PERSONALITY_MESUGAKI) {
+        if (creature.ppersonality == PERSONALITY_MESUGAKI) {
             glm_ptr->muta_which = PlayerMutationType::MAX;
         }
         break;

--- a/src/mutation/lose-mutation-switcher.cpp
+++ b/src/mutation/lose-mutation-switcher.cpp
@@ -5,7 +5,6 @@
 
 void switch_lose_mutation(CreatureEntity &creature, glm_type *glm_ptr)
 {
-    auto &player = creature;
     switch ((glm_ptr->choose_mut != 0) ? glm_ptr->choose_mut : randint1(205)) {
     case 1:
     case 2:
@@ -491,7 +490,7 @@ void switch_lose_mutation(CreatureEntity &creature, glm_type *glm_ptr)
         glm_ptr->muta_desc = _("動作の正確さがなくなった。", "You move with less assurance.");
         break;
     case 193:
-        if (player.ppersonality == PERSONALITY_LUCKY) {
+        if (creature.ppersonality == PERSONALITY_LUCKY) {
             break;
         }
 
@@ -529,7 +528,7 @@ void switch_lose_mutation(CreatureEntity &creature, glm_type *glm_ptr)
         break;
     case 208:
         glm_ptr->muta_which = PlayerMutationType::ATT_PERVERT;
-        if (player.ppersonality == PERSONALITY_MESUGAKI) {
+        if (creature.ppersonality == PERSONALITY_MESUGAKI) {
             glm_ptr->muta_desc = _("メスガキの変質者引きつけは治療対象外だ。", "Mesugaki's pervert attraction is not curable.");
             glm_ptr->muta_which = PlayerMutationType::MAX;
             break;

--- a/src/mutation/mutation-investor-remover.cpp
+++ b/src/mutation/mutation-investor-remover.cpp
@@ -36,12 +36,11 @@ static void sweep_gain_mutation(CreatureEntity &creature, glm_type *gm_ptr)
 
 static void race_dependent_mutation(CreatureEntity &creature, glm_type *gm_ptr)
 {
-    auto &player = creature;
     if (gm_ptr->choose_mut != 0) {
         return;
     }
 
-    CreatureRace pr(&player);
+    CreatureRace pr(&creature);
     if (pr.equals(PlayerRaceType::VAMPIRE) && creature.muta.has_not(PlayerMutationType::HYPN_GAZE) && (randint1(10) < 7)) {
         gm_ptr->muta_which = PlayerMutationType::HYPN_GAZE;
         gm_ptr->muta_desc = _("眼が幻惑的になった...", "Your eyes look mesmerizing...");
@@ -229,7 +228,6 @@ static void neutralize_other_status(CreatureEntity &creature, glm_type *gm_ptr)
  */
 bool gain_mutation(CreatureEntity &creature, MUTATION_IDX choose_mut)
 {
-    auto &player = creature;
     glm_type tmp_gm;
     glm_type *gm_ptr = initialize_glm_type(&tmp_gm, choose_mut);
     sweep_gain_mutation(creature, gm_ptr);
@@ -251,16 +249,16 @@ bool gain_mutation(CreatureEntity &creature, MUTATION_IDX choose_mut)
 
     // 肛門破壊の突然変異を獲得した場合、尻の穴の装備を強制的に外す
     if (gm_ptr->muta_which == PlayerMutationType::DESTROYED_ASSHOLE) {
-        auto &asshole_item = *player.inventory[INVEN_ASSHOLE];
+        auto &asshole_item = *creature.inventory[INVEN_ASSHOLE];
         if (asshole_item.is_valid()) {
             msg_print(_("肛門が破壊されたため、尻の穴の装備が外れた！", "Your asshole equipment has been removed due to destruction!"));
-            (void)inven_takeoff(player, INVEN_ASSHOLE, 255);
+            (void)inven_takeoff(creature, INVEN_ASSHOLE, 255);
         }
     }
 
-    player.mutant_regenerate_mod = calc_mutant_regenerate_mod(player);
+    creature.mutant_regenerate_mod = calc_mutant_regenerate_mod(creature);
     RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(player);
+    handle_stuff(creature);
     return true;
 }
 
@@ -292,7 +290,6 @@ static void sweep_lose_mutation(CreatureEntity &creature, glm_type *glm_ptr)
  */
 bool lose_mutation(CreatureEntity &creature, MUTATION_IDX choose_mut)
 {
-    auto &player = creature;
     glm_type tmp_glm;
     glm_type *glm_ptr = initialize_glm_type(&tmp_glm, choose_mut);
     sweep_lose_mutation(creature, glm_ptr);
@@ -306,20 +303,19 @@ bool lose_mutation(CreatureEntity &creature, MUTATION_IDX choose_mut)
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(player);
-    player.mutant_regenerate_mod = calc_mutant_regenerate_mod(player);
+    handle_stuff(creature);
+    creature.mutant_regenerate_mod = calc_mutant_regenerate_mod(creature);
     return true;
 }
 
 void lose_all_mutations(CreatureEntity &creature)
 {
-    auto &player = creature;
     if (creature.muta.any()) {
         chg_virtue(creature, Virtue::CHANCE, -5);
         msg_print(_("全ての突然変異が治った。", "You are cured of all mutations."));
         creature.muta.clear();
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
-        handle_stuff(player);
-        player.mutant_regenerate_mod = calc_mutant_regenerate_mod(player);
+        handle_stuff(creature);
+        creature.mutant_regenerate_mod = calc_mutant_regenerate_mod(creature);
     }
 }

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -133,11 +133,10 @@ bool activate_judgement(CreatureEntity &creature, std::string_view name)
     msg_format(_("%sは赤く明るく光った！", "The %s flashes bright red!"), name.data());
     chg_virtue(creature, Virtue::KNOWLEDGE, 1);
     chg_virtue(creature, Virtue::ENLIGHTEN, 1);
-    auto &player = creature;
     wiz_lite(creature, false);
 
     msg_format(_("%sはあなたの体力を奪った...", "The %s drains your vitality..."), name.data());
-    take_hit(player, DAMAGE_LOSELIFE, Dice::roll(3, 8), _("審判の宝石", "the Jewel of Judgement"));
+    take_hit(creature, DAMAGE_LOSELIFE, Dice::roll(3, 8), _("審判の宝石", "the Jewel of Judgement"));
 
     (void)detect_traps(creature, DETECT_RAD_DEFAULT, true);
     (void)detect_doors(creature, DETECT_RAD_DEFAULT);

--- a/src/perception/simple-perception.cpp
+++ b/src/perception/simple-perception.cpp
@@ -34,8 +34,7 @@
  */
 static void sense_inventory_aux(CreatureEntity &creature, INVENTORY_IDX slot, bool heavy)
 {
-    auto &player = creature;
-    auto &item = *player.inventory[slot];
+    auto &item = *creature.inventory[slot];
     if (any_bits(item.ident, IDENT_SENSE) || item.is_known()) {
         return;
     }
@@ -45,7 +44,7 @@ static void sense_inventory_aux(CreatureEntity &creature, INVENTORY_IDX slot, bo
         return;
     }
 
-    if ((player.muta.has(PlayerMutationType::BAD_LUCK)) && !randint0(13)) {
+    if ((creature.muta.has(PlayerMutationType::BAD_LUCK)) && !randint0(13)) {
         switch (feel) {
         case FEEL_TERRIBLE: {
             feel = FEEL_SPECIAL;
@@ -145,15 +144,14 @@ static void sense_inventory_aux(CreatureEntity &creature, INVENTORY_IDX slot, bo
  */
 void sense_inventory1(CreatureEntity &creature)
 {
-    auto &player = creature;
-    PLAYER_LEVEL plev = player.level;
+    PLAYER_LEVEL plev = creature.level;
     bool heavy = false;
     ItemEntity *o_ptr;
-    if (player.is_confused()) {
+    if (creature.is_confused()) {
         return;
     }
 
-    switch (player.pclass) {
+    switch (creature.pclass) {
     case PlayerClassType::WARRIOR:
     case PlayerClassType::ARCHER:
     case PlayerClassType::SAMURAI:
@@ -281,7 +279,7 @@ void sense_inventory1(CreatureEntity &creature)
     }
 
     for (INVENTORY_IDX i = 0; i < INVEN_TOTAL; i++) {
-        o_ptr = player.inventory[i].get();
+        o_ptr = creature.inventory[i].get();
 
         if (!o_ptr->is_valid()) {
             continue;
@@ -334,15 +332,14 @@ void sense_inventory1(CreatureEntity &creature)
  */
 void sense_inventory2(CreatureEntity &creature)
 {
-    auto &player = creature;
-    PLAYER_LEVEL plev = player.level;
+    PLAYER_LEVEL plev = creature.level;
     ItemEntity *o_ptr;
 
-    if (player.is_confused()) {
+    if (creature.is_confused()) {
         return;
     }
 
-    switch (player.pclass) {
+    switch (creature.pclass) {
     case PlayerClassType::WARRIOR:
     case PlayerClassType::ARCHER:
     case PlayerClassType::SAMURAI:
@@ -411,7 +408,7 @@ void sense_inventory2(CreatureEntity &creature)
 
     for (INVENTORY_IDX i = 0; i < INVEN_TOTAL; i++) {
         bool okay = false;
-        o_ptr = player.inventory[i].get();
+        o_ptr = creature.inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/pet/pet-util.cpp
+++ b/src/pet/pet-util.cpp
@@ -22,7 +22,6 @@ int total_friends = 0;
  */
 bool can_player_ride_pet(CreatureEntity &creature, const Grid &grid, bool now_riding)
 {
-    auto &player = creature;
     auto &world = AngbandWorld::get_instance();
     const auto old_character_xtra = world.character_xtra;
     const auto old_riding = creature.riding;
@@ -32,9 +31,9 @@ bool can_player_ride_pet(CreatureEntity &creature, const Grid &grid, bool now_ri
     world.character_xtra = true;
 
     if (now_riding) {
-        player.ride_monster(grid.m_idx);
+        creature.ride_monster(grid.m_idx);
     } else {
-        player.ride_monster(0);
+        creature.ride_monster(0);
         creature.pet_extra_flags &= ~(PF_TWO_HANDS);
         creature.riding_ryoute = creature.old_riding_ryoute = false;
     }
@@ -44,7 +43,7 @@ bool can_player_ride_pet(CreatureEntity &creature, const Grid &grid, bool now_ri
     handle_stuff(creature);
 
     bool p_can_enter = player_can_enter(creature, grid.feat, CEM_P_CAN_ENTER_PATTERN);
-    player.ride_monster(old_riding);
+    creature.ride_monster(old_riding);
     if (old_pf_two_hands) {
         creature.pet_extra_flags |= (PF_TWO_HANDS);
     } else {

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -229,13 +229,12 @@ static void attack_teleport_away(CreatureEntity &creature, player_attack_type *p
  */
 static void attack_polymorph(CreatureEntity &creature, player_attack_type *pa_ptr, POSITION y, POSITION x)
 {
-    auto &player = creature;
     const auto &monrace = *pa_ptr->r_ptr;
     if (monrace.kind_flags.has(MonsterKindType::UNIQUE) || monrace.misc_flags.has(MonsterMiscType::QUESTOR) || monrace.resistance_flags.has_any_of(RFR_EFF_RESIST_CHAOS_MASK)) {
         return;
     }
 
-    if (polymorph_monster(player, y, x)) {
+    if (polymorph_monster(creature, y, x)) {
         msg_format(_("%s^は変化した！", "%s^ changes!"), pa_ptr->m_name);
         *(pa_ptr->fear) = false;
         pa_ptr->weak = false;
@@ -254,7 +253,6 @@ static void attack_polymorph(CreatureEntity &creature, player_attack_type *pa_pt
  */
 static void attack_golden_hammer(CreatureEntity &creature, player_attack_type *pa_ptr)
 {
-    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     auto &monster = floor.get_monster(pa_ptr->m_idx);
     if (monster.get_monster_profile().hold_o_idx_list.empty()) {
@@ -262,12 +260,12 @@ static void attack_golden_hammer(CreatureEntity &creature, player_attack_type *p
     }
 
     auto &item = *floor.o_list[monster.get_monster_profile().hold_o_idx_list.front()];
-    const auto item_name = describe_flavor(player, item, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(creature, item, OD_NAME_ONLY);
     item.held_m_idx = 0;
     item.marked.clear().set(OmType::TOUCHED);
     monster.get_monster_profile().hold_o_idx_list.pop_front();
     msg_format(_("%sを奪った。", "You snatched %s."), item_name.data());
-    store_item_to_inventory(player, &item);
+    store_item_to_inventory(creature, &item);
 }
 
 /*!

--- a/src/player-info/body-improvement-info.cpp
+++ b/src/player-info/body-improvement-info.cpp
@@ -41,16 +41,15 @@ void set_body_improvement_info_1(CreatureEntity &creature, self_info_type *self_
 /*!< @todo 並び順の都合で連番を付ける。まとめても良いならまとめてしまう予定 */
 void set_body_improvement_info_2(CreatureEntity &creature, self_info_type *self_ptr)
 {
-    auto &player = creature;
-    if (player.new_spells) {
+    if (creature.new_spells) {
         self_ptr->info_list.emplace_back(_("あなたは呪文や祈りを学ぶことができる。", "You can learn some spells/prayers."));
     }
 
-    if (player.word_recall) {
+    if (creature.word_recall) {
         self_ptr->info_list.emplace_back(_("あなたはすぐに帰還するだろう。", "You will soon be recalled."));
     }
 
-    if (player.alter_reality) {
+    if (creature.alter_reality) {
         self_ptr->info_list.emplace_back(_("あなたはすぐにこの世界を離れるだろう。", "You will soon be altered."));
     }
 

--- a/src/player-info/class-ability-info.cpp
+++ b/src/player-info/class-ability-info.cpp
@@ -6,7 +6,6 @@
 
 void set_class_ability_info(CreatureEntity &creature, self_info_type *self_ptr)
 {
-    auto &player = creature;
     switch (creature.pclass) {
     case PlayerClassType::WARRIOR:
         if (creature.level > 39) {
@@ -15,7 +14,7 @@ void set_class_ability_info(CreatureEntity &creature, self_info_type *self_ptr)
 
         break;
     case PlayerClassType::HIGH_MAGE:
-        if (PlayerRealm(player).is_realm_hex()) {
+        if (PlayerRealm(creature).is_realm_hex()) {
             break;
         }
         [[fallthrough]];
@@ -27,7 +26,7 @@ void set_class_ability_info(CreatureEntity &creature, self_info_type *self_ptr)
 
         break;
     case PlayerClassType::PRIEST:
-        if (PlayerRealm(player).realm1().is_good_attribute()) {
+        if (PlayerRealm(creature).realm1().is_good_attribute()) {
             if (creature.level > 34) {
                 self_ptr->info_list.emplace_back(_("あなたは武器を祝福することができる。(70 MP)", "You can bless a weapon (cost 70)."));
             }
@@ -53,7 +52,7 @@ void set_class_ability_info(CreatureEntity &creature, self_info_type *self_ptr)
 
         break;
     case PlayerClassType::PALADIN:
-        if (PlayerRealm(player).realm1().is_good_attribute()) {
+        if (PlayerRealm(creature).realm1().is_good_attribute()) {
             if (creature.level > 29) {
                 self_ptr->info_list.emplace_back(_("あなたは聖なる槍を放つことができる。(30 MP)", "You can fire a holy spear (cost 30)."));
             }

--- a/src/player/digestion-processor.cpp
+++ b/src/player/digestion-processor.cpp
@@ -26,27 +26,26 @@
  */
 void starve_player(CreatureEntity &creature)
 {
-    auto &player = creature;
     if (AngbandSystem::get_instance().is_phase_out()) {
         return;
     }
 
-    if (player.food >= PY_FOOD_MAX) {
-        (void)set_food(creature, player.food - 100);
+    if (creature.food >= PY_FOOD_MAX) {
+        (void)set_food(creature, creature.food - 100);
     } else if (AngbandWorld::get_instance().game_turn % (TURNS_PER_TICK * 5) == 0) {
         int digestion = speed_to_energy(creature.get_speed());
-        if (player.regenerate) {
+        if (creature.regenerate) {
             digestion += 20;
         }
         CreatureClass pc(creature);
         if (!pc.monk_stance_is(MonkStanceType::NONE) || !pc.samurai_stance_is(SamuraiStanceType::NONE)) {
             digestion += 20;
         }
-        if (player.cursed.has(CurseTraitType::FAST_DIGEST)) {
+        if (creature.cursed.has(CurseTraitType::FAST_DIGEST)) {
             digestion += 30;
         }
 
-        if (player.slow_digest) {
+        if (creature.slow_digest) {
             digestion -= 5;
         }
 
@@ -61,10 +60,10 @@ void starve_player(CreatureEntity &creature)
             digestion *= 100;
         }
 
-        (void)set_food(creature, player.food - digestion);
+        (void)set_food(creature, creature.food - digestion);
     }
 
-    if ((player.food >= PY_FOOD_FAINT)) {
+    if ((creature.food >= PY_FOOD_FAINT)) {
         return;
     }
 
@@ -74,8 +73,8 @@ void starve_player(CreatureEntity &creature)
         (void)BadStatusSetter(creature).mod_paralysis(1 + randint0(5));
     }
 
-    if (player.food < PY_FOOD_STARVE) {
-        int dam = (PY_FOOD_STARVE - player.food) / 10;
+    if (creature.food < PY_FOOD_STARVE) {
+        int dam = (PY_FOOD_STARVE - creature.food) / 10;
         if (!creature.is_invulnerable()) {
             take_hit(creature, DAMAGE_LOSELIFE, dam, _("空腹", "starvation"));
         }
@@ -93,42 +92,41 @@ void starve_player(CreatureEntity &creature)
  * addition of the most "filling" item, Elvish Waybread, which adds
  * 7500 food units, without overflowing the 32767 maximum limit.\n
  *\n
- * Perhaps we should disturb the player with various messages,
+ * Perhaps we should disturb the creature with various messages,
  * especially messages about hunger status changes.  \n
  *\n
  * Digestion of food is handled in "dungeon.c", in which, normally,
- * the player digests about 20 food units per 100 game turns, more
+ * the creature digests about 20 food units per 100 game turns, more
  * when "fast", more when "regenerating", less with "slow digestion",
- * but when the player is "gorged", he digests 100 food units per 10
+ * but when the creature is "gorged", he digests 100 food units per 10
  * game turns, or a full 1000 food units per 100 game turns.\n
  *\n
- * Note that the player's speed is reduced by 10 units while gorged,
- * so if the player eats a single food ration (5000 food units) when
+ * Note that the creature's speed is reduced by 10 units while gorged,
+ * so if the creature eats a single food ration (5000 food units) when
  * full (15000 food units), he will be gorged for (5000/100)*10 = 500
- * game turns, or 500/(100/5) = 25 player turns (if nothing else is
- * affecting the player speed).\n
+ * game turns, or 500/(100/5) = 25 creature turns (if nothing else is
+ * affecting the creature speed).\n
  */
 bool set_food(CreatureEntity &creature, TIME_EFFECT v)
 {
     if (!creature.is_player()) {
         return false;
     }
-    auto &player = creature;
 
     int old_aux, new_aux;
 
     bool notice = false;
     v = (v > 20000) ? 20000 : (v < 0) ? 0
                                       : v;
-    if (player.food < PY_FOOD_FAINT) {
+    if (creature.food < PY_FOOD_FAINT) {
         old_aux = 0;
-    } else if (player.food < PY_FOOD_WEAK) {
+    } else if (creature.food < PY_FOOD_WEAK) {
         old_aux = 1;
-    } else if (player.food < PY_FOOD_ALERT) {
+    } else if (creature.food < PY_FOOD_ALERT) {
         old_aux = 2;
-    } else if (player.food < PY_FOOD_FULL) {
+    } else if (creature.food < PY_FOOD_FULL) {
         old_aux = 3;
-    } else if (player.food < PY_FOOD_MAX) {
+    } else if (creature.food < PY_FOOD_MAX) {
         old_aux = 4;
     } else {
         old_aux = 5;
@@ -211,13 +209,13 @@ bool set_food(CreatureEntity &creature, TIME_EFFECT v)
         }
 
         if (AngbandWorld::get_instance().is_wild_mode() && (new_aux < 2)) {
-            change_wild_mode(player, false);
+            change_wild_mode(creature, false);
         }
 
         notice = true;
     }
 
-    player.food = v;
+    creature.food = v;
     if (!notice) {
         return false;
     }
@@ -229,7 +227,7 @@ bool set_food(CreatureEntity &creature, TIME_EFFECT v)
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
     rfu.set_flag(MainWindowRedrawingFlag::HUNGER);
-    handle_stuff(player);
+    handle_stuff(creature);
 
     return true;
 }

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -36,8 +36,7 @@
 
 static bool process_mod_hallucination(CreatureEntity &creature, std::string_view m_name, const MonraceDefinition &monrace)
 {
-    auto &player = creature;
-    if (!player.effects()->hallucination().is_hallucinated()) {
+    if (!creature.effects()->hallucination().is_hallucinated()) {
         return false;
     }
 
@@ -57,7 +56,6 @@ static bool process_mod_hallucination(CreatureEntity &creature, std::string_view
  */
 void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necro)
 {
-    auto &player = creature;
     const auto &world = AngbandWorld::get_instance();
     if (AngbandSystem::get_instance().is_phase_out() || !world.character_dungeon) {
         return;
@@ -98,7 +96,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
             return;
         }
 
-        if (evaluate_percent(player.skill_sav - power)) {
+        if (evaluate_percent(creature.skill_sav - power)) {
             return;
         }
 
@@ -112,7 +110,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
         case PlayerRaceLifeType::DEMON:
             return;
         case PlayerRaceLifeType::UNDEAD:
-            if (evaluate_percent(25 + player.level)) {
+            if (evaluate_percent(25 + creature.level)) {
                 return;
             }
             break;
@@ -144,7 +142,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
             power *= 2;
         }
 
-        if (evaluate_percent(player.skill_sav * 100 / power)) {
+        if (evaluate_percent(creature.skill_sav * 100 / power)) {
             msg_format(_("夢の中で%sに追いかけられた。", "%s^ chases you through your dreams."), m_name.data());
             return;
         }
@@ -157,12 +155,12 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
         monrace.r_misc_flags.set(MonsterMiscType::ELDRITCH_HORROR);
         switch (CreatureRace(&creature).life()) {
         case PlayerRaceLifeType::DEMON:
-            if (evaluate_percent(20 + player.level)) {
+            if (evaluate_percent(20 + creature.level)) {
                 return;
             }
             break;
         case PlayerRaceLifeType::UNDEAD:
-            if (evaluate_percent(10 + player.level)) {
+            if (evaluate_percent(10 + creature.level)) {
                 return;
             }
             break;
@@ -176,7 +174,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
     /* 過去の効果無効率再現のため5回saving_throw 実行 */
     auto save = true;
     for (auto i = 0; i < 5; i++) {
-        save &= evaluate_percent(player.skill_sav - power);
+        save &= evaluate_percent(creature.skill_sav - power);
     }
 
     if (save) {
@@ -185,48 +183,48 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
 
     switch (randint1(22)) {
     case 1: {
-        if (player.muta.has_not(PlayerMutationType::MORONIC)) {
-            if ((player.stat_use[A_INT] < 4) && (player.stat_use[A_WIS] < 4)) {
+        if (creature.muta.has_not(PlayerMutationType::MORONIC)) {
+            if ((creature.stat_use[A_INT] < 4) && (creature.stat_use[A_WIS] < 4)) {
                 msg_print(_("あなたは完璧な馬鹿になったような気がした。しかしそれは元々だった。", "You turn into an utter moron!"));
             } else {
                 msg_print(_("あなたは完璧な馬鹿になった！", "You turn into an utter moron!"));
             }
 
-            if (player.muta.has(PlayerMutationType::HYPER_INT)) {
+            if (creature.muta.has(PlayerMutationType::HYPER_INT)) {
                 msg_print(_("あなたの脳は生体コンピュータではなくなった。", "Your brain is no longer a living computer."));
-                player.muta.reset(PlayerMutationType::HYPER_INT);
+                creature.muta.reset(PlayerMutationType::HYPER_INT);
             }
 
-            player.muta.set(PlayerMutationType::MORONIC);
+            creature.muta.set(PlayerMutationType::MORONIC);
         }
 
         break;
     }
     case 2: {
-        if (player.muta.has_not(PlayerMutationType::COWARDICE) && !has_resist_fear(creature)) {
+        if (creature.muta.has_not(PlayerMutationType::COWARDICE) && !has_resist_fear(creature)) {
             msg_print(_("あなたはパラノイアになった！", "You become paranoid!"));
-            if (player.muta.has(PlayerMutationType::FEARLESS)) {
+            if (creature.muta.has(PlayerMutationType::FEARLESS)) {
                 msg_print(_("あなたはもう恐れ知らずではなくなった。", "You are no longer fearless."));
-                player.muta.reset(PlayerMutationType::FEARLESS);
+                creature.muta.reset(PlayerMutationType::FEARLESS);
             }
 
-            player.muta.set(PlayerMutationType::COWARDICE);
+            creature.muta.set(PlayerMutationType::COWARDICE);
         }
 
         break;
     }
     case 3: {
-        if (player.muta.has_not(PlayerMutationType::HALLU) && !has_resist_chaos(creature)) {
+        if (creature.muta.has_not(PlayerMutationType::HALLU) && !has_resist_chaos(creature)) {
             msg_print(_("幻覚をひき起こす精神錯乱に陥った！", "You are afflicted by a hallucinatory insanity!"));
-            player.muta.set(PlayerMutationType::HALLU);
+            creature.muta.set(PlayerMutationType::HALLU);
         }
 
         break;
     }
     case 4: {
-        if (player.muta.has_not(PlayerMutationType::BERS_RAGE) && !has_resist_conf(creature)) {
+        if (creature.muta.has_not(PlayerMutationType::BERS_RAGE) && !has_resist_conf(creature)) {
             msg_print(_("激烈な感情の発作におそわれるようになった！", "You become subject to fits of berserk rage!"));
-            player.muta.set(PlayerMutationType::BERS_RAGE);
+            creature.muta.set(PlayerMutationType::BERS_RAGE);
         }
 
         break;
@@ -259,7 +257,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
         if (!has_resist_conf(creature)) {
             (void)bss.mod_confusion(randint0(4) + 4);
         }
-        if (!player.free_act) {
+        if (!creature.free_act) {
             (void)bss.mod_paralysis(randint0(4) + 4);
         }
         if (!has_resist_chaos(creature)) {
@@ -268,11 +266,11 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
 
         do {
             (void)do_dec_stat(creature, A_INT);
-        } while (!player.try_resist_eldritch_horror());
+        } while (!creature.try_resist_eldritch_horror());
 
         do {
             (void)do_dec_stat(creature, A_WIS);
-        } while (!player.try_resist_eldritch_horror());
+        } while (!creature.try_resist_eldritch_horror());
 
         break;
     }

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -149,7 +149,6 @@ Patron::Patron(LocalizedString &&name, std::vector<patron_reward> reward_table, 
 
 void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
 {
-    auto &player = creature;
     int nasty_chance = 6;
     int type;
     patron_reward effect;
@@ -157,18 +156,18 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
     int count = 0;
 
     if (!chosen_reward) {
-        if (player.suppress_multi_reward) {
+        if (creature.suppress_multi_reward) {
             return;
         } else {
-            player.suppress_multi_reward = true;
+            creature.suppress_multi_reward = true;
         }
     }
 
-    if (player.level == 13) {
+    if (creature.level == 13) {
         nasty_chance = 2;
-    } else if (!(player.level % 13)) {
+    } else if (!(creature.level % 13)) {
         nasty_chance = 3;
-    } else if (!(player.level % 14)) {
+    } else if (!(creature.level % 14)) {
         nasty_chance = 12;
     }
 
@@ -193,30 +192,30 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
 
     if (one_in_(6) && !chosen_reward) {
         msg_format(_("%s^は褒美としてあなたを突然変異させた。", "%s^ rewards you with a mutation!"), this->name.data());
-        (void)gain_mutation(player, 0);
+        (void)gain_mutation(creature, 0);
         reward = _("変異した。", "mutation");
     } else {
-        const auto &floor = *player.current_floor_ptr;
+        const auto &floor = *creature.current_floor_ptr;
         switch (chosen_reward ? chosen_reward : effect) {
         case REW_POLY_SLF:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝、新たなる姿を必要とせり！」", "'Thou needst a new form, mortal!'"));
-            do_poly_self(player);
+            do_poly_self(creature);
             reward = _("変異した。", "polymorphing");
             break;
         case REW_GAIN_EXP:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝は良く行いたり！続けよ！」", "'Well done, mortal! Lead on!'"));
-            if (CreatureRace(&player).equals(PlayerRaceType::ANDROID)) {
+            if (CreatureRace(&creature).equals(PlayerRaceType::ANDROID)) {
                 msg_print(_("しかし何も起こらなかった。", "But, nothing happens."));
-            } else if (player.exp < PY_MAX_EXP) {
-                int32_t ee = (player.exp / 2) + 10;
+            } else if (creature.exp < PY_MAX_EXP) {
+                int32_t ee = (creature.exp / 2) + 10;
                 if (ee > 100000L) {
                     ee = 100000L;
                 }
 
                 msg_print(_("更に経験を積んだような気がする。", "You feel more experienced."));
-                gain_exp(player, ee);
+                gain_exp(creature, ee);
                 reward = _("経験値を得た", "experience");
             }
 
@@ -224,10 +223,10 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
         case REW_LOSE_EXP:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「下僕よ、汝それに値せず。」", "'Thou didst not deserve that, slave.'"));
-            if (CreatureRace(&player).equals(PlayerRaceType::ANDROID)) {
+            if (CreatureRace(&creature).equals(PlayerRaceType::ANDROID)) {
                 msg_print(_("しかし何も起こらなかった。", "But, nothing happens."));
             } else {
-                lose_exp(player, player.exp / 6);
+                lose_exp(creature, creature.exp / 6);
                 reward = _("経験値を失った。", "losing experience");
             }
 
@@ -235,44 +234,44 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
         case REW_GOOD_OBJ:
             msg_format(_("%sの声がささやいた:", "The voice of %s whispers:"), this->name.data());
             msg_print(_("「我が与えし物を賢明に使うべし。」", "'Use my gift wisely.'"));
-            acquirement(player, player.y, player.x, 1, false);
+            acquirement(creature, creature.y, creature.x, 1, false);
             reward = _("上質なアイテムを手に入れた。", "a good item");
             break;
         case REW_GREA_OBJ:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「我が与えし物を賂明に使うべし。」", "'Use my gift wisely.'"));
-            acquirement(player, player.y, player.x, 1, true);
+            acquirement(creature, creature.y, creature.x, 1, true);
             reward = _("高級品のアイテムを手に入れた。", "an excellent item");
             break;
         case REW_CHAOS_WP:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝の行いは貴き剣に値せり。」", "'Thy deed hath earned thee a worthy blade.'"));
-            acquire_chaos_weapon(player);
+            acquire_chaos_weapon(creature);
             reward = _("(混沌)の武器を手に入れた。", "chaos weapon");
             break;
         case REW_GOOD_OBS:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝の行いは貴き報いに値せり。」", "'Thy deed hath earned thee a worthy reward.'"));
-            acquirement(player, player.y, player.x, randint1(2) + 1, false);
+            acquirement(creature, creature.y, creature.x, randint1(2) + 1, false);
             reward = _("上質なアイテムを手に入れた。", "good items");
             break;
         case REW_GREA_OBS:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「下僕よ、汝の献身への我が惜しみ無き報いを見るがよい。」", "'Behold, mortal, how generously I reward thy loyalty.'"));
-            acquirement(player, player.y, player.x, randint1(2) + 1, true);
+            acquirement(creature, creature.y, creature.x, randint1(2) + 1, true);
             reward = _("高級品のアイテムを手に入れた。", "excellent items");
             break;
         case REW_TY_CURSE:
             msg_format(_("%sの声が轟き渡った:", "The voice of %s thunders:"), this->name.data());
             msg_print(_("「下僕よ、汝傲慢なり。」", "'Thou art growing arrogant, mortal.'"));
-            (void)activate_ty_curse(player, false, &count);
+            (void)activate_ty_curse(creature, false, &count);
             reward = _("禍々しい呪いをかけられた。", "cursing");
             break;
         case REW_SUMMON_M:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「我が下僕たちよ、かの傲慢なる者を倒すべし！」", "'My pets, destroy the arrogant mortal!'"));
             for (int i = 0, summon_num = randint1(5) + 1; i < summon_num; i++) {
-                (void)summon_specific(player, player.y, player.x, floor.dun_level, SUMMON_NONE,
+                (void)summon_specific(creature, creature.y, creature.x, floor.dun_level, SUMMON_NONE,
                     (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
             }
 
@@ -281,22 +280,22 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
         case REW_H_SUMMON:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝、より強き敵を必要とせり！」", "'Thou needst worthier opponents!'"));
-            activate_hi_summon(player, player.y, player.x, false);
+            activate_hi_summon(creature, creature.y, creature.x, false);
             reward = _("モンスターを召喚された。", "summoning many hostile monsters");
             break;
         case REW_DO_HAVOC:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「死と破壊こそ我が喜びなり！」", "'Death and destruction! This pleaseth me!'"));
-            call_chaos(player);
+            call_chaos(creature);
             reward = _("カオスの力が渦巻いた。", "calling chaos");
             break;
         case REW_GAIN_ABL:
             msg_format(_("%sの声が鳴り響いた:", "The voice of %s rings out:"), this->name.data());
             msg_print(_("「留まるのだ、下僕よ。余が汝の肉体を鍛えん。」", "'Stay, mortal, and let me mold thee.'"));
             if ((this->boost_stat == A_RANDOM) || !one_in_(3)) {
-                do_inc_stat(player, randint0(6));
+                do_inc_stat(creature, randint0(6));
             } else {
-                do_inc_stat(player, this->boost_stat);
+                do_inc_stat(creature, this->boost_stat);
             }
 
             reward = _("能力値が上がった。", "increasing a stat");
@@ -305,9 +304,9 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「下僕よ、余は汝に飽みたり。」", "'I grow tired of thee, mortal.'"));
             if ((this->boost_stat == A_RANDOM) || !one_in_(3)) {
-                do_dec_stat(player, randint0(6));
+                do_dec_stat(creature, randint0(6));
             } else {
-                do_dec_stat(player, this->boost_stat);
+                do_dec_stat(creature, this->boost_stat);
             }
 
             reward = _("能力値が下がった。", "decreasing a stat");
@@ -317,21 +316,21 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
             msg_print(_("「汝、謙虚たることを学ぶべし！」", "'Thou needst a lesson in humility, mortal!'"));
             msg_print(_("あなたは以前より弱くなった！", "You feel less powerful!"));
             for (int stat = 0; stat < A_MAX; stat++) {
-                (void)dec_stat(player, stat, 10 + randint1(15), true);
+                (void)dec_stat(creature, stat, 10 + randint1(15), true);
             }
 
             reward = _("全能力値が下がった。", "decreasing all stats");
             break;
         case REW_POLY_WND:
             msg_format(_("%sの力が触れるのを感じた。", "You feel the power of %s touch you."), this->name.data());
-            do_poly_wounds(player);
+            do_poly_wounds(creature);
             reward = _("傷が変化した。", "polymorphing wounds");
             break;
         case REW_AUGM_ABL:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「我がささやかなる賜物を受けとるがよい！」", "'Receive this modest gift from me!'"));
             for (int stat = 0; stat < A_MAX; stat++) {
-                (void)do_inc_stat(player, stat);
+                (void)do_inc_stat(creature, stat);
             }
 
             reward = _("全能力値が上がった。", "increasing all stats");
@@ -339,48 +338,48 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
         case REW_HURT_LOT:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「苦しむがよい、無能な愚か者よ！」", "'Suffer, pathetic fool!'"));
-            fire_ball(player, AttributeType::DISINTEGRATE, Direction::self(), player.level * 4, 4);
-            take_hit(player, DAMAGE_NOESCAPE, player.level * 4, wrath_reason);
+            fire_ball(creature, AttributeType::DISINTEGRATE, Direction::self(), creature.level * 4, 4);
+            take_hit(creature, DAMAGE_NOESCAPE, creature.level * 4, wrath_reason);
             reward = _("分解の球が発生した。", "generating disintegration ball");
             break;
         case REW_HEAL_FUL:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「甦るがよい、我が下僕よ！」", "'Rise, my servant!'"));
-            (void)restore_level(player);
-            (void)restore_all_status(player);
-            (void)true_healing(player, 5000);
+            (void)restore_level(creature);
+            (void)restore_all_status(creature);
+            (void)true_healing(creature, 5000);
             reward = _("体力が回復した。", "healing");
             break;
         case REW_CURSE_WP: {
             inventory_slot_type slot;
-            if (!has_melee_weapon(player, INVEN_MAIN_HAND) && !has_melee_weapon(player, INVEN_SUB_HAND)) {
+            if (!has_melee_weapon(creature, INVEN_MAIN_HAND) && !has_melee_weapon(creature, INVEN_SUB_HAND)) {
                 break;
             }
 
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝、武器に頼ることなかれ。」", "'Thou reliest too much on thy weapon.'"));
             slot = INVEN_MAIN_HAND;
-            if (has_melee_weapon(player, INVEN_SUB_HAND)) {
+            if (has_melee_weapon(creature, INVEN_SUB_HAND)) {
                 slot = INVEN_SUB_HAND;
-                if (has_melee_weapon(player, INVEN_MAIN_HAND) && one_in_(2)) {
+                if (has_melee_weapon(creature, INVEN_MAIN_HAND) && one_in_(2)) {
                     slot = INVEN_MAIN_HAND;
                 }
             }
 
-            const auto item_name = describe_flavor(player, *player.inventory[slot], OD_NAME_ONLY);
-            (void)curse_weapon_object(player, false, player.inventory[slot].get());
+            const auto item_name = describe_flavor(creature, *creature.inventory[slot], OD_NAME_ONLY);
+            (void)curse_weapon_object(creature, false, creature.inventory[slot].get());
             reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
             break;
         }
         case REW_CURSE_AR: {
-            if (!player.inventory[INVEN_BODY]->is_valid()) {
+            if (!creature.inventory[INVEN_BODY]->is_valid()) {
                 break;
             }
 
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝、防具に頼ることなかれ。」", "'Thou reliest too much on thine equipment.'"));
-            const auto item_name = describe_flavor(player, *player.inventory[INVEN_BODY], OD_NAME_ONLY);
-            (void)curse_armor(player);
+            const auto item_name = describe_flavor(creature, *creature.inventory[INVEN_BODY], OD_NAME_ONLY);
+            (void)curse_armor(creature);
             reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
             break;
         }
@@ -389,43 +388,43 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
             msg_print(_("「我を怒りしめた罪を償うべし。」", "'Now thou shalt pay for annoying me.'"));
             switch (randint1(4)) {
             case 1:
-                (void)activate_ty_curse(player, false, &count);
+                (void)activate_ty_curse(creature, false, &count);
                 reward = _("禍々しい呪いをかけられた。", "cursing");
                 break;
             case 2:
-                activate_hi_summon(player, player.y, player.x, false);
+                activate_hi_summon(creature, creature.y, creature.x, false);
                 reward = _("モンスターを召喚された。", "summoning hostile monsters");
                 break;
             case 3:
                 if (one_in_(2)) {
                     inventory_slot_type slot;
-                    if (!has_melee_weapon(player, INVEN_MAIN_HAND) && !has_melee_weapon(player, INVEN_SUB_HAND)) {
+                    if (!has_melee_weapon(creature, INVEN_MAIN_HAND) && !has_melee_weapon(creature, INVEN_SUB_HAND)) {
                         break;
                     }
                     slot = INVEN_MAIN_HAND;
-                    if (has_melee_weapon(player, INVEN_SUB_HAND)) {
+                    if (has_melee_weapon(creature, INVEN_SUB_HAND)) {
                         slot = INVEN_SUB_HAND;
-                        if (has_melee_weapon(player, INVEN_MAIN_HAND) && one_in_(2)) {
+                        if (has_melee_weapon(creature, INVEN_MAIN_HAND) && one_in_(2)) {
                             slot = INVEN_MAIN_HAND;
                         }
                     }
 
-                    const auto item_name = describe_flavor(player, *player.inventory[slot], OD_NAME_ONLY);
-                    (void)curse_weapon_object(player, false, player.inventory[slot].get());
+                    const auto item_name = describe_flavor(creature, *creature.inventory[slot], OD_NAME_ONLY);
+                    (void)curse_weapon_object(creature, false, creature.inventory[slot].get());
                     reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
                 } else {
-                    if (!player.inventory[INVEN_BODY]->is_valid()) {
+                    if (!creature.inventory[INVEN_BODY]->is_valid()) {
                         break;
                     }
 
-                    const auto item_name = describe_flavor(player, *player.inventory[INVEN_BODY], OD_NAME_ONLY);
-                    (void)curse_armor(player);
+                    const auto item_name = describe_flavor(creature, *creature.inventory[INVEN_BODY], OD_NAME_ONLY);
+                    (void)curse_armor(creature);
                     reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
                 }
                 break;
             default:
                 for (int stat = 0; stat < A_MAX; stat++) {
-                    (void)dec_stat(player, stat, 10 + randint1(15), true);
+                    (void)dec_stat(creature, stat, 10 + randint1(15), true);
                 }
                 reward = _("全能力値が下がった。", "decreasing all stats");
                 break;
@@ -436,60 +435,60 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
         case REW_WRATH:
             msg_format(_("%sの声が轟き渡った:", "The voice of %s thunders:"), this->name.data());
             msg_print(_("「死ぬがよい、下僕よ！」", "'Die, mortal!'"));
-            take_hit(player, DAMAGE_LOSELIFE, player.level * 4, wrath_reason);
+            take_hit(creature, DAMAGE_LOSELIFE, creature.level * 4, wrath_reason);
             for (int stat = 0; stat < A_MAX; stat++) {
-                (void)dec_stat(player, stat, 10 + randint1(15), false);
+                (void)dec_stat(creature, stat, 10 + randint1(15), false);
             }
 
-            activate_hi_summon(player, player.y, player.x, false);
-            (void)activate_ty_curse(player, false, &count);
+            activate_hi_summon(creature, creature.y, creature.x, false);
+            (void)activate_ty_curse(creature, false, &count);
             if (one_in_(2)) {
                 inventory_slot_type slot = INVEN_NONE;
-                if (has_melee_weapon(player, INVEN_MAIN_HAND)) {
+                if (has_melee_weapon(creature, INVEN_MAIN_HAND)) {
                     slot = INVEN_MAIN_HAND;
-                    if (has_melee_weapon(player, INVEN_SUB_HAND) && one_in_(2)) {
+                    if (has_melee_weapon(creature, INVEN_SUB_HAND) && one_in_(2)) {
                         slot = INVEN_SUB_HAND;
                     }
-                } else if (has_melee_weapon(player, INVEN_SUB_HAND)) {
+                } else if (has_melee_weapon(creature, INVEN_SUB_HAND)) {
                     slot = INVEN_SUB_HAND;
                 }
 
                 if (slot) {
-                    (void)curse_weapon_object(player, false, player.inventory[slot].get());
+                    (void)curse_weapon_object(creature, false, creature.inventory[slot].get());
                 }
             }
 
             if (one_in_(2)) {
-                (void)curse_armor(player);
+                (void)curse_armor(creature);
             }
 
             break;
         case REW_DESTRUCT:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「死と破壊こそ我が喜びなり！」", "'Death and destruction! This pleaseth me!'"));
-            (void)destroy_area(player, player.y, player.x, 25, false);
+            (void)destroy_area(creature, creature.y, creature.x, 25, false);
             reward = _("ダンジョンが*破壊*された。", "*destruct*ing dungeon");
             break;
         case REW_GENOCIDE:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「我、汝の敵を抹殺せん！」", "'Let me relieve thee of thine oppressors!'"));
-            (void)symbol_genocide(player, 0, false);
+            (void)symbol_genocide(creature, 0, false);
             reward = _("モンスターが抹殺された。", "genociding monsters");
             break;
         case REW_MASS_GEN:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「我、汝の敵を抹殺せん！」", "'Let me relieve thee of thine oppressors!'"));
-            (void)mass_genocide(player, 0, false);
+            (void)mass_genocide(creature, 0, false);
             reward = _("モンスターが抹殺された。", "genociding nearby monsters");
             break;
         case REW_DISPEL_C:
             msg_format(_("%sの力が敵を攻撃するのを感じた！", "You can feel the power of %s assault your enemies!"), this->name.data());
-            (void)dispel_monsters(player, player.level * 4);
+            (void)dispel_monsters(creature, creature.level * 4);
             break;
         case REW_GOOD_HAFTED:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「殺せ！叩き潰せ！擦り潰せ！」", "'Kill them! Crush them! Grind them into dust!'"));
-            acquire_hafted_weapon(player);
+            acquire_hafted_weapon(creature);
             reward = _("高級品の鈍器を手に入れた。", "a fine hafted weapon");
             break;
         case REW_IGNORE:
@@ -497,7 +496,7 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
             break;
         case REW_SER_DEMO:
             msg_format(_("%sは褒美として悪魔の使いをよこした！", "%s rewards you with a demonic servant!"), this->name.data());
-            if (!summon_specific(player, player.y, player.x, floor.dun_level, SUMMON_DEMON, PM_FORCE_PET)) {
+            if (!summon_specific(creature, creature.y, creature.x, floor.dun_level, SUMMON_DEMON, PM_FORCE_PET)) {
                 msg_print(_("何も現れなかった...", "Nobody ever turns up..."));
             } else {
                 reward = _("悪魔がペットになった。", "a demonic servant");
@@ -506,7 +505,7 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
             break;
         case REW_SER_MONS:
             msg_format(_("%sは褒美として使いをよこした！", "%s rewards you with a servant!"), this->name.data());
-            if (!summon_specific(player, player.y, player.x, floor.dun_level, SUMMON_NONE, PM_FORCE_PET)) {
+            if (!summon_specific(creature, creature.y, creature.x, floor.dun_level, SUMMON_NONE, PM_FORCE_PET)) {
                 msg_print(_("何も現れなかった...", "Nobody ever turns up..."));
             } else {
                 reward = _("モンスターがペットになった。", "a servant");
@@ -515,7 +514,7 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
             break;
         case REW_SER_UNDE:
             msg_format(_("%sは褒美としてアンデッドの使いをよこした。", "%s rewards you with an undead servant!"), this->name.data());
-            if (!summon_specific(player, player.y, player.x, floor.dun_level, SUMMON_UNDEAD, PM_FORCE_PET)) {
+            if (!summon_specific(creature, creature.y, creature.x, floor.dun_level, SUMMON_UNDEAD, PM_FORCE_PET)) {
                 msg_print(_("何も現れなかった...", "Nobody ever turns up..."));
             } else {
                 reward = _("アンデッドがペットになった。", "an undead servant");
@@ -530,14 +529,13 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
 
     if (!reward.empty()) {
         const auto note = format(_("パトロンの報酬で%s", "The patron rewarded you with %s."), reward.data());
-        exe_write_diary(*player.current_floor_ptr, DiaryKind::DESCRIPTION, 0, note);
+        exe_write_diary(*creature.current_floor_ptr, DiaryKind::DESCRIPTION, 0, note);
     }
 }
 
 void Patron::admire(CreatureEntity &creature)
 {
-    auto &player = creature;
-    if (CreatureClass(player).equals(PlayerClassType::CHAOS_WARRIOR) || player.muta.has(PlayerMutationType::CHAOS_GIFT)) {
+    if (CreatureClass(creature).equals(PlayerClassType::CHAOS_WARRIOR) || creature.muta.has(PlayerMutationType::CHAOS_GIFT)) {
         msg_format(_("%sからの声が響いた。", "The voice of %s booms out:"), this->name.data());
         msg_print(_("『よくやった、定命の者よ！』", "'Thou art donst well, mortal!'"));
     }

--- a/src/player/permanent-resistances.cpp
+++ b/src/player/permanent-resistances.cpp
@@ -18,42 +18,41 @@
  * @brief 突然変異による耐性フラグを返す
  * @param creature クリーチャーへの参照
  * @param flags 耐性フラグの配列
- * @todo 最終的にplayer-status系列と統合する
+ * @todo 最終的にcreature-status系列と統合する
  */
 static void add_mutation_flags(CreatureEntity &creature, TrFlags &flags)
 {
-    auto &player = creature;
-    if (player.muta.none()) {
+    if (creature.muta.none()) {
         return;
     }
 
-    if (player.muta.has(PlayerMutationType::FLESH_ROT)) {
+    if (creature.muta.has(PlayerMutationType::FLESH_ROT)) {
         flags.reset(TR_REGEN);
     }
-    if (player.muta.has_any_of({ PlayerMutationType::XTRA_FAT, PlayerMutationType::XTRA_LEGS, PlayerMutationType::SHORT_LEG, PlayerMutationType::WEAK_LOWER_BODY })) {
+    if (creature.muta.has_any_of({ PlayerMutationType::XTRA_FAT, PlayerMutationType::XTRA_LEGS, PlayerMutationType::SHORT_LEG, PlayerMutationType::WEAK_LOWER_BODY })) {
         flags.set(TR_SPEED);
     }
-    if (player.muta.has(PlayerMutationType::ELEC_TOUC)) {
+    if (creature.muta.has(PlayerMutationType::ELEC_TOUC)) {
         flags.set(TR_SH_ELEC);
     }
-    if (player.muta.has(PlayerMutationType::FIRE_BODY)) {
+    if (creature.muta.has(PlayerMutationType::FIRE_BODY)) {
         flags.set(TR_SH_FIRE);
         flags.set(TR_LITE_1);
     }
 
-    if (player.muta.has(PlayerMutationType::WINGS)) {
+    if (creature.muta.has(PlayerMutationType::WINGS)) {
         flags.set(TR_LEVITATION);
     }
-    if (player.muta.has(PlayerMutationType::FEARLESS)) {
+    if (creature.muta.has(PlayerMutationType::FEARLESS)) {
         flags.set(TR_RES_FEAR);
     }
-    if (player.muta.has(PlayerMutationType::REGEN)) {
+    if (creature.muta.has(PlayerMutationType::REGEN)) {
         flags.set(TR_REGEN);
     }
-    if (player.muta.has(PlayerMutationType::ESP)) {
+    if (creature.muta.has(PlayerMutationType::ESP)) {
         flags.set(TR_TELEPATHY);
     }
-    if (player.muta.has(PlayerMutationType::MOTION)) {
+    if (creature.muta.has(PlayerMutationType::MOTION)) {
         flags.set(TR_FREE_ACT);
     }
 }
@@ -62,20 +61,19 @@ static void add_mutation_flags(CreatureEntity &creature, TrFlags &flags)
  * @brief 性格による耐性フラグを返す
  * @param creature クリーチャーへの参照
  * @param flags 耐性フラグの配列
- * @todo 最終的にplayer-status系列と統合する
+ * @todo 最終的にcreature-status系列と統合する
  */
 static void add_personality_flags(CreatureEntity &creature, TrFlags &flags)
 {
-    auto &player = creature;
-    if (player.ppersonality == PERSONALITY_SEXY) {
+    if (creature.ppersonality == PERSONALITY_SEXY) {
         flags.set(TR_AGGRAVATE);
     }
 
-    if (player.ppersonality == PERSONALITY_CHARGEMAN) {
+    if (creature.ppersonality == PERSONALITY_CHARGEMAN) {
         flags.set(TR_RES_CONF);
     }
 
-    if (player.ppersonality != PERSONALITY_MUNCHKIN) {
+    if (creature.ppersonality != PERSONALITY_MUNCHKIN) {
         return;
     }
 
@@ -85,7 +83,7 @@ static void add_personality_flags(CreatureEntity &creature, TrFlags &flags)
     if (!CreatureClass(creature).equals(PlayerClassType::NINJA)) {
         flags.set(TR_LITE_1);
     }
-    if (player.level > 9) {
+    if (creature.level > 9) {
         flags.set(TR_SPEED);
     }
 }
@@ -96,8 +94,8 @@ static void add_personality_flags(CreatureEntity &creature, TrFlags &flags)
  * @param creature クリーチャーへの参照
  * @param flags フラグを保管する配列
  * @details
- * Obtain the "flags" for the player as if he was an item
- * @todo 最終的にplayer-status系列と統合する
+ * Obtain the "flags" for the creature as if he was an item
+ * @todo 最終的にcreature-status系列と統合する
  */
 void player_flags(CreatureEntity &creature, TrFlags &flags)
 {
@@ -122,9 +120,8 @@ void riding_flags(CreatureEntity &creature, TrFlags &flags, TrFlags &negative_fl
     if (!creature.is_player()) {
         return;
     }
-    auto &player = creature;
 
-    if (any_bits(has_levitation(player), FLAG_CAUSE_RIDING)) {
+    if (any_bits(has_levitation(creature), FLAG_CAUSE_RIDING)) {
         flags.set(TR_LEVITATION);
     } else {
         negative_flags.set(TR_LEVITATION);

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -81,17 +81,16 @@ using dam_func = int (*)(CreatureEntity &creature, int dam, std::string_view kb_
 
 /*!
  * @brief 酸攻撃による装備のAC劣化処理 /
- * Acid has hit the player, attempt to affect some armor.
+ * Acid has hit the creature, attempt to affect some armor.
  * @param 酸を浴びたキャラクタへの参照ポインタ
  * @return 装備による軽減があったならTRUEを返す
  * @details
  * 免疫があったらそもそもこの関数は実行されない (確実に錆びない).
  * Note that the "base armor" of an object never changes.
- * If any armor is damaged (or resists), the player takes less damage.
+ * If any armor is damaged (or resists), the creature takes less damage.
  */
 static bool acid_minus_ac(CreatureEntity &creature)
 {
-    auto &player = creature;
     constexpr static auto candidates = {
         INVEN_MAIN_HAND,
         INVEN_SUB_HAND,
@@ -103,12 +102,12 @@ static bool acid_minus_ac(CreatureEntity &creature)
     };
 
     const auto slot = rand_choice(candidates);
-    auto &item = *player.inventory[slot];
+    auto &item = *creature.inventory[slot];
     if (!item.is_valid() || !item.is_protector()) {
         return false;
     }
 
-    const auto item_name = describe_flavor(player, item, OD_OMIT_PREFIX | OD_NAME_ONLY);
+    const auto item_name = describe_flavor(creature, item, OD_OMIT_PREFIX | OD_NAME_ONLY);
     const auto item_flags = item.get_flags();
     if (item.ac + item.to_a <= 0) {
         msg_format(_("%sは既にボロボロだ！", "Your %s is already fully corroded!"), item_name.data());
@@ -135,7 +134,7 @@ static bool acid_minus_ac(CreatureEntity &creature)
 
 /*!
  * @brief 酸属性によるプレイヤー損害処理 /
- * Hurt the player with Acid
+ * Hurt the creature with Acid
  * @param player_ptr 酸を浴びたキャラクタへの参照ポインタ
  * @param dam 基本ダメージ量
  * @param kb_str ダメージ原因記述
@@ -174,7 +173,7 @@ int acid_dam(CreatureEntity &creature, int dam, std::string_view kb_str, bool au
 
 /*!
  * @brief 電撃属性によるプレイヤー損害処理 /
- * Hurt the player with electricity
+ * Hurt the creature with electricity
  * @param player_ptr 電撃を浴びたキャラクタへの参照ポインタ
  * @param dam 基本ダメージ量
  * @param kb_str ダメージ原因記述
@@ -210,7 +209,7 @@ int elec_dam(CreatureEntity &creature, int dam, std::string_view kb_str, bool au
 
 /*!
  * @brief 火炎属性によるプレイヤー損害処理 /
- * Hurt the player with Fire
+ * Hurt the creature with Fire
  * @param player_ptr 火炎を浴びたキャラクタへの参照ポインタ
  * @param dam 基本ダメージ量
  * @param kb_str ダメージ原因記述
@@ -246,7 +245,7 @@ int fire_dam(CreatureEntity &creature, int dam, std::string_view kb_str, bool au
 
 /*!
  * @brief 冷気属性によるプレイヤー損害処理 /
- * Hurt the player with Cold
+ * Hurt the creature with Cold
  * @param player_ptr 冷気を浴びたキャラクタへの参照ポインタ
  * @param dam 基本ダメージ量
  * @param kb_str ダメージ原因記述
@@ -296,34 +295,33 @@ static void death_save(CreatureEntity &creature)
  *
  * Hack -- this function allows the user to save (or quit)
  * the game when he dies, since the "You die." message is shown before
- * setting the player to "dead".
+ * setting the creature to "dead".
  */
 int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_view hit_from, MonraceId killer_monrace_id)
 {
-    auto &player = creature;
-    const auto old_chp = player.hp;
-    const auto hp_warning_threshold = (player.maxhp * hitpoint_warn / 10);
-    if (player.is_dead()) {
+    const auto old_chp = creature.hp;
+    const auto hp_warning_threshold = (creature.maxhp * hitpoint_warn / 10);
+    if (creature.is_dead()) {
         return 0;
     }
 
-    if (player.sutemi) {
+    if (creature.sutemi) {
         damage *= 2;
     }
 
-    if (CreatureClass(player).samurai_stance_is(SamuraiStanceType::IAI)) {
+    if (CreatureClass(creature).samurai_stance_is(SamuraiStanceType::IAI)) {
         damage += (damage + 4) / 5;
     }
 
     if (damage_type != DAMAGE_USELIFE) {
-        disturb(player, true, true);
+        disturb(creature, true, true);
         if (auto_more) {
-            player.now_damaged = true;
+            creature.now_damaged = true;
         }
     }
 
     if ((damage_type != DAMAGE_USELIFE) && (damage_type != DAMAGE_LOSELIFE)) {
-        if (player.is_invulnerable() && (damage < 9000)) {
+        if (creature.is_invulnerable() && (damage < 9000)) {
             if (damage_type == DAMAGE_FORCE) {
                 msg_print(_("バリアが切り裂かれた！", "The attack cuts your shield of invulnerability open!"));
             } else if (one_in_(PENETRATE_INVULNERABILITY)) {
@@ -333,7 +331,7 @@ int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_
             }
         }
 
-        if (check_multishadow(player)) {
+        if (check_multishadow(creature)) {
             if (damage_type == DAMAGE_FORCE) {
                 msg_print(_("幻影もろとも体が切り裂かれた！", "The attack hits Shadow together with you!"));
             } else if (damage_type == DAMAGE_ATTACK) {
@@ -342,7 +340,7 @@ int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_
             }
         }
 
-        if (player.wraith_form) {
+        if (creature.wraith_form) {
             if (damage_type == DAMAGE_FORCE) {
                 msg_print(_("半物質の体が切り裂かれた！", "The attack cuts through your ethereal body!"));
             } else {
@@ -353,7 +351,7 @@ int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_
             }
         }
 
-        if (CreatureClass(player).samurai_stance_is(SamuraiStanceType::MUSOU)) {
+        if (CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU)) {
             damage /= 2;
             if ((damage == 0) && one_in_(2)) {
                 damage = 1;
@@ -361,46 +359,46 @@ int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_
         }
     }
 
-    player.hp -= damage;
-    if (player.hp < -9999) {
-        player.hp = -9999;
+    creature.hp -= damage;
+    if (creature.hp < -9999) {
+        creature.hp = -9999;
     }
 
-    if (damage_type == DAMAGE_GENO && player.hp < 0) {
-        damage += player.hp;
-        player.hp = 0;
+    if (damage_type == DAMAGE_GENO && creature.hp < 0) {
+        damage += creature.hp;
+        creature.hp = 0;
     }
 
     // 与ダメージの蓄積（プレイヤーが受けたダメージとして記録）
     if (damage > 0 && damage_type != DAMAGE_USELIFE && damage_type != DAMAGE_LOSELIFE) {
-        player.on_take_hit(damage);
+        creature.on_take_hit(damage);
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::HP);
     rfu.set_flag(SubWindowRedrawingFlag::PLAYER);
-    if (damage_type != DAMAGE_GENO && player.hp == 0) {
+    if (damage_type != DAMAGE_GENO && creature.hp == 0) {
         chg_virtue(creature, Virtue::SACRIFICE, 1);
         chg_virtue(creature, Virtue::CHANCE, 2);
     }
 
-    const auto &floor = *player.current_floor_ptr;
+    const auto &floor = *creature.current_floor_ptr;
     auto &world = AngbandWorld::get_instance();
-    if (player.hp < 0 && !cheat_immortal) {
-        player.killer_monrace_id = killer_monrace_id;
-        player.on_death(hit_from);
+    if (creature.hp < 0 && !cheat_immortal) {
+        creature.killer_monrace_id = killer_monrace_id;
+        creature.on_death(hit_from);
         return damage;
     }
 
-    handle_stuff(player);
-    if (player.hp < hp_warning_threshold) {
+    handle_stuff(creature);
+    if (creature.hp < hp_warning_threshold) {
         if (old_chp > hp_warning_threshold) {
             bell();
         }
 
         sound(SoundKind::WARN);
         if (record_danger && (old_chp > hp_warning_threshold)) {
-            if (player.effects()->hallucination().is_hallucinated() && damage_type == DAMAGE_ATTACK) {
+            if (creature.effects()->hallucination().is_hallucinated() && damage_type == DAMAGE_ATTACK) {
                 hit_from = _("何か", "something");
             }
 
@@ -412,7 +410,7 @@ int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_
         }
 
         if (auto_more) {
-            player.now_damaged = true;
+            creature.now_damaged = true;
         }
 
         msg_print(_("*** 警告:低ヒット・ポイント！ ***", "*** LOW HITPOINT WARNING! ***"));
@@ -420,8 +418,8 @@ int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_
         flush();
     }
 
-    if (world.is_wild_mode() && !player.leaving && (player.hp < std::max(hp_warning_threshold, player.maxhp / 5))) {
-        change_wild_mode(player, false);
+    if (world.is_wild_mode() && !creature.leaving && (creature.hp < std::max(hp_warning_threshold, creature.maxhp / 5))) {
+        change_wild_mode(creature, false);
     }
 
     return damage;
@@ -725,15 +723,14 @@ void touch_zap_player(const CreatureEntity &source, CreatureEntity &creature)
  */
 void player_defecate(CreatureEntity &creature)
 {
-    auto &player = creature;
     auto &baseitems = BaseitemList::get_instance();
     ItemEntity item;
     disturb(creature, false, true);
     msg_print(_("ブッチッパ！", "BRUUUUP! Oops."));
     msg_erase();
     item.generate(baseitems.lookup_baseitem_id({ ItemKindType::JUNK, SV_JUNK_FECES }));
-    (void)drop_near(creature, item, player.get_position());
+    (void)drop_near(creature, item, creature.get_position());
 
     // 脱糞した数をインシデントに記録
-    player.plus_incident_tree("DEFECATE", 1);
+    creature.plus_incident_tree("DEFECATE", 1);
 }

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -123,7 +123,6 @@ void search(CreatureEntity &creature)
  */
 bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_FLAGS mpe_mode)
 {
-    auto &player = creature;
     const Pos2D pos_new(ny, nx);
     const Pos2D pos_old(creature.y, creature.x);
     auto &floor = *creature.current_floor_ptr;
@@ -162,7 +161,7 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
 
         lite_spot(creature, pos_old);
         lite_spot(creature, pos_new);
-        verify_panel(player);
+        verify_panel(creature);
         if (mpe_mode & MPE_FORGET_FLOW) {
             forget_flow(floor);
             rfu.set_flag(StatusRecalculatingFlag::UN_VIEW);
@@ -191,69 +190,69 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
         }
 
         if (mpe_mode & MPE_HANDLE_STUFF) {
-            handle_stuff(player);
+            handle_stuff(creature);
         }
 
-        if (CreatureClass(player).equals(PlayerClassType::NINJA)) {
+        if (CreatureClass(creature).equals(PlayerClassType::NINJA)) {
             if (grid_new.info & (CAVE_GLOW)) {
-                set_superstealth(player, false);
-            } else if (player.cur_lite <= 0) {
-                set_superstealth(player, true);
+                set_superstealth(creature, false);
+            } else if (creature.cur_lite <= 0) {
+                set_superstealth(creature, true);
             }
         }
 
         using Tc = TerrainCharacteristics;
-        if ((player.action == ACTION_HAYAGAKE) && (terrain_new.flags.has_not(Tc::PROJECTION) || (!player.levitation && terrain_new.flags.has(Tc::DEEP)))) {
+        if ((creature.action == ACTION_HAYAGAKE) && (terrain_new.flags.has_not(Tc::PROJECTION) || (!creature.levitation && terrain_new.flags.has(Tc::DEEP)))) {
             msg_print(_("ここでは素早く動けない。", "You cannot run in here."));
             set_action(creature, ACTION_NONE);
         }
 
-        if (CreatureRace(&player).equals(PlayerRaceType::MERFOLK)) {
+        if (CreatureRace(&creature).equals(PlayerRaceType::MERFOLK)) {
             if (terrain_new.flags.has(Tc::WATER) ^ terrain_old.flags.has(Tc::WATER)) {
                 rfu.set_flag(StatusRecalculatingFlag::BONUS);
-                update_creature(player);
+                update_creature(creature);
             }
         }
 
         if (terrain_new.flags.has(TerrainCharacteristics::SLOW) ^ terrain_old.flags.has(TerrainCharacteristics::SLOW)) {
             rfu.set_flag(StatusRecalculatingFlag::BONUS);
-            update_creature(player);
+            update_creature(creature);
         }
     }
 
     const Pos2D pos(ny, nx);
     if (mpe_mode & MPE_ENERGY_USE) {
-        if (music_singing(player, MUSIC_WALL)) {
-            (void)project(player, 0, 0, player.y, player.x, (60 + player.level), AttributeType::DISINTEGRATE, PROJECT_KILL | PROJECT_ITEM);
-            if (!creature.is_located_at(pos) || creature.is_dead() || player.leaving) {
+        if (music_singing(creature, MUSIC_WALL)) {
+            (void)project(creature, 0, 0, creature.y, creature.x, (60 + creature.level), AttributeType::DISINTEGRATE, PROJECT_KILL | PROJECT_ITEM);
+            if (!creature.is_located_at(pos) || creature.is_dead() || creature.leaving) {
                 return false;
             }
         }
 
-        if ((player.skill_fos >= 50) || (0 == randint0(50 - player.skill_fos))) {
+        if ((creature.skill_fos >= 50) || (0 == randint0(50 - creature.skill_fos))) {
             search(creature);
         }
 
-        if (player.action == ACTION_SEARCH) {
+        if (creature.action == ACTION_SEARCH) {
             search(creature);
         }
     }
 
     if (!(mpe_mode & MPE_DONT_PICKUP)) {
-        carry(player, any_bits(mpe_mode, MPE_DO_PICKUP));
+        carry(creature, any_bits(mpe_mode, MPE_DO_PICKUP));
     }
 
     // 自動拾い/自動破壊により床上のアイテムリストが変化した可能性があるので表示を更新
-    if (!player.running) {
+    if (!creature.running) {
         static constexpr auto flags_swrf = {
             SubWindowRedrawingFlag::FLOOR_ITEMS,
             SubWindowRedrawingFlag::FOUND_ITEMS,
         };
         rfu.set_flags(flags_swrf);
-        window_stuff(player);
+        window_stuff(creature);
     }
 
-    PlayerEnergy energy(player);
+    PlayerEnergy energy(creature);
     if (terrain_new.flags.has(TerrainCharacteristics::STORE)) {
         disturb(creature, false, true);
         energy.reset_player_turn();
@@ -269,17 +268,17 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
     } else if (terrain_new.flags.has(TerrainCharacteristics::QUEST_EXIT)) {
         const auto &quests = QuestList::get_instance();
         if (quests.get_quest(floor.quest_number).type == QuestKindType::FIND_EXIT) {
-            complete_quest(player, floor.quest_number);
+            complete_quest(creature, floor.quest_number);
         }
-        leave_quest_check(player);
+        leave_quest_check(creature);
         floor.quest_number = i2enum<QuestId>(grid_new.special);
         floor.dun_level = 0;
         if (!floor.is_in_quest()) {
-            player.word_recall = 0;
+            creature.word_recall = 0;
         }
-        player.oldpx = 0;
-        player.oldpy = 0;
-        player.leaving = true;
+        creature.oldpx = 0;
+        creature.oldpy = 0;
+        creature.leaving = true;
     } else if (terrain_new.flags.has(TerrainCharacteristics::HIT_TRAP) && !(mpe_mode & MPE_STAYING)) {
         disturb(creature, false, true);
         if (grid_new.mimic || terrain_new.flags.has(TerrainCharacteristics::SECRET)) {
@@ -287,14 +286,14 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
             disclose_grid(creature, creature.get_position());
         }
 
-        hit_trap(player, any_bits(mpe_mode, MPE_BREAK_TRAP));
-        if (!creature.is_located_at(pos) || creature.is_dead() || player.leaving) {
+        hit_trap(creature, any_bits(mpe_mode, MPE_BREAK_TRAP));
+        if (!creature.is_located_at(pos) || creature.is_dead() || creature.leaving) {
             return false;
         }
     }
 
-    if (!(mpe_mode & MPE_STAYING) && (disturb_trap_detect || alert_trap_detect) && player.dtrap && !(grid_new.info & CAVE_IN_DETECT)) {
-        player.dtrap = false;
+    if (!(mpe_mode & MPE_STAYING) && (disturb_trap_detect || alert_trap_detect) && creature.dtrap && !(grid_new.info & CAVE_IN_DETECT)) {
+        creature.dtrap = false;
         if (!(grid_new.info & CAVE_UNSAFE)) {
             if (alert_trap_detect) {
                 msg_print(_("* 注意:この先はトラップの感知範囲外です！ *", "*Leaving trap detect region!*"));
@@ -306,7 +305,7 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
         }
     }
 
-    return creature.is_located_at(pos) && !creature.is_dead() && !player.leaving;
+    return creature.is_located_at(pos) && !creature.is_dead() && !creature.leaving;
 }
 
 /*!

--- a/src/player/player-skill.cpp
+++ b/src/player/player-skill.cpp
@@ -43,7 +43,6 @@ using GainAmountList = std::array<int, enum2i(PlayerSkillRank::MASTER)>;
 
 void gain_attack_skill_exp(CreatureEntity &creature, short &exp, const GainAmountList &gain_amount_list)
 {
-    auto &player = creature;
     auto gain_amount = 0;
     auto calc_gain_amount = [&gain_amount_list, exp](PlayerSkillRank rank, int next_rank_exp) {
         return std::min(gain_amount_list[enum2i(rank)], next_rank_exp - exp);
@@ -53,9 +52,9 @@ void gain_attack_skill_exp(CreatureEntity &creature, short &exp, const GainAmoun
         gain_amount = calc_gain_amount(PlayerSkillRank::UNSKILLED, WEAPON_EXP_BEGINNER);
     } else if (exp < WEAPON_EXP_SKILLED) {
         gain_amount = calc_gain_amount(PlayerSkillRank::BEGINNER, WEAPON_EXP_SKILLED);
-    } else if ((exp < WEAPON_EXP_EXPERT) && (player.level > 19)) {
+    } else if ((exp < WEAPON_EXP_EXPERT) && (creature.level > 19)) {
         gain_amount = calc_gain_amount(PlayerSkillRank::SKILLED, WEAPON_EXP_EXPERT);
-    } else if ((exp < WEAPON_EXP_MASTER) && (player.level > 34)) {
+    } else if ((exp < WEAPON_EXP_MASTER) && (creature.level > 34)) {
         gain_amount = calc_gain_amount(PlayerSkillRank::EXPERT, WEAPON_EXP_MASTER);
     }
 
@@ -65,9 +64,8 @@ void gain_attack_skill_exp(CreatureEntity &creature, short &exp, const GainAmoun
 
 void gain_spell_skill_exp_aux(CreatureEntity &creature, short &exp, const GainAmountList &gain_amount_list, int spell_level)
 {
-    auto &player = creature;
-    const auto dlev = player.current_floor_ptr->dun_level;
-    const auto plev = player.level;
+    const auto dlev = creature.current_floor_ptr->dun_level;
+    const auto plev = creature.level;
 
     auto gain_amount = 0;
     auto calc_gain_amount = [&gain_amount_list, exp](PlayerSkillRank rank, int next_rank_exp) {

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -223,10 +223,10 @@ static void update_ability_scores(CreatureEntity &creature)
  * See also update_max_mana() and update_max_hitpoints().
  *
  * Take note of the new "speed code", in particular, a very strong
- * player will start slowing down as soon as he reaches 150 pounds,
+ * creature will start slowing down as soon as he reaches 150 pounds,
  * but not until he reaches 450 pounds will he be half as fast as
- * a normal kobold.  This both hurts and helps the player, hurts
- * because in the old days a player could just avoid 300 pounds,
+ * a normal kobold.  This both hurts and helps the creature, hurts
+ * because in the old days a creature could just avoid 300 pounds,
  * and helps because now carrying 300 pounds is not very painful.
  *
  * The "weapon" and "bow" do *not* add to the bonuses to hit or to
@@ -479,7 +479,7 @@ static void update_max_hitpoints(CreatureEntity &creature)
 
 /*!
  * @brief プレイヤーの現在学習可能な魔法数を計算し、増減に応じて魔法の忘却、再学習を処置する。 /
- * Calculate number of spells player should have, and forget,
+ * Calculate number of spells creature should have, and forget,
  * or remember, spells until that number is properly reflected.
  * @details
  * Note that this function induces various "status" messages,
@@ -2773,7 +2773,6 @@ void check_experience(CreatureEntity &creature)
     if (!creature.is_player()) {
         return;
     }
-    auto &player = creature;
     if (creature.exp < 0) {
         creature.exp = 0;
     }
@@ -2803,9 +2802,9 @@ void check_experience(CreatureEntity &creature)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::EXP);
-    handle_stuff(player);
+    handle_stuff(creature);
 
-    CreatureRace pr(&player);
+    CreatureRace pr(&creature);
     bool android = pr.equals(PlayerRaceType::ANDROID);
     PLAYER_LEVEL old_lev = creature.level;
     static constexpr auto flags_srf = {
@@ -2814,7 +2813,7 @@ void check_experience(CreatureEntity &creature)
         StatusRecalculatingFlag::MP,
         StatusRecalculatingFlag::SPELLS,
     };
-    while ((creature.level > 1) && (creature.exp < ((android ? player_exp_a : player_exp)[creature.level - 2] * player.expfact / 100L))) {
+    while ((creature.level > 1) && (creature.exp < ((android ? player_exp_a : player_exp)[creature.level - 2] * creature.expfact / 100L))) {
         creature.level--;
         rfu.set_flags(flags_srf);
         static constexpr auto flags_mwrf = {
@@ -2823,18 +2822,18 @@ void check_experience(CreatureEntity &creature)
         };
         rfu.set_flags(flags_mwrf);
         rfu.set_flag(SubWindowRedrawingFlag::PLAYER);
-        handle_stuff(player);
+        handle_stuff(creature);
     }
 
     bool level_reward = false;
     bool level_mutation = false;
     bool level_inc_stat = false;
-    while ((creature.level < PY_MAX_LEVEL) && (creature.exp >= ((android ? player_exp_a : player_exp)[creature.level - 1] * player.expfact / 100L))) {
+    while ((creature.level < PY_MAX_LEVEL) && (creature.exp >= ((android ? player_exp_a : player_exp)[creature.level - 1] * creature.expfact / 100L))) {
         creature.level++;
-        if (creature.level > player.max_plv) {
-            player.max_plv = creature.level;
+        if (creature.level > creature.max_plv) {
+            creature.max_plv = creature.level;
 
-            if (CreatureClass(player).equals(PlayerClassType::CHAOS_WARRIOR) || creature.muta.has(PlayerMutationType::CHAOS_GIFT)) {
+            if (CreatureClass(creature).equals(PlayerClassType::CHAOS_WARRIOR) || creature.muta.has(PlayerMutationType::CHAOS_GIFT)) {
                 level_reward = true;
             }
             if (pr.equals(PlayerRaceType::BEASTMAN)) {
@@ -2862,23 +2861,23 @@ void check_experience(CreatureEntity &creature)
             SubWindowRedrawingFlag::INVENTORY,
         };
         rfu.set_flags(flags_swrf_levelup);
-        player.level_up_message = true;
-        handle_stuff(player);
+        creature.level_up_message = true;
+        handle_stuff(creature);
 
-        player.level_up_message = false;
+        creature.level_up_message = false;
         if (level_inc_stat) {
-            if (!(player.max_plv % 10)) {
+            if (!(creature.max_plv % 10)) {
                 int choice;
                 screen_save();
                 while (true) {
                     int n;
 
-                    prt(format(_("        a) 腕力 (現在値 %s)", "        a) Str (cur %s)"), cnv_stat(player.stat_max[0]).data()), 2, 14);
-                    prt(format(_("        b) 知能 (現在値 %s)", "        b) Int (cur %s)"), cnv_stat(player.stat_max[1]).data()), 3, 14);
-                    prt(format(_("        c) 賢さ (現在値 %s)", "        c) Wis (cur %s)"), cnv_stat(player.stat_max[2]).data()), 4, 14);
-                    prt(format(_("        d) 器用 (現在値 %s)", "        d) Dex (cur %s)"), cnv_stat(player.stat_max[3]).data()), 5, 14);
-                    prt(format(_("        e) 耐久 (現在値 %s)", "        e) Con (cur %s)"), cnv_stat(player.stat_max[4]).data()), 6, 14);
-                    prt(format(_("        f) 魅力 (現在値 %s)", "        f) Chr (cur %s)"), cnv_stat(player.stat_max[5]).data()), 7, 14);
+                    prt(format(_("        a) 腕力 (現在値 %s)", "        a) Str (cur %s)"), cnv_stat(creature.stat_max[0]).data()), 2, 14);
+                    prt(format(_("        b) 知能 (現在値 %s)", "        b) Int (cur %s)"), cnv_stat(creature.stat_max[1]).data()), 3, 14);
+                    prt(format(_("        c) 賢さ (現在値 %s)", "        c) Wis (cur %s)"), cnv_stat(creature.stat_max[2]).data()), 4, 14);
+                    prt(format(_("        d) 器用 (現在値 %s)", "        d) Dex (cur %s)"), cnv_stat(creature.stat_max[3]).data()), 5, 14);
+                    prt(format(_("        e) 耐久 (現在値 %s)", "        e) Con (cur %s)"), cnv_stat(creature.stat_max[4]).data()), 6, 14);
+                    prt(format(_("        f) 魅力 (現在値 %s)", "        f) Chr (cur %s)"), cnv_stat(creature.stat_max[5]).data()), 7, 14);
 
                     prt("", 8, 14);
                     prt(_("        どの能力値を上げますか？", "        Which stat do you want to raise?"), 1, 14);
@@ -2898,25 +2897,25 @@ void check_experience(CreatureEntity &creature)
                         break;
                     }
                 }
-                do_inc_stat(player, choice - 'a');
+                do_inc_stat(creature, choice - 'a');
                 screen_load();
-            } else if (!(player.max_plv % 2)) {
-                do_inc_stat(player, randint0(6));
+            } else if (!(creature.max_plv % 2)) {
+                do_inc_stat(creature, randint0(6));
             }
         }
 
         if (level_mutation) {
             msg_print(_("あなたは変わった気がする...", "You feel different..."));
-            (void)gain_mutation(player, 0);
+            (void)gain_mutation(creature, 0);
             level_mutation = false;
         }
 
         /*
-         * 報酬でレベルが上ると再帰的に check_experience(static_cast<CreatureEntity &>(player)) が
+         * 報酬でレベルが上ると再帰的に check_experience(static_cast<CreatureEntity &>(creature)) が
          * 呼ばれるので順番を最後にする。
          */
         if (level_reward) {
-            patron_list[player.patron].gain_level_reward(player, 0);
+            patron_list[creature.patron].gain_level_reward(creature, 0);
             level_reward = false;
         }
 
@@ -2931,11 +2930,11 @@ void check_experience(CreatureEntity &creature)
             SubWindowRedrawingFlag::SPELL,
         };
         rfu.set_flags(flags_swrf);
-        handle_stuff(player);
+        handle_stuff(creature);
     }
 
     if (old_lev != creature.level) {
-        autopick_load_pref(player, false);
+        autopick_load_pref(creature, false);
     }
 }
 

--- a/src/player/process-name.cpp
+++ b/src/player/process-name.cpp
@@ -19,7 +19,7 @@
 
 /*!
  * @brief プレイヤーの名前をチェックして修正する
- * Process the player name.
+ * Process the creature name.
  * @param creature クリーチャーへの参照
  * @param sf セーブファイル名に合わせた修正を行うならばTRUE
  * @details
@@ -28,12 +28,11 @@
  */
 void process_player_name(CreatureEntity &creature, bool is_new_savefile)
 {
-    auto &player = creature;
     const auto &world = AngbandWorld::get_instance();
-    const std::string old_player_base = world.character_generated ? player.base_name : "";
+    const std::string old_player_base = world.character_generated ? creature.base_name : "";
 
-    const auto name_c_str = player.name.c_str();
-    for (size_t i = 0; i < player.name.length(); i++) {
+    const auto name_c_str = creature.name.c_str();
+    for (size_t i = 0; i < creature.name.length(); i++) {
 #ifdef JP
         if (iskanji(name_c_str[i])) {
             i++;
@@ -48,8 +47,8 @@ void process_player_name(CreatureEntity &creature, bool is_new_savefile)
         }
     }
 
-    player.base_name.clear();
-    for (size_t i = 0; i < player.name.length(); i++) {
+    creature.base_name.clear();
+    for (size_t i = 0; i < creature.name.length(); i++) {
 #ifdef JP
         unsigned char c = name_c_str[i];
 #else
@@ -58,35 +57,35 @@ void process_player_name(CreatureEntity &creature, bool is_new_savefile)
 
 #ifdef JP
         if (iskanji(c)) {
-            if (player.base_name.length() + 2 >= 40 || i + 1 >= player.name.length()) {
+            if (creature.base_name.length() + 2 >= 40 || i + 1 >= creature.name.length()) {
                 break;
             }
 
-            player.base_name += c;
+            creature.base_name += c;
             i++;
-            player.base_name += name_c_str[i];
+            creature.base_name += name_c_str[i];
         }
 #ifdef SJIS
         else if (iskana(c))
-            player.base_name += c;
+            creature.base_name += c;
 #endif
         else
 #endif
             if (!strncmp(PATH_SEP, name_c_str + i, strlen(PATH_SEP))) {
-            player.base_name += '_';
+            creature.base_name += '_';
             i += strlen(PATH_SEP);
         }
 #if defined(WINDOWS)
         else if (angband_strchr("\"*,/:;<>?\\|", c))
-            player.base_name += '_';
+            creature.base_name += '_';
 #endif
         else if (isprint(c)) {
-            player.base_name += c;
+            creature.base_name += c;
         }
     }
 
-    if (player.base_name.empty()) {
-        player.base_name = "PLAYER";
+    if (creature.base_name.empty()) {
+        creature.base_name = "PLAYER";
     }
 
     auto is_modified = false;
@@ -95,9 +94,9 @@ void process_player_name(CreatureEntity &creature, bool is_new_savefile)
 
 #ifdef SAVEFILE_USE_UID
         ss << UnixUserIds::get_instance().get_user_id();
-        ss << '.' << player.base_name;
+        ss << '.' << creature.base_name;
 #else
-        ss << player.base_name;
+        ss << creature.base_name;
 #endif
         savefile = path_build(ANGBAND_DIR_SAVE, ss.str());
         is_modified = true;
@@ -113,7 +112,7 @@ void process_player_name(CreatureEntity &creature, bool is_new_savefile)
 #endif
     }
 
-    if (world.character_generated && old_player_base != player.base_name) {
+    if (world.character_generated && old_player_base != creature.base_name) {
         autopick_load_pref(creature, false);
     }
 }
@@ -127,21 +126,20 @@ void process_player_name(CreatureEntity &creature, bool is_new_savefile)
  */
 void get_name(CreatureEntity &creature)
 {
-    auto &player = creature;
     const auto finalizer = util::make_finalizer([&creature]() {
         display_player_misc_info(creature);
     });
 
-    std::string initial_name = player.name;
+    std::string initial_name = creature.name;
     const auto max_name_size = 40;
     constexpr auto prompt = _("キャラクターの名前を入力して下さい: ", "Enter a name for your character: ");
     const auto name = input_string(prompt, max_name_size, initial_name);
     if (name && !name->empty()) {
-        player.name = *name;
+        creature.name = *name;
         return;
     }
 
     if (initial_name.empty()) {
-        player.name = "PLAYER";
+        creature.name = "PLAYER";
     }
 }

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -87,15 +87,14 @@
 
 bool switch_class_racial_execution(CreatureEntity &creature, const int32_t command)
 {
-    auto &player = creature;
-    switch (player.pclass) {
+    switch (creature.pclass) {
     case PlayerClassType::WARRIOR:
         return sword_dancing(creature);
     case PlayerClassType::HIGH_MAGE:
-        if (PlayerRealm(player).is_realm_hex()) {
-            const auto retval = SpellHex(player).stop_spells_with_selection();
+        if (PlayerRealm(creature).is_realm_hex()) {
+            const auto retval = SpellHex(creature).stop_spells_with_selection();
             if (retval) {
-                PlayerEnergy(player).set_player_turn_energy(10);
+                PlayerEnergy(creature).set_player_turn_energy(10);
             }
 
             return retval;
@@ -106,7 +105,7 @@ bool switch_class_racial_execution(CreatureEntity &creature, const int32_t comma
     case PlayerClassType::SORCERER:
         return eat_magic(creature, creature.level * 2);
     case PlayerClassType::PRIEST:
-        if (!PlayerRealm(player).realm1().is_good_attribute()) {
+        if (!PlayerRealm(creature).realm1().is_good_attribute()) {
             (void)dispel_monsters(creature, creature.level * 4);
             turn_monsters(creature, creature.level * 4);
             banish_monsters(creature, creature.level * 4);
@@ -122,31 +121,31 @@ bool switch_class_racial_execution(CreatureEntity &creature, const int32_t comma
         probing(creature);
         return true;
     case PlayerClassType::PALADIN: {
-        const auto dir = get_aim_dir(player);
+        const auto dir = get_aim_dir(creature);
         if (!dir) {
             return false;
         }
 
-        fire_beam(creature, PlayerRealm(player).realm1().is_good_attribute() ? AttributeType::HOLY_FIRE : AttributeType::HELL_FIRE, dir, creature.level * 3);
+        fire_beam(creature, PlayerRealm(creature).realm1().is_good_attribute() ? AttributeType::HOLY_FIRE : AttributeType::HELL_FIRE, dir, creature.level * 3);
         return true;
     }
     case PlayerClassType::WARRIOR_MAGE:
         if (command == -3) {
-            return comvert_hp_to_mp(player);
+            return comvert_hp_to_mp(creature);
         } else if (command == -4) {
-            return comvert_mp_to_hp(player);
+            return comvert_mp_to_hp(creature);
         }
 
         return true;
     case PlayerClassType::CHAOS_WARRIOR:
-        return confusing_light(player);
+        return confusing_light(creature);
     case PlayerClassType::MONK:
-        if (none_bits(empty_hands(player, true), EMPTY_HAND_MAIN)) {
+        if (none_bits(empty_hands(creature, true), EMPTY_HAND_MAIN)) {
             msg_print(_("素手じゃないとできません。", "You need to be barehanded."));
             return false;
         }
 
-        if (player.riding) {
+        if (creature.riding) {
             msg_print(_("乗馬中はできません。", "You need to get off a pet."));
             return false;
         }
@@ -167,10 +166,10 @@ bool switch_class_racial_execution(CreatureEntity &creature, const int32_t comma
         return true;
     case PlayerClassType::MINDCRAFTER:
     case PlayerClassType::FORCETRAINER:
-        return clear_mind(player);
+        return clear_mind(creature);
     case PlayerClassType::TOURIST:
         if (command == -3) {
-            const auto dir = get_aim_dir(player);
+            const auto dir = get_aim_dir(creature);
             if (!dir) {
                 return false;
             }
@@ -180,13 +179,13 @@ bool switch_class_racial_execution(CreatureEntity &creature, const int32_t comma
             return true;
         }
 
-        return (command != -4) || identify_fully(player, false);
+        return (command != -4) || identify_fully(creature, false);
     case PlayerClassType::IMITATOR:
-        handle_stuff(player);
-        return do_cmd_mane(player, true);
+        handle_stuff(creature);
+        return do_cmd_mane(creature, true);
     case PlayerClassType::BEASTMASTER:
         if (command == -3) {
-            const auto dir = get_aim_dir(player);
+            const auto dir = get_aim_dir(creature);
             if (!dir) {
                 return false;
             }
@@ -207,34 +206,34 @@ bool switch_class_racial_execution(CreatureEntity &creature, const int32_t comma
             return import_magic_device(creature);
         }
 
-        return (command != -4) || (!cmd_limit_cast(creature) && do_cmd_magic_eater(player, false, true));
+        return (command != -4) || (!cmd_limit_cast(creature) && do_cmd_magic_eater(creature, false, true));
     case PlayerClassType::BARD:
-        if ((get_singing_song_effect(player) == 0) && (get_interrupting_song_effect(player) == 0)) {
+        if ((get_singing_song_effect(creature) == 0) && (get_interrupting_song_effect(creature) == 0)) {
             return false;
         }
 
-        stop_singing(player);
-        PlayerEnergy(player).set_player_turn_energy(10);
+        stop_singing(creature);
+        PlayerEnergy(creature).set_player_turn_energy(10);
         return true;
     case PlayerClassType::RED_MAGE:
         if (cmd_limit_cast(creature)) {
             return false;
         }
 
-        handle_stuff(player);
-        if (!do_cmd_cast(player)) {
+        handle_stuff(creature);
+        if (!do_cmd_cast(creature)) {
             return false;
         }
 
-        if (!player.is_paralyzed() && !cmd_limit_cast(creature)) {
-            handle_stuff(player);
+        if (!creature.is_paralyzed() && !cmd_limit_cast(creature)) {
+            handle_stuff(creature);
             command_dir = Direction::none();
-            (void)do_cmd_cast(player);
+            (void)do_cmd_cast(creature);
         }
         return true;
     case PlayerClassType::SAMURAI:
         if (command == -3) {
-            concentration(player);
+            concentration(creature);
             return true;
         }
 
@@ -242,12 +241,12 @@ bool switch_class_racial_execution(CreatureEntity &creature, const int32_t comma
             return true;
         }
 
-        if (!has_melee_weapon(player, INVEN_MAIN_HAND) && !has_melee_weapon(player, INVEN_SUB_HAND)) {
+        if (!has_melee_weapon(creature, INVEN_MAIN_HAND) && !has_melee_weapon(creature, INVEN_SUB_HAND)) {
             msg_print(_("\u6b66\u5668\u3092\u6301\u305f\u306a\u3044\u3068\u3044\u3051\u307e\u305b\u3093\u3002", "You need to wield a weapon."));
             return false;
         }
 
-        if (!choose_samurai_stance(player)) {
+        if (!choose_samurai_stance(creature)) {
             return false;
         }
 
@@ -255,20 +254,20 @@ bool switch_class_racial_execution(CreatureEntity &creature, const int32_t comma
         return true;
     case PlayerClassType::BLUE_MAGE:
         set_action(creature, creature.action == ACTION_LEARN ? ACTION_NONE : ACTION_LEARN);
-        PlayerEnergy(player).reset_player_turn();
+        PlayerEnergy(creature).reset_player_turn();
         return true;
     case PlayerClassType::CAVALRY:
         return rodeo(creature);
     case PlayerClassType::BERSERKER:
         return recall_player(creature, randint0(21) + 15);
     case PlayerClassType::SMITH:
-        if (player.level <= 29) {
-            return ident_spell(player, true);
+        if (creature.level <= 29) {
+            return ident_spell(creature, true);
         }
 
-        return identify_fully(player, true);
+        return identify_fully(creature, true);
     case PlayerClassType::MIRROR_MASTER: {
-        SpellsMirrorMaster smm(player);
+        SpellsMirrorMaster smm(creature);
         if (command == -3) {
             smm.remove_all_mirrors(true);
             return true;
@@ -281,13 +280,13 @@ bool switch_class_racial_execution(CreatureEntity &creature, const int32_t comma
         return true;
     }
     case PlayerClassType::NINJA:
-        return hayagake(player);
+        return hayagake(creature);
     case PlayerClassType::ELEMENTALIST:
         if (command == -3) {
-            return clear_mind(player);
+            return clear_mind(creature);
         }
         if (command == -4) {
-            return switch_element_execution(player);
+            return switch_element_execution(creature);
         }
         return true;
     default:
@@ -312,10 +311,9 @@ bool switch_mimic_racial_execution(CreatureEntity &creature)
 
 bool switch_race_racial_execution(CreatureEntity &creature, const int32_t command)
 {
-    auto &player = creature;
     // 性格ベースのレイシャル能力をチェック
-    if (player.ppersonality == PERSONALITY_MESUGAKI) {
-        const auto dir = get_aim_dir(player);
+    if (creature.ppersonality == PERSONALITY_MESUGAKI) {
+        const auto dir = get_aim_dir(creature);
         if (!dir) {
             return false;
         }
@@ -324,7 +322,7 @@ bool switch_race_racial_execution(CreatureEntity &creature, const int32_t comman
         return true;
     }
 
-    switch (player.prace) {
+    switch (creature.prace) {
     case PlayerRaceType::DWARF:
         msg_print(_("周囲を調べた。", "You examine your surroundings."));
         (void)detect_traps(creature, DETECT_RAD_DEFAULT, true);
@@ -343,7 +341,7 @@ bool switch_race_racial_execution(CreatureEntity &creature, const int32_t comman
         return true;
     case PlayerRaceType::HALF_TROLL:
         msg_print(_("うがぁぁ！", "RAAAGH!"));
-        (void)berserk(player, 10 + randint1(player.level));
+        (void)berserk(creature, 10 + randint1(creature.level));
         return true;
     case PlayerRaceType::AMBERITE:
         if (command == -1) {
@@ -357,25 +355,25 @@ bool switch_race_racial_execution(CreatureEntity &creature, const int32_t comman
         }
 
         msg_print(_("あなたは「パターン」を心に描いてその上を歩いた...", "You picture the Pattern in your mind and walk it..."));
-        (void)true_healing(player, 0);
-        (void)restore_all_status(player);
+        (void)true_healing(creature, 0);
+        (void)restore_all_status(creature);
         (void)restore_level(creature);
         return true;
     case PlayerRaceType::BARBARIAN:
         msg_print(_("うぉぉおお！", "Raaagh!"));
-        (void)berserk(player, 10 + randint1(player.level));
+        (void)berserk(creature, 10 + randint1(creature.level));
         return true;
     case PlayerRaceType::HALF_OGRE:
         msg_print(_("爆発のルーンを慎重に仕掛けた...", "You carefully set an explosive rune..."));
-        (void)create_rune_explosion(player, player.y, player.x);
+        (void)create_rune_explosion(creature, creature.y, creature.x);
         return true;
     case PlayerRaceType::HALF_GIANT: {
-        const auto dir = get_aim_dir(player);
+        const auto dir = get_aim_dir(creature);
         if (!dir) {
             return false;
         }
 
-        (void)wall_to_mud(player, dir, 20 + randint1(30));
+        (void)wall_to_mud(creature, dir, 20 + randint1(30));
         return true;
     }
     case PlayerRaceType::HALF_TITAN:
@@ -383,7 +381,7 @@ bool switch_race_racial_execution(CreatureEntity &creature, const int32_t comman
         (void)probing(creature);
         return true;
     case PlayerRaceType::CYCLOPS: {
-        const auto dir = get_aim_dir(player);
+        const auto dir = get_aim_dir(creature);
         if (!dir) {
             return false;
         }
@@ -393,18 +391,18 @@ bool switch_race_racial_execution(CreatureEntity &creature, const int32_t comman
         return true;
     }
     case PlayerRaceType::YEEK: {
-        const auto dir = get_aim_dir(player);
+        const auto dir = get_aim_dir(creature);
         if (!dir) {
             return false;
         }
 
         stop_mouth(creature);
         msg_print(_("身の毛もよだつ叫び声を上げた！", "You make a horrible scream!"));
-        (void)fear_monster(player, dir, creature.level);
+        (void)fear_monster(creature, dir, creature.level);
         return true;
     }
     case PlayerRaceType::KLACKON: {
-        const auto dir = get_aim_dir(player);
+        const auto dir = get_aim_dir(creature);
         if (!dir) {
             return false;
         }
@@ -420,7 +418,7 @@ bool switch_race_racial_execution(CreatureEntity &creature, const int32_t comman
         return true;
     }
     case PlayerRaceType::KOBOLD: {
-        const auto dir = get_aim_dir(player);
+        const auto dir = get_aim_dir(creature);
         if (!dir) {
             return false;
         }
@@ -436,7 +434,7 @@ bool switch_race_racial_execution(CreatureEntity &creature, const int32_t comman
         (void)detect_stairs(creature, DETECT_RAD_DEFAULT);
         return true;
     case PlayerRaceType::DARK_ELF: {
-        const auto dir = get_aim_dir(player);
+        const auto dir = get_aim_dir(creature);
         if (!dir) {
             return false;
         }
@@ -448,7 +446,7 @@ bool switch_race_racial_execution(CreatureEntity &creature, const int32_t comman
     case PlayerRaceType::DRACONIAN:
         return draconian_breath(creature);
     case PlayerRaceType::MIND_FLAYER: {
-        const auto dir = get_aim_dir(player);
+        const auto dir = get_aim_dir(creature);
         if (!dir) {
             return false;
         }
@@ -458,7 +456,7 @@ bool switch_race_racial_execution(CreatureEntity &creature, const int32_t comman
         return true;
     }
     case PlayerRaceType::IMP: {
-        const auto dir = get_aim_dir(player);
+        const auto dir = get_aim_dir(creature);
         if (!dir) {
             return false;
         }
@@ -474,7 +472,7 @@ bool switch_race_racial_execution(CreatureEntity &creature, const int32_t comman
         return true;
     }
     case PlayerRaceType::GOLEM:
-        (void)set_shield(player, randint1(20) + 30, false);
+        (void)set_shield(creature, randint1(20) + 30, false);
         return true;
     case PlayerRaceType::SKELETON:
     case PlayerRaceType::ZOMBIE:
@@ -485,14 +483,14 @@ bool switch_race_racial_execution(CreatureEntity &creature, const int32_t comman
         (void)vampirism(creature);
         return true;
     case PlayerRaceType::SPECTRE: {
-        const auto dir = get_aim_dir(player);
+        const auto dir = get_aim_dir(creature);
         if (!dir) {
             return false;
         }
 
         stop_mouth(creature);
         msg_print(_("あなたはおどろおどろしい叫び声をあげた！", "You emit an eldritch howl!"));
-        (void)fear_monster(player, dir, creature.level);
+        (void)fear_monster(creature, dir, creature.level);
         return true;
     }
     case PlayerRaceType::SPRITE:
@@ -518,7 +516,7 @@ bool switch_race_racial_execution(CreatureEntity &creature, const int32_t comman
     }
     default:
         msg_print(_("この種族は特殊な能力を持っていません。", "This race has no bonus power."));
-        PlayerEnergy(player).reset_player_turn();
+        PlayerEnergy(creature).reset_player_turn();
         return true;
     }
 }

--- a/src/room/pit-nest-util.cpp
+++ b/src/room/pit-nest-util.cpp
@@ -14,21 +14,20 @@
 
 void nest_pit_type::prepare_filter(CreatureEntity &creature) const
 {
-    auto &player = creature;
     auto &filter = PitNestFilter::get_instance();
     switch (this->pn_hook) {
     case PitNestHook::NONE:
         break;
     case PitNestHook::CLONE: {
         get_mon_num_prep_enum(creature, MonraceHook::VAULT);
-        const auto monrace_id = get_mon_num(player, 0, creature.current_floor_ptr->dun_level + 10, PM_NONE);
+        const auto monrace_id = get_mon_num(creature, 0, creature.current_floor_ptr->dun_level + 10, PM_NONE);
         filter.set_monrace_id(monrace_id);
         get_mon_num_prep_enum(creature);
         break;
     }
     case PitNestHook::SYMBOL: {
         get_mon_num_prep_enum(creature, MonraceHook::VAULT);
-        const auto monrace_id = get_mon_num(player, 0, creature.current_floor_ptr->dun_level + 10, PM_NONE);
+        const auto monrace_id = get_mon_num(creature, 0, creature.current_floor_ptr->dun_level + 10, PM_NONE);
         get_mon_num_prep_enum(creature);
         const auto symbol = MonraceList::get_instance().get_monrace(monrace_id).symbol_definition.character;
         filter.set_monrace_symbol(symbol);
@@ -108,11 +107,10 @@ tl::optional<PitKind> pick_pit_type(const FloorType &floor, const std::map<PitKi
  */
 tl::optional<MonraceId> select_pit_nest_monrace_id(CreatureEntity &creature, uint8_t &sub_align, int boost)
 {
-    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
     const auto &monraces = MonraceList::get_instance();
     for (auto attempts = 100; attempts > 0; attempts--) {
-        const auto monrace_id = get_mon_num(player, 0, floor.dun_level + boost, PM_NONE);
+        const auto monrace_id = get_mon_num(creature, 0, floor.dun_level + boost, PM_NONE);
         const auto &monrace = monraces.get_monrace(monrace_id);
         if (monster_has_hostile_sub_align(sub_align, monrace)) {
             continue;

--- a/src/room/room-generator.cpp
+++ b/src/room/room-generator.cpp
@@ -99,7 +99,6 @@ static void move_prob_list(RoomType dst, RoomType src, std::map<RoomType, int> &
  */
 bool generate_rooms(CreatureEntity &creature, DungeonData *dd_ptr)
 {
-    auto &player = creature;
     auto *floor_ptr = creature.current_floor_ptr;
     auto &dungeon = floor_ptr->get_generated_dungeon_definition();
 
@@ -107,10 +106,10 @@ bool generate_rooms(CreatureEntity &creature, DungeonData *dd_ptr)
     if (dungeon.specific_vault_map.count(floor_ptr->dun_level)) {
         const auto vault_id = dungeon.specific_vault_map.at(floor_ptr->dun_level);
         if (build_fixed_room(creature, dd_ptr, 7, false, enum2i(vault_id))) {
-            msg_print_wizard(player, CHEAT_DUNGEON,
+            msg_print_wizard(creature, CHEAT_DUNGEON,
                 _("特定階層Vaultを生成", "Generated specific floor vault"));
         } else {
-            msg_print_wizard(player, CHEAT_DUNGEON,
+            msg_print_wizard(creature, CHEAT_DUNGEON,
                 _("特定階層Vaultを生成失敗", "Failed generating specific floor vault"));
             return false;
         }
@@ -275,10 +274,10 @@ bool generate_rooms(CreatureEntity &creature, DungeonData *dd_ptr)
     }
 
     if (rooms_built < 2) {
-        msg_format_wizard(player, CHEAT_DUNGEON, _("部屋数が2未満でした。生成を再試行します。", "Number of rooms was under 2. Retry."), rooms_built);
+        msg_format_wizard(creature, CHEAT_DUNGEON, _("部屋数が2未満でした。生成を再試行します。", "Number of rooms was under 2. Retry."), rooms_built);
         return false;
     }
 
-    msg_format_wizard(player, CHEAT_DUNGEON, _("このダンジョンの部屋数は %d です。", "Number of Rooms: %d"), rooms_built);
+    msg_format_wizard(creature, CHEAT_DUNGEON, _("このダンジョンの部屋数は %d です。", "Number of Rooms: %d"), rooms_built);
     return true;
 }

--- a/src/room/rooms-maze-vault.cpp
+++ b/src/room/rooms-maze-vault.cpp
@@ -99,8 +99,7 @@ void r_visit(CreatureEntity &creature, POSITION y1, POSITION x1, POSITION y2, PO
 
 void build_maze_vault(CreatureEntity &creature, const Pos2D &center, const Pos2DVec &vec, bool is_vault)
 {
-    auto &player = creature;
-    msg_print_wizard(player, CHEAT_DUNGEON, _("迷路ランダムVaultを生成しました。", "Maze Vault."));
+    msg_print_wizard(creature, CHEAT_DUNGEON, _("迷路ランダムVaultを生成しました。", "Maze Vault."));
     auto &floor = *creature.current_floor_ptr;
     bool light = ((floor.dun_level <= randint1(25)) && is_vault && floor.get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS));
     const auto dy = vec.y / 2 - 1;
@@ -136,6 +135,6 @@ void build_maze_vault(CreatureEntity &creature, const Pos2D &center, const Pos2D
     std::vector<int> visited(num_vertices);
     r_visit(creature, y1, x1, y2, x2, randint0(num_vertices), 0, visited.data());
     if (is_vault) {
-        fill_treasure(player, { y1, x1, y2, x2 }, randint1(5));
+        fill_treasure(creature, { y1, x1, y2, x2 }, randint1(5));
     }
 }

--- a/src/room/rooms-trap.cpp
+++ b/src/room/rooms-trap.cpp
@@ -22,7 +22,6 @@
  */
 bool build_type14(CreatureEntity &creature, DungeonData *dd_ptr)
 {
-    auto &player = creature;
     /* Pick a room size */
     const auto room_seed_y1 = randint1(4);
     const auto room_seed_x1 = randint1(11);
@@ -38,7 +37,7 @@ bool build_type14(CreatureEntity &creature, DungeonData *dd_ptr)
     }
 
     /* Choose lite or dark */
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     const auto light = ((floor.dun_level <= randint1(25)) && floor.get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS));
 
     /* Get corner values */
@@ -77,6 +76,6 @@ bool build_type14(CreatureEntity &creature, DungeonData *dd_ptr)
     grid.mimic = grid.feat;
     grid.set_terrain_id(trap);
     constexpr auto fmt = _("%sの部屋が生成されました。", "Room of %s was generated.");
-    msg_format_wizard(player, CHEAT_DUNGEON, fmt, TerrainList::get_instance().get_terrain(trap).name.data());
+    msg_format_wizard(creature, CHEAT_DUNGEON, fmt, TerrainList::get_instance().get_terrain(trap).name.data());
     return true;
 }

--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -100,8 +100,7 @@ void set_boundaries(CreatureEntity &creature, const Pos2D &pos)
  */
 static void build_bubble_vault(CreatureEntity &creature, const Pos2D &pos0, const Pos2DVec &vec)
 {
-    auto &player = creature;
-    msg_print_wizard(player, CHEAT_DUNGEON, _("泡型ランダムVaultを生成しました。", "Bubble-shaped Vault."));
+    msg_print_wizard(creature, CHEAT_DUNGEON, _("泡型ランダムVaultを生成しました。", "Bubble-shaped Vault."));
     auto center_points = create_bubbles_center(vec);
 
     const Pos2DVec vec_half(vec.y / 2, vec.x / 2);
@@ -159,21 +158,20 @@ static void build_bubble_vault(CreatureEntity &creature, const Pos2D &pos0, cons
     for (auto i = 0; i < 500; i++) {
         const auto y = randint1(vec.y - 3) - vec_half.y + pos0.y + 1;
         const auto x = randint1(vec.x - 3) - vec_half.x + pos0.x + 1;
-        add_door(player, { y, x }); //!<@ details 乱数引数の評価順を固定する.
+        add_door(creature, { y, x }); //!<@ details 乱数引数の評価順を固定する.
     }
 
     /* Fill with monsters and treasure, low difficulty */
     const auto pos = pos0 + vec_half.inverted();
     const auto area = Rect2D(pos, pos + Pos2DVec(vec.y - 1, vec.x - 1)).resized(-1);
-    fill_treasure(player, area, randint1(5));
+    fill_treasure(creature, area, randint1(5));
 }
 
 /* Create a random vault that looks like a collection of overlapping rooms */
 static void build_room_vault(CreatureEntity &creature, const Pos2D &center, const Pos2DVec &vec)
 {
-    auto &player = creature;
     const Pos2DVec vec_half(vec.y / 2, vec.x / 2);
-    msg_print_wizard(player, CHEAT_DUNGEON, _("部屋型ランダムVaultを生成しました。", "Room Vault."));
+    msg_print_wizard(creature, CHEAT_DUNGEON, _("部屋型ランダムVaultを生成しました。", "Room Vault."));
 
     /* fill area so don't get problems with on_defeat_arena_monster levels */
     auto &floor = *creature.current_floor_ptr;
@@ -199,25 +197,24 @@ static void build_room_vault(CreatureEntity &creature, const Pos2D &center, cons
     for (auto i = 0; i < 500; i++) {
         const auto y = randint1(vec.y - 3) - vec_half.y + center.y + 1;
         const auto x = randint1(vec.x - 3) - vec_half.x + center.x + 1;
-        add_door(player, { y, x }); //!<@ details 乱数引数の評価順を固定する.
+        add_door(creature, { y, x }); //!<@ details 乱数引数の評価順を固定する.
     }
 
     /* Fill with monsters and treasure, high difficulty */
     const auto pos = center + vec_half.inverted();
     const Rect2D area(pos, pos + Pos2DVec(vec.y - 1, vec.x - 1));
-    fill_treasure(player, area.resized(-1), randint1(5) + 5);
+    fill_treasure(creature, area.resized(-1), randint1(5) + 5);
 }
 
 /* Create a random vault out of a fractal grid */
 static void build_cave_vault(CreatureEntity &creature, const Pos2D &center, const Pos2DVec &vec)
 {
-    auto &player = creature;
     /* round to make sizes even */
     const Pos2DVec vec_half(vec.y / 2, vec.x / 2);
     const auto xsize = vec_half.x * 2;
     const auto ysize = vec_half.y * 2;
 
-    msg_print_wizard(player, CHEAT_DUNGEON, _("洞穴ランダムVaultを生成しました。", "Cave Vault."));
+    msg_print_wizard(creature, CHEAT_DUNGEON, _("洞穴ランダムVaultを生成しました。", "Cave Vault."));
 
     auto light = false;
     auto done = false;
@@ -248,7 +245,7 @@ static void build_cave_vault(CreatureEntity &creature, const Pos2D &center, cons
     }
 
     /* Fill with monsters and treasure, low difficulty */
-    fill_treasure(player, area.resized(-1), randint1(5));
+    fill_treasure(creature, area.resized(-1), randint1(5));
 }
 
 /*!
@@ -301,7 +298,6 @@ static Pos2D coord_trans(const Pos2D &pos_initial, const Pos2DVec &offset, int t
  */
 void build_vault(vault_type &vault, CreatureEntity &creature, POSITION yval, POSITION xval, POSITION ymax, POSITION xmax, concptr data, POSITION xoffset, POSITION yoffset, int transno)
 {
-    auto &player = creature;
     /* Place dungeon features and objects */
     auto &floor = *creature.current_floor_ptr;
     auto t = data;
@@ -349,7 +345,7 @@ void build_vault(vault_type &vault, CreatureEntity &creature, POSITION yval, POS
                 }
                 if (vault.place_monster_list.find(*t) != vault.place_monster_list.end()) {
                     const auto monrace_id = vault.place_monster_list.find(*t)->second;
-                    place_specific_monster(player, y, x, monrace_id, PM_NO_KAGE);
+                    place_specific_monster(creature, y, x, monrace_id, PM_NO_KAGE);
                 }
                 continue;
             }
@@ -375,29 +371,29 @@ void build_vault(vault_type &vault, CreatureEntity &creature, POSITION yval, POS
                 break;
             case '*':
                 if (evaluate_percent(75)) {
-                    place_object(player, pos, 0);
+                    place_object(creature, pos, 0);
                 } else {
                     floor.place_trap_at(pos);
                 }
 
                 break;
             case '[':
-                place_object(player, pos, 0);
+                place_object(creature, pos, 0);
                 break;
             case ':':
                 grid.set_terrain_id(TerrainTag::TREE);
                 break;
             case '+':
-                place_secret_door(player, pos);
+                place_secret_door(creature, pos);
                 break;
             case '-':
-                place_secret_door(player, pos, DoorKind::GLASS_DOOR);
+                place_secret_door(creature, pos, DoorKind::GLASS_DOOR);
                 if (floor.has_closed_door_at(pos)) {
                     grid.set_terrain_id(TerrainTag::GLASS_WALL, TerrainKind::MIMIC);
                 }
                 break;
             case '\'':
-                place_secret_door(player, pos, DoorKind::CURTAIN);
+                place_secret_door(creature, pos, DoorKind::CURTAIN);
                 break;
             case '^':
                 floor.place_trap_at(pos);
@@ -429,7 +425,7 @@ void build_vault(vault_type &vault, CreatureEntity &creature, POSITION yval, POS
                 break;
             case 'A':
                 floor.object_level = floor.base_level + 12;
-                place_object(player, pos, AM_GOOD | AM_GREAT);
+                place_object(creature, pos, AM_GOOD | AM_GREAT);
                 floor.object_level = floor.base_level;
                 break;
             case '~':
@@ -505,7 +501,7 @@ void build_vault(vault_type &vault, CreatureEntity &creature, POSITION yval, POS
             switch (*t) {
             case '&': {
                 floor.monster_level = floor.base_level + 5;
-                place_random_monster(player, y, x, (PM_ALLOW_SLEEP | PM_ALLOW_GROUP));
+                place_random_monster(creature, y, x, (PM_ALLOW_SLEEP | PM_ALLOW_GROUP));
                 floor.monster_level = floor.base_level;
                 break;
             }
@@ -513,7 +509,7 @@ void build_vault(vault_type &vault, CreatureEntity &creature, POSITION yval, POS
             /* Meaner monster */
             case '@': {
                 floor.monster_level = floor.base_level + 11;
-                place_random_monster(player, y, x, (PM_ALLOW_SLEEP | PM_ALLOW_GROUP));
+                place_random_monster(creature, y, x, (PM_ALLOW_SLEEP | PM_ALLOW_GROUP));
                 floor.monster_level = floor.base_level;
                 break;
             }
@@ -521,10 +517,10 @@ void build_vault(vault_type &vault, CreatureEntity &creature, POSITION yval, POS
             /* Meaner monster, plus treasure */
             case '9': {
                 floor.monster_level = floor.base_level + 9;
-                place_random_monster(player, y, x, PM_ALLOW_SLEEP);
+                place_random_monster(creature, y, x, PM_ALLOW_SLEEP);
                 floor.monster_level = floor.base_level;
                 floor.object_level = floor.base_level + 7;
-                place_object(player, { y, x }, AM_GOOD);
+                place_object(creature, { y, x }, AM_GOOD);
                 floor.object_level = floor.base_level;
                 break;
             }
@@ -532,10 +528,10 @@ void build_vault(vault_type &vault, CreatureEntity &creature, POSITION yval, POS
             /* Nasty monster and treasure */
             case '8': {
                 floor.monster_level = floor.base_level + 40;
-                place_random_monster(player, y, x, PM_ALLOW_SLEEP);
+                place_random_monster(creature, y, x, PM_ALLOW_SLEEP);
                 floor.monster_level = floor.base_level;
                 floor.object_level = floor.base_level + 20;
-                place_object(player, { y, x }, AM_GOOD | AM_GREAT);
+                place_object(creature, { y, x }, AM_GOOD | AM_GREAT);
                 floor.object_level = floor.base_level;
                 break;
             }
@@ -544,12 +540,12 @@ void build_vault(vault_type &vault, CreatureEntity &creature, POSITION yval, POS
             case ',': {
                 if (one_in_(2)) {
                     floor.monster_level = floor.base_level + 3;
-                    place_random_monster(player, y, x, (PM_ALLOW_SLEEP | PM_ALLOW_GROUP));
+                    place_random_monster(creature, y, x, (PM_ALLOW_SLEEP | PM_ALLOW_GROUP));
                     floor.monster_level = floor.base_level;
                 }
                 if (one_in_(2)) {
                     floor.object_level = floor.base_level + 7;
-                    place_object(player, { y, x }, 0);
+                    place_object(creature, { y, x }, 0);
                     floor.object_level = floor.base_level;
                 }
                 break;
@@ -566,14 +562,13 @@ void build_vault(vault_type &vault, CreatureEntity &creature, POSITION yval, POS
  */
 static void build_target_vault(CreatureEntity &creature, const Pos2D &center, const Pos2DVec &vec)
 {
-    auto &player = creature;
     /* Make a random metric */
     const auto h1 = randint1(32) - 16;
     const auto h2 = randint1(16);
     const auto h3 = randint1(32);
     const auto h4 = randint1(32) - 16;
 
-    msg_print_wizard(player, CHEAT_DUNGEON, _("対称形ランダムVaultを生成しました。", "Target Vault"));
+    msg_print_wizard(creature, CHEAT_DUNGEON, _("対称形ランダムVaultを生成しました。", "Target Vault"));
 
     const auto rad = vec.x > vec.y ? vec.y / 2 : vec.x / 2;
 
@@ -639,19 +634,19 @@ static void build_target_vault(CreatureEntity &creature, const Pos2D &center, co
     /* get two distances so can place doors relative to centre */
     const auto x = (rad - 2) / 4 + 1;
     const auto y = rad / 2 + x;
-    add_door(player, { center.y, center.x + x });
-    add_door(player, { center.y, center.x + y });
-    add_door(player, { center.y, center.x - x });
-    add_door(player, { center.y, center.x - y });
-    add_door(player, { center.y + x, center.x });
-    add_door(player, { center.y + y, center.x });
-    add_door(player, { center.y - x, center.x });
-    add_door(player, { center.y - y, center.x });
+    add_door(creature, { center.y, center.x + x });
+    add_door(creature, { center.y, center.x + y });
+    add_door(creature, { center.y, center.x - x });
+    add_door(creature, { center.y, center.x - y });
+    add_door(creature, { center.y + x, center.x });
+    add_door(creature, { center.y + y, center.x });
+    add_door(creature, { center.y - x, center.x });
+    add_door(creature, { center.y - y, center.x });
 
     /* Fill with stuff - medium difficulty */
     const Pos2DVec vec_radius(rad, rad);
     const Rect2D area(center, vec_radius);
-    fill_treasure(player, area, randint1(3) + 3);
+    fill_treasure(creature, area, randint1(3) + 3);
 }
 
 /*
@@ -663,8 +658,7 @@ static void build_target_vault(CreatureEntity &creature, const Pos2D &center, co
  */
 static void build_elemental_vault(CreatureEntity &creature, const Pos2D &center, const Pos2DVec &vec)
 {
-    auto &player = creature;
-    msg_print_wizard(player, CHEAT_DUNGEON, _("精霊界ランダムVaultを生成しました。", "Elemental Vault"));
+    msg_print_wizard(creature, CHEAT_DUNGEON, _("精霊界ランダムVaultを生成しました。", "Elemental Vault"));
 
     /* round to make sizes even */
     const Pos2DVec vec_half(vec.y / 2, vec.x / 2);
@@ -724,7 +718,7 @@ static void build_elemental_vault(CreatureEntity &creature, const Pos2D &center,
     }
 
     /* Fill with monsters and treasure, low difficulty */
-    fill_treasure(player, area.resized(-1), randint1(5));
+    fill_treasure(creature, area.resized(-1), randint1(5));
 }
 
 /* Build a "mini" checkerboard vault
@@ -736,8 +730,7 @@ static void build_elemental_vault(CreatureEntity &creature, const Pos2D &center,
  */
 static void build_mini_c_vault(CreatureEntity &creature, const Pos2D &center, const Pos2DVec &vec)
 {
-    auto &player = creature;
-    msg_print_wizard(player, CHEAT_DUNGEON, _("小型チェッカーランダムVaultを生成しました。", "Mini Checker Board Vault."));
+    msg_print_wizard(creature, CHEAT_DUNGEON, _("小型チェッカーランダムVaultを生成しました。", "Mini Checker Board Vault."));
 
     /* Pick a random room size */
     const auto dy = vec.y / 2 - 1;
@@ -808,7 +801,7 @@ static void build_mini_c_vault(CreatureEntity &creature, const Pos2D &center, co
     std::vector<int> visited(num_vertices);
 
     /* traverse the graph to create a spannng tree, pick a random root */
-    r_visit(player, y1, x1, y2, x2, randint0(num_vertices), 0, visited.data());
+    r_visit(creature, y1, x1, y2, x2, randint0(num_vertices), 0, visited.data());
 
     /* Make it look like a checker board vault */
     for (auto x = x1; x <= x2; x++) {
@@ -835,7 +828,7 @@ static void build_mini_c_vault(CreatureEntity &creature, const Pos2D &center, co
     }
 
     /* Fill with monsters and treasure, highest difficulty */
-    fill_treasure(player, { y1, x1, y2, x2 }, 10);
+    fill_treasure(creature, { y1, x1, y2, x2 }, 10);
 }
 
 /* Build a castle */
@@ -846,11 +839,10 @@ static void build_mini_c_vault(CreatureEntity &creature, const Pos2D &center, co
  */
 static void build_castle_vault(CreatureEntity &creature, const Pos2D &center, const Pos2DVec &vec)
 {
-    auto &player = creature;
     /* Pick a random room size */
     const Pos2DVec vec_half(vec.y / 2 - 1, vec.x / 2 - 1);
     const Rect2D area(center, vec_half);
-    msg_print_wizard(player, CHEAT_DUNGEON, _("城型ランダムVaultを生成しました。", "Castle Vault"));
+    msg_print_wizard(creature, CHEAT_DUNGEON, _("城型ランダムVaultを生成しました。", "Castle Vault"));
 
     /* generate the room */
     auto &floor = *creature.current_floor_ptr;
@@ -864,7 +856,7 @@ static void build_castle_vault(CreatureEntity &creature, const Pos2D &center, co
     build_recursive_room(creature, area.top_left.x, area.top_left.y, area.bottom_right.x, area.bottom_right.y, randint1(5));
 
     /* Fill with monsters and treasure, low difficulty */
-    fill_treasure(player, area, randint1(3));
+    fill_treasure(creature, area, randint1(3));
 }
 
 /*!
@@ -873,11 +865,10 @@ static void build_castle_vault(CreatureEntity &creature, const Pos2D &center, co
  */
 bool build_type10(CreatureEntity &creature, DungeonData *dd_ptr)
 {
-    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
     const auto xsize = randint1(22) + 22;
     const auto ysize = randint1(11) + 11;
-    const auto center = find_space(player, dd_ptr, ysize + 1, xsize + 1);
+    const auto center = find_space(creature, dd_ptr, ysize + 1, xsize + 1);
     if (!center) {
         return false;
     }
@@ -902,7 +893,7 @@ bool build_type10(CreatureEntity &creature, DungeonData *dd_ptr)
         break;
     case 4:
     case 12:
-        build_maze_vault(player, *center, vec, true);
+        build_maze_vault(creature, *center, vec, true);
         break;
     case 5:
     case 13:
@@ -931,7 +922,6 @@ bool build_type10(CreatureEntity &creature, DungeonData *dd_ptr)
  */
 bool build_fixed_room(CreatureEntity &creature, DungeonData *dd_ptr, int typ, bool more_space, int id = -1)
 {
-    auto &player = creature;
     int result;
 
     ProbabilityTable<int> prob_table;
@@ -979,12 +969,12 @@ bool build_fixed_room(CreatureEntity &creature, DungeonData *dd_ptr, int typ, bo
      */
     const auto xsize = more_space ? std::abs(x) + 2 : std::abs(x);
     const auto ysize = more_space ? std::abs(y) + 2 : std::abs(y);
-    const auto center = find_space(player, dd_ptr, ysize, xsize);
+    const auto center = find_space(creature, dd_ptr, ysize, xsize);
     if (!center) {
         return false;
     }
 
-    msg_format_wizard(player, CHEAT_DUNGEON, _("固定部屋(%s)を生成しました。", "Fixed room (%s)."), vault.name.data());
+    msg_format_wizard(creature, CHEAT_DUNGEON, _("固定部屋(%s)を生成しました。", "Fixed room (%s)."), vault.name.data());
     build_vault(vault, creature, center->y, center->x, vault.hgt, vault.wid, vault.text.data(), x_offset, y_offset, num_transformation);
 
     return true;

--- a/src/room/treasure-deployment.cpp
+++ b/src/room/treasure-deployment.cpp
@@ -18,7 +18,6 @@
 namespace {
 static void deploy_treasure(CreatureEntity &creature, FloorType &floor, const Pos2D &center, const Pos2D &pos, int size, int difficulty)
 {
-    auto &player = creature;
     auto value = Grid::calc_distance(center, pos) * 100 / size + randint1(10) - difficulty;
 
     /// @note
@@ -38,27 +37,27 @@ static void deploy_treasure(CreatureEntity &creature, FloorType &floor, const Po
 
     if (value < 0) {
         floor.monster_level = floor.base_level + 40;
-        place_random_monster(player, pos.y, pos.x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
+        place_random_monster(creature, pos.y, pos.x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
         floor.monster_level = floor.base_level;
         floor.object_level = floor.base_level + 20;
-        place_object(player, pos, AM_GOOD);
+        place_object(creature, pos, AM_GOOD);
         floor.object_level = floor.base_level;
         return;
     }
 
     if (value < 5) {
         floor.monster_level = floor.base_level + 20;
-        place_random_monster(player, pos.y, pos.x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
+        place_random_monster(creature, pos.y, pos.x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
         floor.monster_level = floor.base_level;
         floor.object_level = floor.base_level + 10;
-        place_object(player, pos, AM_GOOD);
+        place_object(creature, pos, AM_GOOD);
         floor.object_level = floor.base_level;
         return;
     }
 
     if (value < 10) {
         floor.monster_level = floor.base_level + 9;
-        place_random_monster(player, pos.y, pos.x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
+        place_random_monster(creature, pos.y, pos.x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
         floor.monster_level = floor.base_level;
         return;
     }
@@ -70,7 +69,7 @@ static void deploy_treasure(CreatureEntity &creature, FloorType &floor, const Po
 
     if (value < 23) {
         if (one_in_(4)) {
-            place_object(player, pos, 0);
+            place_object(creature, pos, 0);
             return;
         }
         floor.place_trap_at(pos);
@@ -79,7 +78,7 @@ static void deploy_treasure(CreatureEntity &creature, FloorType &floor, const Po
 
     if (value < 30) {
         floor.monster_level = floor.base_level + 5;
-        place_random_monster(player, pos.y, pos.x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
+        place_random_monster(creature, pos.y, pos.x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
         floor.monster_level = floor.base_level;
         floor.place_trap_at(pos);
         return;
@@ -88,12 +87,12 @@ static void deploy_treasure(CreatureEntity &creature, FloorType &floor, const Po
     if (value < 40) {
         if (one_in_(2)) {
             floor.monster_level = floor.base_level + 3;
-            place_random_monster(player, pos.y, pos.x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
+            place_random_monster(creature, pos.y, pos.x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
             floor.monster_level = floor.base_level;
         }
         if (one_in_(2)) {
             floor.object_level = floor.base_level + 7;
-            place_object(player, pos, 0);
+            place_object(creature, pos, 0);
             floor.object_level = floor.base_level;
         }
         return;
@@ -105,7 +104,7 @@ static void deploy_treasure(CreatureEntity &creature, FloorType &floor, const Po
     }
 
     if (one_in_(5)) {
-        place_random_monster(player, pos.y, pos.x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
+        place_random_monster(creature, pos.y, pos.x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
         return;
     }
 
@@ -115,7 +114,7 @@ static void deploy_treasure(CreatureEntity &creature, FloorType &floor, const Po
     }
 
     if (one_in_(2)) {
-        place_object(player, pos, 0);
+        place_object(creature, pos, 0);
     }
 }
 }

--- a/src/room/vault-builder.cpp
+++ b/src/room/vault-builder.cpp
@@ -38,7 +38,6 @@ static bool is_cave_empty_grid(const CreatureEntity &creature, const Grid &grid)
  */
 void vault_monsters(CreatureEntity &creature, const Pos2D &pos_center, int num)
 {
-    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     for (auto k = 0; k < num; k++) {
         for (auto i = 0; i < 9; i++) {
@@ -50,7 +49,7 @@ void vault_monsters(CreatureEntity &creature, const Pos2D &pos_center, int num)
             }
 
             floor.monster_level = floor.base_level + 2;
-            const auto has_placed = place_random_monster(player, pos.y, pos.x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
+            const auto has_placed = place_random_monster(creature, pos.y, pos.x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
             floor.monster_level = floor.base_level;
             if (has_placed) {
                 break;
@@ -67,7 +66,6 @@ void vault_monsters(CreatureEntity &creature, const Pos2D &pos_center, int num)
  */
 void vault_objects(CreatureEntity &creature, const Pos2D &pos_center, int num)
 {
-    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     for (; num > 0; --num) {
         Pos2D pos = pos_center;
@@ -94,9 +92,9 @@ void vault_objects(CreatureEntity &creature, const Pos2D &pos_center, int num)
             }
 
             if (evaluate_percent(75)) {
-                place_object(player, pos, 0);
+                place_object(creature, pos, 0);
             } else {
-                place_gold(player, pos);
+                place_gold(creature, pos);
             }
 
             break;

--- a/src/specific-object/monster-ball.cpp
+++ b/src/specific-object/monster-ball.cpp
@@ -94,14 +94,13 @@ static void restore_monster_nickname(CreatureEntity &monster, ItemEntity &item)
 
 static bool release_monster(CreatureEntity &creature, ItemEntity &item, const Direction &dir)
 {
-    auto &player = creature;
     const auto &monrace = item.get_monrace();
     const auto pos = creature.get_neighbor(dir);
     if (!monster_can_enter(&creature, pos.y, pos.x, monrace, 0)) {
         return false;
     }
 
-    const auto m_idx = place_specific_monster(player, pos.y, pos.x, monrace.idx, PM_FORCE_PET | PM_NO_KAGE);
+    const auto m_idx = place_specific_monster(creature, pos.y, pos.x, monrace.idx, PM_FORCE_PET | PM_NO_KAGE);
     if (!m_idx) {
         return false;
     }
@@ -131,7 +130,6 @@ static bool release_monster(CreatureEntity &creature, ItemEntity &item, const Di
 
 bool exe_monster_capture(CreatureEntity &creature, ItemEntity &item)
 {
-    auto &player = creature;
     if (item.bi_key.tval() != ItemKindType::CAPTURE) {
         return false;
     }
@@ -145,7 +143,7 @@ bool exe_monster_capture(CreatureEntity &creature, ItemEntity &item)
         return true;
     }
 
-    const auto dir = get_direction(player);
+    const auto dir = get_direction(creature);
     if (!dir) {
         return true;
     }

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -124,15 +124,13 @@ void process_player_damage_dodged(CreatureEntity &creature, int m_idx)
         return;
     }
 
-    auto &player = creature;
     const auto killer = build_killer_on_earthquake(creature, m_idx);
-    BadStatusSetter(player).mod_stun(randnum1<short>(50));
+    BadStatusSetter(creature).mod_stun(randnum1<short>(50));
     take_hit(creature, DAMAGE_ATTACK, Dice::roll(10, 4), killer);
 }
 
 void process_hit_to_player(CreatureEntity &creature, std::span<const Pos2D> pos_collapses, int m_idx)
 {
-    auto &player = creature;
     const auto has_hit = ranges::contains(pos_collapses, creature.get_position());
     if (!has_hit || has_pass_wall(creature) || has_kill_wall(creature)) {
         return;
@@ -147,7 +145,7 @@ void process_hit_to_player(CreatureEntity &creature, std::span<const Pos2D> pos_
 
     if (const auto pos_dodge = decide_player_dodge_posistion(creature, pos_collapses)) {
         process_player_damage_dodged(creature, m_idx);
-        (void)move_player_effect(player, pos_dodge->y, pos_dodge->x, MPE_DONT_PICKUP);
+        (void)move_player_effect(creature, pos_dodge->y, pos_dodge->x, MPE_DONT_PICKUP);
         return;
     }
     process_player_damage_undodged(creature, m_idx);
@@ -256,7 +254,6 @@ void process_hit_to_monsters(CreatureEntity &creature, std::span<const Pos2D> po
 
 void destruct_earthquake_area(CreatureEntity &creature, std::span<const Pos2D> pos_collapses)
 {
-    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     floor.forget_mon_lite();
     const auto &dungeon = floor.get_dungeon_definition();
@@ -268,7 +265,7 @@ void destruct_earthquake_area(CreatureEntity &creature, std::span<const Pos2D> p
     pt.entry_item(TerrainTag::MAGMA_VEIN, 30);
 
     for (const auto &pos : pos_collapses | ranges::views::filter(is_changeable)) {
-        delete_all_items_from_floor(player, pos);
+        delete_all_items_from_floor(creature, pos);
 
         if (floor.has_terrain_characteristics(pos, TerrainCharacteristics::PROJECTION)) {
             set_terrain_id_to_grid(creature, pos, pt.pick_one_at_random());
@@ -350,7 +347,6 @@ bool earthquake(CreatureEntity &creature, const Pos2D &center, int radius, MONST
 {
     const int earthquake_max = 80;
 
-    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     if ((floor.is_in_quest() && QuestType::is_fixed(floor.quest_number)) || !floor.is_underground()) {
         return false;
@@ -376,7 +372,7 @@ bool earthquake(CreatureEntity &creature, const Pos2D &center, int radius, MONST
     set_redrawing_flags();
 
     if (floor.get_grid(creature.get_position()).info & CAVE_GLOW) {
-        set_superstealth(player, false);
+        set_superstealth(creature, false);
     }
     return true;
 }

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -36,8 +36,7 @@
  */
 static bool detect_feat_flag(CreatureEntity &creature, POSITION range, TerrainCharacteristics flag, bool known)
 {
-    auto &player = creature;
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
@@ -59,14 +58,14 @@ static bool detect_feat_flag(CreatureEntity &creature, POSITION range, TerrainCh
 
                 grid.info &= ~(CAVE_UNSAFE);
 
-                lite_spot(player, pos);
+                lite_spot(creature, pos);
             }
         }
 
         if (grid.has(flag)) {
-            disclose_grid(player, pos);
+            disclose_grid(creature, pos);
             grid.info |= (CAVE_MARK);
-            lite_spot(player, pos);
+            lite_spot(creature, pos);
             detect = true;
         }
     }
@@ -85,17 +84,16 @@ static bool detect_feat_flag(CreatureEntity &creature, POSITION range, TerrainCh
  */
 bool detect_traps(CreatureEntity &creature, POSITION range, bool known)
 {
-    auto &player = creature;
     bool detect = detect_feat_flag(creature, range, TerrainCharacteristics::TRAP, known);
     if (!known && detect) {
         detect_feat_flag(creature, range, TerrainCharacteristics::TRAP, true);
     }
 
     if (known || detect) {
-        player.dtrap = true;
+        creature.dtrap = true;
     }
 
-    if (music_singing(player, MUSIC_DETECT) && get_singing_count(player) > 0) {
+    if (music_singing(creature, MUSIC_DETECT) && get_singing_count(creature) > 0) {
         detect = false;
     }
 
@@ -114,10 +112,9 @@ bool detect_traps(CreatureEntity &creature, POSITION range, bool known)
  */
 bool detect_doors(CreatureEntity &creature, POSITION range)
 {
-    auto &player = creature;
     bool detect = detect_feat_flag(creature, range, TerrainCharacteristics::DOOR, true);
 
-    if (music_singing(player, MUSIC_DETECT) && get_singing_count(player) > 0) {
+    if (music_singing(creature, MUSIC_DETECT) && get_singing_count(creature) > 0) {
         detect = false;
     }
     if (detect) {
@@ -135,10 +132,9 @@ bool detect_doors(CreatureEntity &creature, POSITION range)
  */
 bool detect_stairs(CreatureEntity &creature, POSITION range)
 {
-    auto &player = creature;
     bool detect = detect_feat_flag(creature, range, TerrainCharacteristics::STAIRS, true);
 
-    if (music_singing(player, MUSIC_DETECT) && get_singing_count(player) > 0) {
+    if (music_singing(creature, MUSIC_DETECT) && get_singing_count(creature) > 0) {
         detect = false;
     }
     if (detect) {
@@ -156,10 +152,9 @@ bool detect_stairs(CreatureEntity &creature, POSITION range)
  */
 bool detect_treasure(CreatureEntity &creature, POSITION range)
 {
-    auto &player = creature;
     bool detect = detect_feat_flag(creature, range, TerrainCharacteristics::HAS_GOLD, true);
 
-    if (music_singing(player, MUSIC_DETECT) && get_singing_count(player) > 6) {
+    if (music_singing(creature, MUSIC_DETECT) && get_singing_count(creature) > 6) {
         detect = false;
     }
     if (detect) {
@@ -176,7 +171,6 @@ bool detect_treasure(CreatureEntity &creature, POSITION range)
  */
 bool detect_objects_gold(CreatureEntity &creature, POSITION range)
 {
-    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     POSITION range2 = range;
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
@@ -201,12 +195,12 @@ bool detect_objects_gold(CreatureEntity &creature, POSITION range)
 
         if (item_ptr->bi_key.tval() == ItemKindType::GOLD) {
             item_ptr->marked.set(OmType::FOUND);
-            lite_spot(player, i_pos);
+            lite_spot(creature, i_pos);
             detect = true;
         }
     }
 
-    if (music_singing(player, MUSIC_DETECT) && get_singing_count(player) > 6) {
+    if (music_singing(creature, MUSIC_DETECT) && get_singing_count(creature) > 6) {
         detect = false;
     }
     if (detect) {
@@ -228,7 +222,6 @@ bool detect_objects_gold(CreatureEntity &creature, POSITION range)
  */
 bool detect_objects_normal(CreatureEntity &creature, POSITION range)
 {
-    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     POSITION range2 = range;
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
@@ -251,12 +244,12 @@ bool detect_objects_normal(CreatureEntity &creature, POSITION range)
 
         if (item_ptr->bi_key.tval() != ItemKindType::GOLD) {
             item_ptr->marked.set(OmType::FOUND);
-            lite_spot(player, i_pos);
+            lite_spot(creature, i_pos);
             detect = true;
         }
     }
 
-    if (music_singing(player, MUSIC_DETECT) && get_singing_count(player) > 6) {
+    if (music_singing(creature, MUSIC_DETECT) && get_singing_count(creature) > 6) {
         detect = false;
     }
     if (detect) {
@@ -337,7 +330,6 @@ bool detect_objects_magic(CreatureEntity &creature, POSITION range)
  */
 bool detect_monsters_normal(CreatureEntity &creature, POSITION range)
 {
-    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
@@ -357,14 +349,14 @@ bool detect_monsters_normal(CreatureEntity &creature, POSITION range)
             continue;
         }
 
-        if (monrace.misc_flags.has_not(MonsterMiscType::INVISIBLE) || player.see_inv) {
+        if (monrace.misc_flags.has_not(MonsterMiscType::INVISIBLE) || creature.see_inv) {
             monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
-            update_monster(player, i, false);
+            update_monster(creature, i, false);
             flag = true;
         }
     }
 
-    if (music_singing(player, MUSIC_DETECT) && get_singing_count(player) > 3) {
+    if (music_singing(creature, MUSIC_DETECT) && get_singing_count(creature) > 3) {
         flag = false;
     }
     if (flag) {
@@ -375,14 +367,13 @@ bool detect_monsters_normal(CreatureEntity &creature, POSITION range)
 }
 
 /*!
- * @brief 不可視のモンスターを感知する / Detect all "invisible" monsters around the player
+ * @brief 不可視のモンスターを感知する / Detect all "invisible" monsters around the creature
  * @param creature クリーチャーへの参照
  * @param range 効果範囲
  * @return 効力があった場合TRUEを返す
  */
 bool detect_monsters_invis(CreatureEntity &creature, POSITION range)
 {
-    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
@@ -412,12 +403,12 @@ bool detect_monsters_invis(CreatureEntity &creature, POSITION range)
             }
 
             monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
-            update_monster(player, i, false);
+            update_monster(creature, i, false);
             flag = true;
         }
     }
 
-    if (music_singing(player, MUSIC_DETECT) && get_singing_count(player) > 3) {
+    if (music_singing(creature, MUSIC_DETECT) && get_singing_count(creature) > 3) {
         flag = false;
     }
     if (flag) {
@@ -581,7 +572,6 @@ bool detect_monsters_mind(CreatureEntity &creature, POSITION range)
  */
 bool detect_monsters_string(CreatureEntity &creature, POSITION range, concptr Match)
 {
-    auto &player = creature;
     auto &floor = *creature.current_floor_ptr;
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
@@ -610,12 +600,12 @@ bool detect_monsters_string(CreatureEntity &creature, POSITION range, concptr Ma
             }
 
             monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
-            update_monster(player, i, false);
+            update_monster(creature, i, false);
             flag = true;
         }
     }
 
-    if (music_singing(player, MUSIC_DETECT) && get_singing_count(player) > 3) {
+    if (music_singing(creature, MUSIC_DETECT) && get_singing_count(creature) > 3) {
         flag = false;
     }
     if (flag) {

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -103,17 +103,15 @@ void fetch_item(CreatureEntity &creature, const Direction &dir, WEIGHT wgt, bool
     floor.get_grid(p_pos).o_idx_list.add(floor, item_idx); /* 'move' it */
     item.set_position(p_pos);
 
-    auto &player = creature;
-    const auto item_name = describe_flavor(player, item, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(creature, item, OD_NAME_ONLY);
     msg_format(_("%s^があなたの足元に飛んできた。", "%s^ flies through the air to your feet."), item_name.data());
-    note_spot(player, p_pos);
+    note_spot(creature, p_pos);
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MAP);
 }
 
 bool fetch_monster(CreatureEntity &creature)
 {
-    auto &player = creature;
-    const auto pos = target_set(player, TARGET_KILL).get_position();
+    const auto pos = target_set(creature, TARGET_KILL).get_position();
     if (!pos) {
         return false;
     }
@@ -136,7 +134,7 @@ bool fetch_monster(CreatureEntity &creature)
         return false;
     }
 
-    const auto m_name = monster_desc(player, monster, 0);
+    const auto m_name = monster_desc(creature, monster, 0);
     msg_print(_("{}を引き戻した。", "You pull back {}."), m_name);
     ProjectionPath path_g(floor, AngbandSystem::get_instance().get_max_range(), *pos, p_pos);
     Pos2D pos_target = *pos;
@@ -151,19 +149,19 @@ bool fetch_monster(CreatureEntity &creature)
     floor.get_grid(pos_target).m_idx = m_idx;
     monster.set_position(pos_target);
     (void)set_monster_csleep(floor, m_idx, 0);
-    update_monster(player, m_idx, true);
-    lite_spot(player, *pos);
-    lite_spot(player, pos_target);
+    update_monster(creature, m_idx, true);
+    lite_spot(creature, *pos);
+    lite_spot(creature, pos_target);
     if (monster.get_monrace().brightness_flags.has_any_of(ld_mask)) {
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
     }
 
     if (monster.get_monster_profile().ml) {
-        if (!player.effects()->hallucination().is_hallucinated()) {
+        if (!creature.effects()->hallucination().is_hallucinated()) {
             LoreTracker::get_instance().set_trackee(monster.ap_r_idx);
         }
 
-        health_track(player, m_idx);
+        health_track(creature, m_idx);
     }
 
     return true;

--- a/src/spell-kind/spells-grid.cpp
+++ b/src/spell-kind/spells-grid.cpp
@@ -63,11 +63,10 @@ bool create_rune_explosion(CreatureEntity &creature, POSITION y, POSITION x)
 
 /*!
  * @brief プレイヤーの手による能動的な階段生成処理 /
- * Create stairs at or move previously created stairs into the player location.
+ * Create stairs at or move previously created stairs into the creature location.
  */
 void stair_creation(CreatureEntity &creature)
 {
-    auto &player = creature;
     auto up = !ironman_downward;
     auto &floor = *creature.current_floor_ptr;
     auto down = !inside_quest(floor.get_quest_id()) && (floor.dun_level < floor.get_dungeon_definition().maxdepth);
@@ -82,10 +81,10 @@ void stair_creation(CreatureEntity &creature)
         return;
     }
 
-    delete_all_items_from_floor(player, creature.get_position());
+    delete_all_items_from_floor(creature, creature.get_position());
     auto *sf_ptr = get_sf_ptr(creature.floor_id);
     if (!sf_ptr) {
-        creature.floor_id = get_unused_floor_id(player);
+        creature.floor_id = get_unused_floor_id(creature);
         sf_ptr = get_sf_ptr(creature.floor_id);
     }
 
@@ -129,7 +128,7 @@ void stair_creation(CreatureEntity &creature)
             set_terrain_id_to_grid(creature, pos, dungeon.select_floor_terrain_id());
         }
     } else {
-        dest_floor_id = get_unused_floor_id(player);
+        dest_floor_id = get_unused_floor_id(creature);
         if (up) {
             sf_ptr->upper_floor_id = dest_floor_id;
         } else {

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -38,15 +38,14 @@
  */
 void identify_pack(CreatureEntity &creature)
 {
-    auto &player = creature;
     for (INVENTORY_IDX i = 0; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = player.inventory[i].get();
+        auto *o_ptr = creature.inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
 
         identify_item(creature, o_ptr);
-        autopick_alter_item(player, i, false);
+        autopick_alter_item(creature, i, false);
     }
 }
 
@@ -59,8 +58,7 @@ void identify_pack(CreatureEntity &creature)
  */
 bool identify_item(CreatureEntity &creature, ItemEntity *o_ptr)
 {
-    auto &player = creature;
-    const auto known_item_name = describe_flavor(player, *o_ptr, 0);
+    const auto known_item_name = describe_flavor(creature, *o_ptr, 0);
     const auto old_known = any_bits(o_ptr->ident, IDENT_KNOWN);
     if (!o_ptr->is_fully_known()) {
         if (o_ptr->is_fixed_or_random_artifact() || one_in_(5)) {
@@ -90,7 +88,7 @@ bool identify_item(CreatureEntity &creature, ItemEntity *o_ptr)
     record_item_name = known_item_name;
     record_turn = AngbandWorld::get_instance().game_turn;
 
-    const auto item_name = describe_flavor(player, *o_ptr, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(creature, *o_ptr, OD_NAME_ONLY);
     const auto &floor = *creature.current_floor_ptr;
     if (record_fix_art && !old_known && o_ptr->is_fixed_artifact()) {
         exe_write_diary(floor, DiaryKind::ART, 0, item_name);
@@ -115,11 +113,10 @@ bool identify_item(CreatureEntity &creature, ItemEntity *o_ptr)
  */
 bool ident_spell(CreatureEntity &creature, bool only_equip)
 {
-    auto &player = creature;
     std::unique_ptr<ItemTester> item_tester = std::make_unique<FuncItemTester>(only_equip ? object_is_not_identified_weapon_armor : object_is_not_identified);
 
     concptr q;
-    if (can_get_item(player, *item_tester)) {
+    if (can_get_item(creature, *item_tester)) {
         q = _("どのアイテムを鑑定しますか? ", "Identify which item? ");
     } else {
         if (only_equip) {
@@ -132,22 +129,22 @@ bool ident_spell(CreatureEntity &creature, bool only_equip)
 
     constexpr auto s = _("鑑定するべきアイテムがない。", "You have nothing to identify.");
     short i_idx;
-    auto *o_ptr = choose_object(player, &i_idx, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT), *item_tester);
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT), *item_tester);
     if (!o_ptr) {
         return false;
     }
 
     auto old_known = identify_item(creature, o_ptr);
-    const auto item_name = describe_flavor(player, *o_ptr, 0);
+    const auto item_name = describe_flavor(creature, *o_ptr, 0);
     if (i_idx >= INVEN_MAIN_HAND) {
-        msg_format(_("%s^: %s(%c)。", "%s^: %s (%c)."), describe_use(player, i_idx), item_name.data(), index_to_label(i_idx));
+        msg_format(_("%s^: %s(%c)。", "%s^: %s (%c)."), describe_use(creature, i_idx), item_name.data(), index_to_label(i_idx));
     } else if (i_idx >= 0) {
         msg_format(_("ザック中: %s(%c)。", "In your pack: %s (%c)."), item_name.data(), index_to_label(i_idx));
     } else {
         msg_format(_("床上: %s。", "On the ground: %s."), item_name.data());
     }
 
-    autopick_alter_item(player, i_idx, (bool)(destroy_identify && !old_known));
+    autopick_alter_item(creature, i_idx, (bool)(destroy_identify && !old_known));
     return true;
 }
 
@@ -163,11 +160,10 @@ bool ident_spell(CreatureEntity &creature, bool only_equip)
  */
 bool identify_fully(CreatureEntity &creature, bool only_equip)
 {
-    auto &player = creature;
     std::unique_ptr<ItemTester> item_tester = std::make_unique<FuncItemTester>(only_equip ? object_is_not_fully_identified_weapon_armour : object_is_not_fully_identified);
 
     concptr q;
-    if (can_get_item(player, *item_tester)) {
+    if (can_get_item(creature, *item_tester)) {
         q = _("どのアイテムを*鑑定*しますか? ", "*Identify* which item? ");
     } else {
         if (only_equip) {
@@ -180,17 +176,17 @@ bool identify_fully(CreatureEntity &creature, bool only_equip)
 
     constexpr auto s = _("*鑑定*するべきアイテムがない。", "You have nothing to *identify*.");
     short i_idx;
-    auto *o_ptr = choose_object(player, &i_idx, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT), *item_tester);
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT), *item_tester);
     if (o_ptr == nullptr) {
         return false;
     }
 
     auto old_known = identify_item(creature, o_ptr);
     o_ptr->ident |= (IDENT_FULL_KNOWN);
-    window_stuff(player);
-    const auto item_name = describe_flavor(player, *o_ptr, 0);
+    window_stuff(creature);
+    const auto item_name = describe_flavor(creature, *o_ptr, 0);
     if (i_idx >= INVEN_MAIN_HAND) {
-        msg_format(_("%s^: %s(%c)。", "%s^: %s (%c)."), describe_use(player, i_idx), item_name.data(), index_to_label(i_idx));
+        msg_format(_("%s^: %s(%c)。", "%s^: %s (%c)."), describe_use(creature, i_idx), item_name.data(), index_to_label(i_idx));
     } else if (i_idx >= 0) {
         msg_format(_("ザック中: %s(%c)。", "In your pack: %s (%c)."), item_name.data(), index_to_label(i_idx));
     } else {
@@ -198,6 +194,6 @@ bool identify_fully(CreatureEntity &creature, bool only_equip)
     }
 
     (void)screen_object(creature, *o_ptr, 0L);
-    autopick_alter_item(player, i_idx, (bool)(destroy_identify && !old_known));
+    autopick_alter_item(creature, i_idx, (bool)(destroy_identify && !old_known));
     return true;
 }

--- a/src/spell-kind/spells-pet.cpp
+++ b/src/spell-kind/spells-pet.cpp
@@ -20,7 +20,6 @@
  */
 void discharge_minion(CreatureEntity &creature)
 {
-    auto &player = creature;
     bool okay = true;
     const auto &floor = *creature.current_floor_ptr;
     for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
@@ -49,7 +48,7 @@ void discharge_minion(CreatureEntity &creature)
         if (monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
             const auto m_name = monster_desc(creature, monster, 0x00);
             msg_format(_("%sは爆破されるのを嫌がり、勝手に自分の世界へと帰った。", "%s^ resists being blasted and runs away."), m_name.data());
-            delete_monster_idx(player, i);
+            delete_monster_idx(creature, i);
             continue;
         }
 
@@ -63,13 +62,13 @@ void discharge_minion(CreatureEntity &creature)
         if (dam > 800) {
             dam = 800;
         }
-        project(player, i, 2 + (monrace.level / 20), monster.y, monster.x, dam, AttributeType::PLASMA, PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
+        project(creature, i, 2 + (monrace.level / 20), monster.y, monster.x, dam, AttributeType::PLASMA, PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
 
         if (record_named_pet && monster.is_named()) {
             const auto m_name = monster_desc(creature, monster, MD_INDEF_VISIBLE);
             exe_write_diary(floor, DiaryKind::NAMED_PET, RECORD_NAMED_PET_BLAST, m_name);
         }
 
-        delete_monster_idx(player, i);
+        delete_monster_idx(creature, i);
     }
 }

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -43,7 +43,6 @@
  */
 void call_chaos(CreatureEntity &creature)
 {
-    auto &player = creature;
     constexpr static auto hurt_types = { AttributeType::ELEC, AttributeType::POIS, AttributeType::ACID, AttributeType::COLD, AttributeType::FIRE,
         AttributeType::MISSILE, AttributeType::PLASMA, AttributeType::HOLY_FIRE, AttributeType::WATER, AttributeType::LITE,
         AttributeType::DARK, AttributeType::FORCE, AttributeType::INERTIAL, AttributeType::MANA, AttributeType::METEOR, AttributeType::ICE,
@@ -74,14 +73,14 @@ void call_chaos(CreatureEntity &creature)
         return;
     }
 
-    const auto dir = get_aim_dir(player);
+    const auto dir = get_aim_dir(creature);
     if (!dir) {
         return;
     }
     if (line_chaos) {
         fire_beam(creature, chaos_type, dir, 250);
     } else {
-        fire_ball(creature, chaos_type, dir, 250, 3 + (player.level / 35));
+        fire_ball(creature, chaos_type, dir, 250, 3 + (creature.level / 35));
     }
 }
 
@@ -94,12 +93,11 @@ void call_chaos(CreatureEntity &creature)
  * @details
  * <pre>
  * rr9: Stop the nasty things when a Cyberdemon is summoned
- * or the player gets paralyzed.
+ * or the creature gets paralyzed.
  * </pre>
  */
 bool activate_ty_curse(CreatureEntity &creature, bool stop_ty, int *count)
 {
-    auto &player = creature;
     BIT_FLAGS flg = (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP);
     bool is_first_curse = true;
     const auto &floor = *creature.current_floor_ptr;
@@ -184,7 +182,7 @@ bool activate_ty_curse(CreatureEntity &creature, bool stop_ty, int *count)
         case 11:
         case 12:
             msg_print(_("経験値が体から吸い取られた気がする！", "You feel your experience draining away..."));
-            lose_exp(creature, player.exp / 16);
+            lose_exp(creature, creature.exp / 16);
             if (!one_in_(6)) {
                 break;
             }
@@ -195,12 +193,12 @@ bool activate_ty_curse(CreatureEntity &creature, bool stop_ty, int *count)
         case 19:
         case 20: {
             auto is_statue = stop_ty;
-            is_statue |= player.free_act && (randint1(125) < player.skill_sav);
-            is_statue |= CreatureClass(player).equals(PlayerClassType::BERSERKER);
+            is_statue |= creature.free_act && (randint1(125) < creature.skill_sav);
+            is_statue |= CreatureClass(creature).equals(PlayerClassType::BERSERKER);
             if (!is_statue) {
                 msg_print(_("彫像になった気分だ！", "You feel like a statue!"));
-                TIME_EFFECT turns = player.free_act ? randint1(3) : randint1(13);
-                (void)BadStatusSetter(player).mod_paralysis(turns);
+                TIME_EFFECT turns = creature.free_act ? randint1(3) : randint1(13);
+                (void)BadStatusSetter(creature).mod_paralysis(turns);
                 stop_ty = true;
             }
 
@@ -212,7 +210,7 @@ bool activate_ty_curse(CreatureEntity &creature, bool stop_ty, int *count)
         case 21:
         case 22:
         case 23:
-            (void)do_dec_stat(player, randint0(6));
+            (void)do_dec_stat(creature, randint0(6));
             if (!one_in_(6)) {
                 break;
             }
@@ -238,7 +236,7 @@ bool activate_ty_curse(CreatureEntity &creature, bool stop_ty, int *count)
         default:
             for (int i = 0; i < A_MAX; i++) {
                 do {
-                    (void)do_dec_stat(player, i);
+                    (void)do_dec_stat(creature, i);
                 } while (one_in_(2));
             }
         }
@@ -254,7 +252,6 @@ bool activate_ty_curse(CreatureEntity &creature, bool stop_ty, int *count)
  */
 void wild_magic(CreatureEntity &creature, int spell)
 {
-    auto &player = creature;
     int type = SUMMON_MOLD + randint0(6);
     if (type < SUMMON_MOLD) {
         type = SUMMON_MOLD;
@@ -316,7 +313,7 @@ void wild_magic(CreatureEntity &creature, int spell)
         break;
     case 27:
     case 28:
-        (void)gain_mutation(player, 0);
+        (void)gain_mutation(creature, 0);
         break;
     case 29:
     case 30:
@@ -360,20 +357,19 @@ void wild_magic(CreatureEntity &creature, int spell)
  * @param dir 方向ID
  * @details
  * This spell should become more useful (more controlled) as the\n
- * player gains experience levels.  Thus, add 1/5 of the player's\n
+ * creature gains experience levels.  Thus, add 1/5 of the creature's\n
  * level to the die roll.  This eliminates the worst effects later on,\n
  * while keeping the results quite random.  It also allows some potent\n
  * effects only at high level.
  */
 void cast_wonder(CreatureEntity &creature, const Direction &dir)
 {
-    auto &player = creature;
-    PLAYER_LEVEL plev = player.level;
+    PLAYER_LEVEL plev = creature.level;
     int die = randint1(100) + plev / 5;
     int vir = virtue_number(creature, Virtue::CHANCE);
     if (vir) {
-        auto it = player.virtues.find(Virtue::CHANCE);
-        if (it != player.virtues.end()) {
+        auto it = creature.virtues.find(Virtue::CHANCE);
+        if (it != creature.virtues.end()) {
             if (it->second > 0) {
                 while (randint1(400) < it->second) {
                     die++;
@@ -495,7 +491,7 @@ void cast_wonder(CreatureEntity &creature, const Direction &dir)
     }
 
     if (die < 108) {
-        symbol_genocide(player, plev + 50, true);
+        symbol_genocide(creature, plev + 50, true);
         return;
     }
 
@@ -507,5 +503,5 @@ void cast_wonder(CreatureEntity &creature, const Direction &dir)
     dispel_monsters(creature, 150);
     slow_monsters(creature, plev);
     sleep_monsters(creature, plev);
-    hp_player(player, 300);
+    hp_player(creature, 300);
 }

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -433,7 +433,6 @@ std::string probed_monster_info(CreatureEntity &creature, CreatureEntity &target
  */
 bool probing(CreatureEntity &creature)
 {
-    auto &player = creature;
     bool cu = game_term->scr->cu;
     bool cv = game_term->scr->cv;
     game_term->scr->cu = 0;
@@ -465,7 +464,7 @@ bool probing(CreatureEntity &creature)
 
         message_add(probe_result);
         rfu.set_flag(SubWindowRedrawingFlag::MESSAGE);
-        handle_stuff(player);
+        handle_stuff(creature);
         move_cursor_relative(monster.y, monster.x);
         inkey();
         term_erase(0, 0);

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -44,7 +44,6 @@
  */
 bool teleport_swap(CreatureEntity &creature, const Direction &dir)
 {
-    auto &player = creature;
     const auto pos = dir.get_target_position(creature.get_position());
     if (creature.anti_tele) {
         msg_print(_("不思議な力がテレポートを防いだ！", "A mysterious force prevents you from teleporting!"));
@@ -69,14 +68,14 @@ bool teleport_swap(CreatureEntity &creature, const Direction &dir)
 
     if (monrace.resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT)) {
         msg_print(_("テレポートを邪魔された！", "Your teleportation is blocked!"));
-        if (is_original_ap_and_seen(player, monster)) {
+        if (is_original_ap_and_seen(creature, monster)) {
             monrace.r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
         }
         return false;
     }
 
     sound(SoundKind::TELEPORT);
-    (void)move_player_effect(player, pos.y, pos.x, MPE_FORGET_FLOW | MPE_HANDLE_STUFF | MPE_DONT_PICKUP);
+    (void)move_player_effect(creature, pos.y, pos.x, MPE_FORGET_FLOW | MPE_HANDLE_STUFF | MPE_DONT_PICKUP);
     return true;
 }
 
@@ -255,7 +254,7 @@ void teleport_monster_to(CreatureEntity &creature, MONSTER_IDX m_idx, POSITION t
 
 /*!
  * @brief プレイヤーのテレポート先選定と移動処理 /
- * Teleport the player to a location up to "dis" grids away.
+ * Teleport the creature to a location up to "dis" grids away.
  * @param creature クリーチャーへの参照
  * @param dis 基本移動距離
  * @param is_quantum_effect 量子的効果 (反テレポ無効)によるテレポートアウェイならばTRUE
@@ -264,10 +263,10 @@ void teleport_monster_to(CreatureEntity &creature, MONSTER_IDX m_idx, POSITION t
  * @details
  * <pre>
  * If no such spaces are readily available, the distance may increase.
- * Try very hard to move the player at least a quarter that distance.
+ * Try very hard to move the creature at least a quarter that distance.
  *
  * There was a nasty tendency for a long time; which was causing the
- * player to "bounce" between two or three different spots because
+ * creature to "bounce" between two or three different spots because
  * these are the only spots that are "far enough" way to satisfy the
  * algorithm.
  *
@@ -283,7 +282,6 @@ bool teleport_player_aux(CreatureEntity &creature, POSITION dis, bool is_quantum
         return false;
     }
 
-    auto &player = creature;
     if (!is_quantum_effect && creature.anti_tele && !(mode & TELEPORT_NONMAGICAL)) {
         msg_print(_("不思議な力がテレポートを防いだ！", "A mysterious force prevents you from teleporting!"));
         return false;
@@ -367,11 +365,11 @@ bool teleport_player_aux(CreatureEntity &creature, POSITION dis, bool is_quantum
 
     sound(SoundKind::TELEPORT);
 #ifdef JP
-    if (player.is_echizen()) {
-        msg_format("『こっちだぁ、%s』", player.name.data());
+    if (creature.is_echizen()) {
+        msg_format("『こっちだぁ、%s』", creature.name.data());
     }
 #endif
-    (void)move_player_effect(player, pos.y, pos.x, MPE_FORGET_FLOW | MPE_HANDLE_STUFF | MPE_DONT_PICKUP);
+    (void)move_player_effect(creature, pos.y, pos.x, MPE_FORGET_FLOW | MPE_HANDLE_STUFF | MPE_DONT_PICKUP);
     return true;
 }
 
@@ -390,7 +388,7 @@ void teleport_player(CreatureEntity &creature, POSITION dis, BIT_FLAGS mode)
         return;
     }
 
-    /* Monsters with teleport ability may follow the player */
+    /* Monsters with teleport ability may follow the creature */
     for (POSITION xx = -1; xx < 2; xx++) {
         for (POSITION yy = -1; yy < 2; yy++) {
             MONSTER_IDX tmp_m_idx = creature.current_floor_ptr->grid_array[oy + yy][ox + xx].m_idx;
@@ -433,7 +431,7 @@ void teleport_player_away(MONSTER_IDX m_idx, CreatureEntity &creature, POSITION 
     }
     const auto &floor = *creature.current_floor_ptr;
 
-    /* Monsters with teleport ability may follow the player */
+    /* Monsters with teleport ability may follow the creature */
     for (POSITION xx = -1; xx < 2; xx++) {
         for (POSITION yy = -1; yy < 2; yy++) {
             const auto tmp_m_idx = floor.grid_array[oy + yy][ox + xx].m_idx;
@@ -470,7 +468,6 @@ void teleport_player_away(MONSTER_IDX m_idx, CreatureEntity &creature, POSITION 
  */
 void teleport_player_to(CreatureEntity &creature, POSITION ny, POSITION nx, teleport_flags mode)
 {
-    auto &player = creature;
     if (creature.anti_tele && !(mode & TELEPORT_NONMAGICAL)) {
         msg_print(_("不思議な力がテレポートを防いだ！", "A mysterious force prevents you from teleporting!"));
         return;
@@ -509,12 +506,11 @@ void teleport_player_to(CreatureEntity &creature, POSITION ny, POSITION nx, tele
     }
 
     sound(SoundKind::TELEPORT);
-    (void)move_player_effect(player, pos.y, pos.x, MPE_FORGET_FLOW | MPE_HANDLE_STUFF | MPE_DONT_PICKUP);
+    (void)move_player_effect(creature, pos.y, pos.x, MPE_FORGET_FLOW | MPE_HANDLE_STUFF | MPE_DONT_PICKUP);
 }
 
 void teleport_away_followable(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
     const auto &monster = floor.get_monster(m_idx);
     const auto old_m_pos = monster.get_position();
@@ -533,7 +529,7 @@ void teleport_away_followable(CreatureEntity &creature, MONSTER_IDX m_idx)
     }
 
     bool follow = false;
-    if (creature.muta.has(PlayerMutationType::VTELEPORT) || CreatureClass(player).equals(PlayerClassType::IMITATOR)) {
+    if (creature.muta.has(PlayerMutationType::VTELEPORT) || CreatureClass(creature).equals(PlayerClassType::IMITATOR)) {
         follow = true;
     } else {
         ItemEntity *o_ptr;
@@ -551,7 +547,7 @@ void teleport_away_followable(CreatureEntity &creature, MONSTER_IDX m_idx)
     if (!follow) {
         return;
     }
-    if (!input_check_strict(player, _("ついていきますか？", "Do you follow it? "), UserCheck::OKAY_CANCEL)) {
+    if (!input_check_strict(creature, _("ついていきますか？", "Do you follow it? "), UserCheck::OKAY_CANCEL)) {
         return;
     }
 

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -49,9 +49,9 @@
 
 /*!
  * @brief プレイヤー及びモンスターをレベルテレポートさせる /
- * Teleport the player one level up or down (random when legal)
+ * Teleport the creature one level up or down (random when legal)
  * @param creature クリーチャーへの参照
- * @param m_idx テレポートの対象となるモンスターID(0ならばプレイヤー) / If m_idx <= 0, target is player.
+ * @param m_idx テレポートの対象となるモンスターID(0ならばプレイヤー) / If m_idx <= 0, target is creature.
  * @todo cmd-save.h への依存あり。コールバックで何とかしたい
  */
 void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
@@ -60,10 +60,9 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
         return;
     }
 
-    auto &player = creature;
     std::string m_name;
     auto see_m = true;
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *creature.current_floor_ptr;
     auto &monster = floor.get_monster(m_idx);
     if (m_idx <= 0) {
         m_name = _("あなた", "you");
@@ -79,7 +78,7 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
         return;
     }
 
-    if ((m_idx <= 0) && player.anti_tele) {
+    if ((m_idx <= 0) && creature.anti_tele) {
         msg_print(_("不思議な力がテレポートを防いだ！", "A mysterious force prevents you from teleporting!"));
         return;
     }
@@ -113,9 +112,9 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
 #endif
         if (m_idx <= 0) {
             if (!floor.is_underground()) {
-                floor.set_dungeon_index(ironman_downward ? DungeonId::ANGBAND : player.recall_dungeon);
-                player.oldpy = player.y;
-                player.oldpx = player.x;
+                floor.set_dungeon_index(ironman_downward ? DungeonId::ANGBAND : creature.recall_dungeon);
+                creature.oldpy = creature.y;
+                creature.oldpx = creature.x;
             }
 
             if (record_stair) {
@@ -123,7 +122,7 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
             }
 
             if (autosave_l) {
-                do_cmd_save_game(player, true);
+                do_cmd_save_game(creature, true);
             }
 
             fcms->set(FloorChangeMode::RANDOM_PLACE);
@@ -151,13 +150,13 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
             }
 
             if (autosave_l) {
-                do_cmd_save_game(player, true);
+                do_cmd_save_game(creature, true);
             }
 
             fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::UP, FloorChangeMode::RANDOM_PLACE, FloorChangeMode::RANDOM_CONNECT });
-            leave_quest_check(player);
+            leave_quest_check(creature);
             floor.quest_number = QuestId::NONE;
-            player.leaving = true;
+            creature.leaving = true;
         }
     } else if (go_up) {
 #ifdef JP
@@ -176,11 +175,11 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
             }
 
             if (autosave_l) {
-                do_cmd_save_game(player, true);
+                do_cmd_save_game(creature, true);
             }
 
             fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::UP, FloorChangeMode::RANDOM_PLACE, FloorChangeMode::RANDOM_CONNECT });
-            player.leaving = true;
+            creature.leaving = true;
         }
     } else {
 #ifdef JP
@@ -198,11 +197,11 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
                 exe_write_diary(floor, DiaryKind::TELEPORT_LEVEL, 1);
             }
             if (autosave_l) {
-                do_cmd_save_game(player, true);
+                do_cmd_save_game(creature, true);
             }
 
             fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::DOWN, FloorChangeMode::RANDOM_PLACE, FloorChangeMode::RANDOM_CONNECT });
-            player.leaving = true;
+            creature.leaving = true;
         }
     }
 
@@ -211,13 +210,13 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
         return;
     }
 
-    QuestCompletionChecker(player, monster).complete();
+    QuestCompletionChecker(creature, monster).complete();
     if (record_named_pet && monster.is_named_pet()) {
-        const auto m2_name = monster_desc(player, monster, MD_INDEF_VISIBLE);
+        const auto m2_name = monster_desc(creature, monster, MD_INDEF_VISIBLE);
         exe_write_diary(floor, DiaryKind::NAMED_PET, RECORD_NAMED_PET_TELE_LEVEL, m2_name);
     }
 
-    delete_monster_idx(player, m_idx);
+    delete_monster_idx(creature, m_idx);
     if (see_m) {
         sound(SoundKind::TPLEVEL);
     }
@@ -225,35 +224,34 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
 
 bool teleport_level_other(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     const auto pos = target_set(creature, TARGET_KILL).get_position();
     if (!pos) {
         return false;
     }
 
-    const auto &floor = *player.current_floor_ptr;
+    const auto &floor = *creature.current_floor_ptr;
     const auto &grid = floor.get_grid(*pos);
     const auto target_m_idx = grid.m_idx;
     if ((target_m_idx == 0) || !grid.has_los()) {
         return true;
     }
 
-    const auto p_pos = player.get_position();
+    const auto p_pos = creature.get_position();
     if (!projectable(floor, p_pos, *pos)) {
         return true;
     }
 
     const auto &monster = floor.get_monster(target_m_idx);
     const auto &monrace = monster.get_monrace();
-    const auto m_name = monster_desc(player, monster, 0);
+    const auto m_name = monster_desc(creature, monster, 0);
     msg_format(_("%s^の足を指さした。", "You gesture at %s^'s feet."), m_name.data());
 
     auto has_immune = monrace.resistance_flags.has_any_of(RFR_EFF_RESIST_NEXUS_MASK) || monrace.resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT);
-    if (has_immune || (monrace.misc_flags.has(MonsterMiscType::QUESTOR)) || (monrace.level + randint1(50) > player.level + randint1(60))) {
+    if (has_immune || (monrace.misc_flags.has(MonsterMiscType::QUESTOR)) || (monrace.level + randint1(50) > creature.level + randint1(60))) {
         msg_print(_("しかし効果がなかった！", format("%s^ is unaffected!", m_name.data())));
     } else {
-        teleport_level(player, target_m_idx);
+        teleport_level(creature, target_m_idx);
     }
 
     return true;
@@ -270,13 +268,12 @@ bool tele_town(CreatureEntity &creature)
         return false;
     }
 
-    auto &player = creature;
-    if (player.current_floor_ptr->is_underground()) {
+    if (creature.current_floor_ptr->is_underground()) {
         msg_print(_("この魔法は地上でしか使えない！", "This spell can only be used on the surface!"));
         return false;
     }
 
-    if (player.current_floor_ptr->inside_arena || AngbandSystem::get_instance().is_phase_out()) {
+    if (creature.current_floor_ptr->inside_arena || AngbandSystem::get_instance().is_phase_out()) {
         msg_print(_("この魔法は外でしか使えない！", "This spell can only be used outside!"));
         return false;
     }
@@ -287,7 +284,7 @@ bool tele_town(CreatureEntity &creature)
     auto num = 0;
     const int towns_size = towns_info.size();
     for (auto i = 1; i < towns_size; i++) {
-        if ((i == VALID_TOWNS) || (i == SECRET_TOWN) || (i == player.town_num) || !(player.visit & (1UL << (i - 1)))) {
+        if ((i == VALID_TOWNS) || (i == SECRET_TOWN) || (i == creature.town_num) || !(creature.visit & (1UL << (i - 1)))) {
             continue;
         }
 
@@ -318,7 +315,7 @@ bool tele_town(CreatureEntity &creature)
         }
 
         const auto town_num = key - 'a' + 1;
-        if ((town_num == player.town_num) || (town_num == VALID_TOWNS) || (town_num == SECRET_TOWN) || !(player.visit & (1UL << (key - 'a')))) {
+        if ((town_num == creature.town_num) || (town_num == VALID_TOWNS) || (town_num == SECRET_TOWN) || !(creature.visit & (1UL << (key - 'a')))) {
             continue;
         }
 
@@ -332,8 +329,8 @@ bool tele_town(CreatureEntity &creature)
         }
     }
 
-    player.leaving = true;
-    player.teleport_town = true;
+    creature.leaving = true;
+    creature.teleport_town = true;
     screen_load();
     return true;
 }
@@ -348,21 +345,20 @@ void reserve_alter_reality(CreatureEntity &creature, TIME_EFFECT turns)
         return;
     }
 
-    auto &player = creature;
-    if (player.current_floor_ptr->inside_arena || ironman_downward) {
+    if (creature.current_floor_ptr->inside_arena || ironman_downward) {
         msg_print(_("何も起こらなかった。", "Nothing happens."));
         return;
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (player.alter_reality || turns == 0) {
-        player.alter_reality = 0;
+    if (creature.alter_reality || turns == 0) {
+        creature.alter_reality = 0;
         msg_print(_("景色が元に戻った...", "The view around you returns to normal..."));
         rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
         return;
     }
 
-    player.alter_reality = turns;
+    creature.alter_reality = turns;
     msg_print(_("回りの景色が変わり始めた...", "The view around you begins to change..."));
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
 }
@@ -420,11 +416,11 @@ static tl::optional<DungeonId> choose_dungeon(std::string_view note, int row, in
 
 /*!
  * @brief プレイヤーの帰還発動及び中止処理 /
- * Recall the player to town or dungeon
+ * Recall the creature to town or dungeon
  * @param creature クリーチャーへの参照
  * @param turns 発動までのターン数
  * @return 常にTRUEを返す
- * @todo Recall the player to the last visited town when in the wilderness
+ * @todo Recall the creature to the last visited town when in the wilderness
  */
 bool recall_player(CreatureEntity &creature, TIME_EFFECT turns)
 {
@@ -432,8 +428,7 @@ bool recall_player(CreatureEntity &creature, TIME_EFFECT turns)
         return true;
     }
 
-    auto &player = creature;
-    const auto &floor = *player.current_floor_ptr;
+    const auto &floor = *creature.current_floor_ptr;
     if (floor.inside_arena || ironman_downward) {
         msg_print(_("何も起こらなかった。", "Nothing happens."));
         return true;
@@ -443,7 +438,7 @@ bool recall_player(CreatureEntity &creature, TIME_EFFECT turns)
     auto is_special_floor = floor.is_underground();
     is_special_floor &= dungeon_record.get_max_level() > floor.dun_level;
     is_special_floor &= !floor.is_in_quest();
-    is_special_floor &= !player.word_recall;
+    is_special_floor &= !creature.word_recall;
     if (is_special_floor) {
         if (input_check(_("ここは最深到達階より浅い階です。この階に戻って来ますか？ ", "Reset recall depth? "))) {
             dungeon_record.set_max_level(floor.dun_level);
@@ -454,8 +449,8 @@ bool recall_player(CreatureEntity &creature, TIME_EFFECT turns)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (player.word_recall || turns == 0) {
-        player.word_recall = 0;
+    if (creature.word_recall || turns == 0) {
+        creature.word_recall = 0;
         msg_print(_("張りつめた大気が流れ去った...", "A tension leaves the air around you..."));
         rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
         return true;
@@ -473,10 +468,10 @@ bool recall_player(CreatureEntity &creature, TIME_EFFECT turns)
             return false;
         }
 
-        player.recall_dungeon = *select_dungeon;
+        creature.recall_dungeon = *select_dungeon;
     }
 
-    player.word_recall = turns;
+    creature.word_recall = turns;
     msg_print(_("回りの大気が張りつめてきた...", "The air about you becomes charged..."));
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     return true;
@@ -488,7 +483,6 @@ bool free_level_recall(CreatureEntity &creature)
         return false;
     }
 
-    auto &player = creature;
     const auto select_dungeon = choose_dungeon(_("にテレポート", "teleport"), 4, 0);
     if (!select_dungeon) {
         return false;
@@ -509,14 +503,14 @@ bool free_level_recall(CreatureEntity &creature)
         return false;
     }
 
-    player.word_recall = 1;
-    player.recall_dungeon = *select_dungeon;
+    creature.word_recall = 1;
+    creature.recall_dungeon = *select_dungeon;
     const auto dun_level = (amt > dungeon.maxdepth) ? dungeon.maxdepth : (amt < dungeon.mindepth) ? dungeon.mindepth
                                                                                                   : amt;
-    auto &dungeon_record = DungeonRecords::get_instance().get_record(player.recall_dungeon);
+    auto &dungeon_record = DungeonRecords::get_instance().get_record(creature.recall_dungeon);
     dungeon_record.set_max_level(dun_level);
     if (record_maxdepth) {
-        exe_write_diary(*player.current_floor_ptr, DiaryKind::TRUMP, enum2i(*select_dungeon), _("トランプタワーで", "at Trump Tower"));
+        exe_write_diary(*creature.current_floor_ptr, DiaryKind::TRUMP, enum2i(*select_dungeon), _("トランプタワーで", "at Trump Tower"));
     }
 
     msg_print(_("回りの大気が張りつめてきた...", "The air about you becomes charged..."));
@@ -535,7 +529,6 @@ bool reset_recall(CreatureEntity &creature)
         return false;
     }
 
-    auto &player = creature;
     const auto select_dungeon = choose_dungeon(_("をセット", "reset"), 2, 14);
     if (ironman_downward) {
         msg_print(_("何も起こらなかった。", "Nothing happens."));
@@ -559,7 +552,7 @@ bool reset_recall(CreatureEntity &creature)
     dungeon_record.set_max_level(*reset_level);
     if (record_maxdepth) {
         constexpr auto note = _("フロア・リセットで", "using a scroll of reset recall");
-        exe_write_diary(*player.current_floor_ptr, DiaryKind::TRUMP, enum2i(*select_dungeon), note);
+        exe_write_diary(*creature.current_floor_ptr, DiaryKind::TRUMP, enum2i(*select_dungeon), note);
     }
 #ifdef JP
     msg_format("%sの帰還レベルを %d 階にセット。", dungeon.name.data(), *reset_level);

--- a/src/spell-realm/spells-nature.cpp
+++ b/src/spell-realm/spells-nature.cpp
@@ -23,13 +23,12 @@ bool rustproof(CreatureEntity &creature)
     constexpr auto s = _("錆止めできるものがありません。", "You have nothing to rustproof.");
     short i_idx;
     const auto options = USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT;
-    auto &player = creature;
-    auto *o_ptr = choose_object(player, &i_idx, q, s, options, FuncItemTester(&ItemEntity::is_protector));
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, options, FuncItemTester(&ItemEntity::is_protector));
     if (o_ptr == nullptr) {
         return false;
     }
 
-    const auto item_name = describe_flavor(player, *o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
+    const auto item_name = describe_flavor(creature, *o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
     o_ptr->art_flags.set(TR_IGNORE_ACID);
     if ((o_ptr->to_a < 0) && !o_ptr->is_cursed()) {
 #ifdef JP

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -25,8 +25,7 @@
  */
 void check_music(CreatureEntity &creature)
 {
-    auto &player = creature;
-    if (!CreatureClass(player).equals(PlayerClassType::BARD)) {
+    if (!CreatureClass(creature).equals(PlayerClassType::BARD)) {
         return;
     }
 
@@ -35,7 +34,7 @@ void check_music(CreatureEntity &creature)
         return;
     }
 
-    if (player.anti_magic) {
+    if (creature.anti_magic) {
         stop_singing(creature);
         return;
     }
@@ -47,19 +46,19 @@ void check_music(CreatureEntity &creature)
     uint32_t need_mana_frac = 0;
 
     s64b_rshift(&need_mana, &need_mana_frac, 1);
-    if (s64b_cmp(player.csp, player.csp_frac, need_mana, need_mana_frac) < 0) {
+    if (s64b_cmp(creature.csp, creature.csp_frac, need_mana, need_mana_frac) < 0) {
         stop_singing(creature);
         return;
     }
 
-    s64b_sub(&(player.csp), &(player.csp_frac), need_mana, need_mana_frac);
+    s64b_sub(&(creature.csp), &(creature.csp_frac), need_mana, need_mana_frac);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MP);
     if (interupting_song_effect != 0) {
         set_singing_song_effect(creature, interupting_song_effect);
         set_interrupting_song_effect(creature, MUSIC_NONE);
         msg_print(_("歌を再開した。", "You resume singing."));
-        player.action = ACTION_SING;
+        creature.action = ACTION_SING;
         static constexpr auto flags_srf = {
             StatusRecalculatingFlag::BONUS,
             StatusRecalculatingFlag::HP,
@@ -79,7 +78,7 @@ void check_music(CreatureEntity &creature)
         rfu.set_flags(flags_swrf);
     }
 
-    PlayerSkill(player).gain_continuous_spell_skill_exp(RealmType::MUSIC, spell_id);
+    PlayerSkill(creature).gain_continuous_spell_skill_exp(RealmType::MUSIC, spell_id);
     exe_spell(creature, RealmType::MUSIC, spell_id, SpellProcessType::CONTNUATION);
 }
 
@@ -132,12 +131,11 @@ bool set_tim_stealth(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
 }
 
 /*!
- * @brief 歌の停止を処理する / Stop singing if the player is a Bard
+ * @brief 歌の停止を処理する / Stop singing if the creature is a Bard
  */
 void stop_singing(CreatureEntity &creature)
 {
-    auto &player = creature;
-    if (!CreatureClass(player).equals(PlayerClassType::BARD)) {
+    if (!CreatureClass(creature).equals(PlayerClassType::BARD)) {
         return;
     }
 
@@ -150,7 +148,7 @@ void stop_singing(CreatureEntity &creature)
         return;
     }
 
-    if (player.action == ACTION_SING) {
+    if (creature.action == ACTION_SING) {
         set_action(creature, ACTION_NONE);
     }
 

--- a/src/spell-realm/spells-sorcery.cpp
+++ b/src/spell-realm/spells-sorcery.cpp
@@ -23,7 +23,6 @@
  */
 bool alchemy(CreatureEntity &creature)
 {
-    auto &player = creature;
     bool force = false;
     if (command_arg > 0) {
         force = true;
@@ -32,7 +31,7 @@ bool alchemy(CreatureEntity &creature)
     constexpr auto q = _("どのアイテムを金に変えますか？", "Turn which item to gold? ");
     constexpr auto s = _("金に変えられる物がありません。", "You have nothing to turn to gold.");
     short i_idx;
-    auto *o_ptr = choose_object(player, &i_idx, q, s, (USE_INVEN | USE_FLOOR));
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, (USE_INVEN | USE_FLOOR));
     if (o_ptr == nullptr) {
         return false;
     }
@@ -47,7 +46,7 @@ bool alchemy(CreatureEntity &creature)
 
     const auto old_number = o_ptr->number;
     o_ptr->number = amt;
-    const auto item_name = describe_flavor(player, *o_ptr, 0);
+    const auto item_name = describe_flavor(creature, *o_ptr, 0);
     o_ptr->number = old_number;
 
     if (!force) {
@@ -67,7 +66,7 @@ bool alchemy(CreatureEntity &creature)
     auto price = object_value_real(o_ptr);
     if (price <= 0) {
         msg_format(_("%sをニセの金に変えた。", "You turn %s to fool's gold."), item_name.data());
-        vary_item(player, i_idx, -amt);
+        vary_item(creature, i_idx, -amt);
         return true;
     }
 
@@ -82,10 +81,10 @@ bool alchemy(CreatureEntity &creature)
     }
 
     msg_format(_("%sを＄%d の金に変えた。", "You turn %s to %d coins worth of gold."), item_name.data(), price);
-    player.au += price;
+    creature.au += price;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::GOLD);
     rfu.set_flag(SubWindowRedrawingFlag::PLAYER);
-    vary_item(player, i_idx, -amt);
+    vary_item(creature, i_idx, -amt);
     return true;
 }

--- a/src/spell-realm/spells-trump.cpp
+++ b/src/spell-realm/spells-trump.cpp
@@ -29,13 +29,12 @@
  */
 void cast_shuffle(CreatureEntity &creature)
 {
-    auto &player = creature;
-    PLAYER_LEVEL plev = player.level;
+    PLAYER_LEVEL plev = creature.level;
     int die;
     int vir = virtue_number(creature, Virtue::CHANCE);
     int i;
 
-    CreatureClass pc(player);
+    CreatureClass pc(creature);
     auto is_good_shuffle = pc.equals(PlayerClassType::ROGUE);
     is_good_shuffle |= pc.equals(PlayerClassType::HIGH_MAGE);
     is_good_shuffle |= pc.equals(PlayerClassType::SORCERER);
@@ -46,8 +45,8 @@ void cast_shuffle(CreatureEntity &creature)
     }
 
     if (vir) {
-        auto it = player.virtues.find(Virtue::CHANCE);
-        if (it != player.virtues.end()) {
+        auto it = creature.virtues.find(Virtue::CHANCE);
+        if (it != creature.virtues.end()) {
             if (it->second > 0) {
                 while (randint1(400) < it->second) {
                     die++;
@@ -98,8 +97,8 @@ void cast_shuffle(CreatureEntity &creature)
 
     if (die < 26) {
         msg_print(_("《愚者》だ。", "It's the Fool."));
-        do_dec_stat(player, A_INT);
-        do_dec_stat(player, A_WIS);
+        do_dec_stat(creature, A_INT);
+        do_dec_stat(creature, A_WIS);
         return;
     }
 
@@ -130,7 +129,7 @@ void cast_shuffle(CreatureEntity &creature)
 
     if (die < 42) {
         msg_print(_("《正義》だ。", "It's Justice."));
-        set_blessed(player, player.level, false);
+        set_blessed(creature, creature.level, false);
         return;
     }
 
@@ -191,8 +190,8 @@ void cast_shuffle(CreatureEntity &creature)
     if (die < 96) {
         msg_print(_("《恋人》だ。", "It's the Lovers."));
 
-        if (const auto dir = get_aim_dir(player)) {
-            charm_monster(creature, dir, std::min<short>(player.level, 20));
+        if (const auto dir = get_aim_dir(creature)) {
+            charm_monster(creature, dir, std::min<short>(creature.level, 20));
         }
 
         return;
@@ -207,7 +206,7 @@ void cast_shuffle(CreatureEntity &creature)
     if (die < 111) {
         msg_print(_("《審判》だ。", "It's Judgement."));
         roll_hitdice(creature, SPOP_NONE);
-        lose_all_mutations(player);
+        lose_all_mutations(creature);
         return;
     }
 
@@ -220,11 +219,11 @@ void cast_shuffle(CreatureEntity &creature)
     }
 
     msg_print(_("《世界》だ。", "It's the World."));
-    if (player.exp >= PY_MAX_EXP) {
+    if (creature.exp >= PY_MAX_EXP) {
         return;
     }
 
-    int32_t ee = (player.exp / 25) + 1;
+    int32_t ee = (creature.exp / 25) + 1;
     if (ee > 5000) {
         ee = 5000;
     }
@@ -234,10 +233,9 @@ void cast_shuffle(CreatureEntity &creature)
 
 void become_living_trump(CreatureEntity &creature)
 {
-    auto &player = creature;
     /* 1/7 Teleport control and 6/7 Random teleportation (uncontrolled) */
     MUTATION_IDX mutation = one_in_(7) ? 12 : 77;
-    if (gain_mutation(player, mutation)) {
+    if (gain_mutation(creature, mutation)) {
         msg_print(_("あなたは生きているカードに変わった。", "You have turned into a Living Trump."));
     }
 }

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -52,7 +52,7 @@
 static constexpr std::array<int, 16> enchant_table = { { 0, 10, 50, 100, 200, 300, 400, 500, 650, 800, 950, 987, 993, 995, 998, 1000 } };
 
 /*
- * Scatter some "amusing" objects near the player
+ * Scatter some "amusing" objects near the creature
  */
 enum class AmusementFlagType : byte {
     NOTHING, /* No restriction */
@@ -172,7 +172,7 @@ void generate_amusement(CreatureEntity &creature, int num, bool known)
 
 /*!
  * @brief 獲得ドロップを行う。
- * Scatter some "great" objects near the player
+ * Scatter some "great" objects near the creature
  * @param creature クリーチャーへの参照
  * @param y1 配置したいフロアのY座標
  * @param x1 配置したいフロアのX座標
@@ -199,15 +199,14 @@ void acquirement(CreatureEntity &creature, POSITION y1, POSITION x1, int num, bo
  */
 bool curse_armor(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     /* Curse the body armor */
-    auto &item = *player.inventory[INVEN_BODY];
+    auto &item = *creature.inventory[INVEN_BODY];
     if (!item.is_valid()) {
         return false;
     }
 
-    const auto item_name = describe_flavor(player, item, OD_OMIT_PREFIX);
+    const auto item_name = describe_flavor(creature, item, OD_OMIT_PREFIX);
 
     if (item.is_fixed_or_random_artifact() && one_in_(2)) {
 #ifdef JP
@@ -260,8 +259,7 @@ bool curse_weapon_object(CreatureEntity &creature, bool force, ItemEntity *o_ptr
         return false;
     }
 
-    auto &player = creature;
-    const auto item_name = describe_flavor(player, *o_ptr, OD_OMIT_PREFIX);
+    const auto item_name = describe_flavor(creature, *o_ptr, OD_OMIT_PREFIX);
     if (o_ptr->is_fixed_or_random_artifact() && one_in_(2) && !force) {
 #ifdef JP
         msg_format("%sが%sを包み込もうとしたが、%sはそれを跳ね返した！", "恐怖の暗黒オーラ", "武器", item_name.data());
@@ -308,10 +306,9 @@ bool curse_weapon_object(CreatureEntity &creature, bool force, ItemEntity *o_ptr
  */
 void brand_bolts(CreatureEntity &creature)
 {
-    auto &player = creature;
 
     for (auto i = 0; i < INVEN_PACK; i++) {
-        auto *o_ptr = player.inventory[i].get();
+        auto *o_ptr = creature.inventory[i].get();
         if (o_ptr->bi_key.tval() != ItemKindType::BOLT) {
             continue;
         }
@@ -472,7 +469,6 @@ bool enchant_equipment(ItemEntity *o_ptr, int n, int eflag)
  */
 bool enchant_spell(CreatureEntity &creature, HIT_PROB num_hit, int num_dam, ARMOUR_CLASS num_ac)
 {
-    auto &player = creature;
 
     FuncItemTester item_tester(&ItemEntity::allow_enchant_weapon);
     if (num_ac) {
@@ -483,12 +479,12 @@ bool enchant_spell(CreatureEntity &creature, HIT_PROB num_hit, int num_dam, ARMO
     constexpr auto s = _("強化できるアイテムがない。", "You have nothing to enchant.");
     short i_idx;
     const auto options = USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT;
-    auto *o_ptr = choose_object(player, &i_idx, q, s, options, item_tester);
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, options, item_tester);
     if (o_ptr == nullptr) {
         return false;
     }
 
-    const auto item_name = describe_flavor(player, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(creature, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 #ifdef JP
     msg_format("%s は明るく輝いた！", item_name.data());
 #else
@@ -531,13 +527,12 @@ bool enchant_spell(CreatureEntity &creature, HIT_PROB num_hit, int num_dam, ARMO
  */
 void brand_weapon(CreatureEntity &creature, int brand_type)
 {
-    auto &player = creature;
 
     constexpr auto q = _("どの武器を強化しますか? ", "Enchant which weapon? ");
     constexpr auto s = _("強化できる武器がない。", "You have nothing to enchant.");
     short i_idx;
     const auto options = USE_EQUIP | IGNORE_BOTHHAND_SLOT;
-    auto *o_ptr = choose_object(player, &i_idx, q, s, options, FuncItemTester(&ItemEntity::allow_enchant_melee_weapon));
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, options, FuncItemTester(&ItemEntity::allow_enchant_melee_weapon));
     if (o_ptr == nullptr) {
         return;
     }
@@ -558,7 +553,7 @@ void brand_weapon(CreatureEntity &creature, int brand_type)
         return;
     }
 
-    const auto item_name = describe_flavor(player, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(creature, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     concptr act = nullptr;
     switch (brand_type) {
     case 17:

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -243,11 +243,10 @@ bool cast_summon_octopus(CreatureEntity &creature)
  */
 bool cast_summon_greater_demon(CreatureEntity &creature)
 {
-    auto &player = creature;
     constexpr auto q = _("どの死体を捧げますか? ", "Sacrifice which corpse? ");
     constexpr auto s = _("捧げられる死体を持っていない。", "You have nothing to sacrifice.");
     short i_idx;
-    const auto *o_ptr = choose_object(player, &i_idx, q, s, (USE_INVEN | USE_FLOOR), FuncItemTester(&ItemEntity::is_offerable));
+    const auto *o_ptr = choose_object(creature, &i_idx, q, s, (USE_INVEN | USE_FLOOR), FuncItemTester(&ItemEntity::is_offerable));
     if (!o_ptr) {
         return false;
     }
@@ -256,7 +255,7 @@ bool cast_summon_greater_demon(CreatureEntity &creature)
     if (summon_specific(creature, creature.y, creature.x, summon_lev, SUMMON_HI_DEMON, (PM_ALLOW_GROUP | PM_FORCE_PET))) {
         msg_print(_("硫黄の悪臭が充満した。", "The area fills with a stench of sulphur and brimstone."));
         msg_print(_("「ご用でございますか、ご主人様」", "'What is thy bidding... Master?'"));
-        vary_item(player, i_idx, -1);
+        vary_item(creature, i_idx, -1);
     } else {
         msg_print(_("悪魔は現れなかった。", "No Greater Demon arrives."));
     }
@@ -482,14 +481,13 @@ int activate_hi_summon(CreatureEntity &creature, POSITION y, POSITION x, bool ca
  */
 void cast_invoke_spirits(CreatureEntity &creature, const Direction &dir)
 {
-    auto &player = creature;
     PLAYER_LEVEL plev = creature.level;
     int die = randint1(100) + plev / 5;
     int vir = virtue_number(creature, Virtue::CHANCE);
 
     if (vir != 0) {
-        auto it = player.virtues.find(Virtue::CHANCE);
-        if (it != player.virtues.end()) {
+        auto it = creature.virtues.find(Virtue::CHANCE);
+        if (it != creature.virtues.end()) {
             if (it->second > 0) {
                 while (randint1(400) < it->second) {
                     die++;
@@ -511,7 +509,7 @@ void cast_invoke_spirits(CreatureEntity &creature, const Direction &dir)
         msg_print(_("あなたはおどろおどろしい力のうねりを感じた！", "You feel a surge of eldritch force!"));
     }
 
-    BadStatusSetter bss(player);
+    BadStatusSetter bss(creature);
     if (die < 8) {
         msg_print(_("なんてこった！あなたの周りの地面から朽ちた人影が立ち上がってきた！", "Oh no! Mouldering forms rise from the earth around you!"));
 
@@ -559,14 +557,14 @@ void cast_invoke_spirits(CreatureEntity &creature, const Direction &dir)
     } else if (die < 106) {
         (void)destroy_area(creature, creature.y, creature.x, 13 + randint0(5), false);
     } else if (die < 108) {
-        symbol_genocide(player, plev + 50, true);
+        symbol_genocide(creature, plev + 50, true);
     } else if (die < 110) {
         dispel_monsters(creature, 120);
     } else {
         dispel_monsters(creature, 150);
         slow_monsters(creature, plev);
         sleep_monsters(creature, plev);
-        hp_player(player, 300);
+        hp_player(creature, 300);
     }
 
     if (die < 31) {

--- a/src/status/body-improvement.cpp
+++ b/src/status/body-improvement.cpp
@@ -13,8 +13,8 @@
 #include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
-BodyImprovement::BodyImprovement(CreatureEntity &player)
-    : player_ptr(&player)
+BodyImprovement::BodyImprovement(CreatureEntity &creature)
+    : player_ptr(&creature)
 {
 }
 
@@ -84,12 +84,11 @@ void BodyImprovement::set_protection(short v, bool is_decrease)
  */
 bool set_invuln(CreatureEntity &creature, short v, bool do_dec)
 {
-    auto &player = creature;
     bool notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
 
-    if (player.is_dead()) {
+    if (creature.is_dead()) {
         return false;
     }
 
@@ -99,8 +98,8 @@ bool set_invuln(CreatureEntity &creature, short v, bool do_dec)
         SubWindowRedrawingFlag::DUNGEON,
     };
     if (v) {
-        if (player.invuln && !do_dec) {
-            if (player.invuln > v) {
+        if (creature.invuln && !do_dec) {
+            if (creature.invuln > v) {
                 return false;
             }
         } else if (!creature.is_invulnerable()) {
@@ -115,17 +114,17 @@ bool set_invuln(CreatureEntity &creature, short v, bool do_dec)
             rfu.set_flags(flags_swrf);
         }
     } else {
-        if (player.invuln && !music_singing(player, MUSIC_INVULN)) {
+        if (creature.invuln && !music_singing(creature, MUSIC_INVULN)) {
             msg_print(_("無敵ではなくなった。", "The invulnerability wears off."));
             notice = true;
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
             rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
             rfu.set_flags(flags_swrf);
-            player.energy_need += ENERGY_NEED();
+            creature.energy_need += ENERGY_NEED();
         }
     }
 
-    player.invuln = v;
+    creature.invuln = v;
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
 
     if (!notice) {
@@ -149,32 +148,31 @@ bool set_invuln(CreatureEntity &creature, short v, bool do_dec)
  */
 bool set_tim_regen(CreatureEntity &creature, short v, bool do_dec)
 {
-    auto &player = creature;
     bool notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
 
-    if (player.is_dead()) {
+    if (creature.is_dead()) {
         return false;
     }
 
     if (v) {
-        if (player.tim_regen && !do_dec) {
-            if (player.tim_regen > v) {
+        if (creature.tim_regen && !do_dec) {
+            if (creature.tim_regen > v) {
                 return false;
             }
-        } else if (!player.tim_regen) {
+        } else if (!creature.tim_regen) {
             msg_print(_("回復力が上がった！", "You feel yourself regenerating quickly!"));
             notice = true;
         }
     } else {
-        if (player.tim_regen) {
+        if (creature.tim_regen) {
             msg_print(_("素早く回復する感じがなくなった。", "You feel you are no longer regenerating quickly."));
             notice = true;
         }
     }
 
-    player.tim_regen = v;
+    creature.tim_regen = v;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -198,32 +196,31 @@ bool set_tim_regen(CreatureEntity &creature, short v, bool do_dec)
  */
 bool set_tim_reflect(CreatureEntity &creature, short v, bool do_dec)
 {
-    auto &player = creature;
     bool notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
 
-    if (player.is_dead()) {
+    if (creature.is_dead()) {
         return false;
     }
 
     if (v) {
-        if (player.tim_reflect && !do_dec) {
-            if (player.tim_reflect > v) {
+        if (creature.tim_reflect && !do_dec) {
+            if (creature.tim_reflect > v) {
                 return false;
             }
-        } else if (!player.tim_reflect) {
+        } else if (!creature.tim_reflect) {
             msg_print(_("体の表面が滑かになった気がする。", "Your body becames smooth."));
             notice = true;
         }
     } else {
-        if (player.tim_reflect) {
+        if (creature.tim_reflect) {
             msg_print(_("体の表面が滑かでなくなった。", "Your body is no longer smooth."));
             notice = true;
         }
     }
 
-    player.tim_reflect = v;
+    creature.tim_reflect = v;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -247,32 +244,31 @@ bool set_tim_reflect(CreatureEntity &creature, short v, bool do_dec)
  */
 bool set_pass_wall(CreatureEntity &creature, short v, bool do_dec)
 {
-    auto &player = creature;
     bool notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
 
-    if (player.is_dead()) {
+    if (creature.is_dead()) {
         return false;
     }
 
     if (v) {
-        if (player.tim_pass_wall && !do_dec) {
-            if (player.tim_pass_wall > v) {
+        if (creature.tim_pass_wall && !do_dec) {
+            if (creature.tim_pass_wall > v) {
                 return false;
             }
-        } else if (!player.tim_pass_wall) {
+        } else if (!creature.tim_pass_wall) {
             msg_print(_("体が半物質の状態になった。", "You became ethereal."));
             notice = true;
         }
     } else {
-        if (player.tim_pass_wall) {
+        if (creature.tim_pass_wall) {
             msg_print(_("体が物質化した。", "You are no longer ethereal."));
             notice = true;
         }
     }
 
-    player.tim_pass_wall = v;
+    creature.tim_pass_wall = v;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -296,32 +292,31 @@ bool set_pass_wall(CreatureEntity &creature, short v, bool do_dec)
  */
 bool set_tim_emission(CreatureEntity &creature, short v, bool do_dec)
 {
-    auto &player = creature;
     auto notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
 
-    if (player.is_dead()) {
+    if (creature.is_dead()) {
         return false;
     }
 
     if (v) {
-        if (player.tim_emission && !do_dec) {
-            if (player.tim_emission > v) {
+        if (creature.tim_emission && !do_dec) {
+            if (creature.tim_emission > v) {
                 return false;
             }
-        } else if (!player.tim_emission) {
+        } else if (!creature.tim_emission) {
             msg_print(_("体が発光した。", "Your body emit light."));
             notice = true;
         }
     } else {
-        if (player.tim_emission) {
+        if (creature.tim_emission) {
             msg_print(_("体の光が消え去った。", "Your body stopped emitting light."));
             notice = true;
         }
     }
 
-    player.tim_emission = v;
+    creature.tim_emission = v;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -345,32 +340,31 @@ bool set_tim_emission(CreatureEntity &creature, short v, bool do_dec)
  */
 bool set_tim_exorcism(CreatureEntity &creature, short v, bool do_dec)
 {
-    auto &player = creature;
     auto notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
 
-    if (player.is_dead()) {
+    if (creature.is_dead()) {
         return false;
     }
 
     if (v) {
-        if (player.tim_exorcism && !do_dec) {
-            if (player.tim_exorcism > v) {
+        if (creature.tim_exorcism && !do_dec) {
+            if (creature.tim_exorcism > v) {
                 return false;
             }
-        } else if (!player.tim_exorcism) {
+        } else if (!creature.tim_exorcism) {
             msg_print(_("浄化の力を得た気がする。", "You feel you become an exorcist."));
             notice = true;
         }
     } else {
-        if (player.tim_exorcism) {
+        if (creature.tim_exorcism) {
             msg_print(_("浄化の力を失った。", "You are no longer exorcist."));
             notice = true;
         }
     }
 
-    player.tim_exorcism = v;
+    creature.tim_exorcism = v;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {

--- a/src/status/sight-setter.cpp
+++ b/src/status/sight-setter.cpp
@@ -37,32 +37,31 @@ static bool update_sight(CreatureEntity &creature, const bool notice)
  */
 bool set_tim_esp(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
 {
-    auto &player = creature;
     bool notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
 
-    if (player.is_dead()) {
+    if (creature.is_dead()) {
         return false;
     }
 
     if (v) {
-        if (player.tim_esp && !do_dec) {
-            if (player.tim_esp > v) {
+        if (creature.tim_esp && !do_dec) {
+            if (creature.tim_esp > v) {
                 return false;
             }
-        } else if (!player.is_time_limit_esp()) {
+        } else if (!creature.is_time_limit_esp()) {
             msg_print(_("意識が広がった気がする！", "You feel your consciousness expand!"));
             notice = true;
         }
     } else {
-        if (player.tim_esp && !music_singing(player, MUSIC_MIND)) {
+        if (creature.tim_esp && !music_singing(creature, MUSIC_MIND)) {
             msg_print(_("意識は元に戻った。", "Your consciousness contracts again."));
             notice = true;
         }
     }
 
-    player.tim_esp = v;
+    creature.tim_esp = v;
     return update_sight(creature, notice);
 }
 
@@ -74,32 +73,31 @@ bool set_tim_esp(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
  */
 bool set_tim_invis(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
 {
-    auto &player = creature;
     bool notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
 
-    if (player.is_dead()) {
+    if (creature.is_dead()) {
         return false;
     }
 
     if (v) {
-        if (player.tim_invis && !do_dec) {
-            if (player.tim_invis > v) {
+        if (creature.tim_invis && !do_dec) {
+            if (creature.tim_invis > v) {
                 return false;
             }
-        } else if (!player.tim_invis) {
+        } else if (!creature.tim_invis) {
             msg_print(_("目が非常に敏感になった気がする！", "Your eyes feel very sensitive!"));
             notice = true;
         }
     } else {
-        if (player.tim_invis) {
+        if (creature.tim_invis) {
             msg_print(_("目の敏感さがなくなったようだ。", "Your eyes feel less sensitive."));
             notice = true;
         }
     }
 
-    player.tim_invis = v;
+    creature.tim_invis = v;
     return update_sight(creature, notice);
 }
 
@@ -111,31 +109,30 @@ bool set_tim_invis(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
  */
 bool set_tim_infra(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
 {
-    auto &player = creature;
     bool notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
 
-    if (player.is_dead()) {
+    if (creature.is_dead()) {
         return false;
     }
 
     if (v) {
-        if (player.tim_infra && !do_dec) {
-            if (player.tim_infra > v) {
+        if (creature.tim_infra && !do_dec) {
+            if (creature.tim_infra > v) {
                 return false;
             }
-        } else if (!player.tim_infra) {
+        } else if (!creature.tim_infra) {
             msg_print(_("目がランランと輝き始めた！", "Your eyes begin to tingle!"));
             notice = true;
         }
     } else {
-        if (player.tim_infra) {
+        if (creature.tim_infra) {
             msg_print(_("目の輝きがなくなった。", "Your eyes stop tingling."));
             notice = true;
         }
     }
 
-    player.tim_infra = v;
+    creature.tim_infra = v;
     return update_sight(creature, notice);
 }

--- a/src/target/target-getter.cpp
+++ b/src/target/target-getter.cpp
@@ -29,7 +29,7 @@
  */
 Direction get_aim_dir(CreatureEntity &subject, bool enable_repeat)
 {
-    auto &player = subject;
+    auto &creature = subject;
     auto dir = Direction::none();
     auto target = Target::get_last_target();
     if (enable_repeat) {
@@ -72,7 +72,7 @@ Direction get_aim_dir(CreatureEntity &subject, bool enable_repeat)
         static const std::unordered_set target_commands = { '*', ' ', '\r', 'T', 't', '.', '5', '0', '*' };
         if (target_commands.contains(command)) {
             if (select_new_target_commands.contains(command)) {
-                target = target_set(player, TARGET_KILL);
+                target = target_set(creature, TARGET_KILL);
             }
             if (target.is_okay()) {
                 dir = Direction::targetting(target);
@@ -87,7 +87,7 @@ Direction get_aim_dir(CreatureEntity &subject, bool enable_repeat)
     }
 
     command_dir = dir;
-    if (player.is_confused()) {
+    if (creature.is_confused()) {
         dir = rand_choice(Direction::directions_8());
     }
 
@@ -108,7 +108,6 @@ Direction get_aim_dir(CreatureEntity &subject, bool enable_repeat)
  */
 Direction get_direction(CreatureEntity &creature)
 {
-    auto &player = creature;
     Direction dir = command_dir;
     const auto code = repeat_pull();
     if (code && Direction::is_valid_dir(*code)) {
@@ -146,7 +145,7 @@ Direction get_direction(CreatureEntity &creature)
         return dir;
     }
 
-    const auto &monster = creature.current_floor_ptr->get_monster(player.riding);
+    const auto &monster = creature.current_floor_ptr->get_monster(creature.riding);
     const auto m_name = monster_desc(creature, monster, 0);
     const auto fmt = monster.is_confused()
                          ? _("%sは混乱している。", "%s^ is confused.")
@@ -167,7 +166,6 @@ Direction get_direction(CreatureEntity &creature)
  */
 Direction get_rep_dir(CreatureEntity &creature, bool under)
 {
-    auto &player = creature;
     Direction dir = command_dir;
     const auto code = repeat_pull();
     if (code && Direction::is_valid_dir(*code)) {
@@ -203,8 +201,8 @@ Direction get_rep_dir(CreatureEntity &creature, bool under)
         if (evaluate_percent(75)) {
             dir = rand_choice(Direction::directions_8());
         }
-    } else if (player.riding) {
-        const auto &monster = creature.current_floor_ptr->get_monster(player.riding);
+    } else if (creature.riding) {
+        const auto &monster = creature.current_floor_ptr->get_monster(creature.riding);
         const auto &monrace = monster.get_monrace();
         if (monster.is_confused()) {
             if (evaluate_percent(75)) {
@@ -221,7 +219,7 @@ Direction get_rep_dir(CreatureEntity &creature, bool under)
         if (is_confused) {
             msg_print(_("あなたは混乱している。", "You are confused."));
         } else {
-            const auto &monster = creature.current_floor_ptr->get_monster(player.riding);
+            const auto &monster = creature.current_floor_ptr->get_monster(creature.riding);
             const auto m_name = monster_desc(creature, monster, 0);
             if (monster.is_confused()) {
                 msg_format(_("%sは混乱している。", "%s^ is confused."), m_name.data());

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -21,10 +21,10 @@
  *
  * The concept of "targeting" was stolen from "Morgul" (?)
  *
- * The player can target any location, or any "target-able" monster.
+ * The creature can target any location, or any "target-able" monster.
  *
  * Currently, a monster is "target_able" if it is visible, and if
- * the player can hit it with a projection, and the player is not
+ * the creature can hit it with a projection, and the creature is not
  * hallucinating.  This allows use of "use closest target" macros.
  *
  * Future versions may restrict the ability to target "trappers"
@@ -109,7 +109,6 @@ static bool target_set_accept(CreatureEntity &creature, const Pos2D &pos)
  */
 std::vector<Pos2D> target_set_prepare(CreatureEntity &creature, target_type mode)
 {
-    auto &player = creature;
     POSITION min_hgt, max_hgt, min_wid, max_wid;
     const auto &floor = *creature.current_floor_ptr;
     const auto is_killable = any_bits(mode, TARGET_KILL);
@@ -159,7 +158,7 @@ std::vector<Pos2D> target_set_prepare(CreatureEntity &creature, target_type mode
         });
     }
 
-    if (player.riding == 0 || !target_pet || (std::ssize(pos_list) <= 1) || !is_killable) {
+    if (creature.riding == 0 || !target_pet || (std::ssize(pos_list) <= 1) || !is_killable) {
         return pos_list;
     }
 

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -268,20 +268,19 @@ static void print_pet_list(CreatureEntity &creature, const std::vector<MONSTER_I
  */
 void fix_monster_list(CreatureEntity &creature)
 {
-    auto &player = creature;
     static std::vector<MONSTER_IDX> monster_list;
     std::once_flag once;
 
     display_sub_windows(SubWindowRedrawingFlag::SIGHT_MONSTERS,
-        [&player, &creature, &once] {
+        [&creature, &once] {
             const auto &[wid, hgt] = term_get_size();
-            std::call_once(once, target_sensing_monsters_prepare, std::ref(player), std::ref(monster_list));
+            std::call_once(once, target_sensing_monsters_prepare, std::ref(creature), std::ref(monster_list));
             print_monster_list(*creature.current_floor_ptr, monster_list, 0, 0, hgt);
         });
 
     if (use_music && has_monster_music) {
-        std::call_once(once, target_sensing_monsters_prepare, std::ref(player), std::ref(monster_list));
-        select_monster_music(player, monster_list);
+        std::call_once(once, target_sensing_monsters_prepare, std::ref(creature), std::ref(monster_list));
+        select_monster_music(creature, monster_list);
     }
 }
 
@@ -290,11 +289,10 @@ void fix_monster_list(CreatureEntity &creature)
  */
 void fix_pet_list(CreatureEntity &creature)
 {
-    auto &player = creature;
     display_sub_windows(SubWindowRedrawingFlag::PETS,
-        [&player, &creature] {
+        [&creature] {
             const auto &[wid, hgt] = term_get_size();
-            const auto pets = target_pets_prepare(player);
+            const auto pets = target_pets_prepare(creature);
             print_pet_list(creature, pets, 0, 0, wid, hgt);
         });
 }
@@ -309,7 +307,6 @@ static void display_equipment(CreatureEntity &creature, const ItemTester &item_t
         return;
     }
 
-    auto &player = creature;
     const auto &[wid, hgt] = term_get_size();
     byte attr = TERM_WHITE;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
@@ -319,7 +316,7 @@ static void display_equipment(CreatureEntity &creature, const ItemTester &item_t
         }
 
         const auto &item = *creature.inventory[i];
-        auto do_disp = player.select_ring_slot ? is_ring_slot(i) : item_tester.okay(&item);
+        auto do_disp = creature.select_ring_slot ? is_ring_slot(i) : item_tester.okay(&item);
         std::string tmp_val = "   ";
 
         if (do_disp) {
@@ -338,7 +335,7 @@ static void display_equipment(CreatureEntity &creature, const ItemTester &item_t
             item_name = _("(武器を両手持ち)", "(wielding with two-hands)");
             attr = TERM_WHITE;
         } else {
-            item_name = describe_flavor(player, item, 0);
+            item_name = describe_flavor(creature, item, 0);
             attr = tval_to_attr[enum2i(item.bi_key.tval()) % 128];
         }
 
@@ -365,7 +362,7 @@ static void display_equipment(CreatureEntity &creature, const ItemTester &item_t
 
         if (show_labels) {
             term_putstr(wid - 20, cur_row, -1, TERM_WHITE, " <-- ");
-            prt(mention_use(player, i), cur_row, wid - 15);
+            prt(mention_use(creature, i), cur_row, wid - 15);
         }
     }
 
@@ -443,7 +440,7 @@ void fix_message(void)
  * Adjust for width and split messages
  * @param player_ptr プレイヤーへの参照ポインタ
  * @details
- * Note that the "player" symbol does NOT appear on the map.
+ * Note that the "creature" symbol does NOT appear on the map.
  */
 void fix_overhead(CreatureEntity &creature)
 {
@@ -484,7 +481,7 @@ static void display_dungeon(CreatureEntity &creature)
 }
 
 /*!
- * @brief 自分の周辺のダンジョンの地形をサブウィンドウに表示する / display dungeon view around player in a sub window
+ * @brief 自分の周辺のダンジョンの地形をサブウィンドウに表示する / display dungeon view around creature in a sub window
  * @param player_ptr プレイヤーへの参照ポインタ
  */
 void fix_dungeon(CreatureEntity &creature)
@@ -501,14 +498,13 @@ void fix_dungeon(CreatureEntity &creature)
  */
 void fix_monster(CreatureEntity &creature)
 {
-    auto &player = creature;
     if (!LoreTracker::get_instance().is_tracking()) {
         return;
     }
 
     display_sub_windows(SubWindowRedrawingFlag::MONSTER_LORE,
-        [&player] {
-            display_roff(player);
+        [&creature] {
+            display_roff(creature);
         });
 }
 
@@ -551,7 +547,6 @@ static bool is_seeing_monster_on(const FloorType &floor, const Grid &grid)
  */
 static void display_floor_item_list(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto &player = creature;
     const auto &[wid, hgt] = term_get_size();
     if (hgt <= 0) {
         return;
@@ -611,7 +606,7 @@ static void display_floor_item_list(CreatureEntity &creature, const Pos2D &pos)
         if (is_hallucinated) {
             term_addstr(-1, TERM_WHITE, _("何か奇妙な物", "something strange"));
         } else {
-            const auto item_name = describe_flavor(player, item, 0);
+            const auto item_name = describe_flavor(creature, item, 0);
             TERM_COLOR attr = tval_to_attr[enum2i(tval) % 128];
             term_addstr(-1, attr, item_name);
         }
@@ -637,7 +632,6 @@ void fix_floor_item_list(CreatureEntity &creature, const Pos2D &pos)
  */
 static void display_found_item_list(CreatureEntity &creature)
 {
-    auto &player = creature;
     const auto &[wid, hgt] = term_get_size();
     if (hgt <= 0) {
         return;
@@ -663,8 +657,8 @@ static void display_found_item_list(CreatureEntity &creature)
 
     std::sort(
         found_item_list.begin(), found_item_list.end(),
-        [&player](const ItemEntity *left, const ItemEntity *right) -> bool {
-            return object_sort_comp(player, *left, *right);
+        [&creature](const ItemEntity *left, const ItemEntity *right) -> bool {
+            return object_sort_comp(creature, *left, *right);
         });
 
     term_clear();
@@ -688,7 +682,7 @@ static void display_found_item_list(CreatureEntity &creature)
         const auto symbol_str = format(" %c ", symbol.character);
         term_addstr(-1, symbol.color, symbol_str);
 
-        const auto item_name = describe_flavor(player, *item_ptr, 0);
+        const auto item_name = describe_flavor(creature, *item_ptr, 0);
         const auto color_code_for_item = tval_to_attr[enum2i(item_ptr->bi_key.tval()) % 128];
         term_addstr(-1, color_code_for_item, item_name);
 
@@ -720,7 +714,6 @@ void fix_found_item_list(CreatureEntity &creature)
  */
 static void display_spell_list(CreatureEntity &creature)
 {
-    auto &player = creature;
     TERM_LEN y, x;
     int m[9]{};
 
@@ -819,7 +812,7 @@ static void display_spell_list(CreatureEntity &creature)
         return;
     }
 
-    PlayerRealm pr(player);
+    PlayerRealm pr(creature);
     if (!pr.realm1().is_available()) {
         return;
     }

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -56,9 +56,8 @@ void print_title(CreatureEntity &creature)
  */
 void print_level(CreatureEntity &creature)
 {
-    auto &player = creature;
     const auto tmp = format("%5d", creature.level);
-    if (creature.level >= player.max_plv) {
+    if (creature.level >= creature.max_plv) {
         put_str(_("レベル ", "LEVEL "), ROW_LEVEL, 0);
         c_put_str(TERM_L_GREEN, tmp, ROW_LEVEL, COL_LEVEL + 7);
     } else {
@@ -72,7 +71,6 @@ void print_level(CreatureEntity &creature)
  */
 void print_exp(CreatureEntity &creature)
 {
-    auto &player = creature;
     std::string out_val;
 
     CreatureRace pr(&creature);
@@ -82,7 +80,7 @@ void print_exp(CreatureEntity &creature)
         if (creature.level >= PY_MAX_LEVEL) {
             (void)sprintf(out_val.data(), "********");
         } else {
-            out_val = format("%8d", player_exp[creature.level - 1] * player.expfact / 100 - creature.exp);
+            out_val = format("%8d", player_exp[creature.level - 1] * creature.expfact / 100 - creature.exp);
         }
     }
 

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -244,8 +244,7 @@ void wiz_restore_aware_flag_of_fixed_arfifact(FixedArtifactId reset_artifact_idx
  */
 void wiz_modify_item_activation(CreatureEntity &creature)
 {
-    auto &player = creature;
-    auto *player_ptr = &player;
+    auto *player_ptr = &creature;
     constexpr auto q = _("どのアイテムの発動を変更しますか？ ", "Which item? ");
     constexpr auto s = _("発動を変更するアイテムがない。", "Nothing to do with.");
     short i_idx;
@@ -374,7 +373,7 @@ static void prt_binary(BIT_FLAGS flags, const int row, int col)
 
 /*!
  * @brief アイテムの詳細ステータスを表示する /
- * Change various "permanent" player variables.
+ * Change various "permanent" creature variables.
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param o_ptr 詳細を表示するアイテム情報の参照ポインタ
  */
@@ -735,8 +734,7 @@ static void wiz_quantity_item(ItemEntity *o_ptr)
  */
 void wiz_modify_item(CreatureEntity &creature)
 {
-    auto &player = creature;
-    auto *player_ptr = &player;
+    auto *player_ptr = &creature;
     constexpr auto q = "Play with which object? ";
     constexpr auto s = "You have nothing to play with.";
     short i_idx;

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -59,22 +59,21 @@ void check_random_quest_auto_failure(CreatureEntity &creature)
  * @param creature クリーチャーへの参照
  * @details
  * Autosave BEFORE resetting the recall counter (rr9)
- * The player is yanked up/down as soon as he loads the autosaved game.
+ * The creature is yanked up/down as soon as he loads the autosaved game.
  */
 void execute_recall(CreatureEntity &creature)
 {
-    auto &player = creature;
-    if (player.word_recall == 0) {
+    if (creature.word_recall == 0) {
         return;
     }
 
-    if (autosave_l && (player.word_recall == 1) && !AngbandSystem::get_instance().is_phase_out()) {
-        do_cmd_save_game(player, true);
+    if (autosave_l && (creature.word_recall == 1) && !AngbandSystem::get_instance().is_phase_out()) {
+        do_cmd_save_game(creature, true);
     }
 
-    player.word_recall--;
+    creature.word_recall--;
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (player.word_recall != 0) {
+    if (creature.word_recall != 0) {
         return;
     }
 
@@ -83,7 +82,7 @@ void execute_recall(CreatureEntity &creature)
     if (floor.is_underground() || floor.is_in_quest() || floor.is_entering_dungeon()) {
         msg_print(_("上に引っ張りあげられる感じがする！", "You feel yourself yanked upwards!"));
         if (floor.is_underground()) {
-            player.recall_dungeon = floor.dungeon_id;
+            creature.recall_dungeon = floor.dungeon_id;
         }
         if (record_stair) {
             exe_write_diary(floor, DiaryKind::RECALL, floor.dun_level);
@@ -91,16 +90,16 @@ void execute_recall(CreatureEntity &creature)
 
         floor.dun_level = 0;
         floor.reset_dungeon_index();
-        leave_quest_check(player);
-        leave_tower_check(player);
+        leave_quest_check(creature);
+        leave_tower_check(creature);
         floor.quest_number = QuestId::NONE;
-        player.leaving = true;
+        creature.leaving = true;
         sound(SoundKind::TPLEVEL);
         return;
     }
 
     msg_print(_("下に引きずり降ろされる感じがする！", "You feel yourself yanked downwards!"));
-    floor.set_dungeon_index(player.recall_dungeon);
+    floor.set_dungeon_index(creature.recall_dungeon);
     if (record_stair) {
         exe_write_diary(floor, DiaryKind::RECALL, floor.dun_level);
     }
@@ -134,7 +133,7 @@ void execute_recall(CreatureEntity &creature)
      * and create a first saved floor
      */
     FloorChangeModesStore::get_instace()->set(FloorChangeMode::FIRST_FLOOR);
-    player.leaving = true;
+    creature.leaving = true;
 
     check_random_quest_auto_failure(creature);
     sound(SoundKind::TPLEVEL);
@@ -147,19 +146,18 @@ void execute_recall(CreatureEntity &creature)
  */
 void execute_floor_reset(CreatureEntity &creature)
 {
-    auto &player = creature;
     const auto &floor = *creature.current_floor_ptr;
-    if (player.alter_reality == 0) {
+    if (creature.alter_reality == 0) {
         return;
     }
 
-    if (autosave_l && (player.alter_reality == 1) && !AngbandSystem::get_instance().is_phase_out()) {
-        do_cmd_save_game(player, true);
+    if (autosave_l && (creature.alter_reality == 1) && !AngbandSystem::get_instance().is_phase_out()) {
+        do_cmd_save_game(creature, true);
     }
 
-    player.alter_reality--;
+    creature.alter_reality--;
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (player.alter_reality != 0) {
+    if (creature.alter_reality != 0) {
         return;
     }
 
@@ -174,7 +172,7 @@ void execute_floor_reset(CreatureEntity &creature)
         }
 
         FloorChangeModesStore::get_instace()->set(FloorChangeMode::FIRST_FLOOR);
-        player.leaving = true;
+        creature.leaving = true;
     } else {
         msg_print(_("世界が少しの間変化したようだ。", "The world seems to change for a moment!"));
     }


### PR DESCRIPTION
関数シグネチャが CreatureEntity &creature に変更済みの 166 ファイルから `auto &player = creature;` エイリアスを削除し、player.xxx を creature.xxx に統一。 自己参照エイリアス（auto &creature = creature;）や重複ラムダキャプチャも同時修正。