### PR TITLE
refactor: BodyImprovement::player_ptr を creature_ptr に改名

### DIFF
--- a/src/status/body-improvement.cpp
+++ b/src/status/body-improvement.cpp
@@ -14,7 +14,7 @@
 #include "view/display-messages.h"
 
 BodyImprovement::BodyImprovement(CreatureEntity &creature)
-    : player_ptr(&creature)
+    : creature_ptr(&creature)
 {
 }
 
@@ -25,7 +25,7 @@ bool BodyImprovement::has_effect() const
 
 void BodyImprovement::mod_protection(short v, bool is_decrease)
 {
-    this->set_protection(this->player_ptr->effects()->protection().current() + v, is_decrease);
+    this->set_protection(this->creature_ptr->effects()->protection().current() + v, is_decrease);
 }
 
 /*!
@@ -40,11 +40,11 @@ void BodyImprovement::set_protection(short v, bool is_decrease)
     auto notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
-    if (this->player_ptr->is_dead()) {
+    if (this->creature_ptr->is_dead()) {
         return;
     }
 
-    auto &protection = this->player_ptr->effects()->protection();
+    auto &protection = this->creature_ptr->effects()->protection();
     const auto is_protected = protection.is_protected();
     if (v) {
         if (is_protected && !is_decrease) {
@@ -69,10 +69,10 @@ void BodyImprovement::set_protection(short v, bool is_decrease)
     }
 
     if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(*player_ptr, false, true);
+        disturb(*this->creature_ptr, false, true);
     }
 
-    handle_stuff(*player_ptr);
+    handle_stuff(*this->creature_ptr);
     this->is_affected = true;
 }
 

--- a/src/status/body-improvement.h
+++ b/src/status/body-improvement.h
@@ -1,17 +1,16 @@
 #pragma once
 
-class PlayerType;
 class CreatureEntity;
 class BodyImprovement {
 public:
-    BodyImprovement(CreatureEntity &player);
+    BodyImprovement(CreatureEntity &creature);
 
     bool has_effect() const;
     void mod_protection(short v, bool is_decrease = false);
     void set_protection(short v, bool is_decrease = false);
 
 private:
-    CreatureEntity *player_ptr;
+    CreatureEntity *creature_ptr;
     bool is_affected = false;
 };
 


### PR DESCRIPTION
BodyImprovement クラスの唯一の残存 player_ptr メンバ名を、同種の
保持メンバを持つ他クラス (StoneOfLore / Chest 等) と同じ creature_ptr に統一する。

変更点:
- body-improvement.h:
  - 不要な class PlayerType; 前方宣言を削除
  - コンストラクタ引数名 CreatureEntity &player → CreatureEntity &creature
  - メンバ名 CreatureEntity *player_ptr → CreatureEntity *creature_ptr
- body-improvement.cpp:
  - コンストラクタ初期化子・メソッド内の this->player_ptr 参照を this->creature_ptr に更新
  - 関数末尾の disturb(*player_ptr, ...) / handle_stuff(*player_ptr) を 明示的な this->creature_ptr 参照に変更

これでソースコード上に残っていた player_ptr クラスメンバは撲滅された。
