### PR TITLE
refactor: 残存 auto &player エイリアスを一括削除（Phase 8）

### DIFF
--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -468,9 +468,8 @@ short drop_near(CreatureEntity &subject, ItemEntity &drop_item, const Pos2D &pos
     }
 
     if (drop_item.is_fixed_artifact() && world.character_dungeon && subject.is_player()) {
-        auto &player = subject;
         auto &artifact = drop_item.get_fixed_artifact();
-        artifact.floor_id = player.floor_id;
+        artifact.floor_id = subject.floor_id;
     }
 
     note_spot(subject, pos_drop);

--- a/src/monster-floor/monster-summon.cpp
+++ b/src/monster-floor/monster-summon.cpp
@@ -43,8 +43,7 @@ static bool is_dead_summoning(summon_type type)
  */
 tl::optional<MONSTER_IDX> summon_specific(CreatureEntity &subject, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode, tl::optional<MONSTER_IDX> summoner_m_idx)
 {
-    auto &player = subject;
-    const auto &floor = *player.current_floor_ptr;
+    const auto &floor = *subject.current_floor_ptr;
     if (floor.inside_arena) {
         return tl::nullopt;
     }
@@ -56,14 +55,14 @@ tl::optional<MONSTER_IDX> summon_specific(CreatureEntity &subject, POSITION y1, 
 
     const auto hook = floor.get_monrace_hook_terrain_at(*pos);
     SummonCondition condition(type, mode, summoner_m_idx, hook);
-    get_mon_num_prep_summon(player, condition);
+    get_mon_num_prep_summon(subject, condition);
 
     auto dlev = MAX_DEPTH;
     if (!(mode & PM_IGNORE_LEVEL)) {
         dlev = floor.is_underground() ? floor.get_level() : WildernessGrids::get_instance().get_player_grid().get_level();
     }
 
-    const auto r_idx = get_mon_num(player, 0, (dlev + lev) / 2 + 5, mode);
+    const auto r_idx = get_mon_num(subject, 0, (dlev + lev) / 2 + 5, mode);
     if (!MonraceList::is_valid(r_idx)) {
         return tl::nullopt;
     }
@@ -72,7 +71,7 @@ tl::optional<MONSTER_IDX> summon_specific(CreatureEntity &subject, POSITION y1, 
         mode |= PM_NO_KAGE;
     }
 
-    auto summoned_m_idx = place_specific_monster(player, pos->y, pos->x, r_idx, mode, summoner_m_idx);
+    auto summoned_m_idx = place_specific_monster(subject, pos->y, pos->x, r_idx, mode, summoner_m_idx);
     if (!summoned_m_idx) {
         return tl::nullopt;
     }
@@ -81,7 +80,7 @@ tl::optional<MONSTER_IDX> summon_specific(CreatureEntity &subject, POSITION y1, 
     if (!summoner_m_idx) {
         notice = true;
     } else {
-        const auto &monster = player.current_floor_ptr->get_monster(*summoner_m_idx);
+        const auto &monster = subject.current_floor_ptr->get_monster(*summoner_m_idx);
         if (monster.is_pet()) {
             notice = true;
         } else if (is_seen(subject, monster)) {

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -249,8 +249,7 @@ static void on_dead_drop_tval_item(CreatureEntity &killer, MonsterDeath *md_ptr)
                 ItemMagicApplier(killer, &item, killer.current_floor_ptr->dun_level, AM_GOOD | AM_GREAT | AM_SPECIAL).execute();
                 if (!item.is_fixed_artifact()) {
                     if (killer.is_player()) {
-                        auto &player = killer;
-                        become_random_artifact(player, &item, false);
+                        become_random_artifact(killer, &item, false);
                     }
                 }
                 break;
@@ -337,9 +336,8 @@ static void on_dead_earth_destroyer(CreatureEntity &killer, MonsterDeath *md_ptr
     if (!killer.is_player()) {
         return;
     }
-    auto &player = killer;
     msg_print(_("ワーオ！22世紀の文明の叡知が今炸裂した！", "Wow! The wisdom of 22nd century civilization has now exploded!"));
-    (void)project(player, md_ptr->m_idx, 10, md_ptr->md_y, md_ptr->md_x, 10000, AttributeType::DISINTEGRATE, PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
+    (void)project(killer, md_ptr->m_idx, 10, md_ptr->md_y, md_ptr->md_x, 10000, AttributeType::DISINTEGRATE, PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
 }
 
 static void on_dead_sacred_treasures(CreatureEntity &killer, MonsterDeath *md_ptr)
@@ -347,8 +345,7 @@ static void on_dead_sacred_treasures(CreatureEntity &killer, MonsterDeath *md_pt
     if (!killer.is_player()) {
         return;
     }
-    auto &player = killer;
-    if ((player.ppersonality != PERSONALITY_LAZY) || !md_ptr->drop_chosen_item) {
+    if ((killer.ppersonality != PERSONALITY_LAZY) || !md_ptr->drop_chosen_item) {
         return;
     }
 
@@ -370,7 +367,7 @@ static void on_dead_sacred_treasures(CreatureEntity &killer, MonsterDeath *md_pt
     }
 
     const auto a_idx = rand_choice(candidates);
-    create_named_art(player, a_idx, md_ptr->md_y, md_ptr->md_x);
+    create_named_art(killer, a_idx, md_ptr->md_y, md_ptr->md_x);
 }
 
 static void on_dead_serpent(CreatureEntity &killer, MonsterDeath *md_ptr)
@@ -466,8 +463,7 @@ static void on_dead_random_artifact(CreatureEntity &killer, MonsterDeath *md_ptr
         }
 
         if (killer.is_player()) {
-            auto &player = killer;
-            (void)become_random_artifact(player, &*item, false);
+            (void)become_random_artifact(killer, &*item, false);
         }
         auto is_good_random_art = !item->is_cursed();
         is_good_random_art &= item->to_h > 0;

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -81,7 +81,7 @@ ObjectThrowEntity::ObjectThrowEntity(CreatureEntity &creature, ItemEntity *q_ptr
 
 bool ObjectThrowEntity::check_can_throw()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     if (!this->check_what_throw()) {
         return false;
     }
@@ -92,7 +92,7 @@ bool ObjectThrowEntity::check_can_throw()
     }
 
     const auto is_spike = this->o_ptr->bi_key.tval() == ItemKindType::SPIKE;
-    if (player.current_floor_ptr->inside_arena && !this->boomerang && !is_spike) {
+    if (creature.current_floor_ptr->inside_arena && !this->boomerang && !is_spike) {
         msg_print(_("アリーナではアイテムを使えない！", "You're in the arena now. This is hand-to-hand!"));
         msg_erase();
         return false;
@@ -103,14 +103,14 @@ bool ObjectThrowEntity::check_can_throw()
 
 void ObjectThrowEntity::calc_throw_range()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     *this->q_ptr = this->o_ptr->clone();
     this->obj_flags = this->q_ptr->get_flags();
     torch_flags(this->q_ptr, this->obj_flags);
     distribute_charges(this->o_ptr, this->q_ptr, 1);
     this->q_ptr->number = 1;
-    this->o_name = describe_flavor(player, *this->q_ptr, OD_OMIT_PREFIX);
-    if (player.mighty_throw) {
+    this->o_name = describe_flavor(creature, *this->q_ptr, OD_OMIT_PREFIX);
+    if (creature.mighty_throw) {
         this->mult += 3;
     }
 
@@ -120,7 +120,7 @@ void ObjectThrowEntity::calc_throw_range()
         div /= 2;
     }
 
-    this->tdis = (adj_str_blow[player.stat_index[A_STR]] + 20) * mul / div;
+    this->tdis = (adj_str_blow[creature.stat_index[A_STR]] + 20) * mul / div;
     if (this->tdis > mul) {
         this->tdis = mul;
     }
@@ -128,20 +128,20 @@ void ObjectThrowEntity::calc_throw_range()
 
 bool ObjectThrowEntity::calc_throw_grid()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     if (this->shuriken >= 0) {
-        this->ty = randint0(101) - 50 + player.y;
-        this->tx = randint0(101) - 50 + player.x;
+        this->ty = randint0(101) - 50 + creature.y;
+        this->tx = randint0(101) - 50 + creature.x;
         return true;
     }
 
     project_length = this->tdis + 1;
-    const auto dir = get_aim_dir(player);
+    const auto dir = get_aim_dir(creature);
     if (!dir) {
         return false;
     }
 
-    const auto pos_target = dir.get_target_position(player.get_position(), 99);
+    const auto pos_target = dir.get_target_position(creature.get_position(), 99);
     this->tx = pos_target.x;
     this->ty = pos_target.y;
 
@@ -151,38 +151,38 @@ bool ObjectThrowEntity::calc_throw_grid()
 
 void ObjectThrowEntity::reflect_inventory_by_throw()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     if (this->q_ptr->is_specific_artifact(FixedArtifactId::MJOLLNIR) || this->q_ptr->is_specific_artifact(FixedArtifactId::AEGISFANG) || this->boomerang) {
         this->return_when_thrown = true;
     }
 
     if (this->i_idx < 0) {
-        floor_item_increase(player, 0 - this->i_idx, -1);
-        floor_item_optimize(player, 0 - this->i_idx);
+        floor_item_increase(creature, 0 - this->i_idx, -1);
+        floor_item_optimize(creature, 0 - this->i_idx);
         return;
     }
 
-    inven_item_increase(player, this->i_idx, -1);
+    inven_item_increase(creature, this->i_idx, -1);
     if (!this->return_when_thrown) {
-        inven_item_describe(player, this->i_idx);
+        inven_item_describe(creature, this->i_idx);
     }
 
-    inven_item_optimize(player, this->i_idx);
+    inven_item_optimize(creature, this->i_idx);
 }
 
 void ObjectThrowEntity::set_class_specific_throw_params()
 {
-    auto &player = *this->creature_ptr;
-    PlayerEnergy energy(player);
+    auto &creature = *this->creature_ptr;
+    PlayerEnergy energy(creature);
     energy.set_player_turn_energy(100);
-    CreatureClass pc(player);
+    CreatureClass pc(creature);
     if (pc.equals(PlayerClassType::ROGUE) || pc.equals(PlayerClassType::NINJA)) {
-        energy.sub_player_turn_energy(player.level);
+        energy.sub_player_turn_energy(creature.level);
     }
 
-    this->y = player.y;
-    this->x = player.x;
-    handle_stuff(player);
+    this->y = creature.y;
+    this->x = creature.x;
+    handle_stuff(creature);
     const auto tval = this->q_ptr->bi_key.tval();
     const auto is_spike = tval == ItemKindType::SPIKE;
     const auto is_sword = tval == ItemKindType::SWORD;
@@ -191,9 +191,9 @@ void ObjectThrowEntity::set_class_specific_throw_params()
 
 void ObjectThrowEntity::set_racial_chance()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     auto compensation = this->obj_flags.has(TR_THROW) ? this->q_ptr->to_h : 0;
-    this->chance = player.skill_tht + (player.to_h_b + compensation) * BTH_PLUS_ADJ;
+    this->chance = creature.skill_tht + (creature.to_h_b + compensation) * BTH_PLUS_ADJ;
     if (this->shuriken != 0) {
         this->chance *= 2;
     }
@@ -201,7 +201,7 @@ void ObjectThrowEntity::set_racial_chance()
 
 void ObjectThrowEntity::exe_throw()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     this->cur_dis = 0;
     while (this->cur_dis <= this->tdis) {
         if ((this->y == this->ty) && (this->x == this->tx)) {
@@ -217,7 +217,7 @@ void ObjectThrowEntity::exe_throw()
             continue;
         }
 
-        this->hit_monster = ObjectThrowHitMonster(player, this->y, this->x);
+        this->hit_monster = ObjectThrowHitMonster(creature, this->y, this->x);
         this->attack_racial_power();
         break;
     }
@@ -225,14 +225,14 @@ void ObjectThrowEntity::exe_throw()
 
 void ObjectThrowEntity::display_figurine_throw()
 {
-    auto &player = *this->creature_ptr;
-    if ((this->q_ptr->bi_key.tval() != ItemKindType::FIGURINE) || player.current_floor_ptr->inside_arena) {
+    auto &creature = *this->creature_ptr;
+    if ((this->q_ptr->bi_key.tval() != ItemKindType::FIGURINE) || creature.current_floor_ptr->inside_arena) {
         return;
     }
 
     this->corruption_possibility = 100;
     auto figure_r_idx = i2enum<MonraceId>(this->q_ptr->pval);
-    if (!(summon_named_creature(player, 0, this->y, this->x, figure_r_idx, !(this->q_ptr->is_cursed()) ? PM_FORCE_PET : PM_NONE))) {
+    if (!(summon_named_creature(creature, 0, this->y, this->x, figure_r_idx, !(this->q_ptr->is_cursed()) ? PM_FORCE_PET : PM_NONE))) {
         msg_print(_("人形は捻じ曲がり砕け散ってしまった！", "The Figurine writhes and then shatters."));
         return;
     }
@@ -244,7 +244,7 @@ void ObjectThrowEntity::display_figurine_throw()
 
 void ObjectThrowEntity::display_potion_throw()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     if (!this->q_ptr->is_potion()) {
         return;
     }
@@ -256,7 +256,7 @@ void ObjectThrowEntity::display_potion_throw()
 
     msg_format(_("%sは砕け散った！", "The %s shatters!"), this->o_name.data());
     this->do_drop = false;
-    if (!potion_smash_effect(player, 0, this->y, this->x, this->q_ptr->bi_id)) {
+    if (!potion_smash_effect(creature, 0, this->y, this->x, this->q_ptr->bi_id)) {
         return;
     }
 
@@ -269,19 +269,19 @@ void ObjectThrowEntity::display_potion_throw()
         return;
     }
 
-    const auto angry_m_name = monster_desc(player, monster, 0);
+    const auto angry_m_name = monster_desc(creature, monster, 0);
     msg_format(_("%sは怒った！", "%s^ gets angry!"), angry_m_name.data());
     monster.set_hostile();
 }
 
 void ObjectThrowEntity::check_boomerang_throw()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     if (!this->return_when_thrown) {
         return;
     }
 
-    this->back_chance = randint1(30) + 20 + ((int)(adj_dex_th[player.stat_index[A_DEX]]) - 128);
+    this->back_chance = randint1(30) + 20 + ((int)(adj_dex_th[creature.stat_index[A_DEX]]) - 128);
     this->super_boomerang = ((this->q_ptr->is_specific_artifact(FixedArtifactId::MJOLLNIR) || this->q_ptr->is_specific_artifact(FixedArtifactId::AEGISFANG)) && this->boomerang);
     this->corruption_possibility = -1;
     if (this->boomerang) {
@@ -292,23 +292,23 @@ void ObjectThrowEntity::check_boomerang_throw()
         this->back_chance += 100;
     }
 
-    this->o2_name = describe_flavor(player, *this->q_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
+    this->o2_name = describe_flavor(creature, *this->q_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
     this->process_boomerang_throw();
 }
 
 void ObjectThrowEntity::process_boomerang_back()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     if (this->come_back) {
         if ((this->i_idx != INVEN_MAIN_HAND) && (this->i_idx != INVEN_SUB_HAND)) {
-            store_item_to_inventory(player, this->q_ptr);
+            store_item_to_inventory(creature, this->q_ptr);
             this->do_drop = false;
             return;
         }
 
-        this->o_ptr = player.inventory[this->i_idx].get();
+        this->o_ptr = creature.inventory[this->i_idx].get();
         *this->o_ptr = this->q_ptr->clone();
-        player.equip_cnt++;
+        creature.equip_cnt++;
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         static constexpr auto flags = {
             StatusRecalculatingFlag::BONUS,
@@ -322,23 +322,23 @@ void ObjectThrowEntity::process_boomerang_back()
     }
 
     if (this->equiped_item) {
-        verify_equip_slot(player, this->i_idx);
-        calc_android_exp(player);
+        verify_equip_slot(creature, this->i_idx);
+        calc_android_exp(creature);
     }
 }
 
 void ObjectThrowEntity::drop_thrown_item()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     if (!this->do_drop) {
         return;
     }
 
-    const auto &floor = *player.current_floor_ptr;
+    const auto &floor = *creature.current_floor_ptr;
     const auto has_terrain_projection = floor.has_terrain_characteristics({ this->y, this->x }, TerrainCharacteristics::PROJECTION);
     const auto drop_y = has_terrain_projection ? this->y : this->prev_y;
     const auto drop_x = has_terrain_projection ? this->x : this->prev_x;
-    drop_ammo_near(player, *this->q_ptr, { drop_y, drop_x }, this->corruption_possibility);
+    drop_ammo_near(creature, *this->q_ptr, { drop_y, drop_x }, this->corruption_possibility);
 }
 
 bool ObjectThrowEntity::has_hit_monster() const
@@ -348,10 +348,10 @@ bool ObjectThrowEntity::has_hit_monster() const
 
 bool ObjectThrowEntity::check_what_throw()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     if (this->shuriken >= 0) {
         this->i_idx = this->shuriken;
-        this->o_ptr = player.inventory[this->i_idx].get();
+        this->o_ptr = creature.inventory[this->i_idx].get();
         return true;
     }
 
@@ -361,7 +361,7 @@ bool ObjectThrowEntity::check_what_throw()
 
     constexpr auto q = _("どのアイテムを投げますか? ", "Throw which item? ");
     constexpr auto s = _("投げるアイテムがない。", "You have nothing to throw.");
-    this->o_ptr = choose_object(player, &this->i_idx, q, s, USE_INVEN | USE_FLOOR | USE_EQUIP);
+    this->o_ptr = choose_object(creature, &this->i_idx, q, s, USE_INVEN | USE_FLOOR | USE_EQUIP);
     if (!this->o_ptr) {
         flush();
         return false;
@@ -372,12 +372,12 @@ bool ObjectThrowEntity::check_what_throw()
 
 bool ObjectThrowEntity::check_throw_boomerang()
 {
-    auto &player = *this->creature_ptr;
-    if (has_melee_weapon(player, INVEN_MAIN_HAND) && has_melee_weapon(player, INVEN_SUB_HAND)) {
+    auto &creature = *this->creature_ptr;
+    if (has_melee_weapon(creature, INVEN_MAIN_HAND) && has_melee_weapon(creature, INVEN_SUB_HAND)) {
         concptr q, s;
         q = _("どの武器を投げますか? ", "Throw which item? ");
         s = _("投げる武器がない。", "You have nothing to throw.");
-        this->o_ptr = choose_object(player, &this->i_idx, q, s, USE_EQUIP, FuncItemTester(&ItemEntity::is_throwable));
+        this->o_ptr = choose_object(creature, &this->i_idx, q, s, USE_EQUIP, FuncItemTester(&ItemEntity::is_throwable));
         if (!this->o_ptr) {
             flush();
             return false;
@@ -386,24 +386,24 @@ bool ObjectThrowEntity::check_throw_boomerang()
         return true;
     }
 
-    if (has_melee_weapon(player, INVEN_SUB_HAND)) {
+    if (has_melee_weapon(creature, INVEN_SUB_HAND)) {
         this->i_idx = INVEN_SUB_HAND;
-        this->o_ptr = player.inventory[this->i_idx].get();
+        this->o_ptr = creature.inventory[this->i_idx].get();
         return true;
     }
 
     this->i_idx = INVEN_MAIN_HAND;
-    this->o_ptr = player.inventory[this->i_idx].get();
+    this->o_ptr = creature.inventory[this->i_idx].get();
     return true;
 }
 
 bool ObjectThrowEntity::check_racial_target_bold()
 {
-    auto &player = *this->creature_ptr;
-    const auto pos = mmove2({ this->y, this->x }, player.get_position(), { this->ty, this->tx });
+    auto &creature = *this->creature_ptr;
+    const auto pos = mmove2({ this->y, this->x }, creature.get_position(), { this->ty, this->tx });
     this->ny[this->cur_dis] = pos.y;
     this->nx[this->cur_dis] = pos.x;
-    const auto &floor = *player.current_floor_ptr;
+    const auto &floor = *creature.current_floor_ptr;
     if (floor.has_terrain_characteristics({ this->ny[this->cur_dis], this->nx[this->cur_dis] }, TerrainCharacteristics::PROJECTION)) {
         return false;
     }
@@ -415,8 +415,8 @@ bool ObjectThrowEntity::check_racial_target_bold()
 
 void ObjectThrowEntity::check_racial_target_seen()
 {
-    auto &player = *this->creature_ptr;
-    if (!panel_contains({ this->ny[this->cur_dis], this->nx[this->cur_dis] }) || !player_can_see_bold(player, this->ny[this->cur_dis], this->nx[this->cur_dis])) {
+    auto &creature = *this->creature_ptr;
+    if (!panel_contains({ this->ny[this->cur_dis], this->nx[this->cur_dis] }) || !player_can_see_bold(creature, this->ny[this->cur_dis], this->nx[this->cur_dis])) {
         term_xtra(TERM_XTRA_DELAY, this->msec);
         return;
     }
@@ -426,40 +426,40 @@ void ObjectThrowEntity::check_racial_target_seen()
     }
 
     const auto symbol = this->q_ptr->get_symbol();
-    print_rel(player, symbol, { this->ny[this->cur_dis], this->nx[this->cur_dis] });
+    print_rel(creature, symbol, { this->ny[this->cur_dis], this->nx[this->cur_dis] });
     move_cursor_relative(this->ny[this->cur_dis], this->nx[this->cur_dis]);
     term_fresh();
     term_xtra(TERM_XTRA_DELAY, this->msec);
-    lite_spot(player, { this->ny[this->cur_dis], this->nx[this->cur_dis] });
+    lite_spot(creature, { this->ny[this->cur_dis], this->nx[this->cur_dis] });
     term_fresh();
 }
 
 bool ObjectThrowEntity::check_racial_target_monster()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     this->prev_y = this->y;
     this->prev_x = this->x;
     this->x = this->nx[this->cur_dis];
     this->y = this->ny[this->cur_dis];
     this->cur_dis++;
-    return player.current_floor_ptr->grid_array[this->y][this->x].m_idx == 0;
+    return creature.current_floor_ptr->grid_array[this->y][this->x].m_idx == 0;
 }
 
 void ObjectThrowEntity::attack_racial_power()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     if (!this->hit_monster) {
         return;
     }
 
     auto &monster = *this->hit_monster->m_ptr;
-    if (!test_hit_fire(player, this->chance - this->cur_dis, monster, monster.get_monster_profile().ml, this->o_name)) {
+    if (!test_hit_fire(creature, this->chance - this->cur_dis, monster, monster.get_monster_profile().ml, this->o_name)) {
         return;
     }
 
     this->display_attack_racial_power();
     this->calc_racial_power_damage();
-    msg_format_wizard(player, CHEAT_MONSTER, _("%dのダメージを与えた。(残りHP %d/%d(%d))", "You do %d damage. (left HP %d/%d(%d))"), this->tdam,
+    msg_format_wizard(creature, CHEAT_MONSTER, _("%dのダメージを与えた。(残りHP %d/%d(%d))", "You do %d damage. (left HP %d/%d(%d))"), this->tdam,
         monster.hp - this->tdam, monster.maxhp, monster.max_maxhp);
 
     auto fear = false;
@@ -469,7 +469,7 @@ void ObjectThrowEntity::attack_racial_power()
         attribute_flags.set(AttributeType::FIRE);
     }
 
-    MonsterDamageProcessor mdp(player, this->hit_monster->m_idx, this->tdam, &fear, attribute_flags);
+    MonsterDamageProcessor mdp(creature, this->hit_monster->m_idx, this->tdam, &fear, attribute_flags);
     if (mdp.mon_take_hit(monster.get_died_message())) {
         return;
     }
@@ -479,7 +479,7 @@ void ObjectThrowEntity::attack_racial_power()
     }
 
     if ((this->tdam > 0) && !this->q_ptr->is_potion()) {
-        anger_monster(player, monster);
+        anger_monster(creature, monster);
     }
 
     if (fear && monster.get_monster_profile().ml) {
@@ -490,7 +490,7 @@ void ObjectThrowEntity::attack_racial_power()
 
 void ObjectThrowEntity::display_attack_racial_power()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     if (!this->hit_monster) {
         return;
     }
@@ -502,56 +502,56 @@ void ObjectThrowEntity::display_attack_racial_power()
 
     msg_format(_("%sが%sに命中した。", "The %s hits %s."), this->o_name.data(), this->hit_monster->m_name.data());
 
-    if (!player.effects()->hallucination().is_hallucinated()) {
+    if (!creature.effects()->hallucination().is_hallucinated()) {
         LoreTracker::get_instance().set_trackee(this->hit_monster->m_ptr->ap_r_idx);
     }
 
-    health_track(player, this->hit_monster->m_idx);
+    health_track(creature, this->hit_monster->m_idx);
 }
 
 void ObjectThrowEntity::calc_racial_power_damage()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     if (!this->hit_monster) {
         return;
     }
 
     const auto damage_dice = is_active_torch(this->o_ptr) ? Dice(1, 6) : this->q_ptr->damage_dice;
     this->tdam = damage_dice.roll();
-    this->tdam = calc_attack_damage_with_slay(player, this->q_ptr, this->tdam, *this->hit_monster->m_ptr, HISSATSU_NONE, true);
-    this->tdam = critical_shot(player, this->q_ptr->weight, this->q_ptr->to_h, 0, this->tdam);
+    this->tdam = calc_attack_damage_with_slay(creature, this->q_ptr, this->tdam, *this->hit_monster->m_ptr, HISSATSU_NONE, true);
+    this->tdam = critical_shot(creature, this->q_ptr->weight, this->q_ptr->to_h, 0, this->tdam);
     this->tdam += (this->q_ptr->to_d > 0 ? 1 : -1) * this->q_ptr->to_d;
     if (this->boomerang) {
-        this->tdam *= (this->mult + player.num_blow[this->i_idx - INVEN_MAIN_HAND]);
-        this->tdam += player.to_d_m;
+        this->tdam *= (this->mult + creature.num_blow[this->i_idx - INVEN_MAIN_HAND]);
+        this->tdam += creature.to_d_m;
     } else if (this->obj_flags.has(TR_THROW)) {
         this->tdam *= (3 + this->mult);
-        this->tdam += player.to_d_m;
+        this->tdam += creature.to_d_m;
     } else {
         this->tdam *= this->mult;
     }
 
     if (this->shuriken != 0) {
-        this->tdam += ((player.level + 30) * (player.level + 30) - 900) / 55;
+        this->tdam += ((creature.level + 30) * (creature.level + 30) - 900) / 55;
     }
 
     if (this->tdam < 0) {
         this->tdam = 0;
     }
 
-    this->tdam = mon_damage_mod(player, *this->hit_monster->m_ptr, this->tdam, false);
+    this->tdam = mon_damage_mod(creature, *this->hit_monster->m_ptr, this->tdam, false);
 }
 
 void ObjectThrowEntity::process_boomerang_throw()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     if ((this->back_chance <= 30) || (one_in_(100) && !this->super_boomerang)) {
         msg_format(_("%sが返ってこなかった！", "%s doesn't come back!"), this->o2_name.data());
         return;
     }
 
     for (auto i = this->cur_dis - 1; i > 0; i--) {
-        if (!panel_contains({ this->ny[i], this->nx[i] }) || !player_can_see_bold(player, this->ny[i], this->nx[i])) {
+        if (!panel_contains({ this->ny[i], this->nx[i] }) || !player_can_see_bold(creature, this->ny[i], this->nx[i])) {
             term_xtra(TERM_XTRA_DELAY, this->msec);
             continue;
         }
@@ -561,11 +561,11 @@ void ObjectThrowEntity::process_boomerang_throw()
         }
 
         const auto symbol = this->q_ptr->get_symbol();
-        print_rel(player, symbol, { this->ny[i], this->nx[i] });
+        print_rel(creature, symbol, { this->ny[i], this->nx[i] });
         move_cursor_relative(this->ny[i], this->nx[i]);
         term_fresh();
         term_xtra(TERM_XTRA_DELAY, this->msec);
-        lite_spot(player, { this->ny[i], this->nx[i] });
+        lite_spot(creature, { this->ny[i], this->nx[i] });
         term_fresh();
     }
 

--- a/src/object-use/use-execution.cpp
+++ b/src/object-use/use-execution.cpp
@@ -44,15 +44,15 @@ ObjectUseEntity::ObjectUseEntity(CreatureEntity &creature, INVENTORY_IDX i_idx)
  */
 void ObjectUseEntity::execute()
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     auto use_charge = true;
-    auto *o_ptr = ref_item(player, this->i_idx);
+    auto *o_ptr = ref_item(creature, this->i_idx);
     if ((this->i_idx < 0) && (o_ptr->number > 1)) {
         msg_print(_("まずは杖を拾わなければ。", "You must first pick up the staffs."));
         return;
     }
 
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
     if (!this->check_can_use()) {
         return;
     }
@@ -62,8 +62,8 @@ void ObjectUseEntity::execute()
         item_level = 50 + (item_level - 50) / 2;
     }
 
-    auto chance = player.skill_dev;
-    if (player.is_confused()) {
+    auto chance = creature.skill_dev;
+    if (creature.is_confused()) {
         chance = chance / 2;
     }
 
@@ -72,7 +72,7 @@ void ObjectUseEntity::execute()
         chance = USE_DEVICE;
     }
 
-    if ((chance < USE_DEVICE) || (randint1(chance) < USE_DEVICE) || CreatureClass(player).equals(PlayerClassType::BERSERKER)) {
+    if ((chance < USE_DEVICE) || (randint1(chance) < USE_DEVICE) || CreatureClass(creature).equals(PlayerClassType::BERSERKER)) {
         if (flush_failure) {
             flush();
         }
@@ -100,11 +100,11 @@ void ObjectUseEntity::execute()
     }
 
     sound(SoundKind::ZAP);
-    auto ident = staff_effect(player, *o_ptr->bi_key.sval(), &use_charge, false, false, o_ptr->is_aware());
+    auto ident = staff_effect(creature, *o_ptr->bi_key.sval(), &use_charge, false, false, o_ptr->is_aware());
     if (!(o_ptr->is_aware())) {
-        chg_virtue(player, Virtue::PATIENCE, -1);
-        chg_virtue(player, Virtue::CHANCE, 1);
-        chg_virtue(player, Virtue::KNOWLEDGE, -1);
+        chg_virtue(creature, Virtue::PATIENCE, -1);
+        chg_virtue(creature, Virtue::CHANCE, 1);
+        chg_virtue(creature, Virtue::KNOWLEDGE, -1);
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
@@ -117,8 +117,8 @@ void ObjectUseEntity::execute()
     rfu.reset_flags(flags_srf);
     o_ptr->mark_as_tried();
     if (ident && !o_ptr->is_aware()) {
-        object_aware(player, *o_ptr);
-        gain_exp(player, (item_level + (player.level >> 1)) / player.level);
+        object_aware(creature, *o_ptr);
+        gain_exp(creature, (item_level + (creature.level >> 1)) / creature.level);
     }
 
     static constexpr auto flags_swrf = {
@@ -140,23 +140,23 @@ void ObjectUseEntity::execute()
         used_item.number = 1;
         o_ptr->pval++;
         o_ptr->number--;
-        this->i_idx = store_item_to_inventory(player, &used_item);
+        this->i_idx = store_item_to_inventory(creature, &used_item);
         msg_print(_("杖をまとめなおした。", "You unstack your staff."));
     }
 
     if (this->i_idx >= 0) {
-        inven_item_charges(*player.inventory[this->i_idx]);
+        inven_item_charges(*creature.inventory[this->i_idx]);
     } else {
-        floor_item_charges(*player.current_floor_ptr, 0 - this->i_idx);
+        floor_item_charges(*creature.current_floor_ptr, 0 - this->i_idx);
     }
 }
 
 bool ObjectUseEntity::check_can_use()
 {
-    auto &player = *this->creature_ptr;
-    if (cmd_limit_time_walk(player)) {
+    auto &creature = *this->creature_ptr;
+    if (cmd_limit_time_walk(creature)) {
         return false;
     }
 
-    return ItemUseChecker(player).check_stun(_("朦朧としていて杖を振れなかった！", "You are too stunned to use it!"));
+    return ItemUseChecker(creature).check_stun(_("朦朧としていて杖を振れなかった！", "You are too stunned to use it!"));
 }

--- a/src/object-use/zaprod-execution.cpp
+++ b/src/object-use/zaprod-execution.cpp
@@ -42,9 +42,9 @@ ObjectZapRodEntity::ObjectZapRodEntity(CreatureEntity &creature)
  */
 void ObjectZapRodEntity::execute(INVENTORY_IDX i_idx)
 {
-    auto &player = *this->creature_ptr;
+    auto &creature = *this->creature_ptr;
     auto use_charge = true;
-    auto *o_ptr = ref_item(player, i_idx);
+    auto *o_ptr = ref_item(creature, i_idx);
     if ((i_idx < 0) && (o_ptr->number > 1)) {
         msg_print(_("まずはロッドを拾わなければ。", "You must first pick up the rods."));
         return;
@@ -52,20 +52,20 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX i_idx)
 
     auto dir = Direction::none();
     if (o_ptr->is_aiming_rod() || !o_ptr->is_aware()) {
-        dir = get_aim_dir(player);
+        dir = get_aim_dir(creature);
         if (!dir) {
             return;
         }
     }
 
-    PlayerEnergy(player).set_player_turn_energy(100);
+    PlayerEnergy(creature).set_player_turn_energy(100);
     if (!this->check_can_zap()) {
         return;
     }
 
     const auto item_level = o_ptr->get_baseitem_level();
-    auto chance = player.skill_dev;
-    if (player.is_confused()) {
+    auto chance = creature.skill_dev;
+    if (creature.is_confused()) {
         chance = chance / 2;
     }
 
@@ -85,7 +85,7 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX i_idx)
     }
 
     bool success;
-    if (CreatureClass(player).equals(PlayerClassType::BERSERKER)) {
+    if (CreatureClass(creature).equals(PlayerClassType::BERSERKER)) {
         success = false;
     } else if (chance > fail) {
         success = randint0(chance * 2) >= fail;
@@ -121,7 +121,7 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX i_idx)
     }
 
     sound(SoundKind::ZAP);
-    auto ident = rod_effect(player, *o_ptr->bi_key.sval(), dir, &use_charge, false);
+    auto ident = rod_effect(creature, *o_ptr->bi_key.sval(), dir, &use_charge, false);
     if (use_charge) {
         o_ptr->timeout += base_pval;
     }
@@ -133,15 +133,15 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX i_idx)
     };
     rfu.set_flags(flags_srf);
     if (!(o_ptr->is_aware())) {
-        chg_virtue(player, Virtue::PATIENCE, -1);
-        chg_virtue(player, Virtue::CHANCE, 1);
-        chg_virtue(player, Virtue::KNOWLEDGE, -1);
+        chg_virtue(creature, Virtue::PATIENCE, -1);
+        chg_virtue(creature, Virtue::CHANCE, 1);
+        chg_virtue(creature, Virtue::KNOWLEDGE, -1);
     }
 
     o_ptr->mark_as_tried();
     if ((ident != 0) && !o_ptr->is_aware()) {
-        object_aware(player, *o_ptr);
-        gain_exp(player, (item_level + (player.level >> 1)) / player.level);
+        object_aware(creature, *o_ptr);
+        gain_exp(creature, (item_level + (creature.level >> 1)) / creature.level);
     }
 
     static constexpr auto flags_swrf = {
@@ -156,10 +156,10 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX i_idx)
 
 bool ObjectZapRodEntity::check_can_zap()
 {
-    auto &player = *this->creature_ptr;
-    if (cmd_limit_time_walk(player)) {
+    auto &creature = *this->creature_ptr;
+    if (cmd_limit_time_walk(creature)) {
         return false;
     }
 
-    return ItemUseChecker(player).check_stun(_("朦朧としていてロッドを振れなかった！", "You are too stunned to zap it!"));
+    return ItemUseChecker(creature).check_stun(_("朦朧としていてロッドを振れなかった！", "You are too stunned to zap it!"));
 }

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -42,8 +42,8 @@ bool CreatureClass::equals(PlayerClassType type) const
     if (!this->creature.is_player()) {
         return false;
     }
-    auto &player = this->creature;
-    return player.pclass == type;
+    auto &creature = this->creature;
+    return creature.pclass == type;
 }
 
 /*!
@@ -54,12 +54,12 @@ TrFlags CreatureClass::tr_flags() const
     if (!this->creature.is_player()) {
         return TrFlags();
     }
-    auto &player = this->creature;
+    auto &creature = this->creature;
 
     TrFlags flags;
-    const auto plev = player.level;
+    const auto plev = creature.level;
 
-    switch (player.pclass) {
+    switch (creature.pclass) {
     case PlayerClassType::WARRIOR: {
         if (plev > 29) {
             flags.set(TR_RES_FEAR);
@@ -113,7 +113,7 @@ TrFlags CreatureClass::tr_flags() const
                 flags.set(TR_SPEED);
             }
 
-            if (plev > 24 && !player.is_icky_wield[0] && !player.is_icky_wield[1]) {
+            if (plev > 24 && !creature.is_icky_wield[0] && !creature.is_icky_wield[1]) {
                 flags.set(TR_FREE_ACT);
             }
         }
@@ -173,52 +173,52 @@ TrFlags CreatureClass::tr_flags() const
         break;
     }
     case PlayerClassType::ELEMENTALIST:
-        if (has_element_resist(player, ElementRealmType::FIRE, 1)) {
+        if (has_element_resist(creature, ElementRealmType::FIRE, 1)) {
             flags.set(TR_RES_FIRE);
         }
-        if (has_element_resist(player, ElementRealmType::FIRE, 30)) {
+        if (has_element_resist(creature, ElementRealmType::FIRE, 30)) {
             flags.set(TR_IM_FIRE);
         }
-        if (has_element_resist(player, ElementRealmType::ICE, 1)) {
+        if (has_element_resist(creature, ElementRealmType::ICE, 1)) {
             flags.set(TR_RES_COLD);
         }
-        if (has_element_resist(player, ElementRealmType::ICE, 30)) {
+        if (has_element_resist(creature, ElementRealmType::ICE, 30)) {
             flags.set(TR_IM_COLD);
         }
-        if (has_element_resist(player, ElementRealmType::SKY, 1)) {
+        if (has_element_resist(creature, ElementRealmType::SKY, 1)) {
             flags.set(TR_RES_ELEC);
         }
-        if (has_element_resist(player, ElementRealmType::SKY, 30)) {
+        if (has_element_resist(creature, ElementRealmType::SKY, 30)) {
             flags.set(TR_IM_ELEC);
         }
-        if (has_element_resist(player, ElementRealmType::SEA, 1)) {
+        if (has_element_resist(creature, ElementRealmType::SEA, 1)) {
             flags.set(TR_RES_ACID);
         }
-        if (has_element_resist(player, ElementRealmType::SEA, 30)) {
+        if (has_element_resist(creature, ElementRealmType::SEA, 30)) {
             flags.set(TR_IM_ACID);
         }
-        if (has_element_resist(player, ElementRealmType::DARKNESS, 1)) {
+        if (has_element_resist(creature, ElementRealmType::DARKNESS, 1)) {
             flags.set(TR_RES_DARK);
         }
-        if (has_element_resist(player, ElementRealmType::DARKNESS, 30)) {
+        if (has_element_resist(creature, ElementRealmType::DARKNESS, 30)) {
             flags.set(TR_RES_NETHER);
         }
-        if (has_element_resist(player, ElementRealmType::CHAOS, 1)) {
+        if (has_element_resist(creature, ElementRealmType::CHAOS, 1)) {
             flags.set(TR_RES_CONF);
         }
-        if (has_element_resist(player, ElementRealmType::CHAOS, 30)) {
+        if (has_element_resist(creature, ElementRealmType::CHAOS, 30)) {
             flags.set(TR_RES_CHAOS);
         }
-        if (has_element_resist(player, ElementRealmType::EARTH, 1)) {
+        if (has_element_resist(creature, ElementRealmType::EARTH, 1)) {
             flags.set(TR_RES_SHARDS);
         }
-        if (has_element_resist(player, ElementRealmType::EARTH, 30)) {
+        if (has_element_resist(creature, ElementRealmType::EARTH, 30)) {
             flags.set(TR_REFLECT);
         }
-        if (has_element_resist(player, ElementRealmType::DEATH, 1)) {
+        if (has_element_resist(creature, ElementRealmType::DEATH, 1)) {
             flags.set(TR_RES_POIS);
         }
-        if (has_element_resist(player, ElementRealmType::DEATH, 30)) {
+        if (has_element_resist(creature, ElementRealmType::DEATH, 30)) {
             flags.set(TR_RES_DISEN);
         }
         break;
@@ -234,13 +234,13 @@ TrFlags CreatureClass::stance_tr_flags() const
     if (!this->creature.is_player()) {
         return TrFlags();
     }
-    auto &player = this->creature;
+    auto &creature = this->creature;
 
     TrFlags flags;
 
     switch (this->get_samurai_stance()) {
     case SamuraiStanceType::FUUJIN:
-        if (!player.is_blind()) {
+        if (!creature.is_blind()) {
             flags.set(TR_REFLECT);
         }
         break;
@@ -284,8 +284,8 @@ bool CreatureClass::has_stun_immunity() const
     if (!this->creature.is_player()) {
         return false;
     }
-    auto &player = this->creature;
-    return this->equals(PlayerClassType::BERSERKER) && (player.level > 34);
+    auto &creature = this->creature;
+    return this->equals(PlayerClassType::BERSERKER) && (creature.level > 34);
 }
 
 bool CreatureClass::has_poison_resistance() const
@@ -293,8 +293,8 @@ bool CreatureClass::has_poison_resistance() const
     if (!this->creature.is_player()) {
         return false;
     }
-    auto &player = this->creature;
-    return this->equals(PlayerClassType::NINJA) && (player.level > 44);
+    auto &creature = this->creature;
+    return this->equals(PlayerClassType::NINJA) && (creature.level > 44);
 }
 
 /*!
@@ -411,8 +411,8 @@ bool CreatureClass::lose_balance()
     if (!this->creature.is_player()) {
         return false;
     }
-    auto &player = this->creature;
-    if (player.pclass != PlayerClassType::SAMURAI) {
+    auto &creature = this->creature;
+    if (creature.pclass != PlayerClassType::SAMURAI) {
         return false;
     }
 
@@ -432,7 +432,7 @@ bool CreatureClass::lose_balance()
         MainWindowRedrawingFlag::TIMED_EFFECT,
     };
     rfu.set_flags(flags_mwrf);
-    player.action = ACTION_NONE;
+    creature.action = ACTION_NONE;
     return true;
 }
 
@@ -516,48 +516,48 @@ void CreatureClass::init_specific_data()
     if (!this->creature.is_player()) {
         return;
     }
-    auto &player = this->creature;
+    auto &creature = this->creature;
 
-    switch (player.pclass) {
+    switch (creature.pclass) {
     case PlayerClassType::SMITH:
-        player.class_specific_data = std::make_shared<smith_data_type>();
+        creature.class_specific_data = std::make_shared<smith_data_type>();
         break;
     case PlayerClassType::FORCETRAINER:
-        player.class_specific_data = std::make_shared<force_trainer_data_type>();
+        creature.class_specific_data = std::make_shared<force_trainer_data_type>();
         break;
     case PlayerClassType::BLUE_MAGE:
-        player.class_specific_data = std::make_shared<bluemage_data_type>();
+        creature.class_specific_data = std::make_shared<bluemage_data_type>();
         break;
     case PlayerClassType::MAGIC_EATER:
-        player.class_specific_data = std::make_shared<MagicEaterDataList>();
+        creature.class_specific_data = std::make_shared<MagicEaterDataList>();
         break;
     case PlayerClassType::BARD:
-        player.class_specific_data = std::make_shared<bard_data_type>();
+        creature.class_specific_data = std::make_shared<bard_data_type>();
         break;
     case PlayerClassType::IMITATOR:
-        player.class_specific_data = std::make_shared<mane_data_type>();
+        creature.class_specific_data = std::make_shared<mane_data_type>();
         break;
     case PlayerClassType::SNIPER:
-        player.class_specific_data = std::make_shared<SniperData>();
+        creature.class_specific_data = std::make_shared<SniperData>();
         break;
     case PlayerClassType::SAMURAI:
-        player.class_specific_data = std::make_shared<samurai_data_type>();
+        creature.class_specific_data = std::make_shared<samurai_data_type>();
         break;
     case PlayerClassType::MONK:
-        player.class_specific_data = std::make_shared<monk_data_type>();
+        creature.class_specific_data = std::make_shared<monk_data_type>();
         break;
     case PlayerClassType::NINJA:
-        player.class_specific_data = std::make_shared<ninja_data_type>();
+        creature.class_specific_data = std::make_shared<ninja_data_type>();
         break;
     case PlayerClassType::HIGH_MAGE:
-        if (PlayerRealm(player).is_realm_hex()) {
-            player.class_specific_data = std::make_shared<spell_hex_data_type>();
+        if (PlayerRealm(creature).is_realm_hex()) {
+            creature.class_specific_data = std::make_shared<spell_hex_data_type>();
         } else {
-            player.class_specific_data = no_class_specific_data();
+            creature.class_specific_data = no_class_specific_data();
         }
         break;
     default:
-        player.class_specific_data = no_class_specific_data();
+        creature.class_specific_data = no_class_specific_data();
         break;
     }
 }
@@ -567,12 +567,12 @@ bool CreatureClass::has_ninja_speed() const
     if (!this->creature.is_player()) {
         return false;
     }
-    auto &player = this->creature;
+    auto &creature = this->creature;
 
-    auto has_ninja_speed_main = !player.inventory[INVEN_MAIN_HAND]->is_valid();
-    has_ninja_speed_main |= can_attack_with_main_hand(player);
-    auto has_ninja_speed_sub = !player.inventory[INVEN_SUB_HAND]->is_valid();
-    has_ninja_speed_sub |= can_attack_with_sub_hand(player);
+    auto has_ninja_speed_main = !creature.inventory[INVEN_MAIN_HAND]->is_valid();
+    has_ninja_speed_main |= can_attack_with_main_hand(creature);
+    auto has_ninja_speed_sub = !creature.inventory[INVEN_SUB_HAND]->is_valid();
+    has_ninja_speed_sub |= can_attack_with_sub_hand(creature);
     return has_ninja_speed_main && has_ninja_speed_sub;
 }
 

--- a/src/player-info/self-info.cpp
+++ b/src/player-info/self-info.cpp
@@ -311,9 +311,8 @@ static const std::vector<std::string> report_magic_durations = { _("ごく短い
  */
 void report_magics(CreatureEntity &subject)
 {
-    auto &player = subject;
     std::vector<std::pair<int, std::string>> info;
-    const auto effects = player.effects();
+    const auto effects = subject.effects();
     const auto &blindness = effects->blindness();
     if (blindness.is_blind()) {
         info.emplace_back(report_magics_aux(blindness.current()),
@@ -344,18 +343,18 @@ void report_magics(CreatureEntity &subject)
             _("あなたは幻覚を見ている", "You are hallucinating"));
     }
 
-    if (player.blessed) {
-        info.emplace_back(report_magics_aux(player.blessed),
+    if (subject.blessed) {
+        info.emplace_back(report_magics_aux(subject.blessed),
             _("あなたは高潔さを感じている", "You feel rightous"));
     }
 
-    if (player.hero) {
-        info.emplace_back(report_magics_aux(player.hero),
+    if (subject.hero) {
+        info.emplace_back(report_magics_aux(subject.hero),
             _("あなたはヒーロー気分だ", "You feel heroic"));
     }
 
-    if (player.is_shero()) {
-        info.emplace_back(report_magics_aux(player.berserk),
+    if (subject.is_shero()) {
+        info.emplace_back(report_magics_aux(subject.berserk),
             _("あなたは戦闘狂だ", "You are in a battle rage"));
     }
 
@@ -365,57 +364,57 @@ void report_magics(CreatureEntity &subject)
             _("あなたは邪悪なる存在から守られている", "You are protected from evil"));
     }
 
-    if (player.shield) {
-        info.emplace_back(report_magics_aux(player.shield),
+    if (subject.shield) {
+        info.emplace_back(report_magics_aux(subject.shield),
             _("あなたは神秘のシールドで守られている", "You are protected by a mystic shield"));
     }
 
-    if (player.invuln) {
-        info.emplace_back(report_magics_aux(player.invuln),
+    if (subject.invuln) {
+        info.emplace_back(report_magics_aux(subject.invuln),
             _("あなたは無敵だ", "You are invulnerable"));
     }
 
-    if (player.wraith_form) {
-        info.emplace_back(report_magics_aux(player.wraith_form),
+    if (subject.wraith_form) {
+        info.emplace_back(report_magics_aux(subject.wraith_form),
             _("あなたは幽体化している", "You are incorporeal"));
     }
 
-    if (player.special_attack & ATTACK_CONFUSE) {
+    if (subject.special_attack & ATTACK_CONFUSE) {
         info.emplace_back(7, _("あなたの手は赤く輝いている", "Your hands are glowing dull red."));
     }
 
-    if (player.word_recall) {
-        info.emplace_back(report_magics_aux(player.word_recall),
+    if (subject.word_recall) {
+        info.emplace_back(report_magics_aux(subject.word_recall),
             _("この後帰還の詔が発動する", "You are waiting to be recalled"));
     }
 
-    if (player.alter_reality) {
-        info.emplace_back(report_magics_aux(player.alter_reality),
+    if (subject.alter_reality) {
+        info.emplace_back(report_magics_aux(subject.alter_reality),
             _("この後現実変容が発動する", "You waiting to be altered"));
     }
 
-    if (player.oppose_acid) {
-        info.emplace_back(report_magics_aux(player.oppose_acid),
+    if (subject.oppose_acid) {
+        info.emplace_back(report_magics_aux(subject.oppose_acid),
             _("あなたは酸への耐性を持っている", "You are resistant to acid"));
     }
 
-    if (player.oppose_elec) {
-        info.emplace_back(report_magics_aux(player.oppose_elec),
+    if (subject.oppose_elec) {
+        info.emplace_back(report_magics_aux(subject.oppose_elec),
             _("あなたは電撃への耐性を持っている", "You are resistant to lightning"));
     }
 
-    if (player.oppose_fire) {
-        info.emplace_back(report_magics_aux(player.oppose_fire),
+    if (subject.oppose_fire) {
+        info.emplace_back(report_magics_aux(subject.oppose_fire),
             _("あなたは火への耐性を持っている", "You are resistant to fire"));
     }
 
-    if (player.oppose_cold) {
-        info.emplace_back(report_magics_aux(player.oppose_cold),
+    if (subject.oppose_cold) {
+        info.emplace_back(report_magics_aux(subject.oppose_cold),
             _("あなたは冷気への耐性を持っている", "You are resistant to cold"));
     }
 
-    if (player.oppose_pois) {
-        info.emplace_back(report_magics_aux(player.oppose_pois),
+    if (subject.oppose_pois) {
+        info.emplace_back(report_magics_aux(subject.oppose_pois),
             _("あなたは毒への耐性を持っている", "You are resistant to poison"));
     }
 

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -30,9 +30,9 @@
 /*!< 呪術の最大詠唱数 */
 constexpr int MAX_KEEP = 4;
 
-SpellHex::SpellHex(CreatureEntity &player)
-    : player(player)
-    , spell_hex_data(CreatureClass(player).get_specific_data<spell_hex_data_type>())
+SpellHex::SpellHex(CreatureEntity &creature)
+    : creature(creature)
+    , spell_hex_data(CreatureClass(creature).get_specific_data<spell_hex_data_type>())
 {
     if (!this->spell_hex_data) {
         return;
@@ -51,12 +51,12 @@ SpellHex::SpellHex(CreatureEntity &player)
 void SpellHex::stop_all_spells()
 {
     for (auto spell : this->casting_spells) {
-        exe_spell(this->player, RealmType::HEX, spell, SpellProcessType::STOP);
+        exe_spell(this->creature, RealmType::HEX, spell, SpellProcessType::STOP);
     }
 
     this->spell_hex_data->casting_spells.clear();
-    if (this->player.action == ACTION_SPELL) {
-        set_action(this->player, ACTION_NONE);
+    if (this->creature.action == ACTION_SPELL) {
+        set_action(this->creature, ACTION_NONE);
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
@@ -87,7 +87,7 @@ bool SpellHex::stop_spells_with_selection()
     }
 
     auto casting_num = this->get_casting_num();
-    if ((casting_num == 1) || (this->player.level < 35)) {
+    if ((casting_num == 1) || (this->creature.level < 35)) {
         this->stop_all_spells();
         return true;
     }
@@ -103,7 +103,7 @@ bool SpellHex::stop_spells_with_selection()
     screen_load();
     if (choice) {
         auto n = this->casting_spells[A2I(*choice)];
-        exe_spell(this->player, RealmType::HEX, n, SpellProcessType::STOP);
+        exe_spell(this->creature, RealmType::HEX, n, SpellProcessType::STOP);
         this->reset_casting_flag(i2enum<spell_hex_type>(n));
     }
 
@@ -189,7 +189,7 @@ void SpellHex::decrease_mana()
     }
 
     auto need_restart = this->check_restart();
-    if (this->player.anti_magic) {
+    if (this->creature.anti_magic) {
         this->stop_all_spells();
         return;
     }
@@ -200,7 +200,7 @@ void SpellHex::decrease_mana()
 
     this->gain_exp();
     for (auto spell : this->casting_spells) {
-        exe_spell(this->player, RealmType::HEX, spell, SpellProcessType::CONTNUATION);
+        exe_spell(this->creature, RealmType::HEX, spell, SpellProcessType::CONTNUATION);
     }
 }
 
@@ -217,13 +217,13 @@ bool SpellHex::process_mana_cost(const bool need_restart)
     s64b_div(&need_mana, &need_mana_frac, 0, 3); /* Divide by 3 */
     need_mana += this->get_casting_num() - 1;
 
-    auto enough_mana = s64b_cmp(this->player.csp, this->player.csp_frac, need_mana, need_mana_frac) >= 0;
+    auto enough_mana = s64b_cmp(this->creature.csp, this->creature.csp_frac, need_mana, need_mana_frac) >= 0;
     if (!enough_mana) {
         this->stop_all_spells();
         return false;
     }
 
-    s64b_sub(&(this->player.csp), &(this->player.csp_frac), need_mana, need_mana_frac);
+    s64b_sub(&(this->creature.csp), &(this->creature.csp_frac), need_mana, need_mana_frac);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MP);
     if (!need_restart) {
@@ -231,7 +231,7 @@ bool SpellHex::process_mana_cost(const bool need_restart)
     }
 
     msg_print(_("詠唱を再開した。", "You restart casting."));
-    this->player.action = ACTION_SPELL;
+    this->creature.action = ACTION_SPELL;
     static constexpr auto flags_srf = {
         StatusRecalculatingFlag::BONUS,
         StatusRecalculatingFlag::HP,
@@ -268,7 +268,7 @@ int SpellHex::calc_need_mana()
     auto need_mana = 0;
     for (auto spell_id : this->casting_spells) {
         const auto &spell = PlayerRealm::get_spell_info(RealmType::HEX, spell_id);
-        need_mana += mod_need_mana(this->player, spell.smana, spell_id, RealmType::HEX);
+        need_mana += mod_need_mana(this->creature, spell.smana, spell_id, RealmType::HEX);
     }
 
     return need_mana;
@@ -276,7 +276,7 @@ int SpellHex::calc_need_mana()
 
 void SpellHex::gain_exp()
 {
-    PlayerSkill ps(this->player);
+    PlayerSkill ps(this->creature);
     for (auto spell : this->casting_spells) {
         if (!this->is_spelling_specific(spell)) {
             continue;
@@ -292,7 +292,7 @@ void SpellHex::gain_exp()
  */
 bool SpellHex::is_casting_full_capacity() const
 {
-    auto k_max = (this->player.level / 15) + 1;
+    auto k_max = (this->creature.level / 15) + 1;
     k_max = std::min(k_max, MAX_KEEP);
     return this->get_casting_num() >= k_max;
 }
@@ -308,10 +308,10 @@ void SpellHex::continue_revenge()
 
     switch (this->get_revenge_type()) {
     case SpellHexRevengeType::PATIENCE:
-        exe_spell(this->player, RealmType::HEX, HEX_PATIENCE, SpellProcessType::CONTNUATION);
+        exe_spell(this->creature, RealmType::HEX, HEX_PATIENCE, SpellProcessType::CONTNUATION);
         return;
     case SpellHexRevengeType::REVENGE:
-        exe_spell(this->player, RealmType::HEX, HEX_REVENGE, SpellProcessType::CONTNUATION);
+        exe_spell(this->creature, RealmType::HEX, HEX_REVENGE, SpellProcessType::CONTNUATION);
         return;
     default:
         return;
@@ -339,9 +339,9 @@ void SpellHex::store_vengeful_damage(int dam)
  */
 bool SpellHex::check_hex_barrier(MONSTER_IDX m_idx, spell_hex_type type) const
 {
-    const auto &monster = this->player.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = this->creature.current_floor_ptr->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
-    return this->is_spelling_specific(type) && ((this->player.level * 3 / 2) >= randint1(monrace.level));
+    return this->is_spelling_specific(type) && ((this->creature.level * 3 / 2) >= randint1(monrace.level));
 }
 
 bool SpellHex::is_spelling_specific(int hex) const
@@ -367,25 +367,25 @@ void SpellHex::interrupt_spelling()
  */
 void SpellHex::eyes_on_eyes(MONSTER_IDX m_idx, int dam)
 {
-    auto &player = this->player;
-    const auto is_eyeeye_finished = (this->player.tim_eyeeye == 0) && !this->is_spelling_specific(HEX_EYE_FOR_EYE);
-    if (is_eyeeye_finished || (dam == 0) || this->player.is_dead()) {
+    auto &creature = this->creature;
+    const auto is_eyeeye_finished = (this->creature.tim_eyeeye == 0) && !this->is_spelling_specific(HEX_EYE_FOR_EYE);
+    if (is_eyeeye_finished || (dam == 0) || this->creature.is_dead()) {
         return;
     }
 
-    const auto &monster = this->player.current_floor_ptr->get_monster(m_idx);
-    const auto m_name = monster_desc(player, monster, 0);
+    const auto &monster = this->creature.current_floor_ptr->get_monster(m_idx);
+    const auto m_name = monster_desc(creature, monster, 0);
 #ifdef JP
     msg_format("攻撃が%s自身を傷つけた！", m_name.data());
 #else
-    const auto m_name_self = monster_desc(player, monster, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
+    const auto m_name_self = monster_desc(creature, monster, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
     msg_format("The attack of %s has wounded %s!", m_name.data(), m_name_self.data());
 #endif
     const auto y = monster.y;
     const auto x = monster.x;
-    project(player, 0, 0, y, x, dam, AttributeType::MISSILE, PROJECT_KILL);
-    if (this->player.tim_eyeeye) {
-        set_tim_eyeeye(player, this->player.tim_eyeeye - 5, true);
+    project(creature, 0, 0, y, x, dam, AttributeType::MISSILE, PROJECT_KILL);
+    if (this->creature.tim_eyeeye) {
+        set_tim_eyeeye(creature, this->creature.tim_eyeeye - 5, true);
     }
 }
 

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -16,7 +16,7 @@ class CreatureEntity;
 struct spell_hex_data_type;
 class SpellHex {
 public:
-    SpellHex(CreatureEntity &player);
+    SpellHex(CreatureEntity &creature);
     virtual ~SpellHex() = default;
 
     bool stop_spells_with_selection();
@@ -41,7 +41,7 @@ public:
     void set_revenge_type(SpellHexRevengeType type);
 
 private:
-    CreatureEntity &player;
+    CreatureEntity &creature;
     std::vector<int> casting_spells;
     std::shared_ptr<spell_hex_data_type> spell_hex_data;
 

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -195,9 +195,9 @@ public:
         this->print_rumor(town_name);
 
         const uint32_t visit = (1U << (town_rumor.t_idx - 1));
-        auto &player = this->creature;
-        if ((town_rumor.t_idx != SECRET_TOWN) && !(player.visit & visit)) {
-            player.visit |= visit;
+        auto &creature = this->creature;
+        if ((town_rumor.t_idx != SECRET_TOWN) && !(creature.visit & visit)) {
+            creature.visit |= visit;
             msg_erase();
             msg_print(_("{}に行ったことがある気がする。", "You feel you have been to {}."), town_name);
         }


### PR DESCRIPTION
- subject/killer/this->creature_ptr/this->creature を参照する player エイリアスを削除
- SpellHex::player メンバを CreatureEntity &creature にリネーム
- 合計 11 ファイルの変数名を統一