### PR TITLE
refactor: 不要な CreatureEntity 自身への static_cast を撤廃

### DIFF
--- a/src/blue-magic/blue-magic-checker.cpp
+++ b/src/blue-magic/blue-magic-checker.cpp
@@ -54,7 +54,7 @@ void learn_spell(CreatureEntity &creature, MonsterAbilityType monspell)
     if (randint1(creature.level + 70) > monster_power.level + 40) {
         bluemage_data->learnt_blue_magics.set(monspell);
         msg_format(_("%sを学習した！", "You have learned %s!"), monster_power.name);
-        gain_exp(static_cast<CreatureEntity &>(creature), monster_power.level * monster_power.smana);
+        gain_exp(creature, monster_power.level * monster_power.smana);
         sound(SoundKind::STUDY);
         bluemage_data->new_magic_learned = true;
         RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::ACTION);

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -269,7 +269,7 @@ static void curse_drain_exp(CreatureEntity &creature)
         creature.max_exp = 0;
     }
 
-    check_experience(static_cast<CreatureEntity &>(creature));
+    check_experience(creature);
 }
 
 static void multiply_low_curse(CreatureEntity &creature)

--- a/src/io-dump/player-status-dump-json.cpp
+++ b/src/io-dump/player-status-dump-json.cpp
@@ -74,7 +74,7 @@ static void add_basic_info_to_json(nlohmann::json &j, CreatureEntity &creature)
         return;
     }
 
-    j["basic"]["sex"] = localized_to_utf8_safe(sex_info[creature.psex].title);
+    j["basic"]["sex"] = localized_to_utf8_safe(creature.get_sex_info().title);
     j["basic"]["personality"] = localized_to_utf8_safe(personality_info[creature.ppersonality].title);
 
     if (creature.get_mimic_form() != MimicKindType::NONE) {

--- a/src/market/play-gamble.cpp
+++ b/src/market/play-gamble.cpp
@@ -254,10 +254,10 @@ void gamble_comm(CreatureEntity &creature, int cmd)
     prt("", 18, 37);
     if (creature.au >= oldgold) {
         msg_print(_("「今回は儲けたな！でも次はこっちが勝ってやるからな、絶対に！」", "You came out a winner! We'll win next time, I'm sure."));
-        chg_virtue(static_cast<CreatureEntity &>(creature), Virtue::CHANCE, 3);
+        chg_virtue(creature, Virtue::CHANCE, 3);
     } else {
         msg_print(_("「金をスッてしまったな、わはは！うちに帰った方がいいぜ。」", "You lost gold! Haha, better head home."));
-        chg_virtue(static_cast<CreatureEntity &>(creature), Virtue::CHANCE, -3);
+        chg_virtue(creature, Virtue::CHANCE, -3);
     }
 
     msg_erase();

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -307,7 +307,7 @@ static void calc_blow_drain_mana(CreatureEntity &creature, MonsterAttackPlayer *
 
 static void calc_blow_inertia(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    if (creature.effects()->acceleration().is_fast() || (static_cast<CreatureEntity &>(creature).get_speed() >= 130)) {
+    if (creature.effects()->acceleration().is_fast() || (creature.get_speed() >= 130)) {
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 4) / 9;
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2912,7 +2912,7 @@ void check_experience(CreatureEntity &creature)
         }
 
         /*
-         * 報酬でレベルが上ると再帰的に check_experience(static_cast<CreatureEntity &>(creature)) が
+         * 報酬でレベルが上ると再帰的に check_experience(creature) が
          * 呼ばれるので順番を最後にする。
          */
         if (level_reward) {

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -225,7 +225,7 @@ static void describe_grid_monster(CreatureEntity &creature, GridExamination *ge_
         move_cursor_relative(ge_ptr->y, ge_ptr->x);
         ge_ptr->query = inkey();
         if (ge_ptr->query == 'c') {
-            do_cmd_player_status(static_cast<CreatureEntity *>(ge_ptr->m_ptr));
+            do_cmd_player_status(ge_ptr->m_ptr);
             return;
         } else if (ge_ptr->query != 'r') {
             return;


### PR DESCRIPTION
PlayerType / MonsterEntity から CreatureEntity への変換は CLAUDE.md Phase 1 で完了済みのため、CreatureEntity 同士へのアイデンティティキャストは
コードの読み解きを難しくするだけで意味がない。これらを削除する。

- target/target-describer.cpp: do_cmd_player_status の引数 (m_ptr は既に CreatureEntity *)
- blue-magic/blue-magic-checker.cpp: gain_exp の引数
- inventory/inventory-curse.cpp: check_experience の引数
- market/play-gamble.cpp: chg_virtue の引数 (2 箇所)
- monster-attack/monster-attack-switcher.cpp: get_speed の receiver
- player/player-status.cpp: コメント内の例示

合わせて io-dump/player-status-dump-json.cpp の sex 値出力を sex_info[psex] 直接アクセスから creature.get_sex_info() に統一し、 display 系コードと同じ取得経路に揃える。

https://claude.ai/code/session_01Q6mCnU2BLa2WBs38WzM3y2