### PR TITLE
refactor: MonsterProfile::mtimed を CreatureEntity::timed_effects_map に統合

### DIFF
--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -425,22 +425,13 @@ bool CreatureEntity::is_echizen() const
 
 short CreatureEntity::get_timed_effect(CreatureTimedEffect effect) const
 {
-    if (!this->has_monster_profile()) {
-        return 0;
-    }
-
-    const auto &mtimed = this->get_monster_profile().mtimed;
-    const auto it = mtimed.find(effect);
-    return (it != mtimed.end()) ? it->second : 0;
+    const auto it = this->timed_effects_map.find(effect);
+    return (it != this->timed_effects_map.end()) ? it->second : 0;
 }
 
 void CreatureEntity::set_timed_effect(CreatureTimedEffect effect, short value)
 {
-    if (!this->has_monster_profile()) {
-        return;
-    }
-
-    this->get_monster_profile().mtimed[effect] = value;
+    this->timed_effects_map[effect] = value;
 }
 
 void CreatureEntity::make_lore_treasure(int num_item, int num_gold) const

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -459,8 +459,10 @@ public:
      * @brief クリーチャーの時限効果の残りターン数を取得
      * @param effect 取得する時限効果の種別
      * @return 残りターン数（0なら効果なし）
-     * @details デフォルト実装は MonsterProfile::mtimed を参照する（モンスター用）。
-     *          PlayerType はオーバーライドして TimedEffects を使う。
+     * @details デフォルト実装は CreatureEntity::timed_effects_map を参照する。
+     *          PlayerType は STUN / CONFUSION / FEAR / ACCELERATION / DECELERATION /
+     *          PARALYSIS / BLINDNESS に限り TimedEffects オブジェクト経由で管理し、
+     *          それ以外はデフォルト実装（= map）へフォールバックする。
      */
     virtual short get_timed_effect(CreatureTimedEffect effect) const;
 
@@ -469,8 +471,8 @@ public:
      * @param effect 設定する時限効果の種別
      * @param value 設定するターン数
      * @note メッセージや副作用は発生しない。ゲームロジックからの呼び出しには専用セッターを使うこと。
-     * @details デフォルト実装は MonsterProfile::mtimed を更新する（モンスター用）。
-     *          PlayerType はオーバーライドして TimedEffects を使う。
+     * @details デフォルト実装は CreatureEntity::timed_effects_map を更新する。
+     *          PlayerType は get_timed_effect と同様に特定の効果だけ TimedEffects 経由。
      */
     virtual void set_timed_effect(CreatureTimedEffect effect, short value);
 
@@ -1273,8 +1275,7 @@ protected:
     std::shared_ptr<TimedEffects> timed_effects; /*!< 時限効果管理オブジェクト */
 
     // 時限効果の統一ストレージ（外部からは get/set_timed_effect() 経由でアクセスすること）
-    // モンスターは従来通り MonsterProfile::mtimed を使うが、
-    // プレイヤー側は個別フィールドからこの map に統一した。
+    // プレイヤー・モンスター共通。PlayerType の STUN / CONFUSION 等は TimedEffects オブジェクト経由。
     std::map<CreatureTimedEffect, TIME_EFFECT> timed_effects_map{};
 
     // 変身形態（外部からは get_mimic_form() / set_mimic_form() 経由でアクセスすること）

--- a/src/system/creature-timed-effect-types.h
+++ b/src/system/creature-timed-effect-types.h
@@ -2,8 +2,9 @@
 
 /*!
  * @brief クリーチャー（プレイヤー・モンスター共通）の時限効果の種別
- * @details PlayerType の TimedEffects / 直接フィールドおよび MonsterProfile の mtimed と対応する。
- * モンスターに存在しない効果は get_timed_effect() が 0 を返し、set_timed_effect() は何もしない。
+ * @details CreatureEntity::timed_effects_map の共通ストレージ、および PlayerType の TimedEffects
+ * オブジェクト (STUN / CONFUSION / 等) と対応する。適用のないクリーチャーでは
+ * get_timed_effect() が 0 を返し、set_timed_effect() は map に 0 を書き込むのみとなる。
  */
 enum class CreatureTimedEffect {
     // --- モンスター・プレイヤー共通 ---

--- a/src/system/monster-profile.h
+++ b/src/system/monster-profile.h
@@ -4,10 +4,8 @@
 #include "monster/monster-flag-types.h"
 #include "monster/smart-learn-types.h"
 #include "object/object-index-list.h"
-#include "system/creature-timed-effect-types.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "util/flag-group.h"
-#include <map>
 #include <vector>
 
 enum class PlayerRaceType;
@@ -27,7 +25,6 @@ struct MonsterProfile {
     std::vector<PlayerRaceType> equivalent_player_races{}; /*!< モンスターのフラグに基づいて対応するプレイヤー種族IDリスト */
     std::vector<PlayerClassType> equivalent_player_classes{}; /*!< モンスターのフラグに基づいて対応するプレイヤー職業IDリスト */
     int death_count{}; /*!< 自壊するまでの残りターン数 */
-    std::map<CreatureTimedEffect, short> mtimed{}; /*!< 与えられた時限効果の残りターン / Timed status counter */
     EnumClassFlagGroup<MonsterTemporaryFlagType> mflag{}; /*!< モンスター個体に与えられた特殊フラグ1 (セーブ不要) / Extra monster flags */
     EnumClassFlagGroup<MonsterConstantFlagType> mflag2{}; /*!< モンスター個体に与えられた特殊フラグ2 (セーブ必要) / Extra monster flags */
     bool ml{}; /*!< モンスターがプレイヤーにとって視認できるか(処理のためのテンポラリ変数) Monster is "visible" */

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -63,10 +63,8 @@ short PlayerType::get_timed_effect(CreatureTimedEffect effect) const
         return eff.paralysis().current();
     case CreatureTimedEffect::BLINDNESS:
         return eff.blindness().current();
-    default: {
-        const auto it = this->timed_effects_map.find(effect);
-        return (it != this->timed_effects_map.end()) ? it->second : 0;
-    }
+    default:
+        return CreatureEntity::get_timed_effect(effect);
     }
 }
 
@@ -97,7 +95,7 @@ void PlayerType::set_timed_effect(CreatureTimedEffect effect, short value)
         eff.blindness().set(value);
         break;
     default:
-        this->timed_effects_map[effect] = value;
+        CreatureEntity::set_timed_effect(effect, value);
         break;
     }
 }


### PR DESCRIPTION
Phase 3「タイムドエフェクトの統一」の最終段として、モンスター専用の
ストレージ MonsterProfile::mtimed を削除し、全クリーチャーの時限効果を
CreatureEntity::timed_effects_map で単一管理するようにする。

- CreatureEntity::get_timed_effect / set_timed_effect を timed_effects_map で実装。has_monster_profile() 条件分岐も削除
- MonsterProfile::mtimed フィールドを削除
- MonsterProfile の <map> インクルードも不要となり削除
- PlayerType::get_timed_effect / set_timed_effect の default 分岐は CreatureEntity::get_timed_effect / set_timed_effect へ明示委譲
- 関連する doxygen コメントを更新

これによりストレージが完全統合され：
- プレイヤー・モンスターとも単一 map に時限効果を集約
- セーブ/ロード・ステータスセッター等の仮想 API 経由呼び出しはそのまま動作
- has_monster_profile() 判定が時限効果アクセスから不要になった
- Phase 3 のゴール「両者を同一 map で管理」を達成

残存参照は関数名の一部 (process_monsters_mtimed) のみで動作に影響しない。