### PR TITLE
refactor: モンスター .mtimed 直接アクセスを get/set_timed_effect API へ統一

### DIFF
--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -125,7 +125,7 @@ static MonraceDefinition &set_pet_params(CreatureEntity &creature, const int cur
     monster.x = cx;
     monster.set_floor(creature.get_floor());
     monster.get_monster_profile().ml = true;
-    monster.get_monster_profile().mtimed[CreatureTimedEffect::SLEEP_OR_PARALYSIS] = 0;
+    monster.set_timed_effect(CreatureTimedEffect::SLEEP_OR_PARALYSIS, 0);
     monster.get_monster_profile().hold_o_idx_list.clear();
     monster.reset_target();
     auto &r_ref = monster.get_real_monrace();

--- a/src/load/old/monster-loader-savefile50.cpp
+++ b/src/load/old/monster-loader-savefile50.cpp
@@ -47,7 +47,7 @@ void MonsterLoader50::rd_monster(CreatureEntity &monster)
 
     monster.ap_r_idx = any_bits(flags, SaveDataMonsterFlagType::AP_R_IDX) ? i2enum<MonraceId>(rd_s16b()) : monster.r_idx;
     monster.get_monster_profile().sub_align = any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN) ? rd_byte() : 0;
-    monster.get_monster_profile().mtimed[CreatureTimedEffect::SLEEP_OR_PARALYSIS] = any_bits(flags, SaveDataMonsterFlagType::SLEEP) ? rd_s16b() : 0;
+    monster.set_timed_effect(CreatureTimedEffect::SLEEP_OR_PARALYSIS, any_bits(flags, SaveDataMonsterFlagType::SLEEP) ? rd_s16b() : 0);
     monster.speed = rd_byte();
     monster.energy_need = rd_s16b();
     if (loading_savefile_version_is_older_than(38)) {
@@ -56,14 +56,14 @@ void MonsterLoader50::rd_monster(CreatureEntity &monster)
     } else {
         monster.ac = rd_s16b();
     }
-    monster.get_monster_profile().mtimed[CreatureTimedEffect::ACCELERATION] = any_bits(flags, SaveDataMonsterFlagType::FAST) ? rd_byte() : 0;
-    monster.get_monster_profile().mtimed[CreatureTimedEffect::DECELERATION] = any_bits(flags, SaveDataMonsterFlagType::SLOW) ? rd_byte() : 0;
-    monster.get_monster_profile().mtimed[CreatureTimedEffect::STUN] = any_bits(flags, SaveDataMonsterFlagType::STUNNED) ? rd_byte() : 0;
-    monster.get_monster_profile().mtimed[CreatureTimedEffect::CONFUSION] = any_bits(flags, SaveDataMonsterFlagType::CONFUSED) ? rd_byte() : 0;
-    monster.get_monster_profile().mtimed[CreatureTimedEffect::FEAR] = any_bits(flags, SaveDataMonsterFlagType::MONFEAR) ? rd_byte() : 0;
+    monster.set_timed_effect(CreatureTimedEffect::ACCELERATION, any_bits(flags, SaveDataMonsterFlagType::FAST) ? rd_byte() : 0);
+    monster.set_timed_effect(CreatureTimedEffect::DECELERATION, any_bits(flags, SaveDataMonsterFlagType::SLOW) ? rd_byte() : 0);
+    monster.set_timed_effect(CreatureTimedEffect::STUN, any_bits(flags, SaveDataMonsterFlagType::STUNNED) ? rd_byte() : 0);
+    monster.set_timed_effect(CreatureTimedEffect::CONFUSION, any_bits(flags, SaveDataMonsterFlagType::CONFUSED) ? rd_byte() : 0);
+    monster.set_timed_effect(CreatureTimedEffect::FEAR, any_bits(flags, SaveDataMonsterFlagType::MONFEAR) ? rd_byte() : 0);
     monster.target.y = any_bits(flags, SaveDataMonsterFlagType::TARGET_Y) ? rd_s16b() : 0;
     monster.target.x = any_bits(flags, SaveDataMonsterFlagType::TARGET_X) ? rd_s16b() : 0;
-    monster.get_monster_profile().mtimed[CreatureTimedEffect::INVULNERABILITY] = any_bits(flags, SaveDataMonsterFlagType::INVULNER) ? rd_byte() : 0;
+    monster.set_timed_effect(CreatureTimedEffect::INVULNERABILITY, any_bits(flags, SaveDataMonsterFlagType::INVULNER) ? rd_byte() : 0);
     monster.get_monster_profile().mflag.clear();
     monster.get_monster_profile().mflag2.clear();
     if (any_bits(flags, SaveDataMonsterFlagType::SMART)) {

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -378,7 +378,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     m_ptr->set_floor(&floor);
 
     for (const auto mte : MONSTER_TIMED_EFFECT_LIST) {
-        m_ptr->get_monster_profile().mtimed[mte] = 0;
+        m_ptr->set_timed_effect(mte, 0);
     }
 
     m_ptr->reset_target();
@@ -434,7 +434,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
         }
     }
 
-    m_ptr->get_monster_profile().mtimed[CreatureTimedEffect::SLEEP_OR_PARALYSIS] = 0;
+    m_ptr->set_timed_effect(CreatureTimedEffect::SLEEP_OR_PARALYSIS, 0);
     if (any_bits(mode, PM_ALLOW_SLEEP) && new_monrace.sleep && !ironman_nightmare) {
         int val = new_monrace.sleep;
         (void)set_monster_csleep(floor, g_ptr->m_idx, (val * 2) + randint1(val * 10));

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -85,7 +85,7 @@ bool set_monster_csleep(FloorType &floor, MONSTER_IDX m_idx, int v)
         }
     }
 
-    monster.get_monster_profile().mtimed[CreatureTimedEffect::SLEEP_OR_PARALYSIS] = (int16_t)v;
+    monster.set_timed_effect(CreatureTimedEffect::SLEEP_OR_PARALYSIS, (int16_t)v);
     if (!notice) {
         return false;
     }
@@ -130,7 +130,7 @@ bool set_monster_fast(FloorType &floor, MONSTER_IDX m_idx, int v)
         }
     }
 
-    monster.get_monster_profile().mtimed[CreatureTimedEffect::ACCELERATION] = (int16_t)v;
+    monster.set_timed_effect(CreatureTimedEffect::ACCELERATION, (int16_t)v);
     if (!notice) {
         return false;
     }
@@ -167,7 +167,7 @@ bool set_monster_slow(FloorType &floor, MONSTER_IDX m_idx, int v)
         }
     }
 
-    monster.get_monster_profile().mtimed[CreatureTimedEffect::DECELERATION] = (int16_t)v;
+    monster.set_timed_effect(CreatureTimedEffect::DECELERATION, (int16_t)v);
     if (!notice) {
         return false;
     }
@@ -204,7 +204,7 @@ bool set_monster_stunned(FloorType &floor, MONSTER_IDX m_idx, int v)
         }
     }
 
-    monster.get_monster_profile().mtimed[CreatureTimedEffect::STUN] = (int16_t)v;
+    monster.set_timed_effect(CreatureTimedEffect::STUN, (int16_t)v);
     return notice;
 }
 
@@ -233,7 +233,7 @@ bool set_monster_confused(FloorType &floor, MONSTER_IDX m_idx, int v)
         }
     }
 
-    monster.get_monster_profile().mtimed[CreatureTimedEffect::CONFUSION] = (int16_t)v;
+    monster.set_timed_effect(CreatureTimedEffect::CONFUSION, (int16_t)v);
     return notice;
 }
 
@@ -268,7 +268,7 @@ bool set_monster_monfear(FloorType &floor, MONSTER_IDX m_idx, int v)
         }
     }
 
-    monster.get_monster_profile().mtimed[CreatureTimedEffect::FEAR] = (int16_t)v;
+    monster.set_timed_effect(CreatureTimedEffect::FEAR, (int16_t)v);
 
     if (!notice) {
         return false;
@@ -313,7 +313,7 @@ bool set_monster_invulner(FloorType &floor, MONSTER_IDX m_idx, int v, bool energ
         }
     }
 
-    monster.get_monster_profile().mtimed[CreatureTimedEffect::INVULNERABILITY] = (int16_t)v;
+    monster.set_timed_effect(CreatureTimedEffect::INVULNERABILITY, (int16_t)v);
     if (!notice) {
         return false;
     }

--- a/src/mspell/mspell-selector.cpp
+++ b/src/mspell/mspell-selector.cpp
@@ -451,7 +451,7 @@ MonsterAbilityType choose_attack_spell(CreatureEntity &creature, msa_type *msa_p
         return rand_choice(tactic);
     }
 
-    if (!invul.empty() && !monster.get_monster_profile().mtimed.at(CreatureTimedEffect::INVULNERABILITY) && one_in_(2)) {
+    if (!invul.empty() && !monster.get_timed_effect(CreatureTimedEffect::INVULNERABILITY) && one_in_(2)) {
         return rand_choice(invul);
     }
 

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -130,13 +130,13 @@ static void attack_dispel(CreatureEntity &creature, player_attack_type *pa_ptr)
     }
 
     auto dd = 2;
-    if (pa_ptr->m_ptr->get_monster_profile().mtimed[CreatureTimedEffect::DECELERATION]) {
+    if (pa_ptr->m_ptr->get_timed_effect(CreatureTimedEffect::DECELERATION)) {
         dd += 1;
     }
-    if (pa_ptr->m_ptr->get_monster_profile().mtimed[CreatureTimedEffect::ACCELERATION]) {
+    if (pa_ptr->m_ptr->get_timed_effect(CreatureTimedEffect::ACCELERATION)) {
         dd += 2;
     }
-    if (pa_ptr->m_ptr->get_monster_profile().mtimed[CreatureTimedEffect::INVULNERABILITY]) {
+    if (pa_ptr->m_ptr->get_timed_effect(CreatureTimedEffect::INVULNERABILITY)) {
         dd += 3;
     }
 

--- a/src/save/monster-entity-writer.cpp
+++ b/src/save/monster-entity-writer.cpp
@@ -40,7 +40,7 @@ void MonsterEntityWriter::write_to_savedata() const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::SLEEP)) {
-        wr_s16b(this->monster.get_monster_profile().mtimed.at(CreatureTimedEffect::SLEEP_OR_PARALYSIS));
+        wr_s16b(this->monster.get_timed_effect(CreatureTimedEffect::SLEEP_OR_PARALYSIS));
     }
 
     wr_byte((byte)this->monster.speed);
@@ -156,27 +156,27 @@ void MonsterEntityWriter::write_monster_info(uint32_t flags) const
 {
     byte tmp8u;
     if (any_bits(flags, SaveDataMonsterFlagType::FAST)) {
-        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(CreatureTimedEffect::ACCELERATION);
+        tmp8u = (byte)this->monster.get_timed_effect(CreatureTimedEffect::ACCELERATION);
         wr_byte(tmp8u);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::SLOW)) {
-        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(CreatureTimedEffect::DECELERATION);
+        tmp8u = (byte)this->monster.get_timed_effect(CreatureTimedEffect::DECELERATION);
         wr_byte(tmp8u);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::STUNNED)) {
-        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(CreatureTimedEffect::STUN);
+        tmp8u = (byte)this->monster.get_timed_effect(CreatureTimedEffect::STUN);
         wr_byte(tmp8u);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::CONFUSED)) {
-        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(CreatureTimedEffect::CONFUSION);
+        tmp8u = (byte)this->monster.get_timed_effect(CreatureTimedEffect::CONFUSION);
         wr_byte(tmp8u);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::MONFEAR)) {
-        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(CreatureTimedEffect::FEAR);
+        tmp8u = (byte)this->monster.get_timed_effect(CreatureTimedEffect::FEAR);
         wr_byte(tmp8u);
     }
 
@@ -189,7 +189,7 @@ void MonsterEntityWriter::write_monster_info(uint32_t flags) const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::INVULNER)) {
-        tmp8u = (byte)this->monster.get_monster_profile().mtimed.at(CreatureTimedEffect::INVULNERABILITY);
+        tmp8u = (byte)this->monster.get_timed_effect(CreatureTimedEffect::INVULNERABILITY);
         wr_byte(tmp8u);
     }
 

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -989,7 +989,7 @@ void CreatureEntity::init_monster_profile()
 {
     this->monster_profile.emplace();
     for (const auto mte : MONSTER_TIMED_EFFECT_LIST) {
-        this->get_monster_profile().mtimed[mte] = 0;
+        this->set_timed_effect(mte, 0);
     }
 }
 

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -551,7 +551,7 @@ void FloorType::reset_mproc()
         }
 
         for (const auto mte : MONSTER_TIMED_EFFECT_LIST) {
-            if (monster.get_monster_profile().mtimed.at(mte) > 0) {
+            if (monster.get_timed_effect(mte) > 0) {
                 this->add_mproc(i, mte);
             }
         }

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -5,7 +5,7 @@ MonsterEntity::MonsterEntity()
 {
     this->monster_profile.emplace();
     for (const auto mte : MONSTER_TIMED_EFFECT_RANGE) {
-        this->get_monster_profile().mtimed[mte] = 0;
+        this->set_timed_effect(mte, 0);
     }
 
     // CreatureEntityの基本メンバーを初期化


### PR DESCRIPTION
monster.get_monster_profile().mtimed[effect] の直接参照を CreatureEntity の仮想 API (get_timed_effect / set_timed_effect) に 置き換え、プレイヤー側と完全に同じアクセスパスへ統一する。

対象ファイル:
- monster/monster-status-setter.cpp (7 書込: SLEEP_OR_PARALYSIS / ACCELERATION / DECELERATION / STUN / CONFUSION / FEAR / INVULNERABILITY)
- player-attack/attack-chaos-effect.cpp (3 読込)
- floor/floor-changer.cpp (1 書込)
- mspell/mspell-selector.cpp (1 読込)
- system/floor/floor-info.cpp (1 読込 ループ内)
- monster-floor/one-monster-placer.cpp (2 書込 ゼロ化処理)
- system/monster-entity.cpp (コンストラクタのゼロ化ループ)
- system/creature-entity.cpp (init_monster_profile のゼロ化ループ)
- save/monster-entity-writer.cpp (7 読込)
- load/old/monster-loader-savefile50.cpp (7 書込)

get_monster_profile().mtimed 直接参照が残るのは CreatureEntity 自身の get_timed_effect / set_timed_effect 実装内のみ。将来的にストレージを CreatureEntity::timed_effects_map へ統一する際の移行がこれで 1 箇所で 完結できる。