### PR TITLE
merge: X11版SE機能にiniファイル読み込み機能を追加+非同期化（hengband#5319 相当）

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -834,6 +834,7 @@ hengband_SOURCES = \
 	main-unix/x11-type-string.cpp main-unix/x11-type-string.h \
 	main-unix/unix-music.cpp main-unix/unix-music.h \
 	main-unix/unix-cfg-reader.cpp main-unix/unix-cfg-reader.h \
+	main-unix/unix-sound.cpp main-unix/unix-sound.h \
 	\
 	market/arena.cpp market/arena.h \
 	market/arena-entry.cpp market/arena-entry.h \

--- a/src/main-unix/unix-sound.cpp
+++ b/src/main-unix/unix-sound.cpp
@@ -1,0 +1,161 @@
+/*!
+ * @file unix-sound.cpp
+ * @brief Unix版固有実装(効果音)
+ * @details posix_spawnp()を使用し非同期的にSEを再生する｡
+ * 生成した子プロセスは終了時Linux環境下でゾンビプロセスとなってしまうため､
+ * 溢れないよう再生時にcleanup_processes()で都度回収する｡
+ * @note 設計の都合上1~QueueLimit個のゾンビプロセスを残してしまう｡
+ */
+#include "main-unix/unix-sound.h"
+#include "main-unix/unix-cfg-reader.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
+#include "term/z-term.h"
+#include "util/angband-files.h"
+#include "util/enum-converter.h"
+#include <cerrno>
+#include <cstdlib>
+#include <filesystem>
+#include <queue>
+#include <range/v3/all.hpp>
+#include <simpleini/SimpleIni.h>
+#include <spawn.h>
+#include <sys/wait.h>
+#include <tl/optional.hpp>
+
+extern char **environ;
+namespace unix_sound {
+
+/*
+ * "sound.cfg" data
+ */
+static tl::optional<CfgData> sound_cfg_data;
+
+static std::filesystem::path sound_player;
+
+static std::filesystem::path ANGBAND_DIR_XTRA_SOUND;
+static std::queue<pid_t> sound_pids;
+static constexpr auto QueueLimit = 8;
+
+/*!
+ * @brief action-valに対応する[Sound]セクションのキー名を取得する
+ * @param index "term_xtra()"の第2引数action-valに対応する値
+ * @param buf 使用しない
+ * @return 対応するキー名を返す
+ */
+static tl::optional<std::string>
+sound_key_at(int index)
+{
+    const auto sk = i2enum<SoundKind>(index);
+    if (sk >= SoundKind::MAX) {
+        return tl::nullopt;
+    }
+
+    return sound_names.at(sk);
+}
+
+/*!
+ * @brief cleanup finished child processes
+ *
+ */
+void cleanup_processes()
+{
+    while (!sound_pids.empty()) {
+        auto status = 0;
+        auto pid = sound_pids.front();
+        auto ret = waitpid(pid, &status, WNOHANG);
+        if (ret > 0) {
+            sound_pids.pop(); // Process finished
+        } else if (ret == 0) {
+            break; // Front process still running
+
+        } else { // error handling
+            auto err = errno;
+            if (err == ECHILD) {
+                sound_pids.pop(); // Invalid pid
+            } else {
+                break; // Unexpected error; avoid spinning
+            }
+        }
+    }
+    return;
+}
+
+/*!
+ * @brief 効果音の設定を読み込む。
+ * @retval 正常に設定を読み込めたらtrueを返す
+ * @details
+ * "sound_debug.cfg"ファイルを優先して読み込む。無ければ"sound.cfg"ファイルを読み込む。
+ * この処理は複数回実行されることを想定していない。複数回実行した場合には前回読み込まれた設定のメモリは解放されない。
+ */
+bool init_sound(std::filesystem::path sound_path, std::filesystem::path player)
+{
+    ANGBAND_DIR_XTRA_SOUND = sound_path;
+
+    if (!std::filesystem::exists(player)) {
+        return false;
+    }
+
+    sound_player = player;
+    CfgReader reader(sound_path, { "sound_debug.cfg", "sound.cfg" });
+    sound_cfg_data = reader.read_sections({ { "Sound", TERM_XTRA_SOUND, sound_key_at } });
+    if (!sound_cfg_data.has_value()) {
+        return false;
+    }
+    return true;
+}
+
+void finalize_sound()
+{
+    cleanup_processes();
+    return;
+}
+
+/*!
+ * @brief 指定の効果音を鳴らす。
+ * @param val see SoundKind
+ * @retval true 正常終了
+ * @retval false 正常終了以外
+ */
+bool play_sound(int val)
+{
+    if (!sound_cfg_data) {
+        return false;
+    }
+    if ((val < 0) || (val >= enum2i(SoundKind::MAX))) {
+        return false;
+    }
+
+    if (!sound_pids.empty()) {
+        cleanup_processes();
+    }
+
+    if (sound_pids.size() > QueueLimit) {
+        return false;
+    }
+
+    auto filename = sound_cfg_data->get_rand(TERM_XTRA_SOUND, val);
+    if (!filename) {
+        return false;
+    }
+
+    auto path = path_build(ANGBAND_DIR_XTRA_SOUND, *filename);
+    auto sound_player_pid = 0;
+
+    auto argv_sound_player_buf = sound_player.string() | ranges::to_vector;
+    argv_sound_player_buf.push_back('\0');
+    auto argv_path_sound_buf = path.string() | ranges::to_vector;
+    argv_path_sound_buf.push_back('\0');
+    //  argv must has null end
+    char *const argv[] = { argv_sound_player_buf.data(), argv_path_sound_buf.data(), nullptr };
+    // explicitly pass environment
+    char **envp = environ;
+    auto ret = posix_spawnp(&sound_player_pid, sound_player.c_str(), nullptr, nullptr, argv, envp);
+    if (ret != 0) { // failed to spawn process
+        return false;
+    }
+
+    sound_pids.push(sound_player_pid);
+    return true;
+}
+};

--- a/src/main-unix/unix-sound.h
+++ b/src/main-unix/unix-sound.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <filesystem>
+
+namespace unix_sound {
+
+bool init_sound(std::filesystem::path, std::filesystem::path);
+bool play_sound(int);
+void finalize_sound();
+
+};

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -97,6 +97,7 @@
 #include "locale/japanese.h"
 #include "locale/utf-8.h"
 #include "main-unix/unix-music.h"
+#include "main-unix/unix-sound.h"
 #include "main-unix/x11-type-string.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
@@ -1868,25 +1869,13 @@ static errr CheckEvent(bool wait)
 }
 
 /*
- * An array of sound file names
- */
-static std::map<SoundKind, std::string> sound_files;
-
-/*
  * Initialize sound
  */
 static void init_sound()
 {
-    const auto &dir_xtra_sound = path_build(ANGBAND_DIR_XTRA, "sound");
-    constexpr EnumRange<SoundKind> sound_kinds(SoundKind::HIT, SoundKind::MAX);
-    for (const auto sk : sound_kinds) {
-        std::string wav = sound_names.at(sk);
-        wav.append(".wav");
-        const auto &path = path_build(dir_xtra_sound, wav);
-        sound_files[sk] = std::filesystem::exists(path) ? path.string() : "";
-    }
+    const std::filesystem::path sound_player = "./playwave.sh";
 
-    use_sound = true;
+    use_sound = unix_sound::init_sound(path_build(ANGBAND_DIR_XTRA, "sound"), sound_player);
     return;
 }
 
@@ -1898,13 +1887,11 @@ static errr game_term_xtra_x11_sound(int v)
     if (!use_sound) {
         return 1;
     }
-    if ((v < 0) || (v >= enum2i(SoundKind::MAX))) {
-        return 1;
+    auto ret = unix_sound::play_sound(v);
+    if (ret) {
+        return 0;
     }
-
-    std::string buf = "./playwave.sh ";
-    buf.append(sound_files.at(i2enum<SoundKind>(v))).append("\n");
-    return system(buf.data()) < 0;
+    return 1;
 }
 
 /*
@@ -2301,6 +2288,10 @@ static void game_term_nuke_x11(term_type *)
 
     if (use_music) {
         unix_music::stop_music();
+    }
+
+    if (use_sound) {
+        unix_sound::finalize_sound();
     }
 
     if (Metadpy->xim) {


### PR DESCRIPTION
変愚蛮怒 PR #5319 (sato-rgb/feature/improve-linux-sounds) の内容を bakabakaband にマージ。

上流コミット:
- 8668e8a9a [Add][Feature] X11版SE機能にiniファイル読み込み機能を追加+非同期化
- cb25abb1b play_sound()のエラーハンドリングを修正

主な変更:
- src/main-unix/unix-sound.{cpp,h} 新設: posix_spawn による非同期 SE 再生。ゾンビプロセス対策として waitpid(WNOHANG) でクリーンアップする キューを持ち、QueueLimit=8 で上限管理。sound.cfg / sound_debug.cfg 読み込みは #7820 で導入した CfgReader を利用
- src/main-x11.cpp: sound_files 配列と system() 呼び出しを廃止し、 unix_sound::init_sound / play_sound / finalize_sound への委譲に変更
  - game_term_nuke_x11 で finalize_sound を呼び出し
  - sound-definitions-table.h / <map> の include は上流同様維持 (sound_files 削除後は未使用だが上流 diff に合わせる)
- src/Makefile.am に unix-sound.{cpp,h} を登録

従来は system() によりシェル起動が同期実行され、矢連射や壁衝突時に
ラグが生じていたが、posix_spawn による非同期化で解消される。

unix-sound.o / main-x11.o いずれも -Werror -Wall -Wextra で コンパイル成功、clang-format clean。