### PR TITLE
refactor: birth 系の CreatureEntity * を参照に統一

### DIFF
--- a/src/birth/birth-body-spec.cpp
+++ b/src/birth/birth-body-spec.cpp
@@ -9,27 +9,27 @@
 
 /*!
  * @brief クリーチャーの身長体重を決める / Get creature's height and weight
- * @param creature_ptr クリーチャーへの参照ポインタ
+ * @param creature クリーチャーへの参照
  * @details 種族情報に基づいて身長・体重を設定する。PlayerTypeもCreatureEntityを継承しているため、プレイヤーにも使用可能。
  */
-void get_height_weight(CreatureEntity *creature_ptr)
+void get_height_weight(CreatureEntity &creature)
 {
     // 種族情報が設定されていない場合は何もしない
-    if (creature_ptr->race == nullptr) {
+    if (creature.race == nullptr) {
         return;
     }
 
     int deviation;
-    switch (creature_ptr->psex) {
+    switch (creature.psex) {
     case SEX_MALE:
-        creature_ptr->ht = randnor(creature_ptr->race->m_b_ht, creature_ptr->race->m_m_ht);
-        deviation = (int)(creature_ptr->ht) * 100 / (int)(creature_ptr->race->m_b_ht);
-        creature_ptr->wt = randnor((int)(creature_ptr->race->m_b_wt) * deviation / 100, (int)(creature_ptr->race->m_m_wt) * deviation / 300);
+        creature.ht = randnor(creature.race->m_b_ht, creature.race->m_m_ht);
+        deviation = (int)(creature.ht) * 100 / (int)(creature.race->m_b_ht);
+        creature.wt = randnor((int)(creature.race->m_b_wt) * deviation / 100, (int)(creature.race->m_m_wt) * deviation / 300);
         return;
     case SEX_FEMALE:
-        creature_ptr->ht = randnor(creature_ptr->race->f_b_ht, creature_ptr->race->f_m_ht);
-        deviation = (int)(creature_ptr->ht) * 100 / (int)(creature_ptr->race->f_b_ht);
-        creature_ptr->wt = randnor((int)(creature_ptr->race->f_b_wt) * deviation / 100, (int)(creature_ptr->race->f_m_wt) * deviation / 300);
+        creature.ht = randnor(creature.race->f_b_ht, creature.race->f_m_ht);
+        deviation = (int)(creature.ht) * 100 / (int)(creature.race->f_b_ht);
+        creature.wt = randnor((int)(creature.race->f_b_wt) * deviation / 100, (int)(creature.race->f_m_wt) * deviation / 300);
         return;
     default:
         return;
@@ -43,7 +43,7 @@ void get_height_weight(CreatureEntity *creature_ptr)
 void get_ahw(CreatureEntity &creature)
 {
     creature.age = creature.race->b_age + randint1(creature.race->m_age);
-    get_height_weight(&creature);
+    get_height_weight(creature);
 }
 
 /*!

--- a/src/birth/birth-body-spec.h
+++ b/src/birth/birth-body-spec.h
@@ -1,6 +1,6 @@
 #pragma once
 
 class CreatureEntity;
-void get_height_weight(CreatureEntity *creature_ptr);
+void get_height_weight(CreatureEntity &creature);
 void get_ahw(CreatureEntity &creature);
 void get_money(CreatureEntity &creature);

--- a/src/birth/birth-stat.cpp
+++ b/src/birth/birth-stat.cpp
@@ -55,13 +55,13 @@ int adjust_stat(int value, int amount)
 
 /*!
  * @brief クリーチャー（プレイヤーやモンスター等）の能力値を一通りロールする。 / Roll for a creature's stats
- * @param creature_ptr クリーチャーへの参照ポインタ
+ * @param creature クリーチャーへの参照
  * @details
  * プレイヤーのキャラメイクと同じロジックで能力値を生成する。
  * calc_bonuses()による、独立ステータスからの副次ステータス算出も行っている。
  * For efficiency, we include a chunk of "calc_bonuses()".\n
  */
-void get_stats(CreatureEntity *creature_ptr)
+void get_stats(CreatureEntity &creature)
 {
     while (true) {
         auto sum = 0;
@@ -71,7 +71,7 @@ void get_stats(CreatureEntity *creature_ptr)
                 auto stat = i * 3 + j;
                 auto val = auto_roller_distribution[tmp % random_distribution];
                 sum += val;
-                creature_ptr->stat_cur[stat] = creature_ptr->stat_max[stat] = val;
+                creature.stat_cur[stat] = creature.stat_max[stat] = val;
                 tmp /= random_distribution;
             }
         }
@@ -84,29 +84,29 @@ void get_stats(CreatureEntity *creature_ptr)
 
     // stat_max_maxは初期化する
     for (auto i = 0; i < A_MAX; i++) {
-        creature_ptr->stat_max_max[i] = creature_ptr->stat_max[i];
+        creature.stat_max_max[i] = creature.stat_max[i];
     }
 }
 
 /*!
  * @brief クリーチャーの初期所持金を決める（プレイヤーと同様のロジック）
- * @param creature_ptr クリーチャーへの参照ポインタ
+ * @param creature クリーチャーへの参照
  * @details プレイヤーのget_money()と同等の処理を行う
  */
-void get_money_for_creature(CreatureEntity *creature_ptr)
+void get_money_for_creature(CreatureEntity &creature)
 {
-    int gold = (creature_ptr->prestige * 6) + randint1(100) + 300;
+    int gold = (creature.prestige * 6) + randint1(100) + 300;
 
     // 能力値に応じて所持金を調整
     for (int i = 0; i < A_MAX; i++) {
-        if (creature_ptr->stat_max[i] >= 680) {
+        if (creature.stat_max[i] >= 680) {
             gold -= 300;
-        } else if (creature_ptr->stat_max[i] >= 380) {
+        } else if (creature.stat_max[i] >= 380) {
             gold -= 200;
-        } else if (creature_ptr->stat_max[i] > 180) {
+        } else if (creature.stat_max[i] > 180) {
             gold -= 150;
         } else {
-            gold -= (creature_ptr->stat_max[i] / 10 - 8) * 10;
+            gold -= (creature.stat_max[i] / 10 - 8) * 10;
         }
     }
 
@@ -115,7 +115,7 @@ void get_money_for_creature(CreatureEntity *creature_ptr)
         gold = minimum_deposit;
     }
 
-    creature_ptr->au = gold;
+    creature.au = gold;
 }
 
 /*!

--- a/src/birth/birth-stat.h
+++ b/src/birth/birth-stat.h
@@ -3,11 +3,9 @@
 #include "system/angband.h"
 
 class CreatureEntity;
-class PlayerType;
-class CreatureEntity;
 int adjust_stat(int value, int amount);
-void get_stats(CreatureEntity *creature_ptr);
-void get_money_for_creature(CreatureEntity *creature_ptr);
+void get_stats(CreatureEntity &creature);
+void get_money_for_creature(CreatureEntity &creature);
 uint16_t get_expfact(CreatureEntity &creature);
 void get_extra(CreatureEntity &creature, bool roll_hitdie);
 

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -452,7 +452,7 @@ static bool display_auto_roller_count(CreatureEntity &creature, const int col)
 static void exe_auto_roller(CreatureEntity &creature, chara_limit_type chara_limit, const int col)
 {
     while (autoroller || autochara) {
-        get_stats(&creature);
+        get_stats(creature);
         auto_round++;
         auto_roller_count();
         bool accept = decide_initial_stat(creature);
@@ -548,7 +548,7 @@ static bool display_auto_roller(CreatureEntity &creature, chara_limit_type chara
             put_str(_("回数 :", "Round:"), 10, col + 10);
             put_str(_("(ESCで停止)", "(Hit ESC to stop)"), 13, col + 13);
         } else {
-            get_stats(&creature);
+            get_stats(creature);
             get_ahw(creature);
             get_history(creature);
         }

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -258,7 +258,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     m_ptr->wipe(); // モンスターを初期化（古いデータをクリア）
 
     // モンスターの能力値をランダムに初期化
-    get_stats(m_ptr);
+    get_stats(*m_ptr);
 
     m_ptr->get_monster_profile().alliance_idx = monrace.alliance_idx;
 
@@ -412,10 +412,10 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     m_ptr->initialize_equivalent_player_classes();
 
     // 種族が指定されている場合、身長・体重を設定
-    get_height_weight(m_ptr);
+    get_height_weight(*m_ptr);
 
     // 所持金を初期化（能力値に基づいて計算）
-    get_money_for_creature(m_ptr);
+    get_money_for_creature(*m_ptr);
 
     m_ptr->get_monster_profile().ml = false;
     if (any_bits(mode, PM_FORCE_PET)) {

--- a/src/status/shape-changer.cpp
+++ b/src/status/shape-changer.cpp
@@ -85,7 +85,7 @@ void change_race(CreatureEntity &creature, PlayerRaceType new_race, concptr effe
         creature.expfact -= 15;
     }
 
-    get_height_weight(&creature);
+    get_height_weight(creature);
 
     const auto r_mhp = pc.equals(PlayerClassType::SORCERER) ? creature.race->r_mhp / 2 : creature.race->r_mhp;
     creature.hit_dice = Dice(1, r_mhp + (*creature.pclass_ref).c_mhp + (*creature.personality).a_mhp);


### PR DESCRIPTION
同じモジュール内の get_ahw / get_money / get_expfact 等が既に
CreatureEntity & を受けていたのに対し、以下 3 関数だけが
旧スタイルの CreatureEntity * のまま残っていた：

- get_height_weight (身長体重ロール)
- get_stats (能力値ロール)
- get_money_for_creature (モンスター所持金ロール)

これらの関数は CreatureEntity を受け、プレイヤーとモンスターの両方で
使われているため参照に統一する。

呼出箇所 (birth-wizard / monster-floor/one-monster-placer / status/shape-changer) も追従して &creature → creature や m_ptr → *m_ptr に更新。合わせて birth-stat.h の重複した class CreatureEntity; 宣言と 未使用の class PlayerType; 前方宣言も整理。