### PR TITLE
refactor: モンスター表示でプレイヤー固有の空欄エントリを抑止

### DIFF
--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -302,6 +302,11 @@ static void display_playtime_in_game(CreatureEntity &creature)
         display_player_one_line(ENTRY_HP, format("%4d/%4d", creature.hp, creature.maxhp), TERM_RED);
     }
 
+    // MP を持たないクリーチャー（多くのモンスター等）は SP 行を描画しない
+    if (creature.msp <= 0) {
+        return;
+    }
+
     if (creature.csp >= creature.msp) {
         display_player_one_line(ENTRY_SP, format("%4d/%4d", creature.csp, creature.msp), TERM_L_GREEN);
     } else if (creature.csp > (creature.msp * mana_warn) / 10) {

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -131,23 +131,43 @@ static void display_magic_realms(CreatureEntity &creature)
  * @param creature クリーチャーへの参照
  * @details
  * 日本語版では、身長はcmに、体重はkgに変更してある
+ * モンスターは年齢・威信・死亡回数を持たないため、身長・体重・属性のみを出力する
  */
 static void display_phisique(CreatureEntity &creature)
 {
+    const auto is_player = creature.is_player();
 #ifdef JP
-    display_player_one_line(ENTRY_AGE, format("%d才", (int)creature.age), TERM_L_BLUE);
-    display_player_one_line(ENTRY_HEIGHT, format("%dcm", inch_to_cm(creature.ht)), TERM_L_BLUE);
-    display_player_one_line(ENTRY_WEIGHT, format("%dkg", lb_to_kg(creature.wt)), TERM_L_BLUE);
-    display_player_one_line(ENTRY_SOCIAL, format("%d  ", (int)creature.prestige), TERM_L_BLUE);
+    if (is_player) {
+        display_player_one_line(ENTRY_AGE, format("%d才", (int)creature.age), TERM_L_BLUE);
+    }
+    if (is_player || creature.ht > 0) {
+        display_player_one_line(ENTRY_HEIGHT, format("%dcm", inch_to_cm(creature.ht)), TERM_L_BLUE);
+    }
+    if (is_player || creature.wt > 0) {
+        display_player_one_line(ENTRY_WEIGHT, format("%dkg", lb_to_kg(creature.wt)), TERM_L_BLUE);
+    }
+    if (is_player) {
+        display_player_one_line(ENTRY_SOCIAL, format("%d  ", (int)creature.prestige), TERM_L_BLUE);
+    }
 #else
-    display_player_one_line(ENTRY_AGE, format("%d", (int)creature.age), TERM_L_BLUE);
-    display_player_one_line(ENTRY_HEIGHT, format("%d", (int)creature.ht), TERM_L_BLUE);
-    display_player_one_line(ENTRY_WEIGHT, format("%d", (int)creature.wt), TERM_L_BLUE);
-    display_player_one_line(ENTRY_SOCIAL, format("%d", (int)creature.prestige), TERM_L_BLUE);
+    if (is_player) {
+        display_player_one_line(ENTRY_AGE, format("%d", (int)creature.age), TERM_L_BLUE);
+    }
+    if (is_player || creature.ht > 0) {
+        display_player_one_line(ENTRY_HEIGHT, format("%d", (int)creature.ht), TERM_L_BLUE);
+    }
+    if (is_player || creature.wt > 0) {
+        display_player_one_line(ENTRY_WEIGHT, format("%d", (int)creature.wt), TERM_L_BLUE);
+    }
+    if (is_player) {
+        display_player_one_line(ENTRY_SOCIAL, format("%d", (int)creature.prestige), TERM_L_BLUE);
+    }
 #endif
     std::string alg = PlayerAlignment(creature).get_alignment_description();
     display_player_one_line(ENTRY_ALIGN, format("%s", alg.data()), TERM_L_BLUE);
-    display_player_one_line(ENTRY_DEATH_COUNT, format("%d  ", (int)creature.death_count), TERM_L_BLUE);
+    if (is_player) {
+        display_player_one_line(ENTRY_DEATH_COUNT, format("%d  ", (int)creature.death_count), TERM_L_BLUE);
+    }
 }
 
 /*!


### PR DESCRIPTION
display_player() に吸収したモンスター表示で「年齢: 0才」「威信: 0」
「死亡回数: 0」「SP: 0/0」等のプレイヤー固有ゼロ値エントリが並び
見栄えが悪かったため、該当エントリをモンスターでは出力しないよう調整する。

- display_phisique: 年齢 / 威信 / 死亡回数はプレイヤー専用。身長・体重は モンスターでも値が入っていれば表示 (属性はどちらでも表示)
- display_playtime_in_game: msp <= 0 のクリーチャーでは SP 行を省略

HP 表示は MonsterEntity の hp/maxhp をそのまま流用するため全クリーチャー共通。