### PR TITLE
refactor: word_recall / alter_reality を CreatureTimedEffect に統合

### DIFF
--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -125,7 +125,7 @@ void do_cmd_go_up(CreatureEntity &creature)
 
         if (!inside_quest(quest_id)) {
             floor.dun_level = 0;
-            creature.word_recall = 0;
+            creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, 0);
         }
 
         creature.leaving = true;
@@ -199,7 +199,7 @@ void do_cmd_go_up(CreatureEntity &creature)
         } else {
             msg_print(_("地上に戻った。", "You go back to the surface."));
         }
-        creature.word_recall = 0;
+        creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, 0);
     } else {
         if (creature.is_echizen()) {
             msg_print(_("なんだこの階段は！", "What's this STAIRWAY!"));
@@ -271,7 +271,7 @@ void do_cmd_go_down(CreatureEntity &creature)
 
         if (!floor.is_in_quest()) {
             floor.dun_level = 0;
-            creature.word_recall = 0;
+            creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, 0);
         }
 
         creature.leaving = true;

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -374,7 +374,7 @@ static void exit_to_wilderness(CreatureEntity &creature)
     }
 
     creature.recall_dungeon = floor.dungeon_id;
-    creature.word_recall = 0;
+    creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, 0);
     floor.reset_dungeon_index();
     FloorChangeModesStore::get_instace()->reset(FloorChangeMode::SAVE_FLOORS);
 }

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -475,9 +475,9 @@ static void rd_player_status(CreatureEntity &creature)
     creature.set_timed_effect(CreatureTimedEffect::SHIELD, rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::BLESSED, rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::TIM_INVIS, rd_s16b());
-    creature.word_recall = rd_s16b();
+    creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, rd_s16b());
     creature.recall_dungeon = i2enum<DungeonId>(rd_s16b());
-    creature.alter_reality = rd_s16b();
+    creature.set_timed_effect(CreatureTimedEffect::ALTER_REALITY, rd_s16b());
     creature.see_infra = rd_s16b();
     creature.set_timed_effect(CreatureTimedEffect::TIM_INFRA, rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::OPPOSE_FIRE, rd_s16b());

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -56,7 +56,7 @@ void rd_dungeons(CreatureEntity &creature)
 void rd_alter_reality(CreatureEntity &creature)
 {
     creature.recall_dungeon = i2enum<DungeonId>(rd_s16b());
-    creature.alter_reality = rd_s16b();
+    creature.set_timed_effect(CreatureTimedEffect::ALTER_REALITY, rd_s16b());
 }
 
 void set_gambling_monsters()

--- a/src/player-info/body-improvement-info.cpp
+++ b/src/player-info/body-improvement-info.cpp
@@ -45,11 +45,11 @@ void set_body_improvement_info_2(CreatureEntity &creature, self_info_type *self_
         self_ptr->info_list.emplace_back(_("あなたは呪文や祈りを学ぶことができる。", "You can learn some spells/prayers."));
     }
 
-    if (creature.word_recall) {
+    if (creature.get_timed_effect(CreatureTimedEffect::WORD_RECALL)) {
         self_ptr->info_list.emplace_back(_("あなたはすぐに帰還するだろう。", "You will soon be recalled."));
     }
 
-    if (creature.alter_reality) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ALTER_REALITY)) {
         self_ptr->info_list.emplace_back(_("あなたはすぐにこの世界を離れるだろう。", "You will soon be altered."));
     }
 

--- a/src/player-info/self-info.cpp
+++ b/src/player-info/self-info.cpp
@@ -384,13 +384,13 @@ void report_magics(CreatureEntity &subject)
         info.emplace_back(7, _("あなたの手は赤く輝いている", "Your hands are glowing dull red."));
     }
 
-    if (subject.word_recall) {
-        info.emplace_back(report_magics_aux(subject.word_recall),
+    if (const auto recall = subject.get_timed_effect(CreatureTimedEffect::WORD_RECALL); recall != 0) {
+        info.emplace_back(report_magics_aux(recall),
             _("この後帰還の詔が発動する", "You are waiting to be recalled"));
     }
 
-    if (subject.alter_reality) {
-        info.emplace_back(report_magics_aux(subject.alter_reality),
+    if (const auto alter = subject.get_timed_effect(CreatureTimedEffect::ALTER_REALITY); alter != 0) {
+        info.emplace_back(report_magics_aux(alter),
             _("この後現実変容が発動する", "You waiting to be altered"));
     }
 

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -274,7 +274,7 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
         floor.quest_number = i2enum<QuestId>(grid_new.special);
         floor.dun_level = 0;
         if (!floor.is_in_quest()) {
-            creature.word_recall = 0;
+            creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, 0);
         }
         creature.oldpx = 0;
         creature.oldpy = 0;

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -207,9 +207,9 @@ void wr_player(CreatureEntity &creature)
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::SHIELD));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::BLESSED));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::TIM_INVIS));
-    wr_s16b(creature.word_recall);
+    wr_s16b(creature.get_timed_effect(CreatureTimedEffect::WORD_RECALL));
     wr_s16b(static_cast<int16_t>(creature.recall_dungeon));
-    wr_s16b(creature.alter_reality);
+    wr_s16b(creature.get_timed_effect(CreatureTimedEffect::ALTER_REALITY));
     wr_s16b(creature.see_infra);
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::TIM_INFRA));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE));

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -351,14 +351,14 @@ void reserve_alter_reality(CreatureEntity &creature, TIME_EFFECT turns)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (creature.alter_reality || turns == 0) {
-        creature.alter_reality = 0;
+    if (creature.get_timed_effect(CreatureTimedEffect::ALTER_REALITY) || turns == 0) {
+        creature.set_timed_effect(CreatureTimedEffect::ALTER_REALITY, 0);
         msg_print(_("景色が元に戻った...", "The view around you returns to normal..."));
         rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
         return;
     }
 
-    creature.alter_reality = turns;
+    creature.set_timed_effect(CreatureTimedEffect::ALTER_REALITY, turns);
     msg_print(_("回りの景色が変わり始めた...", "The view around you begins to change..."));
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
 }
@@ -438,7 +438,7 @@ bool recall_player(CreatureEntity &creature, TIME_EFFECT turns)
     auto is_special_floor = floor.is_underground();
     is_special_floor &= dungeon_record.get_max_level() > floor.dun_level;
     is_special_floor &= !floor.is_in_quest();
-    is_special_floor &= !creature.word_recall;
+    is_special_floor &= !creature.get_timed_effect(CreatureTimedEffect::WORD_RECALL);
     if (is_special_floor) {
         if (input_check(_("ここは最深到達階より浅い階です。この階に戻って来ますか？ ", "Reset recall depth? "))) {
             dungeon_record.set_max_level(floor.dun_level);
@@ -449,8 +449,8 @@ bool recall_player(CreatureEntity &creature, TIME_EFFECT turns)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (creature.word_recall || turns == 0) {
-        creature.word_recall = 0;
+    if (creature.get_timed_effect(CreatureTimedEffect::WORD_RECALL) || turns == 0) {
+        creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, 0);
         msg_print(_("張りつめた大気が流れ去った...", "A tension leaves the air around you..."));
         rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
         return true;
@@ -471,7 +471,7 @@ bool recall_player(CreatureEntity &creature, TIME_EFFECT turns)
         creature.recall_dungeon = *select_dungeon;
     }
 
-    creature.word_recall = turns;
+    creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, turns);
     msg_print(_("回りの大気が張りつめてきた...", "The air about you becomes charged..."));
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     return true;
@@ -503,7 +503,7 @@ bool free_level_recall(CreatureEntity &creature)
         return false;
     }
 
-    creature.word_recall = 1;
+    creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, 1);
     creature.recall_dungeon = *select_dungeon;
     const auto dun_level = (amt > dungeon.maxdepth) ? dungeon.maxdepth : (amt < dungeon.mindepth) ? dungeon.mindepth
                                                                                                   : amt;

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -86,9 +86,10 @@ void reset_tim_flags(CreatureEntity &creature)
     creature.set_timed_effect(CreatureTimedEffect::OPPOSE_COLD, 0);
     creature.set_timed_effect(CreatureTimedEffect::OPPOSE_POIS, 0);
 
+    creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, 0);
+    creature.set_timed_effect(CreatureTimedEffect::ALTER_REALITY, 0);
+
     // 非 CreatureTimedEffect のリセット
-    creature.word_recall = 0;
-    creature.alter_reality = 0;
     creature.sutemi = false;
     creature.counter = false;
     creature.special_attack = 0L;

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -62,8 +62,8 @@ bool CreatureEntity::is_fully_healthy() const
     is_healthy &= !effects->deceleration().is_slow();
     is_healthy &= !effects->paralysis().is_paralyzed();
     is_healthy &= !effects->hallucination().is_hallucinated();
-    is_healthy &= !this->word_recall;
-    is_healthy &= !this->alter_reality;
+    is_healthy &= !this->get_timed_effect(CreatureTimedEffect::WORD_RECALL);
+    is_healthy &= !this->get_timed_effect(CreatureTimedEffect::ALTER_REALITY);
     return is_healthy;
 }
 

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1160,8 +1160,6 @@ public:
 #define COMMAND_ARG_REST_FULL_HEALING -1 /*!<休憩コマンド引数 … HPとMPが全回復するまで */
     GAME_TURN resting{}; /* Current counter for resting, if any */
 
-    TIME_EFFECT word_recall{}; /* Word of recall counter */
-    TIME_EFFECT alter_reality{}; /* Alter reality counter */
     DungeonId recall_dungeon{}; /* Dungeon set to be recalled */
 
     ENERGY enchant_energy_need{}; /* Energy needed for next upkeep effect	 */

--- a/src/system/creature-timed-effect-types.h
+++ b/src/system/creature-timed-effect-types.h
@@ -79,5 +79,9 @@ enum class CreatureTimedEffect {
     TIM_EMISSION, /*!< 放射 / Player Emission */
     TIM_EXORCISM, /*!< 退魔 / Exorcism */
 
+    // --- プレイヤー専用：世界操作系 ---
+    WORD_RECALL, /*!< 帰還のカウントダウン / Word of Recall counter */
+    ALTER_REALITY, /*!< 現実改変のカウントダウン / Alter Reality counter */
+
     MAX,
 };

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -576,11 +576,11 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_RESPOIS);
     }
 
-    if (creature.word_recall) {
+    if (creature.get_timed_effect(CreatureTimedEffect::WORD_RECALL)) {
         ADD_BAR_FLAG(BAR_RECALL);
     }
 
-    if (creature.alter_reality) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ALTER_REALITY)) {
         ADD_BAR_FLAG(BAR_ALTER);
     }
 

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -63,17 +63,18 @@ void check_random_quest_auto_failure(CreatureEntity &creature)
  */
 void execute_recall(CreatureEntity &creature)
 {
-    if (creature.word_recall == 0) {
+    const auto recall = creature.get_timed_effect(CreatureTimedEffect::WORD_RECALL);
+    if (recall == 0) {
         return;
     }
 
-    if (autosave_l && (creature.word_recall == 1) && !AngbandSystem::get_instance().is_phase_out()) {
+    if (autosave_l && (recall == 1) && !AngbandSystem::get_instance().is_phase_out()) {
         do_cmd_save_game(creature, true);
     }
 
-    creature.word_recall--;
+    creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, recall - 1);
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (creature.word_recall != 0) {
+    if (creature.get_timed_effect(CreatureTimedEffect::WORD_RECALL) != 0) {
         return;
     }
 
@@ -147,17 +148,18 @@ void execute_recall(CreatureEntity &creature)
 void execute_floor_reset(CreatureEntity &creature)
 {
     const auto &floor = *creature.get_floor();
-    if (creature.alter_reality == 0) {
+    const auto alter = creature.get_timed_effect(CreatureTimedEffect::ALTER_REALITY);
+    if (alter == 0) {
         return;
     }
 
-    if (autosave_l && (creature.alter_reality == 1) && !AngbandSystem::get_instance().is_phase_out()) {
+    if (autosave_l && (alter == 1) && !AngbandSystem::get_instance().is_phase_out()) {
         do_cmd_save_game(creature, true);
     }
 
-    creature.alter_reality--;
+    creature.set_timed_effect(CreatureTimedEffect::ALTER_REALITY, alter - 1);
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (creature.alter_reality != 0) {
+    if (creature.get_timed_effect(CreatureTimedEffect::ALTER_REALITY) != 0) {
         return;
     }
 


### PR DESCRIPTION
CreatureEntity の残存していた直接フィールド word_recall / alter_reality (帰還・現実改変のカウントダウン) を CreatureTimedEffect enum に追加し、 統一 map 管理下へ移行する。

- creature-timed-effect-types.h: WORD_RECALL / ALTER_REALITY を追加 (「プレイヤー専用：世界操作系」セクション)
- creature-entity.h: 直接フィールド word_recall / alter_reality を削除
- 15 ファイル計 37 箇所の直接アクセス (.word_recall / .alter_reality) を get_timed_effect / set_timed_effect API に置換: 世界進行 (world-movement-processor)、マップ表示バー、セーブ/ロード、 自己情報表示、お泊り/帰還コマンド、スペル (spells-world)、他

これで CreatureEntity の TIME_EFFECT 直接フィールドは完全に消え、
全ての時限効果が CreatureEntity::timed_effects_map に集約された。

https://claude.ai/code/session_01Q6mCnU2BLa2WBs38WzM3y2