### PR TITLE
refactor: current_floor_ptr を protected 化し get/set_floor() 経由アクセスに統一（refactor: current_floor_ptr を protected 化し get/set_floor() 経由アクセスに統一（Phase 6）

### DIFF
--- a/src/action/action-limited.cpp
+++ b/src/action/action-limited.cpp
@@ -23,7 +23,7 @@
  */
 bool cmd_limit_cast(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (floor.is_underground() && (floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_MAGIC))) {
         msg_print(_("ダンジョンが魔法を吸収した！", "The dungeon absorbs all attempted magic!"));
         msg_erase();
@@ -75,7 +75,7 @@ bool cmd_limit_stun(const CreatureEntity &creature)
 
 bool cmd_limit_arena(const CreatureEntity &creature)
 {
-    if (creature.current_floor_ptr->inside_arena) {
+    if (creature.get_floor()->inside_arena) {
         msg_print(_("アリーナが魔法を吸収した！", "The arena absorbs all attempted magic!"));
         msg_erase();
         return true;

--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -214,7 +214,7 @@ static bool activate_whistle(CreatureEntity &user, ae_type *ae_ptr)
         (void)SpellHex(user).stop_all_spells();
     }
 
-    const auto &floor = *user.current_floor_ptr;
+    const auto &floor = *user.get_floor();
     std::vector<short> pet_index;
     for (short pet_indice = floor.m_max - 1; pet_indice >= 1; pet_indice--) {
         const auto &monster = floor.get_monster(pet_indice);

--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -82,7 +82,7 @@ static bool boundary_floor(const Grid &grid, const TerrainType &terrain, const T
 void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup, bool break_trap)
 {
     const auto pos = creature.get_neighbor(dir);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &grid = floor.get_grid(pos);
     bool p_can_enter = player_can_enter(creature, grid.feat, CEM_P_CAN_ENTER_PATTERN);
     const auto &world = AngbandWorld::get_instance();
@@ -160,7 +160,7 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
         can_cast &= !is_stunned;
         can_cast &= creature.muta.has_not(PlayerMutationType::BERS_RAGE) || !creature.is_shero();
         if (!monster.is_hostile() && can_cast && pattern_seq(creature, pos) && (p_can_enter || p_can_kill_walls)) {
-            (void)set_monster_csleep(*creature.current_floor_ptr, grid.m_idx, 0);
+            (void)set_monster_csleep(*creature.get_floor(), grid.m_idx, 0);
             m_name = monster_desc(creature, monster, 0);
             if (monster.get_monster_profile().ml) {
                 if (!is_hallucinated) {

--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -62,7 +62,7 @@
 bool exe_mutation_power(CreatureEntity &creature, PlayerMutationType power)
 {
     PLAYER_LEVEL lvl = creature.level;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     switch (power) {
     case PlayerMutationType::SPIT_ACID: {
         const auto dir = get_aim_dir(creature);

--- a/src/action/open-close-execution.cpp
+++ b/src/action/open-close-execution.cpp
@@ -45,7 +45,7 @@
 bool exe_open(CreatureEntity &creature, POSITION y, POSITION x)
 {
     const Pos2D pos(y, x);
-    const auto &grid = creature.current_floor_ptr->get_grid(pos);
+    const auto &grid = creature.get_floor()->get_grid(pos);
     auto &terrain = grid.get_terrain();
     PlayerEnergy(creature).set_player_turn_energy(100);
     if (terrain.flags.has_not(TerrainCharacteristics::OPEN)) {
@@ -108,7 +108,7 @@ bool exe_open(CreatureEntity &creature, POSITION y, POSITION x)
  */
 bool exe_close(CreatureEntity &creature, const Pos2D &pos)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(pos);
     const auto terrain_id = grid.feat;
     auto more = false;
@@ -153,7 +153,7 @@ bool exe_close(CreatureEntity &creature, const Pos2D &pos)
  */
 bool easy_open_door(CreatureEntity &creature, const Pos2D &pos)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!floor.has_closed_door_at(pos)) {
         return false;
     }
@@ -217,7 +217,7 @@ bool easy_open_door(CreatureEntity &creature, const Pos2D &pos)
 bool exe_disarm_chest(CreatureEntity &creature, POSITION y, POSITION x, OBJECT_IDX o_idx)
 {
     const Pos2D pos(y, x);
-    auto *o_ptr = creature.current_floor_ptr->o_list[o_idx].get();
+    auto *o_ptr = creature.get_floor()->o_list[o_idx].get();
     PlayerEnergy(creature).set_player_turn_energy(100);
     int i = creature.skill_dis;
     const auto effects = creature.effects();
@@ -280,7 +280,7 @@ bool exe_disarm(CreatureEntity &creature, POSITION y, POSITION x, const Directio
 {
     const auto &baseitems = BaseitemList::get_instance();
     const Pos2D pos(y, x);
-    const auto &grid = creature.current_floor_ptr->get_grid(pos);
+    const auto &grid = creature.get_floor()->get_grid(pos);
     const auto &terrain = grid.get_terrain();
     const auto &name = terrain.name;
     int power = terrain.power;
@@ -343,7 +343,7 @@ bool exe_disarm(CreatureEntity &creature, POSITION y, POSITION x, const Directio
  */
 bool exe_bash(CreatureEntity &creature, POSITION y, POSITION x, const Direction &dir)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const Pos2D pos(y, x);
     const auto &grid = floor.get_grid(pos);
     const auto &terrain = grid.get_terrain();

--- a/src/action/open-util.cpp
+++ b/src/action/open-util.cpp
@@ -46,12 +46,12 @@ std::pair<int, Direction> count_chests(CreatureEntity &creature, bool trapped)
     auto count = 0;
     for (const auto &d : Direction::directions()) {
         const auto pos_neighbor = creature.get_neighbor(d);
-        const auto o_idx = chest_check(*creature.current_floor_ptr, pos_neighbor, false);
+        const auto o_idx = chest_check(*creature.get_floor(), pos_neighbor, false);
         if (o_idx == 0) {
             continue;
         }
 
-        const auto &item = *creature.current_floor_ptr->o_list[o_idx];
+        const auto &item = *creature.get_floor()->o_list[o_idx];
         if (item.pval == 0) {
             continue;
         }

--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -44,7 +44,7 @@ static bool find_breakleft;
  */
 static bool see_wall(CreatureEntity &creature, const Direction &dir, const Pos2D &pos_orig)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto pos = pos_orig + dir.vec();
     if (!floor.contains(pos, FloorBoundary::OUTER_WALL_INCLUSIVE)) {
         return false;
@@ -99,7 +99,7 @@ static void run_init(CreatureEntity &creature, const Direction &dir)
     creature.run_py = pos.y;
     creature.run_px = pos.x;
     const auto pos_neighbor = creature.get_neighbor(dir);
-    ignore_avoid_run = creature.current_floor_ptr->has_terrain_characteristics(pos_neighbor, TerrainCharacteristics::AVOID_RUN);
+    ignore_avoid_run = creature.get_floor()->has_terrain_characteristics(pos_neighbor, TerrainCharacteristics::AVOID_RUN);
     const auto dir_left45 = dir.rotated_45degree(1);
     const auto dir_right45 = dir.rotated_45degree(-1);
     auto deepleft = false;
@@ -159,7 +159,7 @@ static void run_init(CreatureEntity &creature, const Direction &dir)
 static bool see_nothing(CreatureEntity &creature, const Direction &dir, const Pos2D &pos_orig)
 {
     const auto pos = pos_orig + dir.vec();
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!floor.contains(pos, FloorBoundary::OUTER_WALL_INCLUSIVE)) {
         return true;
     }
@@ -186,7 +186,7 @@ static bool see_nothing(CreatureEntity &creature, const Direction &dir, const Po
 static bool run_test(CreatureEntity &creature)
 {
     const auto prev_dir = find_prevdir;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     const auto &p_grid = floor.get_grid(p_pos);
     if ((disturb_trap_detect || alert_trap_detect) && creature.dtrap && !(p_grid.info & CAVE_IN_DETECT)) {

--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -33,7 +33,7 @@ constexpr auto TRAVEL_UNABLE = 9999;
 int travel_flow_cost(CreatureEntity &creature, const Pos2D &pos)
 {
     int cost = 1;
-    const auto &grid = creature.current_floor_ptr->get_grid(pos);
+    const auto &grid = creature.get_floor()->get_grid(pos);
     const auto &terrain = grid.get_terrain();
     if (terrain.flags.has(TerrainCharacteristics::AVOID_RUN)) {
         cost += 1;
@@ -83,7 +83,7 @@ int travel_flow_cost(CreatureEntity &creature, const Pos2D &pos)
  */
 tl::optional<int> travel_flow_aux(CreatureEntity &creature, const Pos2D pos, int current_cost, bool wall)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(pos);
     const auto &terrain = grid.get_terrain();
     if (!floor.contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
@@ -136,7 +136,7 @@ Direction decide_travel_step_dir(CreatureEntity &creature, const Direction &prev
     }
 
     const auto p_pos = creature.get_position();
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &p_grid = floor.get_grid(p_pos);
     if (creature.is_player()) {
         if ((disturb_trap_detect || alert_trap_detect) && creature.dtrap && none_bits(p_grid.info, CAVE_IN_DETECT)) {
@@ -302,7 +302,7 @@ void Travel::update_flow(CreatureEntity &creature)
         return;
     }
 
-    const auto &terrain = creature.current_floor_ptr->get_grid(creature.get_position()).get_terrain();
+    const auto &terrain = creature.get_floor()->get_grid(creature.get_position()).get_terrain();
     const auto wall = terrain.flags.has(TerrainCharacteristics::MOVE);
 
     using CostAndPos = std::pair<int, Pos2D>;

--- a/src/action/tunnel-execution.cpp
+++ b/src/action/tunnel-execution.cpp
@@ -56,7 +56,7 @@ bool exe_tunnel(CreatureEntity &creature, POSITION y, POSITION x)
 {
     auto more = false;
     const Pos2D pos(y, x);
-    const auto &grid = creature.current_floor_ptr->get_grid(pos);
+    const auto &grid = creature.get_floor()->get_grid(pos);
     if (!do_cmd_tunnel_test(grid)) {
         return false;
     }

--- a/src/alliance/alliance-diabolique.cpp
+++ b/src/alliance/alliance-diabolique.cpp
@@ -81,7 +81,7 @@ void AllianceDiabolique::panishment(CreatureEntity &creature)
 
         /*
         auto m_pos = player_ptr.get_position();
-        m_pos = scatter(*player_ptr.current_floor_ptr, m_pos, 10, PROJECT_NONE);
+        m_pos = scatter(*player_ptr.get_floor(), m_pos, 10, PROJECT_NONE);
         MonraceId avenger_id;
         if (impression < -400) {
             // 極度に嫌われている場合：強力なデーモン
@@ -108,7 +108,7 @@ void AllianceDiabolique::panishment(CreatureEntity &creature)
             // 復讐者の仲間を呼ぶ（低確率）
             for (int k = 0; k < 2; k++) {
                 summon_specific(&player_ptr, m_pos.y, m_pos.x,
-                    std::max(player_ptr.current_floor_ptr->monster_level, 3),
+                    std::max(player_ptr.get_floor()->monster_level, 3),
                     SUMMON_DEMON, PM_ALLOW_GROUP, m_idx);
             }
         }

--- a/src/alliance/alliance-fangfamily.cpp
+++ b/src/alliance/alliance-fangfamily.cpp
@@ -44,7 +44,7 @@ void AllianceFangFamily::panishment(CreatureEntity &creature)
     }
     if (one_in_(25)) {
         Pos2D m_pos(creature.get_position());
-        m_pos = scatter(*creature.current_floor_ptr, m_pos, 10, PROJECT_NONE);
+        m_pos = scatter(*creature.get_floor(), m_pos, 10, PROJECT_NONE);
         MonraceId avenger_id;
         if (impression < -200) {
             avenger_id = MonraceId::KING_FANG_FAMILY;
@@ -63,7 +63,7 @@ void AllianceFangFamily::panishment(CreatureEntity &creature)
 
             disturb(creature, true, true);
             for (int k = 0; k < 4; k++) {
-                summon_specific(creature, m_pos.y, m_pos.x, std::max(creature.current_floor_ptr->monster_level, 5), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
+                summon_specific(creature, m_pos.y, m_pos.x, std::max(creature.get_floor()->monster_level, 5), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
             }
         }
     }

--- a/src/alliance/alliance-hafu.cpp
+++ b/src/alliance/alliance-hafu.cpp
@@ -65,7 +65,7 @@ void AllianceHafu::panishment(CreatureEntity &creature)
     /*
 if (one_in_(18)) {
     Pos2D m_pos(player_ptr.get_position());
-    m_pos = scatter(*player_ptr.current_floor_ptr, m_pos, 12, PROJECT_NONE);
+    m_pos = scatter(*player_ptr.get_floor(), m_pos, 12, PROJECT_NONE);
 
     // 覇府の威信レベルに応じて異なる討伐隊を派遣
     MonraceId avenger_id;
@@ -99,7 +99,7 @@ if (one_in_(18)) {
 
         for (int k = 0; k < retainer_count; k++) {
             summon_specific(&player_ptr, m_pos.y, m_pos.x,
-                std::max(player_ptr.current_floor_ptr->monster_level, 10),
+                std::max(player_ptr.get_floor()->monster_level, 10),
                 SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
         }
     }

--- a/src/alliance/alliance-jural.cpp
+++ b/src/alliance/alliance-jural.cpp
@@ -48,13 +48,13 @@ void AllianceJural::panishment(CreatureEntity &creature)
     }
     if (one_in_(20)) {
         Pos2D m_pos(creature.get_position());
-        m_pos = scatter(*creature.current_floor_ptr, m_pos, 12, PROJECT_NONE);
+        m_pos = scatter(*creature.get_floor(), m_pos, 12, PROJECT_NONE);
         const auto m_idx = place_monster_one(creature, m_pos.y, m_pos.x, MonraceId::ALIEN_JURAL, PM_ALLOW_GROUP | PM_JURAL);
         if (m_idx) {
             msg_print(_("「おーい、行ってみよう！」ジュラル星人があなたに報復すべく追跡してきた！", "\"Hey, let's go!\" Alien Jurals is chasing you for revenge!"));
             disturb(creature, true, true);
             for (int k = 0; k < 4; k++) {
-                summon_specific(creature, m_pos.y, m_pos.x, std::max(creature.current_floor_ptr->monster_level, 5), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
+                summon_specific(creature, m_pos.y, m_pos.x, std::max(creature.get_floor()->monster_level, 5), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
             }
         }
     }

--- a/src/alliance/alliance-khorne.cpp
+++ b/src/alliance/alliance-khorne.cpp
@@ -61,7 +61,7 @@ void AllianceKhorne::panishment(CreatureEntity &creature)
     /*
     if (one_in_(15)) {
         Pos2D m_pos(player_ptr.get_position());
-        m_pos = scatter(*player_ptr.current_floor_ptr, m_pos, 15, PROJECT_NONE);
+        m_pos = scatter(*player_ptr.get_floor(), m_pos, 15, PROJECT_NONE);
 
         // コーンの怒りレベルに応じて異なる復讐者を派遣
         MonraceId avenger_id;
@@ -86,7 +86,7 @@ void AllianceKhorne::panishment(CreatureEntity &creature)
             // 追加の配下召喚（血と戦いの混沌）
             for (int k = 0; k < 3 + (impression < -300 ? 2 : 0); k++) {
                 summon_specific(&player_ptr, m_pos.y, m_pos.x,
-                    std::max(player_ptr.current_floor_ptr->monster_level, 10),
+                    std::max(player_ptr.get_floor()->monster_level, 10),
                     SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
             }
         }
@@ -102,13 +102,13 @@ void AllianceKhorne::panishment(CreatureEntity &creature)
 
     if (one_in_(20)) {
         Pos2D m_pos(creature.get_position());
-        m_pos = scatter(*creature.current_floor_ptr, m_pos, 12, PROJECT_NONE);
+        m_pos = scatter(*creature.get_floor(), m_pos, 12, PROJECT_NONE);
         const auto m_idx = place_monster_one(creature, m_pos.y, m_pos.x, MonraceId::KHORNE_CHOSEN, PM_ALLOW_GROUP);
         if (m_idx) {
             msg_print(_("コーンの選ばれし者があなたを誅すべく追跡してきた！", "Khorne's Chosen is chasing you for revenge!"));
             disturb(creature, true, true);
             for (int k = 0; k < 3; k++) {
-                summon_specific(creature, m_pos.y, m_pos.x, std::max(creature.current_floor_ptr->monster_level, 5), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
+                summon_specific(creature, m_pos.y, m_pos.x, std::max(creature.get_floor()->monster_level, 5), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
             }
         }
     }

--- a/src/alliance/alliance-legendofsavior.cpp
+++ b/src/alliance/alliance-legendofsavior.cpp
@@ -41,7 +41,7 @@ void AllianceLegendOfSavior::panishment(CreatureEntity &creature)
     }
     if (one_in_(30)) {
         Pos2D m_pos(creature.get_position());
-        m_pos = scatter(*creature.current_floor_ptr, m_pos, 6, PROJECT_NONE);
+        m_pos = scatter(*creature.get_floor(), m_pos, 6, PROJECT_NONE);
         if (summon_named_creature(creature, 0, m_pos.y, m_pos.x, MonraceId::KENSHIROU, 0)) {
             msg_print(_("「てめえに今日を生きる資格はねえ！」", "You don't deserve to live today!"));
             msg_print(_("ケンシロウはあなたがミスミ老人を殺したことに義憤を覚えて襲ってきた！", "Kenshiro attacked you because you killed old man Misumi!"));

--- a/src/alliance/alliance-nibelung.cpp
+++ b/src/alliance/alliance-nibelung.cpp
@@ -157,10 +157,10 @@ void AllianceNibelung::panishment([[maybe_unused]] CreatureEntity &creature)
         // ドワーフの戦士を召喚
         for (int i = 0; i < randint1(3) + 1; i++) {
             MONSTER_IDX m_idx = summon_specific(&player_ptr, 0, player_ptr.y, player_ptr.x,
-                player_ptr.current_floor_ptr->dun_level + 10,
+                player_ptr.get_floor()->dun_level + 10,
                 SUMMON_DWARF, PM_FORCE_PET | PM_ALLOW_GROUP);
             if (m_idx) {
-                player_ptr.current_floor_ptr->m_list[m_idx].set_hostile();
+                player_ptr.get_floor()->m_list[m_idx].set_hostile();
                 msg_print("ニーベルングの戦士があなたを討伐しにやってきた！");
             }
         }
@@ -195,10 +195,10 @@ void AllianceNibelung::panishment([[maybe_unused]] CreatureEntity &creature)
         // より強力なドワーフ軍団を召喚
         for (int i = 0; i < randint1(4) + 2; i++) {
             MONSTER_IDX m_idx = summon_specific(&player_ptr, 0, player_ptr.y, player_ptr.x,
-                player_ptr.current_floor_ptr->dun_level + 20,
+                player_ptr.get_floor()->dun_level + 20,
                 SUMMON_DWARF, PM_FORCE_PET | PM_ALLOW_GROUP);
             if (m_idx) {
-                player_ptr.current_floor_ptr->m_list[m_idx].set_hostile();
+                player_ptr.get_floor()->m_list[m_idx].set_hostile();
             }
         }
         return;
@@ -216,10 +216,10 @@ void AllianceNibelung::panishment([[maybe_unused]] CreatureEntity &creature)
     // 大量のドワーフ軍団召喚
     for (int i = 0; i < randint1(6) + 4; i++) {
         MONSTER_IDX m_idx = summon_specific(&player_ptr, 0, player_ptr.y, player_ptr.x,
-            player_ptr.current_floor_ptr->dun_level + 30,
+            player_ptr.get_floor()->dun_level + 30,
             SUMMON_DWARF, PM_FORCE_PET | PM_ALLOW_GROUP);
         if (m_idx) {
-            player_ptr.current_floor_ptr->m_list[m_idx].set_hostile();
+            player_ptr.get_floor()->m_list[m_idx].set_hostile();
         }
     }
 

--- a/src/alliance/alliance-nurgle.cpp
+++ b/src/alliance/alliance-nurgle.cpp
@@ -168,10 +168,10 @@ void AllianceNurgle::panishment(CreatureEntity &creature)
         /*
         for (int i = 0; i < 2; i++) {
             MONSTER_IDX m_idx = summon_specific(&player_ptr, 0, player_ptr.y, player_ptr.x,
-                player_ptr.current_floor_ptr->dun_level + 5,
+                player_ptr.get_floor()->dun_level + 5,
                 SUMMON_DEMON, PM_FORCE_PET | PM_ALLOW_GROUP);
             if (m_idx) {
-                player_ptr.current_floor_ptr->m_list[m_idx].set_hostile();
+                player_ptr.get_floor()->m_list[m_idx].set_hostile();
             }
         }
         return;
@@ -203,10 +203,10 @@ void AllianceNurgle::panishment(CreatureEntity &creature)
         /*
         for (int i = 0; i < 4; i++) {
             MONSTER_IDX m_idx = summon_specific(&player_ptr, 0, player_ptr.y, player_ptr.x,
-                player_ptr.current_floor_ptr->dun_level + 10,
+                player_ptr.get_floor()->dun_level + 10,
                 SUMMON_DEMON, PM_FORCE_PET | PM_ALLOW_GROUP);
             if (m_idx) {
-                player_ptr.current_floor_ptr->m_list[m_idx].set_hostile();
+                player_ptr.get_floor()->m_list[m_idx].set_hostile();
             }
         }
         return;
@@ -238,10 +238,10 @@ void AllianceNurgle::panishment(CreatureEntity &creature)
     /*
     for (int i = 0; i < 8; i++) {
         MONSTER_IDX m_idx = summon_specific(&player_ptr, 0, player_ptr.y, player_ptr.x,
-            player_ptr.current_floor_ptr->dun_level + 15,
+            player_ptr.get_floor()->dun_level + 15,
             SUMMON_DEMON, PM_FORCE_PET | PM_ALLOW_GROUP);
         if (m_idx) {
-            player_ptr.current_floor_ptr->m_list[m_idx].set_hostile();
+            player_ptr.get_floor()->m_list[m_idx].set_hostile();
         }
     }
     */

--- a/src/alliance/alliance-sexy-commando-club.cpp
+++ b/src/alliance/alliance-sexy-commando-club.cpp
@@ -214,7 +214,7 @@ void AllianceSexyCommandoClub::panishment([[maybe_unused]] CreatureEntity &creat
         // 部員召喚
         for (int i = 0; i < 2; i++) {
             summon_specific(creature_ptr, 0, creature.y, creature.x,
-                creature.current_floor_ptr->dun_level + 5,
+                creature.get_floor()->dun_level + 5,
                 SUMMON_HUMAN, PM_FORCE_PET | PM_NO_PET);
         }
     } else if (this->impression >= -150) {
@@ -242,7 +242,7 @@ void AllianceSexyCommandoClub::panishment([[maybe_unused]] CreatureEntity &creat
         // 部員大量召喚
         for (int i = 0; i < 4; i++) {
             summon_specific(creature_ptr, 0, creature.y, creature.x,
-                creature.current_floor_ptr->dun_level + 10,
+                creature.get_floor()->dun_level + 10,
                 SUMMON_HUMAN, PM_FORCE_PET | PM_NO_PET);
         }
     } else {
@@ -273,7 +273,7 @@ void AllianceSexyCommandoClub::panishment([[maybe_unused]] CreatureEntity &creat
         // 部員軍団召喚
         for (int i = 0; i < 8; i++) {
             summon_specific(creature_ptr, 0, creature.y, creature.x,
-                creature.current_floor_ptr->dun_level + 15,
+                creature.get_floor()->dun_level + 15,
                 SUMMON_HUMAN, PM_FORCE_PET | PM_NO_PET);
         }
 

--- a/src/alliance/alliance-shittodan.cpp
+++ b/src/alliance/alliance-shittodan.cpp
@@ -37,7 +37,7 @@ void AllianceShittoDan::panishment(CreatureEntity &creature)
     }
     if (one_in_(20)) {
         Pos2D m_pos(creature.get_position());
-        m_pos = scatter(*creature.current_floor_ptr, m_pos, 8, PROJECT_NONE);
+        m_pos = scatter(*creature.get_floor(), m_pos, 8, PROJECT_NONE);
 
         const auto m_idx = place_monster_one(creature, m_pos.y, m_pos.x, MonraceId::SHITTO_MASK, PM_ALLOW_GROUP);
         if (m_idx) {

--- a/src/alliance/alliance-slaanesh.cpp
+++ b/src/alliance/alliance-slaanesh.cpp
@@ -65,7 +65,7 @@ void AllianceSlaanesh::panishment(CreatureEntity &creature)
     /*
     if (one_in_(20)) {
         Pos2D m_pos(player_ptr.get_position());
-        m_pos = scatter(*player_ptr.current_floor_ptr, m_pos, 12, PROJECT_NONE);
+        m_pos = scatter(*player_ptr.get_floor(), m_pos, 12, PROJECT_NONE);
 
         // スラーネッシュの怒りレベルに応じて異なる復讐者を派遣
         MonraceId avenger_id;
@@ -90,7 +90,7 @@ void AllianceSlaanesh::panishment(CreatureEntity &creature)
             // 追加の配下召喚（快楽と誘惑の混沌）
             for (int k = 0; k < 2 + (impression < -250 ? 3 : 0); k++) {
                 summon_specific(&player_ptr, m_pos.y, m_pos.x,
-                               std::max(player_ptr.current_floor_ptr->monster_level, 8),
+                               std::max(player_ptr.get_floor()->monster_level, 8),
                                SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
             }
         }
@@ -105,13 +105,13 @@ void AllianceSlaanesh::panishment(CreatureEntity &creature)
 
     if (one_in_(25)) {
         Pos2D m_pos(creature.get_position());
-        m_pos = scatter(*creature.current_floor_ptr, m_pos, 10, PROJECT_NONE);
+        m_pos = scatter(*creature.get_floor(), m_pos, 10, PROJECT_NONE);
         const auto m_idx = place_monster_one(creature, m_pos.y, m_pos.x, MonraceId::SLAANESH_CHOSEN, PM_ALLOW_GROUP);
         if (m_idx) {
             msg_print(_("スラーネッシュの選ばれし者があなたを誘惑すべく現れた！", "Slaanesh's Chosen appears to seduce you!"));
             disturb(creature, true, true);
             for (int k = 0; k < 2; k++) {
-                summon_specific(creature, m_pos.y, m_pos.x, std::max(creature.current_floor_ptr->monster_level, 3), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
+                summon_specific(creature, m_pos.y, m_pos.x, std::max(creature.get_floor()->monster_level, 3), SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
             }
         }
     }

--- a/src/alliance/alliance-tzeentch.cpp
+++ b/src/alliance/alliance-tzeentch.cpp
@@ -78,7 +78,7 @@ void AllianceTzeentch::panishment(CreatureEntity &creature)
     }
     if (one_in_(22)) {
         Pos2D m_pos(creature.get_position());
-        m_pos = scatter(*creature.current_floor_ptr, m_pos, 15, PROJECT_NONE);
+        m_pos = scatter(*creature.get_floor(), m_pos, 15, PROJECT_NONE);
 
         // ティーンチの知識と変幻レベルに応じて異なる復讐者を派遣
         /*
@@ -117,7 +117,7 @@ void AllianceTzeentch::panishment(CreatureEntity &creature)
 
             for (int k = 0; k < summon_count; k++) {
                 summon_specific(&player_ptr, m_pos.y, m_pos.x,
-                    std::max(player_ptr.current_floor_ptr->monster_level, 12),
+                    std::max(player_ptr.get_floor()->monster_level, 12),
                     SUMMON_ALLIANCE, PM_ALLOW_GROUP, m_idx);
             }
         }

--- a/src/alliance/alliance-yeek-kingdom.cpp
+++ b/src/alliance/alliance-yeek-kingdom.cpp
@@ -77,7 +77,7 @@ void AllianceYeekKingdom::panishment([[maybe_unused]] CreatureEntity &creature)
     if (impression <= -100) {
         int attack_chance = (-impression - 100) / 50 + 1;
         if (one_in_(std::max(1, 20 - attack_chance))) {
-            summon_specific(&player_ptr, player_ptr.y, player_ptr.x, player_ptr.current_floor_ptr->dun_level + 10, SUMMON_YEEK, PM_AMBUSH);
+            summon_specific(&player_ptr, player_ptr.y, player_ptr.x, player_ptr.get_floor()->dun_level + 10, SUMMON_YEEK, PM_AMBUSH);
         }
     }
     */

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -155,7 +155,7 @@ bool is_autopick_match(CreatureEntity &creature, const ItemEntity *o_ptr, const 
             return false;
         }
 
-        if (!o_ptr->is_known() && o_ptr->is_target_of(creature.current_floor_ptr->quest_number)) {
+        if (!o_ptr->is_known() && o_ptr->is_target_of(creature.get_floor()->quest_number)) {
             return false;
         }
     }

--- a/src/autopick/autopick.cpp
+++ b/src/autopick/autopick.cpp
@@ -69,7 +69,7 @@ void autopick_delayed_alter(CreatureEntity &creature)
     }
 
     const auto p_pos = creature.get_position();
-    auto &grid = creature.current_floor_ptr->get_grid(p_pos);
+    auto &grid = creature.get_floor()->get_grid(p_pos);
     for (auto it = grid.o_idx_list.begin(); it != grid.o_idx_list.end();) {
         INVENTORY_IDX i_idx = *it++;
         autopick_delayed_alter_aux(creature, -i_idx);
@@ -103,7 +103,7 @@ void autopick_pickup_items(CreatureEntity &creature, const Grid &grid)
 {
     for (auto it = grid.o_idx_list.begin(); it != grid.o_idx_list.end();) {
         OBJECT_IDX this_o_idx = *it++;
-        auto &item = *creature.current_floor_ptr->o_list[this_o_idx];
+        auto &item = *creature.get_floor()->o_list[this_o_idx];
         int idx = find_autopick_list(creature, &item);
         auto_inscribe_item(&item, idx);
         if ((idx < 0) || (autopick_list[idx].action & (DO_AUTOPICK | DO_QUERY_AUTOPICK)) == 0) {

--- a/src/avatar/avatar-changer.cpp
+++ b/src/avatar/avatar-changer.cpp
@@ -56,7 +56,7 @@ void AvatarChanger::change_virtue()
  */
 void AvatarChanger::change_virtue_non_beginner()
 {
-    const auto &floor = *this->creature.current_floor_ptr;
+    const auto &floor = *this->creature.get_floor();
     const auto &monrace = this->m_ptr->get_monrace();
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::BEGINNER)) {
         return;
@@ -109,7 +109,7 @@ void AvatarChanger::change_virtue_unique()
  */
 void AvatarChanger::change_virtue_good_evil()
 {
-    const auto &floor = *this->creature.current_floor_ptr;
+    const auto &floor = *this->creature.get_floor();
     const auto &monrace = this->m_ptr->get_monrace();
     if (monrace.kind_flags.has(MonsterKindType::GOOD) && ((monrace.level) / 10 + (3 * floor.dun_level) >= randint1(100))) {
         chg_virtue(this->creature, Virtue::UNLIFE, 1);
@@ -140,7 +140,7 @@ void AvatarChanger::change_virtue_good_evil()
  */
 void AvatarChanger::change_virtue_revenge()
 {
-    const auto &floor = *this->creature.current_floor_ptr;
+    const auto &floor = *this->creature.get_floor();
     const auto &monrace = this->m_ptr->get_monrace();
     if (monrace.r_deaths == 0) {
         return;
@@ -161,7 +161,7 @@ void AvatarChanger::change_virtue_revenge()
  */
 void AvatarChanger::change_virtue_wild_thief()
 {
-    const auto &floor = *this->creature.current_floor_ptr;
+    const auto &floor = *this->creature.get_floor();
     const auto &monrace = this->m_ptr->get_monrace();
     auto innocent = true;
     auto thief = false;

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -64,7 +64,7 @@ static void write_birth_diary(CreatureEntity &creature)
     message_add("====================");
     message_add(" ");
     message_add("  ");
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     exe_write_diary(floor, DiaryKind::GAMESTART, 1, _("-------- 新規ゲーム開始 --------", "------- Started New Game -------"));
     exe_write_diary(floor, DiaryKind::DIALY, 0);
     const auto mes_sex = format(_("%s性別に%sを選択した。", "%schose %s gender."), indent, sex_info[creature.psex].title.data());
@@ -150,7 +150,7 @@ void player_birth(CreatureEntity &creature, std::optional<QuestId> initial_quest
 
         // クエストの初期化処理（ウィザードモードのwiz_enter_quest関数を参考）
         init_flags = i2enum<init_flags_type>(INIT_SHOW_TEXT | INIT_ASSIGN);
-        creature.current_floor_ptr->quest_number = *initial_quest_id;
+        creature.get_floor()->quest_number = *initial_quest_id;
         parse_fixed_map(creature, QUEST_DEFINITION_LIST, 0, 0, 0, 0);
         quest.status = QuestStatusType::TAKEN;
 

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -46,7 +46,7 @@ void player_wipe_without_name(CreatureEntity &creature)
     creature.wipe();
 
     // TODO: キャラ作成からゲーム開始までに  current_floor_ptr を参照しなければならない処理は今後整理して外す。
-    creature.current_floor_ptr = &FloorList::get_instance().get_floor(0);
+    creature.set_floor(&FloorList::get_instance().get_floor(0));
     for (int i = 0; i < 4; i++) {
         creature.history[i][0] = '\0';
     }
@@ -149,7 +149,7 @@ void player_wipe_without_name(CreatureEntity &creature)
 void init_dungeon_quests(CreatureEntity &creature)
 {
     init_flags = INIT_ASSIGN;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &quests = QuestList::get_instance();
     floor.quest_number = QuestId::RANDOM_QUEST1;
     parse_fixed_map(creature, QUEST_DEFINITION_LIST, 0, 0, 0, 0);

--- a/src/blue-magic/blue-magic-caster.cpp
+++ b/src/blue-magic/blue-magic-caster.cpp
@@ -46,7 +46,7 @@ bool cast_blue_dispel(CreatureEntity &creature)
         return false;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(*pos);
     const auto m_idx = grid.m_idx;
     const auto p_pos = creature.get_position();
@@ -99,7 +99,7 @@ static bool cast_blue_hand_doom(CreatureEntity &creature, bmc_type *bmc_ptr)
 /* 効果が抵抗された場合、返される tl::optional には値がありません。*/
 static tl::optional<std::string> exe_blue_teleport_back(CreatureEntity &creature, const Pos2D &pos)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(pos);
     const auto p_pos = creature.get_position();
     if (!grid.has_monster() || !grid.has_los() || !projectable(floor, p_pos, pos)) {
@@ -148,7 +148,7 @@ static bool cast_blue_teleport_back(CreatureEntity &creature)
 
     msg_format(_("%sを引き戻した。", "You command %s to return."), m_name->data());
     teleport_monster_to(
-        creature, creature.current_floor_ptr->get_grid(*pos).m_idx, creature.y, creature.x, 100, TELEPORT_PASSIVE);
+        creature, creature.get_floor()->get_grid(*pos).m_idx, creature.y, creature.x, 100, TELEPORT_PASSIVE);
     return true;
 }
 

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -68,7 +68,7 @@
 static void natural_attack(CreatureEntity &creature, MONSTER_IDX m_idx, PlayerMutationType attack, bool *fear, bool *mdeath)
 {
     WEIGHT n_weight = 0;
-    auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
 
     Dice dice{};
@@ -160,7 +160,7 @@ static void natural_attack(CreatureEntity &creature, MONSTER_IDX m_idx, PlayerMu
  */
 static void headbutt_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *fear, bool *mdeath)
 {
-    auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
 
     // 頭突きの基本パラメータ
@@ -244,7 +244,7 @@ static void headbutt_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *f
  */
 static void bodyslam_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *fear, bool *mdeath)
 {
-    auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
 
     // 体当たりの基本パラメータ（プレイヤーの体重や筋力に依存）
@@ -319,7 +319,7 @@ static void bodyslam_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *f
     // 体当たりによる特殊効果（ノックバック可能性）
     if (k > 20 && one_in_(4) && !monrace.resistance_flags.has(MonsterResistanceType::NO_STUN)) {
         msg_format(_("%sは体当たりでよろめいた！", "%s staggers from your body slam!"), m_name.data());
-        (void)set_monster_stunned(*creature.current_floor_ptr, m_idx, monster.get_remaining_stun() + randint1(5) + 5);
+        (void)set_monster_stunned(*creature.get_floor(), m_idx, monster.get_remaining_stun() + randint1(5) + 5);
     }
 
     // 体当たりによるダメージ処理
@@ -348,7 +348,7 @@ static void bodyslam_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *f
  */
 bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_options mode)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &grid = floor.grid_array[y][x];
     const auto &monster = floor.get_monster(grid.m_idx);
     const auto &monrace = monster.get_monrace();
@@ -427,7 +427,7 @@ bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_opti
             msg_format(_("そっちには何か恐いものがいる！", "There is something scary in your way!"));
         }
 
-        (void)set_monster_csleep(*creature.current_floor_ptr, grid.m_idx, 0);
+        (void)set_monster_csleep(*creature.get_floor(), grid.m_idx, 0);
         return false;
     }
 
@@ -475,7 +475,7 @@ bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_opti
         if (one_in_(20)) {
             auto &current_monster = floor.get_monster(grid.m_idx);
             current_monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::FRENZY);
-            (void)set_monster_monfear(*creature.current_floor_ptr, grid.m_idx, 0);
+            (void)set_monster_monfear(*creature.get_floor(), grid.m_idx, 0);
             sound(SoundKind::FLEE);
             msg_format(_("%s^は恐怖を怒りに変えて狂乱状態になった！", "%s^ turns fear into rage and goes berserk!"), m_name.data());
             fear = false;
@@ -506,7 +506,7 @@ bool do_cmd_headbutt(CreatureEntity &creature)
 
     const auto pos = creature.get_neighbor(dir);
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(pos);
 
     if (!grid.has_monster()) {
@@ -556,7 +556,7 @@ bool do_cmd_headbutt(CreatureEntity &creature)
     }
 
     // モンスターを起こす
-    (void)set_monster_csleep(*creature.current_floor_ptr, grid.m_idx, 0);
+    (void)set_monster_csleep(*creature.get_floor(), grid.m_idx, 0);
 
     // 頭突き攻撃実行
     bool fear = false;
@@ -570,7 +570,7 @@ bool do_cmd_headbutt(CreatureEntity &creature)
         if (one_in_(20)) {
             auto &current_monster = floor.get_monster(grid.m_idx);
             current_monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::FRENZY);
-            (void)set_monster_monfear(*creature.current_floor_ptr, grid.m_idx, 0);
+            (void)set_monster_monfear(*creature.get_floor(), grid.m_idx, 0);
             sound(SoundKind::FLEE);
             msg_format(_("%s^は恐怖を怒りに変えて狂乱状態になった！", "%s^ turns fear into rage and goes berserk!"), m_name.data());
         } else {
@@ -594,7 +594,7 @@ void do_cmd_body_slam(CreatureEntity &creature)
     }
 
     const auto pos = creature.get_neighbor(dir);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(pos);
 
     if (!grid.has_monster()) {
@@ -642,7 +642,7 @@ void do_cmd_body_slam(CreatureEntity &creature)
         if (one_in_(20)) {
             auto &current_monster = floor.get_monster(m_idx);
             current_monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::FRENZY);
-            (void)set_monster_monfear(*creature.current_floor_ptr, m_idx, 0);
+            (void)set_monster_monfear(*creature.get_floor(), m_idx, 0);
             sound(SoundKind::FLEE);
             msg_format(_("%s^は恐怖を怒りに変えて狂乱状態になった！", "%s^ turns fear into rage and goes berserk!"), m_name.data());
         } else {
@@ -661,7 +661,7 @@ void do_cmd_body_slam(CreatureEntity &creature)
  */
 static void enema_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *fear, bool *mdeath)
 {
-    auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
 
     // 浣腸の基本パラメータ（プレイヤーの体重や筋力に依存）
@@ -735,7 +735,7 @@ void do_cmd_enema(CreatureEntity &creature)
     }
 
     const auto pos = creature.get_neighbor(dir);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(pos);
 
     if (!grid.has_monster()) {
@@ -783,7 +783,7 @@ void do_cmd_enema(CreatureEntity &creature)
         if (one_in_(20)) {
             auto &current_monster = floor.get_monster(m_idx);
             current_monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::FRENZY);
-            (void)set_monster_monfear(*creature.current_floor_ptr, m_idx, 0);
+            (void)set_monster_monfear(*creature.get_floor(), m_idx, 0);
             sound(SoundKind::FLEE);
             msg_format(_("%s^は恐怖を怒りに変えて狂乱状態になった！", "%s^ turns fear into rage and goes berserk!"), m_name.data());
         } else {

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -829,7 +829,7 @@ static bool use_mane(CreatureEntity &creature, MonsterAbilityType spell)
         break;
     }
     case MonsterAbilityType::S_CYBER: {
-        int max_cyber = (creature.current_floor_ptr->dun_level / 50) + randint1(3);
+        int max_cyber = (creature.get_floor()->dun_level / 50) + randint1(3);
         const auto pos = target_set(creature, TARGET_KILL).get_position();
         if (!pos) {
             return false;

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -304,7 +304,7 @@ static bool switch_mind_class(CreatureEntity &creature, cm_type *cm_ptr)
         cm_ptr->cast = cast_berserk_spell(creature, i2enum<MindBerserkerType>(cm_ptr->n));
         return true;
     case MindKindType::MIRROR_MASTER:
-        if (creature.current_floor_ptr->grid_array[creature.y][creature.x].is_mirror()) {
+        if (creature.get_floor()->grid_array[creature.y][creature.x].is_mirror()) {
             cm_ptr->on_mirror = true;
         }
 

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -59,7 +59,7 @@
 static bool confirm_leave_level(CreatureEntity &creature, bool down_stair)
 {
     const auto &quests = QuestList::get_instance();
-    const auto &quest = quests.get_quest(creature.current_floor_ptr->quest_number);
+    const auto &quest = quests.get_quest(creature.get_floor()->quest_number);
 
     auto caution_in_tower = any_bits(quest.flags, QUEST_FLAG_TOWER);
     caution_in_tower &= quest.status != QuestStatusType::STAGE_COMPLETED || (down_stair && (quests.get_quest(QuestId::TOWER1).status != QuestStatusType::COMPLETED));
@@ -68,7 +68,7 @@ static bool confirm_leave_level(CreatureEntity &creature, bool down_stair)
     caution_in_quest |= quest.flags & QUEST_FLAG_ONCE && quest.status != QuestStatusType::COMPLETED;
     caution_in_quest |= caution_in_tower;
 
-    if (confirm_quest && creature.current_floor_ptr->is_in_quest() && caution_in_quest) {
+    if (confirm_quest && creature.get_floor()->is_in_quest() && caution_in_quest) {
         msg_print(_("この階を一度去ると二度と戻って来られません。", "You can't come back here once you leave this floor."));
         return input_check(_("本当にこの階を去りますか？", "Really leave this floor? "));
     }
@@ -82,7 +82,7 @@ static bool confirm_leave_level(CreatureEntity &creature, bool down_stair)
 void do_cmd_go_up(CreatureEntity &creature)
 {
     auto &quests = QuestList::get_instance();
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid({ creature.y, creature.x });
     const auto &terrain = grid.get_terrain();
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
@@ -221,7 +221,7 @@ void do_cmd_go_down(CreatureEntity &creature)
 {
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &grid = floor.grid_array[creature.y][creature.x];
     auto &terrain = grid.get_terrain();
 
@@ -416,7 +416,7 @@ void do_cmd_walk(CreatureEntity &creature, bool pickup)
         more = true;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     if (is_wild_mode && !floor.has_terrain_characteristics(p_pos, TerrainCharacteristics::TOWN)) {
         const auto wild_level = WildernessGrids::get_instance().get_player_grid().get_level();
@@ -567,7 +567,7 @@ void do_cmd_rest(CreatureEntity &creature)
  */
 void do_cmd_go_portal(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid({ creature.y, creature.x });
     const auto &terrain = grid.get_terrain();
 

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -47,7 +47,7 @@ static bool exe_open_chest(CreatureEntity &creature, const Pos2D &pos, OBJECT_ID
 {
     auto flag = true;
     auto more = false;
-    auto *o_ptr = creature.current_floor_ptr->o_list[o_idx].get();
+    auto *o_ptr = creature.get_floor()->o_list[o_idx].get();
     PlayerEnergy(creature).set_player_turn_energy(100);
     if (o_ptr->pval > 0) {
         flag = false;
@@ -103,7 +103,7 @@ void do_cmd_open(CreatureEntity &creature)
     }
 
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (easy_open) {
         const auto &[num_doors, dir_door] = floor.count_doors_traps(creature.get_position(), GridCountKind::CLOSED_DOOR, false);
         const auto &[num_chests, dir_chest] = count_chests(creature, false);
@@ -155,7 +155,7 @@ void do_cmd_close(CreatureEntity &creature)
         return;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
     if (easy_open) {
         const auto &[num_doors, dir] = floor.count_doors_traps(creature.get_position(), GridCountKind::OPEN, false);
@@ -200,7 +200,7 @@ void do_cmd_disarm(CreatureEntity &creature)
         return;
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
     if (easy_disarm) {
         const auto &[num_traps, dir_trap] = floor.count_doors_traps(creature.get_position(), GridCountKind::TRAP, true);
@@ -274,7 +274,7 @@ void do_cmd_bash(CreatureEntity &creature)
     auto more = false;
     if (const auto dir = get_rep_dir(creature)) {
         const auto pos = creature.get_neighbor(dir);
-        const Grid &grid = creature.current_floor_ptr->get_grid(pos);
+        const Grid &grid = creature.get_floor()->get_grid(pos);
         if (grid.get_terrain(TerrainKind::MIMIC).flags.has_not(TerrainCharacteristics::BASH)) {
             msg_print(_("そこには体当たりするものが見当たらない。", "You see nothing there to bash."));
         } else if (grid.has_monster()) {
@@ -340,7 +340,7 @@ void do_cmd_spike(CreatureEntity &creature)
     }
 
     const auto pos = creature.get_neighbor(dir);
-    const auto &grid = creature.current_floor_ptr->get_grid(pos);
+    const auto &grid = creature.get_floor()->get_grid(pos);
     const auto &terrain_mimic = grid.get_terrain(TerrainKind::MIMIC);
     INVENTORY_IDX i_idx;
     if (terrain_mimic.flags.has_not(TerrainCharacteristics::SPIKE)) {

--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -69,7 +69,7 @@ static bool exe_alter(CreatureEntity &creature)
     }
 
     const auto pos = creature.get_neighbor(dir);
-    const auto &grid = creature.current_floor_ptr->get_grid(pos);
+    const auto &grid = creature.get_floor()->get_grid(pos);
     const auto &terrain = grid.get_terrain(TerrainKind::MIMIC);
     PlayerEnergy(creature).set_player_turn_energy(100);
     if (grid.has_monster()) {
@@ -195,7 +195,7 @@ void do_cmd_suicide(CreatureEntity &creature)
         world.add_retired_class(creature.pclass);
     } else {
         play_music(TERM_XTRA_MUSIC_BASIC, MUSIC_BASIC_GAMEOVER);
-        const auto &floor = *creature.current_floor_ptr;
+        const auto &floor = *creature.get_floor();
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 0, _("ダンジョンの探索に飽きて自殺した。", "got tired to commit suicide."));
         exe_write_diary(floor, DiaryKind::GAMESTART, 1, _("-------- ゲームオーバー --------", "--------   Game  Over   --------"));
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, "\n\n\n\n");
@@ -209,7 +209,7 @@ void do_cmd_suicide(CreatureEntity &creature)
  */
 void do_cmd_inscribe_terrain(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &grid = floor.get_grid(creature.get_position());
 
     // 現在の説明を表示

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -73,7 +73,7 @@ void do_cmd_pet_dismiss(CreatureEntity &creature)
     auto cv = game_term->scr->cv;
     game_term->scr->cu = false;
     game_term->scr->cv = true;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     std::vector<short> pet_index;
     for (short pet_indice = floor.m_max - 1; pet_indice >= 1; pet_indice--) {
         const auto &monster = floor.get_monster(pet_indice);
@@ -192,7 +192,7 @@ bool do_cmd_riding(CreatureEntity &creature, bool force)
     }
 
     const auto pos = creature.get_neighbor(dir);
-    auto &grid = creature.current_floor_ptr->get_grid(pos);
+    auto &grid = creature.get_floor()->get_grid(pos);
 
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
@@ -224,7 +224,7 @@ bool do_cmd_riding(CreatureEntity &creature, bool force)
             return false;
         }
 
-        const auto &monster = creature.current_floor_ptr->get_monster(grid.m_idx);
+        const auto &monster = creature.get_floor()->get_monster(grid.m_idx);
 
         if (!grid.has_monster() || !monster.get_monster_profile().ml) {
             msg_print(_("その場所にはモンスターはいません。", "There is no monster here."));
@@ -265,7 +265,7 @@ bool do_cmd_riding(CreatureEntity &creature, bool force)
 
         if (monster.is_asleep()) {
             const auto m_name = monster_desc(creature, monster, 0);
-            (void)set_monster_csleep(*creature.current_floor_ptr, grid.m_idx, 0);
+            (void)set_monster_csleep(*creature.get_floor(), grid.m_idx, 0);
             msg_format(_("%sを起こした。", "You have woken %s up."), m_name.data());
         }
 
@@ -312,7 +312,7 @@ static void do_name_pet(CreatureEntity &creature)
     }
 
     target_pet = old_target_pet;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(*pos);
     if (!grid.has_monster()) {
         return;
@@ -382,7 +382,7 @@ void do_cmd_pet(CreatureEntity &creature)
     powers[num++] = PET_DISMISS;
 
     const auto is_hallucinated = creature.effects()->hallucination().is_hallucinated();
-    const auto taget_of_pet = creature.current_floor_ptr->get_monster(creature.pet_t_m_idx).get_appearance_monrace().name.data();
+    const auto taget_of_pet = creature.get_floor()->get_monster(creature.pet_t_m_idx).get_appearance_monrace().name.data();
     const auto target_of_pet_appearance = is_hallucinated ? _("何か奇妙な物", "something strange") : taget_of_pet;
     const auto mes = _("ペットのターゲットを指定 (現在：%s)", "specify a target of pet (now:%s)");
     const auto target_name = creature.pet_t_m_idx > 0 ? target_of_pet_appearance : _("指定なし", "nothing");
@@ -670,8 +670,8 @@ void do_cmd_pet(CreatureEntity &creature)
     case PET_DISMISS: /* Dismiss pets */
     {
         /* Check pets (backwards) */
-        for (pet_ctr = creature.current_floor_ptr->m_max - 1; pet_ctr >= 1; pet_ctr--) {
-            const auto &m_ref = creature.current_floor_ptr->get_monster(pet_ctr);
+        for (pet_ctr = creature.get_floor()->m_max - 1; pet_ctr >= 1; pet_ctr--) {
+            const auto &m_ref = creature.get_floor()->get_monster(pet_ctr);
             if (m_ref.is_pet()) {
                 break;
             }
@@ -691,9 +691,9 @@ void do_cmd_pet(CreatureEntity &creature)
         if (!pos) {
             creature.pet_t_m_idx = 0;
         } else {
-            const auto &grid = creature.current_floor_ptr->get_grid(*pos);
-            if (grid.has_monster() && (creature.current_floor_ptr->get_monster(grid.m_idx).get_monster_profile().ml)) {
-                creature.pet_t_m_idx = creature.current_floor_ptr->get_grid(*pos).m_idx;
+            const auto &grid = creature.get_floor()->get_grid(*pos);
+            if (grid.has_monster() && (creature.get_floor()->get_monster(grid.m_idx).get_monster_profile().ml)) {
+                creature.pet_t_m_idx = creature.get_floor()->get_grid(*pos).m_idx;
                 creature.pet_follow_distance = PET_DESTROY_DIST;
             } else {
                 creature.pet_t_m_idx = 0;
@@ -743,8 +743,8 @@ void do_cmd_pet(CreatureEntity &creature)
     case PET_TAKE_ITEMS: {
         if (creature.pet_extra_flags & PF_PICKUP_ITEMS) {
             creature.pet_extra_flags &= ~(PF_PICKUP_ITEMS);
-            for (pet_ctr = creature.current_floor_ptr->m_max - 1; pet_ctr >= 1; pet_ctr--) {
-                auto &monster = creature.current_floor_ptr->get_monster(pet_ctr);
+            for (pet_ctr = creature.get_floor()->m_max - 1; pet_ctr >= 1; pet_ctr--) {
+                auto &monster = creature.get_floor()->get_monster(pet_ctr);
                 if (monster.is_pet()) {
                     monster_drop_carried_objects(creature, monster);
                 }

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -687,7 +687,7 @@ static void change_realm2(CreatureEntity &creature, PlayerRealm &pr, RealmType n
 
     constexpr auto fmt_realm = _("魔法の領域を%sから%sに変更した。", "changed magic realm from %s to %s.");
     const auto mes = format(fmt_realm, pr.realm2().get_name().data(), PlayerRealm::get_name(next_realm).data());
-    exe_write_diary(*creature.current_floor_ptr, DiaryKind::DESCRIPTION, 0, mes);
+    exe_write_diary(*creature.get_floor(), DiaryKind::DESCRIPTION, 0, mes);
     creature.old_realm |= 1U << (enum2i(pr.realm2().to_enum()) - 1);
     pr.set(pr.realm1().to_enum(), next_realm);
 

--- a/src/cmd-action/cmd-travel.cpp
+++ b/src/cmd-action/cmd-travel.cpp
@@ -37,7 +37,7 @@ void do_cmd_travel(CreatureEntity &creature)
         return;
     }
 
-    if (!Travel::can_travel_to(*creature.current_floor_ptr, *pos)) {
+    if (!Travel::can_travel_to(*creature.get_floor(), *pos)) {
         msg_print(_("そこには行くことができません！", "You cannot travel there!"));
         return;
     }

--- a/src/cmd-action/cmd-tunnel.cpp
+++ b/src/cmd-action/cmd-tunnel.cpp
@@ -50,7 +50,7 @@ void do_cmd_tunnel(CreatureEntity &creature)
 
     auto more = false;
     const auto pos = creature.get_neighbor(dir);
-    const auto &grid = creature.current_floor_ptr->get_grid(pos);
+    const auto &grid = creature.get_floor()->get_grid(pos);
     const auto &terrain_mimic = grid.get_terrain(TerrainKind::MIMIC);
     if (terrain_mimic.flags.has(TerrainCharacteristics::DOOR)) {
         msg_print(_("ドアは掘れない。", "You cannot tunnel through doors."));

--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -369,7 +369,7 @@ void do_cmd_building(CreatureEntity &creature)
     PlayerEnergy energy(creature);
     energy.set_player_turn_energy(100);
     const auto p_pos = creature.get_position();
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (!floor.has_terrain_characteristics(p_pos, TerrainCharacteristics::BLDG)) {
         msg_print(_("ここには建物はない。", "You see no building here."));
         return;

--- a/src/cmd-building/cmd-inn.cpp
+++ b/src/cmd-building/cmd-inn.cpp
@@ -69,7 +69,7 @@ static bool is_player_undead(CreatureEntity &creature)
  */
 static void write_diary_stay_inn(CreatureEntity &creature, int prev_hour)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if ((prev_hour >= 6) && (prev_hour < 18)) {
         const auto stay_message = _(is_player_undead(creature) ? "宿屋に泊まった。" : "日が暮れるまで宿屋で過ごした。", "stayed during the day at the inn.");
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 0, stay_message);
@@ -101,7 +101,7 @@ static bool has_a_nightmare(CreatureEntity &creature)
     }
 
     msg_print(_("あなたは絶叫して目を覚ました。", "You awake screaming."));
-    exe_write_diary(*creature.current_floor_ptr, DiaryKind::DESCRIPTION, 0, _("悪夢にうなされてよく眠れなかった。", "had a nightmare."));
+    exe_write_diary(*creature.get_floor(), DiaryKind::DESCRIPTION, 0, _("悪夢にうなされてよく眠れなかった。", "had a nightmare."));
     return true;
 }
 
@@ -147,7 +147,7 @@ static void charge_magic_eating_energy(CreatureEntity &creature)
  */
 static void display_stay_result(CreatureEntity &creature, int prev_hour)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if ((prev_hour >= 6) && (prev_hour < 18)) {
 #if JP
         char refresh_message_jp[50];
@@ -185,7 +185,7 @@ static bool stay_inn(CreatureEntity &creature)
     prevent_turn_overflow(creature);
     if ((prev_hour >= 18) && (prev_hour <= 23)) {
         determine_daily_bounty(creature);
-        exe_write_diary(*creature.current_floor_ptr, DiaryKind::DIALY, 0);
+        exe_write_diary(*creature.get_floor(), DiaryKind::DIALY, 0);
     }
 
     creature.hp = creature.maxhp;

--- a/src/cmd-io/cmd-diary.cpp
+++ b/src/cmd-io/cmd-diary.cpp
@@ -108,7 +108,7 @@ void do_cmd_diary(CreatureEntity &creature)
 {
     screen_save();
     TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     while (true) {
         term_clear();
         prt(_("[ 記録の設定 ]", "[ Play Record ]"), 2, 0);

--- a/src/cmd-io/cmd-dump.cpp
+++ b/src/cmd-io/cmd-dump.cpp
@@ -237,7 +237,7 @@ void do_cmd_feeling(CreatureEntity &creature)
     if (AngbandWorld::get_instance().is_wild_mode()) {
         return;
     }
-    FloorType *floor_ptr = creature.current_floor_ptr;
+    FloorType *floor_ptr = creature.get_floor();
     int grids_rate = floor_ptr->width * floor_ptr->height * 100 / (MAX_WID * MAX_HGT);
 
     if (floor_ptr->allianceID != AllianceType::NONE) {
@@ -247,7 +247,7 @@ void do_cmd_feeling(CreatureEntity &creature)
         }
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (floor.is_in_quest() && !inside_quest(floor.get_random_quest_id())) {
         msg_print(_("典型的なクエストのダンジョンのようだ。", "Looks like a typical quest level."));
         return;

--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -538,7 +538,7 @@ void do_cmd_options(CreatureEntity &creature)
                 break;
             }
 
-            do_cmd_options_cheat(*creature.current_floor_ptr, creature.name, _("詐欺師は決して勝利できない！", "Cheaters never win"));
+            do_cmd_options_cheat(*creature.get_floor(), creature.name, _("詐欺師は決して勝利できない！", "Cheaters never win"));
             break;
         }
         case 'a':

--- a/src/cmd-io/cmd-save.cpp
+++ b/src/cmd-io/cmd-save.cpp
@@ -52,5 +52,5 @@ void do_cmd_save_and_exit(CreatureEntity &creature)
 {
     creature.playing = false;
     creature.leaving = true;
-    exe_write_diary(*creature.current_floor_ptr, DiaryKind::GAMESTART, 0, _("----ゲーム中断----", "--- Saved and Exited Game ---"));
+    exe_write_diary(*creature.get_floor(), DiaryKind::GAMESTART, 0, _("----ゲーム中断----", "--- Saved and Exited Game ---"));
 }

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -523,7 +523,7 @@ static bool exe_eat_charge_of_magic_device(CreatureEntity &creature, ItemEntity 
     if (i_idx >= 0) {
         inven_item_charges(*creature.inventory[i_idx]);
     } else {
-        floor_item_charges(*creature.current_floor_ptr, 0 - i_idx);
+        floor_item_charges(*creature.get_floor(), 0 - i_idx);
     }
 
     static constexpr auto flags = {

--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -93,7 +93,7 @@ int staff_effect(CreatureEntity &creature, int sval, bool *use_charge, bool powe
     case SV_STAFF_SUMMONING: {
         const int times = randint1(powerful ? 8 : 4);
         for (k = 0; k < times; k++) {
-            if (summon_specific(creature, creature.y, creature.x, creature.current_floor_ptr->dun_level, SUMMON_NONE,
+            if (summon_specific(creature, creature.y, creature.x, creature.get_floor()->dun_level, SUMMON_NONE,
                     (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET))) {
                 ident = true;
             }

--- a/src/combat/aura-counterattack.cpp
+++ b/src/combat/aura-counterattack.cpp
@@ -126,7 +126,7 @@ static void aura_shards_by_monster_attack(CreatureEntity &creature, MonsterAttac
         }
     }
 
-    if (creature.current_floor_ptr->grid_array[creature.y][creature.x].is_mirror()) {
+    if (creature.get_floor()->grid_array[creature.y][creature.x].is_mirror()) {
         teleport_player(creature, 10, TELEPORT_SPONTANEOUS);
     }
 }

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -500,7 +500,7 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
     auto stick_to = false;
 
     /* Access the item (if in the pack) */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (i_idx >= 0) {
         o_ptr = creature.inventory[i_idx].get();
     } else {

--- a/src/core/game-closer.cpp
+++ b/src/core/game-closer.cpp
@@ -91,7 +91,7 @@ static bool check_death(CreatureEntity &creature)
 static void kingly(CreatureEntity &creature)
 {
     bool seppuku = streq(creature.died_from, "Seppuku");
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     floor.dun_level = 0;
     if (!seppuku) {
         /* 引退したときの識別文字 */

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -186,7 +186,7 @@ static void init_world_floor_info(CreatureEntity &creature, std::optional<QuestI
 {
     AngbandWorld::get_instance().character_dungeon = false;
     wc_ptr->collapse_degree = 0;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     floor.reset_dungeon_index();
     floor.dun_level = 0;
     floor.quest_number = QuestId::NONE;
@@ -215,7 +215,7 @@ static void restore_world_floor_info(CreatureEntity &creature)
 {
     write_level = false;
     constexpr auto mes = _("                            ----ゲーム再開----", "                            --- Restarted Game ---");
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     exe_write_diary(floor, DiaryKind::GAMESTART, 1, mes);
 
     if (creature.riding != -1) {
@@ -280,7 +280,7 @@ static void change_floor_if_error(CreatureEntity &creature)
 static void generate_world(CreatureEntity &creature, bool new_game)
 {
     reset_world_info(creature);
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     panel_row_min = floor.height;
     panel_col_min = floor.width;
 
@@ -324,7 +324,7 @@ static void init_riding_pet(CreatureEntity &creature, bool new_game)
     const auto pet_id = pc.equals(PlayerClassType::CAVALRY) ? MonraceId::HORSE : MonraceId::YASE_HORSE;
     const auto &monrace = MonraceList::get_instance().get_monrace(pet_id);
     const auto m_idx = place_specific_monster(creature, creature.y, creature.x - 1, pet_id, (PM_FORCE_PET | PM_NO_KAGE));
-    auto &monster = creature.current_floor_ptr->get_monster(*m_idx);
+    auto &monster = creature.get_floor()->get_monster(*m_idx);
     monster.speed = monrace.speed;
     monster.maxhp = monrace.hit_dice.floored_expected_value();
     monster.max_maxhp = monster.maxhp;
@@ -340,7 +340,7 @@ static void decide_arena_death(CreatureEntity &creature)
     }
 
     auto &world = AngbandWorld::get_instance();
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (!floor.inside_arena) {
 
         while (true) {
@@ -383,7 +383,7 @@ static void decide_arena_death(CreatureEntity &creature)
 static void process_game_turn(CreatureEntity &creature)
 {
     auto load_game = true;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &world = AngbandWorld::get_instance();
     world.play_time.unpause();
     while (true) {
@@ -449,7 +449,7 @@ void play_game(CreatureEntity &creature, bool new_game, bool browsing_movie, std
     }
 
     // クエスト開始時は、マップサイズを事前に取得する
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (new_game && floor.is_in_quest()) {
         init_flags = INIT_GET_SIZE;
         parse_fixed_map(creature, QUEST_DEFINITION_LIST, 0, 0, 0, 0);

--- a/src/core/object-compressor.cpp
+++ b/src/core/object-compressor.cpp
@@ -33,7 +33,7 @@ public:
             return false;
         }
 
-        const auto &floor = *creature.current_floor_ptr;
+        const auto &floor = *creature.get_floor();
         const auto pos = item.is_held_by_monster() ? floor.get_monster(item.held_m_idx).get_position() : item.get_position();
 
         if (Grid::calc_distance(creature.get_position(), pos) < this->distance_threshold) {
@@ -83,7 +83,7 @@ void compact_objects(CreatureEntity &creature, int size)
         rfu.set_flags(flags_swrf);
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (auto deleted_num = 0, try_count = 1; deleted_num < size; try_count++) {
         const ItemCompactionChecker icc(creature, try_count);
         std::vector<OBJECT_IDX> delete_i_idx_list;

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -71,7 +71,7 @@ static void process_fishing(CreatureEntity &creature)
     if (one_in_(1000)) {
         bool success = false;
         get_mon_num_prep_enum(creature, MonraceHook::FISHING);
-        const auto &floor = *creature.current_floor_ptr;
+        const auto &floor = *creature.get_floor();
         const auto wild_level = WildernessGrids::get_instance().get_player_grid().get_level();
         const auto level = floor.is_underground() ? floor.dun_level : wild_level;
         const auto r_idx = get_mon_num(creature, 0, level, PM_NONE);
@@ -122,8 +122,8 @@ void process_player(CreatureEntity &creature)
 
     const auto &system = AngbandSystem::get_instance();
     if (system.is_phase_out()) {
-        for (MONSTER_IDX m_idx = 1; m_idx < creature.current_floor_ptr->m_max; m_idx++) {
-            auto &monster = creature.current_floor_ptr->m_list[m_idx];
+        for (MONSTER_IDX m_idx = 1; m_idx < creature.get_floor()->m_max; m_idx++) {
+            auto &monster = creature.get_floor()->m_list[m_idx];
             if (!monster.is_valid()) {
                 continue;
             }
@@ -182,16 +182,16 @@ void process_player(CreatureEntity &creature)
 
     const auto effects = creature.effects();
     if (creature.riding && !effects->confusion().is_confused() && !effects->blindness().is_blind()) {
-        const auto &monster = creature.current_floor_ptr->m_list[creature.riding];
+        const auto &monster = creature.get_floor()->m_list[creature.riding];
         const auto &monrace = monster.get_monrace();
         if (monster.is_asleep()) {
             const auto m_name = monster_desc(creature, monster, 0);
-            (void)set_monster_csleep(*creature.current_floor_ptr, creature.riding, 0);
+            (void)set_monster_csleep(*creature.get_floor(), creature.riding, 0);
             msg_format(_("%s^を起こした。", "You have woken %s up."), m_name.data());
         }
 
         if (monster.is_stunned()) {
-            if (set_monster_stunned(*creature.current_floor_ptr, creature.riding,
+            if (set_monster_stunned(*creature.get_floor(), creature.riding,
                     (randint0(monrace.level) < creature.skill_exp[PlayerSkillKindType::RIDING]) ? 0 : (monster.get_remaining_stun() - 1))) {
                 const auto m_name = monster_desc(creature, monster, 0);
                 msg_format(_("%s^を朦朧状態から立ち直らせた。", "%s^ is no longer stunned."), m_name.data());
@@ -199,7 +199,7 @@ void process_player(CreatureEntity &creature)
         }
 
         if (monster.is_confused()) {
-            if (set_monster_confused(*creature.current_floor_ptr, creature.riding,
+            if (set_monster_confused(*creature.get_floor(), creature.riding,
                     (randint0(monrace.level) < creature.skill_exp[PlayerSkillKindType::RIDING]) ? 0 : (monster.get_remaining_confusion() - 1))) {
                 const auto m_name = monster_desc(creature, monster, 0);
                 msg_format(_("%s^を混乱状態から立ち直らせた。", "%s^ is no longer confused."), m_name.data());
@@ -207,7 +207,7 @@ void process_player(CreatureEntity &creature)
         }
 
         if (monster.is_fearful()) {
-            if (set_monster_monfear(*creature.current_floor_ptr, creature.riding,
+            if (set_monster_monfear(*creature.get_floor(), creature.riding,
                     (randint0(monrace.level) < creature.skill_exp[PlayerSkillKindType::RIDING]) ? 0 : (monster.get_remaining_fear() - 1))) {
                 const auto m_name = monster_desc(creature, monster, 0);
                 msg_format(_("%s^を恐怖から立ち直らせた。", "%s^ is no longer fearful."), m_name.data());
@@ -339,8 +339,8 @@ void process_player(CreatureEntity &creature)
                 rfu.set_flag(MainWindowRedrawingFlag::MAP);
             }
 
-            for (MONSTER_IDX m_idx = 1; m_idx < creature.current_floor_ptr->m_max; m_idx++) {
-                auto &monster = creature.current_floor_ptr->m_list[m_idx];
+            for (MONSTER_IDX m_idx = 1; m_idx < creature.get_floor()->m_max; m_idx++) {
+                auto &monster = creature.get_floor()->m_list[m_idx];
                 if (!monster.is_valid()) {
                     continue;
                 }
@@ -430,7 +430,7 @@ void process_player(CreatureEntity &creature)
         }
     }
 
-    update_smell(*creature.current_floor_ptr, creature.get_position());
+    update_smell(*creature.get_floor(), creature.get_position());
 }
 
 /*!

--- a/src/core/score-util.cpp
+++ b/src/core/score-util.cpp
@@ -55,7 +55,7 @@ void high_score::copy_info(const CreatureEntity &creature)
     std::copy_n(ppersonality.begin(), ppersonality.length(), this->p_a);
     const auto current_level = format("%3d", std::min<ushort>(creature.level, 999));
     std::copy_n(current_level.begin(), current_level.length(), this->cur_lev);
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto current_dungeon = format("%3d", floor.dun_level);
     std::copy_n(current_dungeon.begin(), current_dungeon.length(), this->cur_dun);
     const auto max_level = format("%3d", std::min<ushort>(creature.max_plv, 999));

--- a/src/core/stuff-handler.cpp
+++ b/src/core/stuff-handler.cpp
@@ -53,7 +53,7 @@ void object_kind_track(CreatureEntity &creature, short bi_id)
  */
 void health_track(CreatureEntity &creature, short m_idx)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     if (monster.is_riding()) {
         return;

--- a/src/core/turn-compensator.cpp
+++ b/src/core/turn-compensator.cpp
@@ -35,7 +35,7 @@ void prevent_turn_overflow(CreatureEntity &creature)
     } else {
         world.game_turn = 1;
     }
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.generated_turn > rollback_turns) {
         floor.generated_turn -= rollback_turns;
     } else {

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -101,7 +101,7 @@ static void redraw_character_xtra(CreatureEntity &creature)
  */
 void process_dungeon(CreatureEntity &creature, bool load_game)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &world = AngbandWorld::get_instance();
     floor.base_level = floor.dun_level;
     world.is_loading_now = false;

--- a/src/dungeon/quest-completion-checker.cpp
+++ b/src/dungeon/quest-completion-checker.cpp
@@ -52,7 +52,7 @@ void QuestCompletionChecker::complete()
 
 static bool check_quest_completion(CreatureEntity &creature, const QuestType &quest, const CreatureEntity &monster)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (quest.status != QuestStatusType::TAKEN) {
         return false;
     }
@@ -86,7 +86,7 @@ static bool check_quest_completion(CreatureEntity &creature, const QuestType &qu
 
 void QuestCompletionChecker::set_quest_idx()
 {
-    const auto &floor = *this->creature_ptr->current_floor_ptr;
+    const auto &floor = *this->creature_ptr->get_floor();
     const auto &quests = QuestList::get_instance();
     this->quest_idx = floor.quest_number;
     if (inside_quest(this->quest_idx)) {
@@ -161,7 +161,7 @@ std::tuple<bool, bool> QuestCompletionChecker::complete_random()
     auto create_stairs = false;
     if (none_bits(this->q_ptr->flags, QUEST_FLAG_PRESET)) {
         create_stairs = true;
-        this->creature_ptr->current_floor_ptr->quest_number = QuestId::NONE;
+        this->creature_ptr->get_floor()->quest_number = QuestId::NONE;
     }
 
     if (this->quest_idx == QuestId::MELKO) {
@@ -212,7 +212,7 @@ void QuestCompletionChecker::complete_tower()
  */
 int QuestCompletionChecker::count_all_hostile_monsters()
 {
-    const auto &floor = *this->creature_ptr->current_floor_ptr;
+    const auto &floor = *this->creature_ptr->get_floor();
     const auto hostile_monster_exists = [&floor](const Pos2D &pos) {
         const auto &grid = floor.get_grid(pos);
         return grid.has_monster() && floor.get_monster(grid.m_idx).is_hostile();
@@ -228,7 +228,7 @@ Pos2D QuestCompletionChecker::make_stairs(const bool create_stairs)
         return m_pos;
     }
 
-    auto &floor = *this->creature_ptr->current_floor_ptr;
+    auto &floor = *this->creature_ptr->get_floor();
     const auto *grid_ptr = &floor.get_grid(m_pos);
     while (floor.has_terrain_characteristics(m_pos, TerrainCharacteristics::PERMANENT) || !grid_ptr->o_idx_list.empty() || grid_ptr->is_object()) {
         m_pos = scatter(floor, m_pos, 1, PROJECT_NONE);
@@ -243,7 +243,7 @@ Pos2D QuestCompletionChecker::make_stairs(const bool create_stairs)
 
 void QuestCompletionChecker::make_reward(const Pos2D pos)
 {
-    const auto drop_num = this->creature_ptr->current_floor_ptr->dun_level / 15 + 1;
+    const auto drop_num = this->creature_ptr->get_floor()->dun_level / 15 + 1;
     const auto &monrace = this->m_ptr->get_monrace();
     for (auto i = 0; i < drop_num; i++) {
         while (auto item = make_object(*this->creature_ptr, AM_GOOD | AM_GREAT, nullptr, monrace.level)) {

--- a/src/dungeon/quest-monster-placer.cpp
+++ b/src/dungeon/quest-monster-placer.cpp
@@ -18,7 +18,7 @@
  */
 bool place_quest_monsters(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &quests = QuestList::get_instance();
     for (const auto &[quest_id, quest] : quests) {
         auto no_quest_monsters = quest.status != QuestStatusType::TAKEN;

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -283,7 +283,7 @@ void quest_discovery(QuestId quest_id)
  */
 void leave_quest_check(CreatureEntity &creature)
 {
-    leaving_quest = creature.current_floor_ptr->quest_number;
+    leaving_quest = creature.get_floor()->quest_number;
     if (!inside_quest(leaving_quest)) {
         return;
     }
@@ -333,7 +333,7 @@ void leave_quest_check(CreatureEntity &creature)
 void leave_tower_check(CreatureEntity &creature)
 {
     auto &quests = QuestList::get_instance();
-    leaving_quest = creature.current_floor_ptr->quest_number;
+    leaving_quest = creature.get_floor()->quest_number;
 
     auto &tower1 = quests.get_quest(QuestId::TOWER1);
     auto is_leaving_from_tower = inside_quest(leaving_quest);
@@ -359,9 +359,9 @@ void exe_enter_quest(CreatureEntity &creature, QuestId quest_id)
 {
     const auto &quests = QuestList::get_instance();
     if (quests.get_quest(quest_id).type != QuestKindType::RANDOM) {
-        creature.current_floor_ptr->dun_level = 1;
+        creature.get_floor()->dun_level = 1;
     }
-    creature.current_floor_ptr->quest_number = quest_id;
+    creature.get_floor()->quest_number = quest_id;
     creature.leaving = true;
 }
 
@@ -376,7 +376,7 @@ void do_cmd_quest(CreatureEntity &creature)
     }
 
     PlayerEnergy(creature).set_player_turn_energy(100);
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!floor.has_terrain_characteristics(creature.get_position(), TerrainCharacteristics::QUEST_ENTER)) {
         msg_print(_("ここにはクエストの入口はない。", "You see no quest level here."));
         return;

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -52,7 +52,7 @@
 bool affect_feature(CreatureEntity &creature, MONSTER_IDX src_idx, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ)
 {
     const Pos2D pos(y, x);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &grid = floor.get_grid(pos);
     const auto &terrain = grid.get_terrain();
 

--- a/src/effect/effect-item.cpp
+++ b/src/effect/effect-item.cpp
@@ -37,7 +37,7 @@
  */
 bool affect_item(CreatureEntity &creature, MONSTER_IDX src_idx, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const Pos2D pos(y, x);
     const auto &grid = floor.get_grid(pos);
 
@@ -48,7 +48,7 @@ bool affect_item(CreatureEntity &creature, MONSTER_IDX src_idx, POSITION r, POSI
     std::vector<OBJECT_IDX> delete_i_idx_list;
     std::vector<short> affected_potions;
     for (const auto this_o_idx : grid.o_idx_list) {
-        auto &item = *creature.current_floor_ptr->o_list[this_o_idx];
+        auto &item = *creature.get_floor()->o_list[this_o_idx];
         auto ignore = false;
         auto do_kill = false;
         concptr note_kill = nullptr;
@@ -225,7 +225,7 @@ bool affect_item(CreatureEntity &creature, MONSTER_IDX src_idx, POSITION r, POSI
             }
 
             BIT_FLAGS mode = 0L;
-            if (is_player(src_idx) || creature.current_floor_ptr->get_monster(src_idx).is_pet()) {
+            if (is_player(src_idx) || creature.get_floor()->get_monster(src_idx).is_pet()) {
                 mode |= PM_FORCE_PET;
             }
 

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -344,7 +344,7 @@ ProcessResult effect_monster_domination(CreatureEntity &creature, EffectMonster 
 
 static bool effect_monster_crusade_domination(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if ((em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::GOOD)) || creature.current_floor_ptr->inside_arena) {
+    if ((em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::GOOD)) || creature.get_floor()->inside_arena) {
         return false;
     }
 
@@ -357,7 +357,7 @@ static bool effect_monster_crusade_domination(CreatureEntity &creature, EffectMo
 
     if (em_ptr->m_ptr->is_pet()) {
         em_ptr->note = _("の動きが速くなった。", " starts moving faster.");
-        (void)set_monster_fast(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_acceleration() + 100);
+        (void)set_monster_fast(*creature.get_floor(), em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_acceleration() + 100);
         return true;
     }
 
@@ -378,7 +378,7 @@ static bool effect_monster_crusade_domination(CreatureEntity &creature, EffectMo
 
     em_ptr->note = _("を支配した。", " is tamed!");
     set_pet(creature, *em_ptr->m_ptr);
-    (void)set_monster_fast(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_acceleration() + 100);
+    (void)set_monster_fast(*creature.get_floor(), em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_acceleration() + 100);
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
         em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::GOOD);
     }
@@ -463,7 +463,7 @@ static void effect_monster_captured(CreatureEntity &creature, EffectMonster *em_
 ProcessResult effect_monster_capture(CreatureEntity &creature, EffectMonster *em_ptr, tl::optional<CapturedMonsterType *> cap_mon_ptr)
 {
     const auto &quests = QuestList::get_instance();
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
 
     auto quest_monster = floor.is_in_quest();
     quest_monster &= (quests.get_quest(floor.quest_number).type == QuestKindType::KILL_ALL);

--- a/src/effect/effect-monster-oldies.cpp
+++ b/src/effect/effect-monster-oldies.cpp
@@ -44,7 +44,7 @@ ProcessResult effect_monster_old_clone(CreatureEntity &creature, EffectMonster *
         em_ptr->obvious = true;
     }
 
-    auto has_resistance = (creature.current_floor_ptr->inside_arena);
+    auto has_resistance = (creature.get_floor()->inside_arena);
     has_resistance |= em_ptr->m_ptr->is_pet();
     has_resistance |= em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
     has_resistance |= em_ptr->r_ptr->misc_flags.has(MonsterMiscType::QUESTOR);
@@ -71,7 +71,7 @@ ProcessResult effect_monster_star_heal(CreatureEntity &creature, EffectMonster *
         em_ptr->obvious = true;
     }
 
-    (void)set_monster_csleep(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, 0);
+    (void)set_monster_csleep(*creature.get_floor(), em_ptr->g_ptr->m_idx, 0);
 
     if (em_ptr->m_ptr->maxhp < em_ptr->m_ptr->max_maxhp) {
         if (em_ptr->seen_msg) {
@@ -127,7 +127,7 @@ static void effect_monster_old_heal_recovery(CreatureEntity &creature, EffectMon
             msg_format(_("%s^は朦朧状態から立ち直った。", "%s^ is no longer stunned."), em_ptr->m_name);
         }
 
-        (void)set_monster_stunned(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, 0);
+        (void)set_monster_stunned(*creature.get_floor(), em_ptr->g_ptr->m_idx, 0);
     }
 
     if (em_ptr->m_ptr->is_confused()) {
@@ -135,7 +135,7 @@ static void effect_monster_old_heal_recovery(CreatureEntity &creature, EffectMon
             msg_format(_("%s^は混乱から立ち直った。", "%s^ is no longer confused."), em_ptr->m_name);
         }
 
-        (void)set_monster_confused(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, 0);
+        (void)set_monster_confused(*creature.get_floor(), em_ptr->g_ptr->m_idx, 0);
     }
 
     if (em_ptr->m_ptr->is_fearful()) {
@@ -143,7 +143,7 @@ static void effect_monster_old_heal_recovery(CreatureEntity &creature, EffectMon
             msg_format(_("%s^は勇気を取り戻した。", "%s^ recovers %s courage."), em_ptr->m_name, em_ptr->m_poss);
         }
 
-        (void)set_monster_monfear(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, 0);
+        (void)set_monster_monfear(*creature.get_floor(), em_ptr->g_ptr->m_idx, 0);
     }
 }
 
@@ -154,7 +154,7 @@ ProcessResult effect_monster_old_heal(CreatureEntity &creature, EffectMonster *e
     }
 
     /* Wake up */
-    (void)set_monster_csleep(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, 0);
+    (void)set_monster_csleep(*creature.get_floor(), em_ptr->g_ptr->m_idx, 0);
     effect_monster_old_heal_recovery(creature, em_ptr);
     if (em_ptr->m_ptr->hp < MONSTER_MAXHP) {
         em_ptr->m_ptr->hp += em_ptr->dam;
@@ -187,7 +187,7 @@ ProcessResult effect_monster_old_speed(CreatureEntity &creature, EffectMonster *
         em_ptr->obvious = true;
     }
 
-    if (set_monster_fast(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_acceleration() + 100)) {
+    if (set_monster_fast(*creature.get_floor(), em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_acceleration() + 100)) {
         em_ptr->note = _("の動きが速くなった。", " starts moving faster.");
     }
 
@@ -221,7 +221,7 @@ ProcessResult effect_monster_old_slow(CreatureEntity &creature, EffectMonster *e
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    if (set_monster_slow(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
+    if (set_monster_slow(*creature.get_floor(), em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
         em_ptr->note = _("の動きが遅くなった。", " starts moving slower.");
     }
 

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -208,7 +208,7 @@ ProcessResult effect_monster_psi(CreatureEntity &creature, EffectMonster *em_ptr
     if (em_ptr->seen) {
         em_ptr->obvious = true;
     }
-    if (!los(*creature.current_floor_ptr, em_ptr->m_ptr->get_position(), creature.get_position())) {
+    if (!los(*creature.get_floor(), em_ptr->m_ptr->get_position(), creature.get_position())) {
         if (em_ptr->seen_msg) {
             msg_format(_("%sはあなたが見えないので影響されない！", "%s^ can't see you, and isn't affected!"), em_ptr->m_name);
         }

--- a/src/effect/effect-monster-resist-hurt.cpp
+++ b/src/effect/effect-monster-resist-hurt.cpp
@@ -499,7 +499,7 @@ ProcessResult effect_monster_inertial(CreatureEntity &creature, EffectMonster *e
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    if (set_monster_slow(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
+    if (set_monster_slow(*creature.get_floor(), em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
         em_ptr->note = _("の動きが遅くなった。", " starts moving slower.");
     }
 
@@ -565,7 +565,7 @@ static void effect_monster_gravity_slow(CreatureEntity &creature, EffectMonster 
         return;
     }
 
-    if (set_monster_slow(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
+    if (set_monster_slow(*creature.get_floor(), em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
         em_ptr->note = _("の動きが遅くなった。", " starts moving slower.");
     }
     em_ptr->obvious = true;
@@ -751,7 +751,7 @@ ProcessResult effect_monster_abyss(CreatureEntity &creature, EffectMonster *em_p
         em_ptr->note = _("は深淵に囚われていく。", " is trapped in the abyss.");
         em_ptr->note_dies = _("は深淵に堕ちてしまった。", " has fallen into the abyss.");
 
-        if (one_in_(3) && set_monster_slow(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
+        if (one_in_(3) && set_monster_slow(*creature.get_floor(), em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
             em_ptr->note = _("の動きが遅くなった。", " starts moving slower.");
         }
     }

--- a/src/effect/effect-monster-spirit.cpp
+++ b/src/effect/effect-monster-spirit.cpp
@@ -158,7 +158,7 @@ ProcessResult effect_monster_brain_smash(CreatureEntity &creature, EffectMonster
             em_ptr->do_stun = randint0(8) + 8;
         }
 
-        (void)set_monster_slow(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 10);
+        (void)set_monster_slow(*creature.get_floor(), em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 10);
     }
 
     return ProcessResult::PROCESS_CONTINUE;

--- a/src/effect/effect-monster-switcher.cpp
+++ b/src/effect/effect-monster-switcher.cpp
@@ -197,7 +197,7 @@ ProcessResult effect_monster_engetsu(CreatureEntity &creature, EffectMonster *em
         switch (randint0(4)) {
         case 0:
             if (em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
-                if (set_monster_slow(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
+                if (set_monster_slow(*creature.get_floor(), em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
                     em_ptr->note = _("の動きが遅くなった。", " starts moving slower.");
                 }
                 done = true;

--- a/src/effect/effect-monster-util.cpp
+++ b/src/effect/effect-monster-util.cpp
@@ -39,7 +39,7 @@ EffectMonster::EffectMonster(CreatureEntity &creature, MONSTER_IDX src_idx, POSI
     , flag(flag)
     , see_s_msg(see_s_msg)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     this->g_ptr = &floor.grid_array[this->y][this->x];
     this->m_ptr = &floor.get_monster(this->g_ptr->m_idx);
     this->m_caster_ptr = this->is_monster() ? &floor.get_monster(this->src_idx) : nullptr;

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -186,7 +186,7 @@ static void effect_damage_killed_pet(CreatureEntity &creature, EffectMonster *em
         if (em_ptr->see_s_msg) {
             msg_format("%s^%s", em_ptr->m_name, em_ptr->note.data());
         } else {
-            creature.current_floor_ptr->monster_noise = true;
+            creature.get_floor()->monster_noise = true;
         }
     }
 
@@ -217,11 +217,11 @@ static void effect_damage_makes_sleep(CreatureEntity &creature, EffectMonster *e
             msg_print(*pain_message);
         }
     } else {
-        creature.current_floor_ptr->monster_noise = true;
+        creature.get_floor()->monster_noise = true;
     }
 
     if (em_ptr->do_sleep) {
-        (void)set_monster_csleep(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->do_sleep);
+        (void)set_monster_csleep(*creature.get_floor(), em_ptr->g_ptr->m_idx, em_ptr->do_sleep);
     }
 }
 
@@ -244,7 +244,7 @@ static bool deal_effect_damage_from_monster(CreatureEntity &creature, EffectMons
         RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
-    (void)set_monster_csleep(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, 0);
+    (void)set_monster_csleep(*creature.get_floor(), em_ptr->g_ptr->m_idx, 0);
     em_ptr->m_ptr->hp -= em_ptr->dam;
     if (em_ptr->m_ptr->hp < 0) {
         effect_damage_killed_pet(creature, em_ptr);
@@ -273,7 +273,7 @@ static bool heal_leaper(CreatureEntity &creature, EffectMonster *em_ptr)
 
     if (record_named_pet && em_ptr->m_ptr->is_named_pet()) {
         const auto m2_name = monster_desc(creature, *em_ptr->m_ptr, MD_INDEF_VISIBLE);
-        exe_write_diary(*creature.current_floor_ptr, DiaryKind::NAMED_PET, RECORD_NAMED_PET_HEAL_LEPER, m2_name);
+        exe_write_diary(*creature.get_floor(), DiaryKind::NAMED_PET, RECORD_NAMED_PET_HEAL_LEPER, m2_name);
     }
 
     delete_monster_idx(creature, em_ptr->g_ptr->m_idx);
@@ -353,7 +353,7 @@ static void deal_effect_damage_to_monster(CreatureEntity &creature, EffectMonste
     }
 
     if (em_ptr->do_sleep) {
-        (void)set_monster_csleep(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->do_sleep);
+        (void)set_monster_csleep(*creature.get_floor(), em_ptr->g_ptr->m_idx, em_ptr->do_sleep);
     }
 }
 
@@ -427,7 +427,7 @@ static void effect_damage_piles_stun(CreatureEntity &creature, EffectMonster *em
         turns = em_ptr->do_stun;
     }
 
-    (void)set_monster_stunned(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, turns);
+    (void)set_monster_stunned(*creature.get_floor(), em_ptr->g_ptr->m_idx, turns);
     em_ptr->get_angry = true;
 }
 
@@ -456,7 +456,7 @@ static void effect_damage_piles_confusion(CreatureEntity &creature, EffectMonste
         turns = em_ptr->do_conf;
     }
 
-    (void)set_monster_confused(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, turns);
+    (void)set_monster_confused(*creature.get_floor(), em_ptr->g_ptr->m_idx, turns);
     em_ptr->get_angry = true;
 }
 
@@ -475,7 +475,7 @@ static void effect_damage_piles_fear(CreatureEntity &creature, EffectMonster *em
         return;
     }
 
-    (void)set_monster_monfear(*creature.current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_fear() + em_ptr->do_fear);
+    (void)set_monster_monfear(*creature.get_floor(), em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_fear() + em_ptr->do_fear);
     em_ptr->get_angry = true;
 }
 
@@ -528,7 +528,7 @@ static void effect_damage_makes_polymorph(CreatureEntity &creature, EffectMonste
         em_ptr->dam = 0;
     }
 
-    em_ptr->m_ptr = &creature.current_floor_ptr->get_monster(em_ptr->g_ptr->m_idx);
+    em_ptr->m_ptr = &creature.get_floor()->get_monster(em_ptr->g_ptr->m_idx);
     em_ptr->r_ptr = &em_ptr->m_ptr->get_monrace();
 }
 
@@ -558,7 +558,7 @@ static void effect_damage_makes_teleport(CreatureEntity &creature, EffectMonster
 
     em_ptr->y = em_ptr->m_ptr->y;
     em_ptr->x = em_ptr->m_ptr->x;
-    em_ptr->g_ptr = &creature.current_floor_ptr->grid_array[em_ptr->y][em_ptr->x];
+    em_ptr->g_ptr = &creature.get_floor()->grid_array[em_ptr->y][em_ptr->x];
 }
 
 /*!

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -93,7 +93,7 @@ static bool process_bolt_reflection(CreatureEntity &creature, EffectPlayerType *
     const auto p_pos = creature.get_position();
     Pos2D pos(0, 0);
     if (ep_ptr->is_monster()) {
-        const auto &floor = *creature.current_floor_ptr;
+        const auto &floor = *creature.get_floor();
         const auto &monster = floor.get_monster(ep_ptr->src_idx);
         do {
             const Pos2DVec vec(randint1(3) - 1, randint1(3) - 1);
@@ -156,7 +156,7 @@ static ProcessResult check_continue_player_effect(CreatureEntity &creature, Effe
 static void describe_effect_source(CreatureEntity &creature, EffectPlayerType *ep_ptr, concptr src_name)
 {
     if (ep_ptr->is_monster()) {
-        ep_ptr->m_ptr = &creature.current_floor_ptr->get_monster(ep_ptr->src_idx);
+        ep_ptr->m_ptr = &creature.get_floor()->get_monster(ep_ptr->src_idx);
         ep_ptr->rlev = ep_ptr->m_ptr->get_monrace().level >= 1 ? ep_ptr->m_ptr->get_monrace().level : 1;
         ep_ptr->m_name = monster_desc(creature, *ep_ptr->m_ptr, 0);
         ep_ptr->killer = src_name;
@@ -194,7 +194,7 @@ static void describe_effect_source(CreatureEntity &creature, EffectPlayerType *e
 bool affect_player(MONSTER_IDX src_idx, CreatureEntity &creature, concptr src_name, int r, POSITION y, POSITION x, int dam, AttributeType attribute,
     BIT_FLAGS flag, FallOffHorseEffect &fall_off_horse_effect, project_func project)
 {
-    EffectPlayerType tmp_effect(*creature.current_floor_ptr, src_idx, dam, attribute, flag);
+    EffectPlayerType tmp_effect(*creature.get_floor(), src_idx, dam, attribute, flag);
     auto *ep_ptr = &tmp_effect;
     auto check_result = check_continue_player_effect(creature, ep_ptr, { y, x }, project);
     if (check_result != ProcessResult::PROCESS_CONTINUE) {

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -37,7 +37,7 @@ Pos2D decide_source_position(CreatureEntity &creature, MONSTER_IDX src_idx, cons
         return pos_target;
     }
     if (is_monster(src_idx)) {
-        return creature.current_floor_ptr->get_monster(src_idx).get_position();
+        return creature.get_floor()->get_monster(src_idx).get_position();
     }
     return creature.get_position();
 }
@@ -111,7 +111,7 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
     /* Calculate the projection path */
     const auto &system = AngbandSystem::get_instance();
     const auto range = project_length != 0 ? project_length : AngbandSystem::get_instance().get_max_range();
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     ProjectionPath path_g(floor, range, creature.get_position(), pos_source, pos_target, flag);
     handle_stuff(creature);
 

--- a/src/effect/spells-effect-util.cpp
+++ b/src/effect/spells-effect-util.cpp
@@ -48,7 +48,7 @@ void FallOffHorseEffect::apply() const
         return;
     }
 
-    const auto &floor = *this->creature_ptr->current_floor_ptr;
+    const auto &floor = *this->creature_ptr->get_floor();
     const auto m_name = monster_desc(*this->creature_ptr, floor.get_monster(creature_ptr->riding), 0);
 
     if (this->shake_off_damage > 0) {

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -142,7 +142,7 @@ static bool should_show_slaying_bonus(const ItemEntity &item)
 
 static std::string describe_weapon_dice(CreatureEntity &creature, const ItemEntity &item, const describe_option_type &opt)
 {
-    if (!opt.known && item.is_target_of(creature.current_floor_ptr->quest_number)) {
+    if (!opt.known && item.is_target_of(creature.get_floor()->quest_number)) {
         return "";
     }
 

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -83,7 +83,7 @@ static tl::optional<DungeonId> select_random_non_beginner_dungeon()
 
 static void check_arena_floor(CreatureEntity &creature, DungeonData *dd_ptr)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!dd_ptr->empty_level) {
         for (const auto &pos : floor.get_area()) {
             place_bold(creature, pos.y, pos.x, GB_EXTRA);
@@ -103,7 +103,7 @@ static void check_arena_floor(CreatureEntity &creature, DungeonData *dd_ptr)
 
 static void place_cave_contents(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.dun_level == 1) {
         constexpr auto density_moss = 2;
         while (one_in_(density_moss)) {
@@ -142,7 +142,7 @@ static void place_cave_contents(CreatureEntity &creature, DungeonData *dd_ptr, c
  */
 static void generate_circular_waterway(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto margin = 2; // 外壁からのマージン
 
     // 環状水路の座標を計算
@@ -179,7 +179,7 @@ static bool decide_tunnel_planned_site(CreatureEntity &creature, DungeonData *dd
     if (dungeon.flags.has(DungeonFeatureType::NO_TUNNEL)) {
         return true;
     }
-    if (randint1(creature.current_floor_ptr->dun_level) > dungeon.tunnel_percent) {
+    if (randint1(creature.get_floor()->dun_level) > dungeon.tunnel_percent) {
         (void)build_tunnel2(creature, dd_ptr, dd_ptr->centers[i], dd_ptr->tunnel_pos, 2, 2);
     } else if (!build_tunnel(creature, dd_ptr, dt_ptr, dd_ptr->centers[i], dd_ptr->tunnel_pos)) {
         dd_ptr->tunnel_fail_count++;
@@ -198,7 +198,7 @@ static void make_tunnels(CreatureEntity &creature, DungeonData *dd_ptr)
 {
     for (size_t i = 0; i < dd_ptr->tunn_n; i++) {
         dd_ptr->tunnel_pos = dd_ptr->tunnels[i];
-        auto &grid = creature.current_floor_ptr->get_grid(dd_ptr->tunnel_pos);
+        auto &grid = creature.get_floor()->get_grid(dd_ptr->tunnel_pos);
         const auto &terrain = grid.get_terrain();
         if (terrain.flags.has_not(TerrainCharacteristics::MOVE) || terrain.flags.has_none_of({ TerrainCharacteristics::WATER, TerrainCharacteristics::LAVA })) {
             grid.mimic = 0;
@@ -211,7 +211,7 @@ static void make_walls(CreatureEntity &creature, DungeonData *dd_ptr, const Dung
 {
     for (size_t j = 0; j < dd_ptr->wall_n; j++) {
         dd_ptr->tunnel_pos = dd_ptr->walls[j];
-        auto &grid = creature.current_floor_ptr->get_grid(dd_ptr->tunnel_pos);
+        auto &grid = creature.get_floor()->get_grid(dd_ptr->tunnel_pos);
         grid.mimic = 0;
         place_grid(creature, grid, GB_FLOOR);
         if (evaluate_percent(dt_ptr->dun_tun_pen) && dungeon.flags.has_not(DungeonFeatureType::NO_DOORS)) {
@@ -260,7 +260,7 @@ static void make_only_tunnel_points(const FloorType &floor, DungeonData *dd_ptr)
 
 static bool make_one_floor(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (dungeon.flags.has(DungeonFeatureType::NO_ROOM)) {
         make_only_tunnel_points(floor, dd_ptr);
     } else {
@@ -326,7 +326,7 @@ static bool make_one_floor(CreatureEntity &creature, DungeonData *dd_ptr, const 
 static bool switch_making_floor(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon)
 {
     if (dungeon.flags.has(DungeonFeatureType::MAZE)) {
-        const auto &floor = *creature.current_floor_ptr;
+        const auto &floor = *creature.get_floor();
         build_maze_vault(creature, { floor.height / 2 - 1, floor.width / 2 - 1 }, { floor.height - 4, floor.width - 4 }, false);
         const auto &terrains = TerrainList::get_instance();
         if (!alloc_stairs(creature, terrains.get_terrain_id(TerrainTag::DOWN_STAIR), rand_range(2, 3), 3)) {
@@ -395,7 +395,7 @@ static void place_bound_perm_wall(CreatureEntity &creature, Grid &grid)
 
     const auto &terrain = grid.get_terrain();
     if (terrain.flags.has_any_of({ TerrainCharacteristics::HAS_GOLD, TerrainCharacteristics::HAS_ITEM }) && terrain.flags.has_not(TerrainCharacteristics::SECRET)) {
-        grid.feat = creature.current_floor_ptr->get_dungeon_definition().convert_terrain_id(grid.feat, TerrainCharacteristics::ENSECRET);
+        grid.feat = creature.get_floor()->get_dungeon_definition().convert_terrain_id(grid.feat, TerrainCharacteristics::ENSECRET);
     }
 
     grid.mimic = grid.feat;
@@ -404,7 +404,7 @@ static void place_bound_perm_wall(CreatureEntity &creature, Grid &grid)
 
 static void make_perm_walls(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     floor.get_area().each_edge([&](const Pos2D &pos) {
         place_bound_perm_wall(creature, floor.get_grid(pos));
     });
@@ -429,7 +429,7 @@ static bool check_place_necessary_objects(CreatureEntity &creature, DungeonData 
 
 static void decide_dungeon_data_allocation(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     dd_ptr->alloc_object_num = floor.dun_level / 3 + 5;
     if (dd_ptr->alloc_object_num > 30) {
         dd_ptr->alloc_object_num = 30;
@@ -460,7 +460,7 @@ static void decide_dungeon_data_allocation(CreatureEntity &creature, DungeonData
 static bool allocate_dungeon_data(CreatureEntity &creature, DungeonData *dd_ptr, const DungeonDefinition &dungeon)
 {
     dd_ptr->alloc_monster_num += randint1(8);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
 
     for (dd_ptr->alloc_monster_num = dd_ptr->alloc_monster_num + dd_ptr->alloc_object_num; dd_ptr->alloc_monster_num > 0; dd_ptr->alloc_monster_num--) {
         if (one_in_(30)) {
@@ -564,7 +564,7 @@ tl::optional<std::string> cave_gen(CreatureEntity &creature, tl::optional<uint32
             *seed);
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     floor.reset_lite_area();
     get_mon_num_prep_enum(creature, floor.get_monrace_hook());
 
@@ -667,7 +667,7 @@ tl::optional<std::string> cave_gen(CreatureEntity &creature, tl::optional<uint32
  */
 void apply_vestige_terrain_replacement(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &terrains = TerrainList::get_instance();
 
     // PERMANENTフラグを持たない地形IDのリストを作成
@@ -721,7 +721,7 @@ void apply_void_terrain_placement(CreatureEntity &creature)
         return;
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &terrains = TerrainList::get_instance();
 
     // 時空崩壊度から配置率を計算

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -76,7 +76,7 @@ static void generate_artifact(CreatureEntity &creature, qtwg_type *qtwg_ptr, con
     }
 
     ItemEntity item({ ItemKindType::SCROLL, SV_SCROLL_ACQUIREMENT });
-    drop_here(*creature.current_floor_ptr, std::move(item), *qtwg_ptr->y, *qtwg_ptr->x);
+    drop_here(*creature.get_floor(), std::move(item), *qtwg_ptr->y, *qtwg_ptr->x);
 }
 
 /**
@@ -85,7 +85,7 @@ static void generate_artifact(CreatureEntity &creature, qtwg_type *qtwg_ptr, con
 static void parse_qtw_D(CreatureEntity &creature, qtwg_type *qtwg_ptr, char *s)
 {
     *qtwg_ptr->x = qtwg_ptr->xmin;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     int len = strlen(s);
     auto &monraces = MonraceList::get_instance();
     const auto &dungeon = floor.get_dungeon_definition();
@@ -345,7 +345,7 @@ static bool parse_qtw_P(CreatureEntity &creature, qtwg_type *qtwg_ptr, char **zz
         panels_y++;
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     floor.height = panels_y * SCREEN_HGT;
     int panels_x = (*qtwg_ptr->x / SCREEN_WID);
     if (*qtwg_ptr->x % SCREEN_WID) {
@@ -417,7 +417,7 @@ parse_error_type generate_fixed_map_floor(CreatureEntity &creature, qtwg_type *q
 
     /* Process "F:<letter>:<terrain>:<cave_info>:<monster>:<object>:<ego>:<artifact>:<trap>:<special>" -- info for dungeon grid */
     if (qtwg_ptr->buf[0] == 'F') {
-        return parse_line_feature(*creature.current_floor_ptr, qtwg_ptr->buf);
+        return parse_line_feature(*creature.get_floor(), qtwg_ptr->buf);
     }
 
     if (qtwg_ptr->buf[0] == 'D') {
@@ -459,11 +459,11 @@ parse_error_type generate_fixed_map_floor(CreatureEntity &creature, qtwg_type *q
         if (init_flags & INIT_ONLY_FEATURES) {
             return PARSE_ERROR_NONE;
         }
-        return parse_line_vault(creature.current_floor_ptr, qtwg_ptr->buf);
+        return parse_line_vault(creature.get_floor(), qtwg_ptr->buf);
     }
 
     if (qtwg_ptr->buf[0] == 'A') {
-        return parse_line_alliance(creature.current_floor_ptr, qtwg_ptr->buf);
+        return parse_line_alliance(creature.get_floor(), qtwg_ptr->buf);
     }
 
     if (qtwg_ptr->buf[0] == 'M') {

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -60,18 +60,18 @@ static void build_dead_end(CreatureEntity &creature, saved_floor_type *sf_ptr)
     msg_print(_("階段は行き止まりだった。", "The staircases come to a dead end..."));
     clear_cave(creature);
     creature.x = creature.y = 0;
-    creature.current_floor_ptr->height = SCREEN_HGT;
-    creature.current_floor_ptr->width = SCREEN_WID;
+    creature.get_floor()->height = SCREEN_HGT;
+    creature.get_floor()->width = SCREEN_WID;
     for (POSITION y = 0; y < MAX_HGT; y++) {
         for (POSITION x = 0; x < MAX_WID; x++) {
             place_bold(creature, y, x, GB_SOLID_PERM);
         }
     }
 
-    creature.y = creature.current_floor_ptr->height / 2;
-    creature.x = creature.current_floor_ptr->width / 2;
+    creature.y = creature.get_floor()->height / 2;
+    creature.x = creature.get_floor()->width / 2;
     place_bold(creature, creature.y, creature.x, GB_FLOOR);
-    wipe_generate_random_floor_flags(*creature.current_floor_ptr);
+    wipe_generate_random_floor_flags(*creature.get_floor());
     const auto &fcms = FloorChangeModesStore::get_instace();
     if (fcms->has(FloorChangeMode::UP)) {
         sf_ptr->upper_floor_id = 0;
@@ -83,7 +83,7 @@ static void build_dead_end(CreatureEntity &creature, saved_floor_type *sf_ptr)
 static std::pair<short, Pos2D> decide_pet_index(CreatureEntity &creature, const int current_monster)
 {
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     Pos2D pos(0, 0);
     if (current_monster == 0) {
@@ -118,12 +118,12 @@ static std::pair<short, Pos2D> decide_pet_index(CreatureEntity &creature, const 
 static MonraceDefinition &set_pet_params(CreatureEntity &creature, const int current_monster, MONSTER_IDX m_idx, const POSITION cy, const POSITION cx)
 {
 
-    creature.current_floor_ptr->grid_array[cy][cx].m_idx = m_idx;
-    auto &monster = creature.current_floor_ptr->m_list[m_idx];
-    monster = party_monsters[current_monster];
+    creature.get_floor()->grid_array[cy][cx].m_idx = m_idx;
+    auto &monster = creature.get_floor()->m_list[m_idx];
+    monster = party_monsters[current_monster].clone();
     monster.y = cy;
     monster.x = cx;
-    monster.current_floor_ptr = creature.current_floor_ptr;
+    monster.set_floor(creature.get_floor());
     monster.get_monster_profile().ml = true;
     monster.get_monster_profile().mtimed[CreatureTimedEffect::SLEEP_OR_PARALYSIS] = 0;
     monster.get_monster_profile().hold_o_idx_list.clear();
@@ -144,7 +144,7 @@ static void place_pet(CreatureEntity &creature)
 {
 
     const auto max_num = AngbandWorld::get_instance().is_wild_mode() ? 1 : PartyMonsters::MAX_SIZE;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (int current_monster = 0; current_monster < max_num; current_monster++) {
         if (!MonraceList::is_valid(party_monsters[current_monster].r_idx)) {
             continue;
@@ -247,7 +247,7 @@ static void update_floor_id(CreatureEntity &creature, saved_floor_type *sf_ptr)
 static void reset_unique_by_floor_change(CreatureEntity &creature)
 {
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (short i = 1; i < floor.m_max; i++) {
         auto &monster = floor.m_list[i];
         if (!monster.is_valid()) {
@@ -279,7 +279,7 @@ static void new_floor_allocation(CreatureEntity &creature, saved_floor_type *sf_
 {
 
     GAME_TURN tmp_last_visit = sf_ptr->last_visit;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     auto alloc_chance = floor.get_dungeon_definition().max_m_alloc_chance;
     const auto &world = AngbandWorld::get_instance();
     while (tmp_last_visit > world.game_turn) {
@@ -321,7 +321,7 @@ static void new_floor_allocation(CreatureEntity &creature, saved_floor_type *sf_
 static void set_stairs(CreatureEntity &creature)
 {
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &grid = floor.grid_array[creature.y][creature.x];
     const auto &fcms = FloorChangeModesStore::get_instace();
     const auto &dungeon = floor.get_dungeon_definition();
@@ -357,7 +357,7 @@ static void update_new_floor_feature(CreatureEntity &creature, saved_floor_type 
     }
 
     sf_ptr->last_visit = AngbandWorld::get_instance().game_turn;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     sf_ptr->dun_level = floor.dun_level;
     if (FloorChangeModesStore::get_instace()->has(FloorChangeMode::NO_RETURN)) {
         return;
@@ -433,7 +433,7 @@ void change_floor(CreatureEntity &creature)
     update_floor(creature);
     place_pet(creature);
     Travel::get_instance().reset_goal();
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     update_unique_artifact(floor, new_floor_id);
     creature.floor_id = new_floor_id;
     world.character_dungeon = true;

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -52,7 +52,7 @@ static void update_sun_light(CreatureEntity &creature)
         SubWindowRedrawingFlag::DUNGEON,
     };
     rfu.set_flags(flags);
-    if ((creature.current_floor_ptr->grid_array[creature.y][creature.x].info & CAVE_GLOW) != 0) {
+    if ((creature.get_floor()->grid_array[creature.y][creature.x].info & CAVE_GLOW) != 0) {
         set_superstealth(creature, false);
     }
 }
@@ -65,7 +65,7 @@ void day_break(CreatureEntity &creature)
         return;
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (const auto &pos : floor.get_area()) {
         auto &grid = floor.get_grid(pos);
         grid.add_info(CAVE_GLOW);
@@ -87,7 +87,7 @@ void night_falls(CreatureEntity &creature)
         return;
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (const auto &pos : floor.get_area()) {
         auto &grid = floor.get_grid(pos);
         const auto &terrain = grid.get_terrain(TerrainKind::MIMIC);
@@ -272,7 +272,7 @@ static int get_dungeon_feeling(const auto &floor)
  */
 void update_dungeon_feeling(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!floor.is_underground()) {
         return;
     }
@@ -321,7 +321,7 @@ void update_dungeon_feeling(CreatureEntity &creature)
  */
 void glow_deep_lava_and_bldg(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         return;
     }

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -73,7 +73,7 @@ static Pos2D build_arena(CreatureEntity &creature)
     const auto y_depth = yval + 15;
     const auto x_left = xval - 15;
     const auto x_right = xval + 15;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (auto y = y_height; y <= y_height + 5; y++) {
         for (auto x = x_left; x <= x_right; x++) {
             const Pos2D pos(y, x);
@@ -141,7 +141,7 @@ static Pos2D build_arena(CreatureEntity &creature)
 static void generate_challenge_arena(CreatureEntity &creature)
 {
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     floor.height = SCREEN_HGT;
     floor.width = SCREEN_WID;
     for (auto y = 0; y < MAX_HGT; y++) {
@@ -186,7 +186,7 @@ static Pos2D build_battle(CreatureEntity &creature)
     const auto y_depth = yval + 15;
     const auto x_left = xval - 15;
     const auto x_right = xval + 15;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (auto y = y_height; y <= y_height + 5; y++) {
         for (auto x = x_left; x <= x_right; x++) {
             const Pos2D pos(y, x);
@@ -246,7 +246,7 @@ static Pos2D build_battle(CreatureEntity &creature)
 static void generate_gambling_arena(CreatureEntity &creature)
 {
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (auto y = 0; y < MAX_HGT; y++) {
         for (auto x = 0; x < MAX_WID; x++) {
             const Pos2D pos(y, x);
@@ -295,7 +295,7 @@ static void generate_gambling_arena(CreatureEntity &creature)
 static void generate_fixed_floor(CreatureEntity &creature)
 {
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (const auto &pos : floor.get_area()) {
         place_bold(creature, pos.y, pos.x, GB_SOLID_PERM);
     }
@@ -339,7 +339,7 @@ static tl::optional<std::string> level_gen(CreatureEntity &creature, tl::optiona
     }
 
     constexpr auto chance_small_floor = 10;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_generated_dungeon_definition();
     int level_height, level_width;
     if (dungeon.flags.has(DungeonFeatureType::ALWAY_MAX_SIZE)) {
@@ -436,7 +436,7 @@ void wipe_generate_random_floor_flags(FloorType &floor)
 void clear_cave(CreatureEntity &creature)
 {
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     floor.o_list.clear();
     floor.o_list.push_back(std::make_shared<ItemEntity>()); // 0番にダミーアイテムを用意
 
@@ -567,7 +567,7 @@ static bool floor_is_connected(const FloorType &floor, const IsWallFunc is_wall)
  */
 void generate_floor(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto is_wild_mode = AngbandWorld::get_instance().is_wild_mode();
     for (int num = 0; true; num++) {
         tl::optional<std::string> why;

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -47,7 +47,7 @@ static void check_riding_preservation(CreatureEntity &creature)
         return;
     }
 
-    const auto &monster = creature.current_floor_ptr->m_list[creature.riding];
+    const auto &monster = creature.get_floor()->m_list[creature.riding];
     if (monster.has_parent()) {
         creature.ride_monster(0);
         creature.pet_extra_flags &= ~(PF_TWO_HANDS);
@@ -73,7 +73,7 @@ static bool check_pet_preservation_conditions(CreatureEntity &creature, const Cr
     }
 
     const auto should_preserve = monster.is_named();
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     auto sight_from_player = floor.has_los_at(m_pos);
     sight_from_player &= projectable(floor, p_pos, m_pos);
     auto sight_from_monster = los(floor, m_pos, p_pos);
@@ -87,18 +87,17 @@ static bool check_pet_preservation_conditions(CreatureEntity &creature, const Cr
 
 static void sweep_preserving_pet(CreatureEntity &creature)
 {
-
-    if (AngbandWorld::get_instance().is_wild_mode() || creature.current_floor_ptr->inside_arena || AngbandSystem::get_instance().is_phase_out()) {
+    if (AngbandWorld::get_instance().is_wild_mode() || creature.get_floor()->inside_arena || AngbandSystem::get_instance().is_phase_out()) {
         return;
     }
 
-    for (MONSTER_IDX i = creature.current_floor_ptr->m_max - 1, party_monster_num = 1; (i >= 1) && (party_monster_num < PartyMonsters::MAX_SIZE); i--) {
-        const auto &monster = creature.current_floor_ptr->m_list[i];
+    for (MONSTER_IDX i = creature.get_floor()->m_max - 1, party_monster_num = 1; (i >= 1) && (party_monster_num < PartyMonsters::MAX_SIZE); i--) {
+        const auto &monster = creature.get_floor()->m_list[i];
         if (!monster.is_valid() || !monster.is_pet() || monster.is_riding() || check_pet_preservation_conditions(creature, monster)) {
             continue;
         }
 
-        party_monsters[party_monster_num] = creature.current_floor_ptr->m_list[i];
+        party_monsters[party_monster_num] = creature.get_floor()->m_list[i].clone();
         party_monster_num++;
         delete_monster_idx(creature, i);
     }
@@ -111,7 +110,7 @@ static void record_pet_diary(CreatureEntity &creature)
         return;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (MONSTER_IDX i = floor.m_max - 1; i >= 1; i--) {
         const auto &monster = floor.m_list[i];
         if (!monster.is_valid() || !monster.is_named_pet() || monster.is_riding()) {
@@ -134,9 +133,9 @@ static void preserve_pet(CreatureEntity &creature)
     check_riding_preservation(creature);
     sweep_preserving_pet(creature);
     record_pet_diary(creature);
-    for (MONSTER_IDX i = creature.current_floor_ptr->m_max - 1; i >= 1; i--) {
-        const auto &monster = creature.current_floor_ptr->m_list[i];
-        const auto parent_r_idx = creature.current_floor_ptr->m_list[monster.get_monster_profile().parent_m_idx].r_idx;
+    for (MONSTER_IDX i = creature.get_floor()->m_max - 1; i >= 1; i--) {
+        const auto &monster = creature.get_floor()->m_list[i];
+        const auto parent_r_idx = creature.get_floor()->m_list[monster.get_monster_profile().parent_m_idx].r_idx;
         if (!monster.has_parent() || MonraceList::is_valid(parent_r_idx)) {
             continue;
         }
@@ -226,7 +225,7 @@ static void get_out_monster(CreatureEntity &creature)
     auto tries = 0;
     auto dis = 1;
     const auto p_pos = creature.get_position();
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &p_grid = floor.get_grid(p_pos);
     const auto m_idx = p_grid.m_idx;
     if (m_idx == 0) {
@@ -268,7 +267,7 @@ static void preserve_info(CreatureEntity &creature)
 
     auto quest_monrace_id = MonraceList::empty_id();
     const auto &quests = QuestList::get_instance();
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (const auto &[quest_id, quest] : quests) {
         auto quest_relating_monster = (quest.status == QuestStatusType::TAKEN);
         quest_relating_monster &= ((quest.type == QuestKindType::KILL_LEVEL) || (quest.type == QuestKindType::RANDOM));
@@ -312,7 +311,7 @@ static Grid *set_grid_by_leaving_floor(CreatureEntity &creature)
     if (FloorChangeModesStore::get_instace()->has_not(FloorChangeMode::SAVE_FLOORS)) {
         return nullptr;
     }
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &grid = floor.get_grid(creature.get_position());
     const auto &terrain = grid.get_terrain();
     if (grid.special && terrain.flags.has_not(TerrainCharacteristics::SPECIAL) && get_sf_ptr(grid.special)) {
@@ -345,7 +344,7 @@ static void jump_floors(CreatureEntity &creature)
         move_num *= 2;
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_dungeon_definition();
     if (fcms->has(FloorChangeMode::DOWN)) {
         if (!floor.is_underground()) {
@@ -363,8 +362,7 @@ static void jump_floors(CreatureEntity &creature)
 //!< @details SAVE_FLOORS フラグを抜く箇所に「TODO」のコメントがあった、何をするかは書いておらず詳細不明
 static void exit_to_wilderness(CreatureEntity &creature)
 {
-
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.is_underground() || (floor.dungeon_id == DungeonId::WILDERNESS)) {
         return;
     }
@@ -425,7 +423,7 @@ static void update_upper_lower_or_floor_id(saved_floor_type *sf_ptr)
 
 static void exe_leave_floor(CreatureEntity &creature, saved_floor_type *sf_ptr)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto *grid_ptr = set_grid_by_leaving_floor(creature);
     jump_floors(creature);
     exit_to_wilderness(creature);
@@ -471,7 +469,7 @@ void leave_floor(CreatureEntity &creature)
     preserve_info(creature);
     saved_floor_type *sf_ptr = get_sf_ptr(creature.floor_id);
     if (FloorChangeModesStore::get_instace()->has(FloorChangeMode::RANDOM_CONNECT)) {
-        locate_connected_stairs(creature, *creature.current_floor_ptr, sf_ptr);
+        locate_connected_stairs(creature, *creature.get_floor(), sf_ptr);
     }
 
     exe_leave_floor(creature, sf_ptr);
@@ -483,8 +481,7 @@ void leave_floor(CreatureEntity &creature)
  */
 void jump_floor(CreatureEntity &creature, DungeonId dun_idx, DEPTH depth)
 {
-
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     floor.set_dungeon_index(dun_idx);
     floor.dun_level = depth;
     auto &fcms = FloorChangeModesStore::get_instace();

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -132,13 +132,13 @@ static void handle_item_disappearance(CreatureEntity &creature, ItemEntity &disa
 tl::optional<ItemEntity> make_object(CreatureEntity &subject, BIT_FLAGS mode, BaseitemRestrict restrict, tl::optional<int> rq_mon_level)
 {
     const auto apply_magic_to = [&subject, mode](ItemEntity &item) {
-        ItemMagicApplier(subject, &item, subject.current_floor_ptr->object_level, mode).execute();
+        ItemMagicApplier(subject, &item, subject.get_floor()->object_level, mode).execute();
         set_ammo_quantity(&item);
         if (cheat_peek) {
             object_mention(subject, item);
         }
     };
-    const auto &floor = *subject.current_floor_ptr;
+    const auto &floor = *subject.get_floor();
     const auto prob = any_bits(mode, AM_GOOD) ? 10 : 1000;
     const auto base = get_base_floor(floor, mode, rq_mon_level);
     if (!restrict && one_in_(prob)) {
@@ -185,7 +185,7 @@ tl::optional<ItemEntity> make_object(CreatureEntity &subject, BIT_FLAGS mode, Ba
  */
 void delete_all_items_from_floor(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (!floor.contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
         return;
     }
@@ -205,7 +205,7 @@ void delete_all_items_from_floor(CreatureEntity &creature, const Pos2D &pos)
  */
 void floor_item_increase(CreatureEntity &creature, INVENTORY_IDX i_idx, ITEM_NUMBER num)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
 
     auto *o_ptr = floor.o_list[i_idx].get();
     num += o_ptr->number;
@@ -232,7 +232,7 @@ void floor_item_increase(CreatureEntity &creature, INVENTORY_IDX i_idx, ITEM_NUM
  */
 void floor_item_optimize(CreatureEntity &creature, INVENTORY_IDX i_idx)
 {
-    auto *o_ptr = creature.current_floor_ptr->o_list[i_idx].get();
+    auto *o_ptr = creature.get_floor()->o_list[i_idx].get();
     if (!o_ptr->is_valid()) {
         return;
     }
@@ -258,7 +258,7 @@ void floor_item_optimize(CreatureEntity &creature, INVENTORY_IDX i_idx)
  */
 void delete_object_idx(CreatureEntity &creature, OBJECT_IDX o_idx)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     excise_object_idx(floor, o_idx);
     auto &item_ptr = floor.o_list[o_idx];
     if (!item_ptr->is_held_by_monster()) {
@@ -348,7 +348,7 @@ short drop_near(CreatureEntity &subject, ItemEntity &drop_item, const Pos2D &pos
     Pos2D pos_drop = pos; //!< @details 実際に落ちる座標.
     auto bs = -1;
     auto bn = 0;
-    auto &floor = *subject.current_floor_ptr;
+    auto &floor = *subject.get_floor();
     auto has_floor_space = false;
     for (auto dy = -3; dy <= 3; dy++) {
         for (auto dx = -3; dx <= 3; dx++) {
@@ -544,7 +544,7 @@ void floor_item_charges(const FloorType &floor, INVENTORY_IDX i_idx)
  */
 void floor_item_describe(CreatureEntity &creature, INVENTORY_IDX i_idx)
 {
-    const auto &item = *creature.current_floor_ptr->o_list[i_idx];
+    const auto &item = *creature.get_floor()->o_list[i_idx];
     const auto item_name = describe_flavor(creature, item, 0);
 #ifdef JP
     if (item.number <= 0) {
@@ -567,7 +567,7 @@ ItemEntity *choose_object(CreatureEntity &creature, short *initial_i_idx, concpt
         *initial_i_idx = INVEN_NONE;
     }
 
-    const auto enable_repeat = util::make_finalizer([&] { creature.current_floor_ptr->prevent_repeat_floor_item_idx = false; });
+    const auto enable_repeat = util::make_finalizer([&] { creature.get_floor()->prevent_repeat_floor_item_idx = false; });
 
     FixItemTesterSetter setter(item_tester);
     short i_idx;

--- a/src/floor/floor-save.cpp
+++ b/src/floor/floor-save.cpp
@@ -193,7 +193,7 @@ FLOOR_IDX get_unused_floor_id(CreatureEntity &creature)
     sf_ptr->upper_floor_id = 0;
     sf_ptr->lower_floor_id = 0;
     sf_ptr->visit_mark = latest_visit_mark++;
-    sf_ptr->dun_level = creature.current_floor_ptr->dun_level;
+    sf_ptr->dun_level = creature.get_floor()->dun_level;
     if (max_floor_id < MAX_SHORT) {
         max_floor_id++;
     } else {

--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -242,7 +242,7 @@ void build_streamer(CreatureEntity &creature, FEAT_IDX feat, int chance)
     bool streamer_may_have_gold = streamer.flags.has(TerrainCharacteristics::MAY_HAVE_GOLD);
 
     /* Hack -- Choose starting point */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto y = rand_spread(floor.height / 2, floor.height / 6);
     auto x = rand_spread(floor.width / 2, floor.width / 6);
 
@@ -370,7 +370,7 @@ void build_streamer(CreatureEntity &creature, FEAT_IDX feat, int chance)
 void place_trees(CreatureEntity &creature, const Pos2D &pos)
 {
     /* place trees/ rubble in ovalish distribution */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (auto x = pos.x - 3; x < pos.x + 4; x++) {
         for (auto y = pos.y - 3; y < pos.y + 4; y++) {
             const Pos2D pos_neighbor(y, x);
@@ -420,7 +420,7 @@ void destroy_level(CreatureEntity &creature)
 
     /* Drop a few epi-centers (usually about two) */
     POSITION y1, x1;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (int n = 0; n < randint1(5); n++) {
         /* Pick an epi-center */
         x1 = rand_range(5, floor.width - 1 - 5);

--- a/src/floor/floor-util.cpp
+++ b/src/floor/floor-util.cpp
@@ -177,7 +177,7 @@ Pos2D scatter(const FloorType &floor, const Pos2D &pos, int d, uint32_t mode)
  */
 std::string map_name(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &quests = QuestList::get_instance();
     auto is_fixed_quest = floor.is_in_quest();
     is_fixed_quest &= QuestType::is_fixed(floor.quest_number);

--- a/src/floor/geometry.cpp
+++ b/src/floor/geometry.cpp
@@ -50,7 +50,7 @@ bool player_can_see_bold(CreatureEntity &creature, POSITION y, POSITION x)
     }
 
     const Pos2D pos(y, x);
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(pos);
 
     /* Note that "torch-lite" yields "illumination" */
@@ -139,7 +139,7 @@ bool is_seen(CreatureEntity &creature, const CreatureEntity &target)
     is_inside_view |= AngbandSystem::get_instance().is_phase_out();
     const auto p_pos = creature.get_position();
     const auto t_pos = target.get_position();
-    is_inside_view |= player_can_see_bold(creature, t_pos.y, t_pos.x) && projectable(*creature.current_floor_ptr, p_pos, t_pos);
+    is_inside_view |= player_can_see_bold(creature, t_pos.y, t_pos.x) && projectable(*creature.get_floor(), p_pos, t_pos);
     const auto ml = target.has_monster_profile() ? target.get_monster_profile().ml : false;
     return ml && is_inside_view;
 }

--- a/src/floor/object-allocator.cpp
+++ b/src/floor/object-allocator.cpp
@@ -47,7 +47,7 @@ static int next_to_walls(const FloorType &floor, const Pos2D &pos)
  */
 static bool alloc_stairs_aux(const CreatureEntity &creature, const Pos2D &pos, int walls)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(pos);
     if (!grid.is_floor() || grid.has(TerrainCharacteristics::PATTERN) || !grid.o_idx_list.empty() || grid.has_monster() || next_to_walls(floor, pos) < walls) {
         return false;
@@ -68,7 +68,7 @@ bool alloc_stairs(CreatureEntity &creature, FEAT_IDX feat, int num, int walls)
 {
     int shaft_num = 0;
     const auto &terrain = TerrainList::get_instance().get_terrain(feat);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_dungeon_definition();
     if (terrain.flags.has(TerrainCharacteristics::LESS)) {
         if (ironman_downward || !floor.is_underground()) {
@@ -138,7 +138,7 @@ bool alloc_stairs(CreatureEntity &creature, FEAT_IDX feat, int num, int walls)
 void alloc_object(CreatureEntity &creature, dap_type set, dungeon_allocation_type typ, int num)
 {
     auto dummy = 0;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     num = num * floor.height * floor.width / (MAX_HGT * MAX_WID) + 1;
     for (auto k = 0; k < num; k++) {
         Pos2D pos(0, 0);
@@ -201,7 +201,7 @@ void alloc_object(CreatureEntity &creature, dap_type set, dungeon_allocation_typ
  */
 void alloc_specific_floor_items(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_generated_dungeon_definition();
 
     // 現在の階層に特定のアイテム生成ルールがあるかチェック

--- a/src/floor/object-scanner.cpp
+++ b/src/floor/object-scanner.cpp
@@ -96,7 +96,7 @@ COMMAND_CODE show_floor_items(CreatureEntity &creature, int target_item, POSITIO
     auto dont_need_to_show_weights = true;
     const auto &[wid, hgt] = term_get_size();
     auto len = std::max((*min_width), 20);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto floor_item_index = scan_floor_items(floor, pos, { ScanFloorMode::ITEM_TESTER, ScanFloorMode::ONLY_MARKED }, item_tester);
     auto k = 0;
     for (size_t i = 0; (i < floor_item_index.size()) && (i < max_items); i++) {

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -40,7 +40,7 @@ void pattern_teleport(CreatureEntity &creature)
     auto *player_ptr = &creature;
     auto min_level = 0;
     auto max_level = 99;
-    auto &floor = *player_ptr->current_floor_ptr;
+    auto &floor = *player_ptr->get_floor();
     auto current_level = static_cast<short>(floor.dun_level);
     if (input_check(_("他の階にテレポートしますか？", "Teleport level? "))) {
         if (ironman_downward) {
@@ -84,7 +84,7 @@ void pattern_teleport(CreatureEntity &creature)
         exe_write_diary(floor, DiaryKind::PAT_TELE, 0);
     }
 
-    player_ptr->current_floor_ptr->quest_number = QuestId::NONE;
+    player_ptr->get_floor()->quest_number = QuestId::NONE;
     PlayerEnergy(*player_ptr).reset_player_turn();
 
     /*
@@ -105,7 +105,7 @@ void pattern_teleport(CreatureEntity &creature)
 bool pattern_effect(CreatureEntity &creature)
 {
     auto *player_ptr = &creature;
-    const auto &floor = *player_ptr->current_floor_ptr;
+    const auto &floor = *player_ptr->get_floor();
     const auto p_pos = player_ptr->get_position();
     const auto &grid = floor.get_grid(p_pos);
     if (!grid.has(TerrainCharacteristics::PATTERN)) {
@@ -170,7 +170,7 @@ bool pattern_effect(CreatureEntity &creature)
 bool pattern_seq(CreatureEntity &creature, const Pos2D &pos)
 {
     auto *player_ptr = &creature;
-    const auto &floor = *player_ptr->current_floor_ptr;
+    const auto &floor = *player_ptr->get_floor();
     const auto &grid_current = floor.get_grid(player_ptr->get_position());
     const auto &grid_new = floor.get_grid(pos);
     const auto &terrain_current = grid_current.get_terrain();

--- a/src/floor/tunnel-generator.cpp
+++ b/src/floor/tunnel-generator.cpp
@@ -54,7 +54,7 @@ bool build_tunnel(CreatureEntity &creature, DungeonData *dd_ptr, dt_type *dt_ptr
     auto main_loop_count = 0;
     auto door_flag = false;
     auto vec = correct_dir(pos_start, pos_end);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     while (pos_current != pos_end) {
         if (main_loop_count++ > 2000) {
             return false;
@@ -160,7 +160,7 @@ bool build_tunnel(CreatureEntity &creature, DungeonData *dd_ptr, dt_type *dt_ptr
 static bool set_tunnel(CreatureEntity &creature, DungeonData *dd_ptr, POSITION *y, POSITION *x, bool affectwall)
 {
     const Pos2D pos(*y, *x);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &grid = floor.get_grid(pos);
     if (!floor.contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE) || grid.is_inner()) {
         return true;
@@ -352,7 +352,7 @@ static void short_seg_hack(
 bool build_tunnel2(CreatureEntity &creature, DungeonData *dd_ptr, const Pos2D &pos_start, const Pos2D &pos_end, int type, int cutoff)
 {
     const auto length = Grid::calc_distance(pos_start, pos_end);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (length <= cutoff) {
         auto initial_failure = true;
         short_seg_hack(creature, dd_ptr, pos_start.x, pos_start.y, pos_end.x, pos_end.y, type, 0, &initial_failure);

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -284,7 +284,7 @@ static void generate_area(CreatureEntity &creature, const Pos2D &pos, bool is_bo
     const auto &wilderness = WildernessGrids::get_instance();
     const auto &wg = wilderness.get_grid(pos);
     creature.town_num = wg.get_town();
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     floor.base_level = wg.get_level();
     floor.dun_level = 0;
     floor.monster_level = floor.base_level;
@@ -406,8 +406,8 @@ static void generate_wild_monsters(CreatureEntity &creature)
             if (!ambush_monsters.empty()) {
                 for (const auto &monster_id : ambush_monsters) {
                     for (int i = 0; i < 3; i++) { // 各モンスターを3体ずつ配置
-                        auto y = randint0(creature.current_floor_ptr->height);
-                        auto x = randint0(creature.current_floor_ptr->width);
+                        auto y = randint0(creature.get_floor()->height);
+                        auto x = randint0(creature.get_floor()->width);
                         (void)place_monster_one(creature, y, x, monster_id, PM_ALLOW_GROUP);
                     }
                 }
@@ -435,7 +435,7 @@ static void generate_wild_monsters(CreatureEntity &creature)
 void wilderness_gen(CreatureEntity &creature)
 {
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     floor.height = MAX_HGT;
     floor.width = MAX_WID;
     panel_row_min = floor.height;
@@ -612,7 +612,7 @@ void wilderness_gen(CreatureEntity &creature)
 void wilderness_gen_small(CreatureEntity &creature)
 {
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (auto x = 0; x < MAX_WID; x++) {
         for (auto y = 0; y < MAX_HGT; y++) {
             floor.get_grid({ y, x }).set_terrain_id(TerrainTag::PERMANENT_WALL);
@@ -861,8 +861,8 @@ bool change_wild_mode(CreatureEntity &creature, bool encount)
 
     bool has_pet = false;
     PlayerEnergy energy(creature);
-    for (int i = 1; i < creature.current_floor_ptr->m_max; i++) {
-        const auto &monster = creature.current_floor_ptr->get_monster(i);
+    for (int i = 1; i < creature.get_floor()->m_max; i++) {
+        const auto &monster = creature.get_floor()->get_monster(i);
         if (!monster.is_valid()) {
             continue;
         }

--- a/src/grid/door.cpp
+++ b/src/grid/door.cpp
@@ -26,7 +26,7 @@
  */
 void add_door(CreatureEntity &creature, const Pos2D &pos)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!floor.get_grid(pos).is_outer()) {
         return;
     }
@@ -56,7 +56,7 @@ void add_door(CreatureEntity &creature, const Pos2D &pos)
  */
 void place_secret_door(CreatureEntity &creature, const Pos2D &pos, tl::optional<DoorKind> door_kind_initial)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_dungeon_definition();
     if (dungeon.flags.has(DungeonFeatureType::NO_DOORS)) {
         place_bold(creature, pos.y, pos.x, GB_FLOOR);
@@ -82,7 +82,7 @@ void place_secret_door(CreatureEntity &creature, const Pos2D &pos, tl::optional<
  */
 void place_locked_door(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_dungeon_definition();
     if (dungeon.flags.has(DungeonFeatureType::NO_DOORS)) {
         place_bold(creature, pos.y, pos.x, GB_FLOOR);
@@ -103,7 +103,7 @@ void place_locked_door(CreatureEntity &creature, const Pos2D &pos)
  */
 void place_random_door(CreatureEntity &creature, const Pos2D &pos, bool is_room_door)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &grid = floor.get_grid(pos);
     grid.set_terrain_id(TerrainTag::NONE, TerrainKind::MIMIC);
     const auto &dungeon = floor.get_dungeon_definition();
@@ -155,7 +155,7 @@ void place_random_door(CreatureEntity &creature, const Pos2D &pos, bool is_room_
  */
 void place_closed_door(CreatureEntity &creature, const Pos2D &pos, DoorKind door_kind)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_DOORS)) {
         place_bold(creature, pos.y, pos.x, GB_FLOOR);
         return;

--- a/src/grid/feature-generator.cpp
+++ b/src/grid/feature-generator.cpp
@@ -32,7 +32,7 @@ static bool decide_cavern(const FloorType &floor, const DungeonDefinition &dunge
  */
 void gen_caverns_and_lakes(CreatureEntity &creature, const DungeonDefinition &dungeon, DungeonData *dd_ptr)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     constexpr auto chance_destroyed = 18;
     if ((floor.dun_level > 30) && one_in_(chance_destroyed * 2) && small_levels && dungeon.flags.has(DungeonFeatureType::DESTROY)) {
         dd_ptr->destroyed = true;
@@ -162,7 +162,7 @@ static bool possible_doorway(const FloorType &floor, POSITION y, POSITION x)
  */
 void try_door(CreatureEntity &creature, dt_type *dt_ptr, const Pos2D &pos)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (!floor.contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE) || floor.has_terrain_characteristics(pos, TerrainCharacteristics::WALL) || floor.get_grid(pos).is_room()) {
         return;
     }

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -63,7 +63,7 @@ void set_terrain_id_to_grid(CreatureEntity &creature, const Pos2D &pos, TerrainT
  */
 void set_terrain_id_to_grid(CreatureEntity &creature, const Pos2D &pos, short terrain_id)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &grid = floor.get_grid(pos);
     const auto &terrain = TerrainList::get_instance().get_terrain(terrain_id);
     const auto &dungeon = floor.get_dungeon_definition();
@@ -154,7 +154,7 @@ void set_terrain_id_to_grid(CreatureEntity &creature, const Pos2D &pos, short te
  */
 tl::optional<Pos2D> new_player_spot(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     auto max_attempts = 10000;
     Pos2D pos(0, 0);
     while (max_attempts--) {
@@ -217,7 +217,7 @@ tl::optional<Pos2D> new_player_spot(CreatureEntity &creature)
  */
 static void update_local_illumination_aux(CreatureEntity &creature, const Pos2D &pos)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(pos);
     if (!grid.has_los()) {
         return;
@@ -238,7 +238,7 @@ static void update_local_illumination_aux(CreatureEntity &creature, const Pos2D 
  */
 void update_local_illumination(CreatureEntity &creature, const Pos2D &pos)
 {
-    if (!creature.current_floor_ptr->contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
+    if (!creature.get_floor()->contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
         return;
     }
 
@@ -359,7 +359,7 @@ void print_bolt_pict(CreatureEntity &creature, const Pos2D &pos_src, const Pos2D
  */
 void note_spot(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &grid = floor.get_grid(pos);
 
     /* Blind players see nothing */
@@ -440,7 +440,7 @@ void note_spot(CreatureEntity &creature, const Pos2D &pos)
  */
 void lite_spot(CreatureEntity &creature, const Pos2D &pos)
 {
-    if (panel_contains(pos) && creature.current_floor_ptr->contains(pos, FloorBoundary::OUTER_WALL_INCLUSIVE)) {
+    if (panel_contains(pos) && creature.get_floor()->contains(pos, FloorBoundary::OUTER_WALL_INCLUSIVE)) {
         auto symbol_pair = map_info(creature, pos);
         symbol_pair.symbol_foreground.color = get_monochrome_display_color(creature).value_or(symbol_pair.symbol_foreground.color);
 
@@ -682,7 +682,7 @@ static POSITION flow_y = 0;
  */
 void update_flow(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
 
     /* The last way-point is on the map */
     const Pos2D flow(flow_y, flow_x);
@@ -780,7 +780,7 @@ void update_flow(CreatureEntity &creature)
 void cave_alter_feat(CreatureEntity &creature, POSITION y, POSITION x, TerrainCharacteristics action)
 {
     const Pos2D pos(y, x);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto old_terrain_id = floor.get_grid(pos).feat;
     const auto &dungeon = floor.get_dungeon_definition();
     const auto new_terrain_id = dungeon.convert_terrain_id(old_terrain_id, action);
@@ -837,7 +837,7 @@ void cave_alter_feat(CreatureEntity &creature, POSITION y, POSITION x, TerrainCh
 bool cave_monster_teleportable_bold(CreatureEntity &creature, MONSTER_IDX m_idx, POSITION y, POSITION x, teleport_flags mode)
 {
     const Pos2D pos(y, x);
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(pos);
     const auto &terrain = grid.get_terrain();
 
@@ -880,7 +880,7 @@ bool cave_monster_teleportable_bold(CreatureEntity &creature, MONSTER_IDX m_idx,
 bool cave_player_teleportable_bold(CreatureEntity &creature, POSITION y, POSITION x, teleport_flags mode)
 {
     const Pos2D pos(y, x);
-    const auto &grid = creature.current_floor_ptr->get_grid(pos);
+    const auto &grid = creature.get_floor()->get_grid(pos);
     const auto &terrain = grid.get_terrain();
 
     /* Require "teleportable" space */
@@ -892,7 +892,7 @@ bool cave_player_teleportable_bold(CreatureEntity &creature, POSITION y, POSITIO
     if (!(mode & TELEPORT_NONMAGICAL) && grid.is_icky()) {
         return false;
     }
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (grid.has_monster() && !floor.get_monster(grid.m_idx).is_riding()) {
         return false;
     }
@@ -940,7 +940,7 @@ bool player_can_enter(CreatureEntity &creature, FEAT_IDX feature, BIT_FLAGS16 mo
     const auto &terrain = TerrainList::get_instance().get_terrain(feature);
     if (creature.riding) {
         return monster_can_cross_terrain(
-            &creature, feature, creature.current_floor_ptr->get_monster(creature.riding).get_monrace(), mode | CEM_RIDING);
+            &creature, feature, creature.get_floor()->get_monster(creature.riding).get_monrace(), mode | CEM_RIDING);
     }
 
     if (terrain.flags.has(TerrainCharacteristics::PATTERN)) {
@@ -968,7 +968,7 @@ bool player_can_enter(CreatureEntity &creature, FEAT_IDX feature, BIT_FLAGS16 mo
 
 void place_grid(CreatureEntity &creature, Grid &grid, grid_bold_type gb_type)
 {
-    const auto &dungeon = creature.current_floor_ptr->get_generated_dungeon_definition();
+    const auto &dungeon = creature.get_floor()->get_generated_dungeon_definition();
     switch (gb_type) {
     case GB_FLOOR: {
         grid.set_terrain_id(dungeon.select_floor_terrain_id());
@@ -1061,6 +1061,6 @@ void place_grid(CreatureEntity &creature, Grid &grid, grid_bold_type gb_type)
 
 void place_bold(CreatureEntity &creature, POSITION y, POSITION x, grid_bold_type gb_type)
 {
-    auto &grid = creature.current_floor_ptr->grid_array[y][x];
+    auto &grid = creature.get_floor()->grid_array[y][x];
     place_grid(creature, grid, gb_type);
 }

--- a/src/grid/object-placer.cpp
+++ b/src/grid/object-placer.cpp
@@ -14,7 +14,7 @@
  */
 void place_gold(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &grid = floor.get_grid(pos);
     if (!floor.contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
         return;
@@ -50,7 +50,7 @@ void place_gold(CreatureEntity &creature, const Pos2D &pos)
  */
 void place_object(CreatureEntity &creature, const Pos2D &pos, uint32_t mode, BaseitemRestrict restrict)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &grid = floor.get_grid(pos);
     if (!floor.contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE) || !floor.can_drop_item_at(pos) || !grid.o_idx_list.empty()) {
         return;

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -122,7 +122,7 @@ const std::vector<EnumClassFlagGroup<ChestTrapType>> chest_traps = {
  */
 void disclose_grid(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto &grid = creature.current_floor_ptr->get_grid(pos);
+    auto &grid = creature.get_floor()->get_grid(pos);
 
     if (grid.has(TerrainCharacteristics::SECRET)) {
         /* No longer hidden */
@@ -288,7 +288,7 @@ static void hit_trap_slow(CreatureEntity &creature)
  */
 void hit_trap(CreatureEntity &creature, bool break_trap)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     const auto &grid = floor.get_grid(p_pos);
     const auto &terrain = grid.get_terrain();
@@ -482,9 +482,9 @@ void hit_trap(CreatureEntity &creature, bool break_trap)
         fire_ball_hide(creature, AttributeType::WATER_FLOW, Direction::self(), 1, 10);
 
         /* Summon Piranhas */
-        const auto num = 1 + creature.current_floor_ptr->dun_level / 20;
+        const auto num = 1 + creature.get_floor()->dun_level / 20;
         for (auto i = 0; i < num; i++) {
-            (void)summon_specific(creature, p_pos.y, p_pos.x, creature.current_floor_ptr->dun_level, SUMMON_PIRANHAS, (PM_ALLOW_GROUP | PM_NO_PET));
+            (void)summon_specific(creature, p_pos.y, p_pos.x, creature.get_floor()->dun_level, SUMMON_PIRANHAS, (PM_ALLOW_GROUP | PM_NO_PET));
         }
         break;
     }
@@ -530,7 +530,7 @@ void hit_trap(CreatureEntity &creature, bool break_trap)
 
     case TrapType::JUMP_VOID: {
         msg_print(_("なんてこった！あなたは猿空間に送られた！", "What a hell! You were sent to the SARU space!"));
-        jump_floor(creature, DungeonId::VOID_TERRITORY, creature.current_floor_ptr->dun_level);
+        jump_floor(creature, DungeonId::VOID_TERRITORY, creature.get_floor()->dun_level);
         break;
     }
 

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -94,7 +94,7 @@ static bool deal_damege_by_feat(CreatureEntity &creature, const Grid &grid, conc
         }
     } else {
         const auto p_pos = creature.get_position();
-        const auto &name = creature.current_floor_ptr->get_grid(p_pos).get_terrain(TerrainKind::MIMIC).name;
+        const auto &name = creature.get_floor()->get_grid(p_pos).get_terrain(TerrainKind::MIMIC).name;
         msg_format(_("%%s%%s\uff01", "The %%s %%s!"), name.data(), msg_normal);
         take_hit(creature, DAMAGE_NOESCAPE, damage, name);
 
@@ -112,7 +112,7 @@ static bool deal_damege_by_feat(CreatureEntity &creature, const Grid &grid, conc
  */
 void process_player_hp_mp(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(creature.get_position());
     const auto &terrain = grid.get_terrain();
     bool cave_no_regen = false;

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -174,8 +174,8 @@ void regenerate_monsters(CreatureEntity &creature)
 {
     auto &tracker = HealthBarTracker::get_instance();
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    for (short i = 1; i < creature.current_floor_ptr->m_max; i++) {
-        auto &monster = creature.current_floor_ptr->get_monster(i);
+    for (short i = 1; i < creature.get_floor()->m_max; i++) {
+        auto &monster = creature.get_floor()->get_monster(i);
         const auto &monrace = monster.get_monrace();
         if (!monster.is_valid()) {
             continue;
@@ -194,7 +194,7 @@ void regenerate_monsters(CreatureEntity &creature)
             }
 
             // Apply hygiene-based regeneration modifier
-            const auto &grid = creature.current_floor_ptr->get_grid(monster.get_position());
+            const auto &grid = creature.get_floor()->get_grid(monster.get_position());
             const auto &terrain = grid.get_terrain();
             if (terrain.hygiene != 0) {
                 const int hygiene_modifier = 100 + terrain.hygiene;
@@ -252,7 +252,7 @@ void regenerate_captured_monsters(CreatureEntity &creature)
             }
 
             // Apply hygiene-based regeneration modifier (based on creature's current terrain)
-            const auto &grid = creature.current_floor_ptr->get_grid(creature.get_position());
+            const auto &grid = creature.get_floor()->get_grid(creature.get_position());
             const auto &terrain = grid.get_terrain();
             if (terrain.hygiene != 0) {
                 const int hygiene_modifier = 100 + terrain.hygiene;

--- a/src/info-reader/fixed-map-parser.cpp
+++ b/src/info-reader/fixed-map-parser.cpp
@@ -202,7 +202,7 @@ static std::string parse_fixed_map_expression(CreatureEntity &creature, char **s
     } else if (streq(b + 1, "LEVEL")) {
         v = std::to_string(creature.level);
     } else if (streq(b + 1, "QUEST_NUMBER")) {
-        v = std::to_string(enum2i(creature.current_floor_ptr->quest_number));
+        v = std::to_string(enum2i(creature.get_floor()->quest_number));
     } else if (streq(b + 1, "LEAVING_QUEST")) {
         v = std::to_string(enum2i(leaving_quest));
     } else if (prefix(b + 1, "QUEST_TYPE")) {

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -149,7 +149,7 @@ static std::pair<tl::optional<short>, char> check_floor_item_tag(CreatureEntity 
         return { *code, prev_tag };
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     const auto &[floor_item_indice, tag_floor] = check_floor_item_tag_aux(floor, p_pos, fis, *code, prev_tag, item_tester);
     if (floor_item_indice) {
@@ -266,7 +266,7 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
     }
 
     if (fis.floor) {
-        const auto &floor = *creature.current_floor_ptr;
+        const auto &floor = *creature.get_floor();
         fis.floor_item_index = scan_floor_items(floor, creature.get_position(), { ScanFloorMode::ITEM_TESTER, ScanFloorMode::ONLY_MARKED }, item_tester);
     }
 
@@ -658,7 +658,7 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
         case '\n':
         case '\r':
         case '+': {
-            auto &grid = creature.current_floor_ptr->grid_array[creature.y][creature.x];
+            auto &grid = creature.get_floor()->grid_array[creature.y][creature.x];
             if (command_wrk != (USE_FLOOR)) {
                 break;
             }
@@ -669,12 +669,12 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
 
             const auto next_o_idx = fis.floor_item_index[1];
             while (grid.o_idx_list.front() != next_o_idx) {
-                grid.o_idx_list.rotate(*creature.current_floor_ptr);
+                grid.o_idx_list.rotate(*creature.get_floor());
             }
 
             rfu.set_flag(SubWindowRedrawingFlag::FLOOR_ITEMS);
             window_stuff(creature);
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             fis.floor_item_index = scan_floor_items(floor, creature.get_position(), { ScanFloorMode::ITEM_TESTER, ScanFloorMode::ONLY_MARKED }, item_tester);
             if (command_see) {
                 screen_load();
@@ -771,7 +771,7 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
                     break;
                 }
             } else {
-                const auto floor_item_idx = get_tag_floor(*creature.current_floor_ptr, fis.which, fis.floor_item_index);
+                const auto floor_item_idx = get_tag_floor(*creature.get_floor(), fis.which, fis.floor_item_index);
                 if (floor_item_idx) {
                     fis.k = -fis.floor_item_index[*floor_item_idx];
                 } else {
@@ -818,7 +818,7 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
                     fis.cur_tag = fis.which;
                 }
             } else {
-                const auto floor_item_idx = get_tag_floor(*creature.current_floor_ptr, fis.which, fis.floor_item_index);
+                const auto floor_item_idx = get_tag_floor(*creature.get_floor(), fis.which, fis.floor_item_index);
                 if (floor_item_idx) {
                     fis.k = -fis.floor_item_index[*floor_item_idx];
                     fis.cur_tag = fis.which;

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -332,7 +332,7 @@ static void curse_call_monster(CreatureEntity &creature)
 {
     const int call_type = PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET;
     const int obj_desc_type = OD_OMIT_PREFIX | OD_NAME_ONLY;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (creature.cursed.has(CurseTraitType::CALL_ANIMAL) && one_in_(2500)) {
         if (summon_specific(creature, creature.y, creature.x, floor.dun_level, SUMMON_ANIMAL, call_type)) {
             const auto item_name = describe_flavor(creature, *choose_cursed_obj_name(creature, CurseTraitType::CALL_ANIMAL), obj_desc_type);
@@ -454,9 +454,9 @@ static void curse_megaton_coin(CreatureEntity &creature)
     if (!get_player_flags(creature, TR_MEGATON_COIN)) {
         return;
     }
-    const auto &dungeon = creature.current_floor_ptr->get_dungeon_definition();
-    if (!one_in_(364) || creature.current_floor_ptr->dun_level == 0 || creature.current_floor_ptr->dun_level == dungeon.maxdepth ||
-        inside_quest(creature.current_floor_ptr->quest_number) || creature.current_floor_ptr->inside_arena) {
+    const auto &dungeon = creature.get_floor()->get_dungeon_definition();
+    if (!one_in_(364) || creature.get_floor()->dun_level == 0 || creature.get_floor()->dun_level == dungeon.maxdepth ||
+        inside_quest(creature.get_floor()->quest_number) || creature.get_floor()->inside_arena) {
         return;
     }
 
@@ -469,7 +469,7 @@ static void curse_megaton_coin(CreatureEntity &creature)
         do_cmd_save_game(creature, true);
     }
 
-    exe_write_diary(*(creature.current_floor_ptr), DiaryKind::DESCRIPTION, 0, _("メガトンコインで落ちた!", "fell through the Megaton Coin"));
+    exe_write_diary(*(creature.get_floor()), DiaryKind::DESCRIPTION, 0, _("メガトンコインで落ちた!", "fell through the Megaton Coin"));
     auto &fcms = FloorChangeModesStore::get_instace();
     fcms->set({ FloorChangeMode::SAVE_FLOORS,
         FloorChangeMode::DOWN,

--- a/src/inventory/inventory-damage.cpp
+++ b/src/inventory/inventory-damage.cpp
@@ -28,7 +28,7 @@
 void inventory_damage(CreatureEntity &creature, const ObjectBreaker &breaker, int perc)
 {
     int j, amt;
-    if (check_multishadow(creature) || creature.current_floor_ptr->inside_arena) {
+    if (check_multishadow(creature) || creature.get_floor()->inside_arena) {
         return;
     }
 

--- a/src/inventory/inventory-util.cpp
+++ b/src/inventory/inventory-util.cpp
@@ -163,7 +163,7 @@ bool get_item_allow(CreatureEntity &creature, INVENTORY_IDX i_idx)
     if (i_idx >= 0) {
         o_ptr = creature.inventory[i_idx].get();
     } else {
-        o_ptr = creature.current_floor_ptr->o_list[0 - i_idx].get();
+        o_ptr = creature.get_floor()->o_list[0 - i_idx].get();
     }
 
     if (!o_ptr->is_inscribed()) {
@@ -237,7 +237,7 @@ INVENTORY_IDX label_to_inventory(CreatureEntity &creature, int c)
  */
 bool verify(CreatureEntity &creature, concptr prompt, INVENTORY_IDX i_idx)
 {
-    const auto &item = i_idx >= 0 ? *creature.inventory[i_idx] : *creature.current_floor_ptr->o_list[0 - i_idx];
+    const auto &item = i_idx >= 0 ? *creature.inventory[i_idx] : *creature.get_floor()->o_list[0 - i_idx];
     const auto item_name = describe_flavor(creature, item, 0);
     std::stringstream ss;
     ss << prompt;

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -55,7 +55,7 @@ bool can_get_item(CreatureEntity &creature, const ItemTester &item_tester)
         }
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto floor_item_index = scan_floor_items(floor, creature.get_position(), { ScanFloorMode::ITEM_TESTER, ScanFloorMode::ONLY_MARKED }, item_tester);
     return !floor_item_index.empty();
 }
@@ -81,7 +81,7 @@ static void py_pickup_all_golds_on_floor(CreatureEntity &creature, const Grid &g
 {
     for (auto it = grid.o_idx_list.begin(); it != grid.o_idx_list.end();) {
         const auto i_idx = *it++;
-        auto &item = *creature.current_floor_ptr->o_list[i_idx];
+        auto &item = *creature.get_floor()->o_list[i_idx];
         if (item.bi_key.tval() != ItemKindType::GOLD) {
             continue;
         }
@@ -103,7 +103,7 @@ static void py_pickup_all_golds_on_floor(CreatureEntity &creature, const Grid &g
 
 static void py_pickup_single_item(CreatureEntity &creature, short i_idx, bool pickup)
 {
-    auto &item = *creature.current_floor_ptr->o_list[i_idx];
+    auto &item = *creature.get_floor()->o_list[i_idx];
     const auto item_name = describe_flavor(creature, item, 0);
 
     if (!pickup) {
@@ -128,7 +128,7 @@ static void py_pickup_single_item(CreatureEntity &creature, short i_idx, bool pi
 
 static void py_pickup_multiple_items(CreatureEntity &creature, bool pickup)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(creature.get_position());
 
     if (!pickup) {
@@ -164,9 +164,9 @@ static void py_pickup_multiple_items(CreatureEntity &creature, bool pickup)
  */
 static void py_pickup_floor(CreatureEntity &creature, bool pickup)
 {
-    const auto &o_list = creature.current_floor_ptr->o_list;
+    const auto &o_list = creature.get_floor()->o_list;
     const auto exclude_marked_as_skip = ranges::views::remove_if([&](auto i_idx) { return o_list.at(i_idx)->marked.has(OmType::SUPRESS_MESSAGE); });
-    const auto &grid = creature.current_floor_ptr->get_grid(creature.get_position());
+    const auto &grid = creature.get_floor()->get_grid(creature.get_position());
 
     const auto i_idx_list = grid.o_idx_list | exclude_marked_as_skip | ranges::to_vector;
     const auto count_of_items = i_idx_list.size();
@@ -239,7 +239,7 @@ static void print_pickup_message(CreatureEntity &creature, [[maybe_unused]] cons
 void process_player_pickup_item(CreatureEntity &creature, OBJECT_IDX o_idx)
 {
     // delete_object_idx()で配列から削除した後にも使用するためshared_ptrをコピーする
-    const std::shared_ptr<ItemEntity> picked_item_ptr = creature.current_floor_ptr->o_list[o_idx];
+    const std::shared_ptr<ItemEntity> picked_item_ptr = creature.get_floor()->o_list[o_idx];
 
     const auto slot = store_item_to_inventory(creature, picked_item_ptr.get());
     delete_object_idx(creature, o_idx);
@@ -273,7 +273,7 @@ void carry(CreatureEntity &creature, bool pickup)
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     rfu.set_flag(SubWindowRedrawingFlag::OVERHEAD);
     handle_stuff(creature);
-    const auto &grid = creature.current_floor_ptr->grid_array[creature.y][creature.x];
+    const auto &grid = creature.get_floor()->grid_array[creature.y][creature.x];
     autopick_pickup_items(creature, grid);
 
     if (!grid.o_idx_list.empty()) {
@@ -289,7 +289,7 @@ void carry(CreatureEntity &creature, bool pickup)
 
     for (auto it = grid.o_idx_list.begin(); it != grid.o_idx_list.end();) {
         const auto this_o_idx = *it++;
-        auto &item = *creature.current_floor_ptr->o_list[this_o_idx];
+        auto &item = *creature.get_floor()->o_list[this_o_idx];
         const auto item_name = describe_flavor(creature, item, 0);
 
         if (item.marked.has(OmType::SUPRESS_MESSAGE)) {

--- a/src/inventory/recharge-processor.cpp
+++ b/src/inventory/recharge-processor.cpp
@@ -115,7 +115,7 @@ void recharge_magic_items(CreatureEntity &creature)
         wild_regen = 20;
     }
 
-    for (const auto &item_ptr : creature.current_floor_ptr->o_list) {
+    for (const auto &item_ptr : creature.get_floor()->o_list) {
         if (!item_ptr->is_valid()) {
             continue;
         }

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -58,7 +58,7 @@
  */
 static void dump_aux_pet(CreatureEntity &creature, FILE *fff)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     auto pet = false;
     auto pet_settings = false;
     for (auto i = floor.m_max - 1; i >= 1; i--) {

--- a/src/io-dump/player-status-dump-json.cpp
+++ b/src/io-dump/player-status-dump-json.cpp
@@ -121,7 +121,7 @@ static void add_status_to_json(nlohmann::json &j, CreatureEntity &creature)
     j["status"]["gold"] = creature.au;
 
     // ダンジョン情報
-    j["status"]["dungeon_level"] = creature.current_floor_ptr->dun_level;
+    j["status"]["dungeon_level"] = creature.get_floor()->dun_level;
     const auto &dungeon_record = DungeonRecords::get_instance().get_record(creature.recall_dungeon);
     j["status"]["max_dungeon_level"] = dungeon_record.get_max_level();
 

--- a/src/io/cursor.cpp
+++ b/src/io/cursor.cpp
@@ -41,7 +41,7 @@ void print_path(CreatureEntity &creature, POSITION y, POSITION x)
         return;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     const auto range = project_length != 0 ? project_length : AngbandSystem::get_instance().get_max_range();
     ProjectionPath path_g(floor, range, p_pos, p_pos, pos, PROJECT_PATH | PROJECT_THRU);
@@ -94,7 +94,7 @@ bool change_panel(CreatureEntity &creature, POSITION dy, POSITION dx)
     POSITION y = panel_row_min + dy * hgt / 2;
     POSITION x = panel_col_min + dx * wid / 2;
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (y > floor.height - hgt) {
         y = floor.height - hgt;
     }

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -179,7 +179,7 @@ void process_command(CreatureEntity &creature)
 
     auto &world = AngbandWorld::get_instance();
     const auto is_wild_mode = world.is_wild_mode();
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     switch (command_cmd) {
     case ESCAPE:
     case ' ':

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -246,7 +246,7 @@ bool report_score(CreatureEntity &creature)
              << fmt::format("version: {}\n", AngbandSystem::get_instance().build_version_expression(VersionExpression::FULL))
              << fmt::format("score: {}\n", calc_score(creature))
              << fmt::format("level: {}\n", creature.level)
-             << fmt::format("depth: {}\n", creature.current_floor_ptr->dun_level)
+             << fmt::format("depth: {}\n", creature.get_floor()->dun_level)
              << fmt::format("maxlv: {}\n", creature.max_plv)
              << fmt::format("maxdp: {}\n", DungeonRecords::get_instance().get_record(DungeonId::ANGBAND).get_max_level())
              << fmt::format("au: {}\n", creature.au);

--- a/src/io/screen-util.cpp
+++ b/src/io/screen-util.cpp
@@ -48,8 +48,8 @@ void resize_map()
 
     panel_row_max = 0;
     panel_col_max = 0;
-    panel_row_min = p_ptr->current_floor_ptr->height;
-    panel_col_min = p_ptr->current_floor_ptr->width;
+    panel_row_min = p_ptr->get_floor()->height;
+    panel_col_min = p_ptr->get_floor()->width;
     verify_panel(*p_ptr);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();

--- a/src/io/signal-handlers.cpp
+++ b/src/io/signal-handlers.cpp
@@ -68,7 +68,7 @@ static void handle_signal_simple(int sig)
     }
 
     signal_count++;
-    auto &floor = *p_ptr->current_floor_ptr;
+    auto &floor = *p_ptr->get_floor();
     if (p_ptr->is_dead()) {
         p_ptr->died_from = _("強制終了", "Abortion");
         floor.forget_lite();
@@ -126,7 +126,7 @@ static void handle_signal_abort(int sig)
         quit("");
     }
 
-    auto &floor = *p_ptr->current_floor_ptr;
+    auto &floor = *p_ptr->get_floor();
     floor.forget_lite();
     floor.forget_view();
     floor.forget_mon_lite();

--- a/src/io/write-diary.cpp
+++ b/src/io/write-diary.cpp
@@ -158,7 +158,7 @@ int exe_write_diary_quest(CreatureEntity &creature, DiaryKind dk, QuestId quest_
         return -1;
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto old_quest = floor.quest_number;
     const auto &quests = QuestList::get_instance();
     const auto &quest = quests.get_quest(quest_id);

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -51,7 +51,7 @@ auto collect_known_fixed_artifacts(CreatureEntity &creature)
         fa_ids.insert(fa_id);
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (const auto &pos : floor.get_area()) {
         const auto &grid = floor.get_grid(pos);
         for (const auto this_o_idx : grid.o_idx_list) {

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -160,8 +160,8 @@ void do_cmd_knowledge_pets(CreatureEntity &creature)
     }
 
     int t_friends = 0;
-    for (int i = creature.current_floor_ptr->m_max - 1; i >= 1; i--) {
-        const auto &monster = creature.current_floor_ptr->get_monster(i);
+    for (int i = creature.get_floor()->m_max - 1; i >= 1; i--) {
+        const auto &monster = creature.get_floor()->get_monster(i);
         if (!monster.is_valid() || !monster.is_pet()) {
             continue;
         }

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -67,14 +67,14 @@ static void do_cmd_knowledge_quests_current(CreatureEntity &creature, FILE *fff)
             continue;
         }
 
-        const auto old_quest = creature.current_floor_ptr->quest_number;
+        const auto old_quest = creature.get_floor()->quest_number;
 
         quest_text_lines.clear();
 
-        creature.current_floor_ptr->quest_number = quest_id;
+        creature.get_floor()->quest_number = quest_id;
         init_flags = INIT_SHOW_TEXT;
         parse_fixed_map(creature, QUEST_DEFINITION_LIST, 0, 0, 0, 0);
-        creature.current_floor_ptr->quest_number = old_quest;
+        creature.get_floor()->quest_number = old_quest;
         if (quest.flags & QUEST_FLAG_SILENT) {
             continue;
         }
@@ -184,7 +184,7 @@ static bool do_cmd_knowledge_quests_aux(CreatureEntity &creature, FILE *fff, Que
     const auto &quests = QuestList::get_instance();
     const auto &quest = quests.get_quest(q_idx);
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto is_fixed_quest = QuestType::is_fixed(q_idx);
     if (is_fixed_quest) {
         const auto old_quest = floor.quest_number;

--- a/src/load/dungeon-loader.cpp
+++ b/src/load/dungeon-loader.cpp
@@ -25,7 +25,7 @@ static errr rd_dungeon(CreatureEntity &creature)
 {
     init_saved_floors(false);
     errr err = 0;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
 
     (void)rd_byte(); // @todo 1byteズレた場所を特定。要修正。
     max_floor_id = rd_s16b();

--- a/src/load/floor-loader.cpp
+++ b/src/load/floor-loader.cpp
@@ -46,7 +46,7 @@
  */
 errr rd_saved_floor(CreatureEntity &creature, saved_floor_type *sf_ptr)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     clear_cave(creature);
     creature.x = creature.y = 0;
 
@@ -182,7 +182,7 @@ errr rd_saved_floor(CreatureEntity &creature, saved_floor_type *sf_ptr)
 
         auto &monster = floor.m_list[m_idx];
         monster_loader->rd_monster(monster);
-        monster.current_floor_ptr = creature.current_floor_ptr;
+        monster.set_floor(creature.get_floor());
         auto &grid = floor.get_grid(monster.get_position());
         grid.m_idx = m_idx;
         monster.get_real_monrace().increment_current_numbers();

--- a/src/load/old/load-v1-7-0.cpp
+++ b/src/load/old/load-v1-7-0.cpp
@@ -13,7 +13,7 @@ void set_exp_frac_old(CreatureEntity &creature)
 
 void remove_water_cave(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.quest_number != i2enum<QuestId>(OLD_QUEST_WATER_CAVE)) {
         return;
     }

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -260,8 +260,8 @@ static void set_imitation(CreatureEntity &creature)
 static void rd_phase_out(CreatureEntity &creature)
 {
     auto &system = AngbandSystem::get_instance();
-    creature.current_floor_ptr->inside_arena = rd_s16b() != 0;
-    creature.current_floor_ptr->quest_number = i2enum<QuestId>(rd_s16b());
+    creature.get_floor()->inside_arena = rd_s16b() != 0;
+    creature.get_floor()->quest_number = i2enum<QuestId>(rd_s16b());
     system.set_phase_out(rd_s16b() != 0);
 }
 

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -85,7 +85,7 @@ static void rd_world_info(CreatureEntity &creature)
     igd.init_turn_limit();
     auto &world = AngbandWorld::get_instance();
     world.dungeon_turn_limit = TURNS_PER_TICK * TOWN_DAWN * (MAX_DAYS - 1) + TURNS_PER_TICK * TOWN_DAWN * 3 / 4;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     floor.generated_turn = rd_s32b();
     auto &df = DungeonFeeling::get_instance();
     df.set_feeling(rd_s32b());

--- a/src/lore/lore-store.cpp
+++ b/src/lore/lore-store.cpp
@@ -113,7 +113,7 @@ int lore_do_probe(CreatureEntity &creature, MonraceId r_idx)
  */
 void lore_treasure(CreatureEntity &creature, MONSTER_IDX m_idx, ITEM_NUMBER num_item, ITEM_NUMBER num_gold)
 {
-    auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    auto &monster = creature.get_floor()->get_monster(m_idx);
     auto &monrace = monster.get_monrace();
     if (!monster.is_original_ap()) {
         return;

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -1645,7 +1645,7 @@ static void process_menus(CreatureEntity &creature, WORD wCmd)
             }
 
             msg_flag = false;
-            auto &floor = *creature.current_floor_ptr;
+            auto &floor = *creature.get_floor();
             floor.forget_lite();
             floor.forget_view();
             floor.forget_mon_lite();
@@ -2441,7 +2441,7 @@ static LRESULT PASCAL angband_window_procedure(HWND hWnd, UINT uMsg, WPARAM wPar
         }
 
         msg_flag = false;
-        auto &floor = *p_ptr->current_floor_ptr;
+        auto &floor = *p_ptr->get_floor();
         floor.forget_lite();
         floor.forget_view();
         floor.forget_mon_lite();
@@ -2458,7 +2458,7 @@ static LRESULT PASCAL angband_window_procedure(HWND hWnd, UINT uMsg, WPARAM wPar
         if (p_ptr->hp < 0) {
             p_ptr->is_dead_ = false;
         }
-        exe_write_diary(*p_ptr->current_floor_ptr, DiaryKind::GAMESTART, 0, _("----ゲーム中断----", "---- Save and Exit Game ----"));
+        exe_write_diary(*p_ptr->get_floor(), DiaryKind::GAMESTART, 0, _("----ゲーム中断----", "---- Save and Exit Game ----"));
         AngbandSystem::get_instance().set_panic_save(true);
         signals_ignore_tstp();
         p_ptr->died_from = _("(緊急セーブ)", "(panic save)");

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -52,7 +52,7 @@ static void init_gf_colors()
 void init_other(CreatureEntity &creature)
 {
     auto &floor_data = FloorList::get_instance();
-    creature.current_floor_ptr = &floor_data.get_floor(0); // TODO:本当はこんなところで初期化したくない ← FloorTypeの方で初期化するべき？
+    creature.set_floor(&floor_data.get_floor(0)); // TODO:本当はこんなところで初期化したくない ← FloorTypeの方で初期化するべき？
 
     init_gf_colors();
 

--- a/src/main/scene-table-floor.cpp
+++ b/src/main/scene-table-floor.cpp
@@ -28,7 +28,7 @@ static bool scene_basic(CreatureEntity &creature, scene_type *value)
         return true;
     }
 
-    if (creature.current_floor_ptr->inside_arena) {
+    if (creature.get_floor()->inside_arena) {
         value->type = TERM_XTRA_MUSIC_BASIC;
         value->val = MUSIC_BASIC_ARENA;
         return true;
@@ -45,7 +45,7 @@ static bool scene_basic(CreatureEntity &creature, scene_type *value)
 
 static bool scene_quest(CreatureEntity &creature, scene_type *value)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto quest_id = floor.get_quest_id();
     const bool enable = (inside_quest(quest_id));
     if (enable) {
@@ -58,7 +58,7 @@ static bool scene_quest(CreatureEntity &creature, scene_type *value)
 
 static bool scene_quest_basic(CreatureEntity &creature, scene_type *value)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto quest_id = floor.get_quest_id();
     const bool enable = (inside_quest(quest_id));
     if (enable) {
@@ -71,7 +71,7 @@ static bool scene_quest_basic(CreatureEntity &creature, scene_type *value)
 
 static bool scene_town(CreatureEntity &creature, scene_type *value)
 {
-    const auto enable = !creature.current_floor_ptr->is_underground() && (creature.town_num > 0);
+    const auto enable = !creature.get_floor()->is_underground() && (creature.town_num > 0);
     if (enable) {
         value->type = TERM_XTRA_MUSIC_TOWN;
         value->val = creature.town_num;
@@ -81,7 +81,7 @@ static bool scene_town(CreatureEntity &creature, scene_type *value)
 
 static bool scene_town_basic(CreatureEntity &creature, scene_type *value)
 {
-    const auto enable = !creature.current_floor_ptr->is_underground() && (creature.town_num > 0);
+    const auto enable = !creature.get_floor()->is_underground() && (creature.town_num > 0);
     if (enable) {
         value->type = TERM_XTRA_MUSIC_BASIC;
         value->val = MUSIC_BASIC_TOWN;
@@ -91,7 +91,7 @@ static bool scene_town_basic(CreatureEntity &creature, scene_type *value)
 
 static bool scene_field(CreatureEntity &creature, scene_type *value)
 {
-    const auto enable = !creature.current_floor_ptr->is_underground();
+    const auto enable = !creature.get_floor()->is_underground();
     if (enable) {
         value->type = TERM_XTRA_MUSIC_BASIC;
 
@@ -126,7 +126,7 @@ static bool scene_dungeon_feeling(CreatureEntity & /*creature*/, scene_type *val
 
 static bool scene_dungeon(CreatureEntity &creature, scene_type *value)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto enable = floor.is_underground();
     if (enable) {
         value->type = TERM_XTRA_MUSIC_DUNGEON;
@@ -137,11 +137,11 @@ static bool scene_dungeon(CreatureEntity &creature, scene_type *value)
 
 static bool scene_dungeon_basic(CreatureEntity &creature, scene_type *value)
 {
-    const auto enable = creature.current_floor_ptr->is_underground();
+    const auto enable = creature.get_floor()->is_underground();
     if (enable) {
         value->type = TERM_XTRA_MUSIC_BASIC;
 
-        const auto dun_level = creature.current_floor_ptr->dun_level;
+        const auto dun_level = creature.get_floor()->dun_level;
         if (dun_level >= 80) {
             value->val = MUSIC_BASIC_DUN_HIGH;
         } else if (dun_level >= 40) {

--- a/src/main/scene-table-monster.cpp
+++ b/src/main/scene-table-monster.cpp
@@ -70,7 +70,7 @@ inline static bool can_mute_scene_monster()
 static bool is_high_rate(CreatureEntity &creature, MONSTER_IDX m_idx1, MONSTER_IDX m_idx2)
 {
     // FIXME 視界内モンスターリストの比較関数と同じ処理
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster1 = floor.get_monster(m_idx1);
     const auto &monster2 = floor.get_monster(m_idx2);
     auto ap_r_ptr1 = &monster1.get_appearance_monrace();
@@ -124,7 +124,7 @@ static void update_target_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
         }
 
         if (do_dwap) {
-            const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+            const auto &monster = creature.get_floor()->get_monster(m_idx);
             auto *ap_r_ptr = &monster.get_appearance_monrace();
             scene_target_monster.m_idx = m_idx;
             scene_target_monster.ap_r_ptr = ap_r_ptr;
@@ -137,7 +137,7 @@ using scene_monster_func = bool (*)(CreatureEntity &creature, scene_type *value)
 
 static bool scene_monster(CreatureEntity &creature, scene_type *value)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(scene_target_monster.m_idx);
+    const auto &monster = creature.get_floor()->get_monster(scene_target_monster.m_idx);
 
     if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::KAGE)) {
         value->type = TERM_XTRA_MUSIC_BASIC;
@@ -229,7 +229,7 @@ void refresh_scene_monster(CreatureEntity &creature, const std::vector<MONSTER_I
                 // 最後に見かけてから一定のゲームターンが経過した場合、BGM対象から外す
                 clear_scene_target_monster();
             } else {
-                const auto &monster = creature.current_floor_ptr->get_monster(scene_target_monster.m_idx);
+                const auto &monster = creature.get_floor()->get_monster(scene_target_monster.m_idx);
                 auto *ap_r_ptr = &monster.get_appearance_monrace();
                 if (ap_r_ptr != scene_target_monster.ap_r_ptr) {
                     // 死亡、チェンジモンスター、etc.

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -65,7 +65,7 @@ static bool check_battle_metal_babble(CreatureEntity &creature)
     AngbandWorld::get_instance().set_arena(false);
     reset_tim_flags(creature);
     FloorChangeModesStore::get_instace()->set(FloorChangeMode::SAVE_FLOORS);
-    creature.current_floor_ptr->inside_arena = true;
+    creature.get_floor()->inside_arena = true;
     creature.leaving = true;
     return true;
 }
@@ -103,7 +103,7 @@ static bool go_to_arena(CreatureEntity &creature)
     AngbandWorld::get_instance().set_arena(false);
     reset_tim_flags(creature);
     FloorChangeModesStore::get_instace()->set(FloorChangeMode::SAVE_FLOORS);
-    creature.current_floor_ptr->inside_arena = true;
+    creature.get_floor()->inside_arena = true;
     creature.leaving = true;
     return true;
 }

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -187,7 +187,7 @@ bool exchange_cash(CreatureEntity &creature)
             msg_format(_("これで合計 %d ポイント獲得しました。", "You earned %d point%s total."), num, (num > 1 ? "s" : ""));
 
             ItemEntity prize_item(prize_list[num - 1]);
-            ItemMagicApplier(creature, &prize_item, creature.current_floor_ptr->object_level, AM_NO_FIXED_ART).execute();
+            ItemMagicApplier(creature, &prize_item, creature.get_floor()->object_level, AM_NO_FIXED_ART).execute();
             object_aware(creature, prize_item);
             prize_item.mark_as_known();
 

--- a/src/market/building-quest.cpp
+++ b/src/market/building-quest.cpp
@@ -26,7 +26,7 @@ static void get_questinfo(CreatureEntity &creature, QuestId quest_id, bool do_in
 {
     quest_text_lines.clear();
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto old_quest = floor.quest_number;
     floor.quest_number = quest_id;
 
@@ -66,7 +66,7 @@ static void print_questinfo(CreatureEntity &creature, QuestId quest_id, bool do_
 void castle_quest(CreatureEntity &creature)
 {
     clear_bldg(4, 18);
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto quest_id = i2enum<QuestId>(floor.get_grid(creature.get_position()).special);
     if (!inside_quest(quest_id)) {
         put_str(_("今のところクエストはありません。", "I don't have a quest for you at the moment."), 8, 0);

--- a/src/melee/melee-postprocess.cpp
+++ b/src/melee/melee-postprocess.cpp
@@ -62,7 +62,7 @@ struct mam_pp_type {
 
 mam_pp_type::mam_pp_type(CreatureEntity &creature, MONSTER_IDX m_idx, int dam, bool *dead, bool *fear, std::string_view note, MONSTER_IDX src_idx)
     : m_idx(m_idx)
-    , m_ptr(&creature.current_floor_ptr->get_monster(m_idx))
+    , m_ptr(&creature.get_floor()->get_monster(m_idx))
     , dam(dam)
     , dead(dead)
     , fear(fear)
@@ -150,7 +150,7 @@ static void print_monster_dead_by_monster(CreatureEntity &creature, mam_pp_type 
 
     mam_pp_ptr->m_name = monster_desc(creature, *mam_pp_ptr->m_ptr, MD_TRUE_NAME);
     if (!mam_pp_ptr->seen) {
-        creature.current_floor_ptr->monster_noise = true;
+        creature.get_floor()->monster_noise = true;
         return;
     }
 
@@ -210,7 +210,7 @@ static void cancel_fear_by_pain(CreatureEntity &creature, mam_pp_type *mam_pp_pt
 {
     const auto &m_ref = *mam_pp_ptr->m_ptr;
     const auto dam = mam_pp_ptr->dam;
-    if (!m_ref.is_fearful() || (dam <= 0) || !set_monster_monfear(*creature.current_floor_ptr, mam_pp_ptr->m_idx, m_ref.get_remaining_fear() - randint1(dam / 4))) {
+    if (!m_ref.is_fearful() || (dam <= 0) || !set_monster_monfear(*creature.get_floor(), mam_pp_ptr->m_idx, m_ref.get_remaining_fear() - randint1(dam / 4))) {
         return;
     }
 
@@ -237,7 +237,7 @@ static void make_monster_fear(CreatureEntity &creature, mam_pp_type *mam_pp_ptr)
 
     *(mam_pp_ptr->fear) = true;
     (void)set_monster_monfear(
-        *creature.current_floor_ptr, mam_pp_ptr->m_idx, (randint1(10) + (((mam_pp_ptr->dam >= mam_pp_ptr->m_ptr->hp) && (percentage > 7)) ? 20 : ((11 - percentage) * 5))));
+        *creature.get_floor(), mam_pp_ptr->m_idx, (randint1(10) + (((mam_pp_ptr->dam >= mam_pp_ptr->m_ptr->hp) && (percentage > 7)) ? 20 : ((11 - percentage) * 5))));
 }
 
 /*!
@@ -274,12 +274,12 @@ static void fall_off_horse_by_melee(CreatureEntity &creature, mam_pp_type *mam_p
  */
 void mon_take_hit_mon(CreatureEntity &creature, MONSTER_IDX m_idx, int dam, bool *dead, bool *fear, std::string_view note, MONSTER_IDX src_idx)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(m_idx);
     mam_pp_type tmp_mam_pp(creature, m_idx, dam, dead, fear, note, src_idx);
     mam_pp_type *mam_pp_ptr = &tmp_mam_pp;
     prepare_redraw(mam_pp_ptr);
-    (void)set_monster_csleep(*creature.current_floor_ptr, m_idx, 0);
+    (void)set_monster_csleep(*creature.get_floor(), m_idx, 0);
 
     if (monster.is_riding()) {
         disturb(creature, true, true);

--- a/src/melee/melee-spell-flags-checker.cpp
+++ b/src/melee/melee-spell-flags-checker.cpp
@@ -31,7 +31,7 @@ static void decide_melee_spell_target(CreatureEntity &creature, melee_spell_type
     }
 
     ms_ptr->target_idx = creature.pet_t_m_idx;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     ms_ptr->t_ptr = &floor.get_monster(ms_ptr->target_idx);
     if ((ms_ptr->m_idx == ms_ptr->target_idx) || !projectable(floor, ms_ptr->m_ptr->get_position(), ms_ptr->t_ptr->get_position())) {
         ms_ptr->target_idx = 0;
@@ -46,7 +46,7 @@ static void decide_indirection_melee_spell(CreatureEntity &creature, melee_spell
         return;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     ms_ptr->target_idx = floor.get_grid(target_pos).m_idx;
     if (ms_ptr->target_idx == 0) {
         return;
@@ -74,7 +74,7 @@ static bool check_melee_spell_projection(CreatureEntity &creature, melee_spell_t
 
     int start;
     auto plus = 1;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (AngbandSystem::get_instance().is_phase_out()) {
         start = randint1(floor.m_max - 1) + floor.m_max;
         if (randint0(2)) {
@@ -120,7 +120,7 @@ static void check_darkness(CreatureEntity &creature, melee_spell_type *ms_ptr)
         return;
     }
 
-    if (creature.current_floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
+    if (creature.get_floor()->get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         ms_ptr->ability_flags.reset(MonsterAbilityType::DARKNESS);
         return;
     }
@@ -159,14 +159,14 @@ static void check_melee_spell_distance(CreatureEntity &creature, melee_spell_typ
         return;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     const auto m_pos = ms_ptr->m_ptr->get_position();
     const auto pos_real = get_project_point(floor, p_pos, m_pos, ms_ptr->get_position(), 0L);
     auto should_preserve = !projectable(floor, pos_real, p_pos);
     should_preserve &= ms_ptr->ability_flags.has(MonsterAbilityType::BA_LITE);
     should_preserve &= Grid::calc_distance(pos_real, p_pos) <= 4;
-    should_preserve &= los(*creature.current_floor_ptr, pos_real, p_pos);
+    should_preserve &= los(*creature.get_floor(), pos_real, p_pos);
     if (should_preserve) {
         ms_ptr->ability_flags.reset(MonsterAbilityType::BA_LITE);
         return;
@@ -202,7 +202,7 @@ static void check_melee_spell_rocket(CreatureEntity &creature, melee_spell_type 
         return;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     const auto m_pos = ms_ptr->m_ptr->get_position();
     const auto pos_real = get_project_point(floor, p_pos, m_pos, ms_ptr->get_position(), PROJECT_STOP);
@@ -344,7 +344,7 @@ static void check_smart(CreatureEntity &creature, melee_spell_type *ms_ptr)
         ms_ptr->ability_flags &= RF_ABILITY_INT_MASK;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (ms_ptr->ability_flags.has(MonsterAbilityType::TELE_LEVEL) && floor.can_teleport_level(!ms_ptr->t_ptr->is_riding() ? ms_ptr->target_idx != 0 : false)) {
         ms_ptr->ability_flags.reset(MonsterAbilityType::TELE_LEVEL);
     }
@@ -378,7 +378,7 @@ bool check_melee_spell_set(CreatureEntity &creature, melee_spell_type *ms_ptr)
     ms_ptr->x = ms_ptr->t_ptr->x;
     ms_ptr->m_ptr->reset_target();
     ms_ptr->ability_flags.reset({ MonsterAbilityType::WORLD, MonsterAbilityType::TRAPS, MonsterAbilityType::FORGET });
-    if (ms_ptr->ability_flags.has(MonsterAbilityType::BR_LITE) && !los(*creature.current_floor_ptr, ms_ptr->m_ptr->get_position(), ms_ptr->t_ptr->get_position())) {
+    if (ms_ptr->ability_flags.has(MonsterAbilityType::BR_LITE) && !los(*creature.get_floor(), ms_ptr->m_ptr->get_position(), ms_ptr->t_ptr->get_position())) {
         ms_ptr->ability_flags.reset(MonsterAbilityType::BR_LITE);
     }
 
@@ -388,7 +388,7 @@ bool check_melee_spell_set(CreatureEntity &creature, melee_spell_type *ms_ptr)
 
     check_darkness(creature, ms_ptr);
     check_stupid(ms_ptr);
-    check_arena(*creature.current_floor_ptr, ms_ptr);
+    check_arena(*creature.get_floor(), ms_ptr);
     if (AngbandSystem::get_instance().is_phase_out() && !one_in_(3)) {
         ms_ptr->ability_flags.reset(MonsterAbilityType::HEAL);
     }

--- a/src/melee/melee-spell-util.cpp
+++ b/src/melee/melee-spell-util.cpp
@@ -12,7 +12,7 @@ melee_spell_type::melee_spell_type(CreatureEntity &creature, MONSTER_IDX m_idx)
     : m_idx(m_idx)
     , thrown_spell(MonsterAbilityType::MAX)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     this->m_ptr = &floor.get_monster(m_idx);
     this->t_ptr = nullptr;
     this->r_ptr = &this->m_ptr->get_monrace();

--- a/src/melee/melee-spell.cpp
+++ b/src/melee/melee-spell.cpp
@@ -128,7 +128,7 @@ bool monst_spell_monst(CreatureEntity &creature, MONSTER_IDX m_idx)
     ms_ptr->dam = res.dam;
     process_special_melee_spell(creature, ms_ptr);
     process_rememberance(ms_ptr);
-    if (creature.is_dead() && (ms_ptr->r_ptr->r_deaths < MAX_SHORT) && !creature.current_floor_ptr->inside_arena) {
+    if (creature.is_dead() && (ms_ptr->r_ptr->r_deaths < MAX_SHORT) && !creature.get_floor()->inside_arena) {
         ms_ptr->r_ptr->r_deaths++;
     }
 

--- a/src/melee/melee-util.cpp
+++ b/src/melee/melee-util.cpp
@@ -13,8 +13,8 @@ mam_type *initialize_mam_type(CreatureEntity &creature, mam_type *mam_ptr, MONST
     mam_ptr->attribute = BlowEffectType::NONE;
     mam_ptr->m_idx = m_idx;
     mam_ptr->t_idx = t_idx;
-    mam_ptr->m_ptr = &creature.current_floor_ptr->get_monster(m_idx);
-    mam_ptr->t_ptr = &creature.current_floor_ptr->get_monster(t_idx);
+    mam_ptr->m_ptr = &creature.get_floor()->get_monster(m_idx);
+    mam_ptr->t_ptr = &creature.get_floor()->get_monster(t_idx);
     mam_ptr->damage = 0;
     if (creature.is_player()) {
         mam_ptr->see_m = is_seen(creature, *mam_ptr->m_ptr);

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -169,7 +169,7 @@ static bool check_same_monster(CreatureEntity &creature, mam_type *mam_ptr)
         return false;
     }
 
-    if (creature.current_floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE)) {
+    if (creature.get_floor()->get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE)) {
         return false;
     }
 
@@ -239,11 +239,11 @@ static void process_melee(CreatureEntity &creature, mam_type *mam_ptr)
 {
     const auto remaining_stun = mam_ptr->m_ptr->get_remaining_stun();
     if (mam_ptr->effect != RaceBlowEffectType::NONE && !check_hit_from_monster_to_monster(mam_ptr->power, mam_ptr->rlev, mam_ptr->ac, remaining_stun)) {
-        describe_monster_missed_monster(*creature.current_floor_ptr, mam_ptr);
+        describe_monster_missed_monster(*creature.get_floor(), mam_ptr);
         return;
     }
 
-    (void)set_monster_csleep(*creature.current_floor_ptr, mam_ptr->t_idx, 0);
+    (void)set_monster_csleep(*creature.get_floor(), mam_ptr->t_idx, 0);
     redraw_health_bar(mam_ptr);
     describe_melee_method(mam_ptr);
     describe_silly_melee(mam_ptr);
@@ -262,7 +262,7 @@ static void thief_runaway_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
             if (mam_ptr->see_m) {
                 msg_print(_("泥棒は笑って逃げ...ようとしたがバリアに防がれた。", "The thief flees laughing...? But a magic barrier obstructs it."));
             } else if (mam_ptr->known) {
-                creature.current_floor_ptr->monster_noise = true;
+                creature.get_floor()->monster_noise = true;
             }
             return;
         }
@@ -270,7 +270,7 @@ static void thief_runaway_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
     if (mam_ptr->see_m) {
         msg_print(_("泥棒は笑って逃げた！", "The thief flees laughing!"));
     } else if (mam_ptr->known) {
-        creature.current_floor_ptr->monster_noise = true;
+        creature.get_floor()->monster_noise = true;
     }
 
     teleport_away(creature, mam_ptr->m_idx, MAX_PLAYER_SIGHT * 2 + 5, TELEPORT_SPONTANEOUS);
@@ -287,7 +287,7 @@ static void explode_monster_by_melee(CreatureEntity &creature, mam_type *mam_ptr
     }
 
     sound(SoundKind::EXPLODE);
-    (void)set_monster_invulner(*creature.current_floor_ptr, mam_ptr->m_idx, 0, false);
+    (void)set_monster_invulner(*creature.get_floor(), mam_ptr->m_idx, 0, false);
     mon_take_hit_mon(creature, mam_ptr->m_idx, mam_ptr->m_ptr->hp + 1, &mam_ptr->dead, &mam_ptr->fear,
         _("は爆発して粉々になった。", " explodes into tiny shreds."), mam_ptr->m_idx);
     mam_ptr->blinked = false;
@@ -359,7 +359,7 @@ bool monst_attack_monst(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX
     angband_strcpy(mam_ptr->m_name, monster_desc(creature, *mam_ptr->m_ptr, 0), sizeof(mam_ptr->m_name));
     angband_strcpy(mam_ptr->t_name, monster_desc(creature, *mam_ptr->t_ptr, 0), sizeof(mam_ptr->t_name));
     if (!mam_ptr->see_either && mam_ptr->known) {
-        creature.current_floor_ptr->monster_noise = true;
+        creature.get_floor()->monster_noise = true;
     }
 
     if (creature.is_player() && mam_ptr->m_ptr->is_riding()) {

--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -109,7 +109,7 @@ bool create_ammo(CreatureEntity &creature)
         }
 
         const auto pos = creature.get_neighbor(dir);
-        const auto &grid = creature.current_floor_ptr->get_grid(pos);
+        const auto &grid = creature.get_floor()->get_grid(pos);
         if (grid.get_terrain(TerrainKind::MIMIC).flags.has_not(TerrainCharacteristics::CAN_DIG)) {
             msg_print(_("そこには岩石がない。", "You need a pile of rubble."));
             return false;

--- a/src/mind/mind-berserker.cpp
+++ b/src/mind/mind-berserker.cpp
@@ -40,7 +40,7 @@ bool cast_berserk_spell(CreatureEntity &creature, MindBerserkerType spell)
         }
 
         const auto pos = creature.get_neighbor(dir);
-        const auto &floor = *creature.current_floor_ptr;
+        const auto &floor = *creature.get_floor();
         const auto &grid = floor.get_grid(pos);
         if (!grid.has_monster()) {
             msg_print(_("その方向にはモンスターはいません。", "There is no monster."));

--- a/src/mind/mind-cavalry.cpp
+++ b/src/mind/mind-cavalry.cpp
@@ -34,7 +34,7 @@ bool rodeo(CreatureEntity &creature)
         return true;
     }
 
-    auto &monster = creature.current_floor_ptr->get_monster(creature.riding);
+    auto &monster = creature.get_floor()->get_monster(creature.riding);
     const auto &monrace = monster.get_monrace();
     const auto m_name = monster_desc(creature, monster, 0);
     msg_format(_("%sに乗った。", "You ride on %s."), m_name.data());
@@ -52,7 +52,7 @@ bool rodeo(CreatureEntity &creature)
         rlev = 60 + (rlev - 60) / 2;
     }
     if ((randint1(creature.skill_exp[PlayerSkillKindType::RIDING] / 120 + creature.level * 2 / 3) > rlev) && one_in_(2) &&
-        !creature.current_floor_ptr->inside_arena && !AngbandSystem::get_instance().is_phase_out() && monrace.misc_flags.has_not(MonsterMiscType::GUARDIAN) && monrace.misc_flags.has_not(MonsterMiscType::QUESTOR) &&
+        !creature.get_floor()->inside_arena && !AngbandSystem::get_instance().is_phase_out() && monrace.misc_flags.has_not(MonsterMiscType::GUARDIAN) && monrace.misc_flags.has_not(MonsterMiscType::QUESTOR) &&
         (rlev < creature.level * 3 / 2 + randint0(creature.level / 5))) {
         msg_format(_("%sを手なずけた。", "You tame %s."), m_name.data());
         set_pet(creature, monster);

--- a/src/mind/mind-chaos-warrior.cpp
+++ b/src/mind/mind-chaos-warrior.cpp
@@ -69,8 +69,8 @@ void acquire_chaos_weapon(CreatureEntity &creature)
     const auto sval = rand_choice(candidates);
 
     ItemEntity item({ ItemKindType::SWORD, sval });
-    item.to_h = 3 + randint1(creature.current_floor_ptr->dun_level) % 10;
-    item.to_d = 3 + randint1(creature.current_floor_ptr->dun_level) % 10;
+    item.to_h = 3 + randint1(creature.get_floor()->dun_level) % 10;
+    item.to_d = 3 + randint1(creature.get_floor()->dun_level) % 10;
     one_resistance(&item);
     item.ego_idx = EgoType::CHAOTIC;
     (void)drop_near(creature, item, creature.get_position());

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -439,7 +439,7 @@ static std::string get_element_effect_info(CreatureEntity &creature, int spell_i
  */
 static bool cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto spell = i2enum<ElementSpells>(spell_idx);
     const auto &power = element_powers.at(spell);
     const auto plev = creature.level;
@@ -1435,7 +1435,7 @@ static bool door_to_darkness(CreatureEntity &creature, int distance)
 {
     const auto p_pos_orig = creature.get_position();
     auto p_pos = tl::make_optional(creature.get_position());
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (auto i = 0; i < 3; i++) {
         p_pos = point_target(creature);
         if (!p_pos) {
@@ -1503,8 +1503,8 @@ bool switch_element_execution(CreatureEntity &creature)
         (void)earthquake(creature, creature.get_position(), 10);
         return true;
     case ElementRealmType::DEATH:
-        if (creature.current_floor_ptr->num_repro <= MAX_REPRODUCTION) {
-            creature.current_floor_ptr->num_repro += MAX_REPRODUCTION;
+        if (creature.get_floor()->num_repro <= MAX_REPRODUCTION) {
+            creature.get_floor()->num_repro += MAX_REPRODUCTION;
         }
 
         return true;

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -209,7 +209,7 @@ bool shock_power(CreatureEntity &creature)
     PLAYER_LEVEL plev = creature.level;
     const auto dam = Dice::roll(8 + ((plev - 5) / 4) + boost / 12, 8);
     fire_beam(creature, AttributeType::MISSILE, dir, dam);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(pos);
     if (!grid.has_monster()) {
         return true;
@@ -337,7 +337,7 @@ bool cast_force_spell(CreatureEntity &creature, MindForceTrainerType spell)
             return false;
         }
 
-        const auto &floor = *creature.current_floor_ptr;
+        const auto &floor = *creature.get_floor();
         const auto &grid = floor.get_grid(*pos);
         const auto m_idx = grid.m_idx;
         const auto p_pos = creature.get_position();

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -79,7 +79,7 @@ bool binding_field(CreatureEntity &creature, int dam)
     monster_target_x = creature.x;
 
     const auto max_range = AngbandSystem::get_instance().get_max_range();
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     for (const auto &pos : floor.get_area()) {
         const auto &grid = floor.get_grid(pos);
@@ -360,7 +360,7 @@ bool cast_mirror_spell(CreatureEntity &creature, MindMirrorMasterType spell)
     PLAYER_LEVEL plev = creature.level;
     int tmp;
     TIME_EFFECT t;
-    const auto &grid = creature.current_floor_ptr->grid_array[creature.y][creature.x];
+    const auto &grid = creature.get_floor()->grid_array[creature.y][creature.x];
     switch (spell) {
     case MindMirrorMasterType::MIRROR_SEEING:
         tmp = grid.is_mirror() ? 4 : 0;
@@ -381,7 +381,7 @@ bool cast_mirror_spell(CreatureEntity &creature, MindMirrorMasterType spell)
         }
         break;
     case MindMirrorMasterType::MAKE_MIRROR:
-        if (number_of_mirrors(*creature.current_floor_ptr) < 4 + plev / 10) {
+        if (number_of_mirrors(*creature.get_floor()) < 4 + plev / 10) {
             const auto error = SpellsMirrorMaster(creature).place_mirror();
             if (error) {
                 msg_print(*error);
@@ -436,8 +436,8 @@ bool cast_mirror_spell(CreatureEntity &creature, MindMirrorMasterType spell)
         break;
     }
     case MindMirrorMasterType::SLEEPING_MIRROR:
-        for (const auto &pos : creature.current_floor_ptr->get_area()) {
-            if (creature.current_floor_ptr->get_grid(pos).is_mirror()) {
+        for (const auto &pos : creature.get_floor()->get_area()) {
+            if (creature.get_floor()->get_grid(pos).is_mirror()) {
                 project(creature, 0, 2, pos.y, pos.x, (int)plev, AttributeType::OLD_SLEEP,
                     (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI));
             }

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -130,7 +130,7 @@ bool rush_attack(CreatureEntity &creature, bool *mdeath)
     const auto pos_target = dir.get_target_position(p_pos, project_length);
 
     auto tm_idx = 0;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.contains(pos_target, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
         tm_idx = floor.get_grid(pos_target).m_idx;
     }
@@ -285,7 +285,7 @@ bool hayagake(CreatureEntity &creature)
         return true;
     }
 
-    const auto &grid = creature.current_floor_ptr->get_grid(creature.get_position());
+    const auto &grid = creature.get_floor()->get_grid(creature.get_position());
     const auto &terrain = grid.get_terrain();
     if (terrain.flags.has_not(TerrainCharacteristics::PROJECTION) || (!player_ptr->levitation && terrain.flags.has(TerrainCharacteristics::DEEP))) {
         msg_print(_("ここでは素早く動けない。", "You cannot run in here."));
@@ -316,7 +316,7 @@ bool set_superstealth(CreatureEntity &creature, bool set)
 
     if (set) {
         if (!ninja_data->s_stealth) {
-            if (creature.current_floor_ptr->grid_array[creature.y][creature.x].info & CAVE_MNLT) {
+            if (creature.get_floor()->grid_array[creature.y][creature.x].info & CAVE_MNLT) {
                 msg_print(_("敵の目から薄い影の中に覆い隠された。", "You are mantled in weak shadow from ordinary eyes."));
                 player_ptr->monlite = player_ptr->old_monlite = true;
             } else {
@@ -492,7 +492,7 @@ bool cast_ninja_spell(CreatureEntity &creature, MindNinjaType spell)
             auto attempts = 1000;
             Pos2D pos(0, 0);
             while (attempts--) {
-                pos = scatter(*creature.current_floor_ptr, creature.get_position(), 4, PROJECT_NONE);
+                pos = scatter(*creature.get_floor(), creature.get_position(), 4, PROJECT_NONE);
                 if (!creature.is_located_at(pos)) {
                     break;
                 }

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -513,7 +513,7 @@ void mineuchi(CreatureEntity &creature, player_attack_type *pa_ptr)
         msg_format(_("%s はもうろうとした。", "%s is dazed."), pa_ptr->m_name);
     }
 
-    (void)set_monster_stunned(*creature.current_floor_ptr, pa_ptr->g_ptr->m_idx, pa_ptr->m_ptr->get_remaining_stun() + tmp);
+    (void)set_monster_stunned(*creature.get_floor(), pa_ptr->g_ptr->m_idx, pa_ptr->m_ptr->get_remaining_stun() + tmp);
 }
 
 /*!

--- a/src/mind/mind-warrior.cpp
+++ b/src/mind/mind-warrior.cpp
@@ -21,7 +21,7 @@ bool hit_and_away(CreatureEntity &creature)
     }
 
     const auto pos = creature.get_neighbor(dir);
-    if (creature.current_floor_ptr->get_grid(pos).has_monster()) {
+    if (creature.get_floor()->get_grid(pos).has_monster()) {
         do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
         if (randint0(creature.skill_dis) < 7) {
             msg_print(_("うまく逃げられなかった。", "You failed to run away."));
@@ -46,7 +46,7 @@ bool sword_dancing(CreatureEntity &creature)
     for (auto i = 0; i < 6; i++) {
         const auto d = rand_choice(Direction::directions_8());
         const auto pos = creature.get_neighbor(d);
-        const auto &grid = creature.current_floor_ptr->get_grid(pos);
+        const auto &grid = creature.get_floor()->get_grid(pos);
         if (grid.has_monster()) {
             do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
         } else {

--- a/src/mind/monk-attack.cpp
+++ b/src/mind/monk-attack.cpp
@@ -229,7 +229,7 @@ static void print_stun_effect(CreatureEntity &creature, player_attack_type *pa_p
     const auto &monrace = pa_ptr->m_ptr->get_monrace();
     if (stun_effect && ((pa_ptr->attack_damage + creature.to_d[pa_ptr->hand]) < pa_ptr->m_ptr->hp)) {
         if (creature.level > randint1(monrace.level + resist_stun + 10)) {
-            if (set_monster_stunned(*creature.current_floor_ptr, pa_ptr->g_ptr->m_idx, stun_effect + pa_ptr->m_ptr->get_remaining_stun())) {
+            if (set_monster_stunned(*creature.get_floor(), pa_ptr->g_ptr->m_idx, stun_effect + pa_ptr->m_ptr->get_remaining_stun())) {
                 msg_format(_("%s^はフラフラになった。", "%s^ is stunned."), pa_ptr->m_name);
             } else {
                 msg_format(_("%s^はさらにフラフラになった。", "%s^ is more stunned."), pa_ptr->m_name);
@@ -275,7 +275,7 @@ bool double_attack(CreatureEntity &creature)
     }
 
     const auto pos = creature.get_neighbor(dir);
-    const auto &grid = creature.current_floor_ptr->get_grid(pos);
+    const auto &grid = creature.get_floor()->get_grid(pos);
     const auto has_monster = grid.has_monster();
     if (!has_monster) {
         msg_print(_("その方向にはモンスターはいません。", "You don't see any monster in this direction"));

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -65,7 +65,7 @@
  */
 MonsterAttackPlayer::MonsterAttackPlayer(CreatureEntity &creature, short m_idx)
     : m_idx(m_idx)
-    , m_ptr(&creature.current_floor_ptr->get_monster(m_idx))
+    , m_ptr(&creature.get_floor()->get_monster(m_idx))
     , method(RaceBlowMethodType::NONE)
     , effect(RaceBlowEffectType::NONE)
     , do_silly_attack(one_in_(2) && creature.effects()->hallucination().is_hallucinated())
@@ -130,7 +130,7 @@ bool MonsterAttackPlayer::check_no_blow()
         return false;
     }
 
-    if (creature.current_floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE)) {
+    if (creature.get_floor()->get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE)) {
         return false;
     }
 
@@ -554,7 +554,7 @@ void MonsterAttackPlayer::postprocess_monster_blows()
     musou_counterattack(creature, this);
     this->process_thief_teleport(spell_hex);
     auto &monrace = this->m_ptr->get_monrace();
-    if (creature.is_dead() && (monrace.r_deaths < MAX_SHORT) && !creature.current_floor_ptr->inside_arena) {
+    if (creature.is_dead() && (monrace.r_deaths < MAX_SHORT) && !creature.get_floor()->inside_arena) {
         monrace.r_deaths++;
     }
 
@@ -596,7 +596,7 @@ void MonsterAttackPlayer::process_sadist_reaction()
 
     // プレイヤーにダメージを与えた場合の興奮状態
     if (this->damage > 0 && one_in_(4)) {
-        (void)set_monster_monfear(*creature.current_floor_ptr, this->m_idx, 0);
+        (void)set_monster_monfear(*creature.get_floor(), this->m_idx, 0);
 
         // 一時的な攻撃力上昇（怒り状態付与）
         this->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::ANGER);

--- a/src/monster-attack/monster-attack-processor.cpp
+++ b/src/monster-attack/monster-attack-processor.cpp
@@ -30,7 +30,7 @@
  */
 void exe_monster_attack_to_player(CreatureEntity &creature, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx, const Pos2D &pos)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     auto &monrace = monster.get_monrace();
     if (!turn_flags_ptr->do_move || !creature.is_located_at(pos)) {
@@ -72,10 +72,10 @@ void exe_monster_attack_to_player(CreatureEntity &creature, turn_flags *turn_fla
  */
 static bool exe_monster_attack_to_monster(CreatureEntity &creature, MONSTER_IDX m_idx, const Grid &grid)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     auto &monrace = monster.get_monrace();
-    const auto &monster_target = creature.current_floor_ptr->get_monster(grid.m_idx);
+    const auto &monster_target = creature.get_floor()->get_monster(grid.m_idx);
     if (monrace.behavior_flags.has(MonsterBehaviorType::NEVER_BLOW)) {
         return false;
     }
@@ -123,9 +123,9 @@ bool process_monster_attack_to_monster(CreatureEntity &creature, turn_flags *tur
     }
 
     turn_flags_ptr->do_move = false;
-    const auto &monster_from = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster_from = creature.get_floor()->get_monster(m_idx);
     const auto &monrace_from = monster_from.get_monrace();
-    const auto &monster_to = creature.current_floor_ptr->get_monster(grid.m_idx);
+    const auto &monster_to = creature.get_floor()->get_monster(grid.m_idx);
     const auto &monrace_to = monster_to.get_monrace();
     auto do_kill_body = monrace_from.behavior_flags.has(MonsterBehaviorType::KILL_BODY) && monrace_from.behavior_flags.has_not(MonsterBehaviorType::NEVER_BLOW);
     do_kill_body &= (monrace_from.mexp * monrace_from.level > monrace_to.mexp * monrace_to.level);
@@ -142,11 +142,11 @@ bool process_monster_attack_to_monster(CreatureEntity &creature, turn_flags *tur
     do_move_body &= (monrace_from.mexp > monrace_to.mexp);
     do_move_body &= can_cross;
     do_move_body &= !monster_to.is_riding();
-    do_move_body &= monster_can_cross_terrain(&creature, creature.current_floor_ptr->grid_array[monster_from.y][monster_from.x].feat, monrace_to, 0);
+    do_move_body &= monster_can_cross_terrain(&creature, creature.get_floor()->grid_array[monster_from.y][monster_from.x].feat, monrace_to, 0);
     if (do_move_body) {
         turn_flags_ptr->do_move = true;
         turn_flags_ptr->did_move_body = true;
-        (void)set_monster_csleep(*creature.current_floor_ptr, grid.m_idx, 0);
+        (void)set_monster_csleep(*creature.get_floor(), grid.m_idx, 0);
     }
 
     return false;

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -563,7 +563,7 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
         }
         if (one_in_(250)) {
             monap_ptr->obvious = true;
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             if (floor.is_underground() && (!floor.is_in_quest() || !QuestType::is_fixed(floor.quest_number))) {
                 if (monap_ptr->damage > 23 || monap_ptr->explode) {
                     msg_print(_("カオスの力でダンジョンが崩れ始める！", "The dungeon tumbles by the chaotic power!"));

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -108,7 +108,7 @@ static void move_item_to_monster(CreatureEntity &creature, MonsterAttackPlayer *
         return;
     }
 
-    auto &item = *creature.current_floor_ptr->o_list[o_idx];
+    auto &item = *creature.get_floor()->o_list[o_idx];
     item = monap_ptr->o_ptr->clone();
     item.number = 1;
     if (monap_ptr->o_ptr->is_wand_rod()) {
@@ -118,7 +118,7 @@ static void move_item_to_monster(CreatureEntity &creature, MonsterAttackPlayer *
 
     item.marked.clear().set(OmType::TOUCHED);
     item.held_m_idx = monap_ptr->m_idx;
-    monap_ptr->m_ptr->get_monster_profile().hold_o_idx_list.add(*creature.current_floor_ptr, o_idx);
+    monap_ptr->m_ptr->get_monster_profile().hold_o_idx_list.add(*creature.get_floor(), o_idx);
 }
 
 /*!
@@ -147,7 +147,7 @@ void process_eat_item(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
         msg_format("%sour %s (%c) was stolen!", ((monap_ptr->o_ptr->number > 1) ? "One of y" : "Y"), item_name.data(), index_to_label(i_idx));
 #endif
         chg_virtue(creature, Virtue::SACRIFICE, 1);
-        const auto item_idx = creature.current_floor_ptr->pop_empty_index_item();
+        const auto item_idx = creature.get_floor()->pop_empty_index_item();
         move_item_to_monster(creature, monap_ptr, item_idx);
         inven_item_increase(creature, i_idx, -1);
         inven_item_optimize(creature, i_idx);

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -61,7 +61,7 @@ static void write_pet_death(CreatureEntity &creature, MonsterDeath *md_ptr)
     md_ptr->md_x = md_ptr->m_ptr->x;
     if (record_named_pet && md_ptr->m_ptr->is_named_pet()) {
         const auto m_name = monster_desc(creature, *md_ptr->m_ptr, MD_INDEF_VISIBLE);
-        exe_write_diary(*creature.current_floor_ptr, DiaryKind::NAMED_PET, 3, m_name);
+        exe_write_diary(*creature.get_floor(), DiaryKind::NAMED_PET, 3, m_name);
     }
 }
 
@@ -82,7 +82,7 @@ static void on_dead_explosion(CreatureEntity &creature, MonsterDeath *md_ptr)
 
 static void on_defeat_arena_monster(CreatureEntity &creature, MonsterDeath *md_ptr)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!floor.inside_arena || md_ptr->m_ptr->is_pet()) {
         return;
     }
@@ -118,7 +118,7 @@ static void on_defeat_arena_monster(CreatureEntity &creature, MonsterDeath *md_p
 
 static void drop_corpse(CreatureEntity &creature, MonsterDeath *md_ptr)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     auto is_drop_corpse = one_in_(md_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? 1 : 4);
     is_drop_corpse &= md_ptr->r_ptr->drop_flags.has_any_of({ MonsterDropType::DROP_CORPSE, MonsterDropType::DROP_SKELETON, MonsterDropType::DROP_JUNK });
     is_drop_corpse &= !(floor.inside_arena || AngbandSystem::get_instance().is_phase_out() || md_ptr->cloned || ((md_ptr->m_ptr->r_idx == AngbandWorld::get_instance().today_mon) && md_ptr->m_ptr->is_pet()));
@@ -207,7 +207,7 @@ bool drop_single_artifact(CreatureEntity &creature, MonsterDeath *md_ptr, FixedA
 
 static tl::optional<short> drop_dungeon_final_artifact(CreatureEntity &creature, MonsterDeath *md_ptr)
 {
-    const auto &dungeon = creature.current_floor_ptr->get_dungeon_definition();
+    const auto &dungeon = creature.get_floor()->get_dungeon_definition();
     const auto has_reward = dungeon.final_object > 0;
     const auto bi_id = has_reward ? dungeon.final_object : BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::SCROLL, SV_SCROLL_ACQUIREMENT });
     if (dungeon.final_artifact == FixedArtifactId::NONE) {
@@ -231,7 +231,7 @@ static void drop_artifacts(CreatureEntity &creature, MonsterDeath *md_ptr)
     }
 
     drop_artifact_from_unique(creature, md_ptr);
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_dungeon_definition();
     if (md_ptr->r_ptr->misc_flags.has_not(MonsterMiscType::GUARDIAN) || (dungeon.final_guardian != md_ptr->m_ptr->r_idx)) {
         return;
@@ -295,7 +295,7 @@ static int decide_drop_numbers(CreatureEntity &creature, MonsterDeath *md_ptr, c
     }
 
     // クローンは、クローン地獄内のユニークモンスター以外はドロップしない
-    if (md_ptr->cloned && !(md_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) && (creature.current_floor_ptr->quest_number == QuestId::CLONE))) {
+    if (md_ptr->cloned && !(md_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) && (creature.get_floor()->quest_number == QuestId::CLONE))) {
         drop_numbers = 0;
     }
 
@@ -318,7 +318,7 @@ static void drop_items_golds(CreatureEntity &creature, MonsterDeath *md_ptr, int
 {
     auto dump_item = 0;
     auto dump_gold = 0;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &monraces = MonraceList::get_instance();
     for (auto i = 0; i < drop_numbers; i++) {
         if (md_ptr->do_gold && (!md_ptr->do_item || one_in_(2))) {
@@ -354,7 +354,7 @@ static void on_defeat_last_boss(CreatureEntity &creature)
     world.add_winner_class(creature.pclass);
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TITLE);
     play_music(TERM_XTRA_MUSIC_BASIC, MUSIC_BASIC_FINAL_QUEST_CLEAR);
-    exe_write_diary(*creature.current_floor_ptr, DiaryKind::DESCRIPTION, 0, _("見事に馬鹿馬鹿蛮怒の勝利者となった！", "finally became *WINNER* of Bakabakaband!"));
+    exe_write_diary(*creature.get_floor(), DiaryKind::DESCRIPTION, 0, _("見事に馬鹿馬鹿蛮怒の勝利者となった！", "finally became *WINNER* of Bakabakaband!"));
     patron_list[creature.patron].admire(creature);
     msg_print(_("*** おめでとう ***", "*** CONGRATULATIONS ***"));
     msg_print(_("あなたはゲームをコンプリートしました。", "You have won the game!"));
@@ -395,7 +395,7 @@ void monster_death(CreatureEntity &creature, MONSTER_IDX m_idx, bool drop_item, 
  */
 void monster_death(CreatureEntity &creature, MONSTER_IDX m_idx, bool drop_item, AttributeFlags attribute_flags)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
 
     MonsterDeath md(floor, m_idx, drop_item);
     auto &world = AngbandWorld::get_instance();

--- a/src/monster-floor/monster-direction.cpp
+++ b/src/monster-floor/monster-direction.cpp
@@ -59,7 +59,7 @@ static bool decide_pet_approch_direction(CreatureEntity &creature, const Creatur
  */
 static void decide_enemy_approch_direction(CreatureEntity &creature, MONSTER_IDX m_idx, int start, int plus, POSITION *y, POSITION *x)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &monster_from = floor.get_monster(m_idx);
     const auto &monrace = monster_from.get_monrace();
     for (int i = start; ((i < start + floor.m_max) && (i > start - floor.m_max)); i += plus) {
@@ -112,7 +112,7 @@ static void decide_enemy_approch_direction(CreatureEntity &creature, MONSTER_IDX
  */
 static tl::optional<MonsterMovementDirectionList> get_enemy_dir(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
 
     POSITION x = 0, y = 0;
@@ -191,7 +191,7 @@ static bool random_walk(CreatureEntity &creature, const CreatureEntity &monster)
  */
 static tl::optional<MonsterMovementDirectionList> decide_pet_movement_direction(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     if (!monster.is_pet()) {
         return tl::nullopt;
     }
@@ -229,7 +229,7 @@ static tl::optional<MonsterMovementDirectionList> decide_pet_movement_direction(
  */
 tl::optional<MonsterMovementDirectionList> decide_monster_movement_direction(CreatureEntity &creature, MONSTER_IDX m_idx, bool aware)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
 
     if (monster.is_confused() || !aware) {

--- a/src/monster-floor/monster-generator.cpp
+++ b/src/monster-floor/monster-generator.cpp
@@ -125,7 +125,7 @@ tl::optional<Pos2D> mon_scatter(CreatureEntity &creature, MonraceId monrace_id, 
  */
 tl::optional<MONSTER_IDX> multiply_monster(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId r_idx, bool clone, BIT_FLAGS mode)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(m_idx);
     const auto pos = mon_scatter(creature, monster.r_idx, monster.get_position(), 1);
     if (!pos) {
@@ -158,7 +158,7 @@ tl::optional<MONSTER_IDX> multiply_monster(CreatureEntity &creature, MONSTER_IDX
 static void place_monster_group(CreatureEntity &creature, const Pos2D &pos_center, MonraceId monrace_id, BIT_FLAGS mode, tl::optional<MONSTER_IDX> summoner_m_idx)
 {
     const auto &monrace = MonraceList::get_instance().get_monrace(monrace_id);
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto floor_level = floor.dun_level;
     auto extra = 0;
     if (monrace.level > floor_level) {
@@ -217,7 +217,7 @@ static void place_monster_group(CreatureEntity &creature, const Pos2D &pos_cente
 tl::optional<MONSTER_IDX> place_specific_monster(CreatureEntity &creature, POSITION y, POSITION x, MonraceId r_idx, BIT_FLAGS mode, tl::optional<MONSTER_IDX> summoner_m_idx)
 {
     const Pos2D pos(y, x);
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monrace = MonraceList::get_instance().get_monrace(r_idx);
     if (!(mode & PM_NO_KAGE) && one_in_(333)) {
         mode |= PM_KAGE;
@@ -270,7 +270,7 @@ tl::optional<MONSTER_IDX> place_specific_monster(CreatureEntity &creature, POSIT
             continue;
         }
 
-        get_mon_num_prep_escort(creature, r_idx, *m_idx, creature.current_floor_ptr->get_monrace_hook_terrain_at(pos_neighbor));
+        get_mon_num_prep_escort(creature, r_idx, *m_idx, creature.get_floor()->get_monrace_hook_terrain_at(pos_neighbor));
         const auto monrace_id = get_mon_num(creature, 0, monrace.level, 0);
         if (!MonraceList::is_valid(monrace_id)) {
             break;
@@ -295,7 +295,7 @@ tl::optional<MONSTER_IDX> place_specific_monster(CreatureEntity &creature, POSIT
 tl::optional<MONSTER_IDX> place_random_monster(CreatureEntity &creature, POSITION y, POSITION x, BIT_FLAGS mode)
 {
     const Pos2D pos(y, x);
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     get_mon_num_prep_enum(creature, floor.get_monrace_hook(), floor.get_monrace_hook_terrain_at(pos));
     const auto &monraces = MonraceList::get_instance();
     MonraceId monrace_id;
@@ -319,7 +319,7 @@ tl::optional<MONSTER_IDX> place_random_monster(CreatureEntity &creature, POSITIO
 
 static tl::optional<MonraceId> select_horde_leader_r_idx(CreatureEntity &creature)
 {
-    const auto *floor_ptr = creature.current_floor_ptr;
+    const auto *floor_ptr = creature.get_floor();
 
     for (auto attempts = 1000; attempts > 0; --attempts) {
         const auto monrace_id = get_mon_num(creature, 0, floor_ptr->monster_level, PM_NONE);
@@ -351,7 +351,7 @@ static tl::optional<MonraceId> select_horde_leader_r_idx(CreatureEntity &creatur
 bool alloc_horde(CreatureEntity &creature, POSITION y, POSITION x, summon_specific_pf summon_specific)
 {
     Pos2D pos(y, x);
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     get_mon_num_prep_enum(creature, floor.get_monrace_hook(), floor.get_monrace_hook_terrain_at(pos));
     const auto monrace_id = select_horde_leader_r_idx(creature);
     if (!monrace_id) {
@@ -393,7 +393,7 @@ bool alloc_horde(CreatureEntity &creature, POSITION y, POSITION x, summon_specif
  */
 bool alloc_guardian(CreatureEntity &creature, bool def_val)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_dungeon_definition();
     if (!dungeon.has_guardian()) {
         return def_val;
@@ -446,7 +446,7 @@ bool alloc_monster(CreatureEntity &creature, int min_dis, BIT_FLAGS mode, summon
     }
 
     const auto p_pos = creature.get_position();
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     Pos2D pos(0, 0);
     auto attempts_left = 10000;
     while (attempts_left--) {

--- a/src/monster-floor/monster-lite.cpp
+++ b/src/monster-floor/monster-lite.cpp
@@ -149,7 +149,7 @@ void update_mon_lite(CreatureEntity &creature)
     std::vector<Pos2D> points;
 
     void (*add_mon_lite)(FloorType &, std::vector<Pos2D> &, const Pos2D &p_pos, const Pos2D &pos, const monster_lite_type &);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_dungeon_definition();
     const auto dis_lim = (dungeon.flags.has(DungeonFeatureType::DARKNESS) && !creature.see_nocto) ? (MAX_PLAYER_SIGHT / 2 + 1) : (MAX_PLAYER_SIGHT + 3);
     floor.reset_mon_lite();

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -57,7 +57,7 @@ static bool check_hp_for_terrain_destruction(const TerrainType &terrain, const C
  */
 static bool process_wall(CreatureEntity &creature, turn_flags *turn_flags_ptr, const CreatureEntity &monster, const Pos2D &pos, bool can_cross)
 {
-    const auto &grid = creature.current_floor_ptr->get_grid(pos);
+    const auto &grid = creature.get_floor()->get_grid(pos);
     const auto &terrain = grid.get_terrain();
     if (creature.is_located_at(pos)) {
         turn_flags_ptr->do_move = true;
@@ -111,7 +111,7 @@ static bool process_wall(CreatureEntity &creature, turn_flags *turn_flags_ptr, c
 static bool bash_normal_door(CreatureEntity &creature, turn_flags *turn_flags_ptr, const CreatureEntity &monster, const Pos2D &pos)
 {
     const auto &monrace = monster.get_monrace();
-    const auto &grid = creature.current_floor_ptr->get_grid(pos);
+    const auto &grid = creature.get_floor()->get_grid(pos);
     const auto &terrain = grid.get_terrain();
     turn_flags_ptr->do_move = false;
     using Tc = TerrainCharacteristics;
@@ -187,7 +187,7 @@ static void bash_glass_door(CreatureEntity &creature, turn_flags *turn_flags_ptr
 static bool process_door(CreatureEntity &creature, turn_flags *turn_flags_ptr, const CreatureEntity &monster, const Pos2D &pos)
 {
     auto &monrace = monster.get_monrace();
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!floor.has_closed_door_at(pos)) {
         return true;
     }
@@ -236,7 +236,7 @@ static bool process_door(CreatureEntity &creature, turn_flags *turn_flags_ptr, c
  */
 static bool process_protection_rune(CreatureEntity &creature, turn_flags *turn_flags_ptr, const CreatureEntity &monster, const Pos2D &pos)
 {
-    auto &grid = creature.current_floor_ptr->get_grid(pos);
+    auto &grid = creature.get_floor()->get_grid(pos);
     const auto &monrace = monster.get_monrace();
     auto can_enter = turn_flags_ptr->do_move;
     can_enter &= grid.is_rune_protection();
@@ -272,7 +272,7 @@ static bool process_protection_rune(CreatureEntity &creature, turn_flags *turn_f
  */
 static bool process_explosive_rune(CreatureEntity &creature, turn_flags *turn_flags_ptr, const CreatureEntity &monster, const Pos2D &pos)
 {
-    const auto &grid = creature.current_floor_ptr->get_grid(pos);
+    const auto &grid = creature.get_floor()->get_grid(pos);
     const auto &monrace = monster.get_monrace();
     auto should_explode = turn_flags_ptr->do_move;
     should_explode &= (monrace.behavior_flags.has_not(MonsterBehaviorType::NEVER_BLOW)) || !creature.is_located_at(pos);
@@ -306,7 +306,7 @@ static bool process_explosive_rune(CreatureEntity &creature, turn_flags *turn_fl
 static bool process_post_dig_wall(CreatureEntity &creature, turn_flags *turn_flags_ptr, const CreatureEntity &monster, const Pos2D &pos)
 {
     auto &monrace = monster.get_monrace();
-    const auto &grid = creature.current_floor_ptr->get_grid(pos);
+    const auto &grid = creature.get_floor()->get_grid(pos);
     const auto &terrain = grid.get_terrain();
     if (!turn_flags_ptr->did_kill_wall || !turn_flags_ptr->do_move) {
         return true;
@@ -351,7 +351,7 @@ static bool process_post_dig_wall(CreatureEntity &creature, turn_flags *turn_fla
  */
 void activate_explosive_rune(CreatureEntity &creature, const Pos2D &pos, const MonraceDefinition &monrace)
 {
-    auto &grid = creature.current_floor_ptr->get_grid(pos);
+    auto &grid = creature.get_floor()->get_grid(pos);
     const auto level = creature.level;
     if (!grid.is_rune_explosion()) {
         return;
@@ -387,7 +387,7 @@ void activate_explosive_rune(CreatureEntity &creature, const Pos2D &pos, const M
  */
 bool process_monster_movement(CreatureEntity &creature, turn_flags *turn_flags_ptr, const MonsterMovementDirectionList &mmdl, const Pos2D &pos, int *count)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto m_idx = mmdl.get_m_idx();
     for (const auto &dir : mmdl.get_movement_directions()) {
         const auto &dir_move = dir.has_direction() ? dir : rand_choice(Direction::directions_8());
@@ -564,7 +564,7 @@ void process_sound(CreatureEntity &creature, MONSTER_IDX m_idx)
         return;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
 
@@ -612,7 +612,7 @@ void process_speak(CreatureEntity &creature, MONSTER_IDX m_idx, POSITION oy, POS
         return;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     constexpr auto chance_speak = 8;

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -128,7 +128,7 @@ static void update_object_flags(const TrFlags &flags, EnumClassFlagGroup<Monster
 static void monster_pickup_object(CreatureEntity &creature, turn_flags *turn_flags_ptr, const MONSTER_IDX m_idx, ItemEntity *o_ptr, const bool is_unpickable_object,
     const POSITION ny, const POSITION nx, std::string_view m_name, std::string_view o_name, const OBJECT_IDX this_o_idx)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     if (is_unpickable_object) {
@@ -148,12 +148,12 @@ static void monster_pickup_object(CreatureEntity &creature, turn_flags *turn_fla
             msg_format(_("%s^が%sを拾った。", "%s^ picks up %s."), m_name.data(), o_name.data());
         }
 
-        excise_object_idx(*creature.current_floor_ptr, this_o_idx);
+        excise_object_idx(*creature.get_floor(), this_o_idx);
         // 意図としては OmType::TOUCHED を維持しつつ OmType::FOUND を消す事と思われるが一応元のロジックを維持しておく
         o_ptr->marked &= { OmType::TOUCHED };
         o_ptr->iy = o_ptr->ix = 0;
         o_ptr->held_m_idx = m_idx;
-        monster.get_monster_profile().hold_o_idx_list.add(*creature.current_floor_ptr, this_o_idx);
+        monster.get_monster_profile().hold_o_idx_list.add(*creature.get_floor(), this_o_idx);
         RedrawingFlagsUpdater::get_instance().set_flag(SubWindowRedrawingFlag::FOUND_ITEMS);
         return;
     }
@@ -180,15 +180,15 @@ static void monster_pickup_object(CreatureEntity &creature, turn_flags *turn_fla
  */
 void update_object_by_monster_movement(CreatureEntity &creature, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx, POSITION ny, POSITION nx)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
-    const auto &grid = creature.current_floor_ptr->grid_array[ny][nx];
+    const auto &grid = creature.get_floor()->grid_array[ny][nx];
     turn_flags_ptr->do_take = monrace.behavior_flags.has(MonsterBehaviorType::TAKE_ITEM);
     for (auto it = grid.o_idx_list.begin(); it != grid.o_idx_list.end();) {
         EnumClassFlagGroup<MonsterKindType> flg_monster_kind;
         EnumClassFlagGroup<MonsterResistanceType> flgr;
         OBJECT_IDX this_o_idx = *it++;
-        auto &item = *creature.current_floor_ptr->o_list[this_o_idx];
+        auto &item = *creature.get_floor()->o_list[this_o_idx];
         if (turn_flags_ptr->do_take) {
             const auto tval = item.bi_key.tval();
             if (tval == ItemKindType::GOLD || (tval == ItemKindType::MONSTER_REMAINS) || (tval == ItemKindType::STATUE)) {
@@ -222,7 +222,7 @@ void monster_drop_carried_objects(CreatureEntity &creature, CreatureEntity &targ
     auto &profile = target.get_monster_profile();
     for (auto it = profile.hold_o_idx_list.begin(); it != profile.hold_o_idx_list.end();) {
         const auto this_o_idx = *it++;
-        auto drop_item = creature.current_floor_ptr->o_list[this_o_idx]->clone();
+        auto drop_item = creature.get_floor()->o_list[this_o_idx]->clone();
         drop_item.held_m_idx = 0;
         delete_object_idx(creature, this_o_idx);
         (void)drop_near(creature, drop_item, target.get_position());

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -21,7 +21,7 @@
  */
 void delete_monster_idx(CreatureEntity &creature, short m_idx)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(m_idx);
     auto &monrace = monster.get_monrace();
     const auto m_pos = monster.get_position();
@@ -99,7 +99,7 @@ void delete_monster_idx(CreatureEntity &creature, short m_idx)
 void wipe_monsters_list(CreatureEntity &creature)
 {
     auto &monraces = MonraceList::get_instance();
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (auto i = floor.m_max - 1; i >= 1; i--) {
         auto &monster = floor.get_monster(i);
         if (!monster.is_valid()) {
@@ -128,7 +128,7 @@ void wipe_monsters_list(CreatureEntity &creature)
  */
 void delete_monster(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (!floor.contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
         return;
     }

--- a/src/monster-floor/monster-runaway.cpp
+++ b/src/monster-floor/monster-runaway.cpp
@@ -59,10 +59,10 @@ static void escape_monster(CreatureEntity &player, turn_flags *turn_flags_ptr, c
 
         auto speak = monster.get_monrace().speak_flags.has_any_of(flags);
         speak &= !is_acting_monster(monster.r_idx);
-        const auto &floor = *player.current_floor_ptr;
+        const auto &floor = *player.get_floor();
         const auto p_pos = player.get_position();
         const auto m_pos = monster.get_position();
-        speak &= player.current_floor_ptr->has_los_at(m_pos);
+        speak &= player.get_floor()->has_los_at(m_pos);
         speak &= projectable(floor, m_pos, p_pos);
         if (speak) {
             msg_format(_("%s^「ピンチだ！退却させてもらう！」", "%s^ says 'It is the pinch! I will retreat'."), m_name);
@@ -87,7 +87,7 @@ static void escape_monster(CreatureEntity &player, turn_flags *turn_flags_ptr, c
  */
 bool runaway_monster(CreatureEntity &creature, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     bool can_runaway = monster.is_pet() || monster.is_friendly();
     can_runaway &= (monrace.kind_flags.has(MonsterKindType::UNIQUE)) || (monrace.population_flags.has(MonsterPopulationType::NAZGUL));

--- a/src/monster-floor/monster-safety-hiding.cpp
+++ b/src/monster-floor/monster-safety-hiding.cpp
@@ -27,8 +27,8 @@
 static coordinate_candidate sweep_safe_coordinate(CreatureEntity &creature, MONSTER_IDX m_idx, std::span<const Pos2DVec> offsets, int d)
 {
     coordinate_candidate candidate;
-    const auto &floor = *creature.current_floor_ptr;
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &floor = *creature.get_floor();
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto p_pos = creature.get_position();
     const auto m_pos = monster.get_position();
     for (const auto &vec : offsets) {
@@ -113,7 +113,7 @@ tl::optional<Pos2D> find_safety(CreatureEntity &creature, short m_idx)
 static void sweep_hiding_candidate(
     CreatureEntity &creature, const CreatureEntity &monster, std::span<const Pos2DVec> offsets, coordinate_candidate &candidate)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monrace = monster.get_monrace();
     const auto p_pos = creature.get_position();
     const auto m_pos = monster.get_position();
@@ -145,7 +145,7 @@ static void sweep_hiding_candidate(
  */
 tl::optional<Pos2D> find_hiding(CreatureEntity &creature, short m_idx)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     coordinate_candidate candidate;
     candidate.gdis = 999;
     for (auto d = 1; d < 10; d++) {

--- a/src/monster-floor/monster-summon.cpp
+++ b/src/monster-floor/monster-summon.cpp
@@ -43,7 +43,7 @@ static bool is_dead_summoning(summon_type type)
  */
 tl::optional<MONSTER_IDX> summon_specific(CreatureEntity &subject, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode, tl::optional<MONSTER_IDX> summoner_m_idx)
 {
-    const auto &floor = *subject.current_floor_ptr;
+    const auto &floor = *subject.get_floor();
     if (floor.inside_arena) {
         return tl::nullopt;
     }
@@ -80,7 +80,7 @@ tl::optional<MONSTER_IDX> summon_specific(CreatureEntity &subject, POSITION y1, 
     if (!summoner_m_idx) {
         notice = true;
     } else {
-        const auto &monster = subject.current_floor_ptr->get_monster(*summoner_m_idx);
+        const auto &monster = subject.get_floor()->get_monster(*summoner_m_idx);
         if (monster.is_pet()) {
             notice = true;
         } else if (is_seen(subject, monster)) {
@@ -113,7 +113,7 @@ tl::optional<MONSTER_IDX> summon_named_creature(CreatureEntity &creature, MONSTE
         return false;
     }
 
-    if (creature.current_floor_ptr->inside_arena) {
+    if (creature.get_floor()->inside_arena) {
         return false;
     }
 

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -33,7 +33,7 @@ namespace {
  */
 bool mon_will_run(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     if (monrace.behavior_flags.has(MonsterBehaviorType::TIMID)) {
         return true;
@@ -114,7 +114,7 @@ public:
      */
     static Pos2D run_away(CreatureEntity &creature, MONSTER_IDX m_idx, const Pos2D &pos_move)
     {
-        const auto &floor = *creature.current_floor_ptr;
+        const auto &floor = *creature.get_floor();
         const auto &monster = floor.get_monster(m_idx);
         const auto &monrace = monster.get_monrace();
         const auto m_pos = monster.get_position();
@@ -164,7 +164,7 @@ public:
 
     tl::optional<Pos2D> decide_move_grid() const override
     {
-        const auto &floor = *this->creature_ptr->current_floor_ptr;
+        const auto &floor = *this->creature_ptr->get_floor();
         const auto &monster = floor.get_monster(this->m_idx);
         const auto pos_target = monster.get_target_position();
         const auto t_m_idx = floor.get_grid(pos_target).m_idx;
@@ -201,7 +201,7 @@ public:
 
     tl::optional<Pos2D> decide_move_grid() const override
     {
-        const auto &floor = *this->creature_ptr->current_floor_ptr;
+        const auto &floor = *this->creature_ptr->get_floor();
         const auto &monrace = floor.get_monster(this->m_idx).get_monrace();
         const auto p_pos = this->creature_ptr->get_position();
 
@@ -251,7 +251,7 @@ public:
 
     tl::optional<Pos2D> decide_move_grid() const override
     {
-        const auto &floor = *this->creature_ptr->current_floor_ptr;
+        const auto &floor = *this->creature_ptr->get_floor();
         const auto &monster = floor.get_monster(this->m_idx);
         const auto &monrace = monster.get_monrace();
         const auto p_pos = this->creature_ptr->get_position();
@@ -294,7 +294,7 @@ public:
 
     tl::optional<Pos2D> decide_move_grid() const override
     {
-        const auto &floor = *this->creature_ptr->current_floor_ptr;
+        const auto &floor = *this->creature_ptr->get_floor();
         const auto &monster = floor.get_monster(this->m_idx);
         const auto &monrace = monster.get_monrace();
         const auto p_pos = this->creature_ptr->get_position();
@@ -377,7 +377,7 @@ public:
 
     tl::optional<Pos2D> decide_move_grid() const override
     {
-        const auto &floor = *this->creature_ptr->current_floor_ptr;
+        const auto &floor = *this->creature_ptr->get_floor();
         const auto &monster = floor.get_monster(this->m_idx);
         const auto &monrace = monster.get_monrace();
         const auto p_pos = this->creature_ptr->get_position();
@@ -423,7 +423,7 @@ public:
 
     tl::optional<Pos2D> decide_move_grid() const override
     {
-        const auto &floor = *this->creature_ptr->current_floor_ptr;
+        const auto &floor = *this->creature_ptr->get_floor();
         const auto &monster = floor.get_monster(this->m_idx);
         const auto p_pos = this->creature_ptr->get_position();
         const auto m_pos = monster.get_position();
@@ -458,7 +458,7 @@ class MonsterMoveGridDecidersFactory {
 public:
     static std::vector<std::unique_ptr<const MonsterMoveGridDecider>> create_deciders(CreatureEntity *creature_ptr, MONSTER_IDX m_idx)
     {
-        const auto &floor = *creature_ptr->current_floor_ptr;
+        const auto &floor = *creature_ptr->get_floor();
         const auto &monster = floor.get_monster(m_idx);
         const auto &monrace = monster.get_monrace();
         const auto will_run = mon_will_run(*creature_ptr, m_idx);
@@ -532,7 +532,7 @@ tl::optional<MonsterMovementDirectionList> MonsterSweepGrid::get_movable_grid()
         pos_move = MonsterMoveGridDecider::run_away(*this->creature_ptr, this->m_idx, pos_move);
     }
 
-    const auto &floor = *this->creature_ptr->current_floor_ptr;
+    const auto &floor = *this->creature_ptr->get_floor();
     const auto &monster = floor.get_monster(this->m_idx);
     const auto vec = monster.get_position() - pos_move;
 

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -65,7 +65,7 @@ static MonraceId initial_r_appearance(CreatureEntity &creature, MonraceId r_idx,
 
     get_mon_num_prep_enum(creature, MonraceHook::TANUKI);
     auto attempts = 1000;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     auto min = std::min(floor.base_level - 5, 50);
     while (--attempts) {
         auto ap_r_idx = get_mon_num(creature, 0, floor.base_level + 10, PM_NONE);
@@ -157,7 +157,7 @@ static bool check_quest_placeable(const FloorType &floor, MonraceId r_idx)
  */
 static bool check_procection_rune(CreatureEntity &creature, MonraceId monrace_id, const Pos2D &pos)
 {
-    auto &grid = creature.current_floor_ptr->get_grid(pos);
+    auto &grid = creature.get_floor()->get_grid(pos);
     if (!grid.is_rune_protection()) {
         return true;
     }
@@ -225,7 +225,7 @@ static void warn_unique_generation(CreatureEntity &creature, MonraceId r_idx)
  */
 tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, POSITION x, MonraceId r_idx, BIT_FLAGS mode, tl::optional<MONSTER_IDX> summoner_m_idx)
 {
-    auto &floor = *player.current_floor_ptr;
+    auto &floor = *player.get_floor();
     auto pos = Pos2D(y, x);
     auto *g_ptr = &floor.grid_array[y][x];
     auto &monrace = MonraceList::get_instance().get_monrace(r_idx);
@@ -264,7 +264,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
 
     m_ptr->get_monster_profile().mflag.clear();
     m_ptr->get_monster_profile().mflag2.clear();
-    m_ptr->current_floor_ptr = player.current_floor_ptr;
+    m_ptr->set_floor(player.get_floor());
 
     if (monrace.misc_flags.has(MonsterMiscType::CHAMELEON)) {
         m_ptr->r_idx = r_idx;
@@ -375,7 +375,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
 
     m_ptr->y = y;
     m_ptr->x = x;
-    m_ptr->current_floor_ptr = &floor;
+    m_ptr->set_floor(&floor);
 
     for (const auto mte : MONSTER_TIMED_EFFECT_LIST) {
         m_ptr->get_monster_profile().mtimed[mte] = 0;

--- a/src/monster-floor/party-generator.cpp
+++ b/src/monster-floor/party-generator.cpp
@@ -21,7 +21,7 @@
  */
 bool alloc_creature_party(CreatureEntity &creature, const Pos2D &pos_center)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
 
     // 現在の階層に適したパーティを取得
     auto &party_list = CreaturePartyList::get_instance();

--- a/src/monster-floor/quantum-effect.cpp
+++ b/src/monster-floor/quantum-effect.cpp
@@ -23,7 +23,7 @@
  */
 static void vanish_nonunique(CreatureEntity &creature, MONSTER_IDX m_idx, bool see_m)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     if (see_m) {
         const auto m_name = monster_desc(creature, monster, 0);
         msg_format(_("%sは消え去った！", "%s^ disappears!"), m_name.data());
@@ -50,7 +50,7 @@ static void vanish_nonunique(CreatureEntity &creature, MONSTER_IDX m_idx, bool s
  */
 static void produce_quantum_effect(CreatureEntity &creature, MONSTER_IDX m_idx, bool see_m)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     const auto coherent = los(floor, monster.get_position(), creature.get_position());
     if (!see_m && !coherent) {
@@ -81,7 +81,7 @@ static void produce_quantum_effect(CreatureEntity &creature, MONSTER_IDX m_idx, 
  */
 bool process_quantum_effect(CreatureEntity &creature, MONSTER_IDX m_idx, bool see_m)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     if (monrace.kind_flags.has_not(MonsterKindType::QUANTUM) && monrace.kind_flags.has_not(MonsterKindType::MONKEY_SPACE)) {
         return false;

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -69,7 +69,7 @@ static BIT_FLAGS dead_mode(MonsterDeath *md_ptr)
  */
 static tl::optional<bool> final_summon(CreatureEntity &creature, MonsterDeath *md_ptr, const MonsterSummon &summon_data)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (floor.inside_arena || AngbandSystem::get_instance().is_phase_out() || !evaluate_percent(summon_data.probability)) {
         return tl::nullopt;
     }
@@ -167,27 +167,27 @@ static void on_dead_drop_kind_item(CreatureEntity &killer, MonsterDeath *md_ptr)
             switch (grade) {
             /* Apply bad magic, but first clear object */
             case -2:
-                ItemMagicApplier(killer, &item, killer.current_floor_ptr->dun_level, AM_NO_FIXED_ART | AM_GOOD | AM_GREAT | AM_CURSED).execute();
+                ItemMagicApplier(killer, &item, killer.get_floor()->dun_level, AM_NO_FIXED_ART | AM_GOOD | AM_GREAT | AM_CURSED).execute();
                 break;
             /* Apply bad magic, but first clear object */
             case -1:
-                ItemMagicApplier(killer, &item, killer.current_floor_ptr->dun_level, AM_NO_FIXED_ART | AM_GOOD | AM_CURSED).execute();
+                ItemMagicApplier(killer, &item, killer.get_floor()->dun_level, AM_NO_FIXED_ART | AM_GOOD | AM_CURSED).execute();
                 break;
             /* Apply normal magic, but first clear object */
             case 0:
-                ItemMagicApplier(killer, &item, killer.current_floor_ptr->dun_level, AM_NO_FIXED_ART).execute();
+                ItemMagicApplier(killer, &item, killer.get_floor()->dun_level, AM_NO_FIXED_ART).execute();
                 break;
             /* Apply good magic, but first clear object */
             case 1:
-                ItemMagicApplier(killer, &item, killer.current_floor_ptr->dun_level, AM_NO_FIXED_ART | AM_GOOD).execute();
+                ItemMagicApplier(killer, &item, killer.get_floor()->dun_level, AM_NO_FIXED_ART | AM_GOOD).execute();
                 break;
             /* Apply great magic, but first clear object */
             case 2:
-                ItemMagicApplier(killer, &item, killer.current_floor_ptr->dun_level, AM_NO_FIXED_ART | AM_GOOD | AM_GREAT).execute();
+                ItemMagicApplier(killer, &item, killer.get_floor()->dun_level, AM_NO_FIXED_ART | AM_GOOD | AM_GREAT).execute();
                 break;
             /* Apply special magic, but first clear object */
             case 3:
-                ItemMagicApplier(killer, &item, killer.current_floor_ptr->dun_level, AM_GOOD | AM_GREAT | AM_SPECIAL).execute();
+                ItemMagicApplier(killer, &item, killer.get_floor()->dun_level, AM_GOOD | AM_GREAT | AM_SPECIAL).execute();
                 if (!item.is_fixed_artifact()) {
                     become_random_artifact(killer, &item, false);
                 }
@@ -226,27 +226,27 @@ static void on_dead_drop_tval_item(CreatureEntity &killer, MonsterDeath *md_ptr)
             switch (grade) {
             /* Apply bad magic, but first clear object */
             case -2:
-                ItemMagicApplier(killer, &item, killer.current_floor_ptr->dun_level, AM_NO_FIXED_ART | AM_GOOD | AM_GREAT | AM_CURSED).execute();
+                ItemMagicApplier(killer, &item, killer.get_floor()->dun_level, AM_NO_FIXED_ART | AM_GOOD | AM_GREAT | AM_CURSED).execute();
                 break;
             /* Apply bad magic, but first clear object */
             case -1:
-                ItemMagicApplier(killer, &item, killer.current_floor_ptr->dun_level, AM_NO_FIXED_ART | AM_GOOD | AM_CURSED).execute();
+                ItemMagicApplier(killer, &item, killer.get_floor()->dun_level, AM_NO_FIXED_ART | AM_GOOD | AM_CURSED).execute();
                 break;
             /* Apply normal magic, but first clear object */
             case 0:
-                ItemMagicApplier(killer, &item, killer.current_floor_ptr->dun_level, AM_NO_FIXED_ART).execute();
+                ItemMagicApplier(killer, &item, killer.get_floor()->dun_level, AM_NO_FIXED_ART).execute();
                 break;
             /* Apply good magic, but first clear object */
             case 1:
-                ItemMagicApplier(killer, &item, killer.current_floor_ptr->dun_level, AM_NO_FIXED_ART | AM_GOOD).execute();
+                ItemMagicApplier(killer, &item, killer.get_floor()->dun_level, AM_NO_FIXED_ART | AM_GOOD).execute();
                 break;
             /* Apply great magic, but first clear object */
             case 2:
-                ItemMagicApplier(killer, &item, killer.current_floor_ptr->dun_level, AM_NO_FIXED_ART | AM_GOOD | AM_GREAT).execute();
+                ItemMagicApplier(killer, &item, killer.get_floor()->dun_level, AM_NO_FIXED_ART | AM_GOOD | AM_GREAT).execute();
                 break;
             /* Apply special magic, but first clear object */
             case 3:
-                ItemMagicApplier(killer, &item, killer.current_floor_ptr->dun_level, AM_GOOD | AM_GREAT | AM_SPECIAL).execute();
+                ItemMagicApplier(killer, &item, killer.get_floor()->dun_level, AM_GOOD | AM_GREAT | AM_SPECIAL).execute();
                 if (!item.is_fixed_artifact()) {
                     if (killer.is_player()) {
                         become_random_artifact(killer, &item, false);
@@ -277,7 +277,7 @@ static void on_dead_bloodletter(CreatureEntity &killer, MonsterDeath *md_ptr)
 
     ItemEntity item;
     item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::SWORD, SV_BLADE_OF_CHAOS }));
-    ItemMagicApplier(killer, &item, killer.current_floor_ptr->object_level, AM_NO_FIXED_ART | md_ptr->mo_mode).execute();
+    ItemMagicApplier(killer, &item, killer.get_floor()->object_level, AM_NO_FIXED_ART | md_ptr->mo_mode).execute();
     (void)drop_near(killer, item, md_ptr->get_position());
 }
 
@@ -286,7 +286,7 @@ static void on_dead_inariman1_2(CreatureEntity &killer, MonsterDeath *md_ptr)
     ItemEntity forge;
     ItemEntity *q_ptr = &forge;
     q_ptr->generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_SUSHI2 }));
-    ItemMagicApplier(killer, q_ptr, killer.current_floor_ptr->dun_level, AM_NO_FIXED_ART | md_ptr->mo_mode).execute();
+    ItemMagicApplier(killer, q_ptr, killer.get_floor()->dun_level, AM_NO_FIXED_ART | md_ptr->mo_mode).execute();
     (void)drop_near(killer, *q_ptr, md_ptr->get_position());
 }
 
@@ -295,13 +295,13 @@ static void on_dead_inariman3(CreatureEntity &killer, MonsterDeath *md_ptr)
     ItemEntity forge;
     ItemEntity *q_ptr = &forge;
     q_ptr->generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_SUSHI3 }));
-    ItemMagicApplier(killer, q_ptr, killer.current_floor_ptr->dun_level, AM_NO_FIXED_ART | md_ptr->mo_mode).execute();
+    ItemMagicApplier(killer, q_ptr, killer.get_floor()->dun_level, AM_NO_FIXED_ART | md_ptr->mo_mode).execute();
     (void)drop_near(killer, *q_ptr, md_ptr->get_position());
 }
 
 static void on_dead_raal(CreatureEntity &killer, MonsterDeath *md_ptr)
 {
-    const auto &floor = *killer.current_floor_ptr;
+    const auto &floor = *killer.get_floor();
     if (!md_ptr->drop_chosen_item || (floor.dun_level <= 9)) {
         return;
     }
@@ -409,7 +409,7 @@ static void on_dead_can_angel(CreatureEntity &killer, MonsterDeath *md_ptr)
 
     ItemEntity item;
     item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::CHEST, SV_CHEST_KANDUME }));
-    ItemMagicApplier(killer, &item, killer.current_floor_ptr->object_level, AM_NO_FIXED_ART).execute();
+    ItemMagicApplier(killer, &item, killer.get_floor()->object_level, AM_NO_FIXED_ART).execute();
     (void)drop_near(killer, item, md_ptr->get_position());
 }
 
@@ -505,28 +505,28 @@ static void on_dead_mimics(CreatureEntity &killer, MonsterDeath *md_ptr)
 
     switch (md_ptr->r_ptr->symbol_definition.character) {
     case '(':
-        if (killer.current_floor_ptr->dun_level <= 0) {
+        if (killer.get_floor()->dun_level <= 0) {
             return;
         }
 
         drop_specific_item_on_dead(killer, md_ptr, kind_is_cloak);
         return;
     case '/':
-        if (killer.current_floor_ptr->dun_level <= 4) {
+        if (killer.get_floor()->dun_level <= 4) {
             return;
         }
 
         drop_specific_item_on_dead(killer, md_ptr, kind_is_polearm);
         return;
     case '[':
-        if (killer.current_floor_ptr->dun_level <= 19) {
+        if (killer.get_floor()->dun_level <= 19) {
             return;
         }
 
         drop_specific_item_on_dead(killer, md_ptr, kind_is_armor);
         return;
     case '\\':
-        if (killer.current_floor_ptr->dun_level <= 4) {
+        if (killer.get_floor()->dun_level <= 4) {
             return;
         }
 
@@ -540,7 +540,7 @@ static void on_dead_mimics(CreatureEntity &killer, MonsterDeath *md_ptr)
         drop_specific_item_on_dead(killer, md_ptr, kind_is_sword);
         return;
     case ']':
-        if (killer.current_floor_ptr->dun_level <= 19) {
+        if (killer.get_floor()->dun_level <= 19) {
             return;
         }
 
@@ -629,7 +629,7 @@ void switch_special_death(CreatureEntity &creature, MonsterDeath *md_ptr, Attrib
         (void)project(creature, md_ptr->m_idx, 3, md_ptr->md_y, md_ptr->md_x, Dice::roll(20, 10), AttributeType::FIRE, PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
         return;
     case MonraceId::CAIT_SITH:
-        if (creature.current_floor_ptr->dun_level <= 0 || md_ptr->is_chameleon) {
+        if (creature.get_floor()->dun_level <= 0 || md_ptr->is_chameleon) {
             return;
         }
         drop_specific_item_on_dead(creature, md_ptr, kind_is_boots);
@@ -641,7 +641,7 @@ void switch_special_death(CreatureEntity &creature, MonsterDeath *md_ptr, Attrib
         on_dead_random_artifact(creature, md_ptr, kind_is_amulet);
         return;
     case MonraceId::YENDOR_WIZARD_2:
-        if (creature.current_floor_ptr->dun_level <= 0 || md_ptr->is_chameleon) {
+        if (creature.get_floor()->dun_level <= 0 || md_ptr->is_chameleon) {
             return;
         }
         drop_specific_item_on_dead(creature, md_ptr, kind_is_amulet);

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -148,7 +148,7 @@ void PitNestFilter::set_dragon_breaths()
 bool vault_aux_dragon(CreatureEntity &creature, MonraceId r_idx)
 {
     const auto &monrace = MonraceList::get_instance().get_monrace(r_idx);
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     auto is_valid = !floor.is_underground() || DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, r_idx);
     is_valid &= monrace.is_suitable_for_special_room();
     if (!is_valid) {
@@ -193,7 +193,7 @@ bool vault_aux_gay(CreatureEntity &creature, MonraceId r_idx)
         return false;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     auto is_valid = !floor.is_underground() || DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, r_idx);
     is_valid &= monrace.is_suitable_for_special_room();
     if (!is_valid) {
@@ -223,7 +223,7 @@ bool vault_aux_les(CreatureEntity &creature, MonraceId r_idx)
         return false;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     auto is_valid = !floor.is_underground() || DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, r_idx);
     is_valid &= monrace.is_suitable_for_special_room();
     if (!is_valid) {

--- a/src/monster/monster-compaction.cpp
+++ b/src/monster/monster-compaction.cpp
@@ -29,7 +29,7 @@ static void compact_monsters_aux(CreatureEntity &creature, MONSTER_IDX i1, MONST
         return;
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(i1);
 
     const auto y = monster.y;
@@ -105,7 +105,7 @@ void compact_monsters(CreatureEntity &creature, int size)
     }
 
     /* Compact at least 'size' objects */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (int num = 0, cnt = 1; num < size; cnt++) {
         int cur_lev = 5 * cnt;
         int cur_dis = 5 * (20 - cnt);

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -98,8 +98,8 @@ MonsterDamageProcessor::MonsterDamageProcessor(CreatureEntity &creature, MONSTER
  */
 bool MonsterDamageProcessor::mon_take_hit(std::string_view note)
 {
-    auto &monster = this->creature.current_floor_ptr->m_list[this->m_idx];
-    const auto exp_mon = monster;
+    auto &monster = this->creature.get_floor()->m_list[this->m_idx];
+    const auto exp_mon = monster.clone();
     auto exp_dam = (monster.hp > this->dam) ? this->dam : monster.hp;
     this->get_exp_from_mon(exp_mon, exp_dam);
     if (this->genocide_patron()) {
@@ -130,13 +130,13 @@ bool MonsterDamageProcessor::mon_take_hit(std::string_view note)
 bool MonsterDamageProcessor::genocide_patron()
 {
     auto &creature = this->creature;
-    const auto &monster = creature.current_floor_ptr->get_monster(this->m_idx);
+    const auto &monster = creature.get_floor()->get_monster(this->m_idx);
     if (!monster.is_valid()) {
         this->m_idx = 0;
     }
 
     this->set_redraw();
-    (void)set_monster_csleep(*creature.current_floor_ptr, this->m_idx, 0);
+    (void)set_monster_csleep(*creature.get_floor(), this->m_idx, 0);
     set_superstealth(this->creature, false);
 
     return this->m_idx == 0;
@@ -145,7 +145,7 @@ bool MonsterDamageProcessor::genocide_patron()
 bool MonsterDamageProcessor::process_dead_exp_virtue(std::string_view note, const CreatureEntity &exp_target)
 {
     auto &creature = this->creature;
-    auto &monster = creature.current_floor_ptr->get_monster(this->m_idx);
+    auto &monster = creature.get_floor()->get_monster(this->m_idx);
     auto &monrace = monster.get_real_monrace();
     if (monster.hp >= 0) {
         return false;
@@ -162,7 +162,7 @@ bool MonsterDamageProcessor::process_dead_exp_virtue(std::string_view note, cons
     if (monrace.kind_flags.has(MonsterKindType::UNIQUE) && record_destroy_uniq) {
         std::stringstream ss;
         ss << monrace.name << (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::CLONED) ? _("(クローン)", "(Clone)") : "");
-        exe_write_diary(*creature.current_floor_ptr, DiaryKind::UNIQUE, 0, ss.str());
+        exe_write_diary(*creature.get_floor(), DiaryKind::UNIQUE, 0, ss.str());
     }
 
     sound(SoundKind::KILL);
@@ -182,7 +182,7 @@ bool MonsterDamageProcessor::process_dead_exp_virtue(std::string_view note, cons
 void MonsterDamageProcessor::death_special_flag_monster()
 {
     auto &creature = this->creature;
-    auto &monster = creature.current_floor_ptr->get_monster(this->m_idx);
+    auto &monster = creature.get_floor()->get_monster(this->m_idx);
     auto monrace_id = monster.r_idx;
     auto &monrace = monster.get_monrace();
     if (monrace.misc_flags.has(MonsterMiscType::TANUKI)) {
@@ -218,7 +218,7 @@ void MonsterDamageProcessor::death_special_flag_monster()
 void MonsterDamageProcessor::increase_kill_numbers()
 {
     auto &creature = this->creature;
-    auto &monster = creature.current_floor_ptr->get_monster(this->m_idx);
+    auto &monster = creature.get_floor()->get_monster(this->m_idx);
     auto &monrace = monster.get_real_monrace();
     monrace.increment_akills();
     creature.plus_incident_tree("KILL", 1);
@@ -262,7 +262,7 @@ void MonsterDamageProcessor::increase_kill_numbers()
 
 void MonsterDamageProcessor::death_amberites(std::string_view m_name)
 {
-    const auto &monster = this->creature.current_floor_ptr->get_monster(this->m_idx);
+    const auto &monster = this->creature.get_floor()->get_monster(this->m_idx);
     const auto &r_ref = monster.get_real_monrace();
     if (r_ref.kind_flags.has_not(MonsterKindType::AMBERITE) || one_in_(2)) {
         return;
@@ -280,7 +280,7 @@ void MonsterDamageProcessor::death_amberites(std::string_view m_name)
 
 void MonsterDamageProcessor::death_choasians(std::string_view m_name)
 {
-    const auto &monster = this->creature.current_floor_ptr->get_monster(this->m_idx);
+    const auto &monster = this->creature.get_floor()->get_monster(this->m_idx);
     const auto &r_ref = monster.get_real_monrace();
     if (r_ref.kind_flags.has_not(MonsterKindType::CHOASIAN) || one_in_(3)) {
         return;
@@ -322,7 +322,7 @@ void MonsterDamageProcessor::death_choasians(std::string_view m_name)
 void MonsterDamageProcessor::dying_scream(std::string_view m_name)
 {
     auto &creature = this->creature;
-    const auto &monster = creature.current_floor_ptr->get_monster(this->m_idx);
+    const auto &monster = creature.get_floor()->get_monster(this->m_idx);
     const auto &r_ref = monster.get_real_monrace();
     if (r_ref.speak_flags.has_none_of({ MonsterSpeakType::SPEAK_ALL, MonsterSpeakType::SPEAK_DEATH })) {
         return;
@@ -342,7 +342,7 @@ void MonsterDamageProcessor::dying_scream(std::string_view m_name)
 
 void MonsterDamageProcessor::show_kill_message(std::string_view note, std::string_view m_name)
 {
-    const auto &floor = *this->creature.current_floor_ptr;
+    const auto &floor = *this->creature.get_floor();
     const auto &monster = floor.get_monster(this->m_idx);
     if (!note.empty()) {
         msg_format("%s^%s", m_name.data(), note.data());
@@ -392,7 +392,7 @@ void MonsterDamageProcessor::show_explosion_message(std::string_view died_mes, s
 void MonsterDamageProcessor::show_bounty_message(std::string_view m_name)
 {
     auto &creature = this->creature;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(this->m_idx);
     const auto &monrace = monster.get_real_monrace();
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) || monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::CLONED) || vanilla_town) {
@@ -443,7 +443,7 @@ void MonsterDamageProcessor::get_exp_from_mon(const CreatureEntity &target, int 
     s64b_mul(&div_h, &div_l, 0, (ironman_nightmare ? 2 : 1) * compensation);
 
     /* Special penalty in the wilderness */
-    if (!this->creature.current_floor_ptr->is_underground()) {
+    if (!this->creature.get_floor()->is_underground()) {
         auto is_dungeon_monster = monrace.wilderness_flags.has_not(MonsterWildernessType::WILD_ONLY);
         is_dungeon_monster |= monrace.kind_flags.has_not(MonsterKindType::UNIQUE);
         if (is_dungeon_monster) {
@@ -488,7 +488,7 @@ void MonsterDamageProcessor::get_exp_from_mon(const CreatureEntity &target, int 
 void MonsterDamageProcessor::set_redraw()
 {
     auto &creature = this->creature;
-    auto &monster = creature.current_floor_ptr->get_monster(this->m_idx);
+    auto &monster = creature.get_floor()->get_monster(this->m_idx);
     HealthBarTracker::get_instance().set_flag_if_tracking(this->m_idx);
     if (monster.is_riding()) {
         RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
@@ -498,10 +498,10 @@ void MonsterDamageProcessor::set_redraw()
 void MonsterDamageProcessor::add_monster_fear()
 {
     auto &creature = this->creature;
-    const auto &monster = creature.current_floor_ptr->get_monster(this->m_idx);
+    const auto &monster = creature.get_floor()->get_monster(this->m_idx);
     if (monster.is_fearful() && (this->dam > 0)) {
         auto fear_remining = monster.get_remaining_fear() - randint1(this->dam);
-        if (set_monster_monfear(*creature.current_floor_ptr, this->m_idx, fear_remining)) {
+        if (set_monster_monfear(*creature.get_floor(), this->m_idx, fear_remining)) {
             *this->fear = false;
         }
     }
@@ -520,7 +520,7 @@ void MonsterDamageProcessor::add_monster_fear()
     *this->fear = true;
     auto fear_condition = (this->dam >= monster.hp) && (percentage > 7);
     auto fear_value = randint1(10) + (fear_condition ? 20 : (11 - percentage) * 5);
-    (void)set_monster_monfear(*creature.current_floor_ptr, this->m_idx, fear_value);
+    (void)set_monster_monfear(*creature.get_floor(), this->m_idx, fear_value);
 }
 
 /*!
@@ -530,7 +530,7 @@ void MonsterDamageProcessor::add_monster_fear()
 void MonsterDamageProcessor::process_masochist_reaction()
 {
     auto &creature = this->creature;
-    auto &monster = creature.current_floor_ptr->get_monster(this->m_idx);
+    auto &monster = creature.get_floor()->get_monster(this->m_idx);
     const auto &monrace = monster.get_monrace();
 
     if (!monrace.misc_flags.has(MonsterMiscType::MASOCHIST)) {
@@ -538,7 +538,7 @@ void MonsterDamageProcessor::process_masochist_reaction()
     }
 
     if (one_in_(3) && this->dam < std::min(monster.maxhp / 10, 40)) {
-        (void)set_monster_monfear(*creature.current_floor_ptr, this->m_idx, 0);
+        (void)set_monster_monfear(*creature.get_floor(), this->m_idx, 0);
         *this->fear = false;
 
         // 一定確率で少量回復
@@ -560,7 +560,7 @@ void MonsterDamageProcessor::process_masochist_reaction()
 void MonsterDamageProcessor::process_sadist_reaction()
 {
     auto &creature = this->creature;
-    auto &monster = creature.current_floor_ptr->get_monster(this->m_idx);
+    auto &monster = creature.get_floor()->get_monster(this->m_idx);
     const auto &monrace = monster.get_monrace();
 
     if (!monrace.misc_flags.has(MonsterMiscType::SADIST)) {
@@ -569,11 +569,11 @@ void MonsterDamageProcessor::process_sadist_reaction()
 
     // SADISTモンスターがプレイヤーにダメージを与えた場合の興奮状態
     if (this->dam > 0 && one_in_(4)) {
-        (void)set_monster_monfear(*creature.current_floor_ptr, this->m_idx, 0);
+        (void)set_monster_monfear(*creature.get_floor(), this->m_idx, 0);
         *this->fear = false;
 
         // 一時的な加速効果付与（興奮状態）
-        (void)set_monster_fast(*creature.current_floor_ptr, this->m_idx, monster.get_remaining_acceleration() + 100);
+        (void)set_monster_fast(*creature.get_floor(), this->m_idx, monster.get_remaining_acceleration() + 100);
 
         if (monster.get_monster_profile().ml) {
             msg_format(_("%s^は他者の苦痛に興奮している！", "%s^ gets excited by others' pain!"), monster.get_monrace().name.data());
@@ -588,7 +588,7 @@ void MonsterDamageProcessor::process_sadist_reaction()
 bool MonsterDamageProcessor::check_and_process_hp_transform()
 {
     auto &creature = this->creature;
-    auto &monster = creature.current_floor_ptr->get_monster(this->m_idx);
+    auto &monster = creature.get_floor()->get_monster(this->m_idx);
 
     // 変身条件のチェック
     if (monster.get_monster_profile().has_transformed) {

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -249,10 +249,10 @@ std::string monster_desc(CreatureEntity &subject, const CreatureEntity &monster,
     std::stringstream ss;
 
     if (monster.get_monster_profile().parent_m_idx > 0) {
-        const auto &parent_monster = subject.current_floor_ptr->get_monster(monster.get_monster_profile().parent_m_idx);
+        const auto &parent_monster = subject.get_floor()->get_monster(monster.get_monster_profile().parent_m_idx);
         // 親ID＝自身のIDでは主を失った状態なのでスキップ
         if (parent_monster.r_idx != monster.r_idx) {
-            auto parent_name = subject.current_floor_ptr->get_monster(monster.get_monster_profile().parent_m_idx).get_monrace().name;
+            auto parent_name = subject.get_floor()->get_monster(monster.get_monster_profile().parent_m_idx).get_monrace().name;
             if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::QUYLTHLUG_BORN)) {
                 ss << parent_name << _("が産んだ", "-born ");
             } else if (monrace.misc_flags.has(MonsterMiscType::BREAK_DOWN)) {

--- a/src/monster/monster-info.cpp
+++ b/src/monster/monster-info.cpp
@@ -258,6 +258,6 @@ bool is_original_ap_and_seen(CreatureEntity &subject, const CreatureEntity &crea
  */
 std::string monster_name(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     return monster_desc(creature, monster, 0x00);
 }

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -42,7 +42,7 @@
  */
 MonraceId get_mon_num(CreatureEntity &creature, int min_level, int max_level, uint32_t mode, AllianceType alliance_type)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (max_level > MAX_DEPTH - 1) {
         max_level = MAX_DEPTH - 1;
     }
@@ -151,7 +151,7 @@ MonraceId get_mon_num(CreatureEntity &creature, int min_level, int max_level, ui
 
 static tl::optional<MonraceId> polymorph_of_chameleon(CreatureEntity &creature, short m_idx, short terrain_id, tl::optional<short> summoner_m_idx)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(m_idx);
     const auto old_unique = monster.get_monrace().kind_flags.has(MonsterKindType::UNIQUE);
     ChameleonTransformation ct(m_idx, terrain_id, old_unique, std::move(summoner_m_idx));
@@ -187,7 +187,7 @@ static tl::optional<MonraceId> polymorph_of_chameleon(CreatureEntity &creature, 
  */
 void choose_chameleon_polymorph(CreatureEntity &creature, short m_idx, short terrain_id, tl::optional<short> summoner_m_idx)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(m_idx);
     auto new_monrace_id = polymorph_of_chameleon(creature, m_idx, terrain_id, summoner_m_idx);
     if (!new_monrace_id) {

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -139,14 +139,14 @@ constexpr auto STALKER_DISTANCE_THRESHOLD = 20; //!< モンスターが背後に
 void process_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
 
-    auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    auto &monster = creature.get_floor()->get_monster(m_idx);
     turn_flags tmp_flags;
     turn_flags *turn_flags_ptr = init_turn_flags(monster.is_riding(), &tmp_flags);
     turn_flags_ptr->see_m = is_seen(creature, monster);
 
     decide_drop_from_monster(creature, m_idx, turn_flags_ptr->is_riding_mon);
     if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::CHAMELEON) && one_in_(13) && !monster.is_asleep()) {
-        const auto &floor = *creature.current_floor_ptr;
+        const auto &floor = *creature.get_floor();
         const auto old_m_name = monster_desc(creature, monster, 0);
         const auto &monrace = monster.get_monrace();
         const auto m_pos = monster.get_position();
@@ -319,7 +319,7 @@ bool process_stealth(CreatureEntity &creature, MONSTER_IDX m_idx)
         return true;
     }
 
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     int tmp = creature.level * 6 + (creature.skill_stl + 10) * 4;
     if (creature.monlite) {
@@ -346,7 +346,7 @@ bool process_stealth(CreatureEntity &creature, MONSTER_IDX m_idx)
 void decide_drop_from_monster(CreatureEntity &creature, MONSTER_IDX m_idx, bool is_riding_mon)
 {
 
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     if (!is_riding_mon || monrace.misc_flags.has(MonsterMiscType::RIDING)) {
         return;
@@ -356,7 +356,7 @@ void decide_drop_from_monster(CreatureEntity &creature, MONSTER_IDX m_idx, bool 
 #ifdef JP
         msg_print("地面に落とされた。");
 #else
-        const auto m_name = monster_desc(creature, creature.current_floor_ptr->get_monster(creature.riding), 0);
+        const auto m_name = monster_desc(creature, creature.get_floor()->get_monster(creature.riding), 0);
         msg_format("You have fallen from %s.", m_name.data());
 #endif
     }
@@ -372,7 +372,7 @@ void decide_drop_from_monster(CreatureEntity &creature, MONSTER_IDX m_idx, bool 
 bool vanish_summoned_children(CreatureEntity &creature, MONSTER_IDX m_idx, bool see_m)
 {
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
 
@@ -420,7 +420,7 @@ bool vanish_summoned_children(CreatureEntity &creature, MONSTER_IDX m_idx, bool 
  */
 bool awake_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     auto &monrace = monster.get_monrace();
     if (!monster.is_asleep()) {
         return true;
@@ -434,7 +434,7 @@ bool awake_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
         return false;
     }
 
-    (void)set_monster_csleep(*creature.current_floor_ptr, m_idx, 0);
+    (void)set_monster_csleep(*creature.get_floor(), m_idx, 0);
     if (monster.get_monster_profile().ml) {
         const auto m_name = monster_desc(creature, monster, 0);
         msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());
@@ -456,7 +456,7 @@ bool awake_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
 void process_angar(CreatureEntity &creature, MONSTER_IDX m_idx, bool see_m)
 {
 
-    auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     auto gets_angry = monster.is_friendly() && has_aggravate(creature);
     const auto should_aggravate = monster.is_pet();
@@ -503,7 +503,7 @@ void process_angar(CreatureEntity &creature, MONSTER_IDX m_idx, bool see_m)
 bool explode_grenade(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
 
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     if (monster.r_idx != MonraceId::GRENADE) {
         return false;
     }
@@ -521,11 +521,11 @@ bool explode_grenade(CreatureEntity &creature, MONSTER_IDX m_idx)
 void process_special(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
 
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     auto &monrace = monster.get_monrace();
     auto can_do_special = monrace.ability_flags.has(MonsterAbilityType::SPECIAL);
     can_do_special &= monster.r_idx == MonraceId::OHMU;
-    can_do_special &= !creature.current_floor_ptr->inside_arena;
+    can_do_special &= !creature.get_floor()->inside_arena;
     can_do_special &= !AngbandSystem::get_instance().is_phase_out();
     can_do_special &= monrace.freq_spell != 0;
     can_do_special &= randint1(100) <= monrace.freq_spell;
@@ -555,7 +555,7 @@ void process_special(CreatureEntity &creature, MONSTER_IDX m_idx)
 
     for (int k = 0; k < A_MAX; k++) {
         if (auto summoned_m_idx = summon_specific(creature, monster.y, monster.x, rlev, SUMMON_MOLD, (PM_ALLOW_GROUP | p_mode), m_idx)) {
-            if (creature.current_floor_ptr->get_monster(*summoned_m_idx).get_monster_profile().ml) {
+            if (creature.get_floor()->get_monster(*summoned_m_idx).get_monster_profile().ml) {
                 count++;
             }
         }
@@ -577,7 +577,7 @@ void process_special(CreatureEntity &creature, MONSTER_IDX m_idx)
 bool decide_monster_multiplication(CreatureEntity &creature, MONSTER_IDX m_idx, POSITION oy, POSITION ox)
 {
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     auto &monrace = monster.get_monrace();
     if (monrace.misc_flags.has_not(MonsterMiscType::MULTIPLY) || (floor.num_repro >= MAX_REPRODUCTION)) {
@@ -605,7 +605,7 @@ bool decide_monster_multiplication(CreatureEntity &creature, MONSTER_IDX m_idx, 
     constexpr auto chance_reproduction = 8;
     if ((k < 4) && (!k || !randint0(k * chance_reproduction))) {
         if (auto multiplied_m_idx = multiply_monster(creature, m_idx, monrace.idx, false, (monster.is_pet() ? PM_FORCE_PET : 0))) {
-            if (creature.current_floor_ptr->get_monster(*multiplied_m_idx).get_monster_profile().ml && is_original_ap_and_seen(creature, monster)) {
+            if (creature.get_floor()->get_monster(*multiplied_m_idx).get_monster_profile().ml && is_original_ap_and_seen(creature, monster)) {
                 monrace.r_misc_flags.set(MonsterMiscType::MULTIPLY);
             }
             if (floor.get_monster(*multiplied_m_idx).get_monster_profile().ml && is_original_ap_and_seen(creature, monster)) {
@@ -622,7 +622,7 @@ bool decide_monster_multiplication(CreatureEntity &creature, MONSTER_IDX m_idx, 
  */
 void process_monster_spawn_item(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    CreatureEntity *m_ptr = &creature.current_floor_ptr->get_monster(m_idx);
+    CreatureEntity *m_ptr = &creature.get_floor()->get_monster(m_idx);
     MonraceDefinition &monrace = MonraceList::get_instance().get_monrace(m_ptr->r_idx);
     for (const auto &spawn_info : monrace.spawn_items) {
         auto num = std::get<0>(spawn_info);
@@ -643,7 +643,7 @@ void process_monster_spawn_item(CreatureEntity &creature, MONSTER_IDX m_idx)
  */
 void process_monster_spawn_zanki(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    CreatureEntity *m_ptr = &creature.current_floor_ptr->get_monster(m_idx);
+    CreatureEntity *m_ptr = &creature.get_floor()->get_monster(m_idx);
     MonraceDefinition *r_ptr = &MonraceList::get_instance().get_monrace(m_ptr->r_idx);
     if (r_ptr->level < 30 || !r_ptr->kind_flags.has(MonsterKindType::UNIQUE) || r_ptr->r_misc_flags.has(MonsterMiscType::EMPTY_MIND)) {
         return;
@@ -667,7 +667,7 @@ void process_monster_spawn_zanki(CreatureEntity &creature, MONSTER_IDX m_idx)
  */
 void process_monster_change_feat(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    auto *m_ptr = &creature.current_floor_ptr->get_monster(m_idx);
+    auto *m_ptr = &creature.get_floor()->get_monster(m_idx);
     auto *r_ptr = &MonraceList::get_instance().get_monrace(m_ptr->r_idx);
     for (const auto &spawn_info : r_ptr->change_feats) {
         auto num = std::get<0>(spawn_info);
@@ -690,9 +690,9 @@ void process_monster_change_feat(CreatureEntity &creature, MONSTER_IDX m_idx)
 bool process_monster_spawn_monster(CreatureEntity &creature, MONSTER_IDX m_idx, POSITION oy, POSITION ox)
 {
 
-    CreatureEntity *m_ptr = &creature.current_floor_ptr->get_monster(m_idx);
+    CreatureEntity *m_ptr = &creature.get_floor()->get_monster(m_idx);
     MonraceDefinition *r_ptr = &MonraceList::get_instance().get_monrace(m_ptr->r_idx);
-    if ((r_ptr->spawn_monsters.size() == 0) || (creature.current_floor_ptr->num_repro >= MAX_REPRODUCTION)) {
+    if ((r_ptr->spawn_monsters.size() == 0) || (creature.get_floor()->num_repro >= MAX_REPRODUCTION)) {
         return false;
     }
 
@@ -706,11 +706,11 @@ bool process_monster_spawn_monster(CreatureEntity &creature, MONSTER_IDX m_idx, 
 
         for (POSITION y = oy - 1; y <= oy + 1; y++) {
             for (POSITION x = ox - 1; x <= ox + 1; x++) {
-                if (!creature.current_floor_ptr->contains(Pos2D(y, x), FloorBoundary::OUTER_WALL_INCLUSIVE)) {
+                if (!creature.get_floor()->contains(Pos2D(y, x), FloorBoundary::OUTER_WALL_INCLUSIVE)) {
                     continue;
                 }
 
-                if (creature.current_floor_ptr->grid_array[y][x].m_idx) {
+                if (creature.get_floor()->grid_array[y][x].m_idx) {
                     k++;
                 }
             }
@@ -725,7 +725,7 @@ bool process_monster_spawn_monster(CreatureEntity &creature, MONSTER_IDX m_idx, 
         auto idx = std::get<2>(spawn_info);
         if (randint1(deno) <= num) {
             if (multiply_monster(creature, m_idx, idx, false, (m_ptr->is_pet() ? PM_FORCE_PET : 0))) {
-                auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+                auto &monster = creature.get_floor()->get_monster(m_idx);
                 if (monster.get_monster_profile().ml && is_original_ap_and_seen(creature, *m_ptr)) {
                     r_ptr->misc_flags.set(MonsterMiscType::MULTIPLY);
                 }
@@ -747,7 +747,7 @@ bool process_monster_spawn_monster(CreatureEntity &creature, MONSTER_IDX m_idx, 
 bool cast_spell(CreatureEntity &creature, MONSTER_IDX m_idx, bool aware)
 {
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster_from = floor.get_monster(m_idx);
     const auto &monrace = monster_from.get_monrace();
 
@@ -796,7 +796,7 @@ bool cast_spell(CreatureEntity &creature, MONSTER_IDX m_idx, bool aware)
 bool process_monster_fear(CreatureEntity &creature, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx)
 {
     const auto &baseitems = BaseitemList::get_instance();
-    auto *m_ptr = &creature.current_floor_ptr->get_monster(m_idx);
+    auto *m_ptr = &creature.get_floor()->get_monster(m_idx);
     const auto m_name = monster_desc(creature, *m_ptr, 0);
     const auto &monrace = m_ptr->get_monrace();
 
@@ -820,13 +820,13 @@ bool process_monster_fear(CreatureEntity &creature, turn_flags *turn_flags_ptr, 
         m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::VOMITED);
     }
 
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     bool is_battle_determined = !turn_flags_ptr->do_turn && !turn_flags_ptr->do_move && monster.is_fearful() && turn_flags_ptr->aware;
     if (!is_battle_determined) {
         return false;
     }
 
-    (void)set_monster_monfear(*creature.current_floor_ptr, m_idx, 0);
+    (void)set_monster_monfear(*creature.get_floor(), m_idx, 0);
     if (!turn_flags_ptr->see_m) {
         return true;
     }
@@ -873,7 +873,7 @@ void process_monsters(CreatureEntity &creature)
     const auto &tracker = LoreTracker::get_instance();
     const auto old_monrace_id = tracker.get_trackee();
     OldRaceFlags flags(old_monrace_id);
-    creature.current_floor_ptr->monster_noise = false;
+    creature.get_floor()->monster_noise = false;
     sweep_monster_process(creature);
     if (!tracker.is_tracking() || !tracker.is_tracking(old_monrace_id)) {
         return;
@@ -889,7 +889,7 @@ void process_monsters(CreatureEntity &creature)
 void sweep_monster_process(CreatureEntity &creature)
 {
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
 
     // 処理中の召喚などで生成されたモンスターが即座に行動しないようにするため、
     // 先に現在存在するモンスターをリストアップしておく
@@ -934,7 +934,7 @@ void sweep_monster_process(CreatureEntity &creature)
             }
         }
 
-        auto g_ptr = &creature.current_floor_ptr->grid_array[monster.y][monster.x];
+        auto g_ptr = &creature.get_floor()->grid_array[monster.y][monster.x];
         auto &f_ptr = TerrainList::get_instance().get_terrain(g_ptr->feat);
         if (f_ptr.flags.has(TerrainCharacteristics::TENTACLE)) {
             int pow = 30;
@@ -956,11 +956,11 @@ void sweep_monster_process(CreatureEntity &creature)
                     switch (randint1(3)) {
                     case 1:
                         msg_format(_("%s「んほぉ！」", "%s 'Nnhor!'"), m_name.data());
-                        (void)set_monster_stunned(*creature.current_floor_ptr, 0, monster.get_remaining_stun() + 10 + randint0(creature.level) / 5);
+                        (void)set_monster_stunned(*creature.get_floor(), 0, monster.get_remaining_stun() + 10 + randint0(creature.level) / 5);
                         break;
                     case 2:
                         msg_format(_("%s「アへぇ！」", "%s 'Aherr!'"), m_name.data());
-                        (void)set_monster_slow(*creature.current_floor_ptr, 0, monster.get_remaining_deceleration() + 10 + randint0(creature.level) / 5);
+                        (void)set_monster_slow(*creature.get_floor(), 0, monster.get_remaining_deceleration() + 10 + randint0(creature.level) / 5);
                         break;
                     case 3: {
                         bool fear = false;
@@ -1011,7 +1011,7 @@ bool decide_process_continue(CreatureEntity &creature, CreatureEntity &monster)
     }
 
     auto should_continue = (cdis <= MAX_PLAYER_SIGHT) || AngbandSystem::get_instance().is_phase_out();
-    should_continue &= creature.current_floor_ptr->has_los_at({ monster.y, monster.x }) || has_aggravate(creature);
+    should_continue &= creature.get_floor()->has_los_at({ monster.y, monster.x }) || has_aggravate(creature);
     if (should_continue) {
         return true;
     }
@@ -1026,7 +1026,7 @@ bool decide_process_continue(CreatureEntity &creature, CreatureEntity &monster)
 bool process_stalking(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
 
-    auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
 
     // モンスターが背後に忍び寄るフラグを持っていないなら何もしない

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -339,7 +339,7 @@ bool set_monster_invulner(FloorType &floor, MONSTER_IDX m_idx, int v, bool energ
  */
 bool set_monster_timewalk(CreatureEntity &creature, MONSTER_IDX m_idx, int num, bool vs_player)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(m_idx);
     auto &world = AngbandWorld::get_instance();
     const auto &monrace = monster.get_real_monrace();

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -109,7 +109,7 @@ int mon_damage_mod(CreatureEntity &creature, const CreatureEntity &target, int d
  */
 static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_idx, CreatureTimedEffect mte)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     const auto cdis = Grid::calc_distance(creature.get_position(), monster.get_position());
     switch (mte) {
@@ -283,7 +283,7 @@ static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_
  */
 void process_monsters_mtimed(CreatureEntity &creature, CreatureTimedEffect mte)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &cur_mproc_list = floor.mproc_list.at(mte);
 
     /* Hack -- calculate the "player noise" */
@@ -306,7 +306,7 @@ void process_monsters_mtimed(CreatureEntity &creature, CreatureTimedEffect mte)
  */
 void dispel_monster_status(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     const auto m_name = monster_desc(creature, monster, 0);
     if (set_monster_invulner(floor, m_idx, 0, true)) {
@@ -340,7 +340,7 @@ void monster_gain_exp(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId mon
         return;
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(m_idx);
     if (!monster.is_valid()) {
         return;

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -75,14 +75,14 @@ bool update_riding_monster(CreatureEntity &creature, turn_flags *turn_flags_ptr,
     if (!creature.is_player()) {
         return false;
     }
-    auto &monster = creature.current_floor_ptr->get_monster(m_idx);
-    auto &grid = creature.current_floor_ptr->grid_array[ny][nx];
-    CreatureEntity *y_ptr = &creature.current_floor_ptr->get_monster(grid.m_idx);
+    auto &monster = creature.get_floor()->get_monster(m_idx);
+    auto &grid = creature.get_floor()->grid_array[ny][nx];
+    CreatureEntity *y_ptr = &creature.get_floor()->get_monster(grid.m_idx);
     if (turn_flags_ptr->is_riding_mon) {
         return move_player_effect(creature, ny, nx, MPE_DONT_PICKUP);
     }
 
-    creature.current_floor_ptr->grid_array[oy][ox].m_idx = grid.m_idx;
+    creature.get_floor()->grid_array[oy][ox].m_idx = grid.m_idx;
     if (grid.has_monster()) {
         y_ptr->y = oy;
         y_ptr->x = ox;
@@ -177,7 +177,7 @@ void update_monster_race_flags(CreatureEntity &creature, turn_flags *turn_flags_
 
 static um_type *initialize_um_type(CreatureEntity &creature, um_type *um_ptr, MONSTER_IDX m_idx, bool full)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     um_ptr->m_ptr = &floor.get_monster(m_idx);
     um_ptr->do_disturb = disturb_move;
     um_ptr->fy = um_ptr->m_ptr->y;
@@ -467,7 +467,7 @@ static void decide_sight_invisible_monster(CreatureEntity &creature, um_type *um
         update_specific_race_telepathy(creature, um_ptr);
     }
 
-    if (!creature.current_floor_ptr->has_los_at({ um_ptr->fy, um_ptr->fx }) || creature.is_blind()) {
+    if (!creature.get_floor()->has_los_at({ um_ptr->fy, um_ptr->fx }) || creature.is_blind()) {
         return;
     }
 
@@ -530,7 +530,7 @@ static void update_invisible_monster(CreatureEntity &creature, um_type *um_ptr, 
         monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::SANITY_BLAST);
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     const auto m_pos = monster.get_position();
     const auto projectable_from_monster = projectable(floor, m_pos, p_pos);
@@ -622,7 +622,7 @@ void update_monster(CreatureEntity &creature, MONSTER_IDX m_idx, bool full)
  */
 void update_monsters(CreatureEntity &creature, bool full)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
         const auto &monster = floor.get_monster(i);
         if (!monster.is_valid()) {
@@ -640,7 +640,7 @@ void update_monsters(CreatureEntity &creature, bool full)
  */
 void update_smart_learn(CreatureEntity &creature, MONSTER_IDX m_idx, int what)
 {
-    auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     if (!smart_learn || (monrace.behavior_flags.has(MonsterBehaviorType::STUPID)) || ((monrace.behavior_flags.has_not(MonsterBehaviorType::SMART)) && one_in_(2))) {
         return;

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -167,7 +167,7 @@ static bool do_hook(CreatureEntity &creature, MonraceHook hook, MonraceId monrac
 {
     const auto &monraces = MonraceList::get_instance();
     const auto &monrace = monraces.get_monrace(monrace_id);
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto is_suitable_for_dungeon = !floor.is_underground() || DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, monrace_id);
     switch (hook) {
     case MonraceHook::NONE:
@@ -268,7 +268,7 @@ static bool do_hook(CreatureEntity &creature, MonraceHook hook, MonraceId monrac
  */
 void get_mon_num_prep_enum(CreatureEntity &creature, MonraceHook hook1, MonraceHookTerrain hook2)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto dungeon_level = floor.dun_level;
     const auto &system = AngbandSystem::get_instance();
     auto &table = MonraceAllocationTable::get_instance();
@@ -313,8 +313,8 @@ void get_mon_num_prep_enum(CreatureEntity &creature, MonraceHook hook1, MonraceH
         mfdi.update(entry.prob2, entry.level);
 
         // フロアの現在所属アライアンスに応じた生成率修正
-        if (creature.current_floor_ptr->allianceID != AllianceType::NONE) {
-            if (entry.is_same_alliance(creature.current_floor_ptr->allianceID)) {
+        if (creature.get_floor()->allianceID != AllianceType::NONE) {
+            if (entry.is_same_alliance(creature.get_floor()->allianceID)) {
                 entry.prob2 *= ALLIANCE_GENERATE_RATE;
             } else {
                 entry.prob2 /= ALLIANCE_GENERATE_RATE;
@@ -339,7 +339,7 @@ void get_mon_num_prep_enum(CreatureEntity &creature, MonraceHook hook1, MonraceH
  */
 static bool place_monster_can_escort(CreatureEntity &creature, MonraceId monrace_id, MonraceId escorted_monrace_id, short escorted_m_idx)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto dungeon_id = floor.dungeon_id;
     const auto &escorted_monster = floor.get_monster(escorted_m_idx);
     const auto &monraces = MonraceList::get_instance();
@@ -393,7 +393,7 @@ static bool place_monster_can_escort(CreatureEntity &creature, MonraceId monrace
  */
 void get_mon_num_prep_escort(CreatureEntity &creature, MonraceId escorted_monrace_id, short m_idx, MonraceHookTerrain hook)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto dungeon_level = floor.dun_level;
     const auto &system = AngbandSystem::get_instance();
     auto &table = MonraceAllocationTable::get_instance();
@@ -449,7 +449,7 @@ void get_mon_num_prep_escort(CreatureEntity &creature, MonraceId escorted_monrac
  */
 static bool summon_specific_okay(CreatureEntity &creature, MonraceId monrace_id, const SummonCondition &condition)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.is_underground() && !DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, monrace_id)) {
         return false;
     }
@@ -498,7 +498,7 @@ static bool summon_specific_okay(CreatureEntity &creature, MonraceId monrace_id,
  */
 void get_mon_num_prep_summon(CreatureEntity &creature, const SummonCondition &condition)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto dungeon_level = floor.dun_level;
     const auto &system = AngbandSystem::get_instance();
     auto &table = MonraceAllocationTable::get_instance();
@@ -575,7 +575,7 @@ static bool monster_hook_chameleon_lord(CreatureEntity &creature, const Chameleo
         return false;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(ct.m_idx);
     const auto &old_monrace = monster.get_monrace();
     if (old_monrace.misc_flags.has_not(MonsterMiscType::CHAMELEON)) {
@@ -616,7 +616,7 @@ static bool monster_hook_chameleon(CreatureEntity &creature, const ChameleonTran
         return false;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(ct.m_idx);
     const auto &old_monrace = monster.get_monrace();
     if (old_monrace.misc_flags.has_not(MonsterMiscType::CHAMELEON)) {
@@ -647,7 +647,7 @@ static bool monster_hook_chameleon(CreatureEntity &creature, const ChameleonTran
  */
 void get_mon_num_prep_chameleon(CreatureEntity &creature, const ChameleonTransformation &ct)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto dungeon_level = floor.dun_level;
     const auto &system = AngbandSystem::get_instance();
     auto &table = MonraceAllocationTable::get_instance();
@@ -687,7 +687,7 @@ void get_mon_num_prep_chameleon(CreatureEntity &creature, const ChameleonTransfo
  */
 void get_mon_num_prep_bounty(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto dungeon_level = floor.dun_level;
     const auto &system = AngbandSystem::get_instance();
     auto &table = MonraceAllocationTable::get_instance();
@@ -723,7 +723,7 @@ void get_mon_num_prep_bounty(CreatureEntity &creature)
  */
 void mark_monsters_present(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
 
     for (MONSTER_IDX m_idx = floor.m_max - 1; m_idx >= 1; m_idx--) {
         auto &monster = floor.get_monster(m_idx);

--- a/src/mspell/assign-monster-spell.cpp
+++ b/src/mspell/assign-monster-spell.cpp
@@ -31,7 +31,7 @@
 
 static MonsterSpellResult monspell_to_player_impl(CreatureEntity &creature, MonsterAbilityType ms_type, POSITION y, POSITION x, MONSTER_IDX m_idx)
 {
-    CreatureEntity *m_ptr = &creature.current_floor_ptr->get_monster(m_idx);
+    CreatureEntity *m_ptr = &creature.get_floor()->get_monster(m_idx);
     MonraceDefinition *r_ptr = &MonraceList::get_instance().get_monrace(m_ptr->r_idx);
 
     // クイルスルグは自身を中心に召喚する
@@ -109,7 +109,7 @@ static MonsterSpellResult monspell_to_player_impl(CreatureEntity &creature, Mons
     case MonsterAbilityType::BA_FIRE:
     case MonsterAbilityType::BA_COLD:
          {
-         auto rad = monster_is_powerful(*creature.current_floor_ptr, m_idx) ? 4 : 2;
+         auto rad = monster_is_powerful(*creature.get_floor(), m_idx) ? 4 : 2;
          return MSpellBall(creature, m_idx, ms_type, rad, MONSTER_TO_PLAYER).shoot(y, x);
          }
 
@@ -215,7 +215,7 @@ static MonsterSpellResult monspell_to_player_impl(CreatureEntity &creature, Mons
 static MonsterSpellResult monspell_to_monster_impl(
     CreatureEntity &creature, MonsterAbilityType ms_type, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, bool is_special_spell)
 {
-    CreatureEntity *m_ptr = &creature.current_floor_ptr->get_monster(m_idx);
+    CreatureEntity *m_ptr = &creature.get_floor()->get_monster(m_idx);
     MonraceDefinition *r_ptr = &MonraceList::get_instance().get_monrace(m_ptr->r_idx);
 
     // クイルスルグは自身を中心に召喚する
@@ -293,7 +293,7 @@ static MonsterSpellResult monspell_to_monster_impl(
     case MonsterAbilityType::BA_FIRE:
     case MonsterAbilityType::BA_COLD:
          {
-         auto rad = monster_is_powerful(*creature.current_floor_ptr, m_idx) ? 4 : 2;
+         auto rad = monster_is_powerful(*creature.get_floor(), m_idx) ? 4 : 2;
          return MSpellBall(creature, m_idx, t_idx, ms_type, rad, MONSTER_TO_MONSTER).shoot(y, x);
          }
 

--- a/src/mspell/improper-mspell-remover.cpp
+++ b/src/mspell/improper-mspell-remover.cpp
@@ -38,7 +38,7 @@ void remove_bad_spells(MONSTER_IDX m_idx, CreatureEntity &creature, EnumClassFla
         return;
     }
 
-    auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    auto &monster = creature.get_floor()->get_monster(m_idx);
     if (smart_learn) {
         /* 時々学習情報を忘れる */
         if (one_in_(100)) {

--- a/src/mspell/mspell-attack-util.cpp
+++ b/src/mspell/mspell-attack-util.cpp
@@ -5,7 +5,7 @@
 
 msa_type::msa_type(CreatureEntity &creature, MONSTER_IDX m_idx)
     : m_idx(m_idx)
-    , m_ptr(&creature.current_floor_ptr->get_monster(m_idx))
+    , m_ptr(&creature.get_floor()->get_monster(m_idx))
     , x(creature.x)
     , y(creature.y)
     , do_spell(DO_SPELL_NONE)

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -52,7 +52,7 @@ static void set_no_magic_mask(msa_type *msa_ptr)
 
 static void check_mspell_stupid(CreatureEntity &creature, msa_type *msa_ptr)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     auto is_in_no_magic_dungeon = floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_MAGIC);
     is_in_no_magic_dungeon &= floor.is_underground();
     is_in_no_magic_dungeon &= !floor.is_in_quest() || QuestType::is_fixed(floor.quest_number);
@@ -163,7 +163,7 @@ static bool check_mspell_continuation(CreatureEntity &creature, msa_type *msa_pt
     }
 
     remove_bad_spells(msa_ptr->m_idx, creature, msa_ptr->ability_flags);
-    check_mspell_arena(*creature.current_floor_ptr, msa_ptr);
+    check_mspell_arena(*creature.get_floor(), msa_ptr);
     if (msa_ptr->ability_flags.none() || !check_mspell_non_stupid(creature, msa_ptr)) {
         return false;
     }
@@ -263,7 +263,7 @@ static bool check_thrown_mspell(CreatureEntity &creature, msa_type *msa_ptr)
 static void check_mspell_imitation(CreatureEntity &creature, msa_type *msa_ptr)
 {
     const auto seen = (!creature.is_blind() && msa_ptr->m_ptr->get_monster_profile().ml);
-    const auto can_imitate = creature.current_floor_ptr->has_los_at({ msa_ptr->m_ptr->y, msa_ptr->m_ptr->x });
+    const auto can_imitate = creature.get_floor()->has_los_at({ msa_ptr->m_ptr->y, msa_ptr->m_ptr->x });
     CreatureClass pc(creature);
     if (!seen || !can_imitate || (AngbandWorld::get_instance().timewalk_m_idx != 0) || !pc.equals(PlayerClassType::IMITATOR)) {
         return;
@@ -331,7 +331,7 @@ bool make_attack_spell(CreatureEntity &creature, MONSTER_IDX m_idx)
     set_no_magic_mask(msa_ptr);
     decide_lite_area(creature, msa_ptr);
     check_mspell_stupid(creature, msa_ptr);
-    check_mspell_smart(*creature.current_floor_ptr, msa_ptr);
+    check_mspell_smart(*creature.get_floor(), msa_ptr);
     if (!check_mspell_continuation(creature, msa_ptr)) {
         return false;
     }
@@ -354,7 +354,7 @@ bool make_attack_spell(CreatureEntity &creature, MONSTER_IDX m_idx)
     msa_ptr->dam = monspell_res.dam;
     check_mspell_imitation(creature, msa_ptr);
     remember_mspell(msa_ptr);
-    if (creature.is_dead() && (msa_ptr->r_ptr->r_deaths < MAX_SHORT) && !creature.current_floor_ptr->inside_arena) {
+    if (creature.is_dead() && (msa_ptr->r_ptr->r_deaths < MAX_SHORT) && !creature.get_floor()->inside_arena) {
         msa_ptr->r_ptr->r_deaths++;
     }
 

--- a/src/mspell/mspell-attack/mspell-ball.cpp
+++ b/src/mspell/mspell-attack/mspell-ball.cpp
@@ -21,7 +21,7 @@
 static bool message_fire_ball(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
     mspell_cast_msg_blind msg;
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
 
     if (monster.r_idx == MonraceId::ROLENTO) {
         msg.blind = _("%sが何かを投げた。", "%s^ throws something.");

--- a/src/mspell/mspell-attack/mspell-breath.cpp
+++ b/src/mspell/mspell-attack/mspell-breath.cpp
@@ -47,7 +47,7 @@ static bool spell_RF4_BREATH_special_message(MonraceId r_idx, AttributeType GF_T
 
 static void message_breath(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type, std::string_view type_s, AttributeType GF_TYPE)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     auto see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
     auto known = monster_near_player(creature, m_idx, t_idx);

--- a/src/mspell/mspell-attack/mspell-curse.cpp
+++ b/src/mspell/mspell-attack/mspell-curse.cpp
@@ -29,7 +29,7 @@ static bool message_curse(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_I
         if (see_monster(creature, m_idx)) {
             msg_format(msg3.data(), m_name.data(), t_name.data());
         } else {
-            creature.current_floor_ptr->monster_noise = true;
+            creature.get_floor()->monster_noise = true;
         }
     }
     return false;

--- a/src/mspell/mspell-checker.cpp
+++ b/src/mspell/mspell-checker.cpp
@@ -35,7 +35,7 @@
 bool summon_possible(CreatureEntity &creature, POSITION y1, POSITION x1)
 {
     const auto p_pos = creature.get_position();
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const Pos2D pos1(y1, x1);
     for (auto y = y1 - 2; y <= y1 + 2; y++) {
         for (auto x = x1 - 2; x <= x1 + 2; x++) {
@@ -71,7 +71,7 @@ bool summon_possible(CreatureEntity &creature, POSITION y1, POSITION x1)
 bool raise_possible(CreatureEntity &creature, const CreatureEntity &target)
 {
     const auto m_pos = target.get_position();
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (auto xx = m_pos.x - 5; xx <= m_pos.x + 5; xx++) {
         for (auto yy = m_pos.y - 5; yy <= m_pos.y + 5; yy++) {
             const Pos2D pos(yy, xx);
@@ -123,7 +123,7 @@ bool raise_possible(CreatureEntity &creature, const CreatureEntity &target)
  */
 bool clean_shot(CreatureEntity &creature, POSITION y1, POSITION x1, POSITION y2, POSITION x2, bool is_friend)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     ProjectionPath grid_g(floor, AngbandSystem::get_instance().get_max_range(), { y1, x1 }, { y2, x2 });
     if (grid_g.path_num() == 0) {
         return false;
@@ -234,7 +234,7 @@ ProjectResult ball(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX
  */
 ProjectResult breath(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, AttributeType typ, int dam_hp, POSITION rad, int target_type)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     BIT_FLAGS flg = PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_BREATH;
     if (target_type == MONSTER_TO_PLAYER) {

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -162,7 +162,7 @@ MonsterSpellResult spell_RF4_DISPEL(MONSTER_IDX m_idx, CreatureEntity &creature,
 
         return res;
     }
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &target = floor.get_monster(t_idx);
     if (target_type == MONSTER_TO_MONSTER) {
         if (target.is_riding()) {

--- a/src/mspell/mspell-floor.cpp
+++ b/src/mspell/mspell-floor.cpp
@@ -56,7 +56,7 @@ MonsterSpellResult spell_RF4_SHRIEK(MONSTER_IDX m_idx, CreatureEntity &creature,
 
     simple_monspell_message(creature, m_idx, t_idx, msg, target_type);
 
-    const auto &monster = player_ptr.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = player_ptr.get_floor()->get_monster(m_idx);
     auto result = MonsterSpellResult::make_valid();
     if (monster.r_idx == MonraceId::LEE_QIEZI) {
         msg_print(_("しかし、その声は誰の心にも響かなかった…。", "However, that voice didn't touch anyone's heart..."));
@@ -66,7 +66,7 @@ MonsterSpellResult spell_RF4_SHRIEK(MONSTER_IDX m_idx, CreatureEntity &creature,
     if (target_type == MONSTER_TO_PLAYER) {
         aggravate_monsters(player_ptr, m_idx);
     } else if (target_type == MONSTER_TO_MONSTER) {
-        set_monster_csleep(*player_ptr.current_floor_ptr, t_idx, 0);
+        set_monster_csleep(*player_ptr.get_floor(), t_idx, 0);
     }
 
     return result;
@@ -175,7 +175,7 @@ MonsterSpellResult spell_RF6_TELE_TO(CreatureEntity &creature, MONSTER_IDX m_idx
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
-    const auto &floor = *player_ptr.current_floor_ptr;
+    const auto &floor = *player_ptr.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     const auto &monster_target = floor.get_monster(t_idx);
     auto &monrace_target = monster_target.get_monrace();
@@ -218,7 +218,7 @@ MonsterSpellResult spell_RF6_TELE_TO(CreatureEntity &creature, MONSTER_IDX m_idx
     }
 
     if (resists_tele) {
-        set_monster_csleep(*player_ptr.current_floor_ptr, t_idx, 0);
+        set_monster_csleep(*player_ptr.get_floor(), t_idx, 0);
         return res;
     }
 
@@ -227,7 +227,7 @@ MonsterSpellResult spell_RF6_TELE_TO(CreatureEntity &creature, MONSTER_IDX m_idx
     } else {
         teleport_monster_to(player_ptr, t_idx, monster.y, monster.x, 100, TELEPORT_PASSIVE);
     }
-    set_monster_csleep(*player_ptr.current_floor_ptr, t_idx, 0);
+    set_monster_csleep(*player_ptr.get_floor(), t_idx, 0);
 
     return res;
 }
@@ -247,7 +247,7 @@ MonsterSpellResult spell_RF6_TELE_AWAY(CreatureEntity &creature, MONSTER_IDX m_i
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
-    const auto &floor = *player_ptr.current_floor_ptr;
+    const auto &floor = *player_ptr.get_floor();
     const auto &monster_target = floor.get_monster(t_idx);
     auto &monrace_target = monster_target.get_monrace();
 
@@ -301,7 +301,7 @@ MonsterSpellResult spell_RF6_TELE_AWAY(CreatureEntity &creature, MONSTER_IDX m_i
     }
 
     if (resists_tele) {
-        set_monster_csleep(*player_ptr.current_floor_ptr, t_idx, 0);
+        set_monster_csleep(*player_ptr.get_floor(), t_idx, 0);
         return res;
     }
 
@@ -310,7 +310,7 @@ MonsterSpellResult spell_RF6_TELE_AWAY(CreatureEntity &creature, MONSTER_IDX m_i
     } else {
         teleport_away(player_ptr, t_idx, MAX_PLAYER_SIGHT * 2 + 5, TELEPORT_PASSIVE);
     }
-    set_monster_csleep(*player_ptr.current_floor_ptr, t_idx, 0);
+    set_monster_csleep(*player_ptr.get_floor(), t_idx, 0);
 
     return res;
 }
@@ -329,7 +329,7 @@ MonsterSpellResult spell_RF6_TELE_LEVEL(CreatureEntity &creature, MONSTER_IDX m_
     auto &player_ptr = creature;
     const auto res = MonsterSpellResult::make_valid();
 
-    const auto &floor = *player_ptr.current_floor_ptr;
+    const auto &floor = *player_ptr.get_floor();
     const auto &monster_target = floor.get_monster(t_idx);
     const auto &monrace_target = monster_target.get_monrace();
     DEPTH rlev = monster_level_idx(floor, m_idx);
@@ -389,7 +389,7 @@ MonsterSpellResult spell_RF6_DARKNESS(CreatureEntity &creature, POSITION y, POSI
     const Pos2D pos(y, x);
     mspell_cast_msg_blind msg;
     concptr msg_done;
-    const auto &floor = *player_ptr.current_floor_ptr;
+    const auto &floor = *player_ptr.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     bool can_use_lite_area = false;
@@ -492,7 +492,7 @@ MonsterSpellResult spell_RF6_TRAPS(CreatureEntity &creature, POSITION y, POSITIO
 MonsterSpellResult spell_RF6_RAISE_DEAD(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
     auto &player_ptr = creature;
-    const auto &monster = player_ptr.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = player_ptr.get_floor()->get_monster(m_idx);
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が死者復活の呪文を唱えた。", "%s^ casts a spell to revive corpses."), _("%s^が死者復活の呪文を唱えた。", "%s^ casts a spell to revive corpses."));
 

--- a/src/mspell/mspell-judgement.cpp
+++ b/src/mspell/mspell-judgement.cpp
@@ -44,7 +44,7 @@
  */
 bool direct_beam(CreatureEntity &creature, const CreatureEntity &caster, const Pos2D &pos_target)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto pos_source = caster.get_position();
     ProjectionPath grid_g(floor, AngbandSystem::get_instance().get_max_range(), creature.get_position(), pos_source, pos_target, PROJECT_THRU);
     if (grid_g.path_num()) {
@@ -99,7 +99,7 @@ bool breath_direct(CreatureEntity &creature, const Pos2D &pos_source, const Pos2
         break;
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     ProjectionPath grid_g(floor, AngbandSystem::get_instance().get_max_range(), creature.get_position(), pos_source, pos_target, flg);
     auto path_n = 0;
     Pos2D pos_breath = pos_source;
@@ -195,7 +195,7 @@ Pos2D get_project_point(const FloorType &floor, const Pos2D &p_pos, const Pos2D 
  */
 bool dispel_check_monster(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx)
 {
-    const auto &t_ref = creature.current_floor_ptr->get_monster(t_idx);
+    const auto &t_ref = creature.get_floor()->get_monster(t_idx);
     if (t_ref.is_invulnerable()) {
         return true;
     }
@@ -256,7 +256,7 @@ bool dispel_check(CreatureEntity &creature, MONSTER_IDX m_idx)
         return true;
     }
 
-    const auto &floor_ref = *creature.current_floor_ptr;
+    const auto &floor_ref = *creature.get_floor();
     const auto &monster = floor_ref.get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     if (monrace.ability_flags.has(MonsterAbilityType::BR_ACID)) {
@@ -349,8 +349,8 @@ bool dispel_check(CreatureEntity &creature, MONSTER_IDX m_idx)
         return true;
     }
 
-    const auto &m_ref = creature.current_floor_ptr->get_monster(creature.riding);
-    if (creature.riding && (creature.current_floor_ptr->get_monster(creature.riding).speed < 135) && m_ref.is_accelerated()) {
+    const auto &m_ref = creature.get_floor()->get_monster(creature.riding);
+    if (creature.riding && (creature.get_floor()->get_monster(creature.riding).speed < 135) && m_ref.is_accelerated()) {
         return true;
     }
 

--- a/src/mspell/mspell-learn-checker.cpp
+++ b/src/mspell/mspell-learn-checker.cpp
@@ -14,7 +14,7 @@
  */
 bool spell_learnable(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     const auto seen = (!creature.is_blind() && monster.get_monster_profile().ml);
     const auto maneable = floor.has_los_at({ monster.y, monster.x });

--- a/src/mspell/mspell-lite.cpp
+++ b/src/mspell/mspell-lite.cpp
@@ -56,7 +56,7 @@ static tl::optional<Pos2D> adjacent_grid_check(CreatureEntity &creature, const C
         next = 3;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto m_pos = monster.get_position();
     for (const auto direction : directions.at(next)) {
         const auto pos_next = pos + Direction(direction).vec();
@@ -92,7 +92,7 @@ void decide_lite_range(CreatureEntity &creature, msa_type *msa_ptr)
 
     msa_ptr->y_br_lite = msa_ptr->y;
     msa_ptr->x_br_lite = msa_ptr->x;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto pos_lite = msa_ptr->get_position_lite();
     if (los(floor, msa_ptr->m_ptr->get_position(), pos_lite)) {
         const auto &terrain = floor.get_grid(pos_lite).get_terrain();
@@ -143,7 +143,7 @@ static void check_lite_area_by_mspell(CreatureEntity &creature, msa_type *msa_pt
     const auto m_pos = msa_ptr->m_ptr->get_position();
     const auto cdis = Grid::calc_distance(p_pos, m_pos);
     light_by_disintegration &= cdis < system.get_max_range() / 2;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     light_by_disintegration &= in_disintegration_range(floor, m_pos, pos);
     light_by_disintegration &= one_in_(10) || (projectable(floor, pos, m_pos) && one_in_(2));
     if (light_by_disintegration) {
@@ -208,7 +208,7 @@ static void decide_lite_breath(CreatureEntity &creature, msa_type *msa_ptr)
 
 bool decide_lite_projection(CreatureEntity &creature, msa_type *msa_ptr)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (projectable(floor, msa_ptr->m_ptr->get_position(), msa_ptr->get_position())) {
         feature_projection(floor, msa_ptr);
         return true;
@@ -244,7 +244,7 @@ void decide_lite_area(CreatureEntity &creature, msa_type *msa_ptr)
         return;
     }
 
-    if (creature.current_floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
+    if (creature.get_floor()->get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         msa_ptr->ability_flags.reset(MonsterAbilityType::DARKNESS);
         return;
     }

--- a/src/mspell/mspell-selector.cpp
+++ b/src/mspell/mspell-selector.cpp
@@ -323,7 +323,7 @@ MonsterAbilityType choose_attack_spell(CreatureEntity &creature, msa_type *msa_p
     std::vector<MonsterAbilityType> heal;
     std::vector<MonsterAbilityType> dispel;
 
-    const auto &monster = creature.current_floor_ptr->get_monster(msa_ptr->m_idx);
+    const auto &monster = creature.get_floor()->get_monster(msa_ptr->m_idx);
     const auto &monrace = monster.get_monrace();
     if (monrace.behavior_flags.has(MonsterBehaviorType::STUPID)) {
         return rand_choice(msa_ptr->mspells);

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -46,7 +46,7 @@
  */
 static MonsterSpellResult spell_RF6_SPECIAL_UNIFICATION(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     auto dummy_y = monster.y;
     auto dummy_x = monster.x;
@@ -176,7 +176,7 @@ static MonsterSpellResult spell_RF6_SPECIAL_ROLENTO(CreatureEntity &creature, PO
 static MonsterSpellResult spell_RF6_SPECIAL_B(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
     mspell_cast_msg_simple msg{};
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     const auto &monster_target = floor.get_monster(t_idx);
     const auto &monrace_target = monster_target.get_monrace();
@@ -261,7 +261,7 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(CreatureEntity &creature, POSITION
  */
 MonsterSpellResult spell_RF6_SPECIAL(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     const auto r_idx = monster.r_idx;

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -91,7 +91,7 @@ void spell_badstatus_message_to_player(CreatureEntity &creature, MONSTER_IDX m_i
 void spell_badstatus_message_to_mons(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, const mspell_cast_msg_bad_status_to_monster &msgs, bool resist,
     bool saved_throw)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
     bool see_t = see_monster(creature, t_idx);
     bool known = monster_near_player(creature, m_idx, t_idx);
@@ -120,7 +120,7 @@ void spell_badstatus_message_to_mons(CreatureEntity &creature, MONSTER_IDX m_idx
         }
     }
 
-    set_monster_csleep(*creature.current_floor_ptr, t_idx, 0);
+    set_monster_csleep(*creature.get_floor(), t_idx, 0);
 }
 
 /*!
@@ -171,7 +171,7 @@ MonsterSpellResult spell_RF5_DRAIN_MANA(CreatureEntity &creature, POSITION y, PO
  */
 MonsterSpellResult spell_RF5_MIND_BLAST(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     bool seen = (!creature.is_blind() && monster.get_monster_profile().ml);
     const auto m_name = monster_name(creature, m_idx);
     const auto t_name = monster_name(creature, t_idx);
@@ -209,7 +209,7 @@ MonsterSpellResult spell_RF5_MIND_BLAST(CreatureEntity &creature, POSITION y, PO
  */
 MonsterSpellResult spell_RF5_BRAIN_SMASH(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     bool seen = (!creature.is_blind() && monster.get_monster_profile().ml);
     const auto m_name = monster_name(creature, m_idx);
     const auto t_name = monster_name(creature, t_idx);
@@ -247,7 +247,7 @@ MonsterSpellResult spell_RF5_SCARE(MONSTER_IDX m_idx, CreatureEntity &creature, 
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster_target = floor.get_monster(t_idx);
     const auto &monrace_target = monster_target.get_monrace();
     DEPTH rlev = monster_level_idx(floor, m_idx);
@@ -285,7 +285,7 @@ MonsterSpellResult spell_RF5_SCARE(MONSTER_IDX m_idx, CreatureEntity &creature, 
     spell_badstatus_message_to_mons(creature, m_idx, t_idx, msg, resist, saving_throw);
 
     if (!resist && !saving_throw) {
-        set_monster_monfear(*creature.current_floor_ptr, t_idx, monster_target.get_remaining_fear() + randint0(4) + 4);
+        set_monster_monfear(*creature.get_floor(), t_idx, monster_target.get_remaining_fear() + randint0(4) + 4);
     }
 
     return res;
@@ -304,7 +304,7 @@ MonsterSpellResult spell_RF5_BLIND(MONSTER_IDX m_idx, CreatureEntity &creature, 
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster_target = floor.get_monster(t_idx);
     const auto &monrace_target = monster_target.get_monrace();
     DEPTH rlev = monster_level_idx(floor, m_idx);
@@ -350,7 +350,7 @@ MonsterSpellResult spell_RF5_BLIND(MONSTER_IDX m_idx, CreatureEntity &creature, 
     spell_badstatus_message_to_mons(creature, m_idx, t_idx, msg, resist, saving_throw);
 
     if (!resist && !saving_throw) {
-        (void)set_monster_confused(*creature.current_floor_ptr, t_idx, monster_target.get_remaining_confusion() + 12 + randint0(4));
+        (void)set_monster_confused(*creature.get_floor(), t_idx, monster_target.get_remaining_confusion() + 12 + randint0(4));
     }
 
     return res;
@@ -369,7 +369,7 @@ MonsterSpellResult spell_RF5_CONF(MONSTER_IDX m_idx, CreatureEntity &creature, M
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster_target = floor.get_monster(t_idx);
     const auto &monrace_target = monster_target.get_monrace();
     DEPTH rlev = monster_level_idx(floor, m_idx);
@@ -408,7 +408,7 @@ MonsterSpellResult spell_RF5_CONF(MONSTER_IDX m_idx, CreatureEntity &creature, M
     spell_badstatus_message_to_mons(creature, m_idx, t_idx, msg, resist, saving_throw);
 
     if (!resist && !saving_throw) {
-        (void)set_monster_confused(*creature.current_floor_ptr, t_idx, monster_target.get_remaining_confusion() + 12 + randint0(4));
+        (void)set_monster_confused(*creature.get_floor(), t_idx, monster_target.get_remaining_confusion() + 12 + randint0(4));
     }
 
     return res;
@@ -427,7 +427,7 @@ MonsterSpellResult spell_RF5_HOLD(MONSTER_IDX m_idx, CreatureEntity &creature, M
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster_target = floor.get_monster(t_idx);
     const auto &monrace_target = monster_target.get_monrace();
     DEPTH rlev = monster_level_idx(floor, m_idx);
@@ -464,7 +464,7 @@ MonsterSpellResult spell_RF5_HOLD(MONSTER_IDX m_idx, CreatureEntity &creature, M
     spell_badstatus_message_to_mons(creature, m_idx, t_idx, msg, (bool)resist, saving_throw);
 
     if (!resist && !saving_throw) {
-        (void)set_monster_csleep(*creature.current_floor_ptr, t_idx, 500);
+        (void)set_monster_csleep(*creature.get_floor(), t_idx, 500);
     }
 
     return res;
@@ -482,7 +482,7 @@ MonsterSpellResult spell_RF5_HOLD(MONSTER_IDX m_idx, CreatureEntity &creature, M
 MonsterSpellResult spell_RF6_HASTE(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
     bool see_m = see_monster(creature, m_idx);
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto m_name = monster_name(creature, m_idx);
     const auto m_poss = monster_desc(creature, monster, MD_PRON_VISIBLE | MD_POSSESSIVE);
 
@@ -493,7 +493,7 @@ MonsterSpellResult spell_RF6_HASTE(CreatureEntity &creature, MONSTER_IDX m_idx, 
 
     monspell_message_base(creature, m_idx, t_idx, msg, creature.is_blind(), target_type);
 
-    if (set_monster_fast(*creature.current_floor_ptr, m_idx, monster.get_remaining_acceleration() + 100)) {
+    if (set_monster_fast(*creature.get_floor(), m_idx, monster.get_remaining_acceleration() + 100)) {
         if (target_type == MONSTER_TO_PLAYER || (target_type == MONSTER_TO_MONSTER && see_m)) {
             msg_format(_("%s^の動きが速くなった。", "%s^ starts moving faster."), m_name.data());
         }
@@ -515,7 +515,7 @@ MonsterSpellResult spell_RF5_SLOW(MONSTER_IDX m_idx, CreatureEntity &creature, M
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster_target = floor.get_monster(t_idx);
     const auto &monrace_target = monster_target.get_monrace();
     DEPTH rlev = monster_level_idx(floor, m_idx);
@@ -561,7 +561,7 @@ MonsterSpellResult spell_RF5_SLOW(MONSTER_IDX m_idx, CreatureEntity &creature, M
     spell_badstatus_message_to_mons(creature, m_idx, t_idx, msg, resist, saving_throw);
 
     if (!resist && !saving_throw) {
-        set_monster_slow(*creature.current_floor_ptr, t_idx, monster_target.get_remaining_deceleration() + 50);
+        set_monster_slow(*creature.get_floor(), t_idx, monster_target.get_remaining_deceleration() + 50);
     }
 
     return res;
@@ -581,7 +581,7 @@ MonsterSpellResult spell_RF6_HEAL(CreatureEntity &creature, MONSTER_IDX m_idx, M
     const auto res = MonsterSpellResult::make_valid();
 
     mspell_cast_msg msg;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(m_idx);
     DEPTH rlev = monster_level_idx(floor, m_idx);
     const auto is_blind = creature.is_blind();
@@ -621,7 +621,7 @@ MonsterSpellResult spell_RF6_HEAL(CreatureEntity &creature, MONSTER_IDX m_idx, M
         return res;
     }
 
-    (void)set_monster_monfear(*creature.current_floor_ptr, m_idx, 0);
+    (void)set_monster_monfear(*creature.get_floor(), m_idx, 0);
 
     if (see_monster(creature, m_idx)) {
         const auto m_name = monster_name(creature, m_idx);
@@ -642,7 +642,7 @@ MonsterSpellResult spell_RF6_HEAL(CreatureEntity &creature, MONSTER_IDX m_idx, M
  */
 MonsterSpellResult spell_RF6_INVULNER(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     bool seen = (!creature.is_blind() && monster.get_monster_profile().ml);
     mspell_cast_msg msg(_("%s^が何かを力強くつぶやいた。", "%s^ mumbles powerfully."),
         _("%s^が何かを力強くつぶやいた。", "%s^ mumbles powerfully."), _("%sは無傷の球の呪文を唱えた。", "%s^ casts a Globe of Invulnerability."),
@@ -668,7 +668,7 @@ MonsterSpellResult spell_RF6_INVULNER(CreatureEntity &creature, MONSTER_IDX m_id
     }
 
     if (!monster.is_invulnerable()) {
-        (void)set_monster_invulner(*creature.current_floor_ptr, m_idx, randint1(4) + 4, false);
+        (void)set_monster_invulner(*creature.get_floor(), m_idx, randint1(4) + 4, false);
     }
 
     return MonsterSpellResult::make_valid();
@@ -683,7 +683,7 @@ MonsterSpellResult spell_RF6_INVULNER(CreatureEntity &creature, MONSTER_IDX m_id
  */
 MonsterSpellResult spell_RF6_FORGET(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    DEPTH rlev = monster_level_idx(*creature.current_floor_ptr, m_idx);
+    DEPTH rlev = monster_level_idx(*creature.get_floor(), m_idx);
     const auto m_name = monster_name(creature, m_idx);
 
     disturb(creature, true, true);

--- a/src/mspell/mspell-summon.cpp
+++ b/src/mspell/mspell-summon.cpp
@@ -103,7 +103,7 @@ static MONSTER_NUMBER summon_Alliance(CreatureEntity &creature, POSITION y, POSI
 static void decide_summon_kin_caster(
     CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type, concptr m_name, concptr m_poss, const bool known)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
     bool mon_to_mon = target_type == MONSTER_TO_MONSTER;
@@ -150,7 +150,7 @@ static void decide_summon_kin_caster(
  */
 MonsterSpellResult spell_RF6_S_KIN(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     DEPTH rlev = monster_level_idx(floor, m_idx);
     const auto m_name = monster_name(creature, m_idx);
@@ -263,7 +263,7 @@ MonsterSpellResult spell_RF6_S_KIN(CreatureEntity &creature, POSITION y, POSITIO
  */
 MonsterSpellResult spell_RF6_S_CYBER(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
@@ -311,7 +311,7 @@ MonsterSpellResult spell_RF6_S_CYBER(CreatureEntity &creature, POSITION y, POSIT
  */
 MonsterSpellResult spell_RF6_S_MONSTER(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -362,7 +362,7 @@ MonsterSpellResult spell_RF6_S_MONSTER(CreatureEntity &creature, POSITION y, POS
  */
 MonsterSpellResult spell_RF6_S_MONSTERS(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -413,7 +413,7 @@ MonsterSpellResult spell_RF6_S_MONSTERS(CreatureEntity &creature, POSITION y, PO
  */
 MonsterSpellResult spell_RF6_S_ANT(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -458,7 +458,7 @@ MonsterSpellResult spell_RF6_S_ANT(CreatureEntity &creature, POSITION y, POSITIO
  */
 MonsterSpellResult spell_RF6_S_SPIDER(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -503,7 +503,7 @@ MonsterSpellResult spell_RF6_S_SPIDER(CreatureEntity &creature, POSITION y, POSI
  */
 MonsterSpellResult spell_RF6_S_HOUND(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -548,7 +548,7 @@ MonsterSpellResult spell_RF6_S_HOUND(CreatureEntity &creature, POSITION y, POSIT
  */
 MonsterSpellResult spell_RF6_S_HYDRA(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -593,7 +593,7 @@ MonsterSpellResult spell_RF6_S_HYDRA(CreatureEntity &creature, POSITION y, POSIT
  */
 MonsterSpellResult spell_RF6_S_FAIRY(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -638,7 +638,7 @@ MonsterSpellResult spell_RF6_S_FAIRY(CreatureEntity &creature, POSITION y, POSIT
  */
 MonsterSpellResult spell_RF6_S_APE(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -683,7 +683,7 @@ MonsterSpellResult spell_RF6_S_APE(CreatureEntity &creature, POSITION y, POSITIO
  */
 MonsterSpellResult spell_RF6_S_BIRD(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -728,7 +728,7 @@ MonsterSpellResult spell_RF6_S_BIRD(CreatureEntity &creature, POSITION y, POSITI
  */
 MonsterSpellResult spell_RF6_S_ANGEL(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
@@ -786,7 +786,7 @@ MonsterSpellResult spell_RF6_S_ANGEL(CreatureEntity &creature, POSITION y, POSIT
  */
 MonsterSpellResult spell_RF6_S_DEMON(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
@@ -831,7 +831,7 @@ MonsterSpellResult spell_RF6_S_DEMON(CreatureEntity &creature, POSITION y, POSIT
  */
 MonsterSpellResult spell_RF6_S_UNDEAD(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
@@ -876,7 +876,7 @@ MonsterSpellResult spell_RF6_S_UNDEAD(CreatureEntity &creature, POSITION y, POSI
  */
 MonsterSpellResult spell_RF6_S_DRAGON(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -925,7 +925,7 @@ MonsterSpellResult spell_RF6_S_DRAGON(CreatureEntity &creature, POSITION y, POSI
  */
 MonsterSpellResult spell_RF6_S_HI_UNDEAD(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &monster = floor.m_list[m_idx];
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
@@ -983,7 +983,7 @@ MonsterSpellResult spell_RF6_S_HI_UNDEAD(CreatureEntity &creature, POSITION y, P
  */
 MonsterSpellResult spell_RF6_S_HI_DRAGON(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -1035,7 +1035,7 @@ MonsterSpellResult spell_RF6_S_HI_DRAGON(CreatureEntity &creature, POSITION y, P
  */
 MonsterSpellResult spell_RF6_S_AMBERITES(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -1081,7 +1081,7 @@ MonsterSpellResult spell_RF6_S_AMBERITES(CreatureEntity &creature, POSITION y, P
  */
 MonsterSpellResult spell_RF6_S_CHOASIANS(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -1127,7 +1127,7 @@ MonsterSpellResult spell_RF6_S_CHOASIANS(CreatureEntity &creature, POSITION y, P
  */
 MonsterSpellResult spell_RF6_S_UNIQUE(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -1191,7 +1191,7 @@ MonsterSpellResult spell_RF6_S_UNIQUE(CreatureEntity &creature, POSITION y, POSI
  */
 MonsterSpellResult spell_RF6_S_DEAD_UNIQUE(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto rlev = monster_level_idx(floor, m_idx);
     auto mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     auto mon_to_player = (target_type == MONSTER_TO_PLAYER);
@@ -1235,7 +1235,7 @@ MonsterSpellResult spell_RF6_S_DEAD_UNIQUE(CreatureEntity &creature, POSITION y,
  */
 MonsterSpellResult spell_RF6_S_NASTY(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^がクッソ汚いモンスターを召喚した！", "%s^ summons nasty monsters!"),
         _("%s^がクッソ汚いモンスターを召喚した！", "%s^ summons nasty monsters!"));
@@ -1277,7 +1277,7 @@ MonsterSpellResult spell_RF6_S_NASTY(CreatureEntity &creature, POSITION y, POSIT
  */
 MonsterSpellResult spell_RF6_S_GOLEM(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法でゴーレムを召喚した！", "%s^ magically summons golems!"),
@@ -1320,7 +1320,7 @@ MonsterSpellResult spell_RF6_S_GOLEM(CreatureEntity &creature, POSITION y, POSIT
  */
 MonsterSpellResult spell_RF6_S_CATS(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法で猫を召喚した！", "%s^ magically summons cats!"),
         _("%s^が魔法で猫を召喚した！", "%s^ magically summons cats!"));
@@ -1362,7 +1362,7 @@ MonsterSpellResult spell_RF6_S_CATS(CreatureEntity &creature, POSITION y, POSITI
  */
 MonsterSpellResult spell_RF6_S_PERVERTS(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法で変質者を召喚した！", "%s^ magically summons perverts!"),
@@ -1405,7 +1405,7 @@ MonsterSpellResult spell_RF6_S_PERVERTS(CreatureEntity &creature, POSITION y, PO
  */
 MonsterSpellResult spell_RF6_S_PUYO(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法でぷよを召喚した！", "%s^ magically summons puyo!"),
@@ -1447,7 +1447,7 @@ MonsterSpellResult spell_RF6_S_PUYO(CreatureEntity &creature, POSITION y, POSITI
  */
 MonsterSpellResult spell_RF6_S_HOMO(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
 
     mspell_cast_msg_blind msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
         _("%s^が魔法でホモを召喚した！", "%s^ magically summons Gays!"),
@@ -1496,7 +1496,7 @@ MonsterSpellResult spell_RF6_S_HOMO(CreatureEntity &creature, POSITION y, POSITI
  */
 MonsterSpellResult spell_RF6_S_WALL(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
@@ -1541,7 +1541,7 @@ MonsterSpellResult spell_RF6_S_WALL(CreatureEntity &creature, POSITION y, POSITI
  */
 MonsterSpellResult spell_RF6_S_INSECT(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     DEPTH rlev = monster_level_idx(floor, m_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
@@ -1585,7 +1585,7 @@ MonsterSpellResult spell_RF6_S_INSECT(CreatureEntity &creature, POSITION y, POSI
  */
 MonsterSpellResult spell_RF6_S_ELDRAZI(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto rlev = monster_level_idx(floor, m_idx);
     const auto known = monster_near_player(creature, m_idx, t_idx);
     const auto see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);

--- a/src/mspell/mspell-util.cpp
+++ b/src/mspell/mspell-util.cpp
@@ -29,7 +29,7 @@ mspell_cast_msg_simple::mspell_cast_msg_simple(concptr to_player, concptr to_mon
  */
 bool see_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     return is_seen(creature, monster);
 }
 
@@ -42,7 +42,7 @@ bool see_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
  */
 bool monster_near_player(const CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     const auto &monster = floor.get_monster(m_idx);
     const auto &monster_target = floor.get_monster(t_idx);
@@ -62,7 +62,7 @@ bool monster_near_player(const CreatureEntity &creature, MONSTER_IDX m_idx, MONS
 bool monspell_message_base(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, const mspell_cast_msg &msgs, bool msg_flag_aux, int target_type)
 {
     bool notice = false;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     bool known = monster_near_player(creature, m_idx, t_idx);
     bool see_either = see_monster(creature, m_idx) || see_monster(creature, t_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);

--- a/src/mspell/smart-mspell-util.cpp
+++ b/src/mspell/smart-mspell-util.cpp
@@ -8,7 +8,7 @@
 msr_type::msr_type(CreatureEntity &creature, short m_idx, const EnumClassFlagGroup<MonsterAbilityType> &ability_flags)
     : ability_flags(ability_flags)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     this->r_ptr = &monster.get_monrace();
 }
 

--- a/src/mspell/specified-summon.cpp
+++ b/src/mspell/specified-summon.cpp
@@ -193,7 +193,7 @@ MONSTER_NUMBER summon_NAZGUL(CreatureEntity &creature, POSITION y, POSITION x, M
     }
 
     msg_erase();
-    const auto &floor = *player_ptr.current_floor_ptr;
+    const auto &floor = *player_ptr.get_floor();
     const auto p_pos = player_ptr.get_position();
     auto count = 0;
     for (auto k = 0; k < 30; k++) {
@@ -351,7 +351,7 @@ MONSTER_NUMBER summon_PLASMA(CreatureEntity &creature, POSITION y, POSITION x, i
 MONSTER_NUMBER summon_LAFFEY_II(CreatureEntity &creature, const Pos2D &position, MONSTER_IDX m_idx)
 {
     auto &player_ptr = creature;
-    auto &floor = *player_ptr.current_floor_ptr;
+    auto &floor = *player_ptr.get_floor();
     auto count = 0;
     constexpr auto summon_num = 2;
     auto real_num = summon_num - MonraceList::get_instance().get_monrace(MonraceId::BUNBUN_STRIKERS).cur_num;

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -89,7 +89,7 @@ void process_world_aux_sudden_attack(CreatureEntity &creature)
                 break;
             }
             if (one_in_(5)) {
-                summon_specific(creature, creature.y, creature.x, creature.current_floor_ptr->dun_level, SUMMON_KACHO, PM_IGNORE_LEVEL | PM_NO_KAGE);
+                summon_specific(creature, creature.y, creature.x, creature.get_floor()->dun_level, SUMMON_KACHO, PM_IGNORE_LEVEL | PM_NO_KAGE);
             }
         }
     }
@@ -225,7 +225,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
             mode |= (PM_ALLOW_UNIQUE | PM_NO_PET);
         }
 
-        if (summon_specific(creature, creature.y, creature.x, creature.current_floor_ptr->dun_level, SUMMON_DEMON, mode)) {
+        if (summon_specific(creature, creature.y, creature.x, creature.get_floor()->dun_level, SUMMON_DEMON, mode)) {
             msg_print(_("あなたはデーモンを引き寄せた！", "You have attracted a demon!"));
             disturb(creature, false, true);
         }
@@ -241,7 +241,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
             mode |= (PM_ALLOW_UNIQUE | PM_NO_PET);
         }
 
-        if (summon_specific(creature, creature.y, creature.x, creature.current_floor_ptr->dun_level, SUMMON_NASTY, mode)) {
+        if (summon_specific(creature, creature.y, creature.x, creature.get_floor()->dun_level, SUMMON_NASTY, mode)) {
             msg_print(_("あなたはクッソ汚い輩を引き寄せた！", "You have attracted nasty creatures!"));
             disturb(creature, false, true);
         }
@@ -257,7 +257,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
             mode |= (PM_ALLOW_UNIQUE | PM_NO_PET);
         }
 
-        if (summon_specific(creature, creature.y, creature.x, creature.current_floor_ptr->dun_level, SUMMON_PERVERTS, mode)) {
+        if (summon_specific(creature, creature.y, creature.x, creature.get_floor()->dun_level, SUMMON_PERVERTS, mode)) {
             msg_print(_("あなたは変質者を引き寄せた！", "You have attracted perverts!"));
             disturb(creature, false, true);
         }
@@ -296,7 +296,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
         msg_print(_("影につつまれた。", "A shadow passes over you."));
         msg_erase();
 
-        if ((creature.current_floor_ptr->grid_array[creature.y][creature.x].info & (CAVE_GLOW | CAVE_MNDK)) == CAVE_GLOW) {
+        if ((creature.get_floor()->grid_array[creature.y][creature.x].info & (CAVE_GLOW | CAVE_MNDK)) == CAVE_GLOW) {
             hp_player(creature, 10);
         }
 
@@ -333,7 +333,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
             mode |= (PM_ALLOW_UNIQUE | PM_NO_PET);
         }
 
-        if (summon_specific(creature, creature.y, creature.x, creature.current_floor_ptr->dun_level, SUMMON_ANIMAL, mode)) {
+        if (summon_specific(creature, creature.y, creature.x, creature.get_floor()->dun_level, SUMMON_ANIMAL, mode)) {
             msg_print(_("動物を引き寄せた！", "You have attracted an animal!"));
             disturb(creature, false, true);
         }
@@ -420,7 +420,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
             mode |= (PM_ALLOW_UNIQUE | PM_NO_PET);
         }
 
-        if (summon_specific(creature, creature.y, creature.x, creature.current_floor_ptr->dun_level, SUMMON_DRAGON, mode)) {
+        if (summon_specific(creature, creature.y, creature.x, creature.get_floor()->dun_level, SUMMON_DRAGON, mode)) {
             msg_print(_("ドラゴンを引き寄せた！", "You have attracted a dragon!"));
             disturb(creature, false, true);
         }
@@ -451,14 +451,14 @@ void process_world_aux_mutation(CreatureEntity &creature)
         }
     }
 
-    if (creature.muta.has(PlayerMutationType::WALK_SHAD) && !creature.anti_magic && one_in_(12000) && !creature.current_floor_ptr->inside_arena) {
+    if (creature.muta.has(PlayerMutationType::WALK_SHAD) && !creature.anti_magic && one_in_(12000) && !creature.get_floor()->inside_arena) {
         reserve_alter_reality(creature, randint0(21) + 15);
     }
 
     if (creature.muta.has(PlayerMutationType::WARNING) && one_in_(1000)) {
         int danger_amount = 0;
-        for (auto m_idx = 0; m_idx < creature.current_floor_ptr->m_max; m_idx++) {
-            const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+        for (auto m_idx = 0; m_idx < creature.get_floor()->m_max; m_idx++) {
+            const auto &monster = creature.get_floor()->get_monster(m_idx);
             const auto &monrace = monster.get_monrace();
             if (!monster.is_valid()) {
                 continue;

--- a/src/mutation/mutation-techniques.cpp
+++ b/src/mutation/mutation-techniques.cpp
@@ -33,7 +33,7 @@ bool eat_rock(CreatureEntity &creature)
     }
 
     const auto pos = creature.get_neighbor(dir);
-    const auto &grid = creature.current_floor_ptr->get_grid(pos);
+    const auto &grid = creature.get_floor()->get_grid(pos);
     const auto &terrain = grid.get_terrain();
     const auto &terrain_mimic = grid.get_terrain(TerrainKind::MIMIC);
 
@@ -43,7 +43,7 @@ bool eat_rock(CreatureEntity &creature)
     } else if (terrain.flags.has(TerrainCharacteristics::PERMANENT)) {
         msg_format(_("いてっ！この%sはあなたの歯より硬い！", "Ouch!  This %s is harder than your teeth!"), terrain_mimic.name.data());
     } else if (grid.has_monster()) {
-        const auto &monster = creature.current_floor_ptr->get_monster(grid.m_idx);
+        const auto &monster = creature.get_floor()->get_monster(grid.m_idx);
         msg_print(_("何かが邪魔しています！", "There's something in the way!"));
         if (!monster.get_monster_profile().ml || !monster.is_pet()) {
             do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);

--- a/src/object-activation/activation-bolt-ball.cpp
+++ b/src/object-activation/activation-bolt-ball.cpp
@@ -337,7 +337,7 @@ bool activate_ball_lite(CreatureEntity &creature, std::string_view name)
     const auto num = Dice::roll(5, 3);
     msg_format(_("% sが稲妻で覆われた...", "The %s is surrounded by lightning..."), name.data());
     const auto p_pos = creature.get_position();
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (auto k = 0; k < num; k++) {
         auto attempts = 1000;
         Pos2D pos(0, 0);

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -164,8 +164,8 @@ bool activate_telekinesis(CreatureEntity &creature, std::string_view name)
 bool activate_unique_detection(CreatureEntity &creature)
 {
     msg_print(_("奇妙な場所が頭の中に浮かんだ．．．", "Some strange places show up in your mind. And you see ..."));
-    for (int i = creature.current_floor_ptr->m_max - 1; i >= 1; i--) {
-        const auto &monster = creature.current_floor_ptr->get_monster(i);
+    for (int i = creature.get_floor()->m_max - 1; i >= 1; i--) {
+        const auto &monster = creature.get_floor()->get_monster(i);
         if (!monster.is_valid()) {
             continue;
         }
@@ -433,7 +433,7 @@ bool activate_dispel_magic(CreatureEntity &creature)
         return false;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto m_idx = floor.get_grid(*pos).m_idx;
     if (m_idx == 0) {
         return true;
@@ -462,7 +462,7 @@ bool activate_whistle(CreatureEntity &creature, const ItemEntity &item)
         (void)SpellHex(creature).stop_all_spells();
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     std::vector<short> pet_index;
     for (short pet_indice = floor.m_max - 1; pet_indice >= 1; pet_indice--) {
         const auto &monster = floor.get_monster(pet_indice);

--- a/src/object-activation/activation-switcher.cpp
+++ b/src/object-activation/activation-switcher.cpp
@@ -168,7 +168,7 @@ bool switch_activation(CreatureEntity &creature, ItemEntity **o_ptr_ptr, const R
         return true;
     case RandomArtActType::SUMMON_PHANTOM:
         msg_print(_("幻霊を召喚した。", "You summon a phantasmal servant."));
-        (void)summon_specific(creature, creature.y, creature.x, creature.current_floor_ptr->dun_level, SUMMON_PHANTOM, PM_ALLOW_GROUP | PM_FORCE_PET);
+        (void)summon_specific(creature, creature.y, creature.x, creature.get_floor()->dun_level, SUMMON_PHANTOM, PM_ALLOW_GROUP | PM_FORCE_PET);
         return true;
     case RandomArtActType::SUMMON_ELEMENTAL:
         return cast_summon_elemental(creature, (creature.level * 3) / 2);
@@ -181,7 +181,7 @@ bool switch_activation(CreatureEntity &creature, ItemEntity **o_ptr_ptr, const R
         return cast_summon_hound(creature, (creature.level * 3) / 2);
     case RandomArtActType::SUMMON_DAWN:
         msg_print(_("暁の師団を召喚した。", "You summon the Legion of the Dawn."));
-        (void)summon_specific(creature, creature.y, creature.x, creature.current_floor_ptr->dun_level, SUMMON_DAWN, PM_ALLOW_GROUP | PM_FORCE_PET);
+        (void)summon_specific(creature, creature.y, creature.x, creature.get_floor()->dun_level, SUMMON_DAWN, PM_ALLOW_GROUP | PM_FORCE_PET);
         return true;
     case RandomArtActType::SUMMON_OCTOPUS:
         return cast_summon_octopus(creature);

--- a/src/object-enchant/item-magic-applier.cpp
+++ b/src/object-enchant/item-magic-applier.cpp
@@ -79,7 +79,7 @@ void ItemMagicApplier::execute()
 std::tuple<int, int> ItemMagicApplier::calculate_chances()
 {
     auto chance_good = this->lev + 10;
-    const auto &floor = *this->creature.current_floor_ptr;
+    const auto &floor = *this->creature.get_floor();
     const auto &dungeon = floor.get_dungeon_definition();
     if (chance_good > dungeon.obj_good) {
         chance_good = dungeon.obj_good;
@@ -166,7 +166,7 @@ int ItemMagicApplier::calculate_rolls(const int power)
  */
 void ItemMagicApplier::try_make_artifact(const int rolls)
 {
-    const auto &floor = *this->creature.current_floor_ptr;
+    const auto &floor = *this->creature.get_floor();
     if (!floor.is_underground()) {
         return;
     }

--- a/src/object-enchant/others/apply-magic-others.cpp
+++ b/src/object-enchant/others/apply-magic-others.cpp
@@ -109,7 +109,7 @@ void OtherItemsEnchanter::enchant_wand_staff()
  */
 void OtherItemsEnchanter::generate_figurine()
 {
-    const auto &floor = *this->creature.current_floor_ptr;
+    const auto &floor = *this->creature.get_floor();
     const auto &monraces = MonraceList::get_instance();
     const auto monrace_id = monraces.select_figurine(floor.dun_level);
     this->o_ptr->pval = enum2i(monrace_id);
@@ -134,7 +134,7 @@ void OtherItemsEnchanter::generate_corpse()
     };
 
     get_mon_num_prep_enum(this->creature, MonraceHook::FIGURINE);
-    const auto &floor = *this->creature.current_floor_ptr;
+    const auto &floor = *this->creature.get_floor();
     const auto &monraces = MonraceList::get_instance();
     MonraceId monrace_id;
     while (true) {
@@ -197,7 +197,7 @@ void OtherItemsEnchanter::generate_chest()
         this->o_ptr->pval = 6;
     }
 
-    this->o_ptr->chest_level = this->creature.current_floor_ptr->dun_level + 5;
+    this->o_ptr->chest_level = this->creature.get_floor()->dun_level + 5;
     if (this->o_ptr->pval > 55) {
         this->o_ptr->pval = 55 + randint0(5);
     }
@@ -205,5 +205,5 @@ void OtherItemsEnchanter::generate_chest()
 
 void OtherItemsEnchanter::generate_disarmed_trap()
 {
-    this->o_ptr->pval = static_cast<PARAMETER_VALUE>(this->creature.current_floor_ptr->select_random_trap());
+    this->o_ptr->pval = static_cast<PARAMETER_VALUE>(this->creature.get_floor()->select_random_trap());
 }

--- a/src/object-use/read/scroll-read-executor.cpp
+++ b/src/object-use/read/scroll-read-executor.cpp
@@ -61,7 +61,7 @@ bool ScrollReadExecutor::is_identified() const
 bool ScrollReadExecutor::read()
 {
     auto used_up = true;
-    const auto &floor = *this->creature.current_floor_ptr;
+    const auto &floor = *this->creature.get_floor();
     switch (*this->o_ptr->bi_key.sval()) {
     case SV_SCROLL_DARKNESS:
         if (!has_resist_blind(this->creature) && !has_resist_dark(this->creature)) {

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -58,7 +58,7 @@
 
 ObjectThrowHitMonster::ObjectThrowHitMonster(CreatureEntity &creature, POSITION y, POSITION x)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid({ y, x });
     if (!grid.has_monster() || std::cmp_greater_equal(grid.m_idx, floor.m_list.size())) {
         THROW_EXCEPTION(std::logic_error, "Invalid monster index");
@@ -92,7 +92,7 @@ bool ObjectThrowEntity::check_can_throw()
     }
 
     const auto is_spike = this->o_ptr->bi_key.tval() == ItemKindType::SPIKE;
-    if (creature.current_floor_ptr->inside_arena && !this->boomerang && !is_spike) {
+    if (creature.get_floor()->inside_arena && !this->boomerang && !is_spike) {
         msg_print(_("アリーナではアイテムを使えない！", "You're in the arena now. This is hand-to-hand!"));
         msg_erase();
         return false;
@@ -226,7 +226,7 @@ void ObjectThrowEntity::exe_throw()
 void ObjectThrowEntity::display_figurine_throw()
 {
     auto &creature = *this->creature_ptr;
-    if ((this->q_ptr->bi_key.tval() != ItemKindType::FIGURINE) || creature.current_floor_ptr->inside_arena) {
+    if ((this->q_ptr->bi_key.tval() != ItemKindType::FIGURINE) || creature.get_floor()->inside_arena) {
         return;
     }
 
@@ -334,7 +334,7 @@ void ObjectThrowEntity::drop_thrown_item()
         return;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto has_terrain_projection = floor.has_terrain_characteristics({ this->y, this->x }, TerrainCharacteristics::PROJECTION);
     const auto drop_y = has_terrain_projection ? this->y : this->prev_y;
     const auto drop_x = has_terrain_projection ? this->x : this->prev_x;
@@ -403,7 +403,7 @@ bool ObjectThrowEntity::check_racial_target_bold()
     const auto pos = mmove2({ this->y, this->x }, creature.get_position(), { this->ty, this->tx });
     this->ny[this->cur_dis] = pos.y;
     this->nx[this->cur_dis] = pos.x;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (floor.has_terrain_characteristics({ this->ny[this->cur_dis], this->nx[this->cur_dis] }, TerrainCharacteristics::PROJECTION)) {
         return false;
     }
@@ -442,7 +442,7 @@ bool ObjectThrowEntity::check_racial_target_monster()
     this->x = this->nx[this->cur_dis];
     this->y = this->ny[this->cur_dis];
     this->cur_dis++;
-    return creature.current_floor_ptr->grid_array[this->y][this->x].m_idx == 0;
+    return creature.get_floor()->grid_array[this->y][this->x].m_idx == 0;
 }
 
 void ObjectThrowEntity::attack_racial_power()

--- a/src/object-use/use-execution.cpp
+++ b/src/object-use/use-execution.cpp
@@ -147,7 +147,7 @@ void ObjectUseEntity::execute()
     if (this->i_idx >= 0) {
         inven_item_charges(*creature.inventory[this->i_idx]);
     } else {
-        floor_item_charges(*creature.current_floor_ptr, 0 - this->i_idx);
+        floor_item_charges(*creature.get_floor(), 0 - this->i_idx);
     }
 }
 

--- a/src/object-use/zapwand-execution.cpp
+++ b/src/object-use/zapwand-execution.cpp
@@ -138,7 +138,7 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX i_idx)
         return;
     }
 
-    floor_item_charges(*this->creature.current_floor_ptr, 0 - i_idx);
+    floor_item_charges(*this->creature.get_floor(), 0 - i_idx);
 }
 
 bool ObjectZapWandEntity::check_can_zap() const

--- a/src/object/object-info.cpp
+++ b/src/object/object-info.cpp
@@ -182,6 +182,6 @@ bool check_book_realm(CreatureEntity &creature, const BaseitemKey &bi_key)
 
 ItemEntity *ref_item(CreatureEntity &creature, INVENTORY_IDX i_idx)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     return i_idx >= 0 ? creature.inventory[i_idx].get() : floor.o_list[0 - i_idx].get();
 }

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -243,7 +243,7 @@ static void spell_damcalc(CreatureEntity &creature, const CreatureEntity &monste
  */
 static void spell_damcalc_by_spellnum(CreatureEntity &creature, MonsterAbilityType ms_type, AttributeType typ, MONSTER_IDX m_idx, int *max)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     int dam = monspell_damage(creature, ms_type, m_idx, DAM_MAX);
     spell_damcalc(creature, monster, typ, dam, max);
 }
@@ -339,7 +339,7 @@ bool process_warning(CreatureEntity &creature, POSITION xx, POSITION yy)
     int dam_max = 0;
     static int old_damage = 0;
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_dungeon_definition();
     for (auto mx = xx - warning_aware_range; mx < xx + warning_aware_range + 1; mx++) {
         for (auto my = yy - warning_aware_range; my < yy + warning_aware_range + 1; my++) {

--- a/src/perception/object-perception.cpp
+++ b/src/perception/object-perception.cpp
@@ -38,5 +38,5 @@ void object_aware(CreatureEntity &creature, const ItemEntity &item)
 
     // playrecordに識別したアイテムを記録
     const auto item_name = describe_flavor(creature, item, OD_NAME_ONLY | OD_OMIT_PREFIX);
-    exe_write_diary(*creature.current_floor_ptr, DiaryKind::FOUND, 0, item_name);
+    exe_write_diary(*creature.get_floor(), DiaryKind::FOUND, 0, item_name);
 }

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -38,7 +38,7 @@ void check_fall_off_horse(CreatureEntity &creature, MonsterAttackPlayer *monap_p
         return;
     }
 
-    const auto m_steed_name = monster_desc(creature, creature.current_floor_ptr->get_monster(creature.riding), 0);
+    const auto m_steed_name = monster_desc(creature, creature.get_floor()->get_monster(creature.riding), 0);
     if (process_fall_off_horse(creature, (monap_ptr->damage > 200) ? 200 : monap_ptr->damage, false)) {
         msg_format(_("%s^から落ちてしまった！", "You have fallen from %s."), m_steed_name.data());
     }
@@ -87,7 +87,7 @@ static bool calc_fall_off_possibility(CreatureEntity &creature, const int dam, c
  */
 bool process_fall_off_horse(CreatureEntity &creature, int dam, bool force)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(creature.riding);
+    const auto &monster = creature.get_floor()->get_monster(creature.riding);
     const auto &monrace = monster.get_monrace();
 
     if (!creature.riding || AngbandWorld::get_instance().is_wild_mode()) {
@@ -105,7 +105,7 @@ bool process_fall_off_horse(CreatureEntity &creature, int dam, bool force)
         for (const auto &d : Direction::directions_8()) {
             const auto pos = creature.get_neighbor(d);
 
-            const auto &grid = creature.current_floor_ptr->get_grid(pos);
+            const auto &grid = creature.get_floor()->get_grid(pos);
 
             if (grid.has_monster()) {
                 continue;

--- a/src/pet/pet-util.cpp
+++ b/src/pet/pet-util.cpp
@@ -68,8 +68,8 @@ PERCENTAGE calculate_upkeep(CreatureEntity &creature)
     bool has_a_unique = false;
     DEPTH total_friend_levels = 0;
     total_friends = 0;
-    for (auto m_idx = creature.current_floor_ptr->m_max - 1; m_idx >= 1; m_idx--) {
-        const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    for (auto m_idx = creature.get_floor()->m_max - 1; m_idx >= 1; m_idx--) {
+        const auto &monster = creature.get_floor()->get_monster(m_idx);
         if (!monster.is_valid()) {
             continue;
         }

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -64,7 +64,7 @@ static void attack_confuse(CreatureEntity &creature, player_attack_type *pa_ptr,
         msg_format(_("%s^には効果がなかった。", "%s^ is unaffected."), pa_ptr->m_name);
     } else {
         msg_format(_("%s^は混乱したようだ。", "%s^ appears confused."), pa_ptr->m_name);
-        (void)set_monster_confused(*creature.current_floor_ptr, pa_ptr->m_idx, pa_ptr->m_ptr->get_remaining_confusion() + 10 + randint0(creature.level) / 5);
+        (void)set_monster_confused(*creature.get_floor(), pa_ptr->m_idx, pa_ptr->m_ptr->get_remaining_confusion() + 10 + randint0(creature.level) / 5);
     }
 }
 
@@ -88,7 +88,7 @@ static void attack_stun(CreatureEntity &creature, player_attack_type *pa_ptr, bo
         msg_format(_("%s^には効果がなかった。", "%s^ is unaffected."), pa_ptr->m_name);
     } else {
         msg_format(_("%s^は朦朧としたようだ。", "%s^ appears stunned."), pa_ptr->m_name);
-        (void)set_monster_stunned(*creature.current_floor_ptr, pa_ptr->m_idx, pa_ptr->m_ptr->get_remaining_stun() + 10 + randint0(creature.level) / 5);
+        (void)set_monster_stunned(*creature.get_floor(), pa_ptr->m_idx, pa_ptr->m_ptr->get_remaining_stun() + 10 + randint0(creature.level) / 5);
     }
 }
 
@@ -112,7 +112,7 @@ static void attack_scare(CreatureEntity &creature, player_attack_type *pa_ptr, b
         msg_format(_("%s^には効果がなかった。", "%s^ is unaffected."), pa_ptr->m_name);
     } else {
         msg_format(_("%s^は恐怖して逃げ出した！", "%s^ flees in terror!"), pa_ptr->m_name);
-        (void)set_monster_monfear(*creature.current_floor_ptr, pa_ptr->m_idx, pa_ptr->m_ptr->get_remaining_fear() + 10 + randint0(creature.level) / 5);
+        (void)set_monster_monfear(*creature.get_floor(), pa_ptr->m_idx, pa_ptr->m_ptr->get_remaining_fear() + 10 + randint0(creature.level) / 5);
     }
 }
 
@@ -242,7 +242,7 @@ static void attack_polymorph(CreatureEntity &creature, player_attack_type *pa_pt
         msg_format(_("%s^には効果がなかった。", "%s^ is unaffected."), pa_ptr->m_name);
     }
 
-    pa_ptr->m_ptr = &creature.current_floor_ptr->get_monster(pa_ptr->m_idx);
+    pa_ptr->m_ptr = &creature.get_floor()->get_monster(pa_ptr->m_idx);
     angband_strcpy(pa_ptr->m_name, monster_desc(creature, *pa_ptr->m_ptr, 0), sizeof(pa_ptr->m_name));
 }
 
@@ -253,7 +253,7 @@ static void attack_polymorph(CreatureEntity &creature, player_attack_type *pa_pt
  */
 static void attack_golden_hammer(CreatureEntity &creature, player_attack_type *pa_ptr)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(pa_ptr->m_idx);
     if (monster.get_monster_profile().hold_o_idx_list.empty()) {
         return;

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -518,7 +518,7 @@ static void cause_earthquake(CreatureEntity &creature, player_attack_type *pa_pt
     }
 
     earthquake(creature, creature.get_position(), 10);
-    if (!creature.current_floor_ptr->grid_array[y][x].has_monster()) {
+    if (!creature.get_floor()->grid_array[y][x].has_monster()) {
         *(pa_ptr->mdeath) = true;
     }
 }
@@ -540,7 +540,7 @@ void exe_player_attack_to_monster(CreatureEntity &creature, POSITION y, POSITION
     bool do_quake = false;
     bool drain_msg = true;
 
-    player_attack_type tmp_attack(*creature.current_floor_ptr, y, x, hand, mode, fear, mdeath);
+    player_attack_type tmp_attack(*creature.get_floor(), y, x, hand, mode, fear, mdeath);
     auto pa_ptr = &tmp_attack;
 
     const auto is_human = pa_ptr->r_ptr->symbol_char_is_any_of("p");
@@ -550,7 +550,7 @@ void exe_player_attack_to_monster(CreatureEntity &creature, POSITION y, POSITION
     get_attack_exp(creature, pa_ptr);
 
     /* Disturb the monster */
-    (void)set_monster_csleep(*creature.current_floor_ptr, pa_ptr->m_idx, 0);
+    (void)set_monster_csleep(*creature.get_floor(), pa_ptr->m_idx, 0);
     angband_strcpy(pa_ptr->m_name, monster_desc(creature, *pa_ptr->m_ptr, 0), sizeof(pa_ptr->m_name));
 
     int chance = calc_attack_quality(creature, pa_ptr);
@@ -607,7 +607,7 @@ void exe_player_attack_to_monster(CreatureEntity &creature, POSITION y, POSITION
  */
 void massacre(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (const auto &d : Direction::directions_8()) {
         const auto pos = creature.get_neighbor(d);
         const auto &grid = floor.get_grid(pos);

--- a/src/player-base/player-race.cpp
+++ b/src/player-base/player-race.cpp
@@ -146,7 +146,7 @@ int16_t CreatureRace::speed() const
 {
     int16_t result = 0;
 
-    FloorType *floor_ptr = this->creature_ptr->current_floor_ptr;
+    FloorType *floor_ptr = this->creature_ptr->get_floor();
     if (creature_ptr->x > 0 && creature_ptr->y > 0 && creature_ptr->x <= floor_ptr->width - 1 && creature_ptr->y <= floor_ptr->height - 1) {
         const auto &f_ptr = TerrainList::get_instance().get_terrain(floor_ptr->grid_array[this->creature_ptr->y][this->creature_ptr->x].feat);
         if (f_ptr.flags.has(TerrainCharacteristics::SLOW)) {
@@ -158,7 +158,7 @@ int16_t CreatureRace::speed() const
     }
 
     if (this->equals(PlayerRaceType::MERFOLK)) {
-        const auto &floor = *this->creature_ptr->current_floor_ptr;
+        const auto &floor = *this->creature_ptr->get_floor();
         const auto &terrain = floor.get_grid(this->creature_ptr->get_position()).get_terrain();
         if (terrain.flags.has(TerrainCharacteristics::WATER)) {
             result += (2 + this->creature_ptr->level / 10);

--- a/src/player-info/alignment.cpp
+++ b/src/player-info/alignment.cpp
@@ -44,7 +44,7 @@ std::string PlayerAlignment::get_alignment_description(bool with_value)
 void PlayerAlignment::update_alignment()
 {
     this->reset_alignment();
-    const auto &floor = *this->creature_ptr->current_floor_ptr;
+    const auto &floor = *this->creature_ptr->get_floor();
     for (MONSTER_IDX m_idx = floor.m_max - 1; m_idx >= 1; m_idx--) {
         const auto &monster = floor.get_monster(m_idx);
         if (!monster.is_valid()) {

--- a/src/player-status/player-speed.cpp
+++ b/src/player-status/player-speed.cpp
@@ -275,7 +275,7 @@ int16_t PlayerSpeed::mutation_bonus()
  */
 int16_t PlayerSpeed::riding_bonus()
 {
-    const auto &monster = (&this->creature)->current_floor_ptr->get_monster(this->creature.riding);
+    const auto &monster = (&this->creature)->get_floor()->get_monster(this->creature.riding);
     int16_t speed = monster.speed;
     int16_t bonus = 0;
     if (!this->creature.riding) {
@@ -315,7 +315,7 @@ int16_t PlayerSpeed::inventory_weight_bonus()
     int16_t bonus = 0;
     auto weight = calc_inventory_weight(this->creature);
     if (this->creature.riding) {
-        const auto &monster = this->creature.current_floor_ptr->get_monster(this->creature.riding);
+        const auto &monster = this->creature.get_floor()->get_monster(this->creature.riding);
         const auto &monrace = monster.get_monrace();
         auto count = 1500 + monrace.level * 25;
         if (weight > count) {

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -64,7 +64,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
     auto &monraces = MonraceList::get_instance();
     auto power = 100;
     if (!necro && m_idx) {
-        auto &monster = creature.current_floor_ptr->get_monster(*m_idx);
+        auto &monster = creature.get_floor()->get_monster(*m_idx);
         auto &monrace = monster.get_appearance_monrace();
         const auto m_name = monster_desc(creature, monster, 0);
         power = monrace.level / 2;

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -195,7 +195,7 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
         (void)gain_mutation(creature, 0);
         reward = _("変異した。", "mutation");
     } else {
-        const auto &floor = *creature.current_floor_ptr;
+        const auto &floor = *creature.get_floor();
         switch (chosen_reward ? chosen_reward : effect) {
         case REW_POLY_SLF:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
@@ -529,7 +529,7 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
 
     if (!reward.empty()) {
         const auto note = format(_("パトロンの報酬で%s", "The patron rewarded you with %s."), reward.data());
-        exe_write_diary(*creature.current_floor_ptr, DiaryKind::DESCRIPTION, 0, note);
+        exe_write_diary(*creature.get_floor(), DiaryKind::DESCRIPTION, 0, note);
     }
 }
 

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -382,7 +382,7 @@ int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_
         chg_virtue(creature, Virtue::CHANCE, 2);
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     auto &world = AngbandWorld::get_instance();
     if (creature.hp < 0 && !cheat_immortal) {
         creature.killer_monrace_id = killer_monrace_id;
@@ -451,7 +451,7 @@ void PlayerType::on_death(std::string_view cause)
     this->leaving = true;
     this->is_dead_ = true;
 
-    const auto &floor = *this->current_floor_ptr;
+    const auto &floor = *this->get_floor();
     auto &world = AngbandWorld::get_instance();
     if (floor.inside_arena) {
         auto &entries = ArenaEntryList::get_instance();

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -58,7 +58,7 @@
  */
 static void discover_hidden_things(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(pos);
     if (grid.mimic && floor.has_trap_at(pos)) {
         disclose_grid(creature, pos);
@@ -125,7 +125,7 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
 {
     const Pos2D pos_new(ny, nx);
     const Pos2D pos_old(creature.y, creature.x);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &grid_new = floor.get_grid(pos_new);
     auto &grid_old = floor.get_grid(pos_old);
     const auto &terrain_new = grid_new.get_terrain();

--- a/src/player/player-skill.cpp
+++ b/src/player/player-skill.cpp
@@ -64,7 +64,7 @@ void gain_attack_skill_exp(CreatureEntity &creature, short &exp, const GainAmoun
 
 void gain_spell_skill_exp_aux(CreatureEntity &creature, short &exp, const GainAmountList &gain_amount_list, int spell_level)
 {
-    const auto dlev = creature.current_floor_ptr->dun_level;
+    const auto dlev = creature.get_floor()->dun_level;
     const auto plev = creature.level;
 
     auto gain_amount = 0;
@@ -337,7 +337,7 @@ void PlayerSkill::gain_riding_skill_exp_on_melee_attack(const MonraceDefinition 
         return;
     }
 
-    auto riding_level = this->creature_ptr->current_floor_ptr->get_monster(this->creature_ptr->riding).get_monrace().level;
+    auto riding_level = this->creature_ptr->get_floor()->get_monster(this->creature_ptr->riding).get_monrace().level;
     int inc = 0;
 
     if ((now_exp / 200 - 5) < monrace.level) {
@@ -364,7 +364,7 @@ void PlayerSkill::gain_riding_skill_exp_on_range_attack()
         return;
     }
 
-    const auto &floor = *this->creature_ptr->current_floor_ptr;
+    const auto &floor = *this->creature_ptr->get_floor();
     const auto &monster = floor.get_monster(this->creature_ptr->riding);
     const auto &monrace = monster.get_monrace();
     if (((this->creature_ptr->skill_exp[PlayerSkillKindType::RIDING] - (RIDING_EXP_BEGINNER * 2)) / 200 < monrace.level) && one_in_(2)) {
@@ -381,7 +381,7 @@ void PlayerSkill::gain_riding_skill_exp_on_fall_off_check(int dam)
         return;
     }
 
-    auto riding_level = this->creature_ptr->current_floor_ptr->get_monster(this->creature_ptr->riding).get_monrace().level;
+    auto riding_level = this->creature_ptr->get_floor()->get_monster(this->creature_ptr->riding).get_monrace().level;
 
     if ((dam / 2 + riding_level) <= (now_exp / 30 + 10)) {
         return;

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -507,7 +507,7 @@ bool has_kill_wall(CreatureEntity &creature)
         return false;
     }
 
-    const auto &riding_monster = creature.current_floor_ptr->get_monster(creature.riding);
+    const auto &riding_monster = creature.get_floor()->get_monster(creature.riding);
     const auto &riding_monrace = riding_monster.get_monrace();
     return riding_monrace.feature_flags.has(MonsterFeatureType::KILL_WALL);
 }
@@ -528,7 +528,7 @@ bool has_pass_wall(CreatureEntity &creature)
         return can_player_pass_wall;
     }
 
-    const auto &monster = creature.current_floor_ptr->get_monster(creature.riding);
+    const auto &monster = creature.get_floor()->get_monster(creature.riding);
     const auto &monrace = monster.get_monrace();
     return can_player_pass_wall && monrace.feature_flags.has(MonsterFeatureType::PASS_WALL);
 }
@@ -767,8 +767,8 @@ void check_no_flowed(CreatureEntity &creature)
         }
     }
 
-    for (const auto this_o_idx : creature.current_floor_ptr->grid_array[creature.y][creature.x].o_idx_list) {
-        o_ptr = creature.current_floor_ptr->o_list[this_o_idx].get();
+    for (const auto this_o_idx : creature.get_floor()->grid_array[creature.y][creature.x].o_idx_list) {
+        o_ptr = creature.get_floor()->o_list[this_o_idx].get();
 
         if (o_ptr->bi_key == BaseitemKey(ItemKindType::NATURE_BOOK, 2)) {
             has_sw = true;
@@ -1036,7 +1036,7 @@ BIT_FLAGS has_levitation(CreatureEntity &creature)
         return result;
     }
 
-    const auto &monster = creature.current_floor_ptr->get_monster(creature.riding);
+    const auto &monster = creature.get_floor()->get_monster(creature.riding);
     const auto &monrace = monster.get_monrace();
     return monrace.feature_flags.has(MonsterFeatureType::CAN_FLY) ? FLAG_CAUSE_RIDING : FLAG_CAUSE_NONE;
 }
@@ -1051,7 +1051,7 @@ bool has_can_swim(CreatureEntity &creature)
         return false;
     }
 
-    const auto &monster = creature.current_floor_ptr->get_monster(creature.riding);
+    const auto &monster = creature.get_floor()->get_monster(creature.riding);
     const auto &monrace = monster.get_monrace();
     return monrace.feature_flags.has_any_of({ MonsterFeatureType::CAN_SWIM, MonsterFeatureType::AQUATIC });
 }

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -152,7 +152,7 @@ static player_hand main_attack_hand(CreatureEntity &creature);
  */
 static void delayed_visual_update(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto points = floor.collect_redraw_points();
     for (const auto &pos : points) {
         auto &grid = floor.get_grid(pos);
@@ -1921,7 +1921,7 @@ static bool is_riding_two_hands(CreatureEntity &creature)
 
 static int16_t calc_riding_bow_penalty(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!creature.riding) {
         return 0;
     }
@@ -2292,7 +2292,7 @@ static short calc_to_hit(CreatureEntity &creature, INVENTORY_IDX slot, bool is_r
                 if (CreatureClass(creature).is_tamer()) {
                     penalty = 5;
                 } else {
-                    penalty = creature.current_floor_ptr->get_monster(creature.riding).get_monrace().level - creature.skill_exp[PlayerSkillKindType::RIDING] / 80;
+                    penalty = creature.get_floor()->get_monster(creature.riding).get_monrace().level - creature.skill_exp[PlayerSkillKindType::RIDING] / 80;
                     penalty += 30;
                     if (penalty < 30) {
                         penalty = 30;
@@ -2616,7 +2616,7 @@ void update_creature(CreatureEntity &creature)
         return;
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (rfu.has(StatusRecalculatingFlag::AUTO_DESTRUCTION)) {
         rfu.reset_flag(StatusRecalculatingFlag::AUTO_DESTRUCTION);
         autopick_delayed_alter(creature);
@@ -2725,7 +2725,7 @@ bool player_has_no_spellbooks(CreatureEntity &creature)
         }
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (const auto this_o_idx : floor.grid_array[creature.y][creature.x].o_idx_list) {
         const auto *o_ptr = floor.o_list[this_o_idx].get();
         if (o_ptr->is_valid() && o_ptr->marked.has(OmType::FOUND) && check_book_realm(creature, o_ptr->bi_key)) {
@@ -2741,7 +2741,7 @@ bool player_has_no_spellbooks(CreatureEntity &creature)
  */
 void wreck_the_pattern(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     const auto &terrain = floor.get_grid(p_pos).get_terrain();
     if (terrain.subtype == PATTERN_TILE_WRECKED) {
@@ -2844,7 +2844,7 @@ void check_experience(CreatureEntity &creature)
             }
             level_inc_stat = true;
 
-            exe_write_diary(*creature.current_floor_ptr, DiaryKind::LEVELUP, creature.level);
+            exe_write_diary(*creature.get_floor(), DiaryKind::LEVELUP, creature.level);
         }
 
         sound(SoundKind::LEVEL);

--- a/src/player/player-view.cpp
+++ b/src/player/player-view.cpp
@@ -28,7 +28,7 @@
 static bool update_view_aux(CreatureEntity &creature, POSITION y, POSITION x, POSITION y1, POSITION x1, POSITION y2, POSITION x2)
 {
     const Pos2D pos(y, x);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     Grid *g1_c_ptr;
     Grid *g2_c_ptr;
     g1_c_ptr = &floor.grid_array[y1][x1];
@@ -103,7 +103,7 @@ void update_view(CreatureEntity &creature)
 
     int full, over;
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     POSITION y_max = floor.height - 1;
     POSITION x_max = floor.width - 1;
 

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -145,7 +145,7 @@ static void show_dead_place(CreatureEntity &creature, int extra_line)
     }
 
     std::string place;
-    if (!creature.current_floor_ptr->is_underground()) {
+    if (!creature.get_floor()->is_underground()) {
         concptr field_name = creature.town_num ? "街" : "荒野";
         if (streq(creature.died_from, "途中終了")) {
             place = format("%sで死んで飽きた", field_name);
@@ -154,9 +154,9 @@ static void show_dead_place(CreatureEntity &creature, int extra_line)
         }
     } else {
         if (streq(creature.died_from, "途中終了")) {
-            place = format("地下 %d 階で死んで飽きた", (int)creature.current_floor_ptr->dun_level);
+            place = format("地下 %d 階で死んで飽きた", (int)creature.get_floor()->dun_level);
         } else {
-            place = format("に地下 %d 階で殺されて飽きた", (int)creature.current_floor_ptr->dun_level);
+            place = format("に地下 %d 階で殺されて飽きた", (int)creature.get_floor()->dun_level);
         }
     }
 
@@ -191,7 +191,7 @@ static void show_tomb_detail(CreatureEntity &creature)
  */
 static void show_tomb_detail(CreatureEntity &creature)
 {
-    show_tomb_line(format("Killed on Level %d", creature.current_floor_ptr->dun_level), GRAVE_DEAD_PLACE_ROW);
+    show_tomb_line(format("Killed on Level %d", creature.get_floor()->dun_level), GRAVE_DEAD_PLACE_ROW);
 
     auto lines = shape_buffer(format("by %s.", creature.died_from.data()).data(), GRAVE_LINE_WIDTH + 1);
     show_tomb_line(lines[0], GRAVE_KILLER_NAME_ROW);

--- a/src/racial/racial-vampire.cpp
+++ b/src/racial/racial-vampire.cpp
@@ -14,7 +14,7 @@
 
 bool vampirism(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE)) {
         msg_print(_("なぜか攻撃することができない。", "Something prevents you from attacking."));
         return false;

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -646,7 +646,7 @@ tl::optional<std::string> do_hex_spell(CreatureEntity &creature, spell_hex_type 
                 }
 
                 flag = false;
-                const auto &floor = *creature.current_floor_ptr;
+                const auto &floor = *creature.get_floor();
                 for (const auto &d : Direction::directions_8()) {
                     const auto pos_neighbor = *pos_target + d.vec();
                     if (floor.get_grid(pos_neighbor).has_monster()) {

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -87,7 +87,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
 
             const auto attack_to = [&creature](const Direction &dir) {
                 const auto pos = creature.get_neighbor(dir);
-                const auto &grid = creature.current_floor_ptr->get_grid(pos);
+                const auto &grid = creature.get_floor()->get_grid(pos);
 
                 if (grid.has_monster()) {
                     do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
@@ -118,7 +118,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            if (creature.current_floor_ptr->get_grid(pos).has_monster()) {
+            if (creature.get_floor()->get_grid(pos).has_monster()) {
                 do_cmd_attack(creature, pos.y, pos.x, HISSATSU_FIRE);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -141,7 +141,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            if (creature.current_floor_ptr->get_grid(pos).has_monster()) {
+            if (creature.get_floor()->get_grid(pos).has_monster()) {
                 do_cmd_attack(creature, pos.y, pos.x, HISSATSU_MINEUCHI);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -174,7 +174,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos_target = creature.get_neighbor(dir);
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             const auto &grid_target = floor.get_grid(pos_target);
             if (!grid_target.has_monster()) {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -203,7 +203,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             if (floor.get_grid(pos).has_monster()) {
                 do_cmd_attack(creature, pos.y, pos.x, HISSATSU_POISON);
             } else {
@@ -221,7 +221,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             if (floor.get_grid(pos).has_monster()) {
                 do_cmd_attack(creature, pos.y, pos.x, HISSATSU_ZANMA);
             } else {
@@ -239,7 +239,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            auto &floor = *creature.current_floor_ptr;
+            auto &floor = *creature.get_floor();
             const auto &grid = floor.get_grid(pos);
             if (grid.has_monster()) {
                 do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
@@ -307,7 +307,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             if (floor.get_grid(pos).has_monster()) {
                 do_cmd_attack(creature, pos.y, pos.x, HISSATSU_HAGAN);
             }
@@ -330,7 +330,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             if (floor.get_grid(pos).has_monster()) {
                 do_cmd_attack(creature, pos.y, pos.x, HISSATSU_COLD);
             } else {
@@ -348,7 +348,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             if (floor.get_grid(pos).has_monster()) {
                 do_cmd_attack(creature, pos.y, pos.x, HISSATSU_KYUSHO);
             } else {
@@ -366,7 +366,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             if (floor.get_grid(pos).has_monster()) {
                 do_cmd_attack(creature, pos.y, pos.x, HISSATSU_MAJIN);
             } else {
@@ -384,7 +384,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             if (floor.get_grid(pos).has_monster()) {
                 do_cmd_attack(creature, pos.y, pos.x, HISSATSU_SUTEMI);
             } else {
@@ -403,7 +403,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             if (floor.get_grid(pos).has_monster()) {
                 do_cmd_attack(creature, pos.y, pos.x, HISSATSU_ELEC);
             } else {
@@ -426,7 +426,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             const auto current_cut = creature.effects()->cut().current();
             short new_cut = current_cut < 300 ? current_cut + 300 : current_cut * 2;
             (void)BadStatusSetter(creature).set_cut(new_cut);
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             for (const auto &d : Direction::directions_8()) {
                 const auto pos = creature.get_position();
                 const auto pos_ddd = pos + d.vec();
@@ -455,7 +455,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             if (floor.get_grid(pos).has_monster()) {
                 do_cmd_attack(creature, pos.y, pos.x, HISSATSU_QUAKE);
             } else {
@@ -519,7 +519,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
                 return tl::nullopt;
             }
 
-            auto &floor = *creature.current_floor_ptr;
+            auto &floor = *creature.get_floor();
             for (auto i = 0; i < 3; i++) {
                 const Pos2D pos = creature.get_neighbor(dir);
                 auto &grid = floor.get_grid(pos);
@@ -591,7 +591,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             if (floor.get_grid(pos).has_monster()) {
                 do_cmd_attack(creature, pos.y, pos.x, HISSATSU_DRAIN);
             } else {
@@ -655,7 +655,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             const auto p_pos = creature.get_position();
             const auto is_teleportable = cave_player_teleportable_bold(creature, pos->y, pos->x, TELEPORT_SPONTANEOUS);
             const auto dist = Grid::calc_distance(*pos, p_pos);
-            if (!is_teleportable || (dist > MAX_PLAYER_SIGHT / 2) || !projectable(*creature.current_floor_ptr, p_pos, *pos)) {
+            if (!is_teleportable || (dist > MAX_PLAYER_SIGHT / 2) || !projectable(*creature.get_floor(), p_pos, *pos)) {
                 msg_print(_("失敗！", "You cannot move to that place!"));
                 break;
             }
@@ -676,7 +676,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            const auto &grid = creature.current_floor_ptr->get_grid(pos);
+            const auto &grid = creature.get_floor()->get_grid(pos);
             if (grid.has_monster()) {
                 do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
                 if (grid.has_monster()) {
@@ -698,7 +698,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE)) {
                 msg_print(_("なぜか攻撃することができない。", "Something prevents you from attacking."));
                 return "";
@@ -745,7 +745,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
             }
 
             const auto pos = creature.get_neighbor(dir);
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             if (floor.get_grid(pos).has_monster()) {
                 do_cmd_attack(creature, pos.y, pos.x, HISSATSU_UNDEAD);
             } else {

--- a/src/realm/realm-life.cpp
+++ b/src/realm/realm-life.cpp
@@ -308,7 +308,7 @@ tl::optional<std::string> do_life_spell(CreatureEntity &creature, SPELL_IDX spel
 
     case 24: {
         if (cast) {
-            creature.current_floor_ptr->num_repro += MAX_REPRODUCTION;
+            creature.get_floor()->num_repro += MAX_REPRODUCTION;
         }
     } break;
 

--- a/src/room/cave-filler.cpp
+++ b/src/room/cave-filler.cpp
@@ -179,7 +179,7 @@ void generate_hmap(FloorType &floor, POSITION y0, POSITION x0, POSITION xsiz, PO
 static bool hack_isnt_wall(CreatureEntity &creature, POSITION y, POSITION x, int c1, int c2, int c3, FEAT_IDX feat1, FEAT_IDX feat2, FEAT_IDX feat3,
     BIT_FLAGS info1, BIT_FLAGS info2, BIT_FLAGS info3)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.grid_array[y][x].info & CAVE_ICKY) {
         return false;
     }
@@ -230,7 +230,7 @@ static bool hack_isnt_wall(CreatureEntity &creature, POSITION y, POSITION x, int
  */
 static void cave_fill(CreatureEntity &creature, const Pos2D &initial_pos)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
 
     // 幅優先探索用のキュー。
     std::queue<Pos2D> que;
@@ -266,7 +266,7 @@ static void cave_fill(CreatureEntity &creature, const Pos2D &initial_pos)
 
 bool generate_fracave(CreatureEntity &creature, POSITION y0, POSITION x0, POSITION xsize, POSITION ysize, int cutoff, bool light, bool room)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_dungeon_definition();
     POSITION xhsize = xsize / 2;
     POSITION yhsize = ysize / 2;
@@ -397,7 +397,7 @@ bool generate_fracave(CreatureEntity &creature, POSITION y0, POSITION x0, POSITI
 
 bool generate_lake(CreatureEntity &creature, POSITION y0, POSITION x0, POSITION xsize, POSITION ysize, int c1, int c2, int c3, int type)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_dungeon_definition();
     const auto &terrains = TerrainList::get_instance();
     const auto terrain_id_rubble = terrains.get_terrain_id(TerrainTag::RUBBLE);

--- a/src/room/pit-nest-util.cpp
+++ b/src/room/pit-nest-util.cpp
@@ -20,14 +20,14 @@ void nest_pit_type::prepare_filter(CreatureEntity &creature) const
         break;
     case PitNestHook::CLONE: {
         get_mon_num_prep_enum(creature, MonraceHook::VAULT);
-        const auto monrace_id = get_mon_num(creature, 0, creature.current_floor_ptr->dun_level + 10, PM_NONE);
+        const auto monrace_id = get_mon_num(creature, 0, creature.get_floor()->dun_level + 10, PM_NONE);
         filter.set_monrace_id(monrace_id);
         get_mon_num_prep_enum(creature);
         break;
     }
     case PitNestHook::SYMBOL: {
         get_mon_num_prep_enum(creature, MonraceHook::VAULT);
-        const auto monrace_id = get_mon_num(creature, 0, creature.current_floor_ptr->dun_level + 10, PM_NONE);
+        const auto monrace_id = get_mon_num(creature, 0, creature.get_floor()->dun_level + 10, PM_NONE);
         get_mon_num_prep_enum(creature);
         const auto symbol = MonraceList::get_instance().get_monrace(monrace_id).symbol_definition.character;
         filter.set_monrace_symbol(symbol);
@@ -107,7 +107,7 @@ tl::optional<PitKind> pick_pit_type(const FloorType &floor, const std::map<PitKi
  */
 tl::optional<MonraceId> select_pit_nest_monrace_id(CreatureEntity &creature, uint8_t &sub_align, int boost)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monraces = MonraceList::get_instance();
     for (auto attempts = 100; attempts > 0; attempts--) {
         const auto monrace_id = get_mon_num(creature, 0, floor.dun_level + boost, PM_NONE);

--- a/src/room/room-generator.cpp
+++ b/src/room/room-generator.cpp
@@ -99,7 +99,7 @@ static void move_prob_list(RoomType dst, RoomType src, std::map<RoomType, int> &
  */
 bool generate_rooms(CreatureEntity &creature, DungeonData *dd_ptr)
 {
-    auto *floor_ptr = creature.current_floor_ptr;
+    auto *floor_ptr = creature.get_floor();
     auto &dungeon = floor_ptr->get_generated_dungeon_definition();
 
     // 特定階層でのVault生成チェック

--- a/src/room/rooms-builder.cpp
+++ b/src/room/rooms-builder.cpp
@@ -77,7 +77,7 @@ void build_small_room(CreatureEntity &creature, POSITION x0, POSITION y0)
     const auto d = rand_choice(Direction::directions_4());
     place_secret_door(creature, pos + d.vec());
 
-    creature.current_floor_ptr->set_terrain_id_at(pos, TerrainTag::NONE, TerrainKind::MIMIC);
+    creature.get_floor()->set_terrain_id_at(pos, TerrainTag::NONE, TerrainKind::MIMIC);
     place_bold(creature, pos.y, pos.x, GB_FLOOR);
 }
 
@@ -88,7 +88,7 @@ void build_cavern(CreatureEntity &creature)
 {
     bool light = false;
     bool done = false;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if ((floor.dun_level <= randint1(50)) && floor.get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS)) {
         light = true;
     }
@@ -119,7 +119,7 @@ void build_lake(CreatureEntity &creature, int type)
         return;
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     int xsize = floor.width - 1;
     int ysize = floor.height - 1;
     int x0 = xsize / 2;
@@ -165,7 +165,7 @@ void build_room(CreatureEntity &creature, POSITION x1, POSITION x2, POSITION y1,
 
     POSITION xsize = x2 - x1;
     POSITION ysize = y2 - y1;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (int i = 0; i <= xsize; i++) {
         place_bold(creature, y1, x1 + i, GB_OUTER_NOPERM);
         floor.grid_array[y1][x1 + i].info |= (CAVE_ROOM | CAVE_ICKY);
@@ -343,7 +343,7 @@ void build_recursive_room(CreatureEntity &creature, POSITION x1, POSITION y1, PO
  */
 void add_outer_wall(CreatureEntity &creature, POSITION x, POSITION y, int light, POSITION x1, POSITION y1, POSITION x2, POSITION y2)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const Pos2D pos(y, x);
     if (!floor.contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
         return;

--- a/src/room/rooms-city.cpp
+++ b/src/room/rooms-city.cpp
@@ -72,7 +72,7 @@ void generate_room_floor(CreatureEntity &creature, const Rect2D &rectangle, int 
     }
 
     for (const auto &pos : rectangle) {
-        auto &grid = creature.current_floor_ptr->get_grid(pos);
+        auto &grid = creature.get_floor()->get_grid(pos);
         place_grid(creature, grid, GB_FLOOR);
         grid.add_info(info);
     }

--- a/src/room/rooms-fractal.cpp
+++ b/src/room/rooms-fractal.cpp
@@ -19,7 +19,7 @@ bool build_type9(CreatureEntity &creature, DungeonData *dd_ptr)
     auto width = randint1(22) * 2 + 6;
     auto height = randint1(15) * 2 + 6;
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto center = find_space(creature, dd_ptr, height + 1, width + 1);
     if (!center) {
         /* Limit to the minimum room size, and retry */

--- a/src/room/rooms-maze-vault.cpp
+++ b/src/room/rooms-maze-vault.cpp
@@ -100,7 +100,7 @@ void r_visit(CreatureEntity &creature, POSITION y1, POSITION x1, POSITION y2, PO
 void build_maze_vault(CreatureEntity &creature, const Pos2D &center, const Pos2DVec &vec, bool is_vault)
 {
     msg_print_wizard(creature, CHEAT_DUNGEON, _("迷路ランダムVaultを生成しました。", "Maze Vault."));
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     bool light = ((floor.dun_level <= randint1(25)) && is_vault && floor.get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS));
     const auto dy = vec.y / 2 - 1;
     const auto dx = vec.x / 2 - 1;

--- a/src/room/rooms-nest.cpp
+++ b/src/room/rooms-nest.cpp
@@ -70,7 +70,7 @@ tl::optional<std::array<NestMonsterInfo, NUM_NEST_MON_TYPE>> pick_nest_monraces(
 
 Rect2D generate_large_room(CreatureEntity &creature, const Pos2D &center)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     constexpr Vector2D vec(4, 11);
     const Rect2D rectangle(center, vec);
     for (const auto &pos : rectangle.resized(1)) {
@@ -88,7 +88,7 @@ Rect2D generate_large_room(CreatureEntity &creature, const Pos2D &center)
 
 void generate_inner_room(CreatureEntity &creature, const Pos2D &center, Rect2D &rectangle)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto inner_rectangle = rectangle.resized(-2);
 
     inner_rectangle.resized(1).each_edge([&creature, &floor](const Pos2D &pos) {
@@ -199,7 +199,7 @@ const MonraceDefinition &NestMonsterInfo::get_monrace() const
  */
 bool build_type5(CreatureEntity &creature, DungeonData *dd_ptr)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto nest_type = pick_nest_type(floor, nest_types);
     if (!nest_type) {
         return false;

--- a/src/room/rooms-normal.cpp
+++ b/src/room/rooms-normal.cpp
@@ -21,7 +21,7 @@
  */
 bool build_type1(CreatureEntity &creature, DungeonData *dd_ptr)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_dungeon_definition();
     const auto is_curtain = dungeon.flags.has(DungeonFeatureType::CURTAIN) && one_in_(dungeon.flags.has(DungeonFeatureType::NO_CAVE) ? 48 : 512);
 
@@ -173,7 +173,7 @@ bool build_type1(CreatureEntity &creature, DungeonData *dd_ptr)
  */
 bool build_type2(CreatureEntity &creature, DungeonData *dd_ptr)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto center = find_space(creature, dd_ptr, 25, 25);
     if (!center) {
         return false;
@@ -270,7 +270,7 @@ bool build_type2(CreatureEntity &creature, DungeonData *dd_ptr)
  */
 bool build_type3(CreatureEntity &creature, DungeonData *dd_ptr)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto center = find_space(creature, dd_ptr, 11, 25);
     if (!center) {
         return false;
@@ -478,7 +478,7 @@ bool build_type3(CreatureEntity &creature, DungeonData *dd_ptr)
 bool build_type4(CreatureEntity &creature, DungeonData *dd_ptr)
 {
     /* Find and reserve some space in the dungeon.  Get center of room. */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_dungeon_definition();
     const auto center = find_space(creature, dd_ptr, 11, 25);
     if (!center) {
@@ -791,7 +791,7 @@ bool build_type4(CreatureEntity &creature, DungeonData *dd_ptr)
 bool build_type11(CreatureEntity &creature, DungeonData *dd_ptr)
 {
     /* Occasional light */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto should_brighten = (randint1(floor.dun_level) <= 15) && floor.get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS);
     const auto rad = randint0(9);
     const auto center = find_space(creature, dd_ptr, rad * 2 + 1, rad * 2 + 1);
@@ -835,7 +835,7 @@ bool build_type12(CreatureEntity &creature, DungeonData *dd_ptr)
     const auto h4 = randint1(32) - 16;
 
     /* Occasional light */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto should_brighten = (randint1(floor.dun_level) <= 5) && floor.get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS);
     const auto rad = randint1(9);
 

--- a/src/room/rooms-pit.cpp
+++ b/src/room/rooms-pit.cpp
@@ -111,7 +111,7 @@ tl::optional<std::array<MonraceId, NUM_PIT_MONRACES>> pick_pit_monraces(Creature
 
 void place_pit_outer(CreatureEntity &creature, const Pos2D &center)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const Rect2D rectangle(center, PIT_SIZE);
     for (auto y = rectangle.top_left.y - 1; y <= rectangle.bottom_right.y + 1; y++) {
         for (auto x = rectangle.top_left.x - 1; x <= rectangle.bottom_right.x + 1; x++) {
@@ -134,7 +134,7 @@ void place_pit_outer(CreatureEntity &creature, const Pos2D &center)
 
 void place_pit_inner(CreatureEntity &creature, const Pos2D &center)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto rectangle = Rect2D(center, PIT_SIZE).resized(-2);
     for (auto y = rectangle.top_left.y - 1; y <= rectangle.bottom_right.y + 1; y++) {
         place_grid(creature, floor.get_grid({ y, rectangle.top_left.x - 1 }), GB_INNER);
@@ -207,7 +207,7 @@ void place_pit_inner(CreatureEntity &creature, const Pos2D &center)
  */
 bool build_type6(CreatureEntity &creature, DungeonData *dd_ptr)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto pit_type = pick_pit_type(floor, pit_types);
     if (!pit_type) {
         return false;
@@ -339,7 +339,7 @@ bool build_type6(CreatureEntity &creature, DungeonData *dd_ptr)
  */
 bool build_type13(CreatureEntity &creature, DungeonData *dd_ptr)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto pit_type = pick_pit_type(floor, pit_types);
 
     /* Only in Angband */

--- a/src/room/rooms-special.cpp
+++ b/src/room/rooms-special.cpp
@@ -60,7 +60,7 @@ bool build_type15(CreatureEntity &creature, DungeonData *dd_ptr)
     const auto width = rand_range(9, 13);
     const auto height = rand_range(9, 13);
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto center = find_space(creature, dd_ptr, height + 2, width + 2);
     if (!center) {
         return false;

--- a/src/room/rooms-trap.cpp
+++ b/src/room/rooms-trap.cpp
@@ -37,7 +37,7 @@ bool build_type14(CreatureEntity &creature, DungeonData *dd_ptr)
     }
 
     /* Choose lite or dark */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto light = ((floor.dun_level <= randint1(25)) && floor.get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS));
 
     /* Get corner values */

--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -88,7 +88,7 @@ std::array<Pos2D, NUM_BUBBLES> create_bubbles_center(const Pos2DVec &vec)
 void set_boundaries(CreatureEntity &creature, const Pos2D &pos)
 {
     place_bold(creature, pos.y, pos.x, GB_OUTER_NOPERM);
-    creature.current_floor_ptr->get_grid(pos).add_info(CAVE_ROOM | CAVE_ICKY);
+    creature.get_floor()->get_grid(pos).add_info(CAVE_ROOM | CAVE_ICKY);
 }
 }
 
@@ -106,7 +106,7 @@ static void build_bubble_vault(CreatureEntity &creature, const Pos2D &pos0, cons
     const Pos2DVec vec_half(vec.y / 2, vec.x / 2);
 
     /* Top and bottom boundaries */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (auto i = 0; i < vec.x; i++) {
         const auto side_x = pos0.x - vec_half.x + i;
         set_boundaries(creature, { pos0.y - vec_half.y, side_x });
@@ -174,7 +174,7 @@ static void build_room_vault(CreatureEntity &creature, const Pos2D &center, cons
     msg_print_wizard(creature, CHEAT_DUNGEON, _("部屋型ランダムVaultを生成しました。", "Room Vault."));
 
     /* fill area so don't get problems with on_defeat_arena_monster levels */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (auto x1 = 0; x1 < vec.x; x1++) {
         const auto x = center.x - vec_half.x + x1;
         for (auto y1 = 0; y1 < vec.y; y1++) {
@@ -220,7 +220,7 @@ static void build_cave_vault(CreatureEntity &creature, const Pos2D &center, cons
     auto done = false;
     auto room = true;
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     while (!done) {
         /* testing values for these parameters feel free to adjust */
         const auto grd = 1 << randint0(4);
@@ -299,7 +299,7 @@ static Pos2D coord_trans(const Pos2D &pos_initial, const Pos2DVec &offset, int t
 void build_vault(vault_type &vault, CreatureEntity &creature, POSITION yval, POSITION xval, POSITION ymax, POSITION xmax, concptr data, POSITION xoffset, POSITION yoffset, int transno)
 {
     /* Place dungeon features and objects */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto t = data;
     for (auto dy = 0; dy < ymax; dy++) {
         for (auto dx = 0; dx < xmax; dx++, t++) {
@@ -573,7 +573,7 @@ static void build_target_vault(CreatureEntity &creature, const Pos2D &center, co
     const auto rad = vec.x > vec.y ? vec.y / 2 : vec.x / 2;
 
     /* Make floor */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (auto x = center.x - rad; x <= center.x + rad; x++) {
         for (auto y = center.y - rad; y <= center.y + rad; y++) {
             const Pos2D pos(y, x);
@@ -665,7 +665,7 @@ static void build_elemental_vault(CreatureEntity &creature, const Pos2D &center,
     const auto xsize = vec_half.x * 2;
     const auto ysize = vec_half.y * 2;
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     lake_type type;
     if (floor.dun_level < 25) {
         /* Earth vault  (Rubble) */
@@ -741,7 +741,7 @@ static void build_mini_c_vault(CreatureEntity &creature, const Pos2D &center, co
     const auto x2 = center.x + dx;
 
     /* generate the room */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (auto x = x1 - 2; x <= x2 + 2; x++) {
         const Pos2D pos(y1 - 2, x);
         if (!floor.contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
@@ -845,7 +845,7 @@ static void build_castle_vault(CreatureEntity &creature, const Pos2D &center, co
     msg_print_wizard(creature, CHEAT_DUNGEON, _("城型ランダムVaultを生成しました。", "Castle Vault"));
 
     /* generate the room */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (const auto &pos : area.resized(1)) {
         floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_ICKY);
         /* Make everything a floor */
@@ -865,7 +865,7 @@ static void build_castle_vault(CreatureEntity &creature, const Pos2D &center, co
  */
 bool build_type10(CreatureEntity &creature, DungeonData *dd_ptr)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto xsize = randint1(22) + 22;
     const auto ysize = randint1(11) + 11;
     const auto center = find_space(creature, dd_ptr, ysize + 1, xsize + 1);
@@ -949,7 +949,7 @@ bool build_fixed_room(CreatureEntity &creature, DungeonData *dd_ptr, int typ, bo
     auto y = vault.hgt;
 
     /* Some huge vault cannot be ratated to fit in the dungeon */
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (x + 2 > floor.height - 2) {
         /* Forbid 90 or 270 degree ratation */
         num_transformation &= ~1;

--- a/src/room/space-finder.cpp
+++ b/src/room/space-finder.cpp
@@ -31,7 +31,7 @@ static bool get_is_floor(const FloorType &floor, const Pos2D &pos)
  */
 static void set_floor(CreatureEntity &creature, const Pos2D &pos)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!floor.contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
         return;
     }
@@ -54,7 +54,7 @@ static void set_floor(CreatureEntity &creature, const Pos2D &pos)
  */
 static void check_room_boundary(CreatureEntity &creature, const Pos2D &pos1, const Pos2D &pos2)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto count = 0;
     auto old_is_floor = get_is_floor(floor, { pos1.y, pos1.x - 1 });
     bool new_is_floor;
@@ -204,7 +204,7 @@ tl::optional<Pos2D> find_space(CreatureEntity &creature, DungeonData *dd_ptr, in
 
     auto block_y = 0;
     auto block_x = 0;
-    const auto &dungeon = creature.current_floor_ptr->get_dungeon_definition();
+    const auto &dungeon = creature.get_floor()->get_dungeon_definition();
     const auto has_cave = dungeon.flags.has_not(DungeonFeatureType::NO_CAVE);
     auto pick = has_cave ? randint1(candidates) : candidates / 2 + 1;
     for (block_y = dd_ptr->row_rooms - blocks_high; block_y >= 0; block_y--) {

--- a/src/room/treasure-deployment.cpp
+++ b/src/room/treasure-deployment.cpp
@@ -126,7 +126,7 @@ void fill_treasure(CreatureEntity &creature, const Rect2D &area, int difficulty)
 {
     const auto center = area.center();
     const auto size = area.width() - 1 + area.height() - 1;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
 
     for (const auto &pos : area) {
         deploy_treasure(creature, floor, center, pos, size, difficulty);

--- a/src/room/vault-builder.cpp
+++ b/src/room/vault-builder.cpp
@@ -16,7 +16,7 @@
  */
 static bool player_grid(const CreatureEntity &creature, const Grid &grid)
 {
-    return &grid == &creature.current_floor_ptr->grid_array[creature.y][creature.x];
+    return &grid == &creature.get_floor()->grid_array[creature.y][creature.x];
 }
 
 /*
@@ -38,7 +38,7 @@ static bool is_cave_empty_grid(const CreatureEntity &creature, const Grid &grid)
  */
 void vault_monsters(CreatureEntity &creature, const Pos2D &pos_center, int num)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (auto k = 0; k < num; k++) {
         for (auto i = 0; i < 9; i++) {
             const auto d = 1;
@@ -66,7 +66,7 @@ void vault_monsters(CreatureEntity &creature, const Pos2D &pos_center, int num)
  */
 void vault_objects(CreatureEntity &creature, const Pos2D &pos_center, int num)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (; num > 0; --num) {
         Pos2D pos = pos_center;
         int dummy = 0;

--- a/src/save/floor-writer.cpp
+++ b/src/save/floor-writer.cpp
@@ -66,7 +66,7 @@ std::vector<GridTemplate> generate_sorted_grid_templates(const FloorType &floor)
  */
 void wr_saved_floor(CreatureEntity &creature, saved_floor_type *sf_ptr)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (!sf_ptr) {
         wr_s16b((int16_t)floor.dun_level);
     } else {
@@ -80,7 +80,7 @@ void wr_saved_floor(CreatureEntity &creature, saved_floor_type *sf_ptr)
     }
 
     wr_u16b((uint16_t)floor.base_level);
-    wr_u16b((int16_t)creature.current_floor_ptr->num_repro);
+    wr_u16b((int16_t)creature.get_floor()->num_repro);
     wr_u16b((uint16_t)creature.y);
     wr_u16b((uint16_t)creature.x);
     wr_u16b((uint16_t)floor.height);
@@ -160,7 +160,7 @@ void wr_saved_floor(CreatureEntity &creature, saved_floor_type *sf_ptr)
  */
 bool wr_dungeon(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     floor.forget_lite();
     floor.forget_view();
     floor.forget_mon_lite();

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -150,8 +150,8 @@ void wr_player(CreatureEntity &creature)
     wr_s16b(static_cast<int16_t>(entries.get_current_entry()));
     const auto defeated_entry = entries.get_defeated_entry();
     wr_s16b(static_cast<int16_t>(defeated_entry.value_or(-1)));
-    wr_s16b(creature.current_floor_ptr->inside_arena);
-    wr_s16b(enum2i(creature.current_floor_ptr->quest_number));
+    wr_s16b(creature.get_floor()->inside_arena);
+    wr_s16b(enum2i(creature.get_floor()->quest_number));
     wr_s16b(AngbandSystem::get_instance().is_phase_out());
     wr_byte(world.get_arena());
     wr_byte(0); /* Unused */
@@ -321,7 +321,7 @@ void wr_player(CreatureEntity &creature)
     wr_bool(creature.is_dead());
     const auto &df = DungeonFeeling::get_instance();
     wr_byte(static_cast<uint8_t>(df.get_feeling()));
-    wr_s32b(creature.current_floor_ptr->generated_turn);
+    wr_s32b(creature.get_floor()->generated_turn);
     wr_s32b(df.get_turns());
     wr_s32b(world.game_turn);
     wr_s32b(world.dungeon_turn);

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -334,7 +334,7 @@ bool save_player(CreatureEntity &creature, SaveType type)
     if (type != SaveType::CLOSE_GAME) {
         world.is_loading_now = false;
         update_creature(creature);
-        creature.current_floor_ptr->reset_mproc();
+        creature.get_floor()->reset_mproc();
         world.is_loading_now = true;
     }
 

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -43,7 +43,7 @@ Chest::Chest(CreatureEntity &creature)
 void Chest::open(bool scatter, const Pos2D &pos, short item_idx)
 {
     BIT_FLAGS mode = AM_GOOD | AM_FORBID_CHEST;
-    auto &floor = *this->creature_ptr->current_floor_ptr;
+    auto &floor = *this->creature_ptr->get_floor();
     auto &item = *floor.o_list[item_idx];
     if (!item.is_valid()) {
         msg_print(_("箱は既に壊れてしまっている…", "The chest was broken and you couldn't open it..."));
@@ -115,7 +115,7 @@ void Chest::open(bool scatter, const Pos2D &pos, short item_idx)
  */
 void Chest::fire_trap(const Pos2D &pos, short item_idx)
 {
-    auto *o_ptr = this->creature_ptr->current_floor_ptr->o_list[item_idx].get();
+    auto *o_ptr = this->creature_ptr->get_floor()->o_list[item_idx].get();
 
     int mon_level = o_ptr->chest_level;
 
@@ -161,7 +161,7 @@ void Chest::fire_trap(const Pos2D &pos, short item_idx)
         int num = 2 + randint1(3);
         msg_print(_("突如吹き出した煙に包み込まれた！", "You are enveloped in a cloud of smoke!"));
         for (auto i = 0; i < num; i++) {
-            if (randint1(100) < this->creature_ptr->current_floor_ptr->dun_level) {
+            if (randint1(100) < this->creature_ptr->get_floor()->dun_level) {
                 activate_hi_summon(*this->creature_ptr, this->creature_ptr->y, this->creature_ptr->x, false);
             } else {
                 (void)summon_specific(*this->creature_ptr, pos.y, pos.x, mon_level, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));

--- a/src/specific-object/monster-ball.cpp
+++ b/src/specific-object/monster-ball.cpp
@@ -105,7 +105,7 @@ static bool release_monster(CreatureEntity &creature, ItemEntity &item, const Di
         return false;
     }
 
-    auto &monster = creature.current_floor_ptr->get_monster(*m_idx);
+    auto &monster = creature.get_floor()->get_monster(*m_idx);
     if (item.captured_monster_speed > 0) {
         monster.speed = item.captured_monster_speed;
     }

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -109,7 +109,7 @@ void update_lite_radius(CreatureEntity &creature)
         creature.cur_lite += creature.level / 5;
     }
 
-    if (creature.current_floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS) && creature.cur_lite > 1) {
+    if (creature.get_floor()->get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS) && creature.cur_lite > 1) {
         creature.cur_lite = 1;
     }
 
@@ -160,7 +160,7 @@ void update_lite_radius(CreatureEntity &creature)
 void update_lite(CreatureEntity &creature)
 {
     POSITION p = creature.cur_lite;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto points = floor.reset_lite();
     const auto p_pos = creature.get_position();
     if (p >= 1) {

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -51,7 +51,7 @@ SpellsMirrorMaster::SpellsMirrorMaster(CreatureEntity &creature)
 void SpellsMirrorMaster::remove_mirror(int y, int x)
 {
     const Pos2D pos(y, x);
-    auto &floor = *this->creature_ptr->current_floor_ptr;
+    auto &floor = *this->creature_ptr->get_floor();
     auto &grid = floor.get_grid(pos);
     reset_bits(grid.info, CAVE_OBJECT);
     grid.mimic = 0;
@@ -79,7 +79,7 @@ void SpellsMirrorMaster::remove_mirror(int y, int x)
  */
 void SpellsMirrorMaster::remove_all_mirrors(bool explode)
 {
-    const auto &floor = *this->creature_ptr->current_floor_ptr;
+    const auto &floor = *this->creature_ptr->get_floor();
     for (const auto &pos : floor.get_area()) {
         if (!floor.get_grid(pos).is_mirror()) {
             continue;
@@ -123,7 +123,7 @@ bool SpellsMirrorMaster::mirror_tunnel()
 tl::optional<std::string> SpellsMirrorMaster::place_mirror()
 {
     const auto p_pos = this->creature_ptr->get_position();
-    auto &floor = *this->creature_ptr->current_floor_ptr;
+    auto &floor = *this->creature_ptr->get_floor();
     auto &grid = floor.get_grid(p_pos);
     if (!grid.is_clean()) {
         return _("床上のアイテムが呪文を跳ね返した。", "The object resists the spell.");
@@ -150,7 +150,7 @@ bool SpellsMirrorMaster::mirror_concentration()
         return false;
     }
 
-    if (!this->creature_ptr->current_floor_ptr->grid_array[this->creature_ptr->y][this->creature_ptr->x].is_mirror()) {
+    if (!this->creature_ptr->get_floor()->grid_array[this->creature_ptr->y][this->creature_ptr->x].is_mirror()) {
         msg_print(_("鏡の上でないと集中できない！", "There's no mirror here!"));
         return true;
     }
@@ -173,7 +173,7 @@ bool SpellsMirrorMaster::mirror_concentration()
  */
 void SpellsMirrorMaster::seal_of_mirror(const int dam)
 {
-    const auto &floor = *this->creature_ptr->current_floor_ptr;
+    const auto &floor = *this->creature_ptr->get_floor();
     for (const auto &pos : floor.get_area()) {
         const auto &g_ref = floor.get_grid(pos);
         if (!g_ref.is_mirror()) {
@@ -210,7 +210,7 @@ void SpellsMirrorMaster::super_ray(const Direction &dir, int dam)
  */
 Pos2D SpellsMirrorMaster::get_next_mirror_position(const Pos2D &pos_current) const
 {
-    const auto &floor = *this->creature_ptr->current_floor_ptr;
+    const auto &floor = *this->creature_ptr->get_floor();
     const auto has_mirror = [&](const Pos2D &pos) { return floor.get_grid(pos).is_mirror(); };
     const auto mirror_positions = floor.get_area() | ranges::views::filter(has_mirror) | ranges::to_vector;
 
@@ -232,7 +232,7 @@ void SpellsMirrorMaster::project_seeker_ray(int target_x, int target_y, int dam)
     BIT_FLAGS flag = PROJECT_BEAM | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM | PROJECT_THRU | PROJECT_MIRROR;
     monster_target_y = this->creature_ptr->y;
     monster_target_x = this->creature_ptr->x;
-    auto &floor = *this->creature_ptr->current_floor_ptr;
+    auto &floor = *this->creature_ptr->get_floor();
 
     ProjectResult res;
 
@@ -339,7 +339,7 @@ static void draw_super_ray_pict(CreatureEntity &creature, const std::map<int, st
     // スーパーレイの描画を行った座標のリスト。スーパーレイの全ての描画完了後に描画を消去するのに使用する。
     std::vector<Pos2D> drawn_pos_list;
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (const auto &[n, pos_list] : pos_list_map) {
         // スーパーレイの最終到達点の座標の描画を行った座標のリスト。最終到達点の描画を '*' で上書きするのに使用する。
         std::vector<Pos2D> drawn_last_pos_list;
@@ -391,7 +391,7 @@ static bool activate_super_ray_effect(CreatureEntity &creature, int y, int x, in
 
     (void)affect_monster(creature, 0, 0, y, x, dam, typ, flag, true);
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &grid = floor.grid_array[project_m_y][project_m_x];
     const auto &monster = floor.get_monster(grid.m_idx);
     if (project_m_n == 1 && grid.has_monster() && monster.get_monster_profile().ml) {
@@ -412,7 +412,7 @@ void SpellsMirrorMaster::project_super_ray(int target_x, int target_y, int dam)
     BIT_FLAGS flag = PROJECT_BEAM | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM | PROJECT_THRU | PROJECT_MIRROR;
     monster_target_y = this->creature_ptr->y;
     monster_target_x = this->creature_ptr->x;
-    const auto &floor = *this->creature_ptr->current_floor_ptr;
+    const auto &floor = *this->creature_ptr->get_floor();
 
     ProjectResult res;
     const auto p_pos = this->creature_ptr->get_position();

--- a/src/spell-kind/blood-curse.cpp
+++ b/src/spell-kind/blood-curse.cpp
@@ -18,8 +18,8 @@
 
 void blood_curse_to_enemy(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
-    const auto &grid = creature.current_floor_ptr->grid_array[monster.y][monster.x];
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
+    const auto &grid = creature.get_floor()->grid_array[monster.y][monster.x];
     BIT_FLAGS curse_flg = (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP);
     int count = 0;
     bool is_first_loop = true;
@@ -103,7 +103,7 @@ void blood_curse_to_enemy(CreatureEntity &creature, MONSTER_IDX m_idx)
                 mode |= (PM_NO_PET | PM_FORCE_FRIENDLY);
             }
 
-            const auto level = pet ? creature.level * 2 / 3 + randint1(creature.level / 2) : creature.current_floor_ptr->dun_level;
+            const auto level = pet ? creature.level * 2 / 3 + randint1(creature.level / 2) : creature.get_floor()->dun_level;
             count += summon_specific(creature, creature.y, creature.x, level, SUMMON_NONE, mode) ? 1 : 0;
             if (!one_in_(6)) {
                 break;

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -83,7 +83,7 @@ tl::optional<Pos2D> decide_player_dodge_posistion(CreatureEntity &creature, std:
     const auto pos_candidates =
         Direction::directions_8() |
         ranges::views::transform([&](const auto &d) { return creature.get_neighbor(d); }) |
-        ranges::views::filter([&](const auto &pos) { return creature.current_floor_ptr->is_empty_at(pos) && (pos != creature.get_position()); }) |
+        ranges::views::filter([&](const auto &pos) { return creature.get_floor()->is_empty_at(pos) && (pos != creature.get_position()); }) |
         ranges::views::filter(std::not_fn(is_collapsed_pos)) |
         ranges::to<std::vector<Pos2D>>();
 
@@ -96,7 +96,7 @@ std::string build_killer_on_earthquake(CreatureEntity &creature, int m_idx)
         return _("地震", "an earthquake");
     }
 
-    const auto &monster = creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto m_name = monster_desc(creature, monster, MD_WRONGDOER_NAME);
     return format(_("%sの起こした地震", "an earthquake caused by %s"), m_name.data());
 }
@@ -178,7 +178,7 @@ tl::optional<Pos2D> decide_monster_dodge_position(const FloorType &floor, const 
 
 void move_monster_to(CreatureEntity &creature, CreatureEntity &monster, const Pos2D &pos_to)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto pos_from = monster.get_position();
     auto &grid_from = floor.get_grid(pos_from);
     auto &grid_to = floor.get_grid(pos_to);
@@ -191,7 +191,7 @@ void move_monster_to(CreatureEntity &creature, CreatureEntity &monster, const Po
 
 bool process_monster_damage(CreatureEntity &creature, CreatureEntity &monster, bool has_dodged)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &grid = floor.get_grid(monster.get_position());
     const auto damage = (has_dodged ? Dice::roll(4, 8) : (monster.hp + 1));
     (void)set_monster_csleep(floor, grid.m_idx, 0);
@@ -216,7 +216,7 @@ bool process_monster_damage(CreatureEntity &creature, CreatureEntity &monster, b
 
 void process_hit_to_monster(CreatureEntity &creature, CreatureEntity &monster, std::span<const Pos2D> pos_collapses)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto pos_dodge = decide_monster_dodge_position(floor, creature.get_position(), monster, pos_collapses);
     const auto m_name = monster_desc(creature, monster, 0);
     if (!ignore_unview || is_seen(creature, monster)) {
@@ -234,7 +234,7 @@ void process_hit_to_monster(CreatureEntity &creature, CreatureEntity &monster, s
 
 void process_hit_to_monsters(CreatureEntity &creature, std::span<const Pos2D> pos_collapses)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto has_monster = [&](const auto &pos) { return floor.get_grid(pos).has_monster(); };
     for (const auto &pos : pos_collapses | ranges::views::filter(has_monster)) {
         auto &grid = floor.get_grid(pos);
@@ -254,7 +254,7 @@ void process_hit_to_monsters(CreatureEntity &creature, std::span<const Pos2D> po
 
 void destruct_earthquake_area(CreatureEntity &creature, std::span<const Pos2D> pos_collapses)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     floor.forget_mon_lite();
     const auto &dungeon = floor.get_dungeon_definition();
     const auto is_changeable = [&](const auto &pos) { return floor.is_grid_changeable(pos); };
@@ -347,7 +347,7 @@ bool earthquake(CreatureEntity &creature, const Pos2D &center, int radius, MONST
 {
     const int earthquake_max = 80;
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if ((floor.is_in_quest() && QuestType::is_fixed(floor.quest_number)) || !floor.is_underground()) {
         return false;
     }

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -36,7 +36,7 @@
  */
 static bool detect_feat_flag(CreatureEntity &creature, POSITION range, TerrainCharacteristics flag, bool known)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
@@ -171,7 +171,7 @@ bool detect_treasure(CreatureEntity &creature, POSITION range)
  */
 bool detect_objects_gold(CreatureEntity &creature, POSITION range)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     POSITION range2 = range;
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range2 /= 3;
@@ -222,7 +222,7 @@ bool detect_objects_gold(CreatureEntity &creature, POSITION range)
  */
 bool detect_objects_normal(CreatureEntity &creature, POSITION range)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     POSITION range2 = range;
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range2 /= 3;
@@ -289,7 +289,7 @@ static bool is_object_magically(const ItemKindType tval)
  */
 bool detect_objects_magic(CreatureEntity &creature, POSITION range)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
@@ -330,7 +330,7 @@ bool detect_objects_magic(CreatureEntity &creature, POSITION range)
  */
 bool detect_monsters_normal(CreatureEntity &creature, POSITION range)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
@@ -374,7 +374,7 @@ bool detect_monsters_normal(CreatureEntity &creature, POSITION range)
  */
 bool detect_monsters_invis(CreatureEntity &creature, POSITION range)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
@@ -426,7 +426,7 @@ bool detect_monsters_invis(CreatureEntity &creature, POSITION range)
  */
 bool detect_monsters_evil(CreatureEntity &creature, POSITION range)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
@@ -477,7 +477,7 @@ bool detect_monsters_evil(CreatureEntity &creature, POSITION range)
  */
 bool detect_monsters_nonliving(CreatureEntity &creature, POSITION range)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
@@ -523,7 +523,7 @@ bool detect_monsters_nonliving(CreatureEntity &creature, POSITION range)
  */
 bool detect_monsters_mind(CreatureEntity &creature, POSITION range)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
@@ -572,7 +572,7 @@ bool detect_monsters_mind(CreatureEntity &creature, POSITION range)
  */
 bool detect_monsters_string(CreatureEntity &creature, POSITION range, concptr Match)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }

--- a/src/spell-kind/spells-enchant.cpp
+++ b/src/spell-kind/spells-enchant.cpp
@@ -97,7 +97,7 @@ bool artifact_scroll(CreatureEntity &creature)
 
     if (record_rand_art) {
         const auto diary_item_name = describe_flavor(creature, *o_ptr, OD_NAME_ONLY);
-        exe_write_diary(*creature.current_floor_ptr, DiaryKind::ART_SCROLL, 0, diary_item_name);
+        exe_write_diary(*creature.get_floor(), DiaryKind::ART_SCROLL, 0, diary_item_name);
     }
 
     chg_virtue(creature, Virtue::ENCHANT, 1);

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -33,7 +33,7 @@
  */
 void fetch_item(CreatureEntity &creature, const Direction &dir, WEIGHT wgt, bool require_los)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     if (!floor.get_grid(p_pos).o_idx_list.empty()) {
         msg_print(_("自分の足の下にある物は取れません。", "You can't fetch when you're already standing on something."));
@@ -116,7 +116,7 @@ bool fetch_monster(CreatureEntity &creature)
         return false;
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto m_idx = floor.get_grid(*pos).m_idx;
     if (!is_monster(m_idx)) {
         return false;

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -46,7 +46,7 @@
 void wiz_lite(CreatureEntity &creature, bool ninja)
 {
     /* Memorize objects */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (auto &item_ptr : floor.o_list) {
         if (!item_ptr->is_valid()) {
             continue;
@@ -115,7 +115,7 @@ void wiz_lite(CreatureEntity &creature, bool ninja)
  */
 void wiz_dark(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     /* Forget every grid */
     for (const auto &pos : floor.get_area(FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
         auto &grid = floor.get_grid(pos);
@@ -171,7 +171,7 @@ void wiz_dark(CreatureEntity &creature)
  */
 void map_area(CreatureEntity &creature, POSITION range)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
@@ -243,7 +243,7 @@ bool destroy_area(CreatureEntity &creature, const POSITION y1, const POSITION x1
     const Pos2D pos1(y1, x1);
 
     /* Prevent destruction of quest levels and town */
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if ((floor.is_in_quest() && QuestType::is_fixed(floor.quest_number)) || !floor.is_underground()) {
         if (!in_generate) {
             msg_print(_("破壊の力はかき消された…", "The power of destruction has been drowned out ..."));

--- a/src/spell-kind/spells-genocide.cpp
+++ b/src/spell-kind/spells-genocide.cpp
@@ -41,7 +41,7 @@
  */
 bool genocide_aux(CreatureEntity &creature, MONSTER_IDX m_idx, int power, bool player_cast, int dam_side, concptr spell_name)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(m_idx);
     auto &monrace = monster.get_monrace();
     if (monster.is_pet() && !player_cast) {
@@ -80,7 +80,7 @@ bool genocide_aux(CreatureEntity &creature, MONSTER_IDX m_idx, int power, bool p
         }
 
         if (monster.is_asleep()) {
-            (void)set_monster_csleep(*creature.current_floor_ptr, m_idx, 0);
+            (void)set_monster_csleep(*creature.get_floor(), m_idx, 0);
             if (monster.get_monster_profile().ml) {
                 msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());
             }
@@ -121,7 +121,7 @@ bool genocide_aux(CreatureEntity &creature, MONSTER_IDX m_idx, int power, bool p
  */
 bool symbol_genocide(CreatureEntity &creature, int power, bool player_cast)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     bool is_special_floor = floor.is_in_quest() && !inside_quest(floor.get_random_quest_id());
     is_special_floor |= floor.inside_arena;
     is_special_floor |= AngbandSystem::get_instance().is_phase_out();
@@ -168,7 +168,7 @@ bool symbol_genocide(CreatureEntity &creature, int power, bool player_cast)
  */
 bool mass_genocide(CreatureEntity &creature, int power, bool player_cast)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     bool is_special_floor = floor.is_in_quest() && !inside_quest(floor.get_random_quest_id());
     is_special_floor |= floor.inside_arena;
     is_special_floor |= AngbandSystem::get_instance().is_phase_out();
@@ -205,7 +205,7 @@ bool mass_genocide(CreatureEntity &creature, int power, bool player_cast)
  */
 bool mass_genocide_undead(CreatureEntity &creature, int power, bool player_cast)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     bool is_special_floor = floor.is_in_quest() && !inside_quest(floor.get_random_quest_id());
     is_special_floor |= floor.inside_arena;
     is_special_floor |= AngbandSystem::get_instance().is_phase_out();

--- a/src/spell-kind/spells-grid.cpp
+++ b/src/spell-kind/spells-grid.cpp
@@ -21,7 +21,7 @@
  */
 bool create_rune_protection_one(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     auto &grid = floor.get_grid(p_pos);
     if (!grid.is_clean()) {
@@ -47,7 +47,7 @@ bool create_rune_protection_one(CreatureEntity &creature)
 bool create_rune_explosion(CreatureEntity &creature, POSITION y, POSITION x)
 {
     const Pos2D pos(y, x);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &grid = floor.get_grid(pos);
     if (!grid.is_clean()) {
         msg_print(_("床上のアイテムが呪文を跳ね返した。", "The object resists the spell."));
@@ -68,7 +68,7 @@ bool create_rune_explosion(CreatureEntity &creature, POSITION y, POSITION x)
 void stair_creation(CreatureEntity &creature)
 {
     auto up = !ironman_downward;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto down = !inside_quest(floor.get_quest_id()) && (floor.dun_level < floor.get_dungeon_definition().maxdepth);
     if (!floor.is_underground() || (!up && !down) || (floor.is_in_quest() && QuestType::is_fixed(floor.quest_number)) || floor.inside_arena || AngbandSystem::get_instance().is_phase_out()) {
         msg_print(_("効果がありません！", "There is no effect!"));

--- a/src/spell-kind/spells-lite.cpp
+++ b/src/spell-kind/spells-lite.cpp
@@ -42,7 +42,7 @@
 /*!< @todo 並び順の都合で連番を付ける。まとめても良いならまとめてしまう予定 */
 static void cave_temp_room_lite(CreatureEntity &creature, const std::vector<Pos2D> &positions)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (const auto &pos : positions) {
         auto &grid = floor.get_grid(pos);
         grid.info &= ~(CAVE_TEMP);
@@ -60,7 +60,7 @@ static void cave_temp_room_lite(CreatureEntity &creature, const std::vector<Pos2
             }
 
             if (monster.is_asleep() && evaluate_percent(chance)) {
-                (void)set_monster_csleep(*creature.current_floor_ptr, grid.m_idx, 0);
+                (void)set_monster_csleep(*creature.get_floor(), grid.m_idx, 0);
                 if (monster.get_monster_profile().ml) {
                     const auto m_name = monster_desc(creature, monster, 0);
                     msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());
@@ -82,7 +82,7 @@ static void cave_temp_room_lite(CreatureEntity &creature, const std::vector<Pos2
 /*!< @todo 並び順の都合で連番を付ける。まとめても良いならまとめてしまう予定 */
 static void cave_temp_room_unlite(CreatureEntity &creature, const std::vector<Pos2D> &positions)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &world = AngbandWorld::get_instance();
     for (const auto &pos : positions) {
         auto &grid = floor.get_grid(pos);
@@ -224,7 +224,7 @@ static bool cave_temp_room_aux(const FloorType &floor, const Pos2D &pos, const P
 void lite_room(CreatureEntity &creature, const Pos2D &pos_start)
 {
     std::vector<Pos2D> positions;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     if (cave_temp_room_aux(floor, pos_start, p_pos, TerrainCharacteristics::LOS)) {
         floor.get_grid(pos_start).info |= CAVE_TEMP;
@@ -261,7 +261,7 @@ void lite_room(CreatureEntity &creature, const Pos2D &pos_start)
 void unlite_room(CreatureEntity &creature, const Pos2D &pos_start)
 {
     std::vector<Pos2D> positions;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     if (cave_temp_room_aux(floor, pos_start, p_pos, TerrainCharacteristics::PROJECTION)) {
         floor.get_grid(pos_start).info |= CAVE_TEMP;
@@ -304,8 +304,8 @@ bool starlight(CreatureEntity &creature, bool magic)
         Pos2D pos(0, 0);
         auto attempts = 1000;
         while (attempts--) {
-            pos = scatter(*creature.current_floor_ptr, p_pos, 4, PROJECT_LOS);
-            if (!creature.current_floor_ptr->has_terrain_characteristics(pos, TerrainCharacteristics::PROJECTION)) {
+            pos = scatter(*creature.get_floor(), p_pos, 4, PROJECT_LOS);
+            if (!creature.get_floor()->has_terrain_characteristics(pos, TerrainCharacteristics::PROJECTION)) {
                 continue;
             }
 
@@ -330,7 +330,7 @@ bool starlight(CreatureEntity &creature, bool magic)
  */
 bool lite_area(CreatureEntity &creature, int dam, int rad)
 {
-    if (creature.current_floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
+    if (creature.get_floor()->get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         msg_print(_("ダンジョンが光を吸収した。", "The darkness of this dungeon absorbs your light."));
         return false;
     }

--- a/src/spell-kind/spells-neighbor.cpp
+++ b/src/spell-kind/spells-neighbor.cpp
@@ -141,8 +141,8 @@ void wall_breaker(CreatureEntity &creature)
     if (randint1(80 + creature.level) < 70) {
         Pos2D pos(0, 0);
         while (attempts--) {
-            pos = scatter(*creature.current_floor_ptr, p_pos, 4, PROJECT_NONE);
-            if (!creature.current_floor_ptr->has_terrain_characteristics(pos, TerrainCharacteristics::PROJECTION)) {
+            pos = scatter(*creature.get_floor(), p_pos, 4, PROJECT_NONE);
+            if (!creature.get_floor()->has_terrain_characteristics(pos, TerrainCharacteristics::PROJECTION)) {
                 continue;
             }
 
@@ -165,7 +165,7 @@ void wall_breaker(CreatureEntity &creature)
     for (auto i = 0; i < num; i++) {
         Pos2D pos(0, 0);
         while (true) {
-            pos = scatter(*creature.current_floor_ptr, p_pos, 10, PROJECT_NONE);
+            pos = scatter(*creature.get_floor(), p_pos, 10, PROJECT_NONE);
             if (!creature.is_located_at(pos)) {
                 break;
             }

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -89,7 +89,7 @@ bool identify_item(CreatureEntity &creature, ItemEntity *o_ptr)
     record_turn = AngbandWorld::get_instance().game_turn;
 
     const auto item_name = describe_flavor(creature, *o_ptr, OD_NAME_ONLY);
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (record_fix_art && !old_known && o_ptr->is_fixed_artifact()) {
         exe_write_diary(floor, DiaryKind::ART, 0, item_name);
     }

--- a/src/spell-kind/spells-pet.cpp
+++ b/src/spell-kind/spells-pet.cpp
@@ -21,7 +21,7 @@
 void discharge_minion(CreatureEntity &creature)
 {
     bool okay = true;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
         const auto &monster = floor.get_monster(i);
         if (!monster.is_valid() || !monster.is_pet()) {

--- a/src/spell-kind/spells-polymorph.cpp
+++ b/src/spell-kind/spells-polymorph.cpp
@@ -44,7 +44,7 @@ static MonraceId select_polymorph_monrace_id(CreatureEntity &creature, MonraceId
     const auto lev1 = monrace.level - ((randint1(20) / randint1(9)) + 1);
     const auto lev2 = monrace.level + ((randint1(20) / randint1(9)) + 1);
     for (auto i = 0; i < 1000; i++) {
-        const auto new_monrace_id = get_mon_num(creature, 0, (creature.current_floor_ptr->dun_level + monrace.level) / 2 + 5, PM_NONE);
+        const auto new_monrace_id = get_mon_num(creature, 0, (creature.get_floor()->dun_level + monrace.level) / 2 + 5, PM_NONE);
         if (!MonraceList::is_valid(new_monrace_id)) {
             break;
         }
@@ -74,7 +74,7 @@ static MonraceId select_polymorph_monrace_id(CreatureEntity &creature, MonraceId
  */
 bool polymorph_monster(CreatureEntity &creature, POSITION y, POSITION x)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &grid = floor.grid_array[y][x];
     auto &monster = floor.get_monster(grid.m_idx);
     MonraceId new_r_idx;

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -100,7 +100,7 @@ bool activate_ty_curse(CreatureEntity &creature, bool stop_ty, int *count)
 {
     BIT_FLAGS flg = (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP);
     bool is_first_curse = true;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     while (is_first_curse || (one_in_(3) && !stop_ty)) {
         is_first_curse = false;
         switch (randint1(34)) {
@@ -259,7 +259,7 @@ void wild_magic(CreatureEntity &creature, int spell)
         type = SUMMON_MIMIC;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     switch (randint1(spell) + randint1(8) + 1) {
     case 1:
     case 2:

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -44,7 +44,7 @@
  */
 bool project_all_los(CreatureEntity &creature, AttributeType typ, int dam)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     for (short i = 1; i < floor.m_max; i++) {
         auto &monster = floor.get_monster(i);
@@ -214,7 +214,7 @@ void aggravate_monsters(CreatureEntity &creature, MONSTER_IDX src_idx)
 {
     auto sleep = false;
     auto speed = false;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     for (short i = 1; i < floor.m_max; i++) {
         auto &monster = floor.get_monster(i);
         if (!monster.is_valid()) {
@@ -438,7 +438,7 @@ bool probing(CreatureEntity &creature)
     game_term->scr->cu = 0;
     game_term->scr->cv = 1;
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     auto probe = false;
     for (short i = 1; i < floor.m_max; i++) {

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -50,8 +50,8 @@ bool teleport_swap(CreatureEntity &creature, const Direction &dir)
         return false;
     }
 
-    const auto &grid = creature.current_floor_ptr->get_grid(pos);
-    if (!grid.has_monster() || creature.current_floor_ptr->get_monster(grid.m_idx).is_riding()) {
+    const auto &grid = creature.get_floor()->get_grid(pos);
+    if (!grid.has_monster() || creature.get_floor()->get_monster(grid.m_idx).is_riding()) {
         msg_print(_("それとは場所を交換できません。", "You can't trade places with that!"));
         return false;
     }
@@ -61,10 +61,10 @@ bool teleport_swap(CreatureEntity &creature, const Direction &dir)
         return false;
     }
 
-    const auto &monster = creature.current_floor_ptr->get_monster(grid.m_idx);
+    const auto &monster = creature.get_floor()->get_monster(grid.m_idx);
     auto &monrace = monster.get_monrace();
 
-    (void)set_monster_csleep(*creature.current_floor_ptr, grid.m_idx, 0);
+    (void)set_monster_csleep(*creature.get_floor(), grid.m_idx, 0);
 
     if (monrace.resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT)) {
         msg_print(_("テレポートを邪魔された！", "Your teleportation is blocked!"));
@@ -106,7 +106,7 @@ bool teleport_monster(CreatureEntity &creature, const Direction &dir, int distan
  */
 bool teleport_away(CreatureEntity &creature, MONSTER_IDX m_idx, POSITION dis, teleport_flags mode)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(m_idx);
     if (!monster.is_valid()) {
         return false;
@@ -190,7 +190,7 @@ bool teleport_away(CreatureEntity &creature, MONSTER_IDX m_idx, POSITION dis, te
  */
 void teleport_monster_to(CreatureEntity &creature, MONSTER_IDX m_idx, POSITION ty, POSITION tx, int power, teleport_flags mode)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(m_idx);
     if (!monster.is_valid()) {
         return;
@@ -293,7 +293,7 @@ bool teleport_player_aux(CreatureEntity &creature, POSITION dis, bool is_quantum
         dis = max_distance;
     }
 
-    const auto &floor_ref = *creature.current_floor_ptr;
+    const auto &floor_ref = *creature.get_floor();
     const auto left = std::max(1, creature.x - dis);
     const auto right = std::min(floor_ref.width - 2, creature.x + dis);
     const auto top = std::max(1, creature.y - dis);
@@ -391,11 +391,11 @@ void teleport_player(CreatureEntity &creature, POSITION dis, BIT_FLAGS mode)
     /* Monsters with teleport ability may follow the creature */
     for (POSITION xx = -1; xx < 2; xx++) {
         for (POSITION yy = -1; yy < 2; yy++) {
-            MONSTER_IDX tmp_m_idx = creature.current_floor_ptr->grid_array[oy + yy][ox + xx].m_idx;
+            MONSTER_IDX tmp_m_idx = creature.get_floor()->grid_array[oy + yy][ox + xx].m_idx;
             if (!is_monster(tmp_m_idx)) {
                 continue;
             }
-            const auto &monster = creature.current_floor_ptr->get_monster(tmp_m_idx);
+            const auto &monster = creature.get_floor()->get_monster(tmp_m_idx);
             if (!monster.is_riding()) {
                 const auto &monrace = monster.get_monrace();
 
@@ -429,7 +429,7 @@ void teleport_player_away(MONSTER_IDX m_idx, CreatureEntity &creature, POSITION 
     if (!teleport_player_aux(creature, dis, is_quantum_effect, TELEPORT_PASSIVE)) {
         return;
     }
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
 
     /* Monsters with teleport ability may follow the creature */
     for (POSITION xx = -1; xx < 2; xx++) {
@@ -441,7 +441,7 @@ void teleport_player_away(MONSTER_IDX m_idx, CreatureEntity &creature, POSITION 
                 continue;
             }
 
-            const auto &monster = creature.current_floor_ptr->get_monster(tmp_m_idx);
+            const auto &monster = creature.get_floor()->get_monster(tmp_m_idx);
             const auto &monrace = monster.get_monrace();
 
             bool can_follow = monrace.ability_flags.has(MonsterAbilityType::TPORT);
@@ -473,7 +473,7 @@ void teleport_player_to(CreatureEntity &creature, POSITION ny, POSITION nx, tele
         return;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     Pos2D pos(0, 0);
     auto dis = 0;
     auto ctr = 0;
@@ -511,7 +511,7 @@ void teleport_player_to(CreatureEntity &creature, POSITION ny, POSITION nx, tele
 
 void teleport_away_followable(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     const auto old_m_pos = monster.get_position();
     bool old_ml = monster.get_monster_profile().ml;

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -62,7 +62,7 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
 
     std::string m_name;
     auto see_m = true;
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(m_idx);
     if (m_idx <= 0) {
         m_name = _("あなた", "you");
@@ -230,7 +230,7 @@ bool teleport_level_other(CreatureEntity &creature)
         return false;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(*pos);
     const auto target_m_idx = grid.m_idx;
     if ((target_m_idx == 0) || !grid.has_los()) {
@@ -268,12 +268,12 @@ bool tele_town(CreatureEntity &creature)
         return false;
     }
 
-    if (creature.current_floor_ptr->is_underground()) {
+    if (creature.get_floor()->is_underground()) {
         msg_print(_("この魔法は地上でしか使えない！", "This spell can only be used on the surface!"));
         return false;
     }
 
-    if (creature.current_floor_ptr->inside_arena || AngbandSystem::get_instance().is_phase_out()) {
+    if (creature.get_floor()->inside_arena || AngbandSystem::get_instance().is_phase_out()) {
         msg_print(_("この魔法は外でしか使えない！", "This spell can only be used outside!"));
         return false;
     }
@@ -345,7 +345,7 @@ void reserve_alter_reality(CreatureEntity &creature, TIME_EFFECT turns)
         return;
     }
 
-    if (creature.current_floor_ptr->inside_arena || ironman_downward) {
+    if (creature.get_floor()->inside_arena || ironman_downward) {
         msg_print(_("何も起こらなかった。", "Nothing happens."));
         return;
     }
@@ -428,7 +428,7 @@ bool recall_player(CreatureEntity &creature, TIME_EFFECT turns)
         return true;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (floor.inside_arena || ironman_downward) {
         msg_print(_("何も起こらなかった。", "Nothing happens."));
         return true;
@@ -510,7 +510,7 @@ bool free_level_recall(CreatureEntity &creature)
     auto &dungeon_record = DungeonRecords::get_instance().get_record(creature.recall_dungeon);
     dungeon_record.set_max_level(dun_level);
     if (record_maxdepth) {
-        exe_write_diary(*creature.current_floor_ptr, DiaryKind::TRUMP, enum2i(*select_dungeon), _("トランプタワーで", "at Trump Tower"));
+        exe_write_diary(*creature.get_floor(), DiaryKind::TRUMP, enum2i(*select_dungeon), _("トランプタワーで", "at Trump Tower"));
     }
 
     msg_print(_("回りの大気が張りつめてきた...", "The air about you becomes charged..."));
@@ -552,7 +552,7 @@ bool reset_recall(CreatureEntity &creature)
     dungeon_record.set_max_level(*reset_level);
     if (record_maxdepth) {
         constexpr auto note = _("フロア・リセットで", "using a scroll of reset recall");
-        exe_write_diary(*creature.current_floor_ptr, DiaryKind::TRUMP, enum2i(*select_dungeon), note);
+        exe_write_diary(*creature.get_floor(), DiaryKind::TRUMP, enum2i(*select_dungeon), note);
     }
 #ifdef JP
     msg_format("%sの帰還レベルを %d 階にセット。", dungeon.name.data(), *reset_level);

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -29,7 +29,7 @@ void call_the_void(CreatureEntity &creature)
 {
     auto &player_ptr = creature;
     auto do_call = true;
-    const auto &floor = *player_ptr.current_floor_ptr;
+    const auto &floor = *player_ptr.get_floor();
     /* 虚無招来そのものを唱えることによる時空崩壊度進行(*破壊*とは別) */
     wc_ptr->plus_perm_collapsion(150);
     for (const auto &d : Direction::directions()) {
@@ -130,7 +130,7 @@ static void erase_all_walls(FloorType &floor)
  */
 bool vanish_dungeon(CreatureEntity &creature)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     auto is_special_floor = floor.is_in_quest() && QuestType::is_fixed(floor.quest_number);
     is_special_floor |= !floor.is_underground();
     if (is_special_floor) {
@@ -188,7 +188,7 @@ void cast_meteor(CreatureEntity &creature, int dam, POSITION rad)
 {
     const auto b = 10 + randint1(10);
     const auto p_pos = creature.get_position();
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (auto i = 0; i < b; i++) {
         Pos2D pos(0, 0);
         int count;

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -339,7 +339,7 @@ void SpellHex::store_vengeful_damage(int dam)
  */
 bool SpellHex::check_hex_barrier(MONSTER_IDX m_idx, spell_hex_type type) const
 {
-    const auto &monster = this->creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = this->creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     return this->is_spelling_specific(type) && ((this->creature.level * 3 / 2) >= randint1(monrace.level));
 }
@@ -373,7 +373,7 @@ void SpellHex::eyes_on_eyes(MONSTER_IDX m_idx, int dam)
         return;
     }
 
-    const auto &monster = this->creature.current_floor_ptr->get_monster(m_idx);
+    const auto &monster = this->creature.get_floor()->get_monster(m_idx);
     const auto m_name = monster_desc(creature, monster, 0);
 #ifdef JP
     msg_format("攻撃が%s自身を傷つけた！", m_name.data());

--- a/src/spell-realm/spells-trump.cpp
+++ b/src/spell-realm/spells-trump.cpp
@@ -65,7 +65,7 @@ void cast_shuffle(CreatureEntity &creature)
         chg_virtue(creature, Virtue::CHANCE, 1);
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (die < 7) {
         msg_print(_("なんてこった！《死》だ！", "Oh no! It's Death!"));
 

--- a/src/spell/range-calc.cpp
+++ b/src/spell/range-calc.cpp
@@ -15,7 +15,7 @@
 namespace {
 bool is_prevent_blast(CreatureEntity &creature, const Pos2D &center, const Pos2D &pos, AttributeType type)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     switch (type) {
     case AttributeType::LITE:
     case AttributeType::LITE_WEAK:
@@ -219,7 +219,7 @@ std::vector<std::pair<int, Pos2D>> breath_shape(CreatureEntity &creature, const 
     auto bx = pos_source.x;
     auto path_n = 0;
     const auto mdis = Grid::calc_distance(pos_source, pos_target) + rad;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     std::vector<std::pair<int, Pos2D>> positions;
 
     for (auto bdis = 0; bdis <= mdis; ++bdis) {
@@ -267,7 +267,7 @@ std::vector<std::pair<int, Pos2D>> breath_shape(CreatureEntity &creature, const 
 std::vector<std::pair<int, Pos2D>> ball_shape(CreatureEntity &creature, const Pos2D &center, int rad, AttributeType typ)
 {
     std::vector<std::pair<int, Pos2D>> positions;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (auto dist = 0; dist <= rad; dist++) {
         for (auto y = center.y - dist; y <= center.y + dist; y++) {
             for (auto x = center.x - dist; x <= center.x + dist; x++) {

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -129,7 +129,7 @@ PERCENTAGE spell_chance(CreatureEntity &creature, SPELL_IDX spell_id, RealmType 
     chance -= 3 * (creature.level - spell.slevel);
     chance -= 3 * (adj_mag_stat[creature.stat_index[mp_ptr->spell_stat]] - 1);
     if (creature.riding) {
-        const auto &riding_monrace = creature.current_floor_ptr->get_monster(creature.riding).get_monrace();
+        const auto &riding_monrace = creature.get_floor()->get_monster(creature.riding).get_monrace();
         chance += (std::max(riding_monrace.level - creature.skill_exp[PlayerSkillKindType::RIDING] / 100 - 10, 0));
     }
 

--- a/src/spell/spells-diceroll.cpp
+++ b/src/spell/spells-diceroll.cpp
@@ -21,7 +21,7 @@ bool common_saving_throw_charm(CreatureEntity &creature, int pow, const Creature
 {
     auto &monrace = target.get_monrace();
 
-    if (creature.current_floor_ptr->inside_arena) {
+    if (creature.get_floor()->inside_arena) {
         return true;
     }
 
@@ -61,7 +61,7 @@ bool common_saving_throw_control(CreatureEntity &creature, int pow, const Creatu
 {
     auto &monrace = target.get_monrace();
 
-    if (creature.current_floor_ptr->inside_arena) {
+    if (creature.get_floor()->inside_arena) {
         return true;
     }
 

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -560,14 +560,14 @@ void brand_weapon(CreatureEntity &creature, int brand_type)
         if (o_ptr->bi_key.tval() == ItemKindType::SWORD) {
             act = _("は鋭さを増した！", "becomes very sharp!");
             o_ptr->ego_idx = EgoType::SHARPNESS;
-            o_ptr->pval = (PARAMETER_VALUE)m_bonus(5, creature.current_floor_ptr->dun_level) + 1;
+            o_ptr->pval = (PARAMETER_VALUE)m_bonus(5, creature.get_floor()->dun_level) + 1;
             if ((o_ptr->bi_key.sval() == SV_HAYABUSA) && (o_ptr->pval > 2)) {
                 o_ptr->pval = 2;
             }
         } else {
             act = _("は破壊力を増した！", "seems very powerful.");
             o_ptr->ego_idx = EgoType::EARTHQUAKES;
-            o_ptr->pval = (PARAMETER_VALUE)m_bonus(3, creature.current_floor_ptr->dun_level);
+            o_ptr->pval = (PARAMETER_VALUE)m_bonus(3, creature.get_floor()->dun_level);
         }
 
         break;

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -586,7 +586,7 @@ bool fishing(CreatureEntity &creature)
 
     const auto pos = creature.get_neighbor(dir);
     creature.fishing_dir = dir.dir();
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!floor.has_terrain_characteristics(pos, TerrainCharacteristics::WATER)) {
         msg_print(_("そこは水辺ではない。", "You can't fish here."));
         return false;
@@ -638,7 +638,7 @@ bool cosmic_cast_off(CreatureEntity &creature, ItemEntity **o_ptr_ptr)
     inven_item_optimize(creature, slot);
 
     const auto old_o_idx = drop_near(creature, item, creature.get_position());
-    *o_ptr_ptr = creature.current_floor_ptr->o_list[old_o_idx].get();
+    *o_ptr_ptr = creature.get_floor()->o_list[old_o_idx].get();
 
     const auto item_name = describe_flavor(creature, item, OD_NAME_ONLY);
     msg_format(_("%sを脱ぎ捨てた。", "You cast off %s."), item_name.data());

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -293,7 +293,7 @@ int summon_cyber(CreatureEntity &creature, POSITION y, POSITION x, tl::optional<
 {
     /* Summoned by a monster */
     BIT_FLAGS mode = PM_ALLOW_GROUP;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (summoner_m_idx) {
         const auto &monster = floor.get_monster(*summoner_m_idx);
         if (monster.is_pet()) {
@@ -331,7 +331,7 @@ void mitokohmon(CreatureEntity &creature)
     }
 
     if (!count) {
-        const auto &floor = *creature.current_floor_ptr;
+        const auto &floor = *creature.get_floor();
         const auto p_pos = creature.get_position();
         for (auto i = floor.m_max - 1; i > 0; i--) {
             const auto &monster = floor.get_monster(i);
@@ -396,7 +396,7 @@ int activate_hi_summon(CreatureEntity &creature, POSITION y, POSITION x, bool ca
         mode |= PM_NO_PET;
     }
 
-    DEPTH dungeon_level = creature.current_floor_ptr->dun_level;
+    DEPTH dungeon_level = creature.get_floor()->dun_level;
     DEPTH summon_lev = (pet ? creature.level * 2 / 3 + randint1(creature.level / 2) : dungeon_level);
     int count = 0;
     for (int i = 0; i < (randint1(7) + (dungeon_level / 40)); i++) {
@@ -513,7 +513,7 @@ void cast_invoke_spirits(CreatureEntity &creature, const Direction &dir)
     if (die < 8) {
         msg_print(_("なんてこった！あなたの周りの地面から朽ちた人影が立ち上がってきた！", "Oh no! Mouldering forms rise from the earth around you!"));
 
-        (void)summon_specific(creature, creature.y, creature.x, creature.current_floor_ptr->dun_level, SUMMON_UNDEAD,
+        (void)summon_specific(creature, creature.y, creature.x, creature.get_floor()->dun_level, SUMMON_UNDEAD,
             (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
         chg_virtue(creature, Virtue::UNLIFE, 1);
     } else if (die < 14) {

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -101,9 +101,9 @@ void reset_tim_flags(CreatureEntity &creature)
     creature.timewalk = false;
 
     if (creature.riding) {
-        (void)set_monster_fast(*creature.current_floor_ptr, creature.riding, 0);
-        (void)set_monster_slow(*creature.current_floor_ptr, creature.riding, 0);
-        (void)set_monster_invulner(*creature.current_floor_ptr, creature.riding, 0, false);
+        (void)set_monster_fast(*creature.get_floor(), creature.riding, 0);
+        (void)set_monster_slow(*creature.get_floor(), creature.riding, 0);
+        (void)set_monster_invulner(*creature.get_floor(), creature.riding, 0, false);
     }
 
     if (CreatureClass(creature).equals(PlayerClassType::BARD)) {

--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -59,7 +59,7 @@ void do_cmd_store(CreatureEntity &creature, std::optional<StoreSaleType> specifi
     xtra_stock = std::min(14 + 26, ((hgt > MAIN_TERM_MIN_ROWS) ? (hgt - MAIN_TERM_MIN_ROWS) : 0));
     store_bottom = MIN_STOCK + xtra_stock;
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     StoreSaleType store_num;
     const auto &grid = floor.get_grid(creature.get_position());
 

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -267,7 +267,7 @@ void store_purchase(CreatureEntity &creature, StoreSaleType store_num)
     msg_print(_("{}を ${}で購入しました。", "You bought {} for {} gold."), purchased_item_name, res.value());
     record_item_name = purchased_item_name;
     record_turn = world.game_turn;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (record_buy) {
         exe_write_diary(floor, DiaryKind::BUY, 0, purchased_item_name);
     }

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -162,7 +162,7 @@ void store_sell(CreatureEntity &creature, StoreSaleType store_num)
             msg_format(_("%sを $%dで売却しました。", "You sold %s for %d gold."), sold_item_name.data(), price);
 
             if (record_sell) {
-                exe_write_diary(*creature.current_floor_ptr, DiaryKind::SELL, 0, sold_item_name);
+                exe_write_diary(*creature.get_floor(), DiaryKind::SELL, 0, sold_item_name);
             }
 
             creature.plus_incident_tree("STORE_SELL", 1);

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -287,7 +287,7 @@ static void store_create(CreatureEntity &creature, short fix_k_idx, StoreSaleTyp
         if (store_num == StoreSaleType::BLACK) {
             level = bm_boost + randint0(25);
             level = std::min(128, level);
-            bi_id = creature.current_floor_ptr->select_baseitem_id(level, 0x00000000);
+            bi_id = creature.get_floor()->select_baseitem_id(level, 0x00000000);
             if (bi_id == 0) {
                 continue;
             }

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -38,7 +38,7 @@
 
 bool CreatureEntity::try_set_position(const Pos2D &pos)
 {
-    if (this->current_floor_ptr->get_grid(pos).has_monster()) {
+    if (this->get_floor()->get_grid(pos).has_monster()) {
         return false;
     }
 
@@ -86,13 +86,13 @@ bool CreatureEntity::try_resist_eldritch_horror() const
 void CreatureEntity::ride_monster(MONSTER_IDX m_idx)
 {
     if (is_monster(this->riding)) {
-        this->current_floor_ptr->get_monster(this->riding).get_monster_profile().mflag2.reset(MonsterConstantFlagType::RIDING);
+        this->get_floor()->get_monster(this->riding).get_monster_profile().mflag2.reset(MonsterConstantFlagType::RIDING);
     }
 
     this->riding = m_idx;
 
     if (is_monster(m_idx)) {
-        this->current_floor_ptr->get_monster(m_idx).get_monster_profile().mflag2.set(MonsterConstantFlagType::RIDING);
+        this->get_floor()->get_monster(m_idx).get_monster_profile().mflag2.set(MonsterConstantFlagType::RIDING);
     }
 }
 
@@ -513,7 +513,7 @@ void CreatureEntity::set_hostile()
     this->get_monster_profile().mflag2.reset({ MonsterConstantFlagType::PET, MonsterConstantFlagType::FRIENDLY });
 
     if (this->get_monster_profile().alliance_idx != AllianceType::NONE) {
-        for (auto &monster : this->current_floor_ptr->m_list) {
+        for (auto &monster : this->get_floor()->m_list) {
             if (monster.get_monster_profile().alliance_idx == this->get_monster_profile().alliance_idx) {
                 monster.get_monster_profile().mflag2.reset({ MonsterConstantFlagType::PET, MonsterConstantFlagType::FRIENDLY });
             }

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -321,6 +321,15 @@ public:
     }
 
     /*!
+     * @brief クリーチャーが所属するフロアを設定
+     * @param floor フロアへのポインタ
+     */
+    void set_floor(FloorType *floor)
+    {
+        this->current_floor_ptr = floor;
+    }
+
+    /*!
      * @brief クリーチャーの実種族定義を取得する
      * @return 実種族定義への参照（r_idx が MonraceId::PLAYER の場合はプレイヤー種族エントリを返す）
      */
@@ -1038,9 +1047,6 @@ public:
     // 死亡履歴
     std::vector<DeathRecord> death_history{}; /*!< 死亡履歴リスト */
 
-    // フロア情報
-    FloorType *current_floor_ptr{}; /*!< 現在所属しているフロアへのポインタ / Current floor pointer */
-
     /*!<
      * @brief 時限効果管理オブジェクトを取得
      * @return 時限効果管理オブジェクトへの共有ポインタ
@@ -1269,6 +1275,9 @@ protected:
     TIME_EFFECT tim_emission{}; /* Timed -- Player Emission */
     TIME_EFFECT tim_exorcism{}; /* Timed -- Exorcism */
     TIME_EFFECT tim_imm_dark{}; /* Timed -- Darkness immunity */
+
+    // フロア情報（外部からは get_floor() / set_floor() 経由でアクセスすること）
+    FloorType *current_floor_ptr{}; /*!< 現在所属しているフロアへのポインタ / Current floor pointer */
 
 private:
     std::string build_damage_description() const;

--- a/src/target/grid-selector.cpp
+++ b/src/target/grid-selector.cpp
@@ -39,7 +39,7 @@ static std::vector<Pos2D> tgt_pt_prepare(CreatureEntity &creature)
     }
 
     std::vector<Pos2D> positions;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     const auto is_hallucinated = creature.effects()->hallucination().is_hallucinated();
     for (const auto &pos : floor.get_area(FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
@@ -155,7 +155,7 @@ void tgt_pt_info::move_to_symbol(CreatureEntity &creature)
     this->n++;
 
     if (this->ch == '+') {
-        const auto pos_building = select_building_pos(*creature.current_floor_ptr);
+        const auto pos_building = select_building_pos(*creature.get_floor());
         if (!pos_building) {
             return;
         }
@@ -164,7 +164,7 @@ void tgt_pt_info::move_to_symbol(CreatureEntity &creature)
     } else {
         for (; this->n < this->positions.size(); ++this->n) {
             const auto &pos_cur = this->positions.at(this->n);
-            const auto &grid = creature.current_floor_ptr->get_grid(pos_cur);
+            const auto &grid = creature.get_floor()->get_grid(pos_cur);
             if (this->callback(grid)) {
                 this->pos = this->positions.at(this->n);
                 break;
@@ -297,7 +297,7 @@ tl::optional<Pos2D> point_target(CreatureEntity &creature)
                 change_panel(creature, dy, dx);
             }
 
-            const auto &floor = *creature.current_floor_ptr;
+            const auto &floor = *creature.get_floor();
             if (info.pos.x >= floor.width - 1) {
                 info.pos.x = floor.width - 2;
             } else if (info.pos.x <= 0) {

--- a/src/target/target-checker.cpp
+++ b/src/target/target-checker.cpp
@@ -43,8 +43,8 @@ void verify_panel(CreatureEntity &creature)
     POSITION y = creature.y;
     POSITION x = creature.x;
     const auto &[wid, hgt] = get_screen_size();
-    int max_prow_min = creature.current_floor_ptr->height - hgt;
-    int max_pcol_min = creature.current_floor_ptr->width - wid;
+    int max_prow_min = creature.get_floor()->height - hgt;
+    int max_pcol_min = creature.get_floor()->width - wid;
     if (max_prow_min < 0) {
         max_prow_min = 0;
     }

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -256,7 +256,7 @@ static void describe_monster_person(GridExamination *ge_ptr)
 static short describe_monster_item(CreatureEntity &creature, GridExamination *ge_ptr)
 {
     for (const auto this_o_idx : ge_ptr->m_ptr->get_monster_profile().hold_o_idx_list) {
-        const auto &item = *creature.current_floor_ptr->o_list[this_o_idx];
+        const auto &item = *creature.get_floor()->o_list[this_o_idx];
         const auto item_name = describe_flavor(creature, item, 0);
 #ifdef JP
         const auto out_val = format("%s%s%s%s[%s]", ge_ptr->s1, item_name.data(), ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
@@ -287,7 +287,7 @@ static bool within_char_util(const short input)
 
 static short describe_grid(CreatureEntity &creature, GridExamination *ge_ptr)
 {
-    if (!ge_ptr->g_ptr->has_monster() || !creature.current_floor_ptr->get_monster(ge_ptr->g_ptr->m_idx).get_monster_profile().ml) {
+    if (!ge_ptr->g_ptr->has_monster() || !creature.get_floor()->get_monster(ge_ptr->g_ptr->m_idx).get_monster_profile().ml) {
         return CONTINUOUS_DESCRIPTION;
     }
 
@@ -325,7 +325,7 @@ static short describe_footing(CreatureEntity &creature, GridExamination *ge_ptr)
         return CONTINUOUS_DESCRIPTION;
     }
 
-    const auto &item = *creature.current_floor_ptr->o_list[ge_ptr->floor_item_index[0]];
+    const auto &item = *creature.get_floor()->o_list[ge_ptr->floor_item_index[0]];
     const auto item_name = describe_flavor(creature, item, 0);
 #ifdef JP
     const auto out_val = format("%s%s%s%s[%s]", ge_ptr->s1, item_name.data(), ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
@@ -382,7 +382,7 @@ static char describe_footing_many_items(CreatureEntity &creature, GridExaminatio
             continue;
         }
 
-        ge_ptr->g_ptr->o_idx_list.rotate(*creature.current_floor_ptr);
+        ge_ptr->g_ptr->o_idx_list.rotate(*creature.get_floor());
 
         // ターゲットしている床の座標を渡す必要があるので、window_stuff経由ではなく直接呼び出す
         fix_floor_item_list(creature, { ge_ptr->y, ge_ptr->x });
@@ -448,7 +448,7 @@ static short describe_footing_sight(CreatureEntity &creature, GridExamination *g
 static int16_t sweep_footing_items(CreatureEntity &creature, GridExamination *ge_ptr)
 {
     for (const auto this_o_idx : ge_ptr->g_ptr->o_idx_list) {
-        const auto &item = *creature.current_floor_ptr->o_list[this_o_idx];
+        const auto &item = *creature.get_floor()->o_list[this_o_idx];
         const auto ret = describe_footing_sight(creature, ge_ptr, item);
         if (within_char_util(ret)) {
             return (char)ret;
@@ -460,7 +460,7 @@ static int16_t sweep_footing_items(CreatureEntity &creature, GridExamination *ge
 
 static std::string decide_target_floor(CreatureEntity &creature, GridExamination *ge_ptr)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (ge_ptr->terrain_ptr->flags.has(TerrainCharacteristics::QUEST_ENTER)) {
         const auto old_quest = floor.quest_number;
         const auto &quests = QuestList::get_instance();
@@ -537,7 +537,7 @@ static std::string describe_grid_monster_all(GridExamination *ge_ptr)
  */
 char examine_grid(CreatureEntity &creature, const POSITION y, const POSITION x, target_type mode, concptr info)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     GridExamination tmp_eg(floor, y, x, mode, info);
     GridExamination *ge_ptr = &tmp_eg;
     describe_scan_result(floor, ge_ptr);
@@ -591,7 +591,7 @@ char examine_grid(CreatureEntity &creature, const POSITION y, const POSITION x, 
 
     auto is_entrance = ge_ptr->terrain_ptr->flags.has(TerrainCharacteristics::STORE);
     is_entrance |= ge_ptr->terrain_ptr->flags.has(TerrainCharacteristics::QUEST_ENTER);
-    is_entrance |= ge_ptr->terrain_ptr->flags.has(TerrainCharacteristics::BLDG) && !creature.current_floor_ptr->inside_arena;
+    is_entrance |= ge_ptr->terrain_ptr->flags.has(TerrainCharacteristics::BLDG) && !creature.get_floor()->inside_arena;
     is_entrance |= ge_ptr->terrain_ptr->flags.has(TerrainCharacteristics::ENTRANCE);
     if (is_entrance) {
         ge_ptr->s2 = _("の入口", "");

--- a/src/target/target-getter.cpp
+++ b/src/target/target-getter.cpp
@@ -145,7 +145,7 @@ Direction get_direction(CreatureEntity &creature)
         return dir;
     }
 
-    const auto &monster = creature.current_floor_ptr->get_monster(creature.riding);
+    const auto &monster = creature.get_floor()->get_monster(creature.riding);
     const auto m_name = monster_desc(creature, monster, 0);
     const auto fmt = monster.is_confused()
                          ? _("%sは混乱している。", "%s^ is confused.")
@@ -202,7 +202,7 @@ Direction get_rep_dir(CreatureEntity &creature, bool under)
             dir = rand_choice(Direction::directions_8());
         }
     } else if (creature.riding) {
-        const auto &monster = creature.current_floor_ptr->get_monster(creature.riding);
+        const auto &monster = creature.get_floor()->get_monster(creature.riding);
         const auto &monrace = monster.get_monrace();
         if (monster.is_confused()) {
             if (evaluate_percent(75)) {
@@ -219,7 +219,7 @@ Direction get_rep_dir(CreatureEntity &creature, bool under)
         if (is_confused) {
             msg_print(_("あなたは混乱している。", "You are confused."));
         } else {
-            const auto &monster = creature.current_floor_ptr->get_monster(creature.riding);
+            const auto &monster = creature.get_floor()->get_monster(creature.riding);
             const auto m_name = monster_desc(creature, monster, 0);
             if (monster.is_confused()) {
                 msg_format(_("%sは混乱している。", "%s^ is confused."), m_name.data());

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -32,7 +32,7 @@
  */
 bool target_able(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     if (!monster.is_valid()) {
         return false;
@@ -63,7 +63,7 @@ bool target_able(CreatureEntity &creature, MONSTER_IDX m_idx)
  */
 static bool target_set_accept(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (!floor.contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
         return false;
     }
@@ -110,7 +110,7 @@ static bool target_set_accept(CreatureEntity &creature, const Pos2D &pos)
 std::vector<Pos2D> target_set_prepare(CreatureEntity &creature, target_type mode)
 {
     POSITION min_hgt, max_hgt, min_wid, max_wid;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto is_killable = any_bits(mode, TARGET_KILL);
     if (is_killable) {
         const auto max_range = AngbandSystem::get_instance().get_max_range();
@@ -177,8 +177,8 @@ void target_sensing_monsters_prepare(CreatureEntity &creature, std::vector<MONST
         return;
     }
 
-    for (MONSTER_IDX i = 1; i < creature.current_floor_ptr->m_max; i++) {
-        const auto &monster = creature.current_floor_ptr->m_list[i];
+    for (MONSTER_IDX i = 1; i < creature.get_floor()->m_max; i++) {
+        const auto &monster = creature.get_floor()->m_list[i];
         if (!monster.is_valid() || !monster.get_monster_profile().ml || monster.is_pet()) {
             continue;
         }
@@ -191,7 +191,7 @@ void target_sensing_monsters_prepare(CreatureEntity &creature, std::vector<MONST
         monster_list.push_back(i);
     }
 
-    auto comp_importance = [&floor = *creature.current_floor_ptr](MONSTER_IDX idx1, MONSTER_IDX idx2) {
+    auto comp_importance = [&floor = *creature.get_floor()](MONSTER_IDX idx1, MONSTER_IDX idx2) {
         const auto &monster1 = floor.get_monster(idx1);
         const auto &monster2 = floor.get_monster(idx2);
         const auto &monrace1 = monster1.get_appearance_monrace();
@@ -241,7 +241,7 @@ void target_sensing_monsters_prepare(CreatureEntity &creature, std::vector<MONST
 std::vector<MONSTER_IDX> target_pets_prepare(CreatureEntity &creature)
 {
     std::vector<MONSTER_IDX> pets;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
 
     for (short i = 1; i < floor.m_max; ++i) {
         const auto &monster = floor.get_monster(i);

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -72,7 +72,7 @@ TargetSetter::TargetSetter(CreatureEntity &creature, target_type mode)
 
 static bool set_travel_goal(CreatureEntity &creature, const Pos2D &pos)
 {
-    if (creature.is_located_at(pos) || !Travel::can_travel_to(*creature.current_floor_ptr, pos)) {
+    if (creature.is_located_at(pos) || !Travel::can_travel_to(*creature.get_floor(), pos)) {
         return false;
     }
 
@@ -189,7 +189,7 @@ std::string TargetSetter::describe_projectablity() const
         print_path(this->player, this->pos_target.y, this->pos_target.x);
     }
 
-    const auto &floor = *this->player.current_floor_ptr;
+    const auto &floor = *this->player.get_floor();
     std::string info;
     const auto &grid = floor.get_grid(this->pos_target);
     if (target_able(this->player, grid.m_idx)) {
@@ -209,7 +209,7 @@ std::string TargetSetter::describe_projectablity() const
     const auto p_pos = this->player.get_position();
     const auto cheatinfo = format(" X:%d Y:%d LOS:%d LOP:%d",
         this->pos_target.x, this->pos_target.y,
-        los(*this->player.current_floor_ptr, p_pos, this->pos_target),
+        los(*this->player.get_floor(), p_pos, this->pos_target),
         projectable(floor, p_pos, this->pos_target));
     return info.append(cheatinfo);
 }
@@ -258,7 +258,7 @@ Direction TargetSetter::switch_target_input()
     case '.':
     case '5':
     case '0': {
-        const auto &grid = this->player.current_floor_ptr->get_grid(this->pos_target);
+        const auto &grid = this->player.get_floor()->get_grid(this->pos_target);
         if (!target_able(this->player, grid.m_idx)) {
             bell();
             return Direction::none();
@@ -379,7 +379,7 @@ tl::optional<int> TargetSetter::sweep_targets(const Direction &dir, int panel_ro
         }
     }
 
-    const auto &floor = *this->player.current_floor_ptr;
+    const auto &floor = *this->player.get_floor();
     x = std::clamp(x, 1, floor.width - 2);
     y = std::clamp(y, 1, floor.height - 2);
     return tl::nullopt;
@@ -414,7 +414,7 @@ std::string TargetSetter::describe_grid_wizard() const
         return "";
     }
 
-    const auto &floor = *this->player.current_floor_ptr;
+    const auto &floor = *this->player.get_floor();
     const auto &grid = floor.get_grid(this->pos_target);
     constexpr auto fmt = " X:%d Y:%d LOS:%d LOP:%d SPECIAL:%d";
     const auto p_pos = this->player.get_position();
@@ -522,7 +522,7 @@ void TargetSetter::decide_change_panel(const Direction &dir, bool move_fast)
         this->pos_interests = target_set_prepare(this->player, this->mode);
     }
 
-    const auto &floor = *this->player.current_floor_ptr;
+    const auto &floor = *this->player.get_floor();
     x = std::clamp(x, 1, floor.width - 2);
     y = std::clamp(y, 1, floor.height - 2);
 }

--- a/src/target/target.cpp
+++ b/src/target/target.cpp
@@ -57,7 +57,7 @@ public:
     }
     tl::optional<Pos2D> operator()(const TargetMonster &target_monster) const
     {
-        const auto &monster = this->creature_ptr->current_floor_ptr->get_monster(target_monster.m_idx);
+        const auto &monster = this->creature_ptr->get_floor()->get_monster(target_monster.m_idx);
         return monster.get_position();
     }
 

--- a/src/terrain/terrain-processor.cpp
+++ b/src/terrain/terrain-processor.cpp
@@ -38,7 +38,7 @@ static void process_volcanic_crater(CreatureEntity &creature, const Pos2D &pos)
     }
 
     // プレイヤーの視界内かチェック
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const bool in_sight = los(floor, creature.get_position(), pos);
 
     // プレイヤーの視界内であればメッセージ表示
@@ -66,7 +66,7 @@ static void process_summoning_circle(CreatureEntity &creature, const Pos2D &pos)
         return;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(pos);
 
     // 既にモンスターがいる場合は生成しない
@@ -134,7 +134,7 @@ void process_terrain_effects(CreatureEntity &creature)
         return;
     }
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     const auto &terrains = TerrainList::get_instance();
     const auto volcanic_crater_id = terrains.get_terrain_id(TerrainTag::VOLCANIC_CRATER);
     const auto summoning_circle_id = terrains.get_terrain_id(TerrainTag::SUMMONING_CIRCLE);

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -131,7 +131,7 @@ static bool is_revealed_wall(const FloorType &floor, const Pos2D &pos)
  */
 DisplaySymbolPair map_info(CreatureEntity &creature, const Pos2D &pos)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(pos);
     const auto &terrains = TerrainList::get_instance();
     const auto &world = AngbandWorld::get_instance();

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -200,7 +200,7 @@ static int calc_temporary_speed(CreatureEntity &creature)
             tmp_speed = 99;
         }
     } else {
-        const auto &m_ref = creature.current_floor_ptr->get_monster(creature.riding);
+        const auto &m_ref = creature.get_floor()->get_monster(creature.riding);
         if (m_ref.is_accelerated()) {
             tmp_speed += 10;
         }

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -177,7 +177,7 @@ static void display_player_stats(CreatureEntity &creature)
  */
 static tl::optional<std::string> search_death_cause(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!creature.is_dead()) {
         return tl::nullopt;
     }
@@ -229,7 +229,7 @@ static tl::optional<std::string> search_death_cause(CreatureEntity &creature)
  */
 static tl::optional<std::string> decide_death_in_quest(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!floor.is_in_quest() || !QuestType::is_fixed(floor.quest_number)) {
         return tl::nullopt;
     }
@@ -254,7 +254,7 @@ static std::string decide_current_floor(CreatureEntity &creature)
         return death_cause.value_or("");
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!floor.is_underground()) {
         return format(_("…あなたは現在、 %s にいる。", "...Now, you are in %s."), map_name(creature).data());
     }

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -323,7 +323,7 @@ static int calculate_hp_regen_rate(CreatureEntity &creature)
     }
 
     // 地形による衛生補正
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto &grid = floor.get_grid(creature.get_position());
     const auto &terrain = grid.get_terrain();
     if (regen_amount > 0 && terrain.hygiene != 0) {

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -245,7 +245,7 @@ static void print_pet_list_oneline(CreatureEntity &creature, const CreatureEntit
 static void print_pet_list(CreatureEntity &creature, const std::vector<MONSTER_IDX> &pets, TERM_LEN x, TERM_LEN y, TERM_LEN width, TERM_LEN height)
 {
     for (auto n = 0U; n < pets.size(); ++n) {
-        const auto &monster = creature.current_floor_ptr->get_monster(pets[n]);
+        const auto &monster = creature.get_floor()->get_monster(pets[n]);
         const int line = y + n;
 
         print_pet_list_oneline(creature, monster, x, line, width);
@@ -275,7 +275,7 @@ void fix_monster_list(CreatureEntity &creature)
         [&creature, &once] {
             const auto &[wid, hgt] = term_get_size();
             std::call_once(once, target_sensing_monsters_prepare, std::ref(creature), std::ref(monster_list));
-            print_monster_list(*creature.current_floor_ptr, monster_list, 0, 0, hgt);
+            print_monster_list(*creature.get_floor(), monster_list, 0, 0, hgt);
         });
 
     if (use_music && has_monster_music) {
@@ -460,7 +460,7 @@ void fix_overhead(CreatureEntity &creature)
  */
 static void display_dungeon(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     for (auto x = p_pos.x - game_term->wid / 2 + 1; x <= p_pos.x + game_term->wid / 2; x++) {
         for (auto y = p_pos.y - game_term->hgt / 2 + 1; y <= p_pos.y + game_term->hgt / 2; y++) {
@@ -555,7 +555,7 @@ static void display_floor_item_list(CreatureEntity &creature, const Pos2D &pos)
     term_clear();
     term_gotoxy(0, 0);
 
-    const auto floor_ptr = creature.current_floor_ptr;
+    const auto floor_ptr = creature.get_floor();
     const auto *g_ptr = &floor_ptr->get_grid(pos);
     std::string line;
 
@@ -637,7 +637,7 @@ static void display_found_item_list(CreatureEntity &creature)
         return;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
 
     // 所持品一覧と同じ順にソートする
     // あらかじめfloor.o_list から↓項目を取り除く

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -192,7 +192,7 @@ void print_depth(CreatureEntity &creature)
     const auto &[wid, hgt] = term_get_size();
     const auto col_depth = wid + COL_DEPTH;
     const auto row_depth = hgt + ROW_DEPTH;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!floor.is_underground()) {
         c_prt(attr, format("%7s", _("地上", "Surf.")), row_depth, col_depth);
         return;
@@ -286,7 +286,7 @@ static void print_health_monster_in_arena_for_wizard(CreatureEntity &creature)
 
         term_putstr(col - 2, row + row_offset, 12, TERM_WHITE, "      /     ");
 
-        auto &monster = creature.current_floor_ptr->get_monster(monster_list_index);
+        auto &monster = creature.get_floor()->get_monster(monster_list_index);
         if (monster.is_valid()) {
             const auto &monrace = monster.get_monrace();
             const auto &symbol_config = monrace.symbol_config;
@@ -387,7 +387,7 @@ void print_health(CreatureEntity &creature, bool riding)
         return;
     }
 
-    const auto &monster = creature.current_floor_ptr->get_monster(monster_idx.value());
+    const auto &monster = creature.get_floor()->get_monster(monster_idx.value());
 
     if ((!monster.get_monster_profile().ml) || (creature.effects()->hallucination().is_hallucinated()) || monster.is_dead()) {
         term_putstr(col, row, max_width, TERM_WHITE, "[----------]");

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -105,7 +105,7 @@ void print_stun(CreatureEntity &creature)
  */
 void print_hunger(CreatureEntity &creature)
 {
-    if (AngbandWorld::get_instance().wizard && creature.current_floor_ptr->inside_arena) {
+    if (AngbandWorld::get_instance().wizard && creature.get_floor()->inside_arena) {
         return;
     }
 
@@ -255,7 +255,7 @@ void print_speed(CreatureEntity &creature)
     auto row_speed = hgt + ROW_SPEED;
 
     const auto speed = creature.get_speed() - STANDARD_SPEED;
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     bool is_player_fast = creature.is_fast();
     char buf[32] = "";
     TERM_COLOR attr = TERM_WHITE;

--- a/src/window/main-window-util.cpp
+++ b/src/window/main-window-util.cpp
@@ -77,7 +77,7 @@ void print_map(CreatureEntity &creature)
     const auto v = term_get_cursor();
     term_set_cursor(false);
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     POSITION xmin = (0 < panel_col_min) ? panel_col_min : 0;
     POSITION xmax = (floor.width - 1 > panel_col_max) ? panel_col_max : floor.width - 1;
     POSITION ymin = (0 < panel_row_min) ? panel_row_min : 0;
@@ -168,7 +168,7 @@ void display_map(CreatureEntity &creature, int *cy, int *cx)
         wid = wid / 2 - 1;
     }
 
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto yrat = (floor.height + hgt - 1) / hgt;
     const auto xrat = (floor.width + wid - 1) / wid;
     view_special_lite = false;

--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -251,7 +251,7 @@ bool exe_cmd_debug(CreatureEntity &creature, char cmd)
         teleport_player(creature, 100, TELEPORT_SPONTANEOUS);
         return true;
     case 'u': {
-        auto &floor = *creature.current_floor_ptr;
+        auto &floor = *creature.get_floor();
         for (const auto &pos : floor.get_area()) {
             floor.get_grid(pos).info |= CAVE_GLOW | CAVE_MARK;
         }

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -114,7 +114,7 @@ void wiz_enter_quest(CreatureEntity &creature)
     }
 
     init_flags = i2enum<init_flags_type>(INIT_SHOW_TEXT | INIT_ASSIGN);
-    creature.current_floor_ptr->quest_number = *quest_id;
+    creature.get_floor()->quest_number = *quest_id;
     parse_fixed_map(creature, QUEST_DEFINITION_LIST, 0, 0, 0, 0);
     auto &quest = quests.get_quest(*quest_id);
     quest.status = QuestStatusType::TAKEN;
@@ -129,7 +129,7 @@ void wiz_enter_quest(CreatureEntity &creature)
  */
 void wiz_complete_quest(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (!floor.is_in_quest()) {
         msg_print("No current quest");
         msg_erase();

--- a/src/wizard/wizard-messages.cpp
+++ b/src/wizard/wizard-messages.cpp
@@ -39,7 +39,7 @@ void msg_print_wizard(CreatureEntity &creature, int cheat_type, std::string_view
     const auto mes = ss.str();
     msg_print(mes);
     if (cheat_diary_output) {
-        exe_write_diary(*creature.current_floor_ptr, DiaryKind::WIZARD_LOG, 0, mes);
+        exe_write_diary(*creature.get_floor(), DiaryKind::WIZARD_LOG, 0, mes);
     }
 }
 

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -181,7 +181,7 @@ void wiz_create_item(CreatureEntity &creature)
 
     ItemEntity item;
     item.generate(*bi_id);
-    ItemMagicApplier(creature, &item, creature.current_floor_ptr->dun_level, AM_NO_FIXED_ART).execute();
+    ItemMagicApplier(creature, &item, creature.get_floor()->dun_level, AM_NO_FIXED_ART).execute();
     (void)drop_near(creature, item, creature.get_position());
     msg_print("Allocated.");
 }
@@ -407,7 +407,7 @@ void wiz_create_feature(CreatureEntity &creature)
         return;
     }
 
-    auto &grid = creature.current_floor_ptr->get_grid(*pos);
+    auto &grid = creature.get_floor()->get_grid(*pos);
     const int max = TerrainList::get_instance().size() - 1;
     const auto f_val1 = input_numerics(_("実地形ID", "FeatureID"), 0, max, grid.feat);
     if (!f_val1.has_value()) {
@@ -472,7 +472,7 @@ static tl::optional<int> select_debugging_floor(const FloorType &floor, DungeonI
  */
 void wiz_jump_to_dungeon(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto dungeon_id = select_debugging_dungeon();
     if (!dungeon_id) {
         return;
@@ -724,7 +724,7 @@ void wiz_dump_options()
  */
 void wiz_zap_surrounding_monsters(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
         const auto &monster = floor.get_monster(i);
         if (!monster.is_valid() || (i == creature.riding) || (Grid::calc_distance(creature.get_position(), monster.get_position()) > MAX_PLAYER_SIGHT)) {
@@ -746,7 +746,7 @@ void wiz_zap_surrounding_monsters(CreatureEntity &creature)
  */
 void wiz_zap_floor_monsters(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
         const auto &monster = floor.get_monster(i);
         if (!monster.is_valid() || monster.is_riding()) {
@@ -824,7 +824,7 @@ void cheat_death(CreatureEntity &creature, bool no_penalty)
     creature.died_from = _("死の欺き", "Cheating death");
     (void)set_food(creature, PY_FOOD_MAX - 1);
 
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     floor.dun_level = 0;
     floor.inside_arena = false;
     AngbandSystem::get_instance().set_phase_out(false);

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -128,7 +128,7 @@ void wiz_summon_specific_monster_common(CreatureEntity &creature, MonraceId monr
 
     const auto p_pos = creature.get_position();
     const auto index_to_monster = [&creature](auto index) -> CreatureEntity & {
-        return creature.current_floor_ptr->get_monster(index);
+        return creature.get_floor()->get_monster(index);
     };
     auto monster =
         summon_named_creature(creature, 0, p_pos.y, p_pos.x, *summon_monrace_id, mode)
@@ -213,7 +213,7 @@ void wiz_dimension_door(CreatureEntity &creature)
  */
 void wiz_summon_horde(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     auto pos = p_pos;
     auto attempts = 1000;
@@ -299,7 +299,7 @@ void wiz_generate_random_monster(CreatureEntity &creature, int num)
  */
 void wiz_summon_random_monster(CreatureEntity &creature, int num)
 {
-    const auto level = creature.current_floor_ptr->dun_level;
+    const auto level = creature.get_floor()->dun_level;
     constexpr auto flags = PM_ALLOW_GROUP | PM_ALLOW_UNIQUE;
     const auto p_pos = creature.get_position();
     for (auto i = 0; i < num; i++) {

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -30,7 +30,7 @@
 void check_random_quest_auto_failure(CreatureEntity &creature)
 {
     auto &quests = QuestList::get_instance();
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (floor.dungeon_id != DungeonId::ANGBAND) {
         return;
     }
@@ -78,7 +78,7 @@ void execute_recall(CreatureEntity &creature)
     }
 
     disturb(creature, false, true);
-    auto &floor = *creature.current_floor_ptr;
+    auto &floor = *creature.get_floor();
     if (floor.is_underground() || floor.is_in_quest() || floor.is_entering_dungeon()) {
         msg_print(_("上に引っ張りあげられる感じがする！", "You feel yourself yanked upwards!"));
         if (floor.is_underground()) {
@@ -146,7 +146,7 @@ void execute_recall(CreatureEntity &creature)
  */
 void execute_floor_reset(CreatureEntity &creature)
 {
-    const auto &floor = *creature.current_floor_ptr;
+    const auto &floor = *creature.get_floor();
     if (creature.alter_reality == 0) {
         return;
     }
@@ -168,7 +168,7 @@ void execute_floor_reset(CreatureEntity &creature)
         /* 時空崩壊度進行 */
         if (creature.prace != PlayerRaceType::AMBERITE) {
             msg_print(_("乱暴な現実の変容で時空崩壊が進んだ！", "World collapsion has progressed due to the violent transformation of reality!"));
-            wc_ptr->plus_perm_collapsion(20 + creature.current_floor_ptr->dun_level / 2);
+            wc_ptr->plus_perm_collapsion(20 + creature.get_floor()->dun_level / 2);
         }
 
         FloorChangeModesStore::get_instace()->set(FloorChangeMode::FIRST_FLOOR);

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -75,7 +75,7 @@ void WorldTurnProcessor::process_world()
     }
 
     decide_auto_save();
-    const auto &floor = *this->creature.current_floor_ptr;
+    const auto &floor = *this->creature.get_floor();
     if (floor.monster_noise && !ignore_unview) {
         msg_print(_("何かが聞こえた。", "You hear noise."));
     }
@@ -157,7 +157,7 @@ void WorldTurnProcessor::print_cheat_position()
 void WorldTurnProcessor::process_downward()
 {
     /* 帰還無しモード時のレベルテレポバグ対策 / Fix for level teleport bugs on ironman_downward.*/
-    auto &floor = *this->creature.current_floor_ptr;
+    auto &floor = *this->creature.get_floor();
     if (!ironman_downward || (floor.dungeon_id == DungeonId::ANGBAND) || !floor.is_underground() || floor.is_in_quest()) {
         return;
     }
@@ -176,7 +176,7 @@ void WorldTurnProcessor::process_monster_arena()
         return;
     }
 
-    const auto &floor = *this->creature.current_floor_ptr;
+    const auto &floor = *this->creature.get_floor();
     const auto monster_exists = [&](const Pos2D &pos) {
         const auto &grid = floor.get_grid(pos);
         return grid.has_monster() && !floor.get_monster(grid.m_idx).is_riding();
@@ -206,7 +206,7 @@ void WorldTurnProcessor::process_monster_arena()
 
 void WorldTurnProcessor::process_monster_arena_winner(int win_m_idx)
 {
-    const auto &monster = this->creature.current_floor_ptr->get_monster(win_m_idx);
+    const auto &monster = this->creature.get_floor()->get_monster(win_m_idx);
     const auto m_name = monster_desc(this->creature, monster, 0);
     msg_format(_("%sが勝利した！", "%s won!"), m_name.data());
     msg_erase();
@@ -228,7 +228,7 @@ void WorldTurnProcessor::process_monster_arena_winner(int win_m_idx)
 
 void WorldTurnProcessor::process_monster_arena_draw()
 {
-    auto turn = this->creature.current_floor_ptr->generated_turn;
+    auto turn = this->creature.get_floor()->generated_turn;
     if (AngbandWorld::get_instance().game_turn - turn != 150 * TURNS_PER_TICK) {
         return;
     }
@@ -257,7 +257,7 @@ void WorldTurnProcessor::decide_auto_save()
 
 void WorldTurnProcessor::process_change_daytime_night()
 {
-    const auto &floor = *this->creature.current_floor_ptr;
+    const auto &floor = *this->creature.get_floor();
     const auto &world = AngbandWorld::get_instance();
     if (!floor.is_underground() && !floor.is_in_quest() && !AngbandSystem::get_instance().is_phase_out() && !floor.inside_arena) {
         if (!(world.game_turn % ((TURNS_PER_TICK * TOWN_DAWN) / 2))) {
@@ -301,7 +301,7 @@ void WorldTurnProcessor::process_world_monsters()
     }
 
     for (const auto mte : MONSTER_TIMED_EFFECT_LIST) {
-        if (this->creature.current_floor_ptr->mproc_max[mte] > 0) {
+        if (this->creature.get_floor()->mproc_max[mte] > 0) {
             process_monsters_mtimed(this->creature, mte);
         }
     }
@@ -309,7 +309,7 @@ void WorldTurnProcessor::process_world_monsters()
 
 void WorldTurnProcessor::decide_alloc_monster()
 {
-    const auto &floor = *this->creature.current_floor_ptr;
+    const auto &floor = *this->creature.get_floor();
     auto should_alloc = one_in_(floor.get_dungeon_definition().max_m_alloc_chance);
     should_alloc &= !floor.inside_arena;
     should_alloc &= !floor.is_in_quest();


### PR DESCRIPTION
CreatureEntity::current_floor_ptr を public → protected に移動し、 外部からは get_floor() / set_floor() 経由でのみアクセスするよう強制した。

- set_floor() メソッドを追加（get_floor() は既存）
- 6 箇所の書き込み (creature.current_floor_ptr = ...) を set_floor() に変換
- 約 1160 箇所の読み取り (creature.current_floor_ptr) を get_floor() に変換
- current_floor_ptr を protected セクションに移動

307 ファイル、+1170/-1173 行の変更。これにより FloorType への直接依存が
明示化され、将来的なフロア管理ロジックの拡張が容易になった。

https://claude.ai/code/session_01L1HaWfCTxckoYkCGTkXPKo