### PR TITLE
merge: 自動登録時にファイルがない場合に新規作成する（hengband#5307 相当）

### DIFF
--- a/src/autopick/autopick-registry.cpp
+++ b/src/autopick/autopick-registry.cpp
@@ -165,9 +165,11 @@ bool autopick_autoregister(CreatureEntity &creature, const ItemEntity *o_ptr)
         creature.autopick_autoregister = false;
     }
 
-    pref_fff = angband_fopen(path_pref, FileOpenMode::APPEND);
+    /* ファイルが存在しなかった場合はプレイヤー個別の新規ファイルを作成する */
+    const auto path_pref_append = !path_pref.empty() ? path_pref : path_build(ANGBAND_DIR_USER, pickpref_filename(creature.base_name, PT_WITH_PNAME));
+    pref_fff = angband_fopen(path_pref_append, FileOpenMode::APPEND);
     if (!pref_fff) {
-        const auto filename_pref = path_pref.string();
+        const auto filename_pref = path_pref_append.string();
         msg_format(_("%s を開くことができませんでした。", "Failed to open %s."), filename_pref.data());
         msg_erase();
         return false;


### PR DESCRIPTION
変愚蛮怒 PR hengband/hengband#5307「Create autopick file as necessary when registering item」を bakabakaband に適応してマージ。

修正内容: autopick_autoregister() で既存の pickpref ファイルが見つからない 場合、path_pref が空文字列のまま angband_fopen(APPEND) に渡されて失敗していた。 ファイル不在時はプレイヤー個別の pickpref ファイル名を新規生成して作成する
ように修正する。

bakabakaband 構造への適応:
- player_ptr->base_name → creature.base_name （CreatureEntity 統合済みのため引数名変換のみ）

上流コミット: ab5effc99 (hengband/develop)
関連 ISSUE: #7822