### PR TITLE
refactor: PlayerType::wipe() を追加し最後の static_cast<PlayerType> を除去（Phase 8）

### DIFF
--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -28,7 +28,6 @@
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
-#include "system/player-type-definition.h"
 #include "util/enum-range.h"
 #include "util/string-processor.h"
 #include "world/world.h"
@@ -44,7 +43,7 @@ void player_wipe_without_name(CreatureEntity &creature)
 {
     const std::string backup_name = creature.name;
     auto &world = AngbandWorld::get_instance();
-    static_cast<PlayerType &>(creature) = {};
+    creature.wipe();
 
     // TODO: キャラ作成からゲーム開始までに  current_floor_ptr を参照しなければならない処理は今後整理して外す。
     creature.current_floor_ptr = &FloorList::get_instance().get_floor(0);

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -99,3 +99,13 @@ void PlayerType::set_timed_effect(CreatureTimedEffect effect, short value)
         break;
     }
 }
+
+/*!
+ * @brief プレイヤー状態を空の初期値にリセットする
+ * @details game-play-initializer 等からのキャラクター再初期化時に使われる。
+ *          名前やフロア情報等は呼び出し側が事前退避・事後復元する前提。
+ */
+void PlayerType::wipe()
+{
+    *this = {};
+}

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -17,6 +17,8 @@ public:
 
     short get_timed_effect(CreatureTimedEffect effect) const override;
     void set_timed_effect(CreatureTimedEffect effect, short value) override;
+
+    void wipe() override;
 };
 
 extern PlayerType *p_ptr;


### PR DESCRIPTION

CreatureEntity::wipe() の仮想オーバーライドを PlayerType にも追加し、 player_wipe_without_name() から `static_cast<PlayerType &>(creature) = {};` を `creature.wipe();` に置き換える。これでコードベース全体から
`static_cast<PlayerType>` が完全に消え、PlayerType / MonsterEntity が 同一インターフェース経由でリセット可能になる。

また game-play-initializer.cpp から不要になった player-type-definition.h インクルードを削除する。