### PR TITLE
feat: カオスパトロンに「衛府」(Efu) を追加 (#1270)

### DIFF
--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -130,6 +130,11 @@ std::vector<Patron> patron_list = {
         { REW_WRATH, REW_WRATH, REW_WRATH, REW_WRATH, REW_WRATH, REW_IGNORE, REW_IGNORE, REW_IGNORE, REW_GOOD_OBJ, REW_GOOD_OBJ, REW_GOOD_OBS,
             REW_GOOD_OBS, REW_CHAOS_WP, REW_CHAOS_WP, REW_GAIN_EXP, REW_GAIN_EXP, REW_GAIN_EXP, REW_AUGM_ABL, REW_AUGM_ABL, REW_SER_MONS },
         A_DEX),
+
+    Patron({ "衛府", "Efu" },
+        { REW_H_SUMMON, REW_H_SUMMON, REW_H_SUMMON, REW_H_SUMMON, REW_WRATH, REW_DESTRUCT, REW_DESTRUCT, REW_DESTRUCT, REW_GENOCIDE, REW_GENOCIDE, REW_GENOCIDE,
+            REW_HEAL_FUL, REW_HEAL_FUL, REW_GAIN_ABL, REW_GAIN_ABL, REW_GAIN_EXP, REW_GAIN_EXP, REW_AUGM_ABL, REW_AUGM_ABL, REW_AUGM_ABL },
+        A_STR),
 };
 
 Patron::Patron(LocalizedString &&name, std::vector<patron_reward> reward_table, const player_ability_type boost_stat)

--- a/src/player/patron.h
+++ b/src/player/patron.h
@@ -7,12 +7,13 @@
 #include <tl/optional.hpp>
 #include <vector>
 
-#define MAX_PATRON 18 /*!< パトロンの最大定義数 / The number of "patrons" available (for Chaos Warriors) */
+#define MAX_PATRON 19 /*!< パトロンの最大定義数 / The number of "patrons" available (for Chaos Warriors) */
 
 enum class PatronType : int16_t {
     NONE = -1, //!< なし
     KHORNE = 11, //!< コーン
     GETTER = 16, //!< ゲッター
+    EFU = 18, //!< 衛府
 };
 
 /* パトロンからの報酬種別定義 / Chaos Warrior: Reward types: */


### PR DESCRIPTION
混沌の戦士のカオスパトロンに「衛府」(Efu) を新規追加。
ゲッターとほぼ同等の恩寵 (H_SUMMON / DESTRUCT / GENOCIDE で攻勢、
HEAL_FUL / GAIN_ABL / GAIN_EXP / AUGM_ABL で強化) を与え、 強化能力値は A_STR を優先する。

- MAX_PATRON を 18 → 19 に増加
- PatronType enum に EFU = 18 を追加
- patron_list に 衛府 (Efu) エントリを追加 (index 18、ロンゲーナの次)
- 報酬テーブルは Getter と同一 (REW_H_SUMMON×4 / REW_WRATH / REW_DESTRUCT×3 / REW_GENOCIDE×3 / REW_HEAL_FUL×2 / REW_GAIN_ABL×2 / REW_GAIN_EXP×2 / REW_AUGM_ABL×3)
- 強化能力値は Getter と同じ A_STR

ISSUE 本文の「化外者/まつろわぬ者/怨身忍者を WH のチョーズンとして
扱う」という着想に沿った追加。将来ロウサイド実装時に予定されている
「覇府」とは別物 (衛府はカオスパトロン)。

player/patron.o / birth/birth-select-patron.o / birth/birth-wizard.o いずれも -Werror -Wall -Wextra でコンパイル成功、clang-format clean。 既存の MAX_PATRON 依存コード (birth-select-patron.cpp の UI 表示・ birth-wizard.cpp の randnum0) は全て MAX_PATRON を定数参照しており、 値を 19 に変えるだけで自動的に 19 エントリに追従する。
