### PR TITLE
refactor: ult_res/wraith_form/tim_esp 等の読み取りを統一インターフェース経由に移行（Phase 3）

### DIFF
--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -181,7 +181,7 @@ int staff_effect(CreatureEntity &creature, int sval, bool *use_charge, bool powe
     }
 
     case SV_STAFF_DETECT_INVIS: {
-        if (set_tim_invis(creature, creature.tim_invis + 12 + randint1(12), false)) {
+        if (set_tim_invis(creature, creature.get_remaining_tim_invis() + 12 + randint1(12), false)) {
             ident = true;
         }
         break;

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -39,16 +39,16 @@ void reduce_magic_effects_timeout(CreatureEntity &creature)
         (void)bss.mod_blindness(-1);
     }
 
-    if (creature.tim_invis) {
-        (void)set_tim_invis(creature, creature.tim_invis - 1, true);
+    if (const auto remaining = creature.get_remaining_tim_invis(); remaining > 0) {
+        (void)set_tim_invis(creature, remaining - 1, true);
     }
 
     if (creature.suppress_multi_reward) {
         creature.suppress_multi_reward = false;
     }
 
-    if (creature.tim_esp) {
-        (void)set_tim_esp(creature, creature.tim_esp - 1, true);
+    if (const auto remaining = creature.get_remaining_tim_esp(); remaining > 0) {
+        (void)set_tim_esp(creature, remaining - 1, true);
     }
 
     if (creature.ele_attack) {
@@ -65,12 +65,12 @@ void reduce_magic_effects_timeout(CreatureEntity &creature)
         }
     }
 
-    if (creature.tim_infra) {
-        (void)set_tim_infra(creature, creature.tim_infra - 1, true);
+    if (const auto remaining = creature.get_remaining_tim_infra(); remaining > 0) {
+        (void)set_tim_infra(creature, remaining - 1, true);
     }
 
-    if (creature.tim_stealth) {
-        (void)set_tim_stealth(creature, creature.tim_stealth - 1, true);
+    if (const auto remaining = creature.get_remaining_tim_stealth(); remaining > 0) {
+        (void)set_tim_stealth(creature, remaining - 1, true);
     }
 
     if (creature.tim_levitation) {
@@ -97,8 +97,8 @@ void reduce_magic_effects_timeout(CreatureEntity &creature)
         (void)set_resist_magic(creature, creature.resist_magic - 1, true);
     }
 
-    if (creature.tim_regen) {
-        (void)set_tim_regen(creature, creature.tim_regen - 1, true);
+    if (const auto remaining = creature.get_remaining_tim_regen(); remaining > 0) {
+        (void)set_tim_regen(creature, remaining - 1, true);
     }
 
     if (creature.tim_res_nether) {
@@ -165,8 +165,8 @@ void reduce_magic_effects_timeout(CreatureEntity &creature)
         (void)set_invuln(creature, creature.invuln - 1, true);
     }
 
-    if (creature.wraith_form) {
-        (void)set_wraith_form(creature, creature.wraith_form - 1, true);
+    if (const auto remaining = creature.get_remaining_wraith_form(); remaining > 0) {
+        (void)set_wraith_form(creature, remaining - 1, true);
     }
 
     if (const auto remaining = creature.get_remaining_hero(); remaining > 0) {
@@ -193,8 +193,8 @@ void reduce_magic_effects_timeout(CreatureEntity &creature)
         (void)set_magicdef(creature, creature.magicdef - 1, true);
     }
 
-    if (creature.tsuyoshi) {
-        (void)set_tsuyoshi(creature, creature.tsuyoshi - 1, true);
+    if (const auto remaining = creature.get_remaining_tsuyoshi(); remaining > 0) {
+        (void)set_tsuyoshi(creature, remaining - 1, true);
     }
 
     if (creature.oppose_acid) {
@@ -229,8 +229,8 @@ void reduce_magic_effects_timeout(CreatureEntity &creature)
         (void)set_tim_imm_dark(creature, creature.tim_imm_dark - 1, true);
     }
 
-    if (creature.ult_res) {
-        (void)set_ultimate_res(creature, creature.ult_res - 1, true);
+    if (const auto remaining = creature.get_remaining_ultimate_resistance(); remaining > 0) {
+        (void)set_ultimate_res(creature, remaining - 1, true);
     }
 
     if (effects->poison().is_poisoned()) {

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -427,11 +427,11 @@ void effect_player_lite(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 
-    if (!creature.wraith_form || check_multishadow(creature)) {
+    if (!creature.get_remaining_wraith_form() || check_multishadow(creature)) {
         return;
     }
 
-    creature.wraith_form = 0;
+    creature.set_timed_effect(CreatureTimedEffect::WRAITH_FORM, 0);
     msg_print(_("閃光のため非物質的な影の存在でいられなくなった。", "The light forces you out of your incorporeal shadow form."));
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -380,7 +380,7 @@ void process_player_hp_mp(CreatureEntity &creature)
      */
     if (terrain.flags.has_none_of({ TerrainCharacteristics::MOVE, TerrainCharacteristics::CAN_FLY })) {
         auto should_damage = !creature.is_invulnerable();
-        should_damage &= creature.wraith_form == 0;
+        should_damage &= creature.get_remaining_wraith_form() == 0;
         should_damage &= creature.tim_pass_wall == 0;
         should_damage &= (creature.hp > (creature.level / 5)) || !has_pass_wall(creature);
         if (should_damage) {

--- a/src/mspell/mspell-judgement.cpp
+++ b/src/mspell/mspell-judgement.cpp
@@ -223,7 +223,7 @@ bool dispel_check(CreatureEntity &creature, MONSTER_IDX m_idx)
         return true;
     }
 
-    if (creature.wraith_form) {
+    if (creature.get_remaining_wraith_form()) {
         return true;
     }
 
@@ -311,11 +311,11 @@ bool dispel_check(CreatureEntity &creature, MONSTER_IDX m_idx)
         }
     }
 
-    if (creature.ult_res) {
+    if (creature.get_remaining_ultimate_resistance()) {
         return true;
     }
 
-    if (creature.tsuyoshi) {
+    if (creature.get_remaining_tsuyoshi()) {
         return true;
     }
 

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -427,7 +427,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
     }
 
     if (creature.muta.has(PlayerMutationType::WEIRD_MIND) && !creature.anti_magic && one_in_(3000)) {
-        if (creature.tim_esp > 0) {
+        if (creature.get_remaining_tim_esp() > 0) {
             msg_print(_("精神にもやがかかった！", "Your mind feels cloudy!"));
             set_tim_esp(creature, 0, true);
         } else {

--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -115,9 +115,9 @@ bool QuaffEffects::influence(const ItemEntity &item, const bool is_rectal)
     case SV_POTION_DEATH:
         return this->death();
     case SV_POTION_INFRAVISION:
-        return set_tim_infra(this->creature, this->creature.tim_infra + 100 + randint1(100), false);
+        return set_tim_infra(this->creature, this->creature.get_remaining_tim_infra() + 100 + randint1(100), false);
     case SV_POTION_DETECT_INVIS:
-        return set_tim_invis(this->creature, this->creature.tim_invis + 12 + randint1(12), false);
+        return set_tim_invis(this->creature, this->creature.get_remaining_tim_invis() + 12 + randint1(12), false);
     case SV_POTION_SLOW_POISON:
         return BadStatusSetter(this->creature).set_poison(this->creature.effects()->poison().current() / 2);
     case SV_POTION_CURE_POISON:
@@ -205,7 +205,7 @@ bool QuaffEffects::influence(const ItemEntity &item, const bool is_rectal)
     case SV_POTION_NEO_TSUYOSHI:
         msg_print(_("「新・オクレ兄さん！」", "NEW Brother OKURE!"));
         msg_erase();
-        this->creature.tsuyoshi = 1;
+        this->creature.set_timed_effect(CreatureTimedEffect::TSUYOSHI, 1);
         (void)set_tsuyoshi(this->creature, 0, true);
         if (!has_resist_chaos(this->creature)) {
             (void)BadStatusSetter(this->creature).mod_hallucination(50 + randint1(100));
@@ -564,7 +564,7 @@ bool QuaffEffects::new_life()
 bool QuaffEffects::neo_tsuyoshi()
 {
     (void)BadStatusSetter(this->creature).hallucination(0);
-    (void)set_tsuyoshi(this->creature, this->creature.tsuyoshi + randint1(100) + 100, false);
+    (void)set_tsuyoshi(this->creature, this->creature.get_remaining_tsuyoshi() + randint1(100) + 100, false);
     return true;
 }
 
@@ -576,7 +576,7 @@ bool QuaffEffects::tsuyoshi()
 {
     msg_print(_("「オクレ兄さん！」", "Brother OKURE!"));
     msg_erase();
-    this->creature.tsuyoshi = 1;
+    this->creature.set_timed_effect(CreatureTimedEffect::TSUYOSHI, 1);
     (void)set_tsuyoshi(this->creature, 0, true);
     if (!has_resist_chaos(this->creature)) {
         (void)BadStatusSetter(this->creature).hallucination(50 + randint1(50));

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -114,7 +114,7 @@ static void spell_damcalc(CreatureEntity &creature, const CreatureEntity &monste
 
     case AttributeType::DARK:
         dam = dam * calc_dark_damage_rate(creature, CALC_MAX) / 100;
-        if (has_immune_dark(creature) || creature.wraith_form) {
+        if (has_immune_dark(creature) || creature.get_remaining_wraith_form()) {
             ignore_wraith_form = true;
         }
         break;
@@ -221,7 +221,7 @@ static void spell_damcalc(CreatureEntity &creature, const CreatureEntity &monste
         break;
     }
 
-    if (creature.wraith_form && !ignore_wraith_form) {
+    if (creature.get_remaining_wraith_form() && !ignore_wraith_form) {
         dam /= 2;
         if (!dam) {
             dam = 1;
@@ -315,7 +315,7 @@ static int blow_damcalc(const CreatureEntity &monster, CreatureEntity &creature,
         break;
     }
 
-    if (check_wraith_form && creature.wraith_form) {
+    if (check_wraith_form && creature.get_remaining_wraith_form()) {
         dam /= 2;
         if (!dam) {
             dam = 1;

--- a/src/player-ability/player-constitution.cpp
+++ b/src/player-ability/player-constitution.cpp
@@ -88,7 +88,7 @@ int16_t PlayerConstitution::stance_bonus()
     } else if (pc.monk_stance_is(MonkStanceType::SUZAKU)) {
         result -= 2;
     }
-    if (this->creature.tsuyoshi) {
+    if (this->creature.get_remaining_tsuyoshi()) {
         result += 4;
     }
 

--- a/src/player-ability/player-strength.cpp
+++ b/src/player-ability/player-strength.cpp
@@ -64,7 +64,7 @@ int16_t PlayerStrength::time_effect_bonus()
         }
     }
 
-    if (this->creature.tsuyoshi) {
+    if (this->creature.get_remaining_tsuyoshi()) {
         result += 4;
     }
 

--- a/src/player-info/body-improvement-info.cpp
+++ b/src/player-info/body-improvement-info.cpp
@@ -33,7 +33,7 @@ void set_body_improvement_info_1(CreatureEntity &creature, self_info_type *self_
         self_ptr->info_list.emplace_back(_("あなたは現在傷つかない。", "You are temporarily invulnerable."));
     }
 
-    if (creature.wraith_form) {
+    if (creature.get_remaining_wraith_form()) {
         self_ptr->info_list.emplace_back(_("あなたは一時的に幽体化している。", "You are temporarily incorporeal."));
     }
 }

--- a/src/player-info/resistance-info.cpp
+++ b/src/player-info/resistance-info.cpp
@@ -75,7 +75,7 @@ void set_high_resistance_info(CreatureEntity &creature, self_info_type *self_ptr
         self_ptr->info_list.emplace_back(_("あなたは閃光に弱い。", "You are susceptible to damage from bright light."));
     }
 
-    if (has_immune_dark(creature) || creature.wraith_form) {
+    if (has_immune_dark(creature) || creature.get_remaining_wraith_form()) {
         self_ptr->info_list.emplace_back(_("あなたは暗黒に対する完全なる免疫を持っている。", "You are completely immune to darkness."));
     } else if (has_resist_dark(creature)) {
         self_ptr->info_list.emplace_back(_("あなたは暗黒への耐性を持っている。", "You are resistant to darkness."));

--- a/src/player-info/self-info.cpp
+++ b/src/player-info/self-info.cpp
@@ -369,13 +369,13 @@ void report_magics(CreatureEntity &subject)
             _("あなたは神秘のシールドで守られている", "You are protected by a mystic shield"));
     }
 
-    if (subject.invuln) {
-        info.emplace_back(report_magics_aux(subject.invuln),
+    if (const auto remaining = subject.get_remaining_invulnerability(); remaining > 0) {
+        info.emplace_back(report_magics_aux(remaining),
             _("あなたは無敵だ", "You are invulnerable"));
     }
 
-    if (subject.wraith_form) {
-        info.emplace_back(report_magics_aux(subject.wraith_form),
+    if (const auto remaining = subject.get_remaining_wraith_form(); remaining > 0) {
+        info.emplace_back(report_magics_aux(remaining),
             _("あなたは幽体化している", "You are incorporeal"));
     }
 

--- a/src/player-status/player-infravision.cpp
+++ b/src/player-status/player-infravision.cpp
@@ -60,7 +60,7 @@ int16_t PlayerInfravision::mutation_bonus()
 int16_t PlayerInfravision::time_effect_bonus()
 {
     int16_t bonus = 0;
-    if (this->creature.tim_infra) {
+    if (this->creature.get_remaining_tim_infra()) {
         bonus += 3;
     }
 

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -340,7 +340,7 @@ int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_
             }
         }
 
-        if (creature.wraith_form) {
+        if (creature.get_remaining_wraith_form()) {
             if (damage_type == DAMAGE_FORCE) {
                 msg_print(_("半物質の体が切り裂かれた！", "The attack cuts through your ethereal body!"));
             } else {

--- a/src/player/player-status-resist.cpp
+++ b/src/player/player-status-resist.cpp
@@ -268,7 +268,7 @@ PERCENTAGE calc_lite_damage_rate(CreatureEntity &creature, rate_calc_type_mode m
         per /= randrate(4, 7, mode);
     }
 
-    if (creature.wraith_form) {
+    if (creature.get_remaining_wraith_form()) {
         per *= 2;
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -447,7 +447,7 @@ static void update_max_hitpoints(CreatureEntity &creature)
     if (creature.is_shero()) {
         mhp += 30;
     }
-    if (creature.tsuyoshi) {
+    if (creature.get_remaining_tsuyoshi()) {
         mhp += 50;
     }
     if (SpellHex(creature).is_spelling_specific(HEX_XTRA_MIGHT)) {
@@ -1161,7 +1161,7 @@ static ACTION_SKILL_POWER calc_saving_throw(CreatureEntity &creature)
         pow = 10;
     }
 
-    if ((creature.ult_res || creature.resist_magic || creature.magicdef) && (pow < (95 + creature.level))) {
+    if ((creature.get_remaining_ultimate_resistance() || creature.resist_magic || creature.magicdef) && (pow < (95 + creature.level))) {
         pow = 95 + creature.level;
     }
 
@@ -1823,7 +1823,7 @@ static ARMOUR_CLASS calc_to_ac(CreatureEntity &creature, bool is_real_value)
         ac -= 50;
     }
 
-    if (creature.ult_res || (pc.samurai_stance_is(SamuraiStanceType::MUSOU))) {
+    if (creature.get_remaining_ultimate_resistance() || (pc.samurai_stance_is(SamuraiStanceType::MUSOU))) {
         ac += 100;
     } else if (creature.tsubureru || creature.get_remaining_shield() || creature.magicdef) {
         ac += 50;
@@ -3083,24 +3083,24 @@ bool is_tim_esp(CreatureEntity &creature)
 {
     auto sniper_data = CreatureClass(creature).get_specific_data<SniperData>();
     auto sniper_concent = sniper_data ? sniper_data->concent : 0;
-    return creature.tim_esp || music_singing(creature, MUSIC_MIND) || (sniper_concent >= CONCENT_TELE_THRESHOLD);
+    return creature.get_remaining_tim_esp() || music_singing(creature, MUSIC_MIND) || (sniper_concent >= CONCENT_TELE_THRESHOLD);
 }
 
 bool is_tim_stealth(CreatureEntity &creature)
 {
-    return creature.tim_stealth || music_singing(creature, MUSIC_STEALTH);
+    return creature.get_remaining_tim_stealth() || music_singing(creature, MUSIC_STEALTH);
 }
 
 bool is_time_limit_esp(CreatureEntity &creature)
 {
     auto sniper_data = CreatureClass(creature).get_specific_data<SniperData>();
     auto sniper_concent = sniper_data ? sniper_data->concent : 0;
-    return creature.tim_esp || music_singing(creature, MUSIC_MIND) || (sniper_concent >= CONCENT_TELE_THRESHOLD);
+    return creature.get_remaining_tim_esp() || music_singing(creature, MUSIC_MIND) || (sniper_concent >= CONCENT_TELE_THRESHOLD);
 }
 
 bool is_time_limit_stealth(CreatureEntity &creature)
 {
-    return creature.tim_stealth || music_singing(creature, MUSIC_STEALTH);
+    return creature.get_remaining_tim_stealth() || music_singing(creature, MUSIC_STEALTH);
 }
 
 /*!

--- a/src/player/race-resistances.cpp
+++ b/src/player/race-resistances.cpp
@@ -69,7 +69,7 @@ void tim_player_immunity(CreatureEntity &creature, TrFlags &flags)
     if (creature.special_defense & DEFENSE_COLD) {
         flags.set(TR_RES_COLD);
     }
-    if (creature.wraith_form) {
+    if (creature.get_remaining_wraith_form()) {
         flags.set(TR_RES_DARK);
     }
 }

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -382,7 +382,7 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         }
 
         if (stop) {
-            if (!creature.tim_stealth) {
+            if (!creature.get_remaining_tim_stealth()) {
                 msg_print(_("姿がはっきりと見えるようになった。", "You are no longer hidden."));
             }
         }

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -650,8 +650,8 @@ bool cosmic_cast_off(CreatureEntity &creature, ItemEntity **o_ptr_ptr)
     BadStatusSetter bss(creature);
     (void)bss.mod_blindness(t);
     (void)bss.set_fear(0);
-    (void)set_tim_esp(creature, creature.tim_esp + t, false);
-    (void)set_tim_regen(creature, creature.tim_regen + t, false);
+    (void)set_tim_esp(creature, creature.get_remaining_tim_esp() + t, false);
+    (void)set_tim_regen(creature, creature.get_remaining_tim_regen() + t, false);
     (void)set_hero(creature, creature.get_remaining_hero() + t, false);
     (void)set_blessed(creature, creature.get_remaining_blessed() + t, false);
     (void)mod_acceleration(creature, t, false);

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -352,7 +352,7 @@ tl::optional<uint8_t> get_monochrome_display_color(CreatureEntity &creature)
     if (creature.is_invulnerable() || creature.timewalk) {
         return TERM_WHITE;
     }
-    if (creature.wraith_form) {
+    if (creature.get_remaining_wraith_form()) {
         return TERM_L_DARK;
     }
 

--- a/src/view/display-player-stat-info.cpp
+++ b/src/view/display-player-stat-info.cpp
@@ -225,7 +225,7 @@ static int compensation_stat_by_mutation(CreatureEntity &creature, int stat)
         if (creature.muta.has(PlayerMutationType::PUNY)) {
             compensation -= 4;
         }
-        if (creature.tsuyoshi) {
+        if (creature.get_remaining_tsuyoshi()) {
             compensation += 4;
         }
         return compensation;
@@ -267,7 +267,7 @@ static int compensation_stat_by_mutation(CreatureEntity &creature, int stat)
         if (creature.muta.has(PlayerMutationType::FLESH_ROT)) {
             compensation -= 2;
         }
-        if (creature.tsuyoshi) {
+        if (creature.get_remaining_tsuyoshi()) {
             compensation += 4;
         }
         return compensation;

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -444,7 +444,7 @@ void print_status(CreatureEntity &creature)
     term_erase(0, row_statbar, max_col_statbar);
     BIT_FLAGS bar_flags[3]{};
     auto effects = creature.effects();
-    if (creature.tsuyoshi) {
+    if (creature.get_remaining_tsuyoshi()) {
         ADD_BAR_FLAG(BAR_TSUYOSHI);
     }
 
@@ -468,7 +468,7 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_POISONED);
     }
 
-    if (creature.tim_invis) {
+    if (creature.get_remaining_tim_invis()) {
         ADD_BAR_FLAG(BAR_SENSEUNSEEN);
     }
 
@@ -482,11 +482,11 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_TELEPATHY);
     }
 
-    if (creature.tim_regen) {
+    if (creature.get_remaining_tim_regen()) {
         ADD_BAR_FLAG(BAR_REGENERATION);
     }
 
-    if (creature.tim_infra) {
+    if (creature.get_remaining_tim_infra()) {
         ADD_BAR_FLAG(BAR_INFRAVISION);
     }
 
@@ -498,7 +498,7 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_INVULN);
     }
 
-    if (creature.wraith_form) {
+    if (creature.get_remaining_wraith_form()) {
         ADD_BAR_FLAG(BAR_WRAITH);
     }
 
@@ -530,7 +530,7 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_EXPAND);
     }
 
-    if (creature.shield) {
+    if (creature.get_remaining_shield()) {
         ADD_BAR_FLAG(BAR_STONESKIN);
     }
 
@@ -603,7 +603,7 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_REGMAGIC);
     }
 
-    if (creature.ult_res) {
+    if (creature.get_remaining_ultimate_resistance()) {
         ADD_BAR_FLAG(BAR_ULTIMATE);
     }
 


### PR DESCRIPTION
先行コミットで追加した get_remaining_ultimate_resistance() / wraith_form() / tim_esp() / tim_stealth() / tim_regen() / tsuyoshi() / tim_invis() / tim_infra() ヘルパーを、ゲームロジック側の読み取り呼び出し 23 ファイルに展開する。

主な対象:
- core/magic-effects-timeout-reducer: 8 種の効果時間カウントダウン
- window/main-window-stat-poster: ステータスバー表示判定
- player/player-status: is_tim_esp / is_time_limit_stealth 等
- mspell/mspell-judgement: ディスペル判定
- spell/spells-status: 小宇宙燃焼（既存残値 + 新規延長）
- object-use/quaff/quaff-effects: つよし系・透明視系ポーション
- effect/effect-player-resist-hurt: wraith_form 解除（write も移行）
- object/warning: 幽体化ダメージ半減判定
- view/display-map / view/display-player-stat-info: 表示色 / ステータス表示
- player-info/self-info / body-improvement-info / resistance-info: 自己情報表示
- player-status/player-infravision: 赤外線視ボーナス
- player-ability/player-strength / constitution: つよし能力値補正
- player/race-resistances / player-status-resist / player-damage: 耐性・ダメージ判定
- cmd-item/cmd-usestaff: 透明視スタッフ
- mutation/mutation-processor: 奇妙な精神変異
- realm/realm-song: 隠密ソング停止

save/load および set_xxx セッター実装側の raw フィールドアクセスは
保存・更新のための直接操作として残す段階的移行方針。