### PR TITLE
refactor: CreatureTimedEffect に ULT_RES/WRAITH_FORM/TIM_ESP 等 8 種を追加（Phase 3）

### DIFF
--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -479,6 +479,46 @@ public:
         return this->get_timed_effect(CreatureTimedEffect::SHIELD);
     }
 
+    short get_remaining_ultimate_resistance() const
+    {
+        return this->get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE);
+    }
+
+    short get_remaining_wraith_form() const
+    {
+        return this->get_timed_effect(CreatureTimedEffect::WRAITH_FORM);
+    }
+
+    short get_remaining_tim_esp() const
+    {
+        return this->get_timed_effect(CreatureTimedEffect::TIM_ESP);
+    }
+
+    short get_remaining_tim_stealth() const
+    {
+        return this->get_timed_effect(CreatureTimedEffect::TIM_STEALTH);
+    }
+
+    short get_remaining_tim_regen() const
+    {
+        return this->get_timed_effect(CreatureTimedEffect::TIM_REGEN);
+    }
+
+    short get_remaining_tsuyoshi() const
+    {
+        return this->get_timed_effect(CreatureTimedEffect::TSUYOSHI);
+    }
+
+    short get_remaining_tim_invis() const
+    {
+        return this->get_timed_effect(CreatureTimedEffect::TIM_INVIS);
+    }
+
+    short get_remaining_tim_infra() const
+    {
+        return this->get_timed_effect(CreatureTimedEffect::TIM_INFRA);
+    }
+
     tl::optional<std::string> get_pain_message(std::string_view monster_name, int damage) const;
 
     /*!

--- a/src/system/creature-timed-effect-types.h
+++ b/src/system/creature-timed-effect-types.h
@@ -18,5 +18,13 @@ enum class CreatureTimedEffect {
     BERSERK, /*!< 狂戦士化 / Super Heroism / Berserk (プレイヤーのみ、モンスターは常に0) */
     BLESSED, /*!< 祝福 / Blessed (プレイヤーのみ、モンスターは常に0) */
     SHIELD, /*!< 魔法の盾 / Shield spell (プレイヤーのみ、モンスターは常に0) */
+    ULTIMATE_RESISTANCE, /*!< 究極耐性 / Ultimate Resistance (プレイヤーのみ、モンスターは常に0) */
+    WRAITH_FORM, /*!< 幽体化 / Wraith form (プレイヤーのみ、モンスターは常に0) */
+    TIM_ESP, /*!< 一時テレパシー / Timed ESP (プレイヤーのみ、モンスターは常に0) */
+    TIM_STEALTH, /*!< 一時隠密 / Timed Stealth (プレイヤーのみ、モンスターは常に0) */
+    TIM_REGEN, /*!< 一時再生 / Timed Regeneration (プレイヤーのみ、モンスターは常に0) */
+    TSUYOSHI, /*!< つよし特殊 / Tsuyoshi Special (プレイヤーのみ、モンスターは常に0) */
+    TIM_INVIS, /*!< 一時透明視 / Timed See Invisible (プレイヤーのみ、モンスターは常に0) */
+    TIM_INFRA, /*!< 一時赤外線視 / Timed Infra Vision (プレイヤーのみ、モンスターは常に0) */
     MAX,
 };

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -67,6 +67,22 @@ short PlayerType::get_timed_effect(CreatureTimedEffect effect) const
         return this->blessed;
     case CreatureTimedEffect::SHIELD:
         return this->shield;
+    case CreatureTimedEffect::ULTIMATE_RESISTANCE:
+        return this->ult_res;
+    case CreatureTimedEffect::WRAITH_FORM:
+        return this->wraith_form;
+    case CreatureTimedEffect::TIM_ESP:
+        return this->tim_esp;
+    case CreatureTimedEffect::TIM_STEALTH:
+        return this->tim_stealth;
+    case CreatureTimedEffect::TIM_REGEN:
+        return this->tim_regen;
+    case CreatureTimedEffect::TSUYOSHI:
+        return this->tsuyoshi;
+    case CreatureTimedEffect::TIM_INVIS:
+        return this->tim_invis;
+    case CreatureTimedEffect::TIM_INFRA:
+        return this->tim_infra;
     default:
         return 0;
     }
@@ -114,6 +130,30 @@ void PlayerType::set_timed_effect(CreatureTimedEffect effect, short value)
         break;
     case CreatureTimedEffect::SHIELD:
         this->shield = value;
+        break;
+    case CreatureTimedEffect::ULTIMATE_RESISTANCE:
+        this->ult_res = value;
+        break;
+    case CreatureTimedEffect::WRAITH_FORM:
+        this->wraith_form = value;
+        break;
+    case CreatureTimedEffect::TIM_ESP:
+        this->tim_esp = value;
+        break;
+    case CreatureTimedEffect::TIM_STEALTH:
+        this->tim_stealth = value;
+        break;
+    case CreatureTimedEffect::TIM_REGEN:
+        this->tim_regen = value;
+        break;
+    case CreatureTimedEffect::TSUYOSHI:
+        this->tsuyoshi = value;
+        break;
+    case CreatureTimedEffect::TIM_INVIS:
+        this->tim_invis = value;
+        break;
+    case CreatureTimedEffect::TIM_INFRA:
+        this->tim_infra = value;
         break;
     default:
         break;


### PR DESCRIPTION
…

Phase 3 タイムドエフェクト統一の拡張。以下 8 種のプレイヤー固有時限効果
を CreatureTimedEffect 列挙に追加し、PlayerType::get_timed_effect / set_timed_effect で対応する直接フィールドへのディスパッチを実装する。

- ULTIMATE_RESISTANCE (ult_res)
- WRAITH_FORM (wraith_form)
- TIM_ESP (tim_esp)
- TIM_STEALTH (tim_stealth)
- TIM_REGEN (tim_regen)
- TSUYOSHI (tsuyoshi)
- TIM_INVIS (tim_invis)
- TIM_INFRA (tim_infra)

合わせて CreatureEntity に get_remaining_xxx() ヘルパーを追加。 モンスターはこれらの効果を持たないためデフォルト実装は 0 を返す。

呼び出しサイトの移行は後続コミットで実施する。