### PR TITLE
refactor: MonsterTimedEffect を廃止し CreatureTimedEffect に統合（Phase 3 仕上げ）

### DIFF
--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -125,7 +125,7 @@ static MonraceDefinition &set_pet_params(CreatureEntity &creature, const int cur
     monster.x = cx;
     monster.current_floor_ptr = creature.current_floor_ptr;
     monster.get_monster_profile().ml = true;
-    monster.get_monster_profile().mtimed[MonsterTimedEffect::SLEEP] = 0;
+    monster.get_monster_profile().mtimed[CreatureTimedEffect::SLEEP_OR_PARALYSIS] = 0;
     monster.get_monster_profile().hold_o_idx_list.clear();
     monster.reset_target();
     auto &r_ref = monster.get_real_monrace();

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -34,6 +34,7 @@
 #include "monster/monster-flag-types.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
+#include "monster/monster-timed-effects.h"
 #include "monster/monster-update.h"
 #include "monster/monster-util.h"
 #include "system/angband-system.h"
@@ -445,7 +446,7 @@ void clear_cave(CreatureEntity &creature)
     }
     floor.m_max = 1;
     floor.m_cnt = 0;
-    for (const auto mte : MONSTER_TIMED_EFFECT_RANGE) {
+    for (const auto mte : MONSTER_TIMED_EFFECT_LIST) {
         floor.mproc_max[mte] = 0;
     }
 

--- a/src/load/old/monster-loader-savefile50.cpp
+++ b/src/load/old/monster-loader-savefile50.cpp
@@ -47,7 +47,7 @@ void MonsterLoader50::rd_monster(CreatureEntity &monster)
 
     monster.ap_r_idx = any_bits(flags, SaveDataMonsterFlagType::AP_R_IDX) ? i2enum<MonraceId>(rd_s16b()) : monster.r_idx;
     monster.get_monster_profile().sub_align = any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN) ? rd_byte() : 0;
-    monster.get_monster_profile().mtimed[MonsterTimedEffect::SLEEP] = any_bits(flags, SaveDataMonsterFlagType::SLEEP) ? rd_s16b() : 0;
+    monster.get_monster_profile().mtimed[CreatureTimedEffect::SLEEP_OR_PARALYSIS] = any_bits(flags, SaveDataMonsterFlagType::SLEEP) ? rd_s16b() : 0;
     monster.speed = rd_byte();
     monster.energy_need = rd_s16b();
     if (loading_savefile_version_is_older_than(38)) {
@@ -56,14 +56,14 @@ void MonsterLoader50::rd_monster(CreatureEntity &monster)
     } else {
         monster.ac = rd_s16b();
     }
-    monster.get_monster_profile().mtimed[MonsterTimedEffect::FAST] = any_bits(flags, SaveDataMonsterFlagType::FAST) ? rd_byte() : 0;
-    monster.get_monster_profile().mtimed[MonsterTimedEffect::SLOW] = any_bits(flags, SaveDataMonsterFlagType::SLOW) ? rd_byte() : 0;
-    monster.get_monster_profile().mtimed[MonsterTimedEffect::STUN] = any_bits(flags, SaveDataMonsterFlagType::STUNNED) ? rd_byte() : 0;
-    monster.get_monster_profile().mtimed[MonsterTimedEffect::CONFUSION] = any_bits(flags, SaveDataMonsterFlagType::CONFUSED) ? rd_byte() : 0;
-    monster.get_monster_profile().mtimed[MonsterTimedEffect::FEAR] = any_bits(flags, SaveDataMonsterFlagType::MONFEAR) ? rd_byte() : 0;
+    monster.get_monster_profile().mtimed[CreatureTimedEffect::ACCELERATION] = any_bits(flags, SaveDataMonsterFlagType::FAST) ? rd_byte() : 0;
+    monster.get_monster_profile().mtimed[CreatureTimedEffect::DECELERATION] = any_bits(flags, SaveDataMonsterFlagType::SLOW) ? rd_byte() : 0;
+    monster.get_monster_profile().mtimed[CreatureTimedEffect::STUN] = any_bits(flags, SaveDataMonsterFlagType::STUNNED) ? rd_byte() : 0;
+    monster.get_monster_profile().mtimed[CreatureTimedEffect::CONFUSION] = any_bits(flags, SaveDataMonsterFlagType::CONFUSED) ? rd_byte() : 0;
+    monster.get_monster_profile().mtimed[CreatureTimedEffect::FEAR] = any_bits(flags, SaveDataMonsterFlagType::MONFEAR) ? rd_byte() : 0;
     monster.target.y = any_bits(flags, SaveDataMonsterFlagType::TARGET_Y) ? rd_s16b() : 0;
     monster.target.x = any_bits(flags, SaveDataMonsterFlagType::TARGET_X) ? rd_s16b() : 0;
-    monster.get_monster_profile().mtimed[MonsterTimedEffect::INVULNERABILITY] = any_bits(flags, SaveDataMonsterFlagType::INVULNER) ? rd_byte() : 0;
+    monster.get_monster_profile().mtimed[CreatureTimedEffect::INVULNERABILITY] = any_bits(flags, SaveDataMonsterFlagType::INVULNER) ? rd_byte() : 0;
     monster.get_monster_profile().mflag.clear();
     monster.get_monster_profile().mflag2.clear();
     if (any_bits(flags, SaveDataMonsterFlagType::SMART)) {

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -28,6 +28,7 @@
 #include "monster/monster-info.h"
 #include "monster/monster-list.h"
 #include "monster/monster-status-setter.h"
+#include "monster/monster-timed-effects.h"
 #include "monster/monster-update.h"
 #include "monster/monster-util.h"
 #include "object/warning.h"
@@ -376,7 +377,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     m_ptr->x = x;
     m_ptr->current_floor_ptr = &floor;
 
-    for (const auto mte : MONSTER_TIMED_EFFECT_RANGE) {
+    for (const auto mte : MONSTER_TIMED_EFFECT_LIST) {
         m_ptr->get_monster_profile().mtimed[mte] = 0;
     }
 
@@ -433,7 +434,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
         }
     }
 
-    m_ptr->get_monster_profile().mtimed[MonsterTimedEffect::SLEEP] = 0;
+    m_ptr->get_monster_profile().mtimed[CreatureTimedEffect::SLEEP_OR_PARALYSIS] = 0;
     if (any_bits(mode, PM_ALLOW_SLEEP) && new_monrace.sleep && !ironman_nightmare) {
         int val = new_monrace.sleep;
         (void)set_monster_csleep(floor, g_ptr->m_idx, (val * 2) + randint1(val * 10));

--- a/src/monster/monster-compaction.cpp
+++ b/src/monster/monster-compaction.cpp
@@ -6,6 +6,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-description-types.h"
 #include "monster/monster-info.h"
+#include "monster/monster-timed-effects.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
@@ -75,7 +76,7 @@ static void compact_monsters_aux(CreatureEntity &creature, MONSTER_IDX i1, MONST
     floor.m_list[i2] = std::move(floor.m_list[i1]);
     floor.m_list[i1].wipe();
 
-    for (const auto mte : MONSTER_TIMED_EFFECT_RANGE) {
+    for (const auto mte : MONSTER_TIMED_EFFECT_LIST) {
         const auto index = floor.get_mproc_index(i1, mte);
         if (index >= 0) {
             floor.mproc_list[mte][*index] = i2;

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -75,17 +75,17 @@ bool set_monster_csleep(FloorType &floor, MONSTER_IDX m_idx, int v)
                                       : v;
     if (v) {
         if (!monster.is_asleep()) {
-            floor.add_mproc(m_idx, MonsterTimedEffect::SLEEP);
+            floor.add_mproc(m_idx, CreatureTimedEffect::SLEEP_OR_PARALYSIS);
             notice = true;
         }
     } else {
         if (monster.is_asleep()) {
-            floor.remove_mproc(m_idx, MonsterTimedEffect::SLEEP);
+            floor.remove_mproc(m_idx, CreatureTimedEffect::SLEEP_OR_PARALYSIS);
             notice = true;
         }
     }
 
-    monster.get_monster_profile().mtimed[MonsterTimedEffect::SLEEP] = (int16_t)v;
+    monster.get_monster_profile().mtimed[CreatureTimedEffect::SLEEP_OR_PARALYSIS] = (int16_t)v;
     if (!notice) {
         return false;
     }
@@ -120,17 +120,17 @@ bool set_monster_fast(FloorType &floor, MONSTER_IDX m_idx, int v)
                                   : v;
     if (v) {
         if (!monster.is_accelerated()) {
-            floor.add_mproc(m_idx, MonsterTimedEffect::FAST);
+            floor.add_mproc(m_idx, CreatureTimedEffect::ACCELERATION);
             notice = true;
         }
     } else {
         if (monster.is_accelerated()) {
-            floor.remove_mproc(m_idx, MonsterTimedEffect::FAST);
+            floor.remove_mproc(m_idx, CreatureTimedEffect::ACCELERATION);
             notice = true;
         }
     }
 
-    monster.get_monster_profile().mtimed[MonsterTimedEffect::FAST] = (int16_t)v;
+    monster.get_monster_profile().mtimed[CreatureTimedEffect::ACCELERATION] = (int16_t)v;
     if (!notice) {
         return false;
     }
@@ -157,17 +157,17 @@ bool set_monster_slow(FloorType &floor, MONSTER_IDX m_idx, int v)
                                   : v;
     if (v) {
         if (!monster.is_decelerated()) {
-            floor.add_mproc(m_idx, MonsterTimedEffect::SLOW);
+            floor.add_mproc(m_idx, CreatureTimedEffect::DECELERATION);
             notice = true;
         }
     } else {
         if (monster.is_decelerated()) {
-            floor.remove_mproc(m_idx, MonsterTimedEffect::SLOW);
+            floor.remove_mproc(m_idx, CreatureTimedEffect::DECELERATION);
             notice = true;
         }
     }
 
-    monster.get_monster_profile().mtimed[MonsterTimedEffect::SLOW] = (int16_t)v;
+    monster.get_monster_profile().mtimed[CreatureTimedEffect::DECELERATION] = (int16_t)v;
     if (!notice) {
         return false;
     }
@@ -194,17 +194,17 @@ bool set_monster_stunned(FloorType &floor, MONSTER_IDX m_idx, int v)
                                   : v;
     if (v) {
         if (!monster.is_stunned()) {
-            floor.add_mproc(m_idx, MonsterTimedEffect::STUN);
+            floor.add_mproc(m_idx, CreatureTimedEffect::STUN);
             notice = true;
         }
     } else {
         if (monster.is_stunned()) {
-            floor.remove_mproc(m_idx, MonsterTimedEffect::STUN);
+            floor.remove_mproc(m_idx, CreatureTimedEffect::STUN);
             notice = true;
         }
     }
 
-    monster.get_monster_profile().mtimed[MonsterTimedEffect::STUN] = (int16_t)v;
+    monster.get_monster_profile().mtimed[CreatureTimedEffect::STUN] = (int16_t)v;
     return notice;
 }
 
@@ -223,17 +223,17 @@ bool set_monster_confused(FloorType &floor, MONSTER_IDX m_idx, int v)
                                   : v;
     if (v) {
         if (!monster.is_confused()) {
-            floor.add_mproc(m_idx, MonsterTimedEffect::CONFUSION);
+            floor.add_mproc(m_idx, CreatureTimedEffect::CONFUSION);
             notice = true;
         }
     } else {
         if (monster.is_confused()) {
-            floor.remove_mproc(m_idx, MonsterTimedEffect::CONFUSION);
+            floor.remove_mproc(m_idx, CreatureTimedEffect::CONFUSION);
             notice = true;
         }
     }
 
-    monster.get_monster_profile().mtimed[MonsterTimedEffect::CONFUSION] = (int16_t)v;
+    monster.get_monster_profile().mtimed[CreatureTimedEffect::CONFUSION] = (int16_t)v;
     return notice;
 }
 
@@ -258,17 +258,17 @@ bool set_monster_monfear(FloorType &floor, MONSTER_IDX m_idx, int v)
                                   : v;
     if (v) {
         if (!monster.is_fearful()) {
-            floor.add_mproc(m_idx, MonsterTimedEffect::FEAR);
+            floor.add_mproc(m_idx, CreatureTimedEffect::FEAR);
             notice = true;
         }
     } else {
         if (monster.is_fearful()) {
-            floor.remove_mproc(m_idx, MonsterTimedEffect::FEAR);
+            floor.remove_mproc(m_idx, CreatureTimedEffect::FEAR);
             notice = true;
         }
     }
 
-    monster.get_monster_profile().mtimed[MonsterTimedEffect::FEAR] = (int16_t)v;
+    monster.get_monster_profile().mtimed[CreatureTimedEffect::FEAR] = (int16_t)v;
 
     if (!notice) {
         return false;
@@ -300,12 +300,12 @@ bool set_monster_invulner(FloorType &floor, MONSTER_IDX m_idx, int v, bool energ
                                   : v;
     if (v) {
         if (!monster.is_invulnerable()) {
-            floor.add_mproc(m_idx, MonsterTimedEffect::INVULNERABILITY);
+            floor.add_mproc(m_idx, CreatureTimedEffect::INVULNERABILITY);
             notice = true;
         }
     } else {
         if (monster.is_invulnerable()) {
-            floor.remove_mproc(m_idx, MonsterTimedEffect::INVULNERABILITY);
+            floor.remove_mproc(m_idx, CreatureTimedEffect::INVULNERABILITY);
             if (energy_need && !AngbandWorld::get_instance().is_wild_mode()) {
                 monster.energy_need += ENERGY_NEED();
             }
@@ -313,7 +313,7 @@ bool set_monster_invulner(FloorType &floor, MONSTER_IDX m_idx, int v, bool energ
         }
     }
 
-    monster.get_monster_profile().mtimed[MonsterTimedEffect::INVULNERABILITY] = (int16_t)v;
+    monster.get_monster_profile().mtimed[CreatureTimedEffect::INVULNERABILITY] = (int16_t)v;
     if (!notice) {
         return false;
     }

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -107,13 +107,13 @@ int mon_damage_mod(CreatureEntity &creature, const CreatureEntity &target, int d
  * @param m_idx モンスター参照ID
  * @param mte 更新するモンスターの時限ステータスID
  */
-static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_idx, MonsterTimedEffect mte)
+static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_idx, CreatureTimedEffect mte)
 {
     auto &floor = *creature.current_floor_ptr;
     const auto &monster = floor.get_monster(m_idx);
     const auto cdis = Grid::calc_distance(creature.get_position(), monster.get_position());
     switch (mte) {
-    case MonsterTimedEffect::SLEEP: {
+    case CreatureTimedEffect::SLEEP_OR_PARALYSIS: {
         auto &monrace = monster.get_monrace();
         auto is_wakeup = false;
         if (cdis < MAX_MONSTER_SENSING) {
@@ -184,7 +184,7 @@ static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_
 
         break;
     }
-    case MonsterTimedEffect::FAST:
+    case CreatureTimedEffect::ACCELERATION:
         /* Reduce by one, note if expires */
         if (set_monster_fast(floor, m_idx, monster.get_remaining_acceleration() - 1)) {
             if (is_seen(creature, monster)) {
@@ -194,7 +194,7 @@ static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_
         }
 
         break;
-    case MonsterTimedEffect::SLOW:
+    case CreatureTimedEffect::DECELERATION:
         /* Reduce by one, note if expires */
         if (set_monster_slow(floor, m_idx, monster.get_remaining_deceleration() - 1)) {
             if (is_seen(creature, monster)) {
@@ -204,7 +204,7 @@ static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_
         }
 
         break;
-    case MonsterTimedEffect::STUN: {
+    case CreatureTimedEffect::STUN: {
         int rlev = monster.get_monrace().level;
 
         /* Recover from stun */
@@ -218,7 +218,7 @@ static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_
 
         break;
     }
-    case MonsterTimedEffect::CONFUSION: {
+    case CreatureTimedEffect::CONFUSION: {
         /* Reduce the confusion */
         if (!set_monster_confused(floor, m_idx, monster.get_remaining_confusion() - randint1(monster.get_monrace().level / 20 + 1))) {
             break;
@@ -232,7 +232,7 @@ static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_
 
         break;
     }
-    case MonsterTimedEffect::FEAR: {
+    case CreatureTimedEffect::FEAR: {
         /* Reduce the fear */
         if (!set_monster_monfear(floor, m_idx, monster.get_remaining_fear() - randint1(monster.get_monrace().level / 20 + 1))) {
             break;
@@ -255,7 +255,7 @@ static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_
 
         break;
     }
-    case MonsterTimedEffect::INVULNERABILITY: {
+    case CreatureTimedEffect::INVULNERABILITY: {
         /* Reduce by one, note if expires */
         if (!set_monster_invulner(floor, m_idx, monster.get_remaining_invulnerability() - 1, true)) {
             break;
@@ -269,7 +269,7 @@ static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_
         break;
     }
     default:
-        THROW_EXCEPTION(std::logic_error, format("Invalid MonsterTimedEffect is specified! %d", enum2i(mte)));
+        THROW_EXCEPTION(std::logic_error, format("Invalid CreatureTimedEffect is specified! %d", enum2i(mte)));
     }
 }
 
@@ -281,13 +281,13 @@ static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_
  * Process the counters of monsters (once per 10 game turns)\n
  * These functions are to process monsters' counters same as player's.
  */
-void process_monsters_mtimed(CreatureEntity &creature, MonsterTimedEffect mte)
+void process_monsters_mtimed(CreatureEntity &creature, CreatureTimedEffect mte)
 {
     const auto &floor = *creature.current_floor_ptr;
     const auto &cur_mproc_list = floor.mproc_list.at(mte);
 
     /* Hack -- calculate the "player noise" */
-    if (mte == MonsterTimedEffect::SLEEP) {
+    if (mte == CreatureTimedEffect::SLEEP_OR_PARALYSIS) {
         csleep_noise = (1U << (30 - creature.skill_stl));
     }
 

--- a/src/monster/monster-status.h
+++ b/src/monster/monster-status.h
@@ -13,5 +13,5 @@ int mon_damage_mod(CreatureEntity &creature, const CreatureEntity &target, int d
 void dispel_monster_status(CreatureEntity &creature, MONSTER_IDX m_idx);
 void monster_gain_exp(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId s_idx);
 
-enum class MonsterTimedEffect : int;
-void process_monsters_mtimed(CreatureEntity &creature, MonsterTimedEffect mte);
+enum class CreatureTimedEffect;
+void process_monsters_mtimed(CreatureEntity &creature, CreatureTimedEffect mte);

--- a/src/monster/monster-timed-effects.cpp
+++ b/src/monster/monster-timed-effects.cpp
@@ -1,12 +1,12 @@
 #include "monster/monster-timed-effects.h"
 #include "locale/language-switcher.h"
 
-const std::map<MonsterTimedEffect, std::string> effect_type_to_label = {
-    { MonsterTimedEffect::SLEEP, _("睡眠", "sleep") },
-    { MonsterTimedEffect::FAST, _("加速", "haste") },
-    { MonsterTimedEffect::SLOW, _("減速", "slow") },
-    { MonsterTimedEffect::STUN, _("朦朧", "stun") },
-    { MonsterTimedEffect::CONFUSION, _("混乱", "confuse") },
-    { MonsterTimedEffect::FEAR, _("恐怖", "scare") },
-    { MonsterTimedEffect::INVULNERABILITY, _("無敵", "invulnerable") }
+const std::map<CreatureTimedEffect, std::string> effect_type_to_label = {
+    { CreatureTimedEffect::SLEEP_OR_PARALYSIS, _("睡眠", "sleep") },
+    { CreatureTimedEffect::ACCELERATION, _("加速", "haste") },
+    { CreatureTimedEffect::DECELERATION, _("減速", "slow") },
+    { CreatureTimedEffect::STUN, _("朦朧", "stun") },
+    { CreatureTimedEffect::CONFUSION, _("混乱", "confuse") },
+    { CreatureTimedEffect::FEAR, _("恐怖", "scare") },
+    { CreatureTimedEffect::INVULNERABILITY, _("無敵", "invulnerable") },
 };

--- a/src/monster/monster-timed-effects.h
+++ b/src/monster/monster-timed-effects.h
@@ -1,20 +1,23 @@
 #pragma once
 
-#include "util/enum-range.h"
+#include "system/creature-timed-effect-types.h"
+#include <array>
 #include <map>
 #include <string>
 
-enum class MonsterTimedEffect : int {
-    SLEEP = 0,
-    FAST = 1,
-    SLOW = 2,
-    STUN = 3,
-    CONFUSION = 4,
-    FEAR = 5,
-    INVULNERABILITY = 6,
-    MAX = 7,
+/*!
+ * @brief モンスターが持ちうる時限効果の一覧
+ * @details CreatureTimedEffect のうちモンスター側で扱う 7 種。
+ * プレイヤー専用効果（HERO/BLESSED 等）はここに含まれない。
+ */
+constexpr std::array<CreatureTimedEffect, 7> MONSTER_TIMED_EFFECT_LIST = {
+    CreatureTimedEffect::SLEEP_OR_PARALYSIS,
+    CreatureTimedEffect::ACCELERATION,
+    CreatureTimedEffect::DECELERATION,
+    CreatureTimedEffect::STUN,
+    CreatureTimedEffect::CONFUSION,
+    CreatureTimedEffect::FEAR,
+    CreatureTimedEffect::INVULNERABILITY,
 };
 
-constexpr auto MONSTER_TIMED_EFFECT_RANGE = EnumRange<MonsterTimedEffect>(MonsterTimedEffect::SLEEP, MonsterTimedEffect::MAX);
-
-extern const std::map<MonsterTimedEffect, std::string> effect_type_to_label;
+extern const std::map<CreatureTimedEffect, std::string> effect_type_to_label;

--- a/src/mspell/mspell-selector.cpp
+++ b/src/mspell/mspell-selector.cpp
@@ -451,7 +451,7 @@ MonsterAbilityType choose_attack_spell(CreatureEntity &creature, msa_type *msa_p
         return rand_choice(tactic);
     }
 
-    if (!invul.empty() && !monster.get_monster_profile().mtimed.at(MonsterTimedEffect::INVULNERABILITY) && one_in_(2)) {
+    if (!invul.empty() && !monster.get_monster_profile().mtimed.at(CreatureTimedEffect::INVULNERABILITY) && one_in_(2)) {
         return rand_choice(invul);
     }
 

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -130,13 +130,13 @@ static void attack_dispel(CreatureEntity &creature, player_attack_type *pa_ptr)
     }
 
     auto dd = 2;
-    if (pa_ptr->m_ptr->get_monster_profile().mtimed[MonsterTimedEffect::SLOW]) {
+    if (pa_ptr->m_ptr->get_monster_profile().mtimed[CreatureTimedEffect::DECELERATION]) {
         dd += 1;
     }
-    if (pa_ptr->m_ptr->get_monster_profile().mtimed[MonsterTimedEffect::FAST]) {
+    if (pa_ptr->m_ptr->get_monster_profile().mtimed[CreatureTimedEffect::ACCELERATION]) {
         dd += 2;
     }
-    if (pa_ptr->m_ptr->get_monster_profile().mtimed[MonsterTimedEffect::INVULNERABILITY]) {
+    if (pa_ptr->m_ptr->get_monster_profile().mtimed[CreatureTimedEffect::INVULNERABILITY]) {
         dd += 3;
     }
 

--- a/src/save/monster-entity-writer.cpp
+++ b/src/save/monster-entity-writer.cpp
@@ -40,7 +40,7 @@ void MonsterEntityWriter::write_to_savedata() const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::SLEEP)) {
-        wr_s16b(this->monster.get_monster_profile().mtimed.at(MonsterTimedEffect::SLEEP));
+        wr_s16b(this->monster.get_monster_profile().mtimed.at(CreatureTimedEffect::SLEEP_OR_PARALYSIS));
     }
 
     wr_byte((byte)this->monster.speed);
@@ -156,27 +156,27 @@ void MonsterEntityWriter::write_monster_info(uint32_t flags) const
 {
     byte tmp8u;
     if (any_bits(flags, SaveDataMonsterFlagType::FAST)) {
-        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(MonsterTimedEffect::FAST);
+        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(CreatureTimedEffect::ACCELERATION);
         wr_byte(tmp8u);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::SLOW)) {
-        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(MonsterTimedEffect::SLOW);
+        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(CreatureTimedEffect::DECELERATION);
         wr_byte(tmp8u);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::STUNNED)) {
-        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(MonsterTimedEffect::STUN);
+        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(CreatureTimedEffect::STUN);
         wr_byte(tmp8u);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::CONFUSED)) {
-        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(MonsterTimedEffect::CONFUSION);
+        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(CreatureTimedEffect::CONFUSION);
         wr_byte(tmp8u);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::MONFEAR)) {
-        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(MonsterTimedEffect::FEAR);
+        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(CreatureTimedEffect::FEAR);
         wr_byte(tmp8u);
     }
 
@@ -189,7 +189,7 @@ void MonsterEntityWriter::write_monster_info(uint32_t flags) const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::INVULNER)) {
-        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(MonsterTimedEffect::INVULNERABILITY);
+        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(CreatureTimedEffect::INVULNERABILITY);
         wr_byte(tmp8u);
     }
 

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -7,6 +7,7 @@
 #include "monster-race/race-kind-flags.h"
 #include "monster/monster-flag-types.h"
 #include "monster/monster-pain-describer.h"
+#include "monster/monster-timed-effects.h"
 #include "monster/monster-util.h"
 #include "player-ability/player-ability-types.h"
 #include "player-info/bard-data-type.h"
@@ -410,25 +411,9 @@ short CreatureEntity::get_timed_effect(CreatureTimedEffect effect) const
         return 0;
     }
 
-    const auto &mp = this->get_monster_profile();
-    switch (effect) {
-    case CreatureTimedEffect::STUN:
-        return mp.mtimed.at(MonsterTimedEffect::STUN);
-    case CreatureTimedEffect::CONFUSION:
-        return mp.mtimed.at(MonsterTimedEffect::CONFUSION);
-    case CreatureTimedEffect::FEAR:
-        return mp.mtimed.at(MonsterTimedEffect::FEAR);
-    case CreatureTimedEffect::INVULNERABILITY:
-        return mp.mtimed.at(MonsterTimedEffect::INVULNERABILITY);
-    case CreatureTimedEffect::ACCELERATION:
-        return mp.mtimed.at(MonsterTimedEffect::FAST);
-    case CreatureTimedEffect::DECELERATION:
-        return mp.mtimed.at(MonsterTimedEffect::SLOW);
-    case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
-        return mp.mtimed.at(MonsterTimedEffect::SLEEP);
-    default:
-        return 0;
-    }
+    const auto &mtimed = this->get_monster_profile().mtimed;
+    const auto it = mtimed.find(effect);
+    return (it != mtimed.end()) ? it->second : 0;
 }
 
 void CreatureEntity::set_timed_effect(CreatureTimedEffect effect, short value)
@@ -437,32 +422,7 @@ void CreatureEntity::set_timed_effect(CreatureTimedEffect effect, short value)
         return;
     }
 
-    auto &mp = this->get_monster_profile();
-    switch (effect) {
-    case CreatureTimedEffect::STUN:
-        mp.mtimed[MonsterTimedEffect::STUN] = value;
-        break;
-    case CreatureTimedEffect::CONFUSION:
-        mp.mtimed[MonsterTimedEffect::CONFUSION] = value;
-        break;
-    case CreatureTimedEffect::FEAR:
-        mp.mtimed[MonsterTimedEffect::FEAR] = value;
-        break;
-    case CreatureTimedEffect::INVULNERABILITY:
-        mp.mtimed[MonsterTimedEffect::INVULNERABILITY] = value;
-        break;
-    case CreatureTimedEffect::ACCELERATION:
-        mp.mtimed[MonsterTimedEffect::FAST] = value;
-        break;
-    case CreatureTimedEffect::DECELERATION:
-        mp.mtimed[MonsterTimedEffect::SLOW] = value;
-        break;
-    case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
-        mp.mtimed[MonsterTimedEffect::SLEEP] = value;
-        break;
-    default:
-        break;
-    }
+    this->get_monster_profile().mtimed[effect] = value;
 }
 
 void CreatureEntity::make_lore_treasure(int num_item, int num_gold) const
@@ -1010,7 +970,7 @@ bool CreatureEntity::can_ring_boss_call_nazgul() const
 void CreatureEntity::init_monster_profile()
 {
     this->monster_profile.emplace();
-    for (const auto mte : MONSTER_TIMED_EFFECT_RANGE) {
+    for (const auto mte : MONSTER_TIMED_EFFECT_LIST) {
         this->get_monster_profile().mtimed[mte] = 0;
     }
 }

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -43,7 +43,7 @@ FloorType::FloorType()
         monster.init_monster_profile();
     }
 
-    for (const auto mte : MONSTER_TIMED_EFFECT_RANGE) {
+    for (const auto mte : MONSTER_TIMED_EFFECT_LIST) {
         this->mproc_list[mte] = std::vector<short>(MAX_FLOOR_MONSTERS, {});
         this->mproc_max[mte] = 0;
     }
@@ -550,7 +550,7 @@ void FloorType::reset_mproc()
             continue;
         }
 
-        for (const auto mte : MONSTER_TIMED_EFFECT_RANGE) {
+        for (const auto mte : MONSTER_TIMED_EFFECT_LIST) {
             if (monster.get_monster_profile().mtimed.at(mte) > 0) {
                 this->add_mproc(i, mte);
             }
@@ -560,7 +560,7 @@ void FloorType::reset_mproc()
 
 void FloorType::reset_mproc_max()
 {
-    for (const auto mte : MONSTER_TIMED_EFFECT_RANGE) {
+    for (const auto mte : MONSTER_TIMED_EFFECT_LIST) {
         this->mproc_max[mte] = 0;
     }
 }
@@ -571,7 +571,7 @@ void FloorType::reset_mproc_max()
  * @param mte モンスターの時限ステータスID
  * @return 残りターン値
  */
-tl::optional<int> FloorType::get_mproc_index(short m_idx, MonsterTimedEffect mte)
+tl::optional<int> FloorType::get_mproc_index(short m_idx, CreatureTimedEffect mte)
 {
     const auto &cur_mproc_list = this->mproc_list[mte];
     for (auto i = this->mproc_max[mte] - 1; i >= 0; i--) {
@@ -588,7 +588,7 @@ tl::optional<int> FloorType::get_mproc_index(short m_idx, MonsterTimedEffect mte
  * @param m_idx モンスターの参照ID
  * @return mte 追加したいモンスターの時限ステータスID
  */
-void FloorType::add_mproc(short m_idx, MonsterTimedEffect mte)
+void FloorType::add_mproc(short m_idx, CreatureTimedEffect mte)
 {
     if (this->mproc_max[mte] < MAX_FLOOR_MONSTERS) {
         this->mproc_list[mte][this->mproc_max[mte]++] = m_idx;
@@ -600,7 +600,7 @@ void FloorType::add_mproc(short m_idx, MonsterTimedEffect mte)
  * @return m_idx モンスターの参照ID
  * @return mte 削除したいモンスターの時限ステータスID
  */
-void FloorType::remove_mproc(short m_idx, MonsterTimedEffect mte)
+void FloorType::remove_mproc(short m_idx, CreatureTimedEffect mte)
 {
     const auto mproc_idx = this->get_mproc_index(m_idx, mte);
     if (mproc_idx >= 0) {

--- a/src/system/floor/floor-info.h
+++ b/src/system/floor/floor-info.h
@@ -50,7 +50,7 @@ enum class FloorBoundary {
 
 enum class DungeonId;
 enum class GridCountKind;
-enum class MonsterTimedEffect : int;
+enum class CreatureTimedEffect;
 enum class MonraceHook;
 enum class MonraceHookTerrain;
 enum class MonraceId : short;
@@ -92,8 +92,8 @@ public:
     MONSTER_IDX m_max = 0; /* Number of allocated monsters */
     MONSTER_IDX m_cnt = 0; /* Number of live monsters */
 
-    std::map<MonsterTimedEffect, std::vector<short>> mproc_list; /*!< The array to process dungeon monsters[max_m_idx] */
-    std::map<MonsterTimedEffect, short> mproc_max; /*!< Number of monsters to be processed */
+    std::map<CreatureTimedEffect, std::vector<short>> mproc_list; /*!< The array to process dungeon monsters[max_m_idx] */
+    std::map<CreatureTimedEffect, short> mproc_max; /*!< Number of monsters to be processed */
 
     bool monster_noise = false;
     QuestId quest_number;
@@ -146,9 +146,9 @@ public:
     void leave_dungeon(bool state);
     void reset_mproc();
     void reset_mproc_max();
-    tl::optional<int> get_mproc_index(short m_idx, MonsterTimedEffect mte);
-    void add_mproc(short m_idx, MonsterTimedEffect mte);
-    void remove_mproc(short m_idx, MonsterTimedEffect mte);
+    tl::optional<int> get_mproc_index(short m_idx, CreatureTimedEffect mte);
+    void add_mproc(short m_idx, CreatureTimedEffect mte);
+    void remove_mproc(short m_idx, CreatureTimedEffect mte);
 
     CreatureEntity &get_monster(MONSTER_IDX m_idx);
     const CreatureEntity &get_monster(MONSTER_IDX m_idx) const;

--- a/src/system/monster-profile.h
+++ b/src/system/monster-profile.h
@@ -2,9 +2,9 @@
 
 #include "alliance/alliance.h"
 #include "monster/monster-flag-types.h"
-#include "monster/monster-timed-effects.h"
 #include "monster/smart-learn-types.h"
 #include "object/object-index-list.h"
+#include "system/creature-timed-effect-types.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "util/flag-group.h"
 #include <map>
@@ -27,7 +27,7 @@ struct MonsterProfile {
     std::vector<PlayerRaceType> equivalent_player_races{}; /*!< モンスターのフラグに基づいて対応するプレイヤー種族IDリスト */
     std::vector<PlayerClassType> equivalent_player_classes{}; /*!< モンスターのフラグに基づいて対応するプレイヤー職業IDリスト */
     int death_count{}; /*!< 自壊するまでの残りターン数 */
-    std::map<MonsterTimedEffect, short> mtimed{}; /*!< 与えられた時限効果の残りターン / Timed status counter */
+    std::map<CreatureTimedEffect, short> mtimed{}; /*!< 与えられた時限効果の残りターン / Timed status counter */
     EnumClassFlagGroup<MonsterTemporaryFlagType> mflag{}; /*!< モンスター個体に与えられた特殊フラグ1 (セーブ不要) / Extra monster flags */
     EnumClassFlagGroup<MonsterConstantFlagType> mflag2{}; /*!< モンスター個体に与えられた特殊フラグ2 (セーブ必要) / Extra monster flags */
     bool ml{}; /*!< モンスターがプレイヤーにとって視認できるか(処理のためのテンポラリ変数) Monster is "visible" */

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -2,6 +2,7 @@
 #include "floor/dungeon-feeling.h"
 #include "game-option/special-options.h"
 #include "game-option/text-display-options.h"
+#include "monster/monster-timed-effects.h"
 #include "player-base/player-race.h"
 #include "player-info/class-info.h"
 #include "player-info/mimic-info-table.h"
@@ -306,25 +307,25 @@ static std::vector<condition_layout_info> get_condition_layout_info(const Creatu
     std::vector<condition_layout_info> result;
 
     if (monster.is_invulnerable()) {
-        result.push_back({ effect_type_to_label.at(MonsterTimedEffect::INVULNERABILITY), TERM_WHITE });
+        result.push_back({ effect_type_to_label.at(CreatureTimedEffect::INVULNERABILITY), TERM_WHITE });
     }
     if (monster.is_accelerated()) {
-        result.push_back({ effect_type_to_label.at(MonsterTimedEffect::FAST), TERM_L_GREEN });
+        result.push_back({ effect_type_to_label.at(CreatureTimedEffect::ACCELERATION), TERM_L_GREEN });
     }
     if (monster.is_decelerated()) {
-        result.push_back({ effect_type_to_label.at(MonsterTimedEffect::SLOW), TERM_UMBER });
+        result.push_back({ effect_type_to_label.at(CreatureTimedEffect::DECELERATION), TERM_UMBER });
     }
     if (monster.is_fearful()) {
-        result.push_back({ effect_type_to_label.at(MonsterTimedEffect::FEAR), TERM_SLATE });
+        result.push_back({ effect_type_to_label.at(CreatureTimedEffect::FEAR), TERM_SLATE });
     }
     if (monster.is_confused()) {
-        result.push_back({ effect_type_to_label.at(MonsterTimedEffect::CONFUSION), TERM_L_UMBER });
+        result.push_back({ effect_type_to_label.at(CreatureTimedEffect::CONFUSION), TERM_L_UMBER });
     }
     if (monster.is_asleep()) {
-        result.push_back({ effect_type_to_label.at(MonsterTimedEffect::SLEEP), TERM_BLUE });
+        result.push_back({ effect_type_to_label.at(CreatureTimedEffect::SLEEP_OR_PARALYSIS), TERM_BLUE });
     }
     if (monster.is_stunned()) {
-        result.push_back({ effect_type_to_label.at(MonsterTimedEffect::STUN), TERM_ORANGE });
+        result.push_back({ effect_type_to_label.at(CreatureTimedEffect::STUN), TERM_ORANGE });
     }
 
     return result;

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -20,6 +20,7 @@
 #include "monster-floor/monster-summon.h"
 #include "monster/monster-describer.h"
 #include "monster/monster-status.h"
+#include "monster/monster-timed-effects.h"
 #include "mutation/mutation-processor.h"
 #include "object/lite-processor.h"
 #include "perception/simple-perception.h"
@@ -299,7 +300,7 @@ void WorldTurnProcessor::process_world_monsters()
         return;
     }
 
-    for (const auto mte : MONSTER_TIMED_EFFECT_RANGE) {
+    for (const auto mte : MONSTER_TIMED_EFFECT_LIST) {
         if (this->creature.current_floor_ptr->mproc_max[mte] > 0) {
             process_monsters_mtimed(this->creature, mte);
         }


### PR DESCRIPTION
MonsterTimedEffect enum を完全に廃止し、モンスター側の時限効果管理も
CreatureTimedEffect enum で統一した。

- MonsterTimedEffect enum を削除し MONSTER_TIMED_EFFECT_LIST (std::array) として CreatureTimedEffect の部分集合（7種）を定義
- MonsterProfile::mtimed を std::map<CreatureTimedEffect, short> に変更
- FloorType::mproc_list / mproc_max / add_mproc / remove_mproc / get_mproc_index を CreatureTimedEffect ベースに変更
- CreatureEntity::get/set_timed_effect() のモンスター側実装を 直接マップ参照に単純化（7ケースのswitch文を削除）
- process_monsters_mtimed() のシグネチャを CreatureTimedEffect に変更
- 旧 enum 値のマッピング: SLEEP → SLEEP_OR_PARALYSIS FAST → ACCELERATION SLOW → DECELERATION STUN/CONFUSION/FEAR/INVULNERABILITY はそのまま

これにより重複 enum が解消され、プレイヤー・モンスターの時限効果が
完全に同一の型システムで管理されるようになった。
