### PR TITLE
fix: display_player_exp でモンスター対象時の配列範囲外アクセスを防止

### DIFF
--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -248,12 +248,14 @@ static void display_player_speed(CreatureEntity &creature, TERM_COLOR attr, int 
     }
 
     display_player_one_line(ENTRY_SPEED, buf, attr);
-    display_player_one_line(ENTRY_LEVEL, format("%d", creature.level), TERM_L_GREEN);
+    display_player_one_line(ENTRY_LEVEL, format("%d", creature.get_level()), TERM_L_GREEN);
 }
 
 /*!
  * @brief プレイヤーの現在経験値・最大経験値・次のレベルまでに必要な経験値を表示する
  * @param creature クリーチャーへの参照
+ * @details モンスターは経験値テーブルを持たないため、次レベル経験値は表示しない
+ * (level == 0 のとき player_exp[level - 1] が配列範囲外となるのを防ぐ)。
  */
 static void display_player_exp(CreatureEntity &creature)
 {
@@ -270,6 +272,12 @@ static void display_player_exp(CreatureEntity &creature)
     }
 
     e = pr.equals(PlayerRaceType::ANDROID) ? ENTRY_EXP_TO_ADV_ANDR : ENTRY_EXP_TO_ADV;
+
+    if (!creature.is_player() || creature.level <= 0) {
+        // モンスター (または無効レベル) は player_exp テーブルを参照できない
+        display_player_one_line(e, "-----", TERM_L_GREEN);
+        return;
+    }
 
     if (creature.level >= PY_MAX_LEVEL) {
         display_player_one_line(e, "*****", TERM_L_GREEN);


### PR DESCRIPTION
先の表示統合で display_player() をモンスター経路にも使うようにしたが、
display_player_middle → display_player_exp が creature.level - 1 を添字に player_exp[] / player_exp_a[] を参照していたため、CreatureEntity のデフォルト level (= 0) をそのまま使うモンスターでは player_exp[-1] の未定義動作を起こす 潜在バグがあった。

修正:
- ENTRY_LEVEL 表示を creature.level → creature.get_level() に変更 (monrace.level / 2 フォールバックを使用)
- display_player_exp のテーブル参照前に is_player() && level > 0 を確認 モンスターでは「次レベル経験値」表示を "-----" に置換

プレイヤー経路の挙動は不変 (is_player() && level > 0 は常に真)。