### PR TITLE
refactor: MonsterEntity::clone() を除去しコピーコンストラクタに統一（Phase 8）

### DIFF
--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -120,7 +120,7 @@ static MonraceDefinition &set_pet_params(CreatureEntity &creature, const int cur
 
     creature.current_floor_ptr->grid_array[cy][cx].m_idx = m_idx;
     auto &monster = creature.current_floor_ptr->m_list[m_idx];
-    monster = party_monsters[current_monster].clone();
+    monster = party_monsters[current_monster];
     monster.y = cy;
     monster.x = cx;
     monster.current_floor_ptr = creature.current_floor_ptr;

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -53,7 +53,7 @@ static void check_riding_preservation(CreatureEntity &creature)
         creature.pet_extra_flags &= ~(PF_TWO_HANDS);
         creature.riding_ryoute = creature.old_riding_ryoute = false;
     } else {
-        party_monsters[0] = monster.clone();
+        party_monsters[0] = monster;
         delete_monster_idx(creature, creature.riding);
     }
 }
@@ -98,7 +98,7 @@ static void sweep_preserving_pet(CreatureEntity &creature)
             continue;
         }
 
-        party_monsters[party_monster_num] = creature.current_floor_ptr->m_list[i].clone();
+        party_monsters[party_monster_num] = creature.current_floor_ptr->m_list[i];
         party_monster_num++;
         delete_monster_idx(creature, i);
     }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -99,7 +99,7 @@ MonsterDamageProcessor::MonsterDamageProcessor(CreatureEntity &creature, MONSTER
 bool MonsterDamageProcessor::mon_take_hit(std::string_view note)
 {
     auto &monster = this->creature.current_floor_ptr->m_list[this->m_idx];
-    const auto exp_mon = monster.clone();
+    const auto exp_mon = monster;
     auto exp_dam = (monster.hp > this->dam) ? this->dam : monster.hp;
     this->get_exp_from_mon(exp_mon, exp_dam);
     if (this->genocide_patron()) {

--- a/src/spell-kind/spells-polymorph.cpp
+++ b/src/spell-kind/spells-polymorph.cpp
@@ -90,7 +90,7 @@ bool polymorph_monster(CreatureEntity &creature, POSITION y, POSITION x)
         return false;
     }
 
-    auto back_m = floor.m_list[grid.m_idx].clone();
+    auto back_m = floor.m_list[grid.m_idx];
     new_r_idx = select_polymorph_monrace_id(creature, old_r_idx);
     if (new_r_idx == old_r_idx) {
         return false;
@@ -122,7 +122,7 @@ bool polymorph_monster(CreatureEntity &creature, POSITION y, POSITION x)
     } else {
         m_idx = place_specific_monster(creature, y, x, old_r_idx, (mode | PM_NO_KAGE | PM_IGNORE_TERRAIN));
         if (m_idx) {
-            floor.m_list[*m_idx] = back_m.clone();
+            floor.m_list[*m_idx] = back_m;
             floor.reset_mproc();
         } else {
             preserve_hold_objects = false;

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -18,8 +18,3 @@ void MonsterEntity::wipe()
 {
     *this = {};
 }
-
-MonsterEntity MonsterEntity::clone() const
-{
-    return *this;
-}

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -19,5 +19,4 @@ public:
     MonsterEntity &operator=(const MonsterEntity &) = default;
 
     void wipe() override;
-    MonsterEntity clone() const;
 };


### PR DESCRIPTION
MonsterEntity::clone() は `return *this;` だけの薄いラッパーで、暗黙の コピー操作と意味的に同じため除去する。呼び出し側は直接コピー構築・
代入に書き換える:

  const auto exp_mon = monster.clone();      // before
  const auto exp_mon = monster;              // after

  party_monsters[0] = monster.clone();       // before
  party_monsters[0] = monster;               // after

これで MonsterEntity は wipe() のみを残すほぼ空のクラスになり、
最終目標である CreatureEntity への完全吸収にまた一歩近づく。