### PR TITLE
refactor: 同一関数内の PlayerType::get_instance() 重複呼出をローカル束縛に整理

### DIFF
--- a/src/io/screen-util.cpp
+++ b/src/io/screen-util.cpp
@@ -46,11 +46,12 @@ void resize_map()
         return;
     }
 
+    auto &creature = PlayerType::get_instance();
     panel_row_max = 0;
     panel_col_max = 0;
-    panel_row_min = PlayerType::get_instance().get_floor()->height;
-    panel_col_min = PlayerType::get_instance().get_floor()->width;
-    verify_panel(PlayerType::get_instance());
+    panel_row_min = creature.get_floor()->height;
+    panel_col_min = creature.get_floor()->width;
+    verify_panel(creature);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
@@ -75,11 +76,11 @@ void resize_map()
         MainWindowRedrawingFlag::EQUIPPY,
     };
     rfu.set_flags(flags_mwrf);
-    handle_stuff(PlayerType::get_instance());
+    handle_stuff(creature);
     term_redraw();
 
     if (can_save) {
-        move_cursor_relative(PlayerType::get_instance().y, PlayerType::get_instance().x);
+        move_cursor_relative(creature.y, creature.x);
     }
 
     term_fresh();

--- a/src/io/signal-handlers.cpp
+++ b/src/io/signal-handlers.cpp
@@ -68,25 +68,26 @@ static void handle_signal_simple(int sig)
     }
 
     signal_count++;
-    auto &floor = *PlayerType::get_instance().get_floor();
-    if (PlayerType::get_instance().is_dead()) {
-        PlayerType::get_instance().died_from = _("強制終了", "Abortion");
+    auto &creature = PlayerType::get_instance();
+    auto &floor = *creature.get_floor();
+    if (creature.is_dead()) {
+        creature.died_from = _("強制終了", "Abortion");
         floor.forget_lite();
         floor.forget_view();
         floor.forget_mon_lite();
-        close_game(PlayerType::get_instance());
+        close_game(creature);
         quit(_("強制終了", "interrupt"));
     } else if (signal_count >= 5) {
-        PlayerType::get_instance().died_from = _("強制終了中", "Interrupting");
+        creature.died_from = _("強制終了中", "Interrupting");
         floor.forget_lite();
         floor.forget_view();
         floor.forget_mon_lite();
-        PlayerType::get_instance().playing = false;
+        creature.playing = false;
         if (!cheat_immortal) {
-            PlayerType::get_instance().is_dead_ = true;
+            creature.is_dead_ = true;
         }
-        PlayerType::get_instance().leaving = true;
-        close_game(PlayerType::get_instance());
+        creature.leaving = true;
+        close_game(creature);
         quit(_("強制終了", "interrupt"));
     } else if (signal_count >= 4) {
         term_xtra(TERM_XTRA_NOISE, 0);
@@ -126,7 +127,8 @@ static void handle_signal_abort(int sig)
         quit("");
     }
 
-    auto &floor = *PlayerType::get_instance().get_floor();
+    auto &creature = PlayerType::get_instance();
+    auto &floor = *creature.get_floor();
     floor.forget_lite();
     floor.forget_view();
     floor.forget_mon_lite();
@@ -140,11 +142,11 @@ static void handle_signal_abort(int sig)
     term_fresh();
 
     AngbandSystem::get_instance().set_panic_save(true);
-    PlayerType::get_instance().died_from = _("(緊急セーブ)", "(panic save)");
+    creature.died_from = _("(緊急セーブ)", "(panic save)");
 
     signals_ignore_tstp();
 
-    if (save_player(PlayerType::get_instance(), SaveType::CLOSE_GAME)) {
+    if (save_player(creature, SaveType::CLOSE_GAME)) {
         term_putstr(45, hgt - 1, -1, TERM_RED, _("緊急セーブ成功！", "Panic save succeeded!"));
     } else {
         term_putstr(45, hgt - 1, -1, TERM_RED, _("緊急セーブ失敗！", "Panic save failed!"));

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -2455,14 +2455,15 @@ static LRESULT PASCAL angband_window_procedure(HWND hWnd, UINT uMsg, WPARAM wPar
         }
 
         msg_flag = false;
-        if (PlayerType::get_instance().hp < 0) {
-            PlayerType::get_instance().is_dead_ = false;
+        auto &creature = PlayerType::get_instance();
+        if (creature.hp < 0) {
+            creature.is_dead_ = false;
         }
-        exe_write_diary(*PlayerType::get_instance().get_floor(), DiaryKind::GAMESTART, 0, _("----ゲーム中断----", "---- Save and Exit Game ----"));
+        exe_write_diary(*creature.get_floor(), DiaryKind::GAMESTART, 0, _("----ゲーム中断----", "---- Save and Exit Game ----"));
         AngbandSystem::get_instance().set_panic_save(true);
         signals_ignore_tstp();
-        PlayerType::get_instance().died_from = _("(緊急セーブ)", "(panic save)");
-        (void)save_player(PlayerType::get_instance(), SaveType::CLOSE_GAME);
+        creature.died_from = _("(緊急セーブ)", "(panic save)");
+        (void)save_player(creature, SaveType::CLOSE_GAME);
         quit("");
         return 0;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -338,9 +338,12 @@ int main(int argc, char *argv[])
                 break;
             }
 
-            PlayerType::get_instance().name = &argv[i][2];
-            if (PlayerType::get_instance().name.length() > 40) {
-                PlayerType::get_instance().name.resize(40);
+            {
+                auto &creature = PlayerType::get_instance();
+                creature.name = &argv[i][2];
+                if (creature.name.length() > 40) {
+                    creature.name.resize(40);
+                }
             }
             break;
         case 'm':


### PR DESCRIPTION
提案 3 の第一歩。同一関数内で PlayerType::get_instance() を複数回
呼んでいた箇所を、関数冒頭で auto &creature = PlayerType::get_instance() としてローカル参照に束縛する形に整理。

対象:
- src/io/screen-util.cpp resize_map()
- src/io/signal-handlers.cpp handle_signal_simple(), handle_signal_abort()
- src/main-win.cpp WM_QUERYENDSESSION ハンドラ
- src/main.cpp プレイヤー名コマンドライン処理

PlayerType::get_instance() 呼出回数が 52 → 32 に削減。
残りはエントリポイント・シグナルハンドラ・UI コールバックの
「プレイヤー参照の根」で正当な使用。