### PR TITLE
refactor: プレイヤー時限効果を CreatureEntity 上の統一 map へ集約

### DIFF
--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1272,50 +1272,13 @@ public:
 protected:
     std::shared_ptr<TimedEffects> timed_effects; /*!< 時限効果管理オブジェクト */
 
-    // 時限効果 / Timed effects（外部からは get/set_timed_effect() 経由でアクセスすること）
-    TIME_EFFECT invuln{}; /* Timed -- Invulnerable */
-    TIME_EFFECT ult_res{}; /* Timed -- Ultimate Resistance */
-    TIME_EFFECT hero{}; /* Timed -- Heroism */
-    TIME_EFFECT berserk{}; /* Timed -- Super Heroism */
-    TIME_EFFECT shield{}; /* Timed -- Shield Spell */
-    TIME_EFFECT blessed{}; /* Timed -- Blessed */
-    TIME_EFFECT tim_invis{}; /* Timed -- See Invisible */
-    TIME_EFFECT tim_infra{}; /* Timed -- Infra Vision */
-    TIME_EFFECT tsuyoshi{}; /* Timed -- Tsuyoshi Special */
-    TIME_EFFECT ele_attack{}; /* Timed -- Elemental Attack */
-    TIME_EFFECT ele_immune{}; /* Timed -- Elemental Immune */
-    TIME_EFFECT oppose_acid{}; /* Timed -- oppose acid */
-    TIME_EFFECT oppose_elec{}; /* Timed -- oppose lightning */
-    TIME_EFFECT oppose_fire{}; /* Timed -- oppose heat */
-    TIME_EFFECT oppose_cold{}; /* Timed -- oppose cold */
-    TIME_EFFECT oppose_pois{}; /* Timed -- oppose poison */
-    TIME_EFFECT tim_esp{}; /* Timed ESP */
-    TIME_EFFECT wraith_form{}; /* Timed wraithform */
-    TIME_EFFECT resist_magic{}; /* Timed Resist Magic (later) */
-    TIME_EFFECT tim_regen{};
-    TIME_EFFECT tim_pass_wall{};
-    TIME_EFFECT tim_stealth{};
-    TIME_EFFECT tim_levitation{};
-    TIME_EFFECT tim_sh_touki{};
-    TIME_EFFECT lightspeed{};
-    TIME_EFFECT tsubureru{};
-    TIME_EFFECT magicdef{};
-    TIME_EFFECT tim_res_nether{}; /* Timed -- Nether resistance */
-    TIME_EFFECT tim_res_lite{}; /* Timed -- Lite resistance */
-    TIME_EFFECT tim_res_dark{}; /* Timed -- Dark resistance */
-    TIME_EFFECT tim_res_fear{}; /* Timed -- Fear resistance */
-    TIME_EFFECT tim_res_time{}; /* Timed -- Time resistance */
+    // 時限効果の統一ストレージ（外部からは get/set_timed_effect() 経由でアクセスすること）
+    // モンスターは従来通り MonsterProfile::mtimed を使うが、
+    // プレイヤー側は個別フィールドからこの map に統一した。
+    std::map<CreatureTimedEffect, TIME_EFFECT> timed_effects_map{};
+
+    // 変身形態（外部からは get_mimic_form() / set_mimic_form() 経由でアクセスすること）
     MimicKindType mimic_form{};
-    TIME_EFFECT tim_mimic{};
-    TIME_EFFECT tim_sh_fire{};
-    TIME_EFFECT tim_sh_holy{};
-    TIME_EFFECT tim_eyeeye{};
-    TIME_EFFECT tim_reflect{}; /* Timed -- Reflect */
-    TIME_EFFECT multishadow{}; /* Timed -- Multi-shadow */
-    TIME_EFFECT dustrobe{}; /* Timed -- Robe of dust */
-    TIME_EFFECT tim_emission{}; /* Timed -- Player Emission */
-    TIME_EFFECT tim_exorcism{}; /* Timed -- Exorcism */
-    TIME_EFFECT tim_imm_dark{}; /* Timed -- Darkness immunity */
 
     // フロア情報（外部からは get_floor() / set_floor() 経由でアクセスすること）
     FloorType *current_floor_ptr{}; /*!< 現在所属しているフロアへのポインタ / Current floor pointer */

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -45,6 +45,7 @@ bool PlayerType::is_player() const
 
 short PlayerType::get_timed_effect(CreatureTimedEffect effect) const
 {
+    // 一部の時限効果はより高機能な TimedEffects オブジェクト経由で管理している
     const auto &eff = *this->effects();
     switch (effect) {
     case CreatureTimedEffect::STUN:
@@ -53,102 +54,19 @@ short PlayerType::get_timed_effect(CreatureTimedEffect effect) const
         return eff.confusion().current();
     case CreatureTimedEffect::FEAR:
         return eff.fear().current();
-    case CreatureTimedEffect::INVULNERABILITY:
-        return this->invuln;
     case CreatureTimedEffect::ACCELERATION:
         return eff.acceleration().current();
     case CreatureTimedEffect::DECELERATION:
         return eff.deceleration().current();
     case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
+    case CreatureTimedEffect::PARALYSIS:
         return eff.paralysis().current();
     case CreatureTimedEffect::BLINDNESS:
         return eff.blindness().current();
-    case CreatureTimedEffect::PARALYSIS:
-        return eff.paralysis().current();
-    case CreatureTimedEffect::HERO:
-        return this->hero;
-    case CreatureTimedEffect::BERSERK:
-        return this->berserk;
-    case CreatureTimedEffect::SHIELD:
-        return this->shield;
-    case CreatureTimedEffect::BLESSED:
-        return this->blessed;
-    case CreatureTimedEffect::MAGICDEF:
-        return this->magicdef;
-    case CreatureTimedEffect::ULTIMATE_RESISTANCE:
-        return this->ult_res;
-    case CreatureTimedEffect::TSUYOSHI:
-        return this->tsuyoshi;
-    case CreatureTimedEffect::OPPOSE_ACID:
-        return this->oppose_acid;
-    case CreatureTimedEffect::OPPOSE_ELEC:
-        return this->oppose_elec;
-    case CreatureTimedEffect::OPPOSE_FIRE:
-        return this->oppose_fire;
-    case CreatureTimedEffect::OPPOSE_COLD:
-        return this->oppose_cold;
-    case CreatureTimedEffect::OPPOSE_POIS:
-        return this->oppose_pois;
-    case CreatureTimedEffect::RESIST_MAGIC:
-        return this->resist_magic;
-    case CreatureTimedEffect::TIM_RES_NETHER:
-        return this->tim_res_nether;
-    case CreatureTimedEffect::TIM_RES_LITE:
-        return this->tim_res_lite;
-    case CreatureTimedEffect::TIM_RES_DARK:
-        return this->tim_res_dark;
-    case CreatureTimedEffect::TIM_RES_FEAR:
-        return this->tim_res_fear;
-    case CreatureTimedEffect::TIM_RES_TIME:
-        return this->tim_res_time;
-    case CreatureTimedEffect::TIM_IMM_DARK:
-        return this->tim_imm_dark;
-    case CreatureTimedEffect::TIM_ESP:
-        return this->tim_esp;
-    case CreatureTimedEffect::TIM_INVIS:
-        return this->tim_invis;
-    case CreatureTimedEffect::TIM_INFRA:
-        return this->tim_infra;
-    case CreatureTimedEffect::TIM_STEALTH:
-        return this->tim_stealth;
-    case CreatureTimedEffect::TIM_REGEN:
-        return this->tim_regen;
-    case CreatureTimedEffect::TIM_PASS_WALL:
-        return this->tim_pass_wall;
-    case CreatureTimedEffect::TIM_LEVITATION:
-        return this->tim_levitation;
-    case CreatureTimedEffect::TIM_REFLECT:
-        return this->tim_reflect;
-    case CreatureTimedEffect::LIGHTSPEED:
-        return this->lightspeed;
-    case CreatureTimedEffect::TSUBURERU:
-        return this->tsubureru;
-    case CreatureTimedEffect::TIM_SH_TOUKI:
-        return this->tim_sh_touki;
-    case CreatureTimedEffect::TIM_SH_FIRE:
-        return this->tim_sh_fire;
-    case CreatureTimedEffect::TIM_SH_HOLY:
-        return this->tim_sh_holy;
-    case CreatureTimedEffect::TIM_EYEEYE:
-        return this->tim_eyeeye;
-    case CreatureTimedEffect::TIM_MIMIC:
-        return this->tim_mimic;
-    case CreatureTimedEffect::WRAITH_FORM:
-        return this->wraith_form;
-    case CreatureTimedEffect::MULTISHADOW:
-        return this->multishadow;
-    case CreatureTimedEffect::DUSTROBE:
-        return this->dustrobe;
-    case CreatureTimedEffect::ELE_ATTACK:
-        return this->ele_attack;
-    case CreatureTimedEffect::ELE_IMMUNE:
-        return this->ele_immune;
-    case CreatureTimedEffect::TIM_EMISSION:
-        return this->tim_emission;
-    case CreatureTimedEffect::TIM_EXORCISM:
-        return this->tim_exorcism;
-    default:
-        return 0;
+    default: {
+        const auto it = this->timed_effects_map.find(effect);
+        return (it != this->timed_effects_map.end()) ? it->second : 0;
+    }
     }
 }
 
@@ -165,9 +83,6 @@ void PlayerType::set_timed_effect(CreatureTimedEffect effect, short value)
     case CreatureTimedEffect::FEAR:
         eff.fear().set(value);
         break;
-    case CreatureTimedEffect::INVULNERABILITY:
-        this->invuln = value;
-        break;
     case CreatureTimedEffect::ACCELERATION:
         eff.acceleration().set(value);
         break;
@@ -175,138 +90,14 @@ void PlayerType::set_timed_effect(CreatureTimedEffect effect, short value)
         eff.deceleration().set(value);
         break;
     case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
+    case CreatureTimedEffect::PARALYSIS:
         eff.paralysis().set(value);
         break;
     case CreatureTimedEffect::BLINDNESS:
         eff.blindness().set(value);
         break;
-    case CreatureTimedEffect::PARALYSIS:
-        eff.paralysis().set(value);
-        break;
-    case CreatureTimedEffect::HERO:
-        this->hero = value;
-        break;
-    case CreatureTimedEffect::BERSERK:
-        this->berserk = value;
-        break;
-    case CreatureTimedEffect::SHIELD:
-        this->shield = value;
-        break;
-    case CreatureTimedEffect::BLESSED:
-        this->blessed = value;
-        break;
-    case CreatureTimedEffect::MAGICDEF:
-        this->magicdef = value;
-        break;
-    case CreatureTimedEffect::ULTIMATE_RESISTANCE:
-        this->ult_res = value;
-        break;
-    case CreatureTimedEffect::TSUYOSHI:
-        this->tsuyoshi = value;
-        break;
-    case CreatureTimedEffect::OPPOSE_ACID:
-        this->oppose_acid = value;
-        break;
-    case CreatureTimedEffect::OPPOSE_ELEC:
-        this->oppose_elec = value;
-        break;
-    case CreatureTimedEffect::OPPOSE_FIRE:
-        this->oppose_fire = value;
-        break;
-    case CreatureTimedEffect::OPPOSE_COLD:
-        this->oppose_cold = value;
-        break;
-    case CreatureTimedEffect::OPPOSE_POIS:
-        this->oppose_pois = value;
-        break;
-    case CreatureTimedEffect::RESIST_MAGIC:
-        this->resist_magic = value;
-        break;
-    case CreatureTimedEffect::TIM_RES_NETHER:
-        this->tim_res_nether = value;
-        break;
-    case CreatureTimedEffect::TIM_RES_LITE:
-        this->tim_res_lite = value;
-        break;
-    case CreatureTimedEffect::TIM_RES_DARK:
-        this->tim_res_dark = value;
-        break;
-    case CreatureTimedEffect::TIM_RES_FEAR:
-        this->tim_res_fear = value;
-        break;
-    case CreatureTimedEffect::TIM_RES_TIME:
-        this->tim_res_time = value;
-        break;
-    case CreatureTimedEffect::TIM_IMM_DARK:
-        this->tim_imm_dark = value;
-        break;
-    case CreatureTimedEffect::TIM_ESP:
-        this->tim_esp = value;
-        break;
-    case CreatureTimedEffect::TIM_INVIS:
-        this->tim_invis = value;
-        break;
-    case CreatureTimedEffect::TIM_INFRA:
-        this->tim_infra = value;
-        break;
-    case CreatureTimedEffect::TIM_STEALTH:
-        this->tim_stealth = value;
-        break;
-    case CreatureTimedEffect::TIM_REGEN:
-        this->tim_regen = value;
-        break;
-    case CreatureTimedEffect::TIM_PASS_WALL:
-        this->tim_pass_wall = value;
-        break;
-    case CreatureTimedEffect::TIM_LEVITATION:
-        this->tim_levitation = value;
-        break;
-    case CreatureTimedEffect::TIM_REFLECT:
-        this->tim_reflect = value;
-        break;
-    case CreatureTimedEffect::LIGHTSPEED:
-        this->lightspeed = value;
-        break;
-    case CreatureTimedEffect::TSUBURERU:
-        this->tsubureru = value;
-        break;
-    case CreatureTimedEffect::TIM_SH_TOUKI:
-        this->tim_sh_touki = value;
-        break;
-    case CreatureTimedEffect::TIM_SH_FIRE:
-        this->tim_sh_fire = value;
-        break;
-    case CreatureTimedEffect::TIM_SH_HOLY:
-        this->tim_sh_holy = value;
-        break;
-    case CreatureTimedEffect::TIM_EYEEYE:
-        this->tim_eyeeye = value;
-        break;
-    case CreatureTimedEffect::TIM_MIMIC:
-        this->tim_mimic = value;
-        break;
-    case CreatureTimedEffect::WRAITH_FORM:
-        this->wraith_form = value;
-        break;
-    case CreatureTimedEffect::MULTISHADOW:
-        this->multishadow = value;
-        break;
-    case CreatureTimedEffect::DUSTROBE:
-        this->dustrobe = value;
-        break;
-    case CreatureTimedEffect::ELE_ATTACK:
-        this->ele_attack = value;
-        break;
-    case CreatureTimedEffect::ELE_IMMUNE:
-        this->ele_immune = value;
-        break;
-    case CreatureTimedEffect::TIM_EMISSION:
-        this->tim_emission = value;
-        break;
-    case CreatureTimedEffect::TIM_EXORCISM:
-        this->tim_exorcism = value;
-        break;
     default:
+        this->timed_effects_map[effect] = value;
         break;
     }
 }


### PR DESCRIPTION
CreatureEntity に std::map<CreatureTimedEffect, TIME_EFFECT> timed_effects_map を追加し、PlayerType が個別フィールド
(hero / invuln / blessed / berserk / shield / oppose_* / tim_* / ele_* / wraith_form / multishadow / dustrobe / 他 計41フィールド) で 持っていた時限効果をこの map に統合する。

- CreatureEntity::timed_effects_map を追加 (protected)
- CreatureEntity から個別の TIME_EFFECT フィールド 41 個を削除 (mimic_form は変身概念として残存)
- PlayerType::get_timed_effect / set_timed_effect を短縮 STUN / CONFUSION / FEAR / ACCELERATION / DECELERATION / PARALYSIS / BLINDNESS は TimedEffects オブジェクト経由のままとし、 それ以外は全て map ルックアップに統一
- SLEEP_OR_PARALYSIS と PARALYSIS は同じ paralysis() を使うため case フォールスルーで統合

これにより：
- CreatureEntity のストレージが大幅に軽量化
- モンスター側は元々個別フィールドを使用しておらず、サイズ削減効果のみ享受
- プレイヤー側の時限効果管理機構がモンスター側の MonsterProfile::mtimed map アプローチと形式的に整合
- 将来的な両者の map 統合 (Phase 3 の完全形) に向けた布石

https://claude.ai/code/session_01Q6mCnU2BLa2WBs38WzM3y2