### PR TITLE
merge: SPEAK_FRIEND の空デフォルトメッセージを削除（hengband#5198 相当）

### DIFF
--- a/lib/edit/MonsterMessages.jsonc
+++ b/lib/edit/MonsterMessages.jsonc
@@ -8335,18 +8335,6 @@
                     }
                 },
                 {
-                    "action": "SPEAK_FRIEND",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            ""
-                        ],
-                        "en": [
-                            ""
-                        ]
-                    }
-                },
-                {
                     "action": "SPEAK_DEATH",
                     "chance": 1,
                     "message": {


### PR DESCRIPTION
変愚蛮怒 PR hengband/hengband#5198「[Fix] SPEAK_FRIEND の挙動の修正」を bakabakaband に適応してマージ。

MonsterMessages.jsonc の DEFAULT グループ内に存在した空文字列の
SPEAK_FRIEND メッセージエントリを削除。デフォルトメッセージが選択された
場合に意図せず空文字列のメッセージが表示される不具合を修正する。

上流コミット: 9478aef4e (hengband/develop)
関連 ISSUE: #6696