### PR TITLE
refactor: ダメージ処理の共通化 - calc_damage_reduction/apply_raw_damage を導入（Phase 4）

### DIFF
--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -107,8 +107,7 @@ bool MonsterDamageProcessor::mon_take_hit(std::string_view note)
     }
 
     this->process_masochist_reaction();
-    monster.hp -= this->dam;
-    monster.on_take_hit(this->dam);
+    monster.apply_raw_damage(this->dam);
 
     if (AngbandWorld::get_instance().wizard) {
         msg_format(_("合計%d/%dのダメージを与えた。", "You do %d (out of %d) damage."), monster.dealt_damage, monster.maxhp);

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -320,58 +320,32 @@ int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_
         }
     }
 
-    if ((damage_type != DAMAGE_USELIFE) && (damage_type != DAMAGE_LOSELIFE)) {
-        if (creature.is_invulnerable() && (damage < 9000)) {
-            if (damage_type == DAMAGE_FORCE) {
-                msg_print(_("バリアが切り裂かれた！", "The attack cuts your shield of invulnerability open!"));
-            } else if (one_in_(PENETRATE_INVULNERABILITY)) {
-                msg_print(_("無敵のバリアを破って攻撃された！", "The attack penetrates your shield of invulnerability!"));
-            } else {
-                return 0;
-            }
-        }
-
-        if (check_multishadow(creature)) {
-            if (damage_type == DAMAGE_FORCE) {
-                msg_print(_("幻影もろとも体が切り裂かれた！", "The attack hits Shadow together with you!"));
-            } else if (damage_type == DAMAGE_ATTACK) {
-                msg_print(_("攻撃は幻影に命中し、あなたには届かなかった。", "The attack hits Shadow, but you are unharmed!"));
-                return 0;
-            }
-        }
-
-        if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
-            if (damage_type == DAMAGE_FORCE) {
-                msg_print(_("半物質の体が切り裂かれた！", "The attack cuts through your ethereal body!"));
-            } else {
-                damage /= 2;
-                if ((damage == 0) && one_in_(2)) {
-                    damage = 1;
-                }
-            }
-        }
-
-        if (CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU)) {
-            damage /= 2;
-            if ((damage == 0) && one_in_(2)) {
-                damage = 1;
-            }
-        }
+    // 防御（無敵・分身・幽体化・無想の構え）による軽減を仮想メソッド経由で処理
+    if (creature.calc_damage_reduction(damage, damage_type)) {
+        return 0;
     }
 
-    creature.hp -= damage;
-    if (creature.hp < -9999) {
-        creature.hp = -9999;
-    }
-
-    if (damage_type == DAMAGE_GENO && creature.hp < 0) {
-        damage += creature.hp;
-        creature.hp = 0;
-    }
-
-    // 与ダメージの蓄積（プレイヤーが受けたダメージとして記録）
-    if (damage > 0 && damage_type != DAMAGE_USELIFE && damage_type != DAMAGE_LOSELIFE) {
-        creature.on_take_hit(damage);
+    // HP にダメージを適用（dealt_damage 蓄積を含む）
+    // DAMAGE_GENO / USELIFE / LOSELIFE は特別扱いのためヘルパーを使わずインラインで処理
+    if (damage_type == DAMAGE_USELIFE || damage_type == DAMAGE_LOSELIFE) {
+        creature.hp -= damage;
+        if (creature.hp < -9999) {
+            creature.hp = -9999;
+        }
+    } else if (damage_type == DAMAGE_GENO) {
+        creature.hp -= damage;
+        if (creature.hp < -9999) {
+            creature.hp = -9999;
+        }
+        if (creature.hp < 0) {
+            damage += creature.hp;
+            creature.hp = 0;
+        }
+        if (damage > 0) {
+            creature.on_take_hit(damage);
+        }
+    } else {
+        creature.apply_raw_damage(damage);
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
@@ -435,6 +409,62 @@ void PlayerType::on_take_hit(int damage)
     if (this->dealt_damage > 999999999) {
         this->dealt_damage = 999999999;
     }
+}
+
+/*!
+ * @brief プレイヤーの防御による被ダメージ軽減処理
+ * @param damage 元のダメージ量（参照渡し。関数内で軽減後の値に書き換えられる）
+ * @param damage_type ダメージ種別
+ * @return true ならダメージが完全吸収された（呼び出し元は以降の処理をスキップすべき）
+ * @details
+ * 無敵バリア・分身・幽体化・無想の構えによるダメージ軽減を処理する。
+ * DAMAGE_USELIFE / DAMAGE_LOSELIFE はスキップする。
+ * ロジックは従来 take_hit() 内にインライン展開されていたものを抽出。
+ */
+bool PlayerType::calc_damage_reduction(int &damage, int damage_type)
+{
+    if ((damage_type == DAMAGE_USELIFE) || (damage_type == DAMAGE_LOSELIFE)) {
+        return false;
+    }
+
+    if (this->is_invulnerable() && (damage < 9000)) {
+        if (damage_type == DAMAGE_FORCE) {
+            msg_print(_("バリアが切り裂かれた！", "The attack cuts your shield of invulnerability open!"));
+        } else if (one_in_(PENETRATE_INVULNERABILITY)) {
+            msg_print(_("無敵のバリアを破って攻撃された！", "The attack penetrates your shield of invulnerability!"));
+        } else {
+            return true;
+        }
+    }
+
+    if (check_multishadow(*this)) {
+        if (damage_type == DAMAGE_FORCE) {
+            msg_print(_("幻影もろとも体が切り裂かれた！", "The attack hits Shadow together with you!"));
+        } else if (damage_type == DAMAGE_ATTACK) {
+            msg_print(_("攻撃は幻影に命中し、あなたには届かなかった。", "The attack hits Shadow, but you are unharmed!"));
+            return true;
+        }
+    }
+
+    if (this->get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
+        if (damage_type == DAMAGE_FORCE) {
+            msg_print(_("半物質の体が切り裂かれた！", "The attack cuts through your ethereal body!"));
+        } else {
+            damage /= 2;
+            if ((damage == 0) && one_in_(2)) {
+                damage = 1;
+            }
+        }
+    }
+
+    if (CreatureClass(*this).samurai_stance_is(SamuraiStanceType::MUSOU)) {
+        damage /= 2;
+        if ((damage == 0) && one_in_(2)) {
+            damage = 1;
+        }
+    }
+
+    return false;
 }
 
 /*!

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -415,6 +415,39 @@ public:
     virtual void on_death([[maybe_unused]] std::string_view cause) {}
 
     /*!
+     * @brief 防御（無敵・幽体化・分身等）による被ダメージ軽減を計算する
+     * @param damage 元のダメージ量（参照渡し。関数内で軽減後の値に書き換えられる）
+     * @param damage_type ダメージ種別（DAMAGE_ATTACK 等）
+     * @return true ならダメージが完全吸収された（呼び出し元は以降の処理をスキップすべき）
+     * @details
+     * プレイヤー側では無敵・幻影・幽体化・無想の構え等による軽減ロジックを実行し、
+     * メッセージ表示も行う（そのため非 const）。
+     * モンスターはデフォルト実装（軽減なし）で十分。
+     */
+    virtual bool calc_damage_reduction(int &damage, [[maybe_unused]] int damage_type)
+    {
+        (void)damage;
+        return false;
+    }
+
+    /*!
+     * @brief ダメージをHPに適用する共通処理
+     * @param damage 適用するダメージ量
+     * @details hp を減算し -9999 でクランプ、on_take_hit() を呼ぶ。
+     * プレイヤー・モンスター両者の基本的なダメージ算術を統一する。
+     */
+    void apply_raw_damage(int damage)
+    {
+        this->hp -= damage;
+        if (this->hp < -9999) {
+            this->hp = -9999;
+        }
+        if (damage > 0) {
+            this->on_take_hit(damage);
+        }
+    }
+
+    /*!
      * @brief クリーチャーの時限効果の残りターン数を取得
      * @param effect 取得する時限効果の種別
      * @return 残りターン数（0なら効果なし）

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -14,6 +14,7 @@ public:
 
     void on_take_hit(int damage) override;
     void on_death(std::string_view cause) override;
+    bool calc_damage_reduction(int &damage, int damage_type) override;
 
     short get_timed_effect(CreatureTimedEffect effect) const override;
     void set_timed_effect(CreatureTimedEffect effect, short value) override;


### PR DESCRIPTION
…

プレイヤーとモンスターで分離していたダメージ処理の共通部分を抽出し、
CreatureEntity の仮想メソッドおよびヘルパーメソッドに集約した。

追加メソッド:
- CreatureEntity::apply_raw_damage(int damage) HP 減算・-9999 クランプ・on_take_hit() 呼び出しを統一。プレイヤー・ モンスター両方の基本的なダメージ算術を 1 箇所に集約。

- virtual bool CreatureEntity::calc_damage_reduction(int &damage, int type) 防御（無敵バリア・分身・幽体化・無想の構え）によるダメージ軽減を処理する 仮想メソッド。戻り値の true は完全吸収を意味する。

- PlayerType::calc_damage_reduction() オーバーライド 従来 take_hit() 内にインラインで展開されていた ~40 行の防御ロジックを このメソッドに移動。メッセージ表示も含む。

リファクタ箇所:
- take_hit(): 防御計算を calc_damage_reduction() に委譲、ダメージ適用を apply_raw_damage() 経由に（DAMAGE_GENO/USELIFE/LOSELIFE はインライン維持）
- MonsterDamageProcessor::mon_take_hit(): hp -= dam; on_take_hit(dam) の 2行を apply_raw_damage(dam) に集約

これにより、将来ダメージ処理を更に統合する際の共通基盤が整備された。