### PR TITLE
refactor: 未使用の旧スタイル状態チェック自由関数群を削除

### DIFF
--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -3072,39 +3072,6 @@ uint32_t calc_score(CreatureEntity &creature)
 }
 
 /*!
- * @param player_ptr プレイヤーへの参照ポインタ
- * @return 祝福状態ならばTRUE
- */
-bool is_blessed(CreatureEntity &creature)
-{
-    return creature.get_timed_effect(CreatureTimedEffect::BLESSED) || music_singing(creature, MUSIC_BLESS) || SpellHex(creature).is_spelling_specific(HEX_BLESS);
-}
-
-bool is_tim_esp(CreatureEntity &creature)
-{
-    auto sniper_data = CreatureClass(creature).get_specific_data<SniperData>();
-    auto sniper_concent = sniper_data ? sniper_data->concent : 0;
-    return creature.get_timed_effect(CreatureTimedEffect::TIM_ESP) || music_singing(creature, MUSIC_MIND) || (sniper_concent >= CONCENT_TELE_THRESHOLD);
-}
-
-bool is_tim_stealth(CreatureEntity &creature)
-{
-    return creature.get_timed_effect(CreatureTimedEffect::TIM_STEALTH) || music_singing(creature, MUSIC_STEALTH);
-}
-
-bool is_time_limit_esp(CreatureEntity &creature)
-{
-    auto sniper_data = CreatureClass(creature).get_specific_data<SniperData>();
-    auto sniper_concent = sniper_data ? sniper_data->concent : 0;
-    return creature.get_timed_effect(CreatureTimedEffect::TIM_ESP) || music_singing(creature, MUSIC_MIND) || (sniper_concent >= CONCENT_TELE_THRESHOLD);
-}
-
-bool is_time_limit_stealth(CreatureEntity &creature)
-{
-    return creature.get_timed_effect(CreatureTimedEffect::TIM_STEALTH) || music_singing(creature, MUSIC_STEALTH);
-}
-
-/*!
 
  * @brief 口を使う継続的な処理を中断する
  * @param player_ptr プレイヤーへの参照ポインタ
@@ -3118,45 +3085,6 @@ void stop_mouth(CreatureEntity &creature)
     if (SpellHex(creature).is_spelling_any()) {
         (void)SpellHex(creature).stop_all_spells();
     }
-}
-
-bool is_fast(CreatureEntity &creature)
-{
-    return creature.effects()->acceleration().is_fast() || music_singing(creature, MUSIC_SPEED) || music_singing(creature, MUSIC_SHERO);
-}
-bool is_invuln(CreatureEntity &creature)
-{
-    return creature.get_timed_effect(CreatureTimedEffect::INVULNERABILITY) || music_singing(creature, MUSIC_INVULN);
-}
-
-bool is_hero(CreatureEntity &creature)
-{
-    return creature.get_timed_effect(CreatureTimedEffect::HERO) || music_singing(creature, MUSIC_HERO) || music_singing(creature, MUSIC_SHERO);
-}
-
-bool is_shero(CreatureEntity &creature)
-{
-    return creature.get_timed_effect(CreatureTimedEffect::BERSERK) || CreatureClass(creature).equals(PlayerClassType::BERSERKER);
-}
-
-bool is_echizen(CreatureEntity &creature)
-{
-    return (creature.ppersonality == PERSONALITY_COMBAT) || creature.is_wielding(FixedArtifactId::CRIMSON);
-}
-
-bool is_tough(CreatureEntity &creature)
-{
-    return (creature.ppersonality == PERSONALITY_TOUGH);
-}
-
-bool is_chargeman(CreatureEntity &creature)
-{
-    return creature.ppersonality == PERSONALITY_CHARGEMAN;
-}
-
-bool is_sushi_eater(CreatureEntity &creature)
-{
-    return (creature.ppersonality == PERSONALITY_SUSHI_EATER);
 }
 
 int calc_weapon_weight_limit(CreatureEntity &creature)


### PR DESCRIPTION
CreatureEntity の仮想メソッド (is_hero / is_shero / is_blessed / is_invulnerable / is_fast / is_echizen / is_tough / is_chargeman / is_sushi_eater / is_time_limit_esp / is_time_limit_stealth) が 既に整備されており、コードベース全体でそちらが使用されている。
player-status.cpp に残っていた同名の自由関数群 (および古い is_tim_esp / is_tim_stealth / is_invuln 変名版) は呼び出し側が無く死にコード化している ため、整理のために削除する。

削除した自由関数:
- is_blessed / is_tim_esp / is_tim_stealth / is_time_limit_esp / is_time_limit_stealth / is_fast / is_invuln / is_hero / is_shero / is_echizen / is_tough / is_chargeman / is_sushi_eater

同ファイル内の stop_mouth() は残存利用のためそのまま保持。

CLAUDE.md 節「変愚蛮怒（上流）からのマージ指針」で示された
`is_hero(player_ptr)` → `creature.is_hero()` 方針に沿う整理。