### PR TITLE
refactor: 全セッター関数の直接フィールドアクセスを get/set_timed_effect() 経由に変換（Phase 3 継続）

### DIFF
--- a/src/status/body-improvement.cpp
+++ b/src/status/body-improvement.cpp
@@ -98,8 +98,8 @@ bool set_invuln(CreatureEntity &creature, short v, bool do_dec)
         SubWindowRedrawingFlag::DUNGEON,
     };
     if (v) {
-        if (creature.invuln && !do_dec) {
-            if (creature.invuln > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::INVULNERABILITY) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::INVULNERABILITY) > v) {
                 return false;
             }
         } else if (!creature.is_invulnerable()) {
@@ -114,7 +114,7 @@ bool set_invuln(CreatureEntity &creature, short v, bool do_dec)
             rfu.set_flags(flags_swrf);
         }
     } else {
-        if (creature.invuln && !music_singing(creature, MUSIC_INVULN)) {
+        if (creature.get_timed_effect(CreatureTimedEffect::INVULNERABILITY) && !music_singing(creature, MUSIC_INVULN)) {
             msg_print(_("無敵ではなくなった。", "The invulnerability wears off."));
             notice = true;
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
@@ -124,7 +124,7 @@ bool set_invuln(CreatureEntity &creature, short v, bool do_dec)
         }
     }
 
-    creature.invuln = v;
+    creature.set_timed_effect(CreatureTimedEffect::INVULNERABILITY, v);
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
 
     if (!notice) {
@@ -157,22 +157,22 @@ bool set_tim_regen(CreatureEntity &creature, short v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_regen && !do_dec) {
-            if (creature.tim_regen > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_REGEN) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_REGEN) > v) {
                 return false;
             }
-        } else if (!creature.tim_regen) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_REGEN)) {
             msg_print(_("回復力が上がった！", "You feel yourself regenerating quickly!"));
             notice = true;
         }
     } else {
-        if (creature.tim_regen) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_REGEN)) {
             msg_print(_("素早く回復する感じがなくなった。", "You feel you are no longer regenerating quickly."));
             notice = true;
         }
     }
 
-    creature.tim_regen = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_REGEN, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -205,22 +205,22 @@ bool set_tim_reflect(CreatureEntity &creature, short v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_reflect && !do_dec) {
-            if (creature.tim_reflect > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_REFLECT) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_REFLECT) > v) {
                 return false;
             }
-        } else if (!creature.tim_reflect) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_REFLECT)) {
             msg_print(_("体の表面が滑かになった気がする。", "Your body becames smooth."));
             notice = true;
         }
     } else {
-        if (creature.tim_reflect) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_REFLECT)) {
             msg_print(_("体の表面が滑かでなくなった。", "Your body is no longer smooth."));
             notice = true;
         }
     }
 
-    creature.tim_reflect = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_REFLECT, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -253,22 +253,22 @@ bool set_pass_wall(CreatureEntity &creature, short v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_pass_wall && !do_dec) {
-            if (creature.tim_pass_wall > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_PASS_WALL) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_PASS_WALL) > v) {
                 return false;
             }
-        } else if (!creature.tim_pass_wall) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_PASS_WALL)) {
             msg_print(_("体が半物質の状態になった。", "You became ethereal."));
             notice = true;
         }
     } else {
-        if (creature.tim_pass_wall) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_PASS_WALL)) {
             msg_print(_("体が物質化した。", "You are no longer ethereal."));
             notice = true;
         }
     }
 
-    creature.tim_pass_wall = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_PASS_WALL, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -301,22 +301,22 @@ bool set_tim_emission(CreatureEntity &creature, short v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_emission && !do_dec) {
-            if (creature.tim_emission > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_EMISSION) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_EMISSION) > v) {
                 return false;
             }
-        } else if (!creature.tim_emission) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_EMISSION)) {
             msg_print(_("体が発光した。", "Your body emit light."));
             notice = true;
         }
     } else {
-        if (creature.tim_emission) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_EMISSION)) {
             msg_print(_("体の光が消え去った。", "Your body stopped emitting light."));
             notice = true;
         }
     }
 
-    creature.tim_emission = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_EMISSION, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -349,22 +349,22 @@ bool set_tim_exorcism(CreatureEntity &creature, short v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_exorcism && !do_dec) {
-            if (creature.tim_exorcism > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_EXORCISM) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_EXORCISM) > v) {
                 return false;
             }
-        } else if (!creature.tim_exorcism) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_EXORCISM)) {
             msg_print(_("浄化の力を得た気がする。", "You feel you become an exorcist."));
             notice = true;
         }
     } else {
-        if (creature.tim_exorcism) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_EXORCISM)) {
             msg_print(_("浄化の力を失った。", "You are no longer exorcist."));
             notice = true;
         }
     }
 
-    creature.tim_exorcism = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_EXORCISM, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -134,14 +134,14 @@ bool set_acceleration(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
             if (acceleration.current() > v) {
                 return false;
             }
-        } else if (!creature.is_fast() && !creature.lightspeed) {
+        } else if (!creature.is_fast() && !creature.get_timed_effect(CreatureTimedEffect::LIGHTSPEED)) {
             msg_print(_("素早く動けるようになった！", "You feel yourself moving much faster!"));
             notice = true;
             chg_virtue(creature, Virtue::PATIENCE, -1);
             chg_virtue(creature, Virtue::DILIGENCE, 1);
         }
     } else {
-        if (acceleration.is_fast() && !creature.lightspeed) {
+        if (acceleration.is_fast() && !creature.get_timed_effect(CreatureTimedEffect::LIGHTSPEED)) {
             auto is_singing = music_singing(creature, MUSIC_SPEED);
             is_singing |= music_singing(creature, MUSIC_SHERO);
             if (!is_singing) {
@@ -186,22 +186,22 @@ bool set_shield(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.shield && !do_dec) {
-            if (creature.shield > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::SHIELD) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::SHIELD) > v) {
                 return false;
             }
-        } else if (!creature.shield) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::SHIELD)) {
             msg_print(_("肌が石になった。", "Your skin turns to stone."));
             notice = true;
         }
     } else {
-        if (creature.shield) {
+        if (creature.get_timed_effect(CreatureTimedEffect::SHIELD)) {
             msg_print(_("肌が元に戻った。", "Your skin returns to normal."));
             notice = true;
         }
     }
 
-    creature.shield = v;
+    creature.set_timed_effect(CreatureTimedEffect::SHIELD, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -234,22 +234,22 @@ bool set_magicdef(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.magicdef && !do_dec) {
-            if (creature.magicdef > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::MAGICDEF) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::MAGICDEF) > v) {
                 return false;
             }
-        } else if (!creature.magicdef) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::MAGICDEF)) {
             msg_print(_("魔法の防御力が増したような気がする。", "You feel more resistant to magic."));
             notice = true;
         }
     } else {
-        if (creature.magicdef) {
+        if (creature.get_timed_effect(CreatureTimedEffect::MAGICDEF)) {
             msg_print(_("魔法の防御力が元に戻った。", "You feel less resistant to magic."));
             notice = true;
         }
     }
 
-    creature.magicdef = v;
+    creature.set_timed_effect(CreatureTimedEffect::MAGICDEF, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -282,8 +282,8 @@ bool set_blessed(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.blessed && !do_dec) {
-            if (creature.blessed > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::BLESSED) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::BLESSED) > v) {
                 return false;
             }
         } else if (!creature.is_blessed()) {
@@ -291,13 +291,13 @@ bool set_blessed(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
             notice = true;
         }
     } else {
-        if (creature.blessed && !music_singing(creature, MUSIC_BLESS)) {
+        if (creature.get_timed_effect(CreatureTimedEffect::BLESSED) && !music_singing(creature, MUSIC_BLESS)) {
             msg_print(_("高潔な気分が消え失せた。", "The prayer has expired."));
             notice = true;
         }
     }
 
-    creature.blessed = v;
+    creature.set_timed_effect(CreatureTimedEffect::BLESSED, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -330,8 +330,8 @@ bool set_hero(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.hero && !do_dec) {
-            if (creature.hero > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::HERO) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::HERO) > v) {
                 return false;
             }
         } else if (!creature.is_hero()) {
@@ -339,13 +339,13 @@ bool set_hero(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
             notice = true;
         }
     } else {
-        if (creature.hero && !music_singing(creature, MUSIC_HERO) && !music_singing(creature, MUSIC_SHERO)) {
+        if (creature.get_timed_effect(CreatureTimedEffect::HERO) && !music_singing(creature, MUSIC_HERO) && !music_singing(creature, MUSIC_SHERO)) {
             msg_print(_("ヒーローの気分が消え失せた。", "The heroism wears off."));
             notice = true;
         }
     }
 
-    creature.hero = v;
+    creature.set_timed_effect(CreatureTimedEffect::HERO, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -383,11 +383,11 @@ bool set_mimic(CreatureEntity &creature, TIME_EFFECT v, MimicKindType mimic_race
     }
 
     if (v) {
-        if (creature.tim_mimic && (creature.mimic_form == mimic_race_idx) && !do_dec) {
-            if (creature.tim_mimic > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC) && (creature.mimic_form == mimic_race_idx) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC) > v) {
                 return false;
             }
-        } else if ((!creature.tim_mimic) || (creature.mimic_form != mimic_race_idx)) {
+        } else if ((!creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC)) || (creature.mimic_form != mimic_race_idx)) {
             msg_print(_("自分の体が変わってゆくのを感じた。", "You feel that your body changes."));
             creature.mimic_form = mimic_race_idx;
             notice = true;
@@ -395,7 +395,7 @@ bool set_mimic(CreatureEntity &creature, TIME_EFFECT v, MimicKindType mimic_race
     }
 
     else {
-        if (creature.tim_mimic) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC)) {
             msg_print(_("変身が解けた。", "You are no longer transformed."));
             if (creature.mimic_form == MimicKindType::DEMON) {
                 set_oppose_fire(creature, 0, true);
@@ -406,7 +406,7 @@ bool set_mimic(CreatureEntity &creature, TIME_EFFECT v, MimicKindType mimic_race
         }
     }
 
-    creature.tim_mimic = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_MIMIC, v);
     if (!notice) {
         return false;
     }
@@ -452,22 +452,22 @@ bool set_berserk(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.berserk && !do_dec) {
-            if (creature.berserk > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::BERSERK) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::BERSERK) > v) {
                 return false;
             }
-        } else if (!creature.berserk) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::BERSERK)) {
             msg_print(_("殺戮マシーンになった気がする！", "You feel like a killing machine!"));
             notice = true;
         }
     } else {
-        if (creature.berserk) {
+        if (creature.get_timed_effect(CreatureTimedEffect::BERSERK)) {
             msg_print(_("野蛮な気持ちが消え失せた。", "You feel less berserk."));
             notice = true;
         }
     }
 
-    creature.berserk = v;
+    creature.set_timed_effect(CreatureTimedEffect::BERSERK, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -509,11 +509,11 @@ bool set_wraith_form(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
         SubWindowRedrawingFlag::DUNGEON,
     };
     if (v) {
-        if (creature.wraith_form && !do_dec) {
-            if (creature.wraith_form > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM) > v) {
                 return false;
             }
-        } else if (!creature.wraith_form) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
             msg_print(_("物質界を離れて幽鬼のような存在になった！", "You leave the physical world and turn into a wraith-being!"));
             notice = true;
             chg_virtue(creature, Virtue::UNLIFE, 3);
@@ -525,7 +525,7 @@ bool set_wraith_form(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
             rfu.set_flags(flags_swrf);
         }
     } else {
-        if (creature.wraith_form) {
+        if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
             msg_print(_("不透明になった感じがする。", "You feel opaque."));
             notice = true;
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
@@ -534,7 +534,7 @@ bool set_wraith_form(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
         }
     }
 
-    creature.wraith_form = v;
+    creature.set_timed_effect(CreatureTimedEffect::WRAITH_FORM, v);
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
         return false;
@@ -566,17 +566,17 @@ bool set_tsuyoshi(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tsuyoshi && !do_dec) {
-            if (creature.tsuyoshi > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TSUYOSHI) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TSUYOSHI) > v) {
                 return false;
             }
-        } else if (!creature.tsuyoshi) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TSUYOSHI)) {
             msg_print(_("「オクレ兄さん！」", "Brother OKURE!"));
             notice = true;
             chg_virtue(creature, Virtue::VITALITY, 2);
         }
     } else {
-        if (creature.tsuyoshi) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TSUYOSHI)) {
             msg_print(_("肉体が急速にしぼんでいった。", "Your body has quickly shriveled."));
 
             (void)dec_stat(creature, A_CON, 20, true);
@@ -587,7 +587,7 @@ bool set_tsuyoshi(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
         }
     }
 
-    creature.tsuyoshi = v;
+    creature.set_timed_effect(CreatureTimedEffect::TSUYOSHI, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {

--- a/src/status/element-resistance.cpp
+++ b/src/status/element-resistance.cpp
@@ -30,8 +30,8 @@ bool set_oppose_acid(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.oppose_acid && !do_dec) {
-            if (creature.oppose_acid > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ACID) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ACID) > v) {
                 return false;
             }
         } else if (!is_oppose_acid(creature)) {
@@ -39,14 +39,14 @@ bool set_oppose_acid(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
             notice = true;
         }
     } else {
-        if (creature.oppose_acid && !music_singing(creature, MUSIC_RESIST) &&
+        if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ACID) && !music_singing(creature, MUSIC_RESIST) &&
             !CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU)) {
             msg_print(_("酸への耐性が薄れた気がする。", "You feel less resistant to acid."));
             notice = true;
         }
     }
 
-    creature.oppose_acid = v;
+    creature.set_timed_effect(CreatureTimedEffect::OPPOSE_ACID, v);
     if (!notice) {
         return false;
     }
@@ -77,8 +77,8 @@ bool set_oppose_elec(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.oppose_elec && !do_dec) {
-            if (creature.oppose_elec > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ELEC) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ELEC) > v) {
                 return false;
             }
         } else if (!is_oppose_elec(creature)) {
@@ -86,14 +86,14 @@ bool set_oppose_elec(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
             notice = true;
         }
     } else {
-        if (creature.oppose_elec && !music_singing(creature, MUSIC_RESIST) &&
+        if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ELEC) && !music_singing(creature, MUSIC_RESIST) &&
             !CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU)) {
             msg_print(_("電撃への耐性が薄れた気がする。", "You feel less resistant to electricity."));
             notice = true;
         }
     }
 
-    creature.oppose_elec = v;
+    creature.set_timed_effect(CreatureTimedEffect::OPPOSE_ELEC, v);
     if (!notice) {
         return false;
     }
@@ -126,8 +126,8 @@ bool set_oppose_fire(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
         v = 1;
     }
     if (v) {
-        if (creature.oppose_fire && !do_dec) {
-            if (creature.oppose_fire > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE) > v) {
                 return false;
             }
         } else if (!is_oppose_fire(creature)) {
@@ -135,14 +135,14 @@ bool set_oppose_fire(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
             notice = true;
         }
     } else {
-        if (creature.oppose_fire && !music_singing(creature, MUSIC_RESIST) &&
+        if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE) && !music_singing(creature, MUSIC_RESIST) &&
             !CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU)) {
             msg_print(_("火への耐性が薄れた気がする。", "You feel less resistant to fire."));
             notice = true;
         }
     }
 
-    creature.oppose_fire = v;
+    creature.set_timed_effect(CreatureTimedEffect::OPPOSE_FIRE, v);
     if (!notice) {
         return false;
     }
@@ -172,8 +172,8 @@ bool set_oppose_cold(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.oppose_cold && !do_dec) {
-            if (creature.oppose_cold > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD) > v) {
                 return false;
             }
         } else if (!is_oppose_cold(creature)) {
@@ -181,14 +181,14 @@ bool set_oppose_cold(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
             notice = true;
         }
     } else {
-        if (creature.oppose_cold && !music_singing(creature, MUSIC_RESIST) &&
+        if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD) && !music_singing(creature, MUSIC_RESIST) &&
             !CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU)) {
             msg_print(_("冷気への耐性が薄れた気がする。", "You feel less resistant to cold."));
             notice = true;
         }
     }
 
-    creature.oppose_cold = v;
+    creature.set_timed_effect(CreatureTimedEffect::OPPOSE_COLD, v);
     if (!notice) {
         return false;
     }
@@ -222,8 +222,8 @@ bool set_oppose_pois(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.oppose_pois && !do_dec) {
-            if (creature.oppose_pois > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_POIS) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_POIS) > v) {
                 return false;
             }
         } else if (!is_oppose_pois(creature)) {
@@ -231,14 +231,14 @@ bool set_oppose_pois(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
             notice = true;
         }
     } else {
-        if (creature.oppose_pois && !music_singing(creature, MUSIC_RESIST) &&
+        if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_POIS) && !music_singing(creature, MUSIC_RESIST) &&
             !pc.samurai_stance_is(SamuraiStanceType::MUSOU)) {
             msg_print(_("毒への耐性が薄れた気がする。", "You feel less resistant to poison."));
             notice = true;
         }
     }
 
-    creature.oppose_pois = v;
+    creature.set_timed_effect(CreatureTimedEffect::OPPOSE_POIS, v);
     if (!notice) {
         return false;
     }
@@ -254,7 +254,7 @@ bool set_oppose_pois(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
 
 bool is_oppose_acid(CreatureEntity &creature)
 {
-    auto can_oppose_acid = creature.oppose_acid != 0;
+    auto can_oppose_acid = creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ACID) != 0;
     can_oppose_acid |= music_singing(creature, MUSIC_RESIST);
     can_oppose_acid |= CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU);
     return can_oppose_acid;
@@ -262,7 +262,7 @@ bool is_oppose_acid(CreatureEntity &creature)
 
 bool is_oppose_elec(CreatureEntity &creature)
 {
-    auto can_oppose_elec = creature.oppose_elec != 0;
+    auto can_oppose_elec = creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ELEC) != 0;
     can_oppose_elec |= music_singing(creature, MUSIC_RESIST);
     can_oppose_elec |= CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU);
     return can_oppose_elec;
@@ -270,7 +270,7 @@ bool is_oppose_elec(CreatureEntity &creature)
 
 bool is_oppose_fire(CreatureEntity &creature)
 {
-    auto can_oppose_fire = creature.oppose_fire != 0;
+    auto can_oppose_fire = creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE) != 0;
     can_oppose_fire |= music_singing(creature, MUSIC_RESIST);
     can_oppose_fire |= CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU);
     can_oppose_fire |= creature.mimic_form == MimicKindType::DEMON;
@@ -280,7 +280,7 @@ bool is_oppose_fire(CreatureEntity &creature)
 
 bool is_oppose_cold(CreatureEntity &creature)
 {
-    auto can_oppose_cold = creature.oppose_cold != 0;
+    auto can_oppose_cold = creature.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD) != 0;
     can_oppose_cold |= music_singing(creature, MUSIC_RESIST);
     can_oppose_cold |= CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU);
     return can_oppose_cold;
@@ -289,7 +289,7 @@ bool is_oppose_cold(CreatureEntity &creature)
 bool is_oppose_pois(CreatureEntity &creature)
 {
     CreatureClass pc(creature);
-    auto can_oppose_pois = creature.oppose_pois != 0;
+    auto can_oppose_pois = creature.get_timed_effect(CreatureTimedEffect::OPPOSE_POIS) != 0;
     can_oppose_pois |= music_singing(creature, MUSIC_RESIST);
     can_oppose_pois |= pc.samurai_stance_is(SamuraiStanceType::MUSOU);
     can_oppose_pois |= pc.has_poison_resistance();

--- a/src/status/sight-setter.cpp
+++ b/src/status/sight-setter.cpp
@@ -46,8 +46,8 @@ bool set_tim_esp(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_esp && !do_dec) {
-            if (creature.tim_esp > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_ESP) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_ESP) > v) {
                 return false;
             }
         } else if (!creature.is_time_limit_esp()) {
@@ -55,13 +55,13 @@ bool set_tim_esp(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
             notice = true;
         }
     } else {
-        if (creature.tim_esp && !music_singing(creature, MUSIC_MIND)) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_ESP) && !music_singing(creature, MUSIC_MIND)) {
             msg_print(_("意識は元に戻った。", "Your consciousness contracts again."));
             notice = true;
         }
     }
 
-    creature.tim_esp = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_ESP, v);
     return update_sight(creature, notice);
 }
 
@@ -82,22 +82,22 @@ bool set_tim_invis(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_invis && !do_dec) {
-            if (creature.tim_invis > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_INVIS) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_INVIS) > v) {
                 return false;
             }
-        } else if (!creature.tim_invis) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_INVIS)) {
             msg_print(_("目が非常に敏感になった気がする！", "Your eyes feel very sensitive!"));
             notice = true;
         }
     } else {
-        if (creature.tim_invis) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_INVIS)) {
             msg_print(_("目の敏感さがなくなったようだ。", "Your eyes feel less sensitive."));
             notice = true;
         }
     }
 
-    creature.tim_invis = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_INVIS, v);
     return update_sight(creature, notice);
 }
 
@@ -118,21 +118,21 @@ bool set_tim_infra(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_infra && !do_dec) {
-            if (creature.tim_infra > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_INFRA) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_INFRA) > v) {
                 return false;
             }
-        } else if (!creature.tim_infra) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_INFRA)) {
             msg_print(_("目がランランと輝き始めた！", "Your eyes begin to tingle!"));
             notice = true;
         }
     } else {
-        if (creature.tim_infra) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_INFRA)) {
             msg_print(_("目の輝きがなくなった。", "Your eyes stop tingling."));
             notice = true;
         }
     }
 
-    creature.tim_infra = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_INFRA, v);
     return update_sight(creature, notice);
 }

--- a/src/status/temporary-resistance.cpp
+++ b/src/status/temporary-resistance.cpp
@@ -24,22 +24,22 @@ bool set_tim_levitation(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_levitation && !do_dec) {
-            if (creature.tim_levitation > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_LEVITATION) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_LEVITATION) > v) {
                 return false;
             }
-        } else if (!creature.tim_levitation) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_LEVITATION)) {
             msg_print(_("体が宙に浮き始めた。", "You begin to fly!"));
             notice = true;
         }
     } else {
-        if (creature.tim_levitation) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_LEVITATION)) {
             msg_print(_("もう宙に浮かべなくなった。", "You stop flying."));
             notice = true;
         }
     }
 
-    creature.tim_levitation = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_LEVITATION, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -66,22 +66,22 @@ bool set_ultimate_res(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.ult_res && !do_dec) {
-            if (creature.ult_res > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE) > v) {
                 return false;
             }
-        } else if (!creature.ult_res) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE)) {
             msg_print(_("あらゆることに対して耐性がついた気がする！", "You feel resistant!"));
             notice = true;
         }
     } else {
-        if (creature.ult_res) {
+        if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE)) {
             msg_print(_("あらゆることに対する耐性が薄れた気がする。", "You feel less resistant"));
             notice = true;
         }
     }
 
-    creature.ult_res = v;
+    creature.set_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -108,24 +108,24 @@ bool set_tim_res_nether(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_res_nether && !do_dec) {
-            if (creature.tim_res_nether > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_NETHER) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_NETHER) > v) {
                 return false;
             }
-        } else if (!creature.tim_res_nether) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_RES_NETHER)) {
             msg_print(_("地獄の力に対して耐性がついた気がする！", "You feel nether-resistant!"));
             notice = true;
         }
     }
 
     else {
-        if (creature.tim_res_nether) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_NETHER)) {
             msg_print(_("地獄の力に対する耐性が薄れた気がする。", "You feel less nether-resistant"));
             notice = true;
         }
     }
 
-    creature.tim_res_nether = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_RES_NETHER, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -151,22 +151,22 @@ bool set_tim_res_lite(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_res_lite && !do_dec) {
-            if (creature.tim_res_lite > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_LITE) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_LITE) > v) {
                 return false;
             }
-        } else if (!creature.tim_res_lite) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_RES_LITE)) {
             msg_print(_("閃光の力に対して耐性がついた気がする！", "You feel lite-resistant!"));
             notice = true;
         }
     } else {
-        if (creature.tim_res_lite) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_LITE)) {
             msg_print(_("閃光の力に対する耐性が薄れた気がする。", "You feel less lite-resistant"));
             notice = true;
         }
     }
 
-    creature.tim_res_lite = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_RES_LITE, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -192,22 +192,22 @@ bool set_tim_res_dark(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_res_dark && !do_dec) {
-            if (creature.tim_res_dark > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_DARK) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_DARK) > v) {
                 return false;
             }
-        } else if (!creature.tim_res_dark) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_RES_DARK)) {
             msg_print(_("暗黒の力に対して耐性がついた気がする！", "You feel dark-resistant!"));
             notice = true;
         }
     } else {
-        if (creature.tim_res_dark) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_DARK)) {
             msg_print(_("暗黒の力に対する耐性が薄れた気がする。", "You feel less dark-resistant"));
             notice = true;
         }
     }
 
-    creature.tim_res_dark = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_RES_DARK, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -232,21 +232,21 @@ bool set_tim_res_fear(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
         return false;
     }
     if (v) {
-        if (creature.tim_res_fear && !do_dec) {
-            if (creature.tim_res_fear > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_FEAR) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_FEAR) > v) {
                 return false;
             }
-        } else if (!creature.tim_res_fear) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_RES_FEAR)) {
             msg_print(_("恐怖の力に対して耐性がついた気がする！", "You feel fear-resistant!"));
             notice = true;
         }
     } else {
-        if (creature.tim_res_fear) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_FEAR)) {
             msg_print(_("恐怖の力に対する耐性が薄れた気がする。", "You feel less fear-resistant"));
             notice = true;
         }
     }
-    creature.tim_res_fear = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_RES_FEAR, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -270,22 +270,22 @@ bool set_tim_res_time(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_res_time && !do_dec) {
-            if (creature.tim_res_time > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_TIME) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_TIME) > v) {
                 return false;
             }
-        } else if (!creature.tim_res_time) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_RES_TIME)) {
             msg_print(_("時間逆転の力に対して耐性がついた気がする！", "You feel time-resistant!"));
             notice = true;
         }
     } else {
-        if (creature.tim_res_time) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_TIME)) {
             msg_print(_("時間逆転の力に対する耐性が薄れた気がする。", "You feel less time-resistant"));
             notice = true;
         }
     }
 
-    creature.tim_res_time = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_RES_TIME, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -310,21 +310,21 @@ bool set_tim_imm_dark(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
         return false;
     }
     if (v) {
-        if (creature.tim_imm_dark && !do_dec) {
-            if (creature.tim_imm_dark > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_IMM_DARK) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_IMM_DARK) > v) {
                 return false;
             }
-        } else if (!creature.tim_imm_dark) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_IMM_DARK)) {
             msg_print(_("暗黒の力に対して完全な耐性がついた気がする！", "You feel dark-immunity!"));
             notice = true;
         }
     } else {
-        if (creature.tim_imm_dark) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_IMM_DARK)) {
             msg_print(_("暗黒の力に対する完全な耐性を喪った気がする。", "You feel lose dark-immunity"));
             notice = true;
         }
     }
-    creature.tim_imm_dark = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_IMM_DARK, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {


### PR DESCRIPTION
buff-setter, body-improvement, sight-setter, temporary-resistance, element-resistance の全セッター関数において、TIME_EFFECT 直接フィールドの 読み書きを CreatureTimedEffect enum 経由の get/set_timed_effect() に統一した。

対象: set_shield, set_magicdef, set_blessed, set_hero, set_berserk, set_mimic, set_wraith_form, set_tsuyoshi, set_invuln, set_tim_regen, set_tim_reflect, set_pass_wall, set_tim_emission, set_tim_exorcism, set_tim_esp, set_tim_invis, set_tim_infra, set_tim_levitation, set_ultimate_res, set_tim_res_nether/lite/dark/fear/time, set_tim_imm_dark, set_oppose_acid/elec/fire/cold/pois, is_oppose_acid/elec/fire/cold/pois

https://claude.ai/code/session_01L1HaWfCTxckoYkCGTkXPKo