### PR TITLE
fix: display_player_name で無名クリーチャー時に「名無し」をフォールバック表示

### DIFF
--- a/src/view/display-player-misc-info.cpp
+++ b/src/view/display-player-misc-info.cpp
@@ -21,7 +21,12 @@ void display_player_name(CreatureEntity &creature, bool name_only)
     if (!name_only && creature.personality != nullptr) {
         ss << (*creature.personality).title << _((*creature.personality).no == 1 ? "の" : "", " ");
     }
-    ss << creature.name;
+    // 無名モンスター（または匿名プレイヤー）の場合は「名無し」表記へフォールバック
+    if (creature.name.empty()) {
+        ss << _("名無し", "No Name");
+    } else {
+        ss << creature.name;
+    }
     const auto display_name = ss.str();
 
     constexpr std::string_view header = _("名前  : ", "Name  : ");


### PR DESCRIPTION
display_player() をモンスターでも使うようにしたことで、creature.name が 空文字列のモンスター（= 未命名）を 'c' キーで表示した際に

    名前  :

だけの不格好な表示になっていた。旧 display_monster_status 時代の
挙動 (「名前: 名無し」) に合わせて、creature.name が空なら「名無し」
を表示する。

プレイヤー側は通常 name が必ずセットされているが、万一の事故でも
空欄ではなく「名無し」と表示されるため副作用は無い。