### PR TITLE
refactor: TIME_EFFECT フィールドを protected 化し mimic_form アクセサを追加（Phase 3 完了）

### DIFF
--- a/src/action/racial-execution.cpp
+++ b/src/action/racial-execution.cpp
@@ -32,7 +32,7 @@ bool exe_racial_power(CreatureEntity &creature, const int32_t command)
         return switch_class_racial_execution(creature, command);
     }
 
-    if (creature.mimic_form != MimicKindType::NONE) {
+    if (creature.get_mimic_form() != MimicKindType::NONE) {
         return switch_mimic_racial_execution(creature);
     }
 

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -481,7 +481,7 @@ void do_cmd_racial_power(CreatureEntity &creature)
 
     switch_class_racial(creature, rc_ptr);
 
-    if (creature.mimic_form != MimicKindType::NONE) {
+    if (creature.get_mimic_form() != MimicKindType::NONE) {
         set_mimic_racial_command(creature, rc_ptr);
     } else {
         set_race_racial_command(creature, rc_ptr);

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -26,7 +26,7 @@
 void reduce_magic_effects_timeout(CreatureEntity &creature)
 {
     if (creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC)) {
-        (void)set_mimic(creature, creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC) - 1, creature.mimic_form, true);
+        (void)set_mimic(creature, creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC) - 1, creature.get_mimic_form(), true);
     }
 
     BadStatusSetter bss(creature);

--- a/src/io-dump/player-status-dump-json.cpp
+++ b/src/io-dump/player-status-dump-json.cpp
@@ -58,8 +58,8 @@ static void add_basic_info_to_json(nlohmann::json &j, CreatureEntity &creature)
     j["basic"]["experience"] = creature.exp;
     j["basic"]["max_experience"] = creature.max_exp;
 
-    if (creature.mimic_form != MimicKindType::NONE) {
-        j["basic"]["mimic_form"] = localized_to_utf8_safe(mimic_info.at(creature.mimic_form).title);
+    if (creature.get_mimic_form() != MimicKindType::NONE) {
+        j["basic"]["mimic_form"] = localized_to_utf8_safe(mimic_info.at(creature.get_mimic_form()).title);
     }
 
     // 性格

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -375,7 +375,7 @@ static void set_timed_effects(CreatureEntity &creature)
     creature.set_timed_effect(CreatureTimedEffect::MAGICDEF, rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::TIM_RES_NETHER, rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::TIM_RES_TIME, rd_s16b());
-    creature.mimic_form = i2enum<MimicKindType>(rd_byte());
+    creature.set_mimic_form(i2enum<MimicKindType>(rd_byte()));
     creature.set_timed_effect(CreatureTimedEffect::TIM_MIMIC, rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::TIM_SH_FIRE, rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::TIM_SH_HOLY, rd_s16b());

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -260,7 +260,7 @@ bool process_un_power(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 bool check_drain_hp(CreatureEntity &creature, const int32_t d)
 {
     bool resist_drain = !drain_exp(creature, d, d / 10, 50);
-    if (creature.mimic_form != MimicKindType::NONE) {
+    if (creature.get_mimic_form() != MimicKindType::NONE) {
         return CreatureRace(&creature).is_mimic_nonliving() ? true : resist_drain;
     }
 

--- a/src/mspell/mspell-judgement.cpp
+++ b/src/mspell/mspell-judgement.cpp
@@ -248,11 +248,11 @@ bool dispel_check(CreatureEntity &creature, MONSTER_IDX m_idx)
         return true;
     }
 
-    if (creature.mimic_form == MimicKindType::DEMON_LORD) {
+    if (creature.get_mimic_form() == MimicKindType::DEMON_LORD) {
         return true;
     }
 
-    if (creature.mimic_form == MimicKindType::DEMIGOD) {
+    if (creature.get_mimic_form() == MimicKindType::DEMIGOD) {
         return true;
     }
 

--- a/src/player-base/player-race.cpp
+++ b/src/player-base/player-race.cpp
@@ -72,7 +72,7 @@ const player_race_info *CreatureRace::get_info() const
         return &race_info[enum2i(this->creature_ptr->prace)];
     }
 
-    switch (this->creature_ptr->mimic_form) {
+    switch (this->creature_ptr->get_mimic_form()) {
     case MimicKindType::NONE:
         return &race_info[enum2i(this->creature_ptr->prace)];
     case MimicKindType::DEMON:
@@ -80,7 +80,7 @@ const player_race_info *CreatureRace::get_info() const
     case MimicKindType::VAMPIRE:
     case MimicKindType::ANGEL:
     case MimicKindType::DEMIGOD:
-        return &mimic_info.at(this->creature_ptr->mimic_form);
+        return &mimic_info.at(this->creature_ptr->get_mimic_form());
     default:
         THROW_EXCEPTION(std::logic_error, "Invalid MimicKindType was specified!");
     }
@@ -110,7 +110,7 @@ PlayerRaceFoodType CreatureRace::food() const
 bool CreatureRace::is_mimic_nonliving() const
 {
     constexpr int nonliving_flag = 1;
-    return any_bits(mimic_info.at(this->creature_ptr->mimic_form).choice, nonliving_flag);
+    return any_bits(mimic_info.at(this->creature_ptr->get_mimic_form()).choice, nonliving_flag);
 }
 
 bool CreatureRace::has_cut_immunity() const
@@ -129,7 +129,7 @@ bool CreatureRace::has_stun_immunity() const
 
 bool CreatureRace::equals(PlayerRaceType prace) const
 {
-    return (this->creature_ptr->mimic_form == MimicKindType::NONE) && (this->creature_ptr->prace == prace);
+    return (this->creature_ptr->get_mimic_form() == MimicKindType::NONE) && (this->creature_ptr->prace == prace);
 }
 
 /*!
@@ -167,7 +167,7 @@ int16_t CreatureRace::speed() const
         }
     }
 
-    switch (this->creature_ptr->mimic_form) {
+    switch (this->creature_ptr->get_mimic_form()) {
     case MimicKindType::NONE:
         return result;
     case MimicKindType::DEMON:

--- a/src/player-info/alignment.cpp
+++ b/src/player-info/alignment.cpp
@@ -65,7 +65,7 @@ void PlayerAlignment::update_alignment()
         }
     }
 
-    switch (this->creature_ptr->mimic_form) {
+    switch (this->creature_ptr->get_mimic_form()) {
     case MimicKindType::NONE:
         switch (this->creature_ptr->prace) {
         case PlayerRaceType::ARCHON:

--- a/src/player-info/self-info.cpp
+++ b/src/player-info/self-info.cpp
@@ -248,7 +248,7 @@ void self_knowledge(CreatureEntity &subject)
     display_max_base_status(subject, self_ptr);
     display_virtue(subject, self_ptr);
     self_ptr->info_list.emplace_back("");
-    if (subject.mimic_form != MimicKindType::NONE) {
+    if (subject.get_mimic_form() != MimicKindType::NONE) {
         display_mimic_race_ability(subject, self_ptr);
     } else {
         set_race_ability_info(subject, self_ptr);

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -499,7 +499,7 @@ BIT_FLAGS get_player_flags(CreatureEntity &creature, tr_type tr_flag)
  */
 bool has_kill_wall(CreatureEntity &creature)
 {
-    if (creature.mimic_form == MimicKindType::DEMON_LORD || music_singing(creature, MUSIC_WALL)) {
+    if (creature.get_mimic_form() == MimicKindType::DEMON_LORD || music_singing(creature, MUSIC_WALL)) {
         return true;
     }
 
@@ -1369,7 +1369,7 @@ BIT_FLAGS has_resist_lite(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_RES_LITE) | common_cause_flags(creature, TR_IM_LITE);
 
-    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE) || creature.get_timed_effect(CreatureTimedEffect::TIM_RES_LITE) || creature.mimic_form == MimicKindType::DEMIGOD) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE) || creature.get_timed_effect(CreatureTimedEffect::TIM_RES_LITE) || creature.get_mimic_form() == MimicKindType::DEMIGOD) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1637,7 +1637,7 @@ BIT_FLAGS has_immune_dark(CreatureEntity &creature)
 BIT_FLAGS has_immune_lite(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_IM_LITE);
-    if (creature.mimic_form == MimicKindType::DEMIGOD) {
+    if (creature.get_mimic_form() == MimicKindType::DEMIGOD) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
     return result;

--- a/src/player/player-status-resist.cpp
+++ b/src/player/player-status-resist.cpp
@@ -216,7 +216,7 @@ PERCENTAGE calc_nuke_damage_rate(CreatureEntity &creature)
 PERCENTAGE calc_deathray_damage_rate(CreatureEntity &creature, rate_calc_type_mode mode)
 {
     (void)mode; // unused
-    if (creature.mimic_form != MimicKindType::NONE) {
+    if (creature.get_mimic_form() != MimicKindType::NONE) {
         if (CreatureRace(&creature).is_mimic_nonliving()) {
             return 0;
         }

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -418,8 +418,8 @@ static void update_max_hitpoints(CreatureEntity &creature)
 
     CreatureClass pc(creature);
     auto is_sorcerer = pc.equals(PlayerClassType::SORCERER);
-    if (creature.mimic_form != MimicKindType::NONE) {
-        auto r_mhp = mimic_info.at(creature.mimic_form).r_mhp;
+    if (creature.get_mimic_form() != MimicKindType::NONE) {
+        auto r_mhp = mimic_info.at(creature.get_mimic_form()).r_mhp;
         const auto mimic_hit_dice = Dice(1, (is_sorcerer ? r_mhp / 2 : r_mhp) + (*creature.pclass_ref).c_mhp + (*creature.personality).a_mhp);
         mhp = mhp * mimic_hit_dice.maxroll() / creature.hit_dice.maxroll();
     }
@@ -1028,8 +1028,8 @@ static ACTION_SKILL_POWER calc_disarming(CreatureEntity &creature)
     ACTION_SKILL_POWER pow;
     const player_race_info *tmp_race_ptr;
 
-    if (creature.mimic_form != MimicKindType::NONE) {
-        tmp_race_ptr = &mimic_info.at(creature.mimic_form);
+    if (creature.get_mimic_form() != MimicKindType::NONE) {
+        tmp_race_ptr = &mimic_info.at(creature.get_mimic_form());
     } else {
         tmp_race_ptr = &race_info[enum2i(creature.prace)];
     }
@@ -1060,8 +1060,8 @@ static ACTION_SKILL_POWER calc_device_ability(CreatureEntity &creature)
     ACTION_SKILL_POWER pow;
     const player_race_info *tmp_race_ptr;
 
-    if (creature.mimic_form != MimicKindType::NONE) {
-        tmp_race_ptr = &mimic_info.at(creature.mimic_form);
+    if (creature.get_mimic_form() != MimicKindType::NONE) {
+        tmp_race_ptr = &mimic_info.at(creature.get_mimic_form());
     } else {
         tmp_race_ptr = &race_info[enum2i(creature.prace)];
     }
@@ -1116,8 +1116,8 @@ static ACTION_SKILL_POWER calc_saving_throw(CreatureEntity &creature)
     ACTION_SKILL_POWER pow;
     const player_race_info *tmp_race_ptr;
 
-    if (creature.mimic_form != MimicKindType::NONE) {
-        tmp_race_ptr = &mimic_info.at(creature.mimic_form);
+    if (creature.get_mimic_form() != MimicKindType::NONE) {
+        tmp_race_ptr = &mimic_info.at(creature.get_mimic_form());
     } else {
         tmp_race_ptr = &race_info[enum2i(creature.prace)];
     }
@@ -1189,8 +1189,8 @@ static ACTION_SKILL_POWER calc_search(CreatureEntity &creature)
     ACTION_SKILL_POWER pow;
     const player_race_info *tmp_race_ptr;
 
-    if (creature.mimic_form != MimicKindType::NONE) {
-        tmp_race_ptr = &mimic_info.at(creature.mimic_form);
+    if (creature.get_mimic_form() != MimicKindType::NONE) {
+        tmp_race_ptr = &mimic_info.at(creature.get_mimic_form());
     } else {
         tmp_race_ptr = &race_info[enum2i(creature.prace)];
     }
@@ -1238,8 +1238,8 @@ static ACTION_SKILL_POWER calc_search_freq(CreatureEntity &creature)
 {
     ACTION_SKILL_POWER pow;
     const player_race_info *tmp_race_ptr;
-    if (creature.mimic_form != MimicKindType::NONE) {
-        tmp_race_ptr = &mimic_info.at(creature.mimic_form);
+    if (creature.get_mimic_form() != MimicKindType::NONE) {
+        tmp_race_ptr = &mimic_info.at(creature.get_mimic_form());
     } else {
         tmp_race_ptr = &race_info[enum2i(creature.prace)];
     }
@@ -1285,8 +1285,8 @@ static ACTION_SKILL_POWER calc_to_hit_melee(CreatureEntity &creature)
     const auto &player_class = class_info.at(creature.pclass);
     const auto &player_personality = personality_info[creature.ppersonality];
     const player_race_info *tmp_race_ptr;
-    if (creature.mimic_form != MimicKindType::NONE) {
-        tmp_race_ptr = &mimic_info.at(creature.mimic_form);
+    if (creature.get_mimic_form() != MimicKindType::NONE) {
+        tmp_race_ptr = &mimic_info.at(creature.get_mimic_form());
     } else {
         tmp_race_ptr = &race_info[enum2i(creature.prace)];
     }
@@ -1309,8 +1309,8 @@ static ACTION_SKILL_POWER calc_to_hit_shoot(CreatureEntity &creature)
     const auto &player_class = class_info.at(creature.pclass);
     const auto &player_personality = personality_info[creature.ppersonality];
     const player_race_info *tmp_race_ptr;
-    if (creature.mimic_form != MimicKindType::NONE) {
-        tmp_race_ptr = &mimic_info.at(creature.mimic_form);
+    if (creature.get_mimic_form() != MimicKindType::NONE) {
+        tmp_race_ptr = &mimic_info.at(creature.get_mimic_form());
     } else {
         tmp_race_ptr = &race_info[enum2i(creature.prace)];
     }
@@ -1334,8 +1334,8 @@ static ACTION_SKILL_POWER calc_to_hit_throw(CreatureEntity &creature)
     const auto &player_class = class_info.at(creature.pclass);
     const auto &player_personality = personality_info[creature.ppersonality];
     const player_race_info *tmp_race_ptr;
-    if (creature.mimic_form != MimicKindType::NONE) {
-        tmp_race_ptr = &mimic_info.at(creature.mimic_form);
+    if (creature.get_mimic_form() != MimicKindType::NONE) {
+        tmp_race_ptr = &mimic_info.at(creature.get_mimic_form());
     } else {
         tmp_race_ptr = &race_info[enum2i(creature.prace)];
     }
@@ -1678,7 +1678,7 @@ static ARMOUR_CLASS calc_to_ac(CreatureEntity &creature, bool is_real_value)
 
     ac += ((int)(adj_dex_ta[creature.stat_index[A_DEX]]) - 128);
 
-    switch (creature.mimic_form) {
+    switch (creature.get_mimic_form()) {
     case MimicKindType::NONE:
         break;
     case MimicKindType::DEMON:

--- a/src/racial/race-racial-command-setter.cpp
+++ b/src/racial/race-racial-command-setter.cpp
@@ -8,7 +8,7 @@
 void set_mimic_racial_command(CreatureEntity &creature, rc_type *rc_ptr)
 {
     rpi_type rpi;
-    switch (creature.mimic_form) {
+    switch (creature.get_mimic_form()) {
     case MimicKindType::NONE:
         return;
     case MimicKindType::DEMON:

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -296,7 +296,7 @@ bool switch_class_racial_execution(CreatureEntity &creature, const int32_t comma
 
 bool switch_mimic_racial_execution(CreatureEntity &creature)
 {
-    switch (creature.mimic_form) {
+    switch (creature.get_mimic_form()) {
     case MimicKindType::DEMON:
     case MimicKindType::DEMON_LORD: {
         return demonic_breath(creature);

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -234,7 +234,7 @@ void wr_player(CreatureEntity &creature)
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::TIM_RES_DARK));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::TIM_RES_FEAR));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::TIM_RES_TIME));
-    wr_byte((byte)creature.mimic_form);
+    wr_byte((byte)creature.get_mimic_form());
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::TIM_SH_FIRE));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::TIM_SH_HOLY));

--- a/src/specific-object/death-scythe.cpp
+++ b/src/specific-object/death-scythe.cpp
@@ -66,7 +66,7 @@ static int calc_death_scythe_reflection_magnification_mimic_none(CreatureEntity 
  */
 static int calc_death_scythe_reflection_magnification(CreatureEntity &creature)
 {
-    switch (creature.mimic_form) {
+    switch (creature.get_mimic_form()) {
     case MimicKindType::NONE:
         return calc_death_scythe_reflection_magnification_mimic_none(creature);
     case MimicKindType::DEMON:

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -97,11 +97,11 @@ void update_lite_radius(CreatureEntity &creature)
         creature.cur_lite = 14;
     }
 
-    if (creature.mimic_form == MimicKindType::ANGEL) {
+    if (creature.get_mimic_form() == MimicKindType::ANGEL) {
         creature.cur_lite += 3;
     }
 
-    if (creature.mimic_form == MimicKindType::DEMIGOD) {
+    if (creature.get_mimic_form() == MimicKindType::DEMIGOD) {
         creature.cur_lite += 6;
     }
 

--- a/src/spell-realm/spells-crusade.cpp
+++ b/src/spell-realm/spells-crusade.cpp
@@ -144,7 +144,7 @@ void check_emission(CreatureEntity &creature)
 
 void check_demigod(CreatureEntity &creature)
 {
-    if (creature.mimic_form == MimicKindType::DEMIGOD) {
+    if (creature.get_mimic_form() == MimicKindType::DEMIGOD) {
         const Dice dice(1, creature.level * 4);
 
         dispel_evil(creature, dice.roll());

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -68,7 +68,7 @@ void reset_tim_flags(CreatureEntity &creature)
     creature.set_timed_effect(CreatureTimedEffect::TIM_RES_FEAR, 0);
     creature.set_timed_effect(CreatureTimedEffect::TIM_RES_TIME, 0);
     creature.set_timed_effect(CreatureTimedEffect::TIM_MIMIC, 0);
-    creature.mimic_form = MimicKindType::NONE;
+    creature.set_mimic_form(MimicKindType::NONE);
     creature.set_timed_effect(CreatureTimedEffect::TIM_REFLECT, 0);
     creature.set_timed_effect(CreatureTimedEffect::MULTISHADOW, 0);
     creature.set_timed_effect(CreatureTimedEffect::DUSTROBE, 0);
@@ -383,13 +383,13 @@ bool set_mimic(CreatureEntity &creature, TIME_EFFECT v, MimicKindType mimic_race
     }
 
     if (v) {
-        if (creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC) && (creature.mimic_form == mimic_race_idx) && !do_dec) {
+        if (creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC) && (creature.get_mimic_form() == mimic_race_idx) && !do_dec) {
             if (creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC) > v) {
                 return false;
             }
-        } else if ((!creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC)) || (creature.mimic_form != mimic_race_idx)) {
+        } else if ((!creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC)) || (creature.get_mimic_form() != mimic_race_idx)) {
             msg_print(_("自分の体が変わってゆくのを感じた。", "You feel that your body changes."));
-            creature.mimic_form = mimic_race_idx;
+            creature.set_mimic_form(mimic_race_idx);
             notice = true;
         }
     }
@@ -397,10 +397,10 @@ bool set_mimic(CreatureEntity &creature, TIME_EFFECT v, MimicKindType mimic_race
     else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC)) {
             msg_print(_("変身が解けた。", "You are no longer transformed."));
-            if (creature.mimic_form == MimicKindType::DEMON) {
+            if (creature.get_mimic_form() == MimicKindType::DEMON) {
                 set_oppose_fire(creature, 0, true);
             }
-            creature.mimic_form = MimicKindType::NONE;
+            creature.set_mimic_form(MimicKindType::NONE);
             notice = true;
             mimic_race_idx = MimicKindType::NONE;
         }

--- a/src/status/element-resistance.cpp
+++ b/src/status/element-resistance.cpp
@@ -122,7 +122,7 @@ bool set_oppose_fire(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if ((CreatureRace(&creature).equals(PlayerRaceType::BALROG) && (creature.level > 44)) || (creature.mimic_form == MimicKindType::DEMON)) {
+    if ((CreatureRace(&creature).equals(PlayerRaceType::BALROG) && (creature.level > 44)) || (creature.get_mimic_form() == MimicKindType::DEMON)) {
         v = 1;
     }
     if (v) {
@@ -273,7 +273,7 @@ bool is_oppose_fire(CreatureEntity &creature)
     auto can_oppose_fire = creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE) != 0;
     can_oppose_fire |= music_singing(creature, MUSIC_RESIST);
     can_oppose_fire |= CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU);
-    can_oppose_fire |= creature.mimic_form == MimicKindType::DEMON;
+    can_oppose_fire |= creature.get_mimic_form() == MimicKindType::DEMON;
     can_oppose_fire |= (CreatureRace(&creature).equals(PlayerRaceType::BALROG) && creature.level > 44);
     return can_oppose_fire;
 }

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -786,6 +786,24 @@ public:
     }
 
     /*!
+     * @brief 現在の変身形態を取得する
+     * @return 変身形態（NONE なら通常状態）
+     */
+    MimicKindType get_mimic_form() const
+    {
+        return this->mimic_form;
+    }
+
+    /*!
+     * @brief 変身形態を設定する
+     * @param form 変身形態
+     */
+    void set_mimic_form(MimicKindType form)
+    {
+        this->mimic_form = form;
+    }
+
+    /*!
      * @brief 体力ランク (0-100) を計算する
      * @return 体力ランク
      */
@@ -976,60 +994,8 @@ public:
     // 地形移動能力 / Terrain movement abilities
     bool can_swim{}; /* No damage in water */
 
-    // 時限効果 / Timed effects
-    TIME_EFFECT invuln{}; /* Timed -- Invulnerable */
-    TIME_EFFECT ult_res{}; /* Timed -- Ultimate Resistance */
-    TIME_EFFECT hero{}; /* Timed -- Heroism */
-    TIME_EFFECT berserk{}; /* Timed -- Super Heroism */
-    TIME_EFFECT shield{}; /* Timed -- Shield Spell */
-    TIME_EFFECT blessed{}; /* Timed -- Blessed */
-    TIME_EFFECT tim_invis{}; /* Timed -- See Invisible */
-    TIME_EFFECT tim_infra{}; /* Timed -- Infra Vision */
-    TIME_EFFECT tsuyoshi{}; /* Timed -- Tsuyoshi Special */
-    TIME_EFFECT ele_attack{}; /* Timed -- Elemental Attack */
-    TIME_EFFECT ele_immune{}; /* Timed -- Elemental Immune */
-
     /* クリーチャーの防御状態の定義 / Bit flags for the "special_defense" variable. -LM- */
     BIT_FLAGS special_defense{};
-
-    TIME_EFFECT oppose_acid{}; /* Timed -- oppose acid */
-    TIME_EFFECT oppose_elec{}; /* Timed -- oppose lightning */
-    TIME_EFFECT oppose_fire{}; /* Timed -- oppose heat */
-    TIME_EFFECT oppose_cold{}; /* Timed -- oppose cold */
-    TIME_EFFECT oppose_pois{}; /* Timed -- oppose poison */
-
-    TIME_EFFECT tim_esp{}; /* Timed ESP */
-    TIME_EFFECT wraith_form{}; /* Timed wraithform */
-
-    TIME_EFFECT resist_magic{}; /* Timed Resist Magic (later) */
-    TIME_EFFECT tim_regen{};
-    TIME_EFFECT tim_pass_wall{};
-    TIME_EFFECT tim_stealth{};
-    TIME_EFFECT tim_levitation{};
-    TIME_EFFECT tim_sh_touki{};
-    TIME_EFFECT lightspeed{};
-    TIME_EFFECT tsubureru{};
-    TIME_EFFECT magicdef{};
-    TIME_EFFECT tim_res_nether{}; /* Timed -- Nether resistance */
-    TIME_EFFECT tim_res_lite{}; /* Timed -- Lite resistance */
-    TIME_EFFECT tim_res_dark{}; /* Timed -- Dark resistance */
-    TIME_EFFECT tim_res_fear{}; /* Timed -- Fear resistance */
-    TIME_EFFECT tim_res_time{}; /* Timed -- Time resistance */
-    MimicKindType mimic_form{};
-    TIME_EFFECT tim_mimic{};
-    TIME_EFFECT tim_sh_fire{};
-    TIME_EFFECT tim_sh_holy{};
-    TIME_EFFECT tim_eyeeye{};
-
-    /* for mirror master */
-    TIME_EFFECT tim_reflect{}; /* Timed -- Reflect */
-    TIME_EFFECT multishadow{}; /* Timed -- Multi-shadow */
-    TIME_EFFECT dustrobe{}; /* Timed -- Robe of dust */
-
-    /* for crusade */
-    TIME_EFFECT tim_emission{}; /* Timed -- Player Emission */
-    TIME_EFFECT tim_exorcism{}; /* Timed -- Exorcism */
-    TIME_EFFECT tim_imm_dark{}; /* Timed -- Darkness immunity */
 
     // 装備・能力関連フラグ / Equipment and ability flags
     bool hack_mutation{};
@@ -1258,6 +1224,51 @@ public:
 
 protected:
     std::shared_ptr<TimedEffects> timed_effects; /*!< 時限効果管理オブジェクト */
+
+    // 時限効果 / Timed effects（外部からは get/set_timed_effect() 経由でアクセスすること）
+    TIME_EFFECT invuln{}; /* Timed -- Invulnerable */
+    TIME_EFFECT ult_res{}; /* Timed -- Ultimate Resistance */
+    TIME_EFFECT hero{}; /* Timed -- Heroism */
+    TIME_EFFECT berserk{}; /* Timed -- Super Heroism */
+    TIME_EFFECT shield{}; /* Timed -- Shield Spell */
+    TIME_EFFECT blessed{}; /* Timed -- Blessed */
+    TIME_EFFECT tim_invis{}; /* Timed -- See Invisible */
+    TIME_EFFECT tim_infra{}; /* Timed -- Infra Vision */
+    TIME_EFFECT tsuyoshi{}; /* Timed -- Tsuyoshi Special */
+    TIME_EFFECT ele_attack{}; /* Timed -- Elemental Attack */
+    TIME_EFFECT ele_immune{}; /* Timed -- Elemental Immune */
+    TIME_EFFECT oppose_acid{}; /* Timed -- oppose acid */
+    TIME_EFFECT oppose_elec{}; /* Timed -- oppose lightning */
+    TIME_EFFECT oppose_fire{}; /* Timed -- oppose heat */
+    TIME_EFFECT oppose_cold{}; /* Timed -- oppose cold */
+    TIME_EFFECT oppose_pois{}; /* Timed -- oppose poison */
+    TIME_EFFECT tim_esp{}; /* Timed ESP */
+    TIME_EFFECT wraith_form{}; /* Timed wraithform */
+    TIME_EFFECT resist_magic{}; /* Timed Resist Magic (later) */
+    TIME_EFFECT tim_regen{};
+    TIME_EFFECT tim_pass_wall{};
+    TIME_EFFECT tim_stealth{};
+    TIME_EFFECT tim_levitation{};
+    TIME_EFFECT tim_sh_touki{};
+    TIME_EFFECT lightspeed{};
+    TIME_EFFECT tsubureru{};
+    TIME_EFFECT magicdef{};
+    TIME_EFFECT tim_res_nether{}; /* Timed -- Nether resistance */
+    TIME_EFFECT tim_res_lite{}; /* Timed -- Lite resistance */
+    TIME_EFFECT tim_res_dark{}; /* Timed -- Dark resistance */
+    TIME_EFFECT tim_res_fear{}; /* Timed -- Fear resistance */
+    TIME_EFFECT tim_res_time{}; /* Timed -- Time resistance */
+    MimicKindType mimic_form{};
+    TIME_EFFECT tim_mimic{};
+    TIME_EFFECT tim_sh_fire{};
+    TIME_EFFECT tim_sh_holy{};
+    TIME_EFFECT tim_eyeeye{};
+    TIME_EFFECT tim_reflect{}; /* Timed -- Reflect */
+    TIME_EFFECT multishadow{}; /* Timed -- Multi-shadow */
+    TIME_EFFECT dustrobe{}; /* Timed -- Robe of dust */
+    TIME_EFFECT tim_emission{}; /* Timed -- Player Emission */
+    TIME_EFFECT tim_exorcism{}; /* Timed -- Exorcism */
+    TIME_EFFECT tim_imm_dark{}; /* Timed -- Darkness immunity */
 
 private:
     std::string build_damage_description() const;

--- a/src/view/display-player-misc-info.cpp
+++ b/src/view/display-player-misc-info.cpp
@@ -50,7 +50,7 @@ void display_player_misc_info(CreatureEntity &creature)
     put_str(_("職業  :", "Class :"), 5, 1);
 
     c_put_str(TERM_L_BLUE, sp_ptr->title, 3, 9);
-    c_put_str(TERM_L_BLUE, (creature.mimic_form != MimicKindType::NONE ? mimic_info.at(creature.mimic_form).title : creature.race->title), 4, 9);
+    c_put_str(TERM_L_BLUE, (creature.get_mimic_form() != MimicKindType::NONE ? mimic_info.at(creature.get_mimic_form()).title : creature.race->title), 4, 9);
     c_put_str(TERM_L_BLUE, (*creature.pclass_ref).title, 5, 9);
 
     put_str(_("レベル:", "Level :"), 6, 1);

--- a/src/view/display-player-stat-info.cpp
+++ b/src/view/display-player-stat-info.cpp
@@ -131,7 +131,7 @@ static void display_basic_stat_value(CreatureEntity &creature, int stat_num, int
 static void process_stats(CreatureEntity &creature, int row, int stat_col)
 {
     for (int i = 0; i < A_MAX; i++) {
-        int r_adj = creature.mimic_form != MimicKindType::NONE ? mimic_info.at(creature.mimic_form).r_adj[i] : creature.race->r_adj[i];
+        int r_adj = creature.get_mimic_form() != MimicKindType::NONE ? mimic_info.at(creature.get_mimic_form()).r_adj[i] : creature.race->r_adj[i];
         int e_adj = calc_basic_stat(creature, i);
         r_adj += compensate_special_race(creature, i);
         e_adj -= r_adj;

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -90,7 +90,7 @@ static void display_player_basic_info(CreatureEntity &creature)
     display_player_name(creature);
     display_player_one_line(ENTRY_SEX, sp_ptr->title, TERM_L_BLUE);
     if (creature.race != nullptr) {
-        display_player_one_line(ENTRY_RACE, (creature.mimic_form != MimicKindType::NONE ? mimic_info.at(creature.mimic_form).title : creature.race->title), TERM_L_BLUE);
+        display_player_one_line(ENTRY_RACE, (creature.get_mimic_form() != MimicKindType::NONE ? mimic_info.at(creature.get_mimic_form()).title : creature.race->title), TERM_L_BLUE);
     }
     if (creature.pclass_ref != nullptr) {
         display_player_one_line(ENTRY_CLASS, (*creature.pclass_ref).title, TERM_L_BLUE);

--- a/src/view/display-self-info.cpp
+++ b/src/view/display-self-info.cpp
@@ -73,7 +73,7 @@ void display_virtue(CreatureEntity &creature, self_info_type *self_ptr)
 
 void display_mimic_race_ability(CreatureEntity &creature, self_info_type *self_ptr)
 {
-    switch (creature.mimic_form) {
+    switch (creature.get_mimic_form()) {
     case MimicKindType::NONE:
         return;
     case MimicKindType::DEMON:

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -248,9 +248,9 @@ void print_depth(CreatureEntity &creature)
  */
 void print_frame_basic(CreatureEntity &creature)
 {
-    const auto &title = creature.mimic_form == MimicKindType::NONE
+    const auto &title = creature.get_mimic_form() == MimicKindType::NONE
                             ? creature.race->title
-                            : mimic_info.at(creature.mimic_form).title;
+                            : mimic_info.at(creature.get_mimic_form()).title;
     print_field(title, ROW_RACE, COL_RACE);
     print_title(creature);
     print_level(creature);


### PR DESCRIPTION
CreatureEntity の 42 個の TIME_EFFECT 直接フィールドを public → protected に 移動し、外部からは get/set_timed_effect() 経由のみでアクセスするよう強制した。

- 全 TIME_EFFECT フィールドを protected セクションに移動
- MimicKindType mimic_form 用に get_mimic_form() / set_mimic_form() アクセサを追加
- 27 ファイルの mimic_form 直接アクセスをアクセサ経由に変換
- 追加の直接フィールドアクセス残存箇所も get/set_timed_effect() に変換

https://claude.ai/code/session_01L1HaWfCTxckoYkCGTkXPKo