### PR TITLE
refactor(creature): TimedEffects/map の分岐管理を基底クラスに統一

### DIFF
--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -453,12 +453,65 @@ bool CreatureEntity::is_echizen() const
 
 short CreatureEntity::get_timed_effect(CreatureTimedEffect effect) const
 {
+    // 一部の時限効果は高機能な TimedEffects オブジェクト経由で管理する。
+    // 提案 5 の方針に従い、プレイヤー・モンスター共通でこの分岐を採用。
+    if (this->timed_effects) {
+        const auto &eff = *this->timed_effects;
+        switch (effect) {
+        case CreatureTimedEffect::STUN:
+            return eff.stun().current();
+        case CreatureTimedEffect::CONFUSION:
+            return eff.confusion().current();
+        case CreatureTimedEffect::FEAR:
+            return eff.fear().current();
+        case CreatureTimedEffect::ACCELERATION:
+            return eff.acceleration().current();
+        case CreatureTimedEffect::DECELERATION:
+            return eff.deceleration().current();
+        case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
+        case CreatureTimedEffect::PARALYSIS:
+            return eff.paralysis().current();
+        case CreatureTimedEffect::BLINDNESS:
+            return eff.blindness().current();
+        default:
+            break;
+        }
+    }
     const auto it = this->timed_effects_map.find(effect);
     return (it != this->timed_effects_map.end()) ? it->second : 0;
 }
 
 void CreatureEntity::set_timed_effect(CreatureTimedEffect effect, short value)
 {
+    if (this->timed_effects) {
+        auto &eff = *this->timed_effects;
+        switch (effect) {
+        case CreatureTimedEffect::STUN:
+            eff.stun().set(value);
+            return;
+        case CreatureTimedEffect::CONFUSION:
+            eff.confusion().set(value);
+            return;
+        case CreatureTimedEffect::FEAR:
+            eff.fear().set(value);
+            return;
+        case CreatureTimedEffect::ACCELERATION:
+            eff.acceleration().set(value);
+            return;
+        case CreatureTimedEffect::DECELERATION:
+            eff.deceleration().set(value);
+            return;
+        case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
+        case CreatureTimedEffect::PARALYSIS:
+            eff.paralysis().set(value);
+            return;
+        case CreatureTimedEffect::BLINDNESS:
+            eff.blindness().set(value);
+            return;
+        default:
+            break;
+        }
+    }
     this->timed_effects_map[effect] = value;
 }
 

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -1,6 +1,5 @@
 #include "system/player-type-definition.h"
 #include "system/creature-entity.h"
-#include "timed-effect/timed-effects.h"
 
 /*!
  * @brief プレイヤー構造体実体 / Static player info record
@@ -33,63 +32,6 @@ bool PlayerType::is_dead() const
 bool PlayerType::is_player() const
 {
     return true;
-}
-
-short PlayerType::get_timed_effect(CreatureTimedEffect effect) const
-{
-    // 一部の時限効果はより高機能な TimedEffects オブジェクト経由で管理している
-    const auto &eff = *this->effects();
-    switch (effect) {
-    case CreatureTimedEffect::STUN:
-        return eff.stun().current();
-    case CreatureTimedEffect::CONFUSION:
-        return eff.confusion().current();
-    case CreatureTimedEffect::FEAR:
-        return eff.fear().current();
-    case CreatureTimedEffect::ACCELERATION:
-        return eff.acceleration().current();
-    case CreatureTimedEffect::DECELERATION:
-        return eff.deceleration().current();
-    case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
-    case CreatureTimedEffect::PARALYSIS:
-        return eff.paralysis().current();
-    case CreatureTimedEffect::BLINDNESS:
-        return eff.blindness().current();
-    default:
-        return CreatureEntity::get_timed_effect(effect);
-    }
-}
-
-void PlayerType::set_timed_effect(CreatureTimedEffect effect, short value)
-{
-    auto &eff = *this->effects();
-    switch (effect) {
-    case CreatureTimedEffect::STUN:
-        eff.stun().set(value);
-        break;
-    case CreatureTimedEffect::CONFUSION:
-        eff.confusion().set(value);
-        break;
-    case CreatureTimedEffect::FEAR:
-        eff.fear().set(value);
-        break;
-    case CreatureTimedEffect::ACCELERATION:
-        eff.acceleration().set(value);
-        break;
-    case CreatureTimedEffect::DECELERATION:
-        eff.deceleration().set(value);
-        break;
-    case CreatureTimedEffect::SLEEP_OR_PARALYSIS:
-    case CreatureTimedEffect::PARALYSIS:
-        eff.paralysis().set(value);
-        break;
-    case CreatureTimedEffect::BLINDNESS:
-        eff.blindness().set(value);
-        break;
-    default:
-        CreatureEntity::set_timed_effect(effect, value);
-        break;
-    }
 }
 
 /*!

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -16,9 +16,6 @@ public:
     void on_death(std::string_view cause) override;
     bool calc_damage_reduction(int &damage, int damage_type) override;
 
-    short get_timed_effect(CreatureTimedEffect effect) const override;
-    void set_timed_effect(CreatureTimedEffect effect, short value) override;
-
     void wipe() override;
 
     /*!


### PR DESCRIPTION
提案 5 第一歩。これまで PlayerType が get_timed_effect / set_timed_effect を オーバーライドして特定効果（STUN/CONFUSION/FEAR/ACCELERATION/
DECELERATION/PARALYSIS/BLINDNESS）を TimedEffects オブジェクト経由、 その他を timed_effects_map 経由で管理する二重構造になっていた。

CreatureEntity 基底実装にこの分岐ロジックを移動し、PlayerType の
オーバーライドを削除。全クリーチャーが timed_effects shared_ptr を
持っているため、モンスターでも同じ経路で動作する。

これで PlayerType 固有の TimedEffects 分岐が消え、プレイヤー・
モンスターで時限効果のアクセス経路が統一された。

https://claude.ai/code/session_01Q6mCnU2BLa2WBs38WzM3y2