### PR TITLE
refactor: 残存する全ファイルの TIME_EFFECT 直接フィールドを get/set_timed_effect() に変換（…

### DIFF
--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
@@ -2818,6 +2818,7 @@
     </ClCompile>
     <ClCompile Include="..\..\src\monster-floor\party-generator.cpp" />
     <ClCompile Include="..\..\src\system\creature-entity.cpp" />
+    <ClCompile Include="..\..\src\floor\party-monsters.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -6080,6 +6081,7 @@
       <Filter>info-reader</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\monster-floor\party-generator.h" />
+    <ClInclude Include="..\..\src\floor\party-monsters.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\wall.bmp" />

--- a/src/cmd-io/cmd-text-command.cpp
+++ b/src/cmd-io/cmd-text-command.cpp
@@ -213,7 +213,7 @@ static std::vector<TextCommand> get_text_commands()
                 // 稀にポジティブ効果
                 if (one_in_(10)) {
                     msg_print(_("素晴らしい踊りで気分が高揚した！", "Your wonderful dance lifts your spirits!"));
-                    set_hero(creature, creature.get_remaining_blessed() + randint1(10), false);
+                    set_hero(creature, creature.get_timed_effect(CreatureTimedEffect::BLESSED) + randint1(10), false);
                 }
             },
             _("踊る", "Dance") },

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -160,7 +160,7 @@ static bool exe_eat_corpse_type_object(CreatureEntity &creature, ItemEntity *o_p
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::BERSERKER)) {
-        set_berserk(creature, creature.get_remaining_berserk() + randint1(10) + 10, false);
+        set_berserk(creature, creature.get_timed_effect(CreatureTimedEffect::BERSERK) + randint1(10) + 10, false);
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::ACIDIC)) {

--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -181,7 +181,7 @@ int staff_effect(CreatureEntity &creature, int sval, bool *use_charge, bool powe
     }
 
     case SV_STAFF_DETECT_INVIS: {
-        if (set_tim_invis(creature, creature.get_remaining_tim_invis() + 12 + randint1(12), false)) {
+        if (set_tim_invis(creature, creature.get_timed_effect(CreatureTimedEffect::TIM_INVIS) + 12 + randint1(12), false)) {
             ident = true;
         }
         break;

--- a/src/combat/aura-counterattack.cpp
+++ b/src/combat/aura-counterattack.cpp
@@ -106,7 +106,7 @@ static void aura_cold_by_monster_attack(CreatureEntity &creature, MonsterAttackP
 
 static void aura_shards_by_monster_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    if (!creature.dustrobe || !monap_ptr->alive || creature.is_dead()) {
+    if (!creature.get_timed_effect(CreatureTimedEffect::DUSTROBE) || !monap_ptr->alive || creature.is_dead()) {
         return;
     }
 
@@ -133,7 +133,7 @@ static void aura_shards_by_monster_attack(CreatureEntity &creature, MonsterAttac
 
 static void aura_holy_by_monster_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    if (!creature.tim_sh_holy || !monap_ptr->alive || creature.is_dead()) {
+    if (!creature.get_timed_effect(CreatureTimedEffect::TIM_SH_HOLY) || !monap_ptr->alive || creature.is_dead()) {
         return;
     }
 
@@ -166,7 +166,7 @@ static void aura_holy_by_monster_attack(CreatureEntity &creature, MonsterAttackP
 
 static void aura_force_by_monster_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    if (!creature.tim_sh_touki || !monap_ptr->alive || creature.is_dead()) {
+    if (!creature.get_timed_effect(CreatureTimedEffect::TIM_SH_TOUKI) || !monap_ptr->alive || creature.is_dead()) {
         return;
     }
 

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -201,36 +201,36 @@ void reduce_magic_effects_timeout(CreatureEntity &creature)
         (void)set_oppose_acid(creature, creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ACID) - 1, true);
     }
 
-    if (const auto remaining = creature.get_remaining_oppose_elec(); remaining > 0) {
-        (void)set_oppose_elec(creature, remaining - 1, true);
+    if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ELEC)) {
+        (void)set_oppose_elec(creature, creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ELEC) - 1, true);
     }
 
-    if (const auto remaining = creature.get_remaining_oppose_fire(); remaining > 0) {
-        (void)set_oppose_fire(creature, remaining - 1, true);
+    if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE)) {
+        (void)set_oppose_fire(creature, creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE) - 1, true);
     }
 
-    if (const auto remaining = creature.get_remaining_oppose_cold(); remaining > 0) {
-        (void)set_oppose_cold(creature, remaining - 1, true);
+    if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD)) {
+        (void)set_oppose_cold(creature, creature.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD) - 1, true);
     }
 
-    if (const auto remaining = creature.get_remaining_oppose_pois(); remaining > 0) {
-        (void)set_oppose_pois(creature, remaining - 1, true);
+    if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_POIS)) {
+        (void)set_oppose_pois(creature, creature.get_timed_effect(CreatureTimedEffect::OPPOSE_POIS) - 1, true);
     }
 
-    if (creature.tim_emission) {
-        (void)set_tim_emission(creature, creature.tim_emission - 1, true);
+    if (creature.get_timed_effect(CreatureTimedEffect::TIM_EMISSION)) {
+        (void)set_tim_emission(creature, creature.get_timed_effect(CreatureTimedEffect::TIM_EMISSION) - 1, true);
     }
 
-    if (creature.tim_exorcism) {
-        (void)set_tim_exorcism(creature, creature.tim_exorcism - 1, true);
+    if (creature.get_timed_effect(CreatureTimedEffect::TIM_EXORCISM)) {
+        (void)set_tim_exorcism(creature, creature.get_timed_effect(CreatureTimedEffect::TIM_EXORCISM) - 1, true);
     }
 
-    if (creature.tim_imm_dark) {
-        (void)set_tim_imm_dark(creature, creature.tim_imm_dark - 1, true);
+    if (creature.get_timed_effect(CreatureTimedEffect::TIM_IMM_DARK)) {
+        (void)set_tim_imm_dark(creature, creature.get_timed_effect(CreatureTimedEffect::TIM_IMM_DARK) - 1, true);
     }
 
-    if (const auto remaining = creature.get_remaining_ultimate_resistance(); remaining > 0) {
-        (void)set_ultimate_res(creature, remaining - 1, true);
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE)) {
+        (void)set_ultimate_res(creature, creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE) - 1, true);
     }
 
     if (effects->poison().is_poisoned()) {

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -218,8 +218,8 @@ void process_player(CreatureEntity &creature)
     }
 
     load = false;
-    if (creature.lightspeed) {
-        set_lightspeed(creature, creature.lightspeed - 1, true);
+    if (creature.get_timed_effect(CreatureTimedEffect::LIGHTSPEED)) {
+        set_lightspeed(creature, creature.get_timed_effect(CreatureTimedEffect::LIGHTSPEED) - 1, true);
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -427,7 +427,7 @@ void effect_player_lite(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 
-    if (!creature.get_remaining_wraith_form() || check_multishadow(creature)) {
+    if (!creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM) || check_multishadow(creature)) {
         return;
     }
 

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -210,12 +210,12 @@ bool affect_player(MONSTER_IDX src_idx, CreatureEntity &creature, concptr src_na
     switch_effects_player(creature, ep_ptr);
 
     SpellHex(creature).store_vengeful_damage(ep_ptr->get_damage);
-    if ((creature.tim_eyeeye || SpellHex(creature).is_spelling_specific(HEX_EYE_FOR_EYE)) && (ep_ptr->get_damage > 0) && !creature.is_dead() && ep_ptr->is_monster()) {
+    if ((creature.get_timed_effect(CreatureTimedEffect::TIM_EYEEYE) || SpellHex(creature).is_spelling_specific(HEX_EYE_FOR_EYE)) && (ep_ptr->get_damage > 0) && !creature.is_dead() && ep_ptr->is_monster()) {
         const auto m_name_self = monster_desc(creature, *ep_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
         msg_print(_(format("攻撃が%s自身を傷つけた！", ep_ptr->m_name.data()), format("The attack of %s has wounded %s!", ep_ptr->m_name.data(), m_name_self.data())));
         (*project)(creature, 0, 0, ep_ptr->m_ptr->y, ep_ptr->m_ptr->x, ep_ptr->get_damage, AttributeType::MISSILE, PROJECT_KILL, tl::nullopt);
-        if (creature.tim_eyeeye) {
-            set_tim_eyeeye(creature, creature.tim_eyeeye - 5, true);
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_EYEEYE)) {
+            set_tim_eyeeye(creature, creature.get_timed_effect(CreatureTimedEffect::TIM_EYEEYE) - 5, true);
         }
     }
 

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -380,8 +380,8 @@ void process_player_hp_mp(CreatureEntity &creature)
      */
     if (terrain.flags.has_none_of({ TerrainCharacteristics::MOVE, TerrainCharacteristics::CAN_FLY })) {
         auto should_damage = !creature.is_invulnerable();
-        should_damage &= creature.get_remaining_wraith_form() == 0;
-        should_damage &= creature.tim_pass_wall == 0;
+        should_damage &= creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM) == 0;
+        should_damage &= creature.get_timed_effect(CreatureTimedEffect::TIM_PASS_WALL) == 0;
         should_damage &= (creature.hp > (creature.level / 5)) || !has_pass_wall(creature);
         if (should_damage) {
             concptr dam_desc;

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -67,7 +67,7 @@ void inven_item_increase(CreatureEntity &creature, INVENTORY_IDX i_idx, ITEM_NUM
         SubWindowRedrawingFlag::EQUIPMENT,
     };
     rfu.set_flags(flags_swrf);
-    if (o_ptr->number || !creature.ele_attack) {
+    if (o_ptr->number || !creature.get_timed_effect(CreatureTimedEffect::ELE_ATTACK)) {
         return;
     }
 

--- a/src/load/player-attack-loader.cpp
+++ b/src/load/player-attack-loader.cpp
@@ -6,10 +6,11 @@
 #include "player-info/samurai-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
+#include "system/creature-entity.h"
 
 void rd_special_attack(CreatureEntity &creature)
 {
-    creature.ele_attack = rd_s16b();
+    creature.set_timed_effect(CreatureTimedEffect::ELE_ATTACK, rd_s16b());
     creature.special_attack = rd_u32b();
 }
 
@@ -27,7 +28,7 @@ void rd_special_action(CreatureEntity &creature)
 
 void rd_special_defense(CreatureEntity &creature)
 {
-    creature.ele_immune = rd_s16b();
+    creature.set_timed_effect(CreatureTimedEffect::ELE_IMMUNE, rd_s16b());
     creature.special_defense = rd_u32b();
 }
 

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -110,24 +110,24 @@ void set_lightspeed(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.lightspeed && !do_dec) {
-            if (creature.lightspeed > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::LIGHTSPEED) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::LIGHTSPEED) > v) {
                 return;
             }
-        } else if (!creature.lightspeed) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::LIGHTSPEED)) {
             msg_print(_("非常に素早く動けるようになった！", "You feel yourself moving extremely fast!"));
             notice = true;
             chg_virtue(creature, Virtue::PATIENCE, -1);
             chg_virtue(creature, Virtue::DILIGENCE, 1);
         }
     } else {
-        if (creature.lightspeed) {
+        if (creature.get_timed_effect(CreatureTimedEffect::LIGHTSPEED)) {
             msg_print(_("動きの素早さがなくなったようだ。", "You feel yourself slow down."));
             notice = true;
         }
     }
 
-    creature.lightspeed = v;
+    creature.set_timed_effect(CreatureTimedEffect::LIGHTSPEED, v);
 
     if (!notice) {
         return;
@@ -158,22 +158,22 @@ bool set_tim_sh_force(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_sh_touki && !do_dec) {
-            if (creature.tim_sh_touki > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_SH_TOUKI) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_SH_TOUKI) > v) {
                 return false;
             }
-        } else if (!creature.tim_sh_touki) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_SH_TOUKI)) {
             msg_print(_("体が闘気のオーラで覆われた。", "You are enveloped by an aura of the Force!"));
             notice = true;
         }
     } else {
-        if (creature.tim_sh_touki) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_SH_TOUKI)) {
             msg_print(_("闘気が消えた。", "The aura of the Force disappeared."));
             notice = true;
         }
     }
 
-    creature.tim_sh_touki = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_SH_TOUKI, v);
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
         return false;

--- a/src/mind/mind-magic-resistance.cpp
+++ b/src/mind/mind-magic-resistance.cpp
@@ -25,22 +25,22 @@ bool set_resist_magic(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.resist_magic && !do_dec) {
-            if (creature.resist_magic > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::RESIST_MAGIC) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::RESIST_MAGIC) > v) {
                 return false;
             }
-        } else if (!creature.resist_magic) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::RESIST_MAGIC)) {
             msg_print(_("魔法への耐性がついた。", "You have been protected from magic!"));
             notice = true;
         }
     } else {
-        if (creature.resist_magic) {
+        if (creature.get_timed_effect(CreatureTimedEffect::RESIST_MAGIC)) {
             msg_print(_("魔法に弱くなった。", "You are no longer protected from magic."));
             notice = true;
         }
     }
 
-    creature.resist_magic = v;
+    creature.set_timed_effect(CreatureTimedEffect::RESIST_MAGIC, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -55,7 +55,7 @@
  */
 bool check_multishadow(const CreatureEntity &creature)
 {
-    return (creature.multishadow != 0) && ((AngbandWorld::get_instance().game_turn & 1) != 0);
+    return (creature.get_timed_effect(CreatureTimedEffect::MULTISHADOW) != 0) && ((AngbandWorld::get_instance().game_turn & 1) != 0);
 }
 
 /*!
@@ -260,22 +260,22 @@ bool set_multishadow(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.multishadow && !do_dec) {
-            if (creature.multishadow > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::MULTISHADOW) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::MULTISHADOW) > v) {
                 return false;
             }
-        } else if (!creature.multishadow) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::MULTISHADOW)) {
             msg_print(_("あなたの周りに幻影が生まれた。", "Your Shadow enveloped you."));
             notice = true;
         }
     } else {
-        if (creature.multishadow) {
+        if (creature.get_timed_effect(CreatureTimedEffect::MULTISHADOW)) {
             msg_print(_("幻影が消えた。", "Your Shadow disappears."));
             notice = true;
         }
     }
 
-    creature.multishadow = v;
+    creature.set_timed_effect(CreatureTimedEffect::MULTISHADOW, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
@@ -308,22 +308,22 @@ bool set_dustrobe(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.dustrobe && !do_dec) {
-            if (creature.dustrobe > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::DUSTROBE) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::DUSTROBE) > v) {
                 return false;
             }
-        } else if (!creature.dustrobe) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::DUSTROBE)) {
             msg_print(_("体が鏡のオーラで覆われた。", "You are enveloped by mirror shards."));
             notice = true;
         }
     } else {
-        if (creature.dustrobe) {
+        if (creature.get_timed_effect(CreatureTimedEffect::DUSTROBE)) {
             msg_print(_("鏡のオーラが消えた。", "The mirror shards disappear."));
             notice = true;
         }
     }
 
-    creature.dustrobe = v;
+    creature.set_timed_effect(CreatureTimedEffect::DUSTROBE, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -228,11 +228,11 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(CreatureEntity &creature, POSITION
 
     if (monster_to_player || (monster_to_monster && monster_target.is_riding())) {
         int get_damage = take_hit(creature, DAMAGE_NOESCAPE, dam, m_name);
-        if (creature.tim_eyeeye && get_damage > 0 && !creature.is_dead()) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_EYEEYE) && get_damage > 0 && !creature.is_dead()) {
             const auto m_name_self = monster_desc(creature, monster, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
             msg_print(_(format("攻撃が%s自身を傷つけた！", m_name.data()), format("The attack of %s has wounded %s!", m_name.data(), m_name_self.data())));
             project(creature, 0, 0, monster.y, monster.x, get_damage, AttributeType::MISSILE, PROJECT_KILL);
-            set_tim_eyeeye(creature, creature.tim_eyeeye - 5, true);
+            set_tim_eyeeye(creature, creature.get_timed_effect(CreatureTimedEffect::TIM_EYEEYE) - 5, true);
         }
     }
 

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -310,8 +310,8 @@ void process_world_aux_mutation(CreatureEntity &creature)
             }
         }
 
-        if (creature.tim_emission > 0) {
-            hp_player(creature, creature.tim_emission);
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_EMISSION) > 0) {
+            hp_player(creature, creature.get_timed_effect(CreatureTimedEffect::TIM_EMISSION));
             set_tim_emission(creature, 0, true);
             msg_print(_("あなたは自身の光をエネルギーとして吸収した！", "You absorb energy from your own light!"));
         }
@@ -427,7 +427,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
     }
 
     if (creature.muta.has(PlayerMutationType::WEIRD_MIND) && !creature.anti_magic && one_in_(3000)) {
-        if (creature.get_remaining_tim_esp() > 0) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_ESP) > 0) {
             msg_print(_("精神にもやがかかった！", "Your mind feels cloudy!"));
             set_tim_esp(creature, 0, true);
         } else {

--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -115,9 +115,9 @@ bool QuaffEffects::influence(const ItemEntity &item, const bool is_rectal)
     case SV_POTION_DEATH:
         return this->death();
     case SV_POTION_INFRAVISION:
-        return set_tim_infra(this->creature, this->creature.get_remaining_tim_infra() + 100 + randint1(100), false);
+        return set_tim_infra(this->creature, this->creature.get_timed_effect(CreatureTimedEffect::TIM_INFRA) + 100 + randint1(100), false);
     case SV_POTION_DETECT_INVIS:
-        return set_tim_invis(this->creature, this->creature.get_remaining_tim_invis() + 12 + randint1(12), false);
+        return set_tim_invis(this->creature, this->creature.get_timed_effect(CreatureTimedEffect::TIM_INVIS) + 12 + randint1(12), false);
     case SV_POTION_SLOW_POISON:
         return BadStatusSetter(this->creature).set_poison(this->creature.effects()->poison().current() / 2);
     case SV_POTION_CURE_POISON:
@@ -127,9 +127,9 @@ bool QuaffEffects::influence(const ItemEntity &item, const bool is_rectal)
     case SV_POTION_SPEED:
         return this->speed();
     case SV_POTION_RESIST_HEAT:
-        return set_oppose_fire(this->creature, this->creature.get_remaining_oppose_fire() + randint1(10) + 10, false);
+        return set_oppose_fire(this->creature, this->creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE) + randint1(10) + 10, false);
     case SV_POTION_RESIST_COLD:
-        return set_oppose_cold(this->creature, this->creature.get_remaining_oppose_cold() + randint1(10) + 10, false);
+        return set_oppose_cold(this->creature, this->creature.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD) + randint1(10) + 10, false);
     case SV_POTION_HEROISM:
         return heroism(this->creature, 25);
     case SV_POTION_BESERK_STRENGTH:
@@ -195,7 +195,7 @@ bool QuaffEffects::influence(const ItemEntity &item, const bool is_rectal)
     case SV_POTION_CURING:
         return true_healing(this->creature, 50);
     case SV_POTION_INVULNERABILITY:
-        (void)set_invuln(this->creature, this->creature.invuln + randint1(4) + 4, false);
+        (void)set_invuln(this->creature, this->creature.get_timed_effect(CreatureTimedEffect::INVULNERABILITY) + randint1(4) + 4, false);
         return true;
     case SV_POTION_NEW_LIFE:
         return this->new_life();
@@ -536,11 +536,11 @@ bool QuaffEffects::experience()
  */
 bool QuaffEffects::resistance()
 {
-    (void)set_oppose_acid(this->creature, this->creature.get_remaining_oppose_acid() + randint1(20) + 20, false);
-    (void)set_oppose_elec(this->creature, this->creature.get_remaining_oppose_elec() + randint1(20) + 20, false);
-    (void)set_oppose_fire(this->creature, this->creature.get_remaining_oppose_fire() + randint1(20) + 20, false);
-    (void)set_oppose_cold(this->creature, this->creature.get_remaining_oppose_cold() + randint1(20) + 20, false);
-    (void)set_oppose_pois(this->creature, this->creature.get_remaining_oppose_pois() + randint1(20) + 20, false);
+    (void)set_oppose_acid(this->creature, this->creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ACID) + randint1(20) + 20, false);
+    (void)set_oppose_elec(this->creature, this->creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ELEC) + randint1(20) + 20, false);
+    (void)set_oppose_fire(this->creature, this->creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE) + randint1(20) + 20, false);
+    (void)set_oppose_cold(this->creature, this->creature.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD) + randint1(20) + 20, false);
+    (void)set_oppose_pois(this->creature, this->creature.get_timed_effect(CreatureTimedEffect::OPPOSE_POIS) + randint1(20) + 20, false);
     return true;
 }
 
@@ -564,7 +564,7 @@ bool QuaffEffects::new_life()
 bool QuaffEffects::neo_tsuyoshi()
 {
     (void)BadStatusSetter(this->creature).hallucination(0);
-    (void)set_tsuyoshi(this->creature, this->creature.get_remaining_tsuyoshi() + randint1(100) + 100, false);
+    (void)set_tsuyoshi(this->creature, this->creature.get_timed_effect(CreatureTimedEffect::TSUYOSHI) + randint1(100) + 100, false);
     return true;
 }
 

--- a/src/object-use/read/scroll-read-executor.cpp
+++ b/src/object-use/read/scroll-read-executor.cpp
@@ -291,19 +291,19 @@ bool ScrollReadExecutor::read()
         break;
     }
     case SV_SCROLL_BLESSING:
-        if (set_blessed(this->creature, this->creature.get_remaining_blessed() + randint1(12) + 6, false)) {
+        if (set_blessed(this->creature, this->creature.get_timed_effect(CreatureTimedEffect::BLESSED) + randint1(12) + 6, false)) {
             this->ident = true;
         }
 
         break;
     case SV_SCROLL_HOLY_CHANT:
-        if (set_blessed(this->creature, this->creature.get_remaining_blessed() + randint1(24) + 12, false)) {
+        if (set_blessed(this->creature, this->creature.get_timed_effect(CreatureTimedEffect::BLESSED) + randint1(24) + 12, false)) {
             this->ident = true;
         }
 
         break;
     case SV_SCROLL_HOLY_PRAYER:
-        if (set_blessed(this->creature, this->creature.get_remaining_blessed() + randint1(48) + 24, false)) {
+        if (set_blessed(this->creature, this->creature.get_timed_effect(CreatureTimedEffect::BLESSED) + randint1(48) + 24, false)) {
             this->ident = true;
         }
 

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -114,7 +114,7 @@ static void spell_damcalc(CreatureEntity &creature, const CreatureEntity &monste
 
     case AttributeType::DARK:
         dam = dam * calc_dark_damage_rate(creature, CALC_MAX) / 100;
-        if (has_immune_dark(creature) || creature.get_remaining_wraith_form()) {
+        if (has_immune_dark(creature) || creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
             ignore_wraith_form = true;
         }
         break;
@@ -221,7 +221,7 @@ static void spell_damcalc(CreatureEntity &creature, const CreatureEntity &monste
         break;
     }
 
-    if (creature.get_remaining_wraith_form() && !ignore_wraith_form) {
+    if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM) && !ignore_wraith_form) {
         dam /= 2;
         if (!dam) {
             dam = 1;
@@ -315,7 +315,7 @@ static int blow_damcalc(const CreatureEntity &monster, CreatureEntity &creature,
         break;
     }
 
-    if (check_wraith_form && creature.get_remaining_wraith_form()) {
+    if (check_wraith_form && creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
         dam /= 2;
         if (!dam) {
             dam = 1;

--- a/src/player-ability/player-constitution.cpp
+++ b/src/player-ability/player-constitution.cpp
@@ -88,7 +88,7 @@ int16_t PlayerConstitution::stance_bonus()
     } else if (pc.monk_stance_is(MonkStanceType::SUZAKU)) {
         result -= 2;
     }
-    if (this->creature.get_remaining_tsuyoshi()) {
+    if (this->creature.get_timed_effect(CreatureTimedEffect::TSUYOSHI)) {
         result += 4;
     }
 

--- a/src/player-ability/player-strength.cpp
+++ b/src/player-ability/player-strength.cpp
@@ -64,7 +64,7 @@ int16_t PlayerStrength::time_effect_bonus()
         }
     }
 
-    if (this->creature.get_remaining_tsuyoshi()) {
+    if (this->creature.get_timed_effect(CreatureTimedEffect::TSUYOSHI)) {
         result += 4;
     }
 

--- a/src/player-attack/blood-sucking-processor.cpp
+++ b/src/player-attack/blood-sucking-processor.cpp
@@ -46,7 +46,7 @@ void decide_blood_sucking(CreatureEntity &creature, player_attack_type *pa_ptr)
  */
 void decide_exorcism(CreatureEntity &creature, player_attack_type *pa_ptr)
 {
-    auto is_exorcism = creature.tim_exorcism > 0;
+    auto is_exorcism = creature.get_timed_effect(CreatureTimedEffect::TIM_EXORCISM) > 0;
     if (!is_exorcism) {
         return;
     }

--- a/src/player-info/body-improvement-info.cpp
+++ b/src/player-info/body-improvement-info.cpp
@@ -25,7 +25,7 @@ void set_body_improvement_info_1(CreatureEntity &creature, self_info_type *self_
         self_ptr->info_list.emplace_back(_("あなたは邪悪なる存在から守られている。", "You are protected from evil."));
     }
 
-    if (creature.get_remaining_shield()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::SHIELD)) {
         self_ptr->info_list.emplace_back(_("あなたは神秘のシールドで守られている。", "You are protected by a mystic shield."));
     }
 
@@ -33,7 +33,7 @@ void set_body_improvement_info_1(CreatureEntity &creature, self_info_type *self_
         self_ptr->info_list.emplace_back(_("あなたは現在傷つかない。", "You are temporarily invulnerable."));
     }
 
-    if (creature.get_remaining_wraith_form()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
         self_ptr->info_list.emplace_back(_("あなたは一時的に幽体化している。", "You are temporarily incorporeal."));
     }
 }
@@ -117,11 +117,11 @@ void set_body_improvement_info_3(CreatureEntity &creature, self_info_type *self_
         self_ptr->info_list.emplace_back(_("あなたは身も凍る冷気に包まれている。", "You are being damaged with coldness."));
     }
 
-    if (creature.tim_sh_holy) {
+    if (creature.get_timed_effect(CreatureTimedEffect::TIM_SH_HOLY)) {
         self_ptr->info_list.emplace_back(_("あなたは聖なるオーラに包まれている。", "You are surrounded with a holy aura."));
     }
 
-    if (creature.tim_sh_touki) {
+    if (creature.get_timed_effect(CreatureTimedEffect::TIM_SH_TOUKI)) {
         self_ptr->info_list.emplace_back(_("あなたは闘気のオーラに包まれている。", "You are surrounded with an energy aura."));
     }
 
@@ -173,7 +173,7 @@ void set_body_improvement_info_4(CreatureEntity &creature, self_info_type *self_
 /*!< @todo 並び順の都合で連番を付ける。 */
 void set_body_improvement_info_5(CreatureEntity &creature, self_info_type *self_ptr)
 {
-    if (creature.tim_exorcism > 0) {
+    if (creature.get_timed_effect(CreatureTimedEffect::TIM_EXORCISM) > 0) {
         if (has_kill_demon_from_exorcism(creature)) {
             self_ptr->info_list.emplace_back(_("あなたはデーモンの天敵である。", "You are a great bane of demons."));
         } else if (has_slay_demon_from_exorcism(creature)) {

--- a/src/player-info/resistance-info.cpp
+++ b/src/player-info/resistance-info.cpp
@@ -75,7 +75,7 @@ void set_high_resistance_info(CreatureEntity &creature, self_info_type *self_ptr
         self_ptr->info_list.emplace_back(_("あなたは閃光に弱い。", "You are susceptible to damage from bright light."));
     }
 
-    if (has_immune_dark(creature) || creature.get_remaining_wraith_form()) {
+    if (has_immune_dark(creature) || creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
         self_ptr->info_list.emplace_back(_("あなたは暗黒に対する完全なる免疫を持っている。", "You are completely immune to darkness."));
     } else if (has_resist_dark(creature)) {
         self_ptr->info_list.emplace_back(_("あなたは暗黒への耐性を持っている。", "You are resistant to darkness."));

--- a/src/player-info/self-info.cpp
+++ b/src/player-info/self-info.cpp
@@ -26,6 +26,7 @@
 #include "player/attack-defense-types.h"
 #include "player/player-status-flags.h"
 #include "system/creature-entity.h"
+#include "system/creature-timed-effect-types.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"
@@ -343,18 +344,18 @@ void report_magics(CreatureEntity &subject)
             _("あなたは幻覚を見ている", "You are hallucinating"));
     }
 
-    if (const auto remaining = subject.get_remaining_blessed(); remaining > 0) {
-        info.emplace_back(report_magics_aux(remaining),
+    if (subject.get_timed_effect(CreatureTimedEffect::BLESSED)) {
+        info.emplace_back(report_magics_aux(subject.get_timed_effect(CreatureTimedEffect::BLESSED)),
             _("あなたは高潔さを感じている", "You feel rightous"));
     }
 
-    if (const auto remaining = subject.get_remaining_hero(); remaining > 0) {
-        info.emplace_back(report_magics_aux(remaining),
+    if (subject.get_timed_effect(CreatureTimedEffect::HERO)) {
+        info.emplace_back(report_magics_aux(subject.get_timed_effect(CreatureTimedEffect::HERO)),
             _("あなたはヒーロー気分だ", "You feel heroic"));
     }
 
     if (subject.is_shero()) {
-        info.emplace_back(report_magics_aux(subject.get_remaining_berserk()),
+        info.emplace_back(report_magics_aux(subject.get_timed_effect(CreatureTimedEffect::BERSERK)),
             _("あなたは戦闘狂だ", "You are in a battle rage"));
     }
 
@@ -364,18 +365,18 @@ void report_magics(CreatureEntity &subject)
             _("あなたは邪悪なる存在から守られている", "You are protected from evil"));
     }
 
-    if (const auto remaining = subject.get_remaining_shield(); remaining > 0) {
-        info.emplace_back(report_magics_aux(remaining),
+    if (subject.get_timed_effect(CreatureTimedEffect::SHIELD)) {
+        info.emplace_back(report_magics_aux(subject.get_timed_effect(CreatureTimedEffect::SHIELD)),
             _("あなたは神秘のシールドで守られている", "You are protected by a mystic shield"));
     }
 
-    if (const auto remaining = subject.get_remaining_invulnerability(); remaining > 0) {
-        info.emplace_back(report_magics_aux(remaining),
+    if (subject.get_timed_effect(CreatureTimedEffect::INVULNERABILITY)) {
+        info.emplace_back(report_magics_aux(subject.get_timed_effect(CreatureTimedEffect::INVULNERABILITY)),
             _("あなたは無敵だ", "You are invulnerable"));
     }
 
-    if (const auto remaining = subject.get_remaining_wraith_form(); remaining > 0) {
-        info.emplace_back(report_magics_aux(remaining),
+    if (subject.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
+        info.emplace_back(report_magics_aux(subject.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)),
             _("あなたは幽体化している", "You are incorporeal"));
     }
 
@@ -393,28 +394,28 @@ void report_magics(CreatureEntity &subject)
             _("この後現実変容が発動する", "You waiting to be altered"));
     }
 
-    if (const auto remaining = subject.get_remaining_oppose_acid(); remaining > 0) {
-        info.emplace_back(report_magics_aux(remaining),
+    if (subject.get_timed_effect(CreatureTimedEffect::OPPOSE_ACID)) {
+        info.emplace_back(report_magics_aux(subject.get_timed_effect(CreatureTimedEffect::OPPOSE_ACID)),
             _("あなたは酸への耐性を持っている", "You are resistant to acid"));
     }
 
-    if (const auto remaining = subject.get_remaining_oppose_elec(); remaining > 0) {
-        info.emplace_back(report_magics_aux(remaining),
+    if (subject.get_timed_effect(CreatureTimedEffect::OPPOSE_ELEC)) {
+        info.emplace_back(report_magics_aux(subject.get_timed_effect(CreatureTimedEffect::OPPOSE_ELEC)),
             _("あなたは電撃への耐性を持っている", "You are resistant to lightning"));
     }
 
-    if (const auto remaining = subject.get_remaining_oppose_fire(); remaining > 0) {
-        info.emplace_back(report_magics_aux(remaining),
+    if (subject.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE)) {
+        info.emplace_back(report_magics_aux(subject.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE)),
             _("あなたは火への耐性を持っている", "You are resistant to fire"));
     }
 
-    if (const auto remaining = subject.get_remaining_oppose_cold(); remaining > 0) {
-        info.emplace_back(report_magics_aux(remaining),
+    if (subject.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD)) {
+        info.emplace_back(report_magics_aux(subject.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD)),
             _("あなたは冷気への耐性を持っている", "You are resistant to cold"));
     }
 
-    if (const auto remaining = subject.get_remaining_oppose_pois(); remaining > 0) {
-        info.emplace_back(report_magics_aux(remaining),
+    if (subject.get_timed_effect(CreatureTimedEffect::OPPOSE_POIS)) {
+        info.emplace_back(report_magics_aux(subject.get_timed_effect(CreatureTimedEffect::OPPOSE_POIS)),
             _("あなたは毒への耐性を持っている", "You are resistant to poison"));
     }
 

--- a/src/player-status/player-infravision.cpp
+++ b/src/player-status/player-infravision.cpp
@@ -60,7 +60,7 @@ int16_t PlayerInfravision::mutation_bonus()
 int16_t PlayerInfravision::time_effect_bonus()
 {
     int16_t bonus = 0;
-    if (this->creature.get_remaining_tim_infra()) {
+    if (this->creature.get_timed_effect(CreatureTimedEffect::TIM_INFRA)) {
         bonus += 3;
     }
 

--- a/src/player-status/player-speed.cpp
+++ b/src/player-status/player-speed.cpp
@@ -207,7 +207,7 @@ int16_t PlayerSpeed::time_effect_bonus()
         bonus -= 10;
     }
 
-    if (this->creature.lightspeed) {
+    if (this->creature.get_timed_effect(CreatureTimedEffect::LIGHTSPEED)) {
         bonus += 999;
     }
 

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -340,7 +340,7 @@ int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_
             }
         }
 
-        if (creature.get_remaining_wraith_form()) {
+        if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
             if (damage_type == DAMAGE_FORCE) {
                 msg_print(_("半物質の体が切り裂かれた！", "The attack cuts through your ethereal body!"));
             } else {

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -1308,7 +1308,7 @@ BIT_FLAGS has_resist_cold(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_RES_COLD);
 
-    if (creature.get_remaining_ultimate_resistance()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1332,7 +1332,7 @@ BIT_FLAGS has_resist_pois(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_RES_POIS);
 
-    if (creature.get_remaining_ultimate_resistance()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1347,7 +1347,7 @@ BIT_FLAGS has_resist_conf(CreatureEntity &creature)
         result |= FLAG_CAUSE_PERSONALITY;
     }
 
-    if (creature.get_remaining_ultimate_resistance() || creature.magicdef) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE) || creature.get_timed_effect(CreatureTimedEffect::MAGICDEF)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1358,7 +1358,7 @@ BIT_FLAGS has_resist_sound(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_RES_SOUND);
 
-    if (creature.get_remaining_ultimate_resistance()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1369,7 +1369,7 @@ BIT_FLAGS has_resist_lite(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_RES_LITE) | common_cause_flags(creature, TR_IM_LITE);
 
-    if (creature.get_remaining_ultimate_resistance() || creature.tim_res_lite || creature.mimic_form == MimicKindType::DEMIGOD) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE) || creature.get_timed_effect(CreatureTimedEffect::TIM_RES_LITE) || creature.mimic_form == MimicKindType::DEMIGOD) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1380,7 +1380,7 @@ BIT_FLAGS has_vuln_lite(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_VUL_LITE);
 
-    if (creature.get_remaining_wraith_form()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1391,7 +1391,7 @@ BIT_FLAGS has_resist_dark(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_RES_DARK) | common_cause_flags(creature, TR_IM_DARK);
 
-    if (creature.get_remaining_ultimate_resistance() || creature.tim_res_dark || creature.tim_imm_dark) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE) || creature.get_timed_effect(CreatureTimedEffect::TIM_RES_DARK) || creature.get_timed_effect(CreatureTimedEffect::TIM_IMM_DARK)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1402,7 +1402,7 @@ BIT_FLAGS has_resist_chaos(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_RES_CHAOS);
 
-    if (creature.get_remaining_ultimate_resistance()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1413,7 +1413,7 @@ BIT_FLAGS has_resist_disen(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_RES_DISEN);
 
-    if (creature.get_remaining_ultimate_resistance()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1424,7 +1424,7 @@ BIT_FLAGS has_resist_shard(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_RES_SHARDS);
 
-    if (creature.get_remaining_ultimate_resistance()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1435,7 +1435,7 @@ BIT_FLAGS has_resist_nexus(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_RES_NEXUS);
 
-    if (creature.get_remaining_ultimate_resistance()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1450,7 +1450,7 @@ BIT_FLAGS has_resist_blind(CreatureEntity &creature)
         result |= FLAG_CAUSE_PERSONALITY;
     }
 
-    if (creature.get_remaining_ultimate_resistance() || creature.magicdef) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE) || creature.get_timed_effect(CreatureTimedEffect::MAGICDEF)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1461,7 +1461,7 @@ BIT_FLAGS has_resist_neth(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_RES_NETHER);
 
-    if (creature.get_remaining_ultimate_resistance() || creature.tim_res_nether) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE) || creature.get_timed_effect(CreatureTimedEffect::TIM_RES_NETHER)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1472,7 +1472,7 @@ BIT_FLAGS has_resist_time(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_RES_TIME);
 
-    if (creature.get_remaining_ultimate_resistance() || creature.tim_res_time) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE) || creature.get_timed_effect(CreatureTimedEffect::TIM_RES_TIME)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1483,7 +1483,7 @@ BIT_FLAGS has_resist_water(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_RES_WATER);
 
-    if (creature.get_remaining_ultimate_resistance()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1499,7 +1499,7 @@ BIT_FLAGS has_resist_curse(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_RES_CURSE);
 
-    if (creature.get_remaining_ultimate_resistance()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1564,7 +1564,7 @@ BIT_FLAGS has_resist_fear(CreatureEntity &creature)
         result |= FLAG_CAUSE_MUTATION;
     }
 
-    if (creature.is_hero() || creature.is_shero() || creature.get_remaining_ultimate_resistance() || creature.tim_res_fear) {
+    if (creature.is_hero() || creature.is_shero() || creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE) || creature.get_timed_effect(CreatureTimedEffect::TIM_RES_FEAR)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1575,7 +1575,7 @@ BIT_FLAGS has_immune_acid(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_IM_ACID);
 
-    if (creature.ele_immune) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ELE_IMMUNE)) {
         if (creature.special_defense & DEFENSE_ACID) {
             result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
         }
@@ -1588,7 +1588,7 @@ BIT_FLAGS has_immune_elec(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_IM_ELEC);
 
-    if (creature.ele_immune) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ELE_IMMUNE)) {
         if (creature.special_defense & DEFENSE_ELEC) {
             result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
         }
@@ -1601,7 +1601,7 @@ BIT_FLAGS has_immune_fire(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_IM_FIRE);
 
-    if (creature.ele_immune) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ELE_IMMUNE)) {
         if (creature.special_defense & DEFENSE_FIRE) {
             result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
         }
@@ -1614,7 +1614,7 @@ BIT_FLAGS has_immune_cold(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_IM_COLD);
 
-    if (creature.ele_immune) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ELE_IMMUNE)) {
         if (creature.special_defense & DEFENSE_COLD) {
             result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
         }
@@ -1627,7 +1627,7 @@ BIT_FLAGS has_immune_dark(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_IM_DARK);
 
-    if (creature.get_remaining_wraith_form() || creature.tim_imm_dark) {
+    if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM) || creature.get_timed_effect(CreatureTimedEffect::TIM_IMM_DARK)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1734,7 +1734,7 @@ BIT_FLAGS has_lite(CreatureEntity &creature)
         result |= FLAG_CAUSE_RACE;
     }
 
-    if (creature.get_remaining_ultimate_resistance()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 

--- a/src/player/player-status-resist.cpp
+++ b/src/player/player-status-resist.cpp
@@ -268,7 +268,7 @@ PERCENTAGE calc_lite_damage_rate(CreatureEntity &creature, rate_calc_type_mode m
         per /= randrate(4, 7, mode);
     }
 
-    if (creature.get_remaining_wraith_form()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
         per *= 2;
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -93,6 +93,7 @@
 #include "sv-definition/sv-lite-types.h"
 #include "sv-definition/sv-weapon-types.h"
 #include "system/creature-entity.h"
+#include "system/creature-timed-effect-types.h"
 #include "system/enums/terrain/terrain-tag.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
@@ -447,7 +448,7 @@ static void update_max_hitpoints(CreatureEntity &creature)
     if (creature.is_shero()) {
         mhp += 30;
     }
-    if (creature.get_remaining_tsuyoshi()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::TSUYOSHI)) {
         mhp += 50;
     }
     if (SpellHex(creature).is_spelling_specific(HEX_XTRA_MIGHT)) {
@@ -1157,11 +1158,11 @@ static ACTION_SKILL_POWER calc_saving_throw(CreatureEntity &creature)
         pow = 90 + creature.level;
     }
 
-    if (creature.tsubureru) {
+    if (creature.get_timed_effect(CreatureTimedEffect::TSUBURERU)) {
         pow = 10;
     }
 
-    if ((creature.get_remaining_ultimate_resistance() || creature.resist_magic || creature.magicdef) && (pow < (95 + creature.level))) {
+    if ((creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE) || creature.get_timed_effect(CreatureTimedEffect::RESIST_MAGIC) || creature.get_timed_effect(CreatureTimedEffect::MAGICDEF)) && (pow < (95 + creature.level))) {
         pow = 95 + creature.level;
     }
 
@@ -1823,9 +1824,9 @@ static ARMOUR_CLASS calc_to_ac(CreatureEntity &creature, bool is_real_value)
         ac -= 50;
     }
 
-    if (creature.get_remaining_ultimate_resistance() || (pc.samurai_stance_is(SamuraiStanceType::MUSOU))) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE) || (pc.samurai_stance_is(SamuraiStanceType::MUSOU))) {
         ac += 100;
-    } else if (creature.tsubureru || creature.get_remaining_shield() || creature.magicdef) {
+    } else if (creature.get_timed_effect(CreatureTimedEffect::TSUBURERU) || creature.get_timed_effect(CreatureTimedEffect::SHIELD) || creature.get_timed_effect(CreatureTimedEffect::MAGICDEF)) {
         ac += 50;
     }
 
@@ -3076,31 +3077,31 @@ uint32_t calc_score(CreatureEntity &creature)
  */
 bool is_blessed(CreatureEntity &creature)
 {
-    return creature.get_remaining_blessed() || music_singing(creature, MUSIC_BLESS) || SpellHex(creature).is_spelling_specific(HEX_BLESS);
+    return creature.get_timed_effect(CreatureTimedEffect::BLESSED) || music_singing(creature, MUSIC_BLESS) || SpellHex(creature).is_spelling_specific(HEX_BLESS);
 }
 
 bool is_tim_esp(CreatureEntity &creature)
 {
     auto sniper_data = CreatureClass(creature).get_specific_data<SniperData>();
     auto sniper_concent = sniper_data ? sniper_data->concent : 0;
-    return creature.get_remaining_tim_esp() || music_singing(creature, MUSIC_MIND) || (sniper_concent >= CONCENT_TELE_THRESHOLD);
+    return creature.get_timed_effect(CreatureTimedEffect::TIM_ESP) || music_singing(creature, MUSIC_MIND) || (sniper_concent >= CONCENT_TELE_THRESHOLD);
 }
 
 bool is_tim_stealth(CreatureEntity &creature)
 {
-    return creature.get_remaining_tim_stealth() || music_singing(creature, MUSIC_STEALTH);
+    return creature.get_timed_effect(CreatureTimedEffect::TIM_STEALTH) || music_singing(creature, MUSIC_STEALTH);
 }
 
 bool is_time_limit_esp(CreatureEntity &creature)
 {
     auto sniper_data = CreatureClass(creature).get_specific_data<SniperData>();
     auto sniper_concent = sniper_data ? sniper_data->concent : 0;
-    return creature.get_remaining_tim_esp() || music_singing(creature, MUSIC_MIND) || (sniper_concent >= CONCENT_TELE_THRESHOLD);
+    return creature.get_timed_effect(CreatureTimedEffect::TIM_ESP) || music_singing(creature, MUSIC_MIND) || (sniper_concent >= CONCENT_TELE_THRESHOLD);
 }
 
 bool is_time_limit_stealth(CreatureEntity &creature)
 {
-    return creature.get_remaining_tim_stealth() || music_singing(creature, MUSIC_STEALTH);
+    return creature.get_timed_effect(CreatureTimedEffect::TIM_STEALTH) || music_singing(creature, MUSIC_STEALTH);
 }
 
 /*!
@@ -3125,17 +3126,17 @@ bool is_fast(CreatureEntity &creature)
 }
 bool is_invuln(CreatureEntity &creature)
 {
-    return creature.get_remaining_invulnerability() || music_singing(creature, MUSIC_INVULN);
+    return creature.get_timed_effect(CreatureTimedEffect::INVULNERABILITY) || music_singing(creature, MUSIC_INVULN);
 }
 
 bool is_hero(CreatureEntity &creature)
 {
-    return creature.get_remaining_hero() || music_singing(creature, MUSIC_HERO) || music_singing(creature, MUSIC_SHERO);
+    return creature.get_timed_effect(CreatureTimedEffect::HERO) || music_singing(creature, MUSIC_HERO) || music_singing(creature, MUSIC_SHERO);
 }
 
 bool is_shero(CreatureEntity &creature)
 {
-    return creature.get_remaining_berserk() || CreatureClass(creature).equals(PlayerClassType::BERSERKER);
+    return creature.get_timed_effect(CreatureTimedEffect::BERSERK) || CreatureClass(creature).equals(PlayerClassType::BERSERKER);
 }
 
 bool is_echizen(CreatureEntity &creature)

--- a/src/player/race-resistances.cpp
+++ b/src/player/race-resistances.cpp
@@ -69,7 +69,7 @@ void tim_player_immunity(CreatureEntity &creature, TrFlags &flags)
     if (creature.special_defense & DEFENSE_COLD) {
         flags.set(TR_RES_COLD);
     }
-    if (creature.get_remaining_wraith_form()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
         flags.set(TR_RES_DARK);
     }
 }

--- a/src/racial/racial-kutar.cpp
+++ b/src/racial/racial-kutar.cpp
@@ -24,22 +24,22 @@ bool set_leveling(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tsubureru && !do_dec) {
-            if (creature.tsubureru > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TSUBURERU) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TSUBURERU) > v) {
                 return false;
             }
-        } else if (!creature.tsubureru) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TSUBURERU)) {
             msg_print(_("横に伸びた。", "Your body expands horizontally."));
             notice = true;
         }
     } else {
-        if (creature.tsubureru) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TSUBURERU)) {
             msg_print(_("もう横に伸びていない。", "Your body returns to normal."));
             notice = true;
         }
     }
 
-    creature.tsubureru = v;
+    creature.set_timed_effect(CreatureTimedEffect::TSUBURERU, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -74,12 +74,12 @@ tl::optional<std::string> do_hex_spell(CreatureEntity &creature, spell_hex_type 
         /*** 1st book (0-7) ***/
     case HEX_BLESS:
         if (cast) {
-            if (!creature.get_remaining_blessed()) {
+            if (!creature.get_timed_effect(CreatureTimedEffect::BLESSED)) {
                 msg_print(_("高潔な気分になった！", "You feel righteous!"));
             }
         }
         if (stop) {
-            if (!creature.get_remaining_blessed()) {
+            if (!creature.get_timed_effect(CreatureTimedEffect::BLESSED)) {
                 msg_print(_("高潔な気分が消え失せた。", "The prayer has expired."));
             }
         }

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -105,7 +105,7 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         }
 
         if (stop) {
-            if (!creature.get_remaining_blessed()) {
+            if (!creature.get_timed_effect(CreatureTimedEffect::BLESSED)) {
                 msg_print(_("高潔な気分が消え失せた。", "The prayer has expired."));
             }
         }
@@ -247,7 +247,7 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         }
 
         if (stop) {
-            if (!creature.get_remaining_hero()) {
+            if (!creature.get_timed_effect(CreatureTimedEffect::HERO)) {
                 msg_print(_("ヒーローの気分が消え失せた。", "The heroism wears off."));
                 RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::HP);
             }
@@ -382,7 +382,7 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         }
 
         if (stop) {
-            if (!creature.get_remaining_tim_stealth()) {
+            if (!creature.get_timed_effect(CreatureTimedEffect::TIM_STEALTH)) {
                 msg_print(_("姿がはっきりと見えるようになった。", "You are no longer hidden."));
             }
         }
@@ -510,23 +510,23 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         }
 
         if (stop) {
-            if (!creature.get_remaining_oppose_acid()) {
+            if (!creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ACID)) {
                 msg_print(_("酸への耐性が薄れた気がする。", "You feel less resistant to acid."));
             }
 
-            if (!creature.get_remaining_oppose_elec()) {
+            if (!creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ELEC)) {
                 msg_print(_("電撃への耐性が薄れた気がする。", "You feel less resistant to elec."));
             }
 
-            if (!creature.get_remaining_oppose_fire()) {
+            if (!creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE)) {
                 msg_print(_("火への耐性が薄れた気がする。", "You feel less resistant to fire."));
             }
 
-            if (!creature.get_remaining_oppose_cold()) {
+            if (!creature.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD)) {
                 msg_print(_("冷気への耐性が薄れた気がする。", "You feel less resistant to cold."));
             }
 
-            if (!creature.get_remaining_oppose_pois()) {
+            if (!creature.get_timed_effect(CreatureTimedEffect::OPPOSE_POIS)) {
                 msg_print(_("毒への耐性が薄れた気がする。", "You feel less resistant to pois."));
             }
         }
@@ -741,7 +741,7 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         }
 
         if (stop) {
-            if (!creature.get_remaining_hero()) {
+            if (!creature.get_timed_effect(CreatureTimedEffect::HERO)) {
                 msg_print(_("ヒーローの気分が消え失せた。", "The heroism wears off."));
                 RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::HP);
             }
@@ -844,7 +844,7 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         }
 
         if (stop) {
-            if (!creature.invuln) {
+            if (!creature.get_timed_effect(CreatureTimedEffect::INVULNERABILITY)) {
                 msg_print(_("無敵ではなくなった。", "The invulnerability wears off."));
                 auto &rfu = RedrawingFlagsUpdater::get_instance();
                 rfu.set_flag(MainWindowRedrawingFlag::MAP);

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -105,7 +105,7 @@ void update_lite_radius(CreatureEntity &creature)
         creature.cur_lite += 6;
     }
 
-    if (creature.tim_emission > 0) {
+    if (creature.get_timed_effect(CreatureTimedEffect::TIM_EMISSION) > 0) {
         creature.cur_lite += creature.level / 5;
     }
 

--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -63,7 +63,7 @@ bool set_ele_attack(CreatureEntity &creature, uint32_t attack_type, TIME_EFFECT 
 
     if ((v) && (attack_type)) {
         creature.special_attack |= (attack_type);
-        creature.ele_attack = v;
+        creature.set_timed_effect(CreatureTimedEffect::ELE_ATTACK, v);
         std::string element;
         switch (attack_type) {
         case ATTACK_ACID:
@@ -141,7 +141,7 @@ bool set_ele_immune(CreatureEntity &creature, uint32_t immune_type, TIME_EFFECT 
 
     if ((v) && (immune_type)) {
         creature.special_defense |= (immune_type);
-        creature.ele_immune = v;
+        creature.set_timed_effect(CreatureTimedEffect::ELE_IMMUNE, v);
         std::string element;
         switch (immune_type) {
         case DEFENSE_ACID:

--- a/src/spell-realm/spells-demon.cpp
+++ b/src/spell-realm/spells-demon.cpp
@@ -24,22 +24,22 @@ bool set_tim_sh_fire(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_sh_fire && !do_dec) {
-            if (creature.tim_sh_fire > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_SH_FIRE) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_SH_FIRE) > v) {
                 return false;
             }
-        } else if (!creature.tim_sh_fire) {
+        } else if (!creature.get_timed_effect(CreatureTimedEffect::TIM_SH_FIRE)) {
             msg_print(_("体が炎のオーラで覆われた。", "You are enveloped by a fiery aura!"));
             notice = true;
         }
     } else {
-        if (creature.tim_sh_fire) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_SH_FIRE)) {
             msg_print(_("炎のオーラが消えた。", "The fiery aura disappeared."));
             notice = true;
         }
     }
 
-    creature.tim_sh_fire = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_SH_FIRE, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
 

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -368,7 +368,7 @@ void SpellHex::interrupt_spelling()
 void SpellHex::eyes_on_eyes(MONSTER_IDX m_idx, int dam)
 {
     auto &creature = this->creature;
-    const auto is_eyeeye_finished = (this->creature.tim_eyeeye == 0) && !this->is_spelling_specific(HEX_EYE_FOR_EYE);
+    const auto is_eyeeye_finished = (this->creature.get_timed_effect(CreatureTimedEffect::TIM_EYEEYE) == 0) && !this->is_spelling_specific(HEX_EYE_FOR_EYE);
     if (is_eyeeye_finished || (dam == 0) || this->creature.is_dead()) {
         return;
     }
@@ -384,8 +384,8 @@ void SpellHex::eyes_on_eyes(MONSTER_IDX m_idx, int dam)
     const auto y = monster.y;
     const auto x = monster.x;
     project(creature, 0, 0, y, x, dam, AttributeType::MISSILE, PROJECT_KILL);
-    if (this->creature.tim_eyeeye) {
-        set_tim_eyeeye(creature, this->creature.tim_eyeeye - 5, true);
+    if (this->creature.get_timed_effect(CreatureTimedEffect::TIM_EYEEYE)) {
+        set_tim_eyeeye(creature, this->creature.get_timed_effect(CreatureTimedEffect::TIM_EYEEYE) - 5, true);
     }
 }
 

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -99,8 +99,8 @@ bool set_tim_stealth(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (creature.tim_stealth && !do_dec) {
-            if (creature.tim_stealth > v) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_STEALTH) && !do_dec) {
+            if (creature.get_timed_effect(CreatureTimedEffect::TIM_STEALTH) > v) {
                 return false;
             }
         } else if (!creature.is_time_limit_stealth()) {
@@ -108,13 +108,13 @@ bool set_tim_stealth(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
             notice = true;
         }
     } else {
-        if (creature.tim_stealth && !music_singing(creature, MUSIC_STEALTH)) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_STEALTH) && !music_singing(creature, MUSIC_STEALTH)) {
             msg_print(_("足音が大きくなった。", "You no longer walk silently."));
             notice = true;
         }
     }
 
-    creature.tim_stealth = v;
+    creature.set_timed_effect(CreatureTimedEffect::TIM_STEALTH, v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -327,7 +327,7 @@ bool heroism(CreatureEntity &creature, int base)
         ident = true;
     }
 
-    if (set_hero(creature, creature.get_remaining_hero() + randint1(base) + base, false)) {
+    if (set_hero(creature, creature.get_timed_effect(CreatureTimedEffect::HERO) + randint1(base) + base, false)) {
         ident = true;
     }
 
@@ -349,7 +349,7 @@ bool berserk(CreatureEntity &creature, int base)
         ident = true;
     }
 
-    if (set_berserk(creature, creature.get_remaining_berserk() + randint1(base) + base, false)) {
+    if (set_berserk(creature, creature.get_timed_effect(CreatureTimedEffect::BERSERK) + randint1(base) + base, false)) {
         ident = true;
     }
 
@@ -650,12 +650,12 @@ bool cosmic_cast_off(CreatureEntity &creature, ItemEntity **o_ptr_ptr)
     BadStatusSetter bss(creature);
     (void)bss.mod_blindness(t);
     (void)bss.set_fear(0);
-    (void)set_tim_esp(creature, creature.get_remaining_tim_esp() + t, false);
-    (void)set_tim_regen(creature, creature.get_remaining_tim_regen() + t, false);
-    (void)set_hero(creature, creature.get_remaining_hero() + t, false);
-    (void)set_blessed(creature, creature.get_remaining_blessed() + t, false);
+    (void)set_tim_esp(creature, creature.get_timed_effect(CreatureTimedEffect::TIM_ESP) + t, false);
+    (void)set_tim_regen(creature, creature.get_timed_effect(CreatureTimedEffect::TIM_REGEN) + t, false);
+    (void)set_hero(creature, creature.get_timed_effect(CreatureTimedEffect::HERO) + t, false);
+    (void)set_blessed(creature, creature.get_timed_effect(CreatureTimedEffect::BLESSED) + t, false);
     (void)mod_acceleration(creature, t, false);
-    (void)set_berserk(creature, creature.get_remaining_berserk() + t, false);
+    (void)set_berserk(creature, creature.get_timed_effect(CreatureTimedEffect::BERSERK) + t, false);
     if (CreatureClass(creature).equals(PlayerClassType::FORCETRAINER)) {
         set_current_ki(creature, true, creature.level * 5 + 190);
         msg_print(_("気が爆発寸前になった。", "Your force absorbs the explosion."));

--- a/src/view/display-characteristic.cpp
+++ b/src/view/display-characteristic.cpp
@@ -190,7 +190,7 @@ static void process_light_equipment_characteristics(CreatureEntity &creature, al
         }
     }
 
-    if (creature.tim_emission > 0) {
+    if (creature.get_timed_effect(CreatureTimedEffect::TIM_EMISSION) > 0) {
         char_stat.syms.emplace_back("#");
         char_stat.has_tim = true;
         return;

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -352,7 +352,7 @@ tl::optional<uint8_t> get_monochrome_display_color(CreatureEntity &creature)
     if (creature.is_invulnerable() || creature.timewalk) {
         return TERM_WHITE;
     }
-    if (creature.get_remaining_wraith_form()) {
+    if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
         return TERM_L_DARK;
     }
 

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -196,7 +196,7 @@ static int calc_temporary_speed(CreatureEntity &creature)
             tmp_speed -= 10;
         }
 
-        if (creature.lightspeed) {
+        if (creature.get_timed_effect(CreatureTimedEffect::LIGHTSPEED)) {
             tmp_speed = 99;
         }
     } else {
@@ -225,7 +225,7 @@ static void display_player_speed(CreatureEntity &creature, TERM_COLOR attr, int 
     char buf[160];
     if (tmp_speed) {
         if (!creature.riding) {
-            if (creature.lightspeed) {
+            if (creature.get_timed_effect(CreatureTimedEffect::LIGHTSPEED)) {
                 sprintf(buf, _("光速化 (+99)", "Lightspeed (+99)"));
             } else {
                 sprintf(buf, "(%+d%+d)", base_speed - tmp_speed, tmp_speed);

--- a/src/view/display-player-stat-info.cpp
+++ b/src/view/display-player-stat-info.cpp
@@ -225,7 +225,7 @@ static int compensation_stat_by_mutation(CreatureEntity &creature, int stat)
         if (creature.muta.has(PlayerMutationType::PUNY)) {
             compensation -= 4;
         }
-        if (creature.get_remaining_tsuyoshi()) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TSUYOSHI)) {
             compensation += 4;
         }
         return compensation;
@@ -267,7 +267,7 @@ static int compensation_stat_by_mutation(CreatureEntity &creature, int stat)
         if (creature.muta.has(PlayerMutationType::FLESH_ROT)) {
             compensation -= 2;
         }
-        if (creature.get_remaining_tsuyoshi()) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TSUYOSHI)) {
             compensation += 4;
         }
         return compensation;

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -664,27 +664,27 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_EYEEYE);
     }
 
-    if (creature.tim_res_lite) {
+    if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_LITE)) {
         ADD_BAR_FLAG(BAR_RESLITE);
     }
 
-    if (creature.tim_res_dark) {
+    if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_DARK)) {
         ADD_BAR_FLAG(BAR_RESDARK);
     }
 
-    if (creature.tim_res_fear) {
+    if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_FEAR)) {
         ADD_BAR_FLAG(BAR_RESFEAR);
     }
 
-    if (creature.tim_emission) {
+    if (creature.get_timed_effect(CreatureTimedEffect::TIM_EMISSION)) {
         ADD_BAR_FLAG(BAR_EMISSION);
     }
 
-    if (creature.tim_exorcism) {
+    if (creature.get_timed_effect(CreatureTimedEffect::TIM_EXORCISM)) {
         ADD_BAR_FLAG(BAR_EXORCISM);
     }
 
-    if (creature.tim_imm_dark) {
+    if (creature.get_timed_effect(CreatureTimedEffect::TIM_IMM_DARK)) {
         ADD_BAR_FLAG(BAR_IMMDARK);
     }
 


### PR DESCRIPTION
…Phase 3 完了）

コードベース全体の TIME_EFFECT 直接フィールドアクセスを CreatureTimedEffect enum 経由の get/set_timed_effect() に変換。46ファイル、約210箇所を変更。

対象カテゴリ:
- 魔法/呪文系: spells-crusade, spells-demon, spells-hex, spells-craft, spells-song, spells-status, realm-song, realm-hex
- 精神系: mind-mirror-master, mind-force-trainer, mind-magic-resistance
- モンスター魔法: mspell-judgement, mspell-special
- 戦闘系: aura-counterattack, blood-sucking-processor, player-damage
- 効果系: effect-player, effect-player-resist-hurt, quaff-effects, scroll-read-executor
- 表示系: self-info, body-improvement-info, resistance-info, display-characteristic, display-map, display-player-middle, display-player-stat-info, main-window-stat-poster
- ステータス系: player-status, player-status-flags, player-status-resist, player-speed, player-infravision, player-strength, player-constitution, race-resistances
- コア/その他: magic-effects-timeout-reducer, player-processor, hp-mp-processor, mutation-processor, inventory-object, cmd-eat, cmd-usestaff, cmd-text-command, racial-kutar, torch, warning, player-attack-loader

https://claude.ai/code/session_01L1HaWfCTxckoYkCGTkXPKo