### PR TITLE
merge: モンスターの思い出表記に要約をつける（hengband#5312 相当）

### DIFF
--- a/lib/pref/pref-opt.prf
+++ b/lib/pref/pref-opt.prf
@@ -73,6 +73,7 @@ Y:show_ammo_detail
 X:show_ammo_no_crit
 X:show_ammo_crit_ratio
 Y:show_actual_value
+X:show_lore_summary
 
 ##### Game-Play #####
 

--- a/src/game-option/option-types-table.cpp
+++ b/src/game-option/option-types-table.cpp
@@ -149,6 +149,8 @@ const std::vector<GameOption> option_info = {
 
     { &show_actual_value, true, 2, 17, "show_actual_value", _("技能値等に実値を並記する", "Show actual values of skills or etc."), GameOptionPage::TEXT },
 
+    { &show_lore_summary, true, 2, 18, "show_lore_summary", _("モンスターの思い出を要約表記にする", " Show a summary of monster lore."), GameOptionPage::TEXT },
+
     /*** Game-Play ***/
     { &stack_force_notes, true, 0, 8, "stack_force_notes", _("異なる銘のアイテムをまとめる", "Merge inscriptions when stacking"), GameOptionPage::GAMEPLAY },
 

--- a/src/game-option/text-display-options.cpp
+++ b/src/game-option/text-display-options.cpp
@@ -18,3 +18,4 @@ bool show_ammo_detail; /* Show Description of ammo damage */
 bool show_ammo_no_crit; /* Show No-crit damage of ammo */
 bool show_ammo_crit_ratio; /* Show critical ratio of ammo */
 bool show_actual_value; /* Show actual value of skill */
+bool show_lore_summary; /* Show lore summary in monster recall */

--- a/src/game-option/text-display-options.h
+++ b/src/game-option/text-display-options.h
@@ -20,3 +20,4 @@ extern bool show_ammo_detail; /* Show Description of ammo damage */
 extern bool show_ammo_no_crit; /* Show No-crit damage of ammo */
 extern bool show_ammo_crit_ratio; /* Show critical ratio of ammo */
 extern bool show_actual_value; /* Show actual value of skill */
+extern bool show_lore_summary; /* Show lore summary in monster recall */

--- a/src/lore/lore-calculator.cpp
+++ b/src/lore/lore-calculator.cpp
@@ -45,6 +45,19 @@ std::string dice_to_string(int base_damage, int dice_num, int dice_side, int dic
     return ss.str();
 }
 
+std::string get_skill_damage(CreatureEntity &creature, lore_type *lore_ptr, MonsterAbilityType ms_type)
+{
+    const auto monrace_id = lore_ptr->monrace_id;
+    const auto base_damage = monspell_race_damage(creature, ms_type, monrace_id, BASE_DAM);
+    const auto dice_num = monspell_race_damage(creature, ms_type, monrace_id, DICE_NUM);
+    const auto dice_side = monspell_race_damage(creature, ms_type, monrace_id, DICE_SIDE);
+    const auto dice_mult = monspell_race_damage(creature, ms_type, monrace_id, DICE_MULT);
+    const auto dice_div = monspell_race_damage(creature, ms_type, monrace_id, DICE_DIV);
+    std::stringstream dam_info;
+    dam_info << '(' << dice_to_string(base_damage, dice_num, dice_side, dice_mult, dice_div) << ')';
+    return dam_info.str();
+}
+
 /*!
  * @brief lore_ptrにダメージを与えるスキルの情報を追加する
  * @param lore_ptr 知識情報
@@ -68,7 +81,7 @@ void add_lore_of_damage_skill(CreatureEntity &creature, lore_type *lore_ptr, Mon
     const auto dice_div = monspell_race_damage(creature, ms_type, monrace_id, DICE_DIV);
     std::stringstream dam_info;
     dam_info << '(' << dice_to_string(base_damage, dice_num, dice_side, dice_mult, dice_div) << ')';
-    lore_ptr->lore_msgs.emplace_back(format(msg, dam_info.str().data()), color);
+    lore_ptr->lore_msgs.emplace_back(format(msg, get_skill_damage(creature, lore_ptr, ms_type).data()), color);
 }
 
 void set_flags_for_full_knowledge(lore_type *lore_ptr)

--- a/src/lore/lore-calculator.h
+++ b/src/lore/lore-calculator.h
@@ -9,5 +9,6 @@ enum class MonraceId : int16_t;
 struct lore_type;
 class CreatureEntity;
 std::string dice_to_string(int base_damage, int dice_num, int dice_side, int dice_mult, int dice_div);
+std::string get_skill_damage(CreatureEntity &creature, lore_type *lore_ptr, MonsterAbilityType ms_type);
 void add_lore_of_damage_skill(CreatureEntity &creature, lore_type *lore_ptr, MonsterAbilityType ms_type, concptr msg, byte color);
 void set_flags_for_full_knowledge(lore_type *lore_ptr);

--- a/src/lore/lore-util.cpp
+++ b/src/lore/lore-util.cpp
@@ -76,9 +76,55 @@ bool lore_type::is_blow_damage_known(int num_blow) const
     return MonraceList::get_instance().get_monrace(this->monrace_id).is_blow_damage_known(num_blow);
 }
 
+term_color_type lore_type::get_speed_color() const
+{
+    if (this->speed > 199) {
+        return TERM_YELLOW;
+    } else if (this->speed > 189) {
+        return TERM_YELLOW;
+    } else if (this->speed > STANDARD_SPEED) {
+        if (this->speed > 149) {
+            return TERM_VIOLET;
+        } else if (this->speed > 144) {
+            return TERM_RED;
+        } else if (this->speed > 139) {
+            return TERM_L_RED;
+        } else if (this->speed > 134) {
+            return TERM_ORANGE;
+        } else if (this->speed > 129) {
+            return TERM_UMBER;
+        } else if (this->speed > 124) {
+            return TERM_L_UMBER;
+        } else if (this->speed < 115) {
+            return TERM_L_GREEN;
+        } else if (this->speed < 120) {
+            return TERM_YELLOW;
+        } else {
+            return TERM_L_RED;
+        }
+    } else if (this->speed < STANDARD_SPEED) {
+        if (this->speed < 86) {
+            return TERM_L_GREEN;
+        } else if (this->speed < 91) {
+            return TERM_GREEN;
+        } else if (this->speed < 96) {
+            return TERM_L_BLUE;
+        } else if (this->speed > 105) {
+            return TERM_WHITE;
+        } else if (this->speed > 100) {
+            return TERM_BLUE;
+        } else {
+            return TERM_L_BLUE;
+        }
+    } else {
+        return TERM_WHITE;
+    }
+}
+
 std::vector<lore_msg> lore_type::build_speed_description() const
 {
     std::vector<lore_msg> texts;
+    const auto speed_color = this->get_speed_color();
 #ifdef JP
 #else
     texts.emplace_back("moves");
@@ -86,43 +132,43 @@ std::vector<lore_msg> lore_type::build_speed_description() const
     const auto random_movement_description = this->build_random_movement_description();
     texts.insert(texts.end(), random_movement_description.begin(), random_movement_description.end());
     if (this->speed > 199) {
-        texts.emplace_back(_("光速で", " at light speed"), TERM_YELLOW);
+        texts.emplace_back(_("光速で", " at light speed"), speed_color);
     } else if (this->speed > 189) {
-        texts.emplace_back(_("亜光速で", " at sub-light speed"), TERM_YELLOW);
+        texts.emplace_back(_("亜光速で", " at sub-light speed"), speed_color);
     } else if (this->speed > STANDARD_SPEED) {
         if (this->speed > 149) {
-            texts.emplace_back(_("信じ難いほど", " incredibly"), TERM_VIOLET);
+            texts.emplace_back(_("信じ難いほど", " incredibly"), speed_color);
         } else if (this->speed > 144) {
-            texts.emplace_back(_("音速よりも", " inexplicably"), TERM_RED);
+            texts.emplace_back(_("音速よりも", " inexplicably"), speed_color);
         } else if (this->speed > 139) {
-            texts.emplace_back(_("悪夢的に", " nightmarely"), TERM_L_RED);
+            texts.emplace_back(_("悪夢的に", " nightmarely"), speed_color);
         } else if (this->speed > 134) {
-            texts.emplace_back(_("猛烈に", " extremely"), TERM_ORANGE);
+            texts.emplace_back(_("猛烈に", " extremely"), speed_color);
         } else if (this->speed > 129) {
-            texts.emplace_back(_("非常に", " very"), TERM_UMBER);
+            texts.emplace_back(_("非常に", " very"), speed_color);
         } else if (this->speed > 124) {
-            texts.emplace_back(_("かなり", " fairly"), TERM_L_UMBER);
+            texts.emplace_back(_("かなり", " fairly"), speed_color);
         } else if (this->speed < 115) {
-            texts.emplace_back(_("僅かに", " slightly"), TERM_L_GREEN);
+            texts.emplace_back(_("僅かに", " slightly"), speed_color);
         } else if (this->speed < 120) {
-            texts.emplace_back(_("やや", " somewhat"), TERM_YELLOW);
+            texts.emplace_back(_("やや", " somewhat"), speed_color);
         }
-        texts.emplace_back(_("素早く", " quickly"), TERM_L_RED);
+        texts.emplace_back(_("素早く", " quickly"), speed_color);
     } else if (this->speed < STANDARD_SPEED) {
         if (this->speed < 86) {
-            texts.emplace_back(_("信じ難いほど", " incredibly"), TERM_L_GREEN);
+            texts.emplace_back(_("信じ難いほど", " incredibly"), speed_color);
         } else if (this->speed < 91) {
-            texts.emplace_back(_("非常に", " very"), TERM_GREEN);
+            texts.emplace_back(_("非常に", " very"), speed_color);
         } else if (this->speed < 96) {
-            texts.emplace_back(_("かなり", " fairly"), TERM_L_BLUE);
+            texts.emplace_back(_("かなり", " fairly"), speed_color);
         } else if (this->speed > 105) {
-            texts.emplace_back(_("僅かに", " slightly"));
+            texts.emplace_back(_("僅かに", " slightly"), speed_color);
         } else if (this->speed > 100) {
-            texts.emplace_back(_("やや", " somewhat"), TERM_BLUE);
+            texts.emplace_back(_("やや", " somewhat"), speed_color);
         }
-        texts.emplace_back(_("ゆっくりと", " slowly"), TERM_L_BLUE);
+        texts.emplace_back(_("ゆっくりと", " slowly"), speed_color);
     } else {
-        texts.emplace_back(_("普通の速さで", " at normal speed"));
+        texts.emplace_back(_("普通の速さで", " at normal speed"), speed_color);
     }
 
 #ifdef JP

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -88,6 +88,7 @@ struct lore_type {
     bool has_reinforce() const;
     bool is_details_known() const;
     bool is_blow_damage_known(int num_blow) const;
+    term_color_type get_speed_color() const;
 
     tl::optional<std::vector<lore_msg>> build_kill_unique_description() const;
     std::string build_revenge_description(bool has_defeated) const;

--- a/src/lore/monster-lore.cpp
+++ b/src/lore/monster-lore.cpp
@@ -6,6 +6,7 @@
 
 #include "lore/monster-lore.h"
 #include "game-option/cheat-options.h"
+#include "game-option/text-display-options.h"
 #include "lore/lore-calculator.h"
 #include "lore/lore-util.h"
 #include "lore/magic-types-setter.h"
@@ -587,13 +588,34 @@ void process_monster_lore(CreatureEntity &creature, MonraceId r_idx, monster_lor
     if (cheat_know || (mode == MONSTER_LORE_RESEARCH) || (mode == MONSTER_LORE_DEBUG)) {
         lore_ptr->know_everything = true;
     }
-
     set_flags_for_full_knowledge(lore_ptr);
     set_msex_flags(lore_ptr);
     set_flags1(lore_ptr);
     set_race_flags(lore_ptr);
-    display_kill_numbers(lore_ptr);
     const auto &text = lore_ptr->r_ptr->text;
+
+    if (show_lore_summary) {
+        display_monster_kind_tags(lore_ptr);
+        display_monster_hp_ac_summary(lore_ptr);
+        display_monster_speed_summary(lore_ptr);
+        display_monster_alert_summary(lore_ptr);
+        display_monster_kills_summary(lore_ptr);
+        display_where_to_appear_summary(lore_ptr);
+        display_monster_exp_summary(lore_ptr);
+        display_monster_evolution_summary(lore_ptr);
+        hooked_roff("\n");
+        set_monster_aura_summary(lore_ptr);
+        display_monster_behavior_summary(lore_ptr);
+        display_monster_drops_summary(lore_ptr);
+        display_monster_melee_summary_line(lore_ptr);
+        display_monster_magic_rate(lore_ptr);
+        display_monster_magic_tables(creature, lore_ptr);
+        display_monster_resistance_table(lore_ptr);
+        hook_c_roff(TERM_L_DARK, "------------------------------------------------------------\n");
+    }
+
+    display_kill_numbers(lore_ptr);
+
     if (!text.empty()) {
         hooked_roff(text);
         hooked_roff("\n");

--- a/src/view/display-lore-attacks.cpp
+++ b/src/view/display-lore-attacks.cpp
@@ -6,6 +6,223 @@
 #include "monster-attack/monster-attack-table.h"
 #include "system/monrace/monrace-definition.h"
 #include "term/term-color-types.h"
+#include <string>
+#include <vector>
+
+static std::string build_melee_method_abbrev(const RaceBlowMethodType method)
+{
+    switch (method) {
+    case RaceBlowMethodType::HIT:
+        return _("殴", "Hit");
+    case RaceBlowMethodType::TOUCH:
+        return _("触", "Touch");
+    case RaceBlowMethodType::PUNCH:
+        return _("拳", "Punch");
+    case RaceBlowMethodType::KICK:
+        return _("蹴", "Kick");
+    case RaceBlowMethodType::CLAW:
+        return _("爪", "Claw");
+    case RaceBlowMethodType::BITE:
+        return _("噛", "Bite");
+    case RaceBlowMethodType::STING:
+        return _("刺", "Sting");
+    case RaceBlowMethodType::SLASH:
+        return _("斬", "Slash");
+    case RaceBlowMethodType::BUTT:
+        return _("角", "Butt");
+    case RaceBlowMethodType::CRUSH:
+        return _("潰", "Crush");
+    case RaceBlowMethodType::ENGULF:
+        return _("巻", "Engulf");
+    case RaceBlowMethodType::CHARGE:
+        return _("請", "Charge");
+    case RaceBlowMethodType::CRAWL:
+        return _("這", "Crawl");
+    case RaceBlowMethodType::DROOL:
+        return _("涎", "Drool");
+    case RaceBlowMethodType::SPIT:
+        return _("吐", "Spit");
+    case RaceBlowMethodType::EXPLODE:
+        return _("爆", "Explode");
+    case RaceBlowMethodType::GAZE:
+        return _("視", "Gaze");
+    case RaceBlowMethodType::WAIL:
+        return _("叫", "Wail");
+    case RaceBlowMethodType::SPORE:
+        return _("胞", "Spore");
+    case RaceBlowMethodType::BEG:
+        return _("乞", "Beg");
+    case RaceBlowMethodType::INSULT:
+        return _("罵", "Insult");
+    case RaceBlowMethodType::MOAN:
+        return _("唸", "Moan");
+    case RaceBlowMethodType::SHOW:
+        return _("歌", "Show");
+    case RaceBlowMethodType::NONE:
+    case RaceBlowMethodType::XXX4:
+    case RaceBlowMethodType::MAX:
+    default:
+        return _("?", "??");
+    }
+}
+
+static std::string build_melee_effect_abbrev(const RaceBlowEffectType effect)
+{
+    switch (effect) {
+    case RaceBlowEffectType::POISON:
+        return _("毒", "+Pois");
+    case RaceBlowEffectType::UN_BONUS:
+        return _("劣", "+UnBonus");
+    case RaceBlowEffectType::UN_POWER:
+        return _("充-", "+UnPower");
+    case RaceBlowEffectType::EAT_GOLD:
+        return _("金-", "Gold-");
+    case RaceBlowEffectType::EAT_ITEM:
+        return _("物-", "Item-");
+    case RaceBlowEffectType::EAT_FOOD:
+        return _("食-", "Food-");
+    case RaceBlowEffectType::EAT_LITE:
+        return _("灯-", "Lite-");
+    case RaceBlowEffectType::ACID:
+        return _("酸", "+Acid");
+    case RaceBlowEffectType::ELEC:
+        return _("電", "+Elec");
+    case RaceBlowEffectType::FIRE:
+        return _("火", "+Fire");
+    case RaceBlowEffectType::COLD:
+        return _("冷", "+Cold");
+    case RaceBlowEffectType::BLIND:
+        return _("盲", "+Blind");
+    case RaceBlowEffectType::CONFUSE:
+        return _("乱", "+Conf");
+    case RaceBlowEffectType::TERRIFY:
+        return _("恐", "+Fear");
+    case RaceBlowEffectType::PARALYZE:
+        return _("麻", "+Para");
+    case RaceBlowEffectType::LOSE_STR:
+        return _("腕-", "Str-");
+    case RaceBlowEffectType::LOSE_INT:
+        return _("知-", "Int-");
+    case RaceBlowEffectType::LOSE_WIS:
+        return _("賢-", "Wiz-");
+    case RaceBlowEffectType::LOSE_DEX:
+        return _("器-", "Dex-");
+    case RaceBlowEffectType::LOSE_CON:
+        return _("耐-", "Con-");
+    case RaceBlowEffectType::LOSE_CHR:
+        return _("魅-", "Chr-");
+    case RaceBlowEffectType::LOSE_ALL:
+        return _("全-", "Stat-");
+    case RaceBlowEffectType::SHATTER:
+        return _("地震", "+Shatter");
+    case RaceBlowEffectType::EXP_10:
+    case RaceBlowEffectType::EXP_20:
+    case RaceBlowEffectType::EXP_40:
+    case RaceBlowEffectType::EXP_80:
+        return _("経-", "Exp-");
+    case RaceBlowEffectType::DISEASE:
+        return _("病", "+Disease");
+    case RaceBlowEffectType::TIME:
+        return _("時", "+Time");
+    case RaceBlowEffectType::DR_LIFE:
+        return _("命-", "Life-");
+    case RaceBlowEffectType::DR_MANA:
+        return _("魔-", "Mana-");
+    case RaceBlowEffectType::SUPERHURT:
+        return _("強", "SuperHurt");
+    case RaceBlowEffectType::INERTIA:
+        return _("減速", "Inertia");
+    case RaceBlowEffectType::STUN:
+        return _("朦朧", "Stun");
+    case RaceBlowEffectType::HUNGRY:
+        return _("飢-", "Hunger-");
+    case RaceBlowEffectType::CHAOS:
+        return _("沌", "+Chaos");
+    case RaceBlowEffectType::FLAVOR:
+    case RaceBlowEffectType::NONE:
+    case RaceBlowEffectType::HURT:
+    case RaceBlowEffectType::MAX:
+    default:
+        return "";
+    }
+}
+
+/*!
+ * @brief モンスター打撃を方式1(手段ダイス効果)で1行要約して表示する
+ */
+void display_monster_melee_summary_line(lore_type *lore_ptr)
+{
+    if (!lore_ptr->is_details_known() && !lore_ptr->know_everything) {
+        return;
+    }
+
+    // lore_ptr の作業領域(p/q/色)を壊さないよう退避
+    const char *saved_p = lore_ptr->p;
+    const char *saved_q = lore_ptr->q;
+    const int saved_pc = lore_ptr->pc;
+    const int saved_qc = lore_ptr->qc;
+
+    const int max_attack_numbers = 4;
+    bool any = false;
+
+    hooked_roff(_("[打撃] ", "[Melee] "));
+
+    for (int m = 0; m < max_attack_numbers; m++) {
+        const auto &blow = lore_ptr->r_ptr->blows[m];
+        if (blow.method == RaceBlowMethodType::NONE) {
+            continue;
+        }
+
+        if (!lore_ptr->know_everything && (lore_ptr->r_ptr->r_blows[m] == 0)) {
+            continue;
+        }
+
+        if (any) {
+            hooked_roff(" | ");
+        }
+        any = true;
+
+        // 既存と同じ色決定ロジックを流用
+        set_monster_blow_method(lore_ptr, m);
+        set_monster_blow_effect(lore_ptr, m);
+
+        const auto method_abbrev = build_melee_method_abbrev(blow.method);
+        const auto effect_abbrev = build_melee_effect_abbrev(blow.effect);
+
+        // 手段（pc）
+        hook_c_roff(lore_ptr->pc, method_abbrev);
+
+        const bool blow_seen = lore_ptr->know_everything || (lore_ptr->r_ptr->r_blows[m] != 0);
+        const bool dmg_known = lore_ptr->know_everything || lore_ptr->is_blow_damage_known(m);
+
+        // ダイスあり
+        if (blow.damage_dice.is_valid()) {
+            if (dmg_known) {
+                hook_c_roff(TERM_L_WHITE, blow.damage_dice.to_string());
+            } else {
+                hook_c_roff(TERM_L_WHITE, "??");
+            }
+            // ダイスなし（触る等）：既知なら 無表記、未知なら ??
+        } else {
+            if (!blow_seen) {
+                hook_c_roff(TERM_L_WHITE, "??");
+            }
+        }
+
+        // 効果（qc）
+        if (!effect_abbrev.empty()) {
+            hook_c_roff(lore_ptr->qc, effect_abbrev);
+        }
+    }
+
+    hooked_roff("\n");
+
+    // 退避復元
+    lore_ptr->p = saved_p;
+    lore_ptr->q = saved_q;
+    lore_ptr->pc = saved_pc;
+    lore_ptr->qc = saved_qc;
+}
 
 #ifdef JP
 /*!

--- a/src/view/display-lore-attacks.h
+++ b/src/view/display-lore-attacks.h
@@ -2,3 +2,4 @@
 
 struct lore_type;
 void display_monster_blows(lore_type *lore_ptr);
+void display_monster_melee_summary_line(lore_type *lore_ptr);

--- a/src/view/display-lore-drops.cpp
+++ b/src/view/display-lore-drops.cpp
@@ -99,6 +99,36 @@ void display_monster_drop_golds(lore_type *lore_ptr)
 #endif
 }
 
+void display_monster_drops_summary(lore_type *lore_ptr)
+{
+    if ((lore_ptr->drop_gold == 0) && (lore_ptr->drop_item == 0)) {
+        return;
+    }
+    const auto drop_num = std::max(lore_ptr->drop_gold, lore_ptr->drop_item);
+    std::string drop_what;
+    std::string drop_quality;
+
+    if (lore_ptr->drop_flags.has(MonsterDropType::DROP_GREAT)) {
+        drop_quality = _("特別 ", "great ");
+    } else if (lore_ptr->drop_flags.has(MonsterDropType::DROP_GOOD)) {
+        drop_quality = _("上質 ", "good ");
+    }
+
+    auto is_item_only = lore_ptr->drop_gold == 0;
+    is_item_only |= lore_ptr->drop_flags.has_any_of({ MonsterDropType::DROP_GOOD, MonsterDropType::DROP_GREAT });
+    if (is_item_only && lore_ptr->drop_item > 0) {
+        drop_what = _("アイテム", "item");
+    }
+    if (!is_item_only && lore_ptr->drop_item > 0 && lore_ptr->drop_gold > 0) {
+        drop_what = _("アイテム/財宝", "item/treasure");
+    }
+    if (!is_item_only && lore_ptr->drop_item == 0 && lore_ptr->drop_gold > 0) {
+        drop_what = _("財宝", "treasure");
+    }
+
+    hooked_roff(format(_("[ドロップ] %s(%s最大%d)\n", "[drop] %s(%smax %d)\n"), drop_what.data(), drop_quality.data(), drop_num));
+}
+
 void display_monster_drops(lore_type *lore_ptr)
 {
     if ((lore_ptr->drop_gold == 0) && (lore_ptr->drop_item == 0)) {

--- a/src/view/display-lore-drops.h
+++ b/src/view/display-lore-drops.h
@@ -5,4 +5,5 @@ void display_monster_drop_quantity(lore_type *lore_ptr);
 void display_monster_drop_quality(lore_type *lore_ptr);
 void display_monster_drop_items(lore_type *lore_ptr);
 void display_monster_drop_golds(lore_type *lore_ptr);
+void display_monster_drops_summary(lore_type *lore_ptr);
 void display_monster_drops(lore_type *lore_ptr);

--- a/src/view/display-lore-magics.cpp
+++ b/src/view/display-lore-magics.cpp
@@ -1,5 +1,7 @@
 #include "view/display-lore-magics.h"
+#include "lore/lore-calculator.h"
 #include "lore/lore-util.h"
+#include "monster-race/race-ability-flags.h"
 #include "system/monrace/monrace-definition.h"
 #include "term/term-color-types.h"
 
@@ -101,4 +103,290 @@ void display_mosnter_magic_possibility(lore_type *lore_ptr)
     }
 
     hooked_roff(_("。", ".  "));
+}
+
+namespace {
+struct AbilityCellDef {
+    MonsterAbilityType flag;
+    const char *jp;
+    const char *en;
+    byte color;
+};
+
+static bool has_percent_s(std::string_view s)
+{
+    return s.find("%s") != std::string_view::npos;
+}
+
+static std::string build_magic_label(CreatureEntity &creature, lore_type *lore_ptr, MonsterAbilityType type, const char *msg)
+{
+    if (!has_percent_s(msg)) {
+        return msg;
+    }
+
+    if (!lore_ptr->is_details_known() && !lore_ptr->know_everything) {
+        return format(msg, "");
+    }
+
+    return format(msg, get_skill_damage(creature, lore_ptr, type).data());
+}
+
+enum class FlagState {
+    HAVE,
+    ABSENT,
+    UNKNOWN
+};
+
+static FlagState get_ability_state(lore_type *lore_ptr, MonsterAbilityType flag)
+{
+    const bool fully_known = lore_ptr->know_everything || lore_ptr->is_details_known();
+    if (fully_known) {
+        return lore_ptr->r_ptr->ability_flags.has(flag) ? FlagState::HAVE : FlagState::ABSENT;
+    }
+    return lore_ptr->r_ptr->r_ability_flags.has(flag) ? FlagState::HAVE : FlagState::UNKNOWN;
+}
+
+static std::string mind_tag(const lore_type *lore_ptr)
+{
+    const bool fully_known = lore_ptr->know_everything || lore_ptr->is_details_known();
+    const auto &flags = fully_known ? lore_ptr->r_ptr->behavior_flags : lore_ptr->r_ptr->r_behavior_flags;
+
+    const bool has_smart = flags.has(MonsterBehaviorType::SMART);
+    const bool has_stupid = flags.has(MonsterBehaviorType::STUPID);
+
+    if (has_smart && has_stupid) {
+        return _("[聡明][愚昧]", "[SMART][STUPID]");
+    }
+    if (has_smart) {
+        return _("[聡明]", "[SMART]");
+    }
+    if (has_stupid) {
+        return _("[愚昧]", "[STUPID]");
+    }
+
+    return fully_known ? "---" : "???";
+}
+
+static std::string rate_tag(const lore_type *lore_ptr)
+{
+    const int m = lore_ptr->r_ptr->r_cast_spell;
+    int n = lore_ptr->r_ptr->freq_spell;
+    if (n <= 0) {
+        const bool fully_known = lore_ptr->know_everything || lore_ptr->is_details_known();
+        return fully_known ? "---" : "???";
+    }
+
+    if (m > 100 || lore_ptr->know_everything) {
+        return format(_("1/%d", "1/%d"), 100 / n);
+    }
+    if (m) {
+        n = ((n + 9) / 10) * 10;
+        return format(_("約1/%d", "about 1/%d"), 100 / n);
+    }
+    return "???";
+}
+
+static void print_table(CreatureEntity &creature, lore_type *lore_ptr, concptr header, const std::vector<AbilityCellDef> &defs)
+{
+    auto COL_NUM = 6;
+    int col = 0;
+    auto any = false;
+    for (const auto &d : defs) {
+        const auto st = get_ability_state(lore_ptr, d.flag);
+        if (st == FlagState::HAVE) {
+            auto label = build_magic_label(creature, lore_ptr, d.flag, _(d.jp, d.en));
+            lore_ptr->lore_msgs.emplace_back(label + " ", d.color);
+            col++;
+            any = true;
+            if (col >= COL_NUM) {
+                lore_ptr->lore_msgs.emplace_back("\n", d.color);
+                col = 0;
+            }
+        }
+    }
+    if (any) {
+        hooked_roff(header);
+    }
+
+    for (const auto &[msg, color] : lore_ptr->lore_msgs) {
+        hook_c_roff(color, msg);
+    }
+
+    if (col != 0) {
+        hooked_roff("\n");
+    }
+    lore_ptr->lore_msgs.clear();
+}
+
+static const std::vector<AbilityCellDef> &launch_defs()
+{
+    static const std::vector<AbilityCellDef> defs = {
+        { MonsterAbilityType::ROCKET, "ロケット%s", "rocket%s", TERM_UMBER },
+        { MonsterAbilityType::SHOOT, "射撃%s", "shoot%s", TERM_UMBER },
+    };
+    return defs;
+}
+
+static const std::vector<AbilityCellDef> &breath_defs()
+{
+    static const std::vector<AbilityCellDef> defs = {
+        { MonsterAbilityType::BR_ACID, "酸%s", "acid%s", TERM_GREEN },
+        { MonsterAbilityType::BR_ELEC, "稲妻%s", "lightning%s", TERM_BLUE },
+        { MonsterAbilityType::BR_FIRE, "火炎%s", "fire%s", TERM_RED },
+        { MonsterAbilityType::BR_COLD, "冷気%s", "frost%s", TERM_L_WHITE },
+        { MonsterAbilityType::BR_POIS, "毒%s", "poison%s", TERM_L_GREEN },
+        { MonsterAbilityType::BR_NETH, "地獄%s", "nether%s", TERM_L_DARK },
+        { MonsterAbilityType::BR_LITE, "閃光%s", "light%s", TERM_YELLOW },
+        { MonsterAbilityType::BR_DARK, "暗黒%s", "darkness%s", TERM_L_DARK },
+        { MonsterAbilityType::BR_CONF, "混乱%s", "confusion%s", TERM_L_UMBER },
+        { MonsterAbilityType::BR_SOUN, "轟音%s", "sound%s", TERM_ORANGE },
+        { MonsterAbilityType::BR_CHAO, "カオス%s", "chaos%s", TERM_VIOLET },
+        { MonsterAbilityType::BR_DISE, "劣化%s", "disenchantment%s", TERM_VIOLET },
+        { MonsterAbilityType::BR_NEXU, "因果混乱%s", "nexus%s", TERM_VIOLET },
+        { MonsterAbilityType::BR_TIME, "時間逆転%s", "time%s", TERM_L_BLUE },
+        { MonsterAbilityType::BR_INER, "遅鈍%s", "inertia%s", TERM_SLATE },
+        { MonsterAbilityType::BR_GRAV, "重力%s", "gravity%s", TERM_SLATE },
+        { MonsterAbilityType::BR_SHAR, "破片%s", "shards%s", TERM_L_UMBER },
+        { MonsterAbilityType::BR_PLAS, "プラズマ%s", "plasma%s", TERM_L_RED },
+        { MonsterAbilityType::BR_FORC, "フォース%s", "force%s", TERM_UMBER },
+        { MonsterAbilityType::BR_MANA, "魔力%s", "mana%s", TERM_L_BLUE },
+        { MonsterAbilityType::BR_NUKE, "放射性廃棄物%s", "nuke%s", TERM_L_GREEN },
+        { MonsterAbilityType::BR_DISI, "分解%s", "disintegration%s", TERM_SLATE },
+        { MonsterAbilityType::BR_VOID, "虚無%s", "void%s", TERM_L_DARK },
+        { MonsterAbilityType::BR_ABYSS, "深淵%s", "abyss%s", TERM_L_DARK },
+    };
+    return defs;
+}
+
+static const std::vector<AbilityCellDef> &attack_magic_defs()
+{
+    static const std::vector<AbilityCellDef> defs = {
+        // set_ball_types()
+        { MonsterAbilityType::BA_ACID, "酸球%s", "acid ball%s", TERM_GREEN },
+        { MonsterAbilityType::BA_ELEC, "雷球%s", "lightning ball%s", TERM_BLUE },
+        { MonsterAbilityType::BA_FIRE, "炎球%s", "fire ball%s", TERM_RED },
+        { MonsterAbilityType::BA_COLD, "冷球%s", "frost ball%s", TERM_L_WHITE },
+        { MonsterAbilityType::BA_POIS, "悪臭雲%s", "poison ball%s", TERM_L_GREEN },
+        { MonsterAbilityType::BA_NETH, "地獄球%s", "nether ball%s", TERM_L_DARK },
+        { MonsterAbilityType::BA_WATE, "水球%s", "water ball%s", TERM_BLUE },
+        { MonsterAbilityType::BA_NUKE, "放射能球%s", "balls of radiation%s", TERM_L_GREEN },
+        { MonsterAbilityType::BA_MANA, "魔力嵐%s", "mana storm%s", TERM_L_BLUE },
+        { MonsterAbilityType::BA_DARK, "暗黒嵐%s", "darkness storm%s", TERM_L_DARK },
+        { MonsterAbilityType::BA_LITE, "スターバースト%s", "star burst%s", TERM_YELLOW },
+        { MonsterAbilityType::BA_CHAO, "純ログルス%s", "logrus%s", TERM_VIOLET },
+        { MonsterAbilityType::BA_VOID, "虚無嵐%s", "void storm%s", TERM_L_DARK },
+        { MonsterAbilityType::BA_ABYSS, "深淵嵐%s", "abyss storm%s", TERM_L_DARK },
+        { MonsterAbilityType::BA_METEOR, "メテオスウォーム%s", "meteor swarm%s", TERM_UMBER },
+
+        // set_particular_types()
+        { MonsterAbilityType::HAND_DOOM, "破滅の手(40%-60%)", "the Hand of Doom(40%-60%)", TERM_VIOLET },
+        { MonsterAbilityType::PSY_SPEAR, "光の剣%s", "psycho-spear%s", TERM_YELLOW },
+        { MonsterAbilityType::DRAIN_MANA, "魔力吸収%s", "drain mana%s", TERM_SLATE },
+        { MonsterAbilityType::MIND_BLAST, "精神攻撃%s", "mind blasting%s", TERM_L_RED },
+        { MonsterAbilityType::BRAIN_SMASH, "脳攻撃%s", "brain smashing%s", TERM_RED },
+        { MonsterAbilityType::CAUSE_1, "軽傷%s", "light wounds%s", TERM_L_WHITE },
+        { MonsterAbilityType::CAUSE_2, "重傷%s", "serious wounds%s", TERM_L_WHITE },
+        { MonsterAbilityType::CAUSE_3, "致命傷%s", "critical wounds%s", TERM_L_WHITE },
+        { MonsterAbilityType::CAUSE_4, "秘孔%s", "mortal wounds%s", TERM_L_WHITE },
+
+        // set_bolt_types()
+        { MonsterAbilityType::BO_ACID, "酸矢%s", "acid bolt%s", TERM_GREEN },
+        { MonsterAbilityType::BO_ELEC, "雷矢%s", "lightning bolt%s", TERM_BLUE },
+        { MonsterAbilityType::BO_FIRE, "炎矢%s", "fire bolt%s", TERM_RED },
+        { MonsterAbilityType::BO_COLD, "冷矢%s", "frost bolt%s", TERM_L_WHITE },
+        { MonsterAbilityType::BO_NETH, "地獄矢%s", "nether bolt%s", TERM_L_DARK },
+        { MonsterAbilityType::BO_WATE, "水矢%s", "water bolt%s", TERM_BLUE },
+        { MonsterAbilityType::BO_MANA, "魔力矢%s", "mana bolt%s", TERM_L_BLUE },
+        { MonsterAbilityType::BO_PLAS, "プラズマ矢%s", "plasma bolt%s", TERM_L_RED },
+        { MonsterAbilityType::BO_ICEE, "極寒矢%s", "ice bolt%s", TERM_L_WHITE },
+        { MonsterAbilityType::BO_VOID, "虚無矢%s", "void bolt%s", TERM_L_DARK },
+        { MonsterAbilityType::BO_ABYSS, "深淵矢%s", "abyss bolt%s", TERM_L_DARK },
+        { MonsterAbilityType::BO_METEOR, "メテオストライク%s", "meteor strike%s", TERM_UMBER },
+        { MonsterAbilityType::BO_LITE, "スターライトアロー%s", "starlight arrow%s", TERM_YELLOW },
+        { MonsterAbilityType::MISSILE, "マジックミサイル%s", "magic missile%s", TERM_L_WHITE },
+    };
+    return defs;
+}
+
+static const std::vector<AbilityCellDef> &summon_magic_defs()
+{
+    static const std::vector<AbilityCellDef> defs = {
+        // set_summon_types()
+        { MonsterAbilityType::S_MONSTER, "モンスター一体", "a monster", TERM_SLATE },
+        { MonsterAbilityType::S_MONSTERS, "モンスター複数", "monsters", TERM_L_WHITE },
+        { MonsterAbilityType::S_KIN, "救援", "aid", TERM_ORANGE },
+        { MonsterAbilityType::S_ANT, "アリ", "ants", TERM_RED },
+        { MonsterAbilityType::S_SPIDER, "クモ", "spiders", TERM_L_DARK },
+        { MonsterAbilityType::S_HOUND, "ハウンド", "hounds", TERM_L_UMBER },
+        { MonsterAbilityType::S_HYDRA, "ヒドラ", "hydras", TERM_L_GREEN },
+        { MonsterAbilityType::S_ANGEL, "天使", "an angel", TERM_YELLOW },
+        { MonsterAbilityType::S_DEMON, "デーモン", "a demon", TERM_L_RED },
+        { MonsterAbilityType::S_UNDEAD, "アンデッド", "an undead", TERM_L_DARK },
+        { MonsterAbilityType::S_DRAGON, "ドラゴン", "a dragon", TERM_ORANGE },
+        { MonsterAbilityType::S_HI_UNDEAD, "強力なアンデッド", "Greater Undead", TERM_L_DARK },
+        { MonsterAbilityType::S_HI_DRAGON, "古代ドラゴン", "Ancient Dragons", TERM_ORANGE },
+        { MonsterAbilityType::S_CYBER, "サイバーデーモン", "Cyberdemons", TERM_UMBER },
+        { MonsterAbilityType::S_AMBERITES, "アンバーの王族", "Lords of Amber", TERM_VIOLET },
+        { MonsterAbilityType::S_UNIQUE, "ユニークモンスター", "Unique Monsters", TERM_VIOLET },
+        { MonsterAbilityType::S_DEAD_UNIQUE, "ユニークモンスター口寄せ", "animate Unique Monsters", TERM_VIOLET },
+    };
+    return defs;
+}
+
+static const std::vector<AbilityCellDef> &support_magic_defs()
+{
+    static const std::vector<AbilityCellDef> defs = {
+        // set_status_types()
+        { MonsterAbilityType::SCARE, "恐怖", "terrify", TERM_SLATE },
+        { MonsterAbilityType::BLIND, "目くらまし", "blind", TERM_L_DARK },
+        { MonsterAbilityType::CONF, "混乱", "confuse", TERM_L_UMBER },
+        { MonsterAbilityType::SLOW, "減速", "slow", TERM_UMBER },
+        { MonsterAbilityType::HOLD, "麻痺", "paralyze", TERM_RED },
+        { MonsterAbilityType::HASTE, "加速", "haste-self", TERM_L_GREEN },
+        { MonsterAbilityType::HEAL, "治癒", "heal-self", TERM_WHITE },
+        { MonsterAbilityType::INVULNER, "無敵化", "make invulnerable", TERM_WHITE },
+        { MonsterAbilityType::DISPEL, "魔力消去", "dispel-magic", TERM_L_WHITE },
+
+        // set_teleport_types()
+        { MonsterAbilityType::BLINK, "ショートテレポート", "blink-self", TERM_UMBER },
+        { MonsterAbilityType::TPORT, "テレポート", "teleport-self", TERM_ORANGE },
+        { MonsterAbilityType::WORLD, "時を止める", "stop time", TERM_L_BLUE },
+        { MonsterAbilityType::TELE_TO, "テレポートバック", "teleport to", TERM_L_UMBER },
+        { MonsterAbilityType::TELE_AWAY, "テレポートアウェイ", "teleport away", TERM_UMBER },
+        { MonsterAbilityType::TELE_LEVEL, "テレポート・レベル", "teleport level", TERM_ORANGE },
+
+        // set_floor_types()
+        { MonsterAbilityType::DARKNESS, "暗闇", "create darkness", TERM_L_DARK },
+        { MonsterAbilityType::TRAPS, "トラップ", "create traps", TERM_BLUE },
+        { MonsterAbilityType::FORGET, "記憶消去", "cause amnesia", TERM_BLUE },
+        { MonsterAbilityType::RAISE_DEAD, "死者復活", "raise dead", TERM_RED },
+    };
+    return defs;
+}
+} // namespace
+
+void display_monster_magic_rate(lore_type *lore_ptr)
+{
+    const bool fully_known = lore_ptr->know_everything || lore_ptr->is_details_known();
+    if (!fully_known && lore_ptr->r_ptr->r_ability_flags.none()) {
+        return;
+    }
+
+    hooked_roff(format(_("特技使用率:%s ", "AbilityRate:%s "), rate_tag(lore_ptr).c_str()));
+    hooked_roff(format(_("%s", "%s"), mind_tag(lore_ptr).c_str()));
+    hooked_roff("\n");
+}
+
+void display_monster_magic_tables(CreatureEntity &creature, lore_type *lore_ptr)
+{
+    const bool fully_known = lore_ptr->know_everything || lore_ptr->is_details_known();
+    if (!fully_known && lore_ptr->r_ptr->r_ability_flags.none()) {
+        return;
+    }
+
+    print_table(creature, lore_ptr, _("[発射] ", "[Launching] "), launch_defs());
+    print_table(creature, lore_ptr, _("[ブレス] ", "[Breath] "), breath_defs());
+    print_table(creature, lore_ptr, _("[攻撃魔法] ", "[Attack magic] "), attack_magic_defs());
+    print_table(creature, lore_ptr, _("[召喚魔法] ", "[Summon magic] "), summon_magic_defs());
+    print_table(creature, lore_ptr, _("[その他魔法] ", "[Other magic] "), support_magic_defs());
 }

--- a/src/view/display-lore-magics.h
+++ b/src/view/display-lore-magics.h
@@ -1,6 +1,9 @@
 #pragma once
 
 struct lore_type;
+class CreatureEntity;
 void display_monster_breath(lore_type *lore_ptr);
 void display_monster_magic_types(lore_type *lore_ptr);
 void display_mosnter_magic_possibility(lore_type *lore_ptr);
+void display_monster_magic_rate(lore_type *lore_ptr);
+void display_monster_magic_tables(CreatureEntity &creature, lore_type *lore_ptr);

--- a/src/view/display-lore-status.cpp
+++ b/src/view/display-lore-status.cpp
@@ -7,6 +7,8 @@
 #include "system/creature-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "term/term-color-types.h"
+#include <tl/optional.hpp>
+#include <vector>
 
 void display_monster_hp_ac(lore_type *lore_ptr)
 {
@@ -26,6 +28,31 @@ void display_monster_hp_ac(lore_type *lore_ptr)
         hooked_roff(format(
             _(" %s の体力がある。", " and a life rating of %s.  "), hit_dice.to_string().data()));
     }
+}
+
+void display_monster_hp_ac_summary(lore_type *lore_ptr)
+{
+    if (!lore_ptr->is_details_known() && !lore_ptr->know_everything) {
+        hooked_roff(_("最大HP:???  AC:??? ",
+            "MaxHP:???  AC:??? "));
+        return;
+    }
+
+    std::string hp_text;
+    if (lore_ptr->misc_flags.has(MonsterMiscType::FORCE_MAXHP) || (lore_ptr->r_ptr->hit_dice.sides == 1)) {
+        auto hp = lore_ptr->r_ptr->hit_dice.maxroll() * (lore_ptr->nightmare ? 2 : 1);
+        hp_text = format("%d", std::min(MONSTER_MAXHP, hp));
+    } else {
+        auto hit_dice = lore_ptr->r_ptr->hit_dice;
+        if (lore_ptr->nightmare) {
+            hit_dice.num *= 2;
+        }
+        hp_text = hit_dice.to_string().data();
+    }
+
+    const auto ac = lore_ptr->r_ptr->ac;
+
+    hooked_roff(format(_("最大HP:%s AC:%d ", "MaxHP:%s AC:%d "), hp_text.data(), ac));
 }
 
 void display_monster_concrete_abilities(lore_type *lore_ptr)
@@ -351,6 +378,20 @@ void display_monster_resistances(lore_type *lore_ptr)
     hooked_roff(_("の耐性を持っている。", ".  "));
 }
 
+void display_monster_evolution_summary(lore_type *lore_ptr)
+{
+    if (!lore_ptr->r_ptr->r_can_evolve && !lore_ptr->know_everything) {
+        return;
+    }
+
+    const auto &monrace_next = lore_ptr->r_ptr->get_next();
+    if (monrace_next.is_valid()) {
+        hooked_roff(format(_("進化:%s ", "evolve:%s "), monrace_next.name.data()));
+    } else if (lore_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
+        hooked_roff(_("進化:なし ", "evolve:none "));
+    }
+}
+
 void display_monster_evolution(lore_type *lore_ptr)
 {
     if (!lore_ptr->r_ptr->r_can_evolve && !lore_ptr->know_everything) {
@@ -422,6 +463,18 @@ void display_monster_immunities(lore_type *lore_ptr)
     hooked_roff(_("。", ".  "));
 }
 
+void display_monster_alert_summary(lore_type *lore_ptr)
+{
+    auto alert = ((int)lore_ptr->r_ptr->r_wake * (int)lore_ptr->r_ptr->r_wake) > lore_ptr->r_ptr->sleep;
+    alert |= lore_ptr->r_ptr->r_ignore == MAX_UCHAR;
+    alert |= (lore_ptr->r_ptr->sleep == 0) && (lore_ptr->r_ptr->r_tkills >= 10);
+    alert |= lore_ptr->know_everything;
+    if (!alert) {
+        return;
+    }
+    hooked_roff(format(_("警戒度:%d/255 感知範囲:%dft ", "alertness:%d notice:%dft"), 255 - lore_ptr->r_ptr->sleep, 10 * lore_ptr->r_ptr->aaf));
+}
+
 void display_monster_alert(lore_type *lore_ptr)
 {
     auto alert = ((int)lore_ptr->r_ptr->r_wake * (int)lore_ptr->r_ptr->r_wake) > lore_ptr->r_ptr->sleep;
@@ -461,4 +514,414 @@ void display_monster_alert(lore_type *lore_ptr)
     const auto who = Who::who(lore_ptr->msex);
     hooked_roff(_(format(fmt, who.data(), action.data(), 10 * lore_ptr->r_ptr->aaf),
         format(fmt, who.data(), action.data(), who.data(), 10 * lore_ptr->r_ptr->aaf)));
+}
+
+static void push_tag(std::vector<std::string> &tags, const char *msg)
+{
+    tags.emplace_back(msg);
+}
+
+void display_monster_behavior_summary(lore_type *lore_ptr)
+{
+    if (!lore_ptr->is_details_known() && !lore_ptr->know_everything && lore_ptr->lore_msgs.empty()) {
+        return;
+    }
+    std::vector<std::string> tags;
+    // --- behavior_flags (MonsterBehaviorType) ---
+    const auto &bf = lore_ptr->behavior_flags;
+    if (bf.has(MonsterBehaviorType::NEVER_MOVE)) {
+        push_tag(tags, _("不動", "NEVER_MOVE"));
+    }
+    if (bf.has(MonsterBehaviorType::OPEN_DOOR)) {
+        push_tag(tags, _("扉開", "OPEN_DOOR"));
+    }
+    if (bf.has(MonsterBehaviorType::BASH_DOOR)) {
+        push_tag(tags, _("扉壊", "BASH_DOOR"));
+    }
+    if (bf.has(MonsterBehaviorType::MOVE_BODY)) {
+        push_tag(tags, _("他者移動", "MOVE_BODY"));
+    }
+    if (bf.has(MonsterBehaviorType::KILL_BODY)) {
+        push_tag(tags, _("他者攻撃", "KILL_BODY"));
+    }
+    if (bf.has(MonsterBehaviorType::TAKE_ITEM)) {
+        push_tag(tags, _("アイテム拾得", "TAKE_ITEM"));
+    }
+    if (bf.has(MonsterBehaviorType::KILL_ITEM)) {
+        push_tag(tags, _("アイテム破壊", "KILL_ITEM"));
+    }
+    if (bf.has(MonsterBehaviorType::RAND_MOVE_25) && bf.has(MonsterBehaviorType::RAND_MOVE_50)) {
+        push_tag(tags, _("乱歩75", "RAND_MOVE_75"));
+    } else {
+        if (bf.has(MonsterBehaviorType::RAND_MOVE_25)) {
+            push_tag(tags, _("乱歩25", "RAND_MOVE_25"));
+        }
+        if (bf.has(MonsterBehaviorType::RAND_MOVE_50)) {
+            push_tag(tags, _("乱歩50", "RAND_MOVE_50"));
+        }
+    }
+    if (bf.has(MonsterBehaviorType::FRIENDLY)) {
+        push_tag(tags, _("友好", "FRIENDLY"));
+    }
+
+    const auto &mf = lore_ptr->misc_flags;
+    if (mf.has(MonsterMiscType::FORCE_DEPTH)) {
+        push_tag(tags, _("深度固定", "FORCE_DEPTH"));
+    }
+    if (mf.has(MonsterMiscType::HAS_FRIENDS)) {
+        push_tag(tags, _("群体", "HAS_FRIENDS"));
+    }
+    if (mf.has(MonsterMiscType::ESCORT)) {
+        push_tag(tags, _("護衛", "ESCORT"));
+    }
+    if (mf.has(MonsterMiscType::MORE_ESCORT)) {
+        push_tag(tags, _("護衛多", "MORE_ESCORT"));
+    }
+    if (mf.has(MonsterMiscType::RIDING)) {
+        push_tag(tags, _("乗馬可", "RIDING"));
+    }
+    if (mf.has(MonsterMiscType::INVISIBLE)) {
+        push_tag(tags, _("透明", "INVISIBLE"));
+    }
+    if (mf.has(MonsterMiscType::COLD_BLOOD)) {
+        push_tag(tags, _("冷血", "COLD_BLOOD"));
+    }
+    if (mf.has(MonsterMiscType::KAGE)) {
+        push_tag(tags, _("影", "KAGE"));
+    }
+    if (mf.has(MonsterMiscType::CHAMELEON)) {
+        push_tag(tags, _("変身", "CHAMELEON"));
+    }
+    if (mf.has(MonsterMiscType::TANUKI)) {
+        push_tag(tags, _("狸", "TANUKI"));
+    }
+    if (mf.has(MonsterMiscType::ELDRITCH_HORROR)) {
+        push_tag(tags, _("狂気", "ELDRITCH_HORROR"));
+    }
+    if (mf.has(MonsterMiscType::MULTIPLY)) {
+        push_tag(tags, _("増殖", "MULTIPLY"));
+    }
+    if (mf.has(MonsterMiscType::REGENERATE)) {
+        push_tag(tags, _("再生", "REGENERATE"));
+    }
+    if (mf.has(MonsterMiscType::EMPTY_MIND)) {
+        push_tag(tags, _("精神無", "EMPTY_MIND"));
+    }
+    if (mf.has(MonsterMiscType::WEIRD_MIND)) {
+        push_tag(tags, _("精神歪", "WEIRD_MIND"));
+    }
+
+    const auto &ff = lore_ptr->feature_flags;
+    if (ff.has(MonsterFeatureType::AQUATIC)) {
+        push_tag(tags, _("水棲", "AQUATIC"));
+    }
+    if (ff.has(MonsterFeatureType::CAN_SWIM)) {
+        push_tag(tags, _("水渡", "CAN_SWIM"));
+    }
+    if (ff.has(MonsterFeatureType::CAN_FLY)) {
+        push_tag(tags, _("飛行", "CAN_FLY"));
+    }
+    if (ff.has(MonsterFeatureType::PASS_WALL)) {
+        push_tag(tags, _("壁抜け", "PASS_WALL"));
+    }
+    if (ff.has(MonsterFeatureType::KILL_WALL)) {
+        push_tag(tags, _("壁破壊", "KILL_WALL"));
+    }
+    if (tags.empty()) {
+        return;
+    }
+    hooked_roff(_("[特性] ", "[Traits] "));
+
+    for (auto &[msg, color] : lore_ptr->lore_msgs) {
+        hook_c_roff(color, msg);
+    }
+    for (size_t i = 0; i < tags.size(); i++) {
+        if (i > 0) {
+            hooked_roff(" | ");
+        }
+        hooked_roff(tags[i]);
+    }
+    hooked_roff("\n");
+    lore_ptr->lore_msgs.clear();
+}
+
+namespace {
+struct ResistGroupDef {
+    tl::optional<MonsterResistanceType> weak;
+    tl::optional<MonsterResistanceType> resist;
+    tl::optional<MonsterResistanceType> immune;
+
+    const char *jp_weak;
+    const char *jp_resist;
+    const char *jp_immune;
+
+    const char *en_weak;
+    const char *en_resist;
+    const char *en_immune;
+
+    byte color_weak;
+    byte color_resist;
+    byte color_immune;
+};
+
+static void roff_cell(byte color, std::string_view s, int width)
+{
+    std::string out = format("%-*s", width, s.data());
+    hook_c_roff(color, out);
+}
+
+static constexpr byte RES_UNKNOWN_COLOR = TERM_SLATE; // ??? の灰色
+static constexpr byte RES_ABSENT_COLOR = TERM_SLATE; // --- の灰色
+
+enum class GroupStateKind { WEAK,
+    RESIST,
+    IMMUNE,
+    ABSENT,
+    UNKNOWN };
+
+struct GroupState {
+    GroupStateKind kind;
+    std::string_view label; // 出す文字列（JP or EN）
+    byte color;
+};
+
+static GroupState get_group_state(const lore_type *lore_ptr, const ResistGroupDef &d)
+{
+    const bool fully_known = lore_ptr->know_everything || lore_ptr->is_details_known();
+    const auto &flags = fully_known ? lore_ptr->r_ptr->resistance_flags : lore_ptr->r_ptr->r_resistance_flags;
+
+    if (d.immune) {
+        const auto no_teleport = d.immune.value() == MonsterResistanceType::RESIST_TELEPORT && lore_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
+        const auto other_flag = d.immune.value() != MonsterResistanceType::RESIST_TELEPORT;
+        const auto no_inst_death = d.immune.value() == MonsterResistanceType::NO_INSTANTLY_DEATH && lore_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
+        if ((no_teleport || other_flag) && (flags.has(d.immune.value()) || no_inst_death)) {
+            return { GroupStateKind::IMMUNE, _(d.jp_immune, d.en_immune), d.color_immune };
+        }
+    }
+
+    if (d.resist) {
+        const auto res_teleport = d.resist.value() == MonsterResistanceType::RESIST_TELEPORT && lore_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE);
+        const auto other_flag = d.resist.value() != MonsterResistanceType::RESIST_TELEPORT;
+        if ((res_teleport || other_flag) && flags.has(d.resist.value())) {
+            return { GroupStateKind::RESIST, _(d.jp_resist, d.en_resist), d.color_resist };
+        }
+    }
+
+    if (d.weak) {
+        if (flags.has(d.weak.value())) {
+            return { GroupStateKind::WEAK, _(d.jp_weak, d.en_weak), d.color_weak };
+        }
+    }
+
+    if (fully_known) {
+        return { GroupStateKind::ABSENT, "------", RES_ABSENT_COLOR };
+    }
+
+    return { GroupStateKind::UNKNOWN, "??????", RES_UNKNOWN_COLOR };
+}
+
+static const std::vector<ResistGroupDef> &resist_group_defs()
+{
+    static const std::vector<ResistGroupDef> defs = {
+        // 酸
+        { MonsterResistanceType::HURT_ACID, MonsterResistanceType::RESIST_ACID, MonsterResistanceType::IMMUNE_ACID,
+            "酸弱点", "酸耐性", "酸免疫", "HURT_ACID", "RESIST_ACID", "IMMUNE_ACID",
+            TERM_L_RED, TERM_GREEN, TERM_GREEN },
+
+        // 電撃
+        { MonsterResistanceType::HURT_ELEC, MonsterResistanceType::RESIST_ELEC, MonsterResistanceType::IMMUNE_ELEC,
+            "電弱点", "電耐性", "電免疫", "HURT_ELEC", "RESIST_ELEC", "IMMUNE_ELEC",
+            TERM_L_RED, TERM_BLUE, TERM_BLUE },
+
+        // 火炎
+        { MonsterResistanceType::HURT_FIRE, MonsterResistanceType::RESIST_FIRE, MonsterResistanceType::IMMUNE_FIRE,
+            "火弱点", "火耐性", "火免疫", "HURT_FIRE", "RESIST_FIRE", "IMMUNE_FIRE",
+            TERM_L_RED, TERM_RED, TERM_RED },
+
+        // 冷気
+        { MonsterResistanceType::HURT_COLD, MonsterResistanceType::RESIST_COLD, MonsterResistanceType::IMMUNE_COLD,
+            "冷弱点", "冷耐性", "冷免疫", "HURT_COLD", "RESIST_COLD", "IMMUNE_COLD",
+            TERM_L_RED, TERM_L_WHITE, TERM_L_WHITE },
+
+        // 毒
+        { MonsterResistanceType::HURT_POISON, MonsterResistanceType::RESIST_POISON, MonsterResistanceType::IMMUNE_POISON,
+            "毒弱点", "毒耐性", "毒免疫", "HURT_POISON", "RESIST_POISON", "IMMUNE_POISON",
+            TERM_L_RED, TERM_L_GREEN, TERM_L_GREEN },
+
+        // 閃光
+        { MonsterResistanceType::HURT_LITE, MonsterResistanceType::RESIST_LITE, tl::nullopt,
+            "閃光弱点", "閃光耐性", "閃光免疫", "HURT_LITE", "RESIST_LITE", "IMMUNE_LITE",
+            TERM_L_RED, TERM_YELLOW, TERM_YELLOW },
+
+        // 暗黒
+        { MonsterResistanceType::HURT_DARK, MonsterResistanceType::RESIST_DARK, tl::nullopt,
+            "暗黒弱点", "暗黒耐性", "暗黒免疫", "HURT_DARK", "RESIST_DARK", "IMMUNE_DARK",
+            TERM_L_RED, TERM_L_DARK, TERM_L_DARK },
+
+        // 地獄
+        { MonsterResistanceType::HURT_NETHER, MonsterResistanceType::RESIST_NETHER, tl::nullopt,
+            "地獄弱点", "地獄耐性", "地獄免疫", "HURT_NETHER", "RESIST_NETHER", "IMMUNE_NETHER",
+            TERM_L_RED, TERM_L_DARK, TERM_L_DARK },
+
+        // 水
+        { MonsterResistanceType::HURT_WATER, MonsterResistanceType::RESIST_WATER, tl::nullopt,
+            "水弱点", "水耐性", "水免疫", "HURT_WATER", "RESIST_WATER", "IMMUNE_WATER",
+            TERM_L_RED, TERM_BLUE, TERM_BLUE },
+
+        // プラズマ
+        { MonsterResistanceType::HURT_PLASMA, MonsterResistanceType::RESIST_PLASMA, tl::nullopt,
+            "プラズマ弱点", "プラズマ耐性", "プラズマ免疫", "HURT_PLASMA", "RESIST_PLASMA", "IMMUNE_PLASMA",
+            TERM_L_RED, TERM_L_RED, TERM_L_RED },
+
+        // 破片
+        { MonsterResistanceType::HURT_SHARDS, MonsterResistanceType::RESIST_SHARDS, tl::nullopt,
+            "破片弱点", "破片耐性", "破片免疫", "HURT_SHARDS", "RESIST_SHARDS", "IMMUNE_SHARDS",
+            TERM_L_RED, TERM_L_UMBER, TERM_L_UMBER },
+
+        // 轟音
+        { MonsterResistanceType::HURT_SOUND, MonsterResistanceType::RESIST_SOUND, tl::nullopt,
+            "轟音弱点", "轟音耐性", "轟音免疫", "HURT_SOUND", "RESIST_SOUND", "IMMUNE_SOUND",
+            TERM_L_RED, TERM_ORANGE, TERM_ORANGE },
+
+        // カオス
+        { MonsterResistanceType::HURT_CHAOS, MonsterResistanceType::RESIST_CHAOS, tl::nullopt,
+            "混沌弱点", "混沌耐性", "混沌免疫", "HURT_CHAOS", "RESIST_CHAOS", "IMMUNE_CHAOS",
+            TERM_L_RED, TERM_VIOLET, TERM_VIOLET },
+
+        // 因果
+        { MonsterResistanceType::HURT_NEXUS, MonsterResistanceType::RESIST_NEXUS, tl::nullopt,
+            "因混弱点", "因混耐性", "因混免疫", "HURT_NEXUS", "RESIST_NEXUS", "IMMUNE_NEXUS",
+            TERM_L_RED, TERM_VIOLET, TERM_VIOLET },
+
+        // 劣化
+        { MonsterResistanceType::HURT_DISENCHANT, MonsterResistanceType::RESIST_DISENCHANT, tl::nullopt,
+            "劣化弱点", "劣化耐性", "劣化免疫", "HURT_DISENCHANT", "RESIST_DISENCHANT", "IMMUNE_DISENCHANT",
+            TERM_L_RED, TERM_VIOLET, TERM_VIOLET },
+
+        // フォース
+        { MonsterResistanceType::HURT_FORCE, MonsterResistanceType::RESIST_FORCE, tl::nullopt,
+            "フォース弱点", "フォース耐性", "フォース免疫", "HURT_FORCE", "RESIST_FORCE", "IMMUNE_FORCE",
+            TERM_L_RED, TERM_UMBER, TERM_UMBER },
+
+        // 遅鈍（INERTIA）
+        { MonsterResistanceType::HURT_INERTIA, MonsterResistanceType::RESIST_INERTIA, tl::nullopt,
+            "遅鈍弱点", "遅鈍耐性", "遅鈍免疫", "HURT_INERTIA", "RESIST_INERTIA", "IMMUNE_INERTIA",
+            TERM_L_RED, TERM_SLATE, TERM_SLATE },
+
+        // 時間
+        { MonsterResistanceType::HURT_TIME, MonsterResistanceType::RESIST_TIME, tl::nullopt,
+            "時間逆転弱点", "時間逆転耐性", "時間逆転免疫", "HURT_TIME", "RESIST_TIME", "IMMUNE_TIME",
+            TERM_L_RED, TERM_L_BLUE, TERM_L_BLUE },
+
+        // 重力
+        { MonsterResistanceType::HURT_GRAVITY, MonsterResistanceType::RESIST_GRAVITY, tl::nullopt,
+            "重力弱点", "重力耐性", "重力免疫", "HURT_GRAVITY", "RESIST_GRAVITY", "IMMUNE_GRAVITY",
+            TERM_L_RED, TERM_SLATE, TERM_SLATE },
+
+        // 岩
+        { MonsterResistanceType::HURT_ROCK, MonsterResistanceType::RESIST_ROCK, tl::nullopt,
+            "岩石溶解弱点", "岩石溶解耐性", "岩石溶解免疫", "HURT_ROCK", "RESIST_ROCK", "IMMUNE_ROCK",
+            TERM_L_RED, TERM_UMBER, TERM_UMBER },
+
+        // 深淵
+        { MonsterResistanceType::HURT_ABYSS, MonsterResistanceType::RESIST_ABYSS, tl::nullopt,
+            "深淵弱点", "深淵耐性", "深淵免疫", "HURT_ABYSS", "RESIST_ABYSS", "IMMUNE_ABYSS",
+            TERM_L_RED, TERM_L_DARK, TERM_L_DARK },
+
+        // 虚無魔法
+        { MonsterResistanceType::HURT_VOID_MAGIC, MonsterResistanceType::RESIST_VOID_MAGIC, tl::nullopt,
+            "虚無弱点", "虚無耐性", "虚無免疫", "HURT_VOID_MAGIC", "RESIST_VOID_MAGIC", "IMMUNE_VOID_MAGIC",
+            TERM_L_RED, TERM_VIOLET, TERM_VIOLET },
+
+        // 隕石
+        { MonsterResistanceType::HURT_METEOR, MonsterResistanceType::RESIST_METEOR, tl::nullopt,
+            "隕石弱点", "隕石耐性", "隕石石免", "HURT_METEOR", "RESIST_METEOR", "IMMUNE_METEOR",
+            TERM_L_RED, TERM_UMBER, TERM_UMBER },
+
+        // 恐怖
+        { tl::nullopt, tl::nullopt, MonsterResistanceType::NO_FEAR,
+            "---", "---", "恐怖無効", "---", "---", "NO_FEAR",
+            TERM_SLATE, TERM_SLATE, TERM_SLATE },
+
+        // 朦朧
+        { tl::nullopt, tl::nullopt, MonsterResistanceType::NO_STUN,
+            "---", "---", "朦朧無効", "---", "---", "NO_STUN",
+            TERM_ORANGE, TERM_ORANGE, TERM_ORANGE },
+
+        // 混乱
+        { tl::nullopt, tl::nullopt, MonsterResistanceType::NO_CONF,
+            "---", "---", "混乱無効", "---", "---", "NO_CONF",
+            TERM_L_UMBER, TERM_L_UMBER, TERM_L_UMBER },
+
+        // 睡眠
+        { tl::nullopt, tl::nullopt, MonsterResistanceType::NO_SLEEP,
+            "---", "---", "睡眠無効", "---", "---", "NO_SLEEP",
+            TERM_BLUE, TERM_BLUE, TERM_BLUE },
+
+        // テレポート耐性
+        { tl::nullopt, MonsterResistanceType::RESIST_TELEPORT, MonsterResistanceType::RESIST_TELEPORT,
+            "---", "テレポート耐性", "テレポート無効", "---", "RESIST_TELEPORT", "NO_TELEPORT",
+            TERM_ORANGE, TERM_ORANGE, TERM_ORANGE },
+
+        // 即死無効
+        { tl::nullopt, tl::nullopt, MonsterResistanceType::NO_INSTANTLY_DEATH,
+            "---", "---", "即死無効", "---", "---", "NO_INST_DEATH",
+            TERM_L_DARK, TERM_L_DARK, TERM_L_DARK },
+
+        // 全攻撃無効
+        { tl::nullopt, tl::nullopt, MonsterResistanceType::RESIST_ALL,
+            "---", "---", "全攻撃無効", "---", "---", "RESIST_ALL",
+            TERM_YELLOW, TERM_YELLOW, TERM_YELLOW },
+    };
+    return defs;
+}
+} // namespace
+
+void display_monster_resistance_table(lore_type *lore_ptr)
+{
+    const auto see_reflecting = lore_ptr->r_ptr->r_misc_flags.has(MonsterMiscType::REFLECTING);
+    const bool fully_known = lore_ptr->know_everything || lore_ptr->is_details_known();
+
+    if (!fully_known && lore_ptr->r_ptr->r_resistance_flags.none() && !see_reflecting) {
+        return;
+    }
+
+    const int COL_NUM = _(8, 5);
+    const int CELL_WIDTH = _(6, 14);
+
+    hooked_roff(_("[耐性] ", "[Resists] "));
+
+    if (fully_known) {
+        if (lore_ptr->r_ptr->misc_flags.has(MonsterMiscType::REFLECTING)) {
+            hook_c_roff(TERM_L_WHITE, _("反射 ", "REFLECTING "));
+        } else {
+            hook_c_roff(RES_ABSENT_COLOR, "------ ");
+        }
+    } else {
+        if (see_reflecting) {
+            hook_c_roff(TERM_L_WHITE, _("反射 ", "REFLECTING "));
+        } else {
+            hook_c_roff(RES_UNKNOWN_COLOR, "?????? ");
+        }
+    }
+
+    int col = 0;
+    for (const auto &d : resist_group_defs()) {
+        if (col != 0) {
+            hooked_roff(" ");
+        }
+
+        const auto st = get_group_state(lore_ptr, d);
+        roff_cell(st.color, st.label, CELL_WIDTH);
+
+        col++;
+        if (col >= COL_NUM) {
+            hooked_roff("\n");
+            col = 0;
+        }
+    }
+
+    if (col != 0) {
+        hooked_roff("\n");
+    }
 }

--- a/src/view/display-lore-status.h
+++ b/src/view/display-lore-status.h
@@ -2,6 +2,7 @@
 
 struct lore_type;
 void display_monster_hp_ac(lore_type *lore_ptr);
+void display_monster_hp_ac_summary(lore_type *lore_ptr);
 void display_monster_concrete_abilities(lore_type *lore_ptr);
 void display_monster_abilities(lore_type *lore_ptr);
 void display_monster_constitutions(lore_type *lore_ptr);
@@ -9,7 +10,11 @@ void display_monster_concrete_weakness(lore_type *lore_ptr);
 void display_monster_weakness(lore_type *lore_ptr);
 void display_monster_concrete_resistances(lore_type *lore_ptr);
 void display_monster_resistances(lore_type *lore_ptr);
+void display_monster_evolution_summary(lore_type *lore_ptr);
 void display_monster_evolution(lore_type *lore_ptr);
 void display_monster_concrete_immunities(lore_type *lore_ptr);
 void display_monster_immunities(lore_type *lore_ptr);
+void display_monster_alert_summary(lore_type *lore_ptr);
 void display_monster_alert(lore_type *lore_ptr);
+void display_monster_behavior_summary(lore_type *lore_ptr);
+void display_monster_resistance_table(lore_type *lore_ptr);

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -218,6 +218,21 @@ void display_kill_numbers(lore_type *lore_ptr)
     hooked_roff("\n");
 }
 
+void display_where_to_appear_summary(lore_type *lore_ptr)
+{
+    if (lore_ptr->r_ptr->level == 0) {
+        hooked_roff(_("出現:町 ", "live:town "));
+        lore_ptr->old = true;
+    } else if (lore_ptr->r_ptr->r_tkills || lore_ptr->know_everything) {
+        if (depth_in_feet) {
+            hooked_roff(format(
+                _("出現:%d フィート ", "depth:%d ft "), lore_ptr->r_ptr->level * 50));
+        } else {
+            hooked_roff(format(_("出現:%d階 ", "depth:%d F "), lore_ptr->r_ptr->level));
+        }
+    }
+}
+
 /*!
  * @brief どこに出没するかを表示する
  * @param lore_ptr モンスターの思い出構造体への参照ポインタ
@@ -255,6 +270,14 @@ bool display_where_to_appear(lore_type *lore_ptr)
     return true;
 }
 
+void display_monster_speed_summary(lore_type *lore_ptr)
+{
+    const int speed = lore_ptr->speed - STANDARD_SPEED;
+    const auto speed_color = lore_ptr->get_speed_color();
+
+    hook_c_roff(speed_color, format(_("速度:%+d ", "speed:%+d "), speed));
+}
+
 void display_monster_move(lore_type *lore_ptr)
 {
     for (const auto &[text, color] : lore_ptr->build_speed_description()) {
@@ -276,6 +299,100 @@ void display_monster_never_move(lore_type *lore_ptr)
     }
 
     hooked_roff(_("侵入者を追跡しない", "does not deign to chase intruders"));
+}
+
+void display_monster_exp_summary(lore_type *lore_ptr)
+{
+    if ((lore_ptr->r_ptr->r_tkills == 0) && !lore_ptr->know_everything) {
+        hooked_roff(_("経験:??? ", "Exp:??? "));
+        return;
+    }
+    hooked_roff(format(_("経験:%d ", "Exp:%d "), lore_ptr->r_ptr->mexp));
+}
+
+void display_monster_kills_summary(lore_type *lore_ptr)
+{
+    if (lore_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
+        if (lore_ptr->r_ptr->r_pkills == 0) {
+            hook_c_roff(TERM_L_GREEN, _("生存 ", "alive "));
+            return;
+        }
+
+        hook_c_roff(TERM_RED, _("死亡 ", "dead "));
+        return;
+    }
+
+    hooked_roff(format(_("殺:%d ", "kill:%d "), lore_ptr->r_ptr->r_pkills));
+
+    if (!lore_ptr->r_ptr->population_flags.has(MonsterPopulationType::NAZGUL)) {
+        return;
+    }
+    hooked_roff(format(_("残:%d ", "remain:%d "), lore_ptr->r_ptr->max_num));
+}
+
+void display_monster_kind_tags(lore_type *lore_ptr)
+{
+    if (lore_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
+        hooked_roff(_("[ユニーク]", "[UNIQ]"));
+    }
+
+    if (lore_ptr->misc_flags.has(MonsterMiscType::ELDRITCH_HORROR)) {
+        hook_c_roff(TERM_VIOLET, _("[狂気]", "[sanity-blasting]"));
+    }
+
+    if (lore_ptr->kind_flags.has(MonsterKindType::ANIMAL)) {
+        hook_c_roff(TERM_L_GREEN, _("[自然界]", "[natural]"));
+    }
+
+    if (lore_ptr->kind_flags.has(MonsterKindType::EVIL)) {
+        hook_c_roff(TERM_L_DARK, _("[邪悪]", "[evil]"));
+    }
+
+    if (lore_ptr->kind_flags.has(MonsterKindType::GOOD)) {
+        hook_c_roff(TERM_YELLOW, _("[善良]", "[good]"));
+    }
+
+    if (lore_ptr->kind_flags.has(MonsterKindType::UNDEAD)) {
+        hook_c_roff(TERM_VIOLET, _("[アンデッド]", "[undead]"));
+    }
+
+    if (lore_ptr->kind_flags.has(MonsterKindType::AMBERITE)) {
+        hook_c_roff(TERM_VIOLET, _("[アンバー]", "[Amberite]"));
+    }
+
+    if (lore_ptr->kind_flags.has(MonsterKindType::DRAGON)) {
+        hook_c_roff(TERM_ORANGE, _("[ドラゴン]", "[dragon]"));
+    }
+
+    if (lore_ptr->kind_flags.has(MonsterKindType::DEMON)) {
+        hook_c_roff(TERM_VIOLET, _("[デーモン]", "[demon]"));
+    }
+
+    if (lore_ptr->kind_flags.has(MonsterKindType::GIANT)) {
+        hook_c_roff(TERM_L_UMBER, _("[巨人]", "[giant]"));
+    }
+
+    if (lore_ptr->kind_flags.has(MonsterKindType::TROLL)) {
+        hook_c_roff(TERM_BLUE, _("[トロル]", "[troll]"));
+    }
+
+    if (lore_ptr->kind_flags.has(MonsterKindType::ORC)) {
+        hook_c_roff(TERM_UMBER, _("[オーク]", "[orc]"));
+    }
+
+    if (lore_ptr->kind_flags.has(MonsterKindType::HUMAN)) {
+        hook_c_roff(TERM_L_WHITE, _("[人間]", "[human]"));
+    }
+
+    if (lore_ptr->kind_flags.has(MonsterKindType::QUANTUM)) {
+        hook_c_roff(TERM_VIOLET, _("[量子生物]", "[quantum]"));
+    }
+
+    if (lore_ptr->kind_flags.has(MonsterKindType::ANGEL)) {
+        hook_c_roff(TERM_YELLOW, _("[天使]", "[angel]"));
+    }
+
+    hooked_roff("\n");
 }
 
 void display_monster_kind(lore_type *lore_ptr)
@@ -1079,6 +1196,29 @@ void display_monster_exp(CreatureEntity &creature, lore_type *lore_ptr)
 
     hooked_roff(format(" for a%s %d%s level character.  ", vowel, creature.level, ordinal));
 #endif
+}
+
+void set_monster_aura_summary(lore_type *lore_ptr)
+{
+    auto has_fire_aura = lore_ptr->aura_flags.has(MonsterAuraType::FIRE);
+    auto has_cold_aura = lore_ptr->aura_flags.has(MonsterAuraType::COLD);
+    auto has_elec_aura = lore_ptr->aura_flags.has(MonsterAuraType::ELEC);
+
+    if (has_fire_aura || has_elec_aura || has_cold_aura) {
+        lore_ptr->lore_msgs.emplace_back(_("オーラ:", "aura:"), TERM_WHITE);
+    }
+    if (has_fire_aura) {
+        lore_ptr->lore_msgs.emplace_back(_("炎", "fire"), TERM_RED);
+    }
+    if (has_cold_aura) {
+        lore_ptr->lore_msgs.emplace_back(_("氷", "cold"), TERM_BLUE);
+    }
+    if (has_elec_aura) {
+        lore_ptr->lore_msgs.emplace_back(_("電", "elec"), TERM_L_BLUE);
+    }
+    if (has_fire_aura || has_elec_aura || has_cold_aura) {
+        lore_ptr->lore_msgs.emplace_back(" | ", TERM_WHITE);
+    }
 }
 
 void display_monster_aura(lore_type *lore_ptr)

--- a/src/view/display-lore.h
+++ b/src/view/display-lore.h
@@ -11,12 +11,18 @@ void screen_roff(CreatureEntity &creature, MonraceId r_idx, monster_lore_mode mo
 void display_roff(CreatureEntity &creature);
 void output_monster_spoiler(MonraceId r_idx, hook_c_roff_pf roff_func);
 void display_kill_numbers(lore_type *lore_ptr);
+void display_where_to_appear_summary(lore_type *lore_ptr);
 bool display_where_to_appear(lore_type *lore_ptr);
+void display_monster_speed_summary(lore_type *lore_ptr);
 void display_monster_move(lore_type *lore_ptr);
 void display_monster_never_move(lore_type *lore_ptr);
+void display_monster_exp_summary(lore_type *lore_ptr);
+void display_monster_kills_summary(lore_type *lore_ptr);
+void display_monster_kind_tags(lore_type *lore_ptr);
 void display_monster_kind(lore_type *lore_ptr);
 void display_monster_alignment(lore_type *lore_ptr);
 void display_monster_exp(CreatureEntity &creature, lore_type *lore_ptr);
+void set_monster_aura_summary(lore_type *lore_ptr);
 void display_monster_aura(lore_type *lore_ptr);
 void display_lore_this(CreatureEntity &creature, lore_type *lore_ptr);
 void display_monster_collective(lore_type *lore_ptr);


### PR DESCRIPTION
変愚蛮怒 PR #5312 (dis-/feature/add_monster_lore_summary) を bakabakaband 構造に適応してマージ。

上流コミット: 4a56a5a40 (hengband/develop)

モンスターの思い出表記に無機質かつ視認性の良い要約モードを追加。
テキスト表示オプション「モンスターの思い出を要約表記にする」
(show_lore_summary) から切り替え可能。

主な変更:
- src/view/display-lore-attacks.cpp: 要約モードの打撃表を追加 (display_monster_melee_summary_line 等)
- src/view/display-lore-drops.cpp: 要約モードのドロップ表 (display_monster_drops_summary)
- src/view/display-lore-magics.cpp: 要約モードの魔法テーブル (display_monster_magic_tables, build_magic_label, print_table)
- src/view/display-lore-status.cpp: 要約モードのステータス表 (display_monster_resistance_table, display_monster_behavior_summary 等)
- src/view/display-lore.cpp: 経験値/オーラ/種別等の要約表示 (display_monster_exp_summary, set_monster_aura_summary, display_monster_kills_summary, display_monster_kind_tags, display_where_to_appear_summary, display_monster_speed_summary 等)
- src/lore/lore-calculator.cpp: 新規 get_skill_damage ヘルパー関数
- src/lore/lore-util.cpp: 要約モードのフラグ情報収集
- src/lore/monster-lore.cpp: process_monster_lore に要約モード分岐
- src/game-option/text-display-options.{cpp,h}, src/game-option/option-types-table.cpp: show_lore_summary オプション
- lib/pref/pref-opt.prf: プリファレンス定義

bakabakaband 適応点:
- 新規関数 get_skill_damage, build_magic_label, print_table, display_monster_magic_tables の引数を `PlayerType *` から `CreatureEntity &` に変換
- src/lore/lore-calculator.h / src/view/display-lore.h の ヘッダ衝突を手動解決

全改変ファイル (19 件) が -Werror -Wall -Wextra でコンパイル成功、
clang-format clean。