### PR TITLE
fix: セーブデータ XOR 鎖チェックサムを修復し SAVEFILE_VERSION を 47 に繰り上げ (#1857)

### DIFF
--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -52,6 +52,7 @@
 #include "world/world.h"
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 /*!
@@ -384,18 +385,51 @@ bool load_savedata(CreatureEntity &creature, bool *new_game)
         return false;
     }
 
-    fd_close(fd);
+    if (!err) {
+        // v0.0.X～v3.0.0 Alpha51までは、セーブデータの第1バイトがFAKE_MAJOR_VERというZangbandと互換性を取ったバージョン番号フィールドだった.
+        // v3.0.0 Alpha52以降は、バリアント名の長さフィールドとして再定義した.
+        // 10～13はその名残。変愚蛮怒から更にバリアントを切ったらこの評価は不要.
+        auto &system = AngbandSystem::get_instance();
+        auto tmp_major = tmp_ver[0];
+        auto is_old_ver = (10 <= tmp_major) && (tmp_major <= 13);
+        if (tmp_major == variant_length) {
+            if (std::string_view(&tmp_ver[1], variant_length) != VARIANT_NAME) {
+                THROW_EXCEPTION(std::runtime_error, _("セーブデータのバリアントは Bakabaka 以外です", "The variant of save data is other than Bakabaka!"));
+            }
+
+            system.savefile_key = tmp_ver[version_length - 1];
+            (void)fd_close(fd);
+        } else if (is_old_ver) {
+            system.savefile_key = tmp_ver[3];
+            (void)fd_close(fd);
+        } else {
+            (void)fd_close(fd);
+            THROW_EXCEPTION(std::runtime_error, _("異常なバージョンが検出されました！", "Invalid version is detected!"));
+        }
+    }
 
     if (!err) {
         term_clear();
         auto ret_rd_savefile = rd_savefile(creature);
-        if (ret_rd_savefile != 0 && ret_rd_savefile != 11) {
+        // SAVEFILE_VERSION 47 以降は checksum エラー (11) をエラーとして扱う。
+        // 46 以前は XOR 鎖バグで v_check が必ずズレていたため許容する互換処理。
+        const auto ignore_checksum_error = loading_savefile_version_is_older_than(47);
+        const auto is_fatal = [ignore_checksum_error](errr ret) {
+            if (ret == 0) {
+                return false;
+            }
+            if (ret == 11 && ignore_checksum_error) {
+                return false;
+            }
+            return true;
+        };
+        if (is_fatal(ret_rd_savefile)) {
             err = true;
         }
 
         if (ret_rd_savefile < 0) {
             what = _("セーブファイルを解析出来ません。", "Cannot parse savefile");
-        } else if (ret_rd_savefile > 0 && ret_rd_savefile != 11) {
+        } else if (ret_rd_savefile > 0 && is_fatal(ret_rd_savefile)) {
             return on_read_save_data_not_supported(creature, new_game);
         }
     }

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -20,8 +20,11 @@ constexpr std::string_view VARIANT_NAME("Bakabaka");
 
 /*!
  * @brief セーブファイルのバージョン(3.0.0から導入)
+ * @details
+ * 47: XOR 鎖チェックサム修復 (hengband#1372 相当)。本バージョン以降は
+ * verify_checksum() / verify_encoded_checksum() の失敗をエラーとして扱う。
  */
-constexpr uint32_t SAVEFILE_VERSION = 46;
+constexpr uint32_t SAVEFILE_VERSION = 47;
 
 /*!
  * @brief バージョンが開発版が安定版かを返す(廃止予定)


### PR DESCRIPTION
変愚蛮怒 #1372 相当の savefile_key 伝搬ロジックを load_savedata() に 復元し、2022-02-13 の変愚マージ以降壊れていたセーブデータチェックサム
計算を正常化する。

## 問題の詳細

save 側 (src/save/save.cpp:65-82) では save_xor_byte を `H_VER_MAJOR ^ H_VER_MINOR ^ H_VER_PATCH ^ H_VER_EXTRA ^ tmp8u` の XOR 鎖状態にした後、リセットせずに本体データを書き始めていた。
v_stamp / x_stamp だけはゼロにリセット。

load 側 (src/load/info-loader.cpp:40) では
`load_xor_byte = system.savefile_key;` で XOR 鎖を復元しようとしていたが、 bakabakaband では `system.savefile_key` を設定する前処理が
load_savedata() から欠落しており、savefile_key がデフォルト値 0 の
ままになっていた。

結果として load_xor_byte が 0 にリセットされて XOR 鎖が途切れ、
world.sf_system の先頭 1 バイトだけ鎖状態の残留値 (非ゼロ) として
復号されてしまい、それ以降 v_check は v_stamp に対して
`H_VER ^ tmp8u` の 1 バイト分だけ永久にズレる状態になっていた。

暫定対応として load.cpp で verify_checksum() のエラーコード 11 を
特別扱いして許容していたが、本質的な修復ではなかった (ISSUE #1857)。

## 修正内容

1. load_savedata() 内で先頭 peek した tmp_ver バッファから `system.savefile_key = tmp_ver[version_length - 1]` を復元 (変愚蛮怒 hengband/hengband#1372 refactor 相当)
2. SAVEFILE_VERSION を 46 → 47 に繰り上げ
3. SAVEFILE_VERSION 47 以降は checksum 不一致 (11) を本来どおり fatal 扱いし、46 以前の既存セーブデータは従来通り許容する 後方互換処理を追加

## 互換性

- **SAVEFILE_VERSION 46 以前のセーブデータ**: `loading_savefile_version_is_older_than(47)` が true になり、 checksum 不一致を許容する従来の経路で読み込まれる。既存ユーザーは 問題なくロード可能で、次回セーブ時に自動的に SAVEFILE_VERSION 47 の正しいチェックサム付きに書き換わる
- **SAVEFILE_VERSION 47 以降のセーブデータ**: 従来通り checksum 不一致を "Invalid checksum" エラーとしてロード拒否する。新規保存は save_xor_byte / load_xor_byte の XOR 鎖が正しく維持されるため v_stamp == v_check が常に成立する

## 確認

Python シミュレーション (/tmp/checksum_sim.py) で save→load の XOR 鎖と checksum 累積を再現し、

- savefile_key 欠落 (現状): v_stamp(0x127) vs v_check(0x164), 差 0x3d
- savefile_key = tmp_ver[version_length-1] (修正後): 両者一致 0x127

であることを実測確認済み。

src/load/load.o は -Werror -Wall -Wextra でコンパイル成功、
clang-format clean。

https://claude.ai/code/session_01L1HaWfCTxckoYkCGTkXPKo