### PR TITLE
merge: ユニーク「はらへりじじい」とモンスター「まわるポリゴン」を追加（hengband#5180 相当）

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -151198,5 +151198,115 @@
         ],
         "probability": "1_IN_4"
     }
+},
+{
+    "id": 2343,
+    "name": {
+        "ja": "まわるポリゴン",
+        "en": "Polygon Spin"
+    },
+    "symbol": {
+        "character": "g",
+        "color": "Light Brown"
+    },
+    "speed": 0,
+    "hit_point": "33d8",
+    "vision": 20,
+    "armor_class": 40,
+    "alertness": 50,
+    "level": 15,
+    "rarity": 3,
+    "exp": 70,
+    "blows": [
+        {
+            "method": "HIT",
+            "effect": "HURT",
+            "damage_dice": "4d4"
+        },
+        {
+            "method": "SHOW",
+            "effect": "HUNGRY",
+            "damage_dice": "500d1"
+        }
+    ],
+    "flags": [
+        "DROP_60",
+        "EVIL",
+        "NONLIVING",
+        "NO_FEAR",
+        "COLD_BLOOD"
+    ],
+    "flavor": {
+        "ja": "踊りながらハラヘリーの呪文を唱え、お腹を空かせてくる。",
+        "en": "While dancing, they chanted a hunger spell to make you hungry."
+    }
+},
+{
+    "id": 2344,
+    "name": {
+        "ja": "亡霊『はらへりじじい』",
+        "en": "Hungry old man, the ghost"
+    },
+    "symbol": {
+        "character": "G",
+        "color": "Orange"
+    },
+    "speed": 0,
+    "hit_point": "33d10",
+    "vision": 20,
+    "armor_class": 35,
+    "alertness": 50,
+    "level": 17,
+    "rarity": 3,
+    "exp": 220,
+    "sex": "MALE",
+    "blows": [
+        {
+            "method": "WAIL",
+            "effect": "EAT_FOOD"
+        },
+        {
+            "method": "WAIL",
+            "effect": "EAT_FOOD"
+        },
+        {
+            "method": "MOAN",
+            "effect": "EAT_FOOD"
+        }
+    ],
+    "flags": [
+        "UNIQUE",
+        "FORCE_MAXHP",
+        "SPEAK_ALL",
+        "DROP_60",
+        "DROP_GOOD",
+        "UNDEAD",
+        "HUMAN",
+        "NO_FEAR",
+        "NO_CONF",
+        "RES_CHAO",
+        "RES_NEXU",
+        "RES_DISE",
+        "RAND_50",
+        "CAN_FLY",
+        "PASS_WALL",
+        "COLD_BLOOD"
+    ],
+    "skill": {
+        "probability": "1_IN_5",
+        "list": [
+            "S_KIN"
+        ]
+    },
+    "escorts": [
+        {
+            "escorts_id": 2343,
+            "escort_num": "8d1"
+        }
+    ],
+    "flavor": {
+        "ja": "餓死した老人の亡霊だ。あなたの事を食料をくれなかった冒険者と勘違いしている。",
+        "en": "It is the ghost of an old man who died of starvation. He mistakes you for an adventurer who didn't give him food."
+    }
 }]
 }

--- a/lib/edit/MonsterMessages.jsonc
+++ b/lib/edit/MonsterMessages.jsonc
@@ -7964,6 +7964,27 @@
             ]
         },
         {
+            "id_list": [
+                2344 /*亡霊『はらへりじじい』/ Hungry old man, the ghost (hengband#5180 相当)*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「おにぎりをくれぇ！ おにぎりをくれぇぇーー！」",
+                            "「うはっ、うはははははーーーーーー！」"
+                        ],
+                        "en": [
+                            "says, 'Give me food! Give me food!'",
+                            "says, 'Uh, Uhhhhhhhhhhhhhhhhhhh!'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
             "name": "DEFAULT",
             "message": [
                 {

--- a/src/system/enums/monrace/monrace-id.h
+++ b/src/system/enums/monrace/monrace-id.h
@@ -323,6 +323,6 @@ enum class MonraceId : int16_t {
     IDE = 2277,
     KING_SHIN = 2281,
     KING_SOLDIER = 2282,
-    POLYGON_SPIN = -1, // TODO: 変愚から後日移植
-    HUNGRY_OLD_MAN = -2 // TODO: 変愚から後日移植
+    POLYGON_SPIN = 2343, // まわるポリゴン（hengband#5180 相当）
+    HUNGRY_OLD_MAN = 2344, // 亡霊『はらへりじじい』（hengband#5180 相当）
 };


### PR DESCRIPTION
変愚蛮怒 PR hengband/hengband#5180 を bakabakaband に適応してマージ。

既存コード側（monster-attack-describer.cpp, mspell-summon.cpp, specified-summon.cpp, specified-summon.h）は既に取り込み済みだったが、 monrace-id.h に placeholder の -1/-2 が残っており、データファイルも 未追加だったため、以下を完成させた:

- monrace-id.h: POLYGON_SPIN = 2343, HUNGRY_OLD_MAN = 2344 に割り当て （変愚の 1386/1387 は bakabakaband では別種族のため独自 ID 体系を使用）
- MonraceDefinitions.jsonc: id 2343/2344 の定義を追加、 はらへりじじい の escorts_id を 2343 (POLYGON_SPIN) に調整
- MonsterMessages.jsonc: id 2344 の SPEAK_ALL メッセージを追加 （ja/en 統合形式で 1 エントリとして追加）

上流コミット: 3e3d2128c (hengband/develop)
関連 ISSUE: #6520