### PR TITLE
merge: モンスターノックバック処理を move_monster_to() に統一（hengband#5322 相当）

### DIFF
--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -33,6 +33,7 @@
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "object/object-broken.h"
 #include "object/object-info.h"
 #include "object/object-mark-types.h"
@@ -885,8 +886,6 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
                             //!< @details プレイヤーの場所が同一であることが保証できないので変数を再宣言する.
                             const auto p_pos1 = creature.get_position();
                             auto n = randint1(5) + 3;
-                            const auto n0 = n;
-                            const auto m_idx = c_mon_ptr->m_idx;
                             for (; cur_dis <= tdis;) {
                                 const Pos2D pos_orig = { y, x };
                                 if (n == 0) {
@@ -911,17 +910,10 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
                                     break;
                                 }
 
-                                floor.get_grid(pos_to).m_idx = m_idx;
-                                floor.get_grid(pos_orig).m_idx = 0;
-                                monster.set_position(pos_to);
-                                update_monster(creature, m_idx, true);
+                                move_monster_to(creature, monster, pos_to);
                                 if (delay_factor > 0) {
-                                    lite_spot(creature, pos_to);
-                                    lite_spot(creature, pos_orig);
                                     term_fresh();
                                     term_xtra(TERM_XTRA_DELAY, delay_factor);
-                                } else if (n == n0) {
-                                    lite_spot(creature, pos_orig);
                                 }
 
                                 x = pos_to.x;

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -16,6 +16,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "pet/pet-util.h"
 #include "player-base/player-class.h"
 #include "player-info/equipment-info.h"
@@ -242,14 +243,8 @@ bool shock_power(CreatureEntity &creature)
     }
 
     msg_format(_("%sを吹き飛ばした！", "You blow %s away!"), m_name.data());
-    floor.get_grid(pos_origin).m_idx = 0;
-    floor.get_grid(pos_target).m_idx = m_idx;
-    monster.y = pos_target.y;
-    monster.x = pos_target.x;
-
-    update_monster(creature, m_idx, true);
-    lite_spot(creature, pos_origin);
-    lite_spot(creature, pos_target);
+    monster.set_target(creature.get_position());
+    move_monster_to(creature, monster, pos_target);
 
     if (monrace.brightness_flags.has_any_of(ld_mask)) {
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -2,6 +2,7 @@
 #include "dungeon/dungeon-flag-types.h"
 #include "dungeon/quest.h"
 #include "game-option/cheat-options.h"
+#include "grid/grid.h"
 #include "monster-floor/place-monster-types.h"
 #include "monster-race/monster-kind-mask.h"
 #include "monster-race/monster-race-hook.h"
@@ -9,6 +10,7 @@
 #include "monster-race/race-flags-resistance.h"
 #include "monster-race/race-misc-flags.h"
 #include "monster/monster-info.h"
+#include "monster/monster-update.h"
 #include "mspell/summon-checker.h"
 #include "spell/summon-types.h"
 #include "system/angband-exceptions.h"
@@ -742,4 +744,23 @@ bool is_player(MONSTER_IDX m_idx)
 bool is_monster(MONSTER_IDX m_idx)
 {
     return m_idx > 0;
+}
+
+/*!
+ * @brief モンスターを指定位置へ移動する（ノックバック・地震逃げ共通処理）
+ * @param creature プレイヤー（視点クリーチャー）
+ * @param monster 移動するモンスター
+ * @param pos_to 移動先座標
+ */
+void move_monster_to(CreatureEntity &creature, CreatureEntity &monster, const Pos2D &pos_to)
+{
+    auto &floor = *creature.get_floor();
+    const auto pos_from = monster.get_position();
+    auto &grid_from = floor.get_grid(pos_from);
+    auto &grid_to = floor.get_grid(pos_to);
+    grid_to.m_idx = std::exchange(grid_from.m_idx, {});
+    monster.set_position(pos_to);
+    update_monster(creature, grid_to.m_idx, true);
+    lite_spot(creature, pos_from);
+    lite_spot(creature, pos_to);
 }

--- a/src/monster/monster-util.h
+++ b/src/monster/monster-util.h
@@ -57,3 +57,4 @@ void get_mon_num_prep_bounty(CreatureEntity &creature);
 void mark_monsters_present(CreatureEntity &creature);
 bool is_player(MONSTER_IDX m_idx);
 bool is_monster(MONSTER_IDX m_idx);
+void move_monster_to(CreatureEntity &creature, CreatureEntity &monster, const Pos2D &pos_to);

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -22,6 +22,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-info.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "object-enchant/tr-types.h"
 #include "player-info/equipment-info.h"
 #include "player/player-damage.h"
@@ -268,15 +269,8 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
                 }
                 if (pos_target != pos_origin) {
                     msg_format(_("%sを吹き飛ばした！", "You blow %s away!"), m_name.data());
-                    floor.get_grid(pos_origin).m_idx = 0;
-                    floor.get_grid(pos_target).m_idx = m_idx;
-                    monster.y = pos_target.y;
-                    monster.x = pos_target.x;
-
-                    update_monster(creature, m_idx, true);
-                    lite_spot(creature, pos_origin);
-                    lite_spot(creature, pos_target);
-
+                    monster.set_target(creature.get_position());
+                    move_monster_to(creature, monster, pos_target);
                     if (monster.get_monrace().brightness_flags.has_any_of(ld_mask)) {
                         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
                     }

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -11,6 +11,7 @@
 #include "monster/monster-description-types.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "player/player-damage.h"
 #include "player/player-move.h"
 #include "player/player-status-flags.h"
@@ -174,19 +175,6 @@ tl::optional<Pos2D> decide_monster_dodge_position(const FloorType &floor, const 
         ranges::to<std::vector<Pos2D>>();
 
     return pos_candidates.empty() ? tl::nullopt : tl::make_optional(rand_choice(pos_candidates));
-}
-
-void move_monster_to(CreatureEntity &creature, CreatureEntity &monster, const Pos2D &pos_to)
-{
-    auto &floor = *creature.get_floor();
-    const auto pos_from = monster.get_position();
-    auto &grid_from = floor.get_grid(pos_from);
-    auto &grid_to = floor.get_grid(pos_to);
-    grid_to.m_idx = std::exchange(grid_from.m_idx, {});
-    monster.set_position(pos_to);
-    update_monster(creature, grid_to.m_idx, true);
-    lite_spot(creature, pos_from);
-    lite_spot(creature, pos_to);
 }
 
 bool process_monster_damage(CreatureEntity &creature, CreatureEntity &monster, bool has_dodged)


### PR DESCRIPTION
変愚蛮怒 PR hengband/hengband#5322「[Refactor] 烈風剣などモンスター ノックバック処理の統一」を bakabakaband に適応してマージ。

従来 earthquake.cpp に private な static 関数として定義されていた
move_monster_to() を monster-util に昇格させ、烈風剣・衝波・狙撃など モンスターノックバックを生じさせる複数箇所で共用できるようにした。

バグ修正効果: 烈風剣、衝波で視界外にモンスターを押し出したときに
反撃召喚などの update_monster() が行われなかったバグが修正される。

変更内容:
- monster-util.h: move_monster_to() を宣言
- monster-util.cpp: 実装を移動、grid.h / monster-update.h を追加 include
- earthquake.cpp: 重複実装を削除、monster-util.h を include
- combat/shoot.cpp: SP_RUSH 時のインライン実装を move_monster_to() 呼び出しに置換
- mind/mind-force-trainer.cpp: shock_power() を move_monster_to() に置換
- realm/realm-hissatsu.cpp: 烈風剣を move_monster_to() に置換

bakabakaband 構造への適応:
- PlayerType * → CreatureEntity &
- MonsterEntity & → CreatureEntity &
- player_ptr->current_floor_ptr → creature.get_floor()

上流コミット: 922cbe21c (hengband/develop)
関連 ISSUE: #7824