### PR TITLE
refactor: process_monsters_mtimed を process_monsters_timed_effect に改名

### DIFF
--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -107,7 +107,7 @@ int mon_damage_mod(CreatureEntity &creature, const CreatureEntity &target, int d
  * @param m_idx モンスター参照ID
  * @param mte 更新するモンスターの時限ステータスID
  */
-static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_idx, CreatureTimedEffect mte)
+static void process_monsters_timed_effect_aux(CreatureEntity &creature, MONSTER_IDX m_idx, CreatureTimedEffect mte)
 {
     auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
@@ -281,7 +281,7 @@ static void process_monsters_mtimed_aux(CreatureEntity &creature, MONSTER_IDX m_
  * Process the counters of monsters (once per 10 game turns)\n
  * These functions are to process monsters' counters same as player's.
  */
-void process_monsters_mtimed(CreatureEntity &creature, CreatureTimedEffect mte)
+void process_monsters_timed_effect(CreatureEntity &creature, CreatureTimedEffect mte)
 {
     const auto &floor = *creature.get_floor();
     const auto &cur_mproc_list = floor.mproc_list.at(mte);
@@ -294,7 +294,7 @@ void process_monsters_mtimed(CreatureEntity &creature, CreatureTimedEffect mte)
     /* Process the monsters (backwards) */
     for (auto i = floor.mproc_max.at(mte) - 1; i >= 0; i--) {
         const auto m_idx = cur_mproc_list[i];
-        process_monsters_mtimed_aux(creature, m_idx, mte);
+        process_monsters_timed_effect_aux(creature, m_idx, mte);
         HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
     }
 }

--- a/src/monster/monster-status.h
+++ b/src/monster/monster-status.h
@@ -14,4 +14,4 @@ void dispel_monster_status(CreatureEntity &creature, MONSTER_IDX m_idx);
 void monster_gain_exp(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId s_idx);
 
 enum class CreatureTimedEffect;
-void process_monsters_mtimed(CreatureEntity &creature, CreatureTimedEffect mte);
+void process_monsters_timed_effect(CreatureEntity &creature, CreatureTimedEffect mte);

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -302,7 +302,7 @@ void WorldTurnProcessor::process_world_monsters()
 
     for (const auto mte : MONSTER_TIMED_EFFECT_LIST) {
         if (this->creature.get_floor()->mproc_max[mte] > 0) {
-            process_monsters_mtimed(this->creature, mte);
+            process_monsters_timed_effect(this->creature, mte);
         }
     }
 }


### PR DESCRIPTION
Phase 3 で MonsterProfile::mtimed ストレージを廃止した結果、
関数名の「mtimed」表記が実装内容と乖離したため、以下のように改名する。

- process_monsters_mtimed → process_monsters_timed_effect
- process_monsters_mtimed_aux → process_monsters_timed_effect_aux

影響:
- monster/monster-status.h: 宣言
- monster/monster-status.cpp: 定義・内部呼出
- world/world-turn-processor.cpp: 唯一の外部呼出箇所

ソースコード上の「mtimed」識別子はこれで完全に消滅した。

https://claude.ai/code/session_01Q6mCnU2BLa2WBs38WzM3y2