### PR TITLE
refactor: CreatureEntity 引数関数内のローカル player_ptr エイリアスを除去

### DIFF
--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -359,13 +359,12 @@ static int get_mane_power(CreatureEntity &creature, int *sn, bool baigaesi)
 /*!
  * @brief ものまね処理の発動 /
  * do_cmd_cast calls this function if the creature's class is 'imitator'.
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param creature クリーチャーへの参照
  * @param spell 発動するモンスター攻撃のID
  * @return 処理を実行したらTRUE、キャンセルした場合FALSEを返す。
  */
 static bool use_mane(CreatureEntity &creature, MonsterAbilityType spell)
 {
-    auto *player_ptr = &creature;
     PLAYER_LEVEL plev = creature.get_level();
     BIT_FLAGS mode = (PM_ALLOW_GROUP | PM_FORCE_PET);
     BIT_FLAGS u_mode = 0L;
@@ -695,23 +694,23 @@ static bool use_mane(CreatureEntity &creature, MonsterAbilityType spell)
         break;
     case MonsterAbilityType::SCARE:
         msg_print(_("恐ろしげな幻覚を作り出した。", "You cast a fearful illusion."));
-        fear_monster(*player_ptr, dir, plev + 10);
+        fear_monster(creature, dir, plev + 10);
         break;
     case MonsterAbilityType::BLIND:
-        confuse_monster(*player_ptr, dir, plev * 2);
+        confuse_monster(creature, dir, plev * 2);
         break;
     case MonsterAbilityType::CONF:
         msg_print(_("誘惑的な幻覚をつくり出した。", "You cast a mesmerizing illusion."));
-        confuse_monster(*player_ptr, dir, plev * 2);
+        confuse_monster(creature, dir, plev * 2);
         break;
     case MonsterAbilityType::SLOW:
-        slow_monster(*player_ptr, dir, plev);
+        slow_monster(creature, dir, plev);
         break;
     case MonsterAbilityType::HOLD:
-        sleep_monster(*player_ptr, dir, plev);
+        sleep_monster(creature, dir, plev);
         break;
     case MonsterAbilityType::HASTE:
-        (void)set_acceleration(*player_ptr, randint1(20 + plev) + plev, false);
+        (void)set_acceleration(creature, randint1(20 + plev) + plev, false);
         break;
     case MonsterAbilityType::HAND_DOOM: {
         msg_print(_("<破滅の手>を放った！", "You invoke the Hand of Doom!"));
@@ -720,7 +719,7 @@ static bool use_mane(CreatureEntity &creature, MonsterAbilityType spell)
     }
     case MonsterAbilityType::HEAL: {
         msg_print(_("自分の傷に念を集中した。", "You concentrate on your wounds!"));
-        (void)hp_player(*player_ptr, plev * 6);
+        (void)hp_player(creature, plev * 6);
         BadStatusSetter bss(creature);
         (void)bss.set_stun(0);
         (void)bss.set_cut(0);
@@ -728,16 +727,16 @@ static bool use_mane(CreatureEntity &creature, MonsterAbilityType spell)
     }
     case MonsterAbilityType::INVULNER:
         msg_print(_("無傷の球の呪文を唱えた。", "You cast a Globe of Invulnerability."));
-        (void)set_invuln(*player_ptr, randint1(7) + 7, false);
+        (void)set_invuln(creature, randint1(7) + 7, false);
         break;
     case MonsterAbilityType::BLINK:
-        teleport_player(*player_ptr, 10, TELEPORT_SPONTANEOUS);
+        teleport_player(creature, 10, TELEPORT_SPONTANEOUS);
         break;
     case MonsterAbilityType::TPORT:
-        teleport_player(*player_ptr, plev * 5, TELEPORT_SPONTANEOUS);
+        teleport_player(creature, plev * 5, TELEPORT_SPONTANEOUS);
         break;
     case MonsterAbilityType::WORLD:
-        (void)time_walk(*player_ptr);
+        (void)time_walk(creature);
         break;
     case MonsterAbilityType::SPECIAL:
         break;
@@ -797,7 +796,7 @@ static bool use_mane(CreatureEntity &creature, MonsterAbilityType spell)
 
     case MonsterAbilityType::DARKNESS:
         msg_print(_("暗闇の中で手を振った。", "You gesture in shadow."));
-        (void)unlite_area(*player_ptr, 10, 3);
+        (void)unlite_area(creature, 10, 3);
         break;
 
     case MonsterAbilityType::TRAPS: {

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -37,10 +37,9 @@
  */
 void pattern_teleport(CreatureEntity &creature)
 {
-    auto *player_ptr = &creature;
     auto min_level = 0;
     auto max_level = 99;
-    auto &floor = *player_ptr->get_floor();
+    auto &floor = *creature.get_floor();
     auto current_level = static_cast<short>(floor.dun_level);
     if (input_check(_("他の階にテレポートしますか？", "Teleport level? "))) {
         if (ironman_downward) {
@@ -67,7 +66,7 @@ void pattern_teleport(CreatureEntity &creature)
 
         command_arg = *input_level;
     } else if (input_check(_("通常テレポート？", "Normal teleport? "))) {
-        teleport_player(*player_ptr, 200, TELEPORT_SPONTANEOUS);
+        teleport_player(creature, 200, TELEPORT_SPONTANEOUS);
         return;
     } else {
         return;
@@ -75,17 +74,17 @@ void pattern_teleport(CreatureEntity &creature)
 
     msg_format(_("%d 階にテレポートしました。", "You teleport to dungeon level %d."), command_arg);
     if (autosave_l) {
-        do_cmd_save_game(*player_ptr, true);
+        do_cmd_save_game(creature, true);
     }
 
     floor.dun_level = command_arg;
-    leave_quest_check(*player_ptr);
+    leave_quest_check(creature);
     if (record_stair) {
         exe_write_diary(floor, DiaryKind::PAT_TELE, 0);
     }
 
-    player_ptr->get_floor()->quest_number = QuestId::NONE;
-    PlayerEnergy(*player_ptr).reset_player_turn();
+    creature.get_floor()->quest_number = QuestId::NONE;
+    PlayerEnergy(creature).reset_player_turn();
 
     /*
      * Clear all saved floors
@@ -93,9 +92,9 @@ void pattern_teleport(CreatureEntity &creature)
      */
     FloorChangeModesStore::get_instace()->set(FloorChangeMode::FIRST_FLOOR);
 
-    check_random_quest_auto_failure(*player_ptr);
+    check_random_quest_auto_failure(creature);
 
-    player_ptr->leaving = true;
+    creature.leaving = true;
 }
 
 /*!
@@ -104,27 +103,26 @@ void pattern_teleport(CreatureEntity &creature)
  */
 bool pattern_effect(CreatureEntity &creature)
 {
-    auto *player_ptr = &creature;
-    const auto &floor = *player_ptr->get_floor();
-    const auto p_pos = player_ptr->get_position();
+    const auto &floor = *creature.get_floor();
+    const auto p_pos = creature.get_position();
     const auto &grid = floor.get_grid(p_pos);
     if (!grid.has(TerrainCharacteristics::PATTERN)) {
         return false;
     }
 
-    const auto is_cut = player_ptr->effects()->cut().is_cut();
-    if ((CreatureRace(player_ptr).equals(PlayerRaceType::AMBERITE)) && is_cut && one_in_(10)) {
-        wreck_the_pattern(*player_ptr);
+    const auto is_cut = creature.effects()->cut().is_cut();
+    if ((CreatureRace(&creature).equals(PlayerRaceType::AMBERITE)) && is_cut && one_in_(10)) {
+        wreck_the_pattern(creature);
     }
 
     switch (grid.get_terrain().subtype) {
     case PATTERN_TILE_END:
-        (void)BadStatusSetter(*player_ptr).hallucination(0);
-        (void)restore_all_status(*player_ptr);
-        (void)restore_level(static_cast<CreatureEntity &>(*player_ptr));
-        (void)cure_critical_wounds(*player_ptr, 1000);
+        (void)BadStatusSetter(creature).hallucination(0);
+        (void)restore_all_status(creature);
+        (void)restore_level(creature);
+        (void)cure_critical_wounds(creature, 1000);
 
-        set_terrain_id_to_grid(*player_ptr, player_ptr->get_position(), TerrainTag::PATTERN_OLD);
+        set_terrain_id_to_grid(creature, creature.get_position(), TerrainTag::PATTERN_OLD);
         msg_print(_("「パターン」のこの部分は他の部分より強力でないようだ。", "This section of the Pattern looks less powerful."));
 
         /*
@@ -144,16 +142,16 @@ bool pattern_effect(CreatureEntity &creature)
         break;
 
     case PATTERN_TILE_WRECKED:
-        if (!player_ptr->is_invulnerable()) {
-            take_hit(*player_ptr, DAMAGE_NOESCAPE, 200, _("壊れた「パターン」を歩いたダメージ", "walking the corrupted Pattern"));
+        if (!creature.is_invulnerable()) {
+            take_hit(creature, DAMAGE_NOESCAPE, 200, _("壊れた「パターン」を歩いたダメージ", "walking the corrupted Pattern"));
         }
         break;
 
     default:
-        if (CreatureRace(player_ptr).equals(PlayerRaceType::AMBERITE) && !one_in_(2)) {
+        if (CreatureRace(&creature).equals(PlayerRaceType::AMBERITE) && !one_in_(2)) {
             return true;
-        } else if (!player_ptr->is_invulnerable()) {
-            take_hit(*player_ptr, DAMAGE_NOESCAPE, Dice::roll(1, 3), _("「パターン」を歩いたダメージ", "walking the Pattern"));
+        } else if (!creature.is_invulnerable()) {
+            take_hit(creature, DAMAGE_NOESCAPE, Dice::roll(1, 3), _("「パターン」を歩いたダメージ", "walking the Pattern"));
         }
         break;
     }
@@ -163,15 +161,14 @@ bool pattern_effect(CreatureEntity &creature)
 
 /*!
  * @brief パターンによる移動制限処理
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param creature クリーチャーへの参照
  * @param pos プレイヤーの移動先座標
  * @return 移動処理が可能である場合（可能な場合に選択した場合）TRUEを返す。
  */
 bool pattern_seq(CreatureEntity &creature, const Pos2D &pos)
 {
-    auto *player_ptr = &creature;
-    const auto &floor = *player_ptr->get_floor();
-    const auto &grid_current = floor.get_grid(player_ptr->get_position());
+    const auto &floor = *creature.get_floor();
+    const auto &grid_current = floor.get_grid(creature.get_position());
     const auto &grid_new = floor.get_grid(pos);
     const auto &terrain_current = grid_current.get_terrain();
     const auto &terrain_new = grid_new.get_terrain();
@@ -184,9 +181,9 @@ bool pattern_seq(CreatureEntity &creature, const Pos2D &pos)
     int pattern_type_cur = is_pattern_tile_cur ? terrain_current.subtype : NOT_PATTERN_TILE;
     int pattern_type_new = is_pattern_tile_new ? terrain_new.subtype : NOT_PATTERN_TILE;
     if (pattern_type_new == PATTERN_TILE_START) {
-        const auto effects = player_ptr->effects();
-        const auto is_stunned = player_ptr->is_stunned();
-        const auto is_confused = player_ptr->is_confused();
+        const auto effects = creature.effects();
+        const auto is_stunned = creature.is_stunned();
+        const auto is_confused = creature.is_confused();
         const auto is_hallucinated = effects->hallucination().is_hallucinated();
         if (is_pattern_tile_cur || is_confused || is_stunned || is_hallucinated) {
             return true;

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -141,7 +141,6 @@ bool rush_attack(CreatureEntity &creature, bool *mdeath)
         return true;
     }
 
-    auto *player_ptr = &creature;
     auto p_pos_new = p_pos;
     auto tmp_mdeath = false;
     auto moved = false;
@@ -159,10 +158,10 @@ bool rush_attack(CreatureEntity &creature, bool *mdeath)
         }
 
         if (!creature.is_located_at(p_pos_new)) {
-            teleport_player_to(*player_ptr, p_pos_new.y, p_pos_new.x, TELEPORT_NONMAGICAL);
+            teleport_player_to(creature, p_pos_new.y, p_pos_new.x, TELEPORT_NONMAGICAL);
         }
 
-        update_monster(*player_ptr, grid_new.m_idx, true);
+        update_monster(creature, grid_new.m_idx, true);
         const auto &monster = floor.get_monster(grid_new.m_idx);
         if (tm_idx != grid_new.m_idx) {
 #ifdef JP
@@ -176,16 +175,16 @@ bool rush_attack(CreatureEntity &creature, bool *mdeath)
         }
 
         if (!creature.is_located_at(p_pos_new)) {
-            teleport_player_to(*player_ptr, p_pos_new.y, p_pos_new.x, TELEPORT_NONMAGICAL);
+            teleport_player_to(creature, p_pos_new.y, p_pos_new.x, TELEPORT_NONMAGICAL);
         }
 
         moved = true;
-        tmp_mdeath = do_cmd_attack(*player_ptr, pos.y, pos.x, HISSATSU_NYUSIN);
+        tmp_mdeath = do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NYUSIN);
         break;
     }
 
     if (!moved && !creature.is_located_at(p_pos_new)) {
-        teleport_player_to(*player_ptr, p_pos_new.y, p_pos_new.x, TELEPORT_NONMAGICAL);
+        teleport_player_to(creature, p_pos_new.y, p_pos_new.x, TELEPORT_NONMAGICAL);
     }
 
     if (mdeath) {
@@ -202,21 +201,20 @@ bool rush_attack(CreatureEntity &creature, bool *mdeath)
  */
 void process_surprise_attack(CreatureEntity &creature, player_attack_type *pa_ptr)
 {
-    auto *player_ptr = &creature;
 
     const auto &monrace = pa_ptr->m_ptr->get_monrace();
-    if (!has_melee_weapon(creature, enum2i(INVEN_MAIN_HAND) + pa_ptr->hand) || player_ptr->is_icky_wield[pa_ptr->hand]) {
+    if (!has_melee_weapon(creature, enum2i(INVEN_MAIN_HAND) + pa_ptr->hand) || creature.is_icky_wield[pa_ptr->hand]) {
         return;
     }
 
-    int tmp = player_ptr->level * 6 + (player_ptr->skill_stl + 10) * 4;
-    if (player_ptr->monlite && (pa_ptr->mode != HISSATSU_NYUSIN)) {
+    int tmp = creature.level * 6 + (creature.skill_stl + 10) * 4;
+    if (creature.monlite && (pa_ptr->mode != HISSATSU_NYUSIN)) {
         tmp /= 3;
     }
     if (has_aggravate(creature)) {
         tmp /= 2;
     }
-    if (monrace.level > (player_ptr->level * player_ptr->level / 20 + 10)) {
+    if (monrace.level > (creature.level * creature.level / 20 + 10)) {
         tmp /= 3;
     }
 
@@ -277,9 +275,8 @@ void calc_surprise_attack_damage(CreatureEntity &creature, player_attack_type *p
  */
 bool hayagake(CreatureEntity &creature)
 {
-    auto *player_ptr = &creature;
     PlayerEnergy energy(creature);
-    if (player_ptr->action == ACTION_HAYAGAKE) {
+    if (creature.action == ACTION_HAYAGAKE) {
         set_action(creature, ACTION_NONE);
         energy.reset_player_turn();
         return true;
@@ -287,7 +284,7 @@ bool hayagake(CreatureEntity &creature)
 
     const auto &grid = creature.get_floor()->get_grid(creature.get_position());
     const auto &terrain = grid.get_terrain();
-    if (terrain.flags.has_not(TerrainCharacteristics::PROJECTION) || (!player_ptr->levitation && terrain.flags.has(TerrainCharacteristics::DEEP))) {
+    if (terrain.flags.has_not(TerrainCharacteristics::PROJECTION) || (!creature.levitation && terrain.flags.has(TerrainCharacteristics::DEEP))) {
         msg_print(_("ここでは素早く動けない。", "You cannot run in here."));
     } else {
         set_action(creature, ACTION_HAYAGAKE);
@@ -307,8 +304,6 @@ bool set_superstealth(CreatureEntity &creature, bool set)
 {
     bool notice = false;
 
-    auto *player_ptr = &creature;
-
     auto ninja_data = CreatureClass(creature).get_specific_data<ninja_data_type>();
     if (!ninja_data || creature.is_dead()) {
         return false;
@@ -318,10 +313,10 @@ bool set_superstealth(CreatureEntity &creature, bool set)
         if (!ninja_data->s_stealth) {
             if (creature.get_floor()->grid_array[creature.y][creature.x].info & CAVE_MNLT) {
                 msg_print(_("敵の目から薄い影の中に覆い隠された。", "You are mantled in weak shadow from ordinary eyes."));
-                player_ptr->monlite = player_ptr->old_monlite = true;
+                creature.monlite = creature.old_monlite = true;
             } else {
                 msg_print(_("敵の目から影の中に覆い隠された！", "You are mantled in shadow from ordinary eyes!"));
-                player_ptr->monlite = player_ptr->old_monlite = false;
+                creature.monlite = creature.old_monlite = false;
             }
 
             notice = true;
@@ -356,12 +351,11 @@ bool set_superstealth(CreatureEntity &creature, bool set)
  */
 bool cast_ninja_spell(CreatureEntity &creature, MindNinjaType spell)
 {
-    auto *player_ptr = &creature;
     PLAYER_LEVEL plev = creature.level;
     auto ninja_data = CreatureClass(creature).get_specific_data<ninja_data_type>();
     switch (spell) {
     case MindNinjaType::DARKNESS_CREATION:
-        (void)unlite_area(*player_ptr, 0, 3);
+        (void)unlite_area(creature, 0, 3);
         break;
     case MindNinjaType::DETECT_NEAR:
         if (plev > 44) {
@@ -381,7 +375,7 @@ bool cast_ninja_spell(CreatureEntity &creature, MindNinjaType spell)
 
         break;
     case MindNinjaType::HIDE_LEAVES:
-        teleport_player(*player_ptr, 10, TELEPORT_SPONTANEOUS);
+        teleport_player(creature, 10, TELEPORT_SPONTANEOUS);
         break;
     case MindNinjaType::KAWARIMI:
         if (ninja_data && !ninja_data->kawarimi) {
@@ -392,7 +386,7 @@ bool cast_ninja_spell(CreatureEntity &creature, MindNinjaType spell)
 
         break;
     case MindNinjaType::ABSCONDING:
-        teleport_player(*player_ptr, plev * 5, TELEPORT_SPONTANEOUS);
+        teleport_player(creature, plev * 5, TELEPORT_SPONTANEOUS);
         break;
     case MindNinjaType::HIT_AND_AWAY:
         if (!hit_and_away(creature)) {
@@ -406,18 +400,18 @@ bool cast_ninja_spell(CreatureEntity &creature, MindNinjaType spell)
             return false;
         }
 
-        (void)stasis_monster(*player_ptr, dir);
+        (void)stasis_monster(creature, dir);
         break;
     }
     case MindNinjaType::ANCIENT_KNOWLEDGE:
-        return ident_spell(*player_ptr, false);
+        return ident_spell(creature, false);
     case MindNinjaType::FLOATING:
         set_tim_levitation(creature, randint1(20) + 20, false);
         break;
     case MindNinjaType::HIDE_FLAMES:
         fire_ball(creature, AttributeType::FIRE, Direction::self(), 50 + plev, plev / 10 + 2);
-        teleport_player(*player_ptr, 30, TELEPORT_SPONTANEOUS);
-        set_oppose_fire(*player_ptr, (TIME_EFFECT)plev, false);
+        teleport_player(creature, 30, TELEPORT_SPONTANEOUS);
+        set_oppose_fire(creature, (TIME_EFFECT)plev, false);
         break;
     case MindNinjaType::NYUSIN:
         return rush_attack(creature, nullptr);
@@ -426,7 +420,7 @@ bool cast_ninja_spell(CreatureEntity &creature, MindNinjaType spell)
             OBJECT_IDX slot;
 
             for (slot = 0; slot < INVEN_PACK; slot++) {
-                if (player_ptr->inventory[slot]->bi_key.tval() == ItemKindType::SPIKE) {
+                if (creature.inventory[slot]->bi_key.tval() == ItemKindType::SPIKE) {
                     break;
                 }
             }
@@ -441,8 +435,8 @@ bool cast_ninja_spell(CreatureEntity &creature, MindNinjaType spell)
                 return false;
             }
 
-            (void)ThrowCommand(*player_ptr).do_cmd_throw(1, false, slot);
-            PlayerEnergy(*player_ptr).set_player_turn_energy(100);
+            (void)ThrowCommand(creature).do_cmd_throw(1, false, slot);
+            PlayerEnergy(creature).set_player_turn_energy(100);
         }
 
         break;
@@ -468,21 +462,21 @@ bool cast_ninja_spell(CreatureEntity &creature, MindNinjaType spell)
         }
 
         project_length = 0;
-        (void)teleport_swap(*player_ptr, dir);
+        (void)teleport_swap(creature, dir);
         break;
     }
     case MindNinjaType::EXPLOSIVE_RUNE:
-        create_rune_explosion(*player_ptr, creature.y, creature.x);
+        create_rune_explosion(creature, creature.y, creature.x);
         break;
     case MindNinjaType::HIDE_MUD:
-        (void)set_pass_wall(*player_ptr, randint1(plev / 2) + plev / 2, false);
-        set_oppose_acid(*player_ptr, (TIME_EFFECT)plev, false);
+        (void)set_pass_wall(creature, randint1(plev / 2) + plev / 2, false);
+        set_oppose_acid(creature, (TIME_EFFECT)plev, false);
         break;
     case MindNinjaType::HIDE_MIST:
         fire_ball(creature, AttributeType::POIS, Direction::self(), 75 + plev * 2 / 3, plev / 5 + 2);
         fire_ball(creature, AttributeType::HYPODYNAMIA, Direction::self(), 75 + plev * 2 / 3, plev / 5 + 2);
         fire_ball(creature, AttributeType::CONFUSION, Direction::self(), 75 + plev * 2 / 3, plev / 5 + 2);
-        teleport_player(*player_ptr, 30, TELEPORT_SPONTANEOUS);
+        teleport_player(creature, 30, TELEPORT_SPONTANEOUS);
         break;
     case MindNinjaType::PURGATORY_FLAME: {
         const auto num = Dice::roll(3, 9);

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -244,11 +244,10 @@ void wiz_restore_aware_flag_of_fixed_arfifact(FixedArtifactId reset_artifact_idx
  */
 void wiz_modify_item_activation(CreatureEntity &creature)
 {
-    auto *player_ptr = &creature;
     constexpr auto q = _("どのアイテムの発動を変更しますか？ ", "Which item? ");
     constexpr auto s = _("発動を変更するアイテムがない。", "Nothing to do with.");
     short i_idx;
-    auto *o_ptr = choose_object(*player_ptr, &i_idx, q, s, USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT);
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT);
     if (!o_ptr) {
         return;
     }
@@ -734,11 +733,10 @@ static void wiz_quantity_item(ItemEntity *o_ptr)
  */
 void wiz_modify_item(CreatureEntity &creature)
 {
-    auto *player_ptr = &creature;
     constexpr auto q = "Play with which object? ";
     constexpr auto s = "You have nothing to play with.";
     short i_idx;
-    auto *o_ptr = choose_object(*player_ptr, &i_idx, q, s, USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT);
+    auto *o_ptr = choose_object(creature, &i_idx, q, s, USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT);
     if (!o_ptr) {
         return;
     }


### PR DESCRIPTION
CreatureEntity &creature を引数に取る関数の内部で
auto *player_ptr = &creature; としていた互換的なローカルエイリアスを撤廃し、 creature へ直接アクセスする形に統一する。

対象ファイル:
- floor/pattern-walk.cpp (3 関数)
- mind/mind-ninja.cpp (5 関数)
- wizard/wizard-item-modifier.cpp (2 関数: wiz_modify_item_activation / wiz_modify_item)
- cmd-action/cmd-mane.cpp (1 関数: use_mane)

cmd-mane.cpp の doxygen コメント @param player_ptr も @param creature に修正。

CLAUDE.md Phase 1「関数シグネチャの統一」で PlayerType *player_ptr を CreatureEntity &creature に変更した後の残存エイリアス整理。