### PR TITLE
refactor: 加減速判定を is_accelerated() / is_decelerated() 仮想メソッドへ統一

### DIFF
--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -307,7 +307,7 @@ static void calc_blow_drain_mana(CreatureEntity &creature, MonsterAttackPlayer *
 
 static void calc_blow_inertia(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    if (creature.effects()->acceleration().is_fast() || (creature.get_speed() >= 130)) {
+    if (creature.is_accelerated() || (creature.get_speed() >= 130)) {
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 4) / 9;
     }
 

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -267,14 +267,14 @@ void process_world_aux_mutation(CreatureEntity &creature)
         disturb(creature, false, true);
         if (one_in_(2)) {
             msg_print(_("精力的でなくなった気がする。", "You feel less energetic."));
-            if (creature.effects()->acceleration().is_fast()) {
+            if (creature.is_accelerated()) {
                 set_acceleration(creature, 0, true);
             } else {
                 (void)bss.set_deceleration(randint1(30) + 10, false);
             }
         } else {
             msg_print(_("精力的になった気がする。", "You feel more energetic."));
-            if (creature.effects()->deceleration().is_slow()) {
+            if (creature.is_decelerated()) {
                 (void)bss.set_deceleration(0, true);
             } else {
                 set_acceleration(creature, randint1(30) + 10, false);

--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -425,7 +425,7 @@ bool QuaffEffects::death()
  */
 bool QuaffEffects::speed()
 {
-    if (this->creature.effects()->acceleration().is_fast()) {
+    if (this->creature.is_accelerated()) {
         (void)mod_acceleration(this->creature, 5, false);
         return false;
     }


### PR DESCRIPTION
creature.effects()->acceleration().is_fast() /
creature.effects()->deceleration().is_slow() と書かれていた加減速判定を、 同等だがモンスターでも安全で短い CreatureEntity の仮想メソッド
is_accelerated() / is_decelerated() に置換する。

変更箇所:
- object-use/quaff/quaff-effects.cpp (速度ポーションの既速度チェック)
- mutation/mutation-processor.cpp (変異による加減速チェック 2 箇所)
- monster-attack/monster-attack-switcher.cpp (モンスターの高速攻撃判定)

これらは ACCELERATION 時限効果の在否のみを見る判定で、is_fast() /
is_slow() (吟遊楽効果も含む) ではなく is_accelerated() / is_decelerated() と意味的に一致する。