### PR TITLE
merge: X11 版グラフィックの filename 未設定バグを修正（hengband#3685 相当）

### DIFF
--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -2568,6 +2568,7 @@ errr init_x11(int argc, char *argv[])
     }
 
 #ifndef USE_XFT
+    char filename[1024]{};
     switch (arg_graphics) {
     case GRAPHICS_ORIGINAL: {
         const auto &path = path_build(ANGBAND_DIR_XTRA, "graf/8x8.bmp");
@@ -2575,6 +2576,7 @@ errr init_x11(int argc, char *argv[])
             use_graphics = true;
             pict_wid = pict_hgt = 8;
             ANGBAND_GRAF = "old";
+            angband_strcpy(filename, path.string().data(), sizeof(filename));
         }
         break;
     }
@@ -2584,6 +2586,7 @@ errr init_x11(int argc, char *argv[])
             use_graphics = true;
             pict_wid = pict_hgt = 16;
             ANGBAND_GRAF = "new";
+            angband_strcpy(filename, path.string().data(), sizeof(filename));
         }
         break;
     }
@@ -2592,7 +2595,6 @@ errr init_x11(int argc, char *argv[])
     if (use_graphics) {
         Display *dpy = Metadpy->dpy;
         XImage *tiles_raw;
-        char filename[1024]{};
         tiles_raw = ReadBMP(dpy, filename);
         for (i = 0; i < num_term; i++) {
             term_data *td = &data[i];


### PR DESCRIPTION
変愚蛮怒 PR hengband/hengband#3685「Fix X11 graphics」を適応してマージ。

バグ内容: init_x11() 内で use_graphics が有効な場合、ReadBMP() が未初期化の filename バッファで呼ばれていたため、X11 版のグラフィック (8x8.bmp / 16x16.bmp) が正しく読み込まれない。

修正内容:
- char filename[1024]{} の宣言を switch 文の前に移動
- GRAPHICS_ORIGINAL/GRAPHICS_ADAM_BOLT の各ケースで path を filename へ保存
- コピーには strcpy ではなく angband_strcpy を使用（バッファサイズチェック付き）

上流コミット: c0ad3e1da + 0dfa3b2f0 (hengband/develop)
関連 ISSUE: #3829