### PR TITLE
refactor: グローバル p_ptr を廃止し PlayerType::get_instance() アクセサに置換（Phase 1仕上げ）

### DIFF
--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -198,7 +198,7 @@ tl::optional<std::string> input_string(std::string_view prompt, int len, std::st
  */
 bool input_check(std::string_view prompt)
 {
-    return input_check_strict(*p_ptr, prompt, UserCheck::NONE);
+    return input_check_strict(PlayerType::get_instance(), prompt, UserCheck::NONE);
 }
 
 /*!

--- a/src/core/window-redrawer.cpp
+++ b/src/core/window-redrawer.cpp
@@ -39,7 +39,7 @@ void redraw_window()
     }
 
     RedrawingFlagsUpdater::get_instance().fill_up_sub_flags();
-    handle_stuff(*p_ptr);
+    handle_stuff(PlayerType::get_instance());
     term_redraw();
 }
 

--- a/src/io/input-key-acceptor.cpp
+++ b/src/io/input-key-acceptor.cpp
@@ -54,7 +54,7 @@ static void all_term_fresh()
     auto [x, y] = term_locate();
 
     RedrawingFlagsUpdater::get_instance().fill_up_sub_flags();
-    handle_stuff(*p_ptr);
+    handle_stuff(PlayerType::get_instance());
 
     term_activate(angband_terms[0]);
     term_gotoxy(x, y);

--- a/src/io/screen-util.cpp
+++ b/src/io/screen-util.cpp
@@ -48,9 +48,9 @@ void resize_map()
 
     panel_row_max = 0;
     panel_col_max = 0;
-    panel_row_min = p_ptr->get_floor()->height;
-    panel_col_min = p_ptr->get_floor()->width;
-    verify_panel(*p_ptr);
+    panel_row_min = PlayerType::get_instance().get_floor()->height;
+    panel_col_min = PlayerType::get_instance().get_floor()->width;
+    verify_panel(PlayerType::get_instance());
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
@@ -75,11 +75,11 @@ void resize_map()
         MainWindowRedrawingFlag::EQUIPPY,
     };
     rfu.set_flags(flags_mwrf);
-    handle_stuff(*p_ptr);
+    handle_stuff(PlayerType::get_instance());
     term_redraw();
 
     if (can_save) {
-        move_cursor_relative(p_ptr->y, p_ptr->x);
+        move_cursor_relative(PlayerType::get_instance().y, PlayerType::get_instance().x);
     }
 
     term_fresh();

--- a/src/io/signal-handlers.cpp
+++ b/src/io/signal-handlers.cpp
@@ -68,25 +68,25 @@ static void handle_signal_simple(int sig)
     }
 
     signal_count++;
-    auto &floor = *p_ptr->get_floor();
-    if (p_ptr->is_dead()) {
-        p_ptr->died_from = _("強制終了", "Abortion");
+    auto &floor = *PlayerType::get_instance().get_floor();
+    if (PlayerType::get_instance().is_dead()) {
+        PlayerType::get_instance().died_from = _("強制終了", "Abortion");
         floor.forget_lite();
         floor.forget_view();
         floor.forget_mon_lite();
-        close_game(*p_ptr);
+        close_game(PlayerType::get_instance());
         quit(_("強制終了", "interrupt"));
     } else if (signal_count >= 5) {
-        p_ptr->died_from = _("強制終了中", "Interrupting");
+        PlayerType::get_instance().died_from = _("強制終了中", "Interrupting");
         floor.forget_lite();
         floor.forget_view();
         floor.forget_mon_lite();
-        p_ptr->playing = false;
+        PlayerType::get_instance().playing = false;
         if (!cheat_immortal) {
-            p_ptr->is_dead_ = true;
+            PlayerType::get_instance().is_dead_ = true;
         }
-        p_ptr->leaving = true;
-        close_game(*p_ptr);
+        PlayerType::get_instance().leaving = true;
+        close_game(PlayerType::get_instance());
         quit(_("強制終了", "interrupt"));
     } else if (signal_count >= 4) {
         term_xtra(TERM_XTRA_NOISE, 0);
@@ -126,7 +126,7 @@ static void handle_signal_abort(int sig)
         quit("");
     }
 
-    auto &floor = *p_ptr->get_floor();
+    auto &floor = *PlayerType::get_instance().get_floor();
     floor.forget_lite();
     floor.forget_view();
     floor.forget_mon_lite();
@@ -140,11 +140,11 @@ static void handle_signal_abort(int sig)
     term_fresh();
 
     AngbandSystem::get_instance().set_panic_save(true);
-    p_ptr->died_from = _("(緊急セーブ)", "(panic save)");
+    PlayerType::get_instance().died_from = _("(緊急セーブ)", "(panic save)");
 
     signals_ignore_tstp();
 
-    if (save_player(*p_ptr, SaveType::CLOSE_GAME)) {
+    if (save_player(PlayerType::get_instance(), SaveType::CLOSE_GAME)) {
         term_putstr(45, hgt - 1, -1, TERM_RED, _("緊急セーブ成功！", "Panic save succeeded!"));
     } else {
         term_putstr(45, hgt - 1, -1, TERM_RED, _("緊急セーブ失敗！", "Panic save failed!"));

--- a/src/main-cap.cpp
+++ b/src/main-cap.cpp
@@ -733,7 +733,7 @@ static errr game_term_xtra_cap_event(int v)
 
         /* Hack -- Handle "errors" */
         if ((i <= 0) && (errno != EINTR)) {
-            exit_game_panic(*p_ptr);
+            exit_game_panic(PlayerType::get_instance());
         }
     }
 

--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -694,10 +694,10 @@ static errr game_term_xtra_gcu_event(int v)
 
         /* Broken input is special */
         if (i == ERR) {
-            exit_game_panic(*p_ptr);
+            exit_game_panic(PlayerType::get_instance());
         }
         if (i == EOF) {
-            exit_game_panic(*p_ptr);
+            exit_game_panic(PlayerType::get_instance());
         }
 
         *bp++ = (char)i;
@@ -707,7 +707,7 @@ static errr game_term_xtra_gcu_event(int v)
 
         while ((i = getch()) != EOF) {
             if (i == ERR) {
-                exit_game_panic(*p_ptr);
+                exit_game_panic(PlayerType::get_instance());
             }
             *bp++ = (char)i;
             if (bp == &buf[255]) {
@@ -776,7 +776,7 @@ static errr game_term_xtra_gcu_event(int v)
 
         /* Hack -- Handle bizarre "errors" */
         if ((i <= 0) && (errno != EINTR)) {
-            exit_game_panic(*p_ptr);
+            exit_game_panic(PlayerType::get_instance());
         }
 
         /* Get the current flags for stdin */

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -1010,7 +1010,7 @@ static errr term_xtra_win(int n, int v)
         return term_xtra_win_clear();
     }
     case TERM_XTRA_REACT: {
-        return term_xtra_win_react(*p_ptr);
+        return term_xtra_win_react(PlayerType::get_instance());
     }
     case TERM_XTRA_DELAY: {
         return term_xtra_win_delay(v);
@@ -2160,7 +2160,7 @@ static void fit_term_size_to_window(term_data *td, bool recalc_window_size = fal
 
         if (!is_main_term(td)) {
             RedrawingFlagsUpdater::get_instance().fill_up_sub_flags();
-            handle_stuff(*p_ptr);
+            handle_stuff(PlayerType::get_instance());
         }
     }
 }
@@ -2441,7 +2441,7 @@ static LRESULT PASCAL angband_window_procedure(HWND hWnd, UINT uMsg, WPARAM wPar
         }
 
         msg_flag = false;
-        auto &floor = *p_ptr->get_floor();
+        auto &floor = *PlayerType::get_instance().get_floor();
         floor.forget_lite();
         floor.forget_view();
         floor.forget_mon_lite();
@@ -2455,14 +2455,14 @@ static LRESULT PASCAL angband_window_procedure(HWND hWnd, UINT uMsg, WPARAM wPar
         }
 
         msg_flag = false;
-        if (p_ptr->hp < 0) {
-            p_ptr->is_dead_ = false;
+        if (PlayerType::get_instance().hp < 0) {
+            PlayerType::get_instance().is_dead_ = false;
         }
-        exe_write_diary(*p_ptr->get_floor(), DiaryKind::GAMESTART, 0, _("----ゲーム中断----", "---- Save and Exit Game ----"));
+        exe_write_diary(*PlayerType::get_instance().get_floor(), DiaryKind::GAMESTART, 0, _("----ゲーム中断----", "---- Save and Exit Game ----"));
         AngbandSystem::get_instance().set_panic_save(true);
         signals_ignore_tstp();
-        p_ptr->died_from = _("(緊急セーブ)", "(panic save)");
-        (void)save_player(*p_ptr, SaveType::CLOSE_GAME);
+        PlayerType::get_instance().died_from = _("(緊急セーブ)", "(panic save)");
+        (void)save_player(PlayerType::get_instance(), SaveType::CLOSE_GAME);
         quit("");
         return 0;
     }
@@ -2471,7 +2471,7 @@ static LRESULT PASCAL angband_window_procedure(HWND hWnd, UINT uMsg, WPARAM wPar
         return 0;
     }
     case WM_COMMAND: {
-        process_menus(*p_ptr, LOWORD(wParam));
+        process_menus(PlayerType::get_instance(), LOWORD(wParam));
         return 0;
     }
     case WM_ACTIVATE: {
@@ -2717,7 +2717,7 @@ static void init_stuff()
 void create_debug_spoiler()
 {
     init_stuff();
-    init_angband(*p_ptr, true);
+    init_angband(PlayerType::get_instance(), true);
 
     switch (output_all_spoilers()) {
     case SpoilerOutputResultType::SUCCESSFUL:
@@ -2821,7 +2821,7 @@ int WINAPI WinMain(
     {
         TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
 
-        init_angband(*p_ptr, false);
+        init_angband(PlayerType::get_instance(), false);
         initialized = true;
 
         check_for_save_file(command_line.get_savefile_option());
@@ -2848,13 +2848,13 @@ int WINAPI WinMain(
     term_flush();
     if (movie_in_progress) {
         // selected movie
-        play_game(*p_ptr, false, true);
+        play_game(PlayerType::get_instance(), false, true);
     } else if (savefile.empty()) {
         // new game
-        play_game(*p_ptr, true, false);
+        play_game(PlayerType::get_instance(), true, false);
     } else {
         // selected savefile
-        play_game(*p_ptr, false, false);
+        play_game(PlayerType::get_instance(), false, false);
     }
 
     quit("");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,7 +225,7 @@ static bool parse_long_opt(const char *opt)
     }
 
     init_stuff();
-    init_angband(*p_ptr, true);
+    init_angband(PlayerType::get_instance(), true);
     switch (output_all_spoilers()) {
     case SpoilerOutputResultType::SUCCESSFUL:
         puts("Successfully created a spoiler file.");
@@ -284,7 +284,7 @@ int main(int argc, char *argv[])
 #ifdef SET_UID
     char tmp_name[128];
     user_name(tmp_name, ids.get_user_id());
-    p_ptr->name = tmp_name;
+    PlayerType::get_instance().name = tmp_name;
 #ifdef PRIVATE_USER_PATH
     create_user_dir();
 #endif /* PRIVATE_USER_PATH */
@@ -338,9 +338,9 @@ int main(int argc, char *argv[])
                 break;
             }
 
-            p_ptr->name = &argv[i][2];
-            if (p_ptr->name.length() > 40) {
-                p_ptr->name.resize(40);
+            PlayerType::get_instance().name = &argv[i][2];
+            if (PlayerType::get_instance().name.length() > 40) {
+                PlayerType::get_instance().name.resize(40);
             }
             break;
         case 'm':
@@ -395,7 +395,7 @@ int main(int argc, char *argv[])
         argv[1] = nullptr;
     }
 
-    process_player_name(*p_ptr, true);
+    process_player_name(PlayerType::get_instance(), true);
     quit_aux = quit_hook;
 
 #ifdef USE_X11
@@ -440,7 +440,7 @@ int main(int argc, char *argv[])
 
     {
         TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
-        init_angband(*p_ptr, false);
+        init_angband(PlayerType::get_instance(), false);
         pause_line(MAIN_TERM_MIN_ROWS - 1);
     }
 
@@ -449,7 +449,7 @@ int main(int argc, char *argv[])
     clear_png_display();
 #endif
 
-    play_game(*p_ptr, new_game, browsing_movie);
+    play_game(PlayerType::get_instance(), new_game, browsing_movie);
     quit("");
     return 0;
 }

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -7,19 +7,25 @@
 
 /*!
  * @brief プレイヤー構造体実体 / Static player info record
+ * @note get_instance() を通してのみアクセスすること。直接参照しないこと。
  */
-PlayerType p_body;
-
-/*!
- * @brief プレイヤー構造体へのグローバル参照ポインタ / Pointer to the player info
- */
-PlayerType *p_ptr = &p_body;
+static PlayerType p_body;
 
 PlayerType::PlayerType()
 {
     this->inventory.resize(INVEN_TOTAL);
     ranges::generate(this->inventory, [] { return std::make_shared<ItemEntity>(); });
     this->timed_effects = std::make_shared<TimedEffects>();
+}
+
+PlayerType &PlayerType::get_instance()
+{
+    return p_body;
+}
+
+PlayerType *PlayerType::get_instance_ptr()
+{
+    return &p_body;
 }
 
 bool PlayerType::is_valid() const

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -20,6 +20,20 @@ public:
     void set_timed_effect(CreatureTimedEffect effect, short value) override;
 
     void wipe() override;
-};
 
-extern PlayerType *p_ptr;
+    /*!
+     * @brief プレイヤー唯一のインスタンスを取得する
+     * @return プレイヤーインスタンスへの参照
+     * @note 原則としてエントリポイント・シグナルハンドラ・UIコールバック等の
+     * 「プレイヤー参照の根」でのみ使用すること。通常のゲームロジックからは
+     * CreatureEntity & 引数経由で受け取ること。
+     */
+    static PlayerType &get_instance();
+
+    /*!
+     * @brief プレイヤー唯一のインスタンスを取得する（ポインタ版）
+     * @return プレイヤーインスタンスへのポインタ
+     * @note 用途は get_instance() と同じ。ポインタが必要な場所専用。
+     */
+    static PlayerType *get_instance_ptr();
+};

--- a/src/view/display-messages.cpp
+++ b/src/view/display-messages.cpp
@@ -295,7 +295,7 @@ void msg_print(std::string_view msg)
     const auto split_width = wid - 8;
 
     if ((msg_head_pos > 0) && ((msg_head_pos + std::ssize(msg)) > split_width)) {
-        msg_flush(*p_ptr, msg_head_pos);
+        msg_flush(PlayerType::get_instance(), msg_head_pos);
         msg_flag = false;
         msg_head_pos = 0;
     }
@@ -311,13 +311,13 @@ void msg_print(std::string_view msg)
     while (std::ssize(msg) > split_width) {
         auto split = split_length(msg, split_width);
         term_putstr(0, 0, split, TERM_WHITE, msg.data());
-        msg_flush(*p_ptr, split + 1);
+        msg_flush(PlayerType::get_instance(), split + 1);
         msg.remove_prefix(split);
     }
 
     term_putstr(msg_head_pos, 0, msg.size(), TERM_WHITE, msg.data());
     RedrawingFlagsUpdater::get_instance().set_flag(SubWindowRedrawingFlag::MESSAGE);
-    window_stuff(*p_ptr);
+    window_stuff(PlayerType::get_instance());
 
     msg_flag = true;
     msg_head_pos += msg.size() + _(0, 1);
@@ -339,7 +339,7 @@ void msg_erase()
     }
 
     if (msg_head_pos > 0) {
-        msg_flush(*p_ptr, msg_head_pos);
+        msg_flush(PlayerType::get_instance(), msg_head_pos);
         msg_flag = false;
         msg_head_pos = 0;
     }


### PR DESCRIPTION
… 

グローバル変数 PlayerType *p_ptr を完全に廃止し、エントリポイント・
シグナルハンドラ・UIコールバック等から PlayerType::get_instance() 静的 メソッド経由でアクセスするよう統一した。

主な変更:
- PlayerType::get_instance() / get_instance_ptr() 静的アクセサを追加
- p_body を file-local static 化（外部参照不可に）
- extern PlayerType *p_ptr; 宣言を削除
- PlayerType *p_ptr = &p_body; 定義を削除
- 全 52 箇所の p_ptr 使用を get_instance() 経由に変換

影響ファイル:
- エントリポイント: main.cpp, main-win.cpp, main-gcu.cpp, main-cap.cpp
- シグナルハンドラ: io/signal-handlers.cpp
- UIコールバック: core/asking-player.cpp, core/window-redrawer.cpp, io/input-key-acceptor.cpp, io/screen-util.cpp, view/display-messages.cpp

これにより Phase 1（関数シグネチャ統一）が実質完了した。残るグローバルは
file-local な p_body のみとなり、依存関係が明示化された。