### PR TITLE
refactor: do_cmd_player_status / display_player のポインタ引数を参照に変更

### DIFF
--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -479,7 +479,7 @@ static bool display_auto_roller_result(CreatureEntity &creature, bool prev, char
         update_creature(creature);
         creature.hp = creature.maxhp;
         creature.csp = creature.msp;
-        (void)display_player(&creature, mode);
+        (void)display_player(creature, mode);
         term_gotoxy(2, 23);
         const char b1 = '[';
         term_addch({ TERM_WHITE, b1 });

--- a/src/birth/history-editor.cpp
+++ b/src/birth/history-editor.cpp
@@ -33,7 +33,7 @@ void edit_history(CreatureEntity &creature)
         creature.history[i][59] = '\0';
     }
 
-    (void)display_player(&creature, 1);
+    (void)display_player(creature, 1);
     c_put_str(TERM_L_GREEN, _("(キャラクターの生い立ち - 編集モード)", "(Character Background - Edit Mode)"), 11, 20);
     put_str(_("[ カーソルキーで移動、Enterで終了、Ctrl-Aでファイル読み込み ]", "[ Cursor key for Move, Enter for End, Ctrl-A for Read pref ]"), 17, 10);
     TERM_LEN y = 0;

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -165,26 +165,26 @@ static tl::optional<int> input_status_command(CreatureEntity &creature, int page
 /*!
  * @brief プレイヤー／モンスターのステータス表示
  */
-void do_cmd_player_status(CreatureEntity *creature_ptr)
+void do_cmd_player_status(CreatureEntity &creature)
 {
     auto page = 0;
     screen_save();
     constexpr auto player_prompt = _("['c'で名前変更, 'f'でファイルへ書出, 'g'でJSON書出, 'h'でモード変更, ESCで終了]", "['c' to change name, 'f' to file, 'g' to JSON, 'h' to change mode, or ESC]");
     constexpr auto monster_prompt = _("['f'でファイルへ書出, 'g'でJSON書出, ESCで終了]", "['f' to file, 'g' to JSON, or ESC]");
-    const auto prompt = creature_ptr->is_player() ? player_prompt : monster_prompt;
+    const auto prompt = creature.is_player() ? player_prompt : monster_prompt;
     auto &world = AngbandWorld::get_instance();
     while (true) {
         TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
 
         world.play_time.update();
-        (void)display_player(creature_ptr, page);
+        (void)display_player(creature, page);
         if (page == 5) {
             page = 0;
-            (void)display_player(creature_ptr, page);
+            (void)display_player(creature, page);
         }
 
         term_putstr(2, 23, -1, TERM_WHITE, prompt);
-        auto next_page = input_status_command(*creature_ptr, page);
+        auto next_page = input_status_command(creature, page);
         if (!next_page.has_value()) {
             break;
         }
@@ -203,7 +203,7 @@ void do_cmd_player_status(CreatureEntity *creature_ptr)
         MainWindowRedrawingFlag::MAP,
     };
     rfu.set_flags(flags_mwrf);
-    handle_stuff(*creature_ptr);
+    handle_stuff(creature);
 }
 
 /*!

--- a/src/cmd-visual/cmd-draw.h
+++ b/src/cmd-visual/cmd-draw.h
@@ -1,8 +1,7 @@
 #pragma once
 
 class CreatureEntity;
-class PlayerType;
 void do_cmd_redraw(CreatureEntity &creature);
-void do_cmd_player_status(CreatureEntity *creature_ptr);
+void do_cmd_player_status(CreatureEntity &creature);
 void do_cmd_message_one(void);
 void do_cmd_messages(int num_now);

--- a/src/io-dump/player-status-dump.cpp
+++ b/src/io-dump/player-status-dump.cpp
@@ -18,7 +18,7 @@ static void dump_player_status_with_screen_num(CreatureEntity &creature, FILE *f
     const int mode, const TERM_LEN start_y, const TERM_LEN tmp_end_y, const bool change_color)
 {
     char buf[1024]{};
-    auto num_lines = display_player(&creature, mode);
+    auto num_lines = display_player(creature, mode);
     auto end_y = tmp_end_y + num_lines.value_or(0);
     for (auto y = start_y; y < end_y; y++) {
         TERM_LEN x;

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -588,7 +588,7 @@ void process_command(CreatureEntity &creature)
         break;
     }
     case 'C': {
-        do_cmd_player_status(&creature);
+        do_cmd_player_status(creature);
         break;
     }
     case '!':

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -444,7 +444,7 @@ void show_death_info(CreatureEntity &creature)
     }
 
     export_player_info(creature);
-    (void)display_player(&creature, 0);
+    (void)display_player(creature, 0);
     prt(_("何かキーを押すとさらに情報が続きます (ESCで中断): ", "Hit any key to see more information (ESC to abort): "), 23, 0);
     if (inkey() == ESCAPE) {
         return;

--- a/src/store/store-key-processor.cpp
+++ b/src/store/store-key-processor.cpp
@@ -190,7 +190,7 @@ void store_process_command(CreatureEntity &creature, StoreSaleType store_num)
     }
     case 'C': {
         creature.town_num = old_town_num;
-        do_cmd_player_status(&creature);
+        do_cmd_player_status(creature);
         creature.town_num = inner_town_num;
         display_store(creature, store_num);
         break;

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -225,7 +225,7 @@ static void describe_grid_monster(CreatureEntity &creature, GridExamination *ge_
         move_cursor_relative(ge_ptr->y, ge_ptr->x);
         ge_ptr->query = inkey();
         if (ge_ptr->query == 'c') {
-            do_cmd_player_status(ge_ptr->m_ptr);
+            do_cmd_player_status(*ge_ptr->m_ptr);
             return;
         } else if (ge_ptr->query != 'r') {
             return;

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -311,48 +311,48 @@ static std::string decide_current_floor(CreatureEntity &creature)
  * Mode 4 = mutations.
  * Mode 5 = ??? (コード上の定義より6で割った余りは5になりうるが元のコメントに記載なし).
  */
-tl::optional<int> display_player(CreatureEntity *creature_ptr, const int tmp_mode)
+tl::optional<int> display_player(CreatureEntity &creature, const int tmp_mode)
 {
-    auto has_any_mutation = (creature_ptr->muta.any() || has_good_luck(*creature_ptr) || has_pervert_attraction(*creature_ptr)) && display_mutations;
+    auto has_any_mutation = (creature.muta.any() || has_good_luck(creature) || has_pervert_attraction(creature)) && display_mutations;
     // モンスターはプレイヤー固有のページ (history, misc/stat/flag info) を持たないため mode 0 固定で描画する
-    auto mode = creature_ptr->is_player() ? (has_any_mutation ? tmp_mode % 6 : tmp_mode % 5) : 0;
+    auto mode = creature.is_player() ? (has_any_mutation ? tmp_mode % 6 : tmp_mode % 5) : 0;
     {
         TermOffsetSetter tos(0, 0);
         clear_from(0);
     }
-    if (display_player_info(*creature_ptr, mode)) {
+    if (display_player_info(creature, mode)) {
         return tl::nullopt;
     }
 
-    display_player_basic_info(*creature_ptr);
-    display_magic_realms(*creature_ptr);
-    if (CreatureClass(*creature_ptr).equals(PlayerClassType::CHAOS_WARRIOR) || (creature_ptr->muta.has(PlayerMutationType::CHAOS_GIFT))) {
-        display_player_one_line(ENTRY_PATRON, patron_list[creature_ptr->patron].name, TERM_L_BLUE);
+    display_player_basic_info(creature);
+    display_magic_realms(creature);
+    if (CreatureClass(creature).equals(PlayerClassType::CHAOS_WARRIOR) || (creature.muta.has(PlayerMutationType::CHAOS_GIFT))) {
+        display_player_one_line(ENTRY_PATRON, patron_list[creature.patron].name, TERM_L_BLUE);
     }
 
     // 実際の種族と見かけの種族を表示
-    const auto &actual_monrace = MonraceList::get_instance().get_monrace(creature_ptr->r_idx);
+    const auto &actual_monrace = MonraceList::get_instance().get_monrace(creature.r_idx);
     display_player_one_line(ENTRY_ACTUAL_RACE, actual_monrace.name, TERM_L_GREEN);
-    if (creature_ptr->r_idx != creature_ptr->ap_r_idx) {
-        const auto &apparent_monrace = MonraceList::get_instance().get_monrace(creature_ptr->ap_r_idx);
-        auto color = (creature_ptr->r_idx == creature_ptr->ap_r_idx) ? TERM_L_GREEN : TERM_YELLOW;
+    if (creature.r_idx != creature.ap_r_idx) {
+        const auto &apparent_monrace = MonraceList::get_instance().get_monrace(creature.ap_r_idx);
+        auto color = (creature.r_idx == creature.ap_r_idx) ? TERM_L_GREEN : TERM_YELLOW;
         display_player_one_line(ENTRY_APPARENT_RACE, apparent_monrace.name, color);
     }
 
-    display_phisique(*creature_ptr);
-    display_player_stats(*creature_ptr);
+    display_phisique(creature);
+    display_player_stats(creature);
     if (mode == 0) {
-        display_player_middle(*creature_ptr);
-        display_player_various(*creature_ptr);
+        display_player_middle(creature);
+        display_player_various(creature);
         return tl::nullopt;
     }
 
     put_str(_("(キャラクターの生い立ち)", "(Character Background)"), 11, 25);
     for (auto i = 0; i < 4; i++) {
-        put_str(creature_ptr->history[i], i + 12, 10);
+        put_str(creature.history[i], i + 12, 10);
     }
 
-    auto statmsg = decide_current_floor(*creature_ptr);
+    auto statmsg = decide_current_floor(creature);
     if (statmsg.empty()) {
         return tl::nullopt;
     }

--- a/src/view/display-player.h
+++ b/src/view/display-player.h
@@ -4,6 +4,5 @@
 #include <tl/optional.hpp>
 
 class CreatureEntity;
-class PlayerType;
-tl::optional<int> display_player(CreatureEntity *creature_ptr, const int tmp_mode);
+tl::optional<int> display_player(CreatureEntity &creature, const int tmp_mode);
 void display_player_equippy(CreatureEntity &creature, TERM_LEN y, TERM_LEN x, BIT_FLAGS16 mode);

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -394,7 +394,7 @@ void fix_player(CreatureEntity &creature)
     AngbandWorld::get_instance().play_time.update();
     display_sub_windows(SubWindowRedrawingFlag::PLAYER,
         [&creature] {
-            display_player(&creature, 0);
+            display_player(creature, 0);
         });
 }
 


### PR DESCRIPTION
CreatureEntity を引数に取る他の関数群 (do_cmd_redraw / handle_stuff 等) が 既に参照を採用している一方、ステータス表示の 2 大エントリである
do_cmd_player_status と display_player は歴史的経緯で
CreatureEntity * ポインタ引数のまま残っていた。null 入力を想定する
意味は無いため参照に統一する。

signature 変更:
- void do_cmd_player_status(CreatureEntity *creature_ptr) → void do_cmd_player_status(CreatureEntity &creature)
- tl::optional<int> display_player(CreatureEntity *creature_ptr, const int) → tl::optional<int> display_player(CreatureEntity &creature, const int)

呼出箇所 (9 ファイル) を追従して creature / &creature の渡し方を調整。
特に target-describer.cpp では do_cmd_player_status(ge_ptr->m_ptr) を do_cmd_player_status(*ge_ptr->m_ptr) に変更。

合わせてヘッダの未使用 class PlayerType; 前方宣言を削除。

https://claude.ai/code/session_01Q6mCnU2BLa2WBs38WzM3y2