### PR TITLE
refactor(creature): 追加 BIT_FLAGS の virtual アクセサ化と読取り移行

### DIFF
--- a/src/action/action-limited.cpp
+++ b/src/action/action-limited.cpp
@@ -30,7 +30,7 @@ bool cmd_limit_cast(CreatureEntity &creature)
         return true;
     }
 
-    if (creature.anti_magic) {
+    if (creature.has_anti_magic()) {
         msg_print(_("反魔法バリアが魔法を邪魔した！", "An anti-magic shell disrupts your magic!"));
         return true;
     }

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -1102,7 +1102,7 @@ bool do_cmd_cast(CreatureEntity &creature)
                 msg_print(_("痛い！", "It hurts!"));
                 take_hit(creature, DAMAGE_LOSELIFE, Dice::roll(sval + 1, 6), _("暗黒魔法の逆流", "a miscast Death spell"));
 
-                if ((spell_id > 15) && one_in_(6) && !creature.hold_exp) {
+                if ((spell_id > 15) && one_in_(6) && !creature.has_hold_exp()) {
                     lose_exp(creature, spell_id * 250);
                 }
             }

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -154,7 +154,7 @@ static bool exe_eat_corpse_type_object(CreatureEntity &creature, ItemEntity *o_p
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::SLEEP)) {
-        if (!creature.free_act) {
+        if (!creature.has_free_act()) {
             BadStatusSetter(creature).set_paralysis(10 + randint1(10));
         }
     }
@@ -317,7 +317,7 @@ static bool exe_eat_food_type_object(CreatureEntity &creature, const BaseitemKey
         }
         break;
     case SV_FOOD_PARALYSIS:
-        if (!creature.free_act) {
+        if (!creature.has_free_act()) {
             if (bss.set_paralysis(10 + randint1(10))) {
                 creature.plus_incident_tree("EAT_POISON", 1);
                 return true;

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -122,7 +122,7 @@ static void effect_monster_psi_reflect_extra_effect(CreatureEntity &creature, Ef
 
         return;
     default:
-        if (!creature.free_act) {
+        if (!creature.has_free_act()) {
             (void)bss.mod_paralysis(randnum1<short>(em_ptr->dam));
         }
 

--- a/src/effect/effect-player-oldies.cpp
+++ b/src/effect/effect-player-oldies.cpp
@@ -40,7 +40,7 @@ void effect_player_old_slow(CreatureEntity &creature)
 
 void effect_player_old_sleep(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 {
-    if (creature.free_act) {
+    if (creature.has_free_act()) {
         return;
     }
 

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -654,7 +654,7 @@ void effect_player_void(CreatureEntity &creature, EffectPlayerType *ep_ptr)
     auto effect_mes = creature.is_blind() ? _("何かに身体が引っ張りこまれる！", "Something absorbs you!")
                                           : _("周辺の空間が歪んだ。", "Sight warps around you.");
     msg_print(effect_mes);
-    if (!check_multishadow(creature) && !creature.has_levitation() && !creature.anti_tele) {
+    if (!check_multishadow(creature) && !creature.has_levitation() && !creature.has_anti_tele()) {
         (void)BadStatusSetter(creature).mod_deceleration(randint0(4) + 4, false);
     }
 

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -135,7 +135,7 @@ void effect_player_brain_smash(CreatureEntity &creature, EffectPlayerType *ep_pt
         (void)bss.mod_confusion(randint0(4) + 4);
     }
 
-    if (!creature.free_act) {
+    if (!creature.has_free_act()) {
         (void)bss.mod_paralysis(randint0(4) + 4);
     }
 

--- a/src/floor/geometry.cpp
+++ b/src/floor/geometry.cpp
@@ -64,7 +64,7 @@ bool player_can_see_bold(CreatureEntity &creature, POSITION y, POSITION x)
     }
 
     /* Noctovision of Ninja */
-    if (creature.see_nocto) {
+    if (creature.has_see_nocto()) {
         return true;
     }
 

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -377,7 +377,7 @@ void note_spot(CreatureEntity &creature, const Pos2D &pos)
         /* Require "perma-lite" of the grid */
         if ((grid.info & (CAVE_GLOW | CAVE_MNDK)) != CAVE_GLOW) {
             /* Not Ninja */
-            if (!creature.see_nocto) {
+            if (!creature.has_see_nocto()) {
                 return;
             }
         }
@@ -398,7 +398,7 @@ void note_spot(CreatureEntity &creature, const Pos2D &pos)
         /* Memorize some "boring" grids */
         if (terrain.flags.has_not(TerrainCharacteristics::REMEMBER)) {
             /* Option -- memorize all torch-lit floors */
-            if (view_torch_grids && ((grid.info & (CAVE_LITE | CAVE_MNLT)) || creature.see_nocto)) {
+            if (view_torch_grids && ((grid.info & (CAVE_LITE | CAVE_MNLT)) || creature.has_see_nocto())) {
                 grid.info |= (CAVE_MARK);
             }
 
@@ -419,7 +419,7 @@ void note_spot(CreatureEntity &creature, const Pos2D &pos)
         }
 
         /* Memorize walls seen by noctovision of Ninja */
-        else if (creature.see_nocto) {
+        else if (creature.has_see_nocto()) {
             grid.info |= (CAVE_MARK);
         }
 

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -410,7 +410,7 @@ void hit_trap(CreatureEntity &creature, bool break_trap)
         break;
     case TrapType::SLEEP:
         msg_print(_("奇妙な白い霧に包まれた！", "A strange white mist surrounds you!"));
-        if (creature.free_act) {
+        if (creature.has_free_act()) {
             break;
         }
 

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -413,7 +413,7 @@ void process_player_hp_mp(CreatureEntity &creature)
     if (pattern_effect(creature)) {
         cave_no_regen = true;
     } else {
-        if (creature.regenerate) {
+        if (creature.has_regen_flag()) {
             regen_amount = regen_amount * 2;
         }
 

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -502,7 +502,7 @@ static void occur_curse_effects(CreatureEntity &creature)
     curse_call_monster(creature);
     curse_cowardice(creature);
     curse_berserk_rage(creature);
-    if (creature.cursed.has(CurseTraitType::TELEPORT) && one_in_(200) && !creature.anti_tele) {
+    if (creature.cursed.has(CurseTraitType::TELEPORT) && one_in_(200) && !creature.has_anti_tele()) {
         disturb(creature, false, true);
         teleport_player(creature, 40, TELEPORT_PASSIVE);
     }
@@ -520,7 +520,7 @@ static void occur_curse_effects(CreatureEntity &creature)
 void execute_cursed_items_effect(CreatureEntity &creature)
 {
     occur_curse_effects(creature);
-    if (!one_in_(999) || creature.anti_magic || (one_in_(2) && has_resist_curse(creature))) {
+    if (!one_in_(999) || creature.has_anti_magic() || (one_in_(2) && has_resist_curse(creature))) {
         return;
     }
 

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -432,7 +432,7 @@ void process_command(CreatureEntity &creature)
             break;
         }
 
-        if (creature.anti_magic && !non_magic_class) {
+        if (creature.has_anti_magic() && !non_magic_class) {
             concptr which_power = _("魔法", "magic");
             switch (creature.pclass) {
             case PlayerClassType::MINDCRAFTER:

--- a/src/monster-attack/monster-attack-status.cpp
+++ b/src/monster-attack/monster-attack-status.cpp
@@ -76,7 +76,7 @@ void process_paralyze_attack(CreatureEntity &creature, MonsterAttackPlayer *mona
     }
 
     const auto &monrace = monap_ptr->m_ptr->get_monrace();
-    if (creature.free_act) {
+    if (creature.has_free_act()) {
         msg_print(_("しかし効果がなかった！", "You are unaffected!"));
         monap_ptr->obvious = true;
         return;

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -266,7 +266,7 @@ static void calc_blow_drain_life(CreatureEntity &creature, MonsterAttackPlayer *
 {
     int32_t d = Dice::roll(60, 6) + (creature.exp / 100) * MON_DRAIN_LIFE;
     monap_ptr->obvious = true;
-    if (creature.hold_exp) {
+    if (creature.has_hold_exp()) {
         monap_ptr->damage = monap_ptr->damage * 9 / 10;
     }
 
@@ -326,10 +326,10 @@ static void calc_blow_inertia(CreatureEntity &creature, MonsterAttackPlayer *mon
  */
 static void calc_blow_hungry(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    if (creature.regenerate) {
+    if (creature.has_regen_flag()) {
         monap_ptr->damage = monap_ptr->damage * 2;
     }
-    if (creature.slow_digest) {
+    if (creature.has_slow_digest_flag()) {
         monap_ptr->damage = monap_ptr->damage / 2;
     }
 
@@ -590,7 +590,7 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
             }
             monap_ptr->obvious = true;
 
-            if (!has_chaos_resist && creature.anti_tele == 0) {
+            if (!has_chaos_resist && creature.has_anti_tele() == 0) {
                 msg_print(_("突然体が浮きだした！", "Your body floats suddenly!"));
                 teleport_player(creature, 50, TELEPORT_PASSIVE);
             }
@@ -635,7 +635,7 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
     }
 
     case RaceBlowEffectType::LOCKUP: { /* AC軽減あり / Player armor reduces total damage */
-        if (creature.anti_tele == 0) {
+        if (creature.has_anti_tele() == 0) {
             teleport_player(creature, 50, TELEPORT_PASSIVE);
             wall_creation(creature, creature.y, creature.x);
         }

--- a/src/monster-floor/monster-lite.cpp
+++ b/src/monster-floor/monster-lite.cpp
@@ -151,7 +151,7 @@ void update_mon_lite(CreatureEntity &creature)
     void (*add_mon_lite)(FloorType &, std::vector<Pos2D> &, const Pos2D &p_pos, const Pos2D &pos, const monster_lite_type &);
     auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_dungeon_definition();
-    const auto dis_lim = (dungeon.flags.has(DungeonFeatureType::DARKNESS) && !creature.see_nocto) ? (MAX_PLAYER_SIGHT / 2 + 1) : (MAX_PLAYER_SIGHT + 3);
+    const auto dis_lim = (dungeon.flags.has(DungeonFeatureType::DARKNESS) && !creature.has_see_nocto()) ? (MAX_PLAYER_SIGHT / 2 + 1) : (MAX_PLAYER_SIGHT + 3);
     floor.reset_mon_lite();
     const auto &world = AngbandWorld::get_instance();
     const auto p_pos = creature.get_position();

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -184,7 +184,7 @@ static um_type *initialize_um_type(CreatureEntity &creature, um_type *um_ptr, MO
     um_ptr->fx = um_ptr->m_ptr->x;
     um_ptr->flag = false;
     um_ptr->easy = false;
-    um_ptr->in_darkness = floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS) && !creature.see_nocto;
+    um_ptr->in_darkness = floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS) && !creature.has_see_nocto();
     um_ptr->full = full;
     return um_ptr;
 }
@@ -780,7 +780,7 @@ void update_smart_learn(CreatureEntity &creature, MONSTER_IDX m_idx, int what)
 
         break;
     case DRS_FREE:
-        if (creature.free_act) {
+        if (creature.has_free_act()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_FREE);
         }
 

--- a/src/mspell/high-resistance-checker.cpp
+++ b/src/mspell/high-resistance-checker.cpp
@@ -58,7 +58,7 @@ void add_cheat_remove_flags_others(CreatureEntity &creature, msr_type *msr_ptr)
         msr_ptr->smart_flags.set(MonsterSmartLearnType::IMM_REFLECT);
     }
 
-    if (creature.free_act) {
+    if (creature.has_free_act()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::IMM_FREE);
     }
 

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -434,7 +434,7 @@ MonsterSpellResult spell_RF5_HOLD(MONSTER_IDX m_idx, CreatureEntity &creature, M
     bool resist, saving_throw;
 
     if (target_type == MONSTER_TO_PLAYER) {
-        resist = (creature.free_act != 0);
+        resist = (creature.has_free_act() != 0);
         saving_throw = (randint0(100 + rlev / 2) < creature.skill_sav);
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -123,7 +123,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
     }
 
     if (creature.muta.has(PlayerMutationType::RTELEPORT) && (randint1(5000) == 88)) {
-        if (!has_resist_shard(creature) && creature.muta.has_not(PlayerMutationType::VTELEPORT) && !creature.anti_tele) {
+        if (!has_resist_shard(creature) && creature.muta.has_not(PlayerMutationType::VTELEPORT) && !creature.has_anti_tele()) {
             disturb(creature, false, true);
             msg_print(_("あなたの位置は突然ひじょうに不確定になった...", "Your position suddenly seems very uncertain..."));
             msg_erase();
@@ -204,7 +204,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
         (void)set_acceleration(creature, 10 + randint1(creature.level), false);
     }
 
-    if (creature.muta.has(PlayerMutationType::PROD_MANA) && !creature.anti_magic && one_in_(9000)) {
+    if (creature.muta.has(PlayerMutationType::PROD_MANA) && !creature.has_anti_magic() && one_in_(9000)) {
         disturb(creature, false, true);
         msg_print(_("魔法のエネルギーが突然あなたの中に流れ込んできた！エネルギーを解放しなければならない！",
             "Magical energy flows through you! You must release it!"));
@@ -215,7 +215,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
         fire_ball(creature, AttributeType::MANA, dir ? dir : Direction::self(), creature.level * 2, 3);
     }
 
-    if (creature.muta.has(PlayerMutationType::ATT_DEMON) && !creature.anti_magic && (randint1(6666) == 666)) {
+    if (creature.muta.has(PlayerMutationType::ATT_DEMON) && !creature.has_anti_magic() && (randint1(6666) == 666)) {
         bool pet = one_in_(6);
         BIT_FLAGS mode = PM_ALLOW_GROUP;
 
@@ -231,7 +231,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
         }
     }
 
-    if (creature.muta.has(PlayerMutationType::ATT_NASTY) && !creature.anti_magic && (randint1(6666) == 666)) {
+    if (creature.muta.has(PlayerMutationType::ATT_NASTY) && !creature.has_anti_magic() && (randint1(6666) == 666)) {
         bool pet = one_in_(6);
         BIT_FLAGS mode = PM_ALLOW_GROUP;
 
@@ -247,7 +247,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
         }
     }
 
-    if (has_pervert_attraction(creature) && !creature.anti_magic && (randint1(6666) == 666)) {
+    if (has_pervert_attraction(creature) && !creature.has_anti_magic() && (randint1(6666) == 666)) {
         bool pet = one_in_(6);
         BIT_FLAGS mode = PM_ALLOW_GROUP;
 
@@ -323,7 +323,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
         unlite_area(creature, 50, 10);
     }
 
-    if (creature.muta.has(PlayerMutationType::ATT_ANIMAL) && !creature.anti_magic && one_in_(7000)) {
+    if (creature.muta.has(PlayerMutationType::ATT_ANIMAL) && !creature.has_anti_magic() && one_in_(7000)) {
         bool pet = one_in_(3);
         BIT_FLAGS mode = PM_ALLOW_GROUP;
 
@@ -339,7 +339,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
         }
     }
 
-    if (creature.muta.has(PlayerMutationType::RAW_CHAOS) && !creature.anti_magic && one_in_(8000)) {
+    if (creature.muta.has(PlayerMutationType::RAW_CHAOS) && !creature.has_anti_magic() && one_in_(8000)) {
         disturb(creature, false, true);
         msg_print(_("周りの空間が歪んでいる気がする！", "You feel the world warping around you!"));
         msg_erase();
@@ -352,7 +352,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
         }
     }
 
-    if (creature.muta.has(PlayerMutationType::WRAITH) && !creature.anti_magic && one_in_(3000)) {
+    if (creature.muta.has(PlayerMutationType::WRAITH) && !creature.has_anti_magic() && one_in_(3000)) {
         disturb(creature, false, true);
         msg_print(_("非物質化した！", "You feel insubstantial!"));
         msg_erase();
@@ -411,7 +411,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
         }
     }
 
-    if (creature.muta.has(PlayerMutationType::ATT_DRAGON) && !creature.anti_magic && one_in_(3000)) {
+    if (creature.muta.has(PlayerMutationType::ATT_DRAGON) && !creature.has_anti_magic() && one_in_(3000)) {
         bool pet = one_in_(5);
         BIT_FLAGS mode = PM_ALLOW_GROUP;
         if (pet) {
@@ -426,7 +426,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
         }
     }
 
-    if (creature.muta.has(PlayerMutationType::WEIRD_MIND) && !creature.anti_magic && one_in_(3000)) {
+    if (creature.muta.has(PlayerMutationType::WEIRD_MIND) && !creature.has_anti_magic() && one_in_(3000)) {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_ESP) > 0) {
             msg_print(_("精神にもやがかかった！", "Your mind feels cloudy!"));
             set_tim_esp(creature, 0, true);
@@ -436,7 +436,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
         }
     }
 
-    if (creature.muta.has(PlayerMutationType::NAUSEA) && !creature.slow_digest && one_in_(9000)) {
+    if (creature.muta.has(PlayerMutationType::NAUSEA) && !creature.has_slow_digest_flag() && one_in_(9000)) {
         disturb(creature, false, true);
         msg_print(_("胃が痙攣し、食事を失った！", "Your stomach roils, and you lose your lunch!"));
         msg_erase();
@@ -451,7 +451,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
         }
     }
 
-    if (creature.muta.has(PlayerMutationType::WALK_SHAD) && !creature.anti_magic && one_in_(12000) && !creature.get_floor()->inside_arena) {
+    if (creature.muta.has(PlayerMutationType::WALK_SHAD) && !creature.has_anti_magic() && one_in_(12000) && !creature.get_floor()->inside_arena) {
         reserve_alter_reality(creature, randint0(21) + 15);
     }
 
@@ -484,7 +484,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
         }
     }
 
-    if (creature.muta.has(PlayerMutationType::INVULN) && !creature.anti_magic && one_in_(5000)) {
+    if (creature.muta.has(PlayerMutationType::INVULN) && !creature.has_anti_magic() && one_in_(5000)) {
         disturb(creature, false, true);
         msg_print(_("無敵な気がする！", "You feel invincible!"));
         msg_erase();
@@ -509,7 +509,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
         }
     }
 
-    if (creature.muta.has(PlayerMutationType::HP_TO_SP) && !creature.anti_magic && one_in_(4000)) {
+    if (creature.muta.has(PlayerMutationType::HP_TO_SP) && !creature.has_anti_magic() && one_in_(4000)) {
         int wounds = (int)(creature.msp - creature.csp);
         if (wounds > 0) {
             int healing = creature.hp;

--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -346,7 +346,7 @@ bool QuaffEffects::booze()
  */
 bool QuaffEffects::sleep()
 {
-    if (this->creature.free_act) {
+    if (this->creature.has_free_act()) {
         return false;
     }
 
@@ -365,7 +365,7 @@ bool QuaffEffects::sleep()
  */
 bool QuaffEffects::lose_memories()
 {
-    if (this->creature.hold_exp || (this->creature.exp <= 0)) {
+    if (this->creature.has_hold_exp() || (this->creature.exp <= 0)) {
         return false;
     }
 

--- a/src/player-info/body-improvement-info.cpp
+++ b/src/player-info/body-improvement-info.cpp
@@ -65,15 +65,15 @@ void set_body_improvement_info_2(CreatureEntity &creature, self_info_type *self_
         self_ptr->info_list.emplace_back(_("あなたは飛ぶことができる。", "You can fly."));
     }
 
-    if (creature.free_act) {
+    if (creature.has_free_act()) {
         self_ptr->info_list.emplace_back(_("あなたは麻痺知らずの効果を持っている。", "You have free action."));
     }
 
-    if (creature.regenerate) {
+    if (creature.has_regen_flag()) {
         self_ptr->info_list.emplace_back(_("あなたは素早く体力を回復する。", "You regenerate quickly."));
     }
 
-    if (creature.slow_digest) {
+    if (creature.has_slow_digest_flag()) {
         self_ptr->info_list.emplace_back(_("あなたは食欲が少ない。", "Your appetite is small."));
     }
 }
@@ -81,7 +81,7 @@ void set_body_improvement_info_2(CreatureEntity &creature, self_info_type *self_
 /*!< @todo 並び順の都合で連番を付ける。まとめても良いならまとめてしまう予定 */
 void set_body_improvement_info_3(CreatureEntity &creature, self_info_type *self_ptr)
 {
-    if (creature.hold_exp) {
+    if (creature.has_hold_exp()) {
         self_ptr->info_list.emplace_back(_("あなたは自己の経験値をしっかりと維持する。", "You have a firm hold on your experience."));
     }
 
@@ -125,11 +125,11 @@ void set_body_improvement_info_3(CreatureEntity &creature, self_info_type *self_
         self_ptr->info_list.emplace_back(_("あなたは闘気のオーラに包まれている。", "You are surrounded with an energy aura."));
     }
 
-    if (creature.anti_magic) {
+    if (creature.has_anti_magic()) {
         self_ptr->info_list.emplace_back(_("あなたは反魔法シールドに包まれている。", "You are surrounded by an anti-magic shell."));
     }
 
-    if (creature.anti_tele) {
+    if (creature.has_anti_tele()) {
         self_ptr->info_list.emplace_back(_("あなたはテレポートできない。", "You cannot teleport."));
     }
 

--- a/src/player/digestion-processor.cpp
+++ b/src/player/digestion-processor.cpp
@@ -34,7 +34,7 @@ void starve_player(CreatureEntity &creature)
         (void)set_food(creature, creature.food - 100);
     } else if (AngbandWorld::get_instance().game_turn % (TURNS_PER_TICK * 5) == 0) {
         int digestion = speed_to_energy(creature.get_speed());
-        if (creature.regenerate) {
+        if (creature.has_regen_flag()) {
             digestion += 20;
         }
         CreatureClass pc(creature);
@@ -45,7 +45,7 @@ void starve_player(CreatureEntity &creature)
             digestion += 30;
         }
 
-        if (creature.slow_digest) {
+        if (creature.has_slow_digest_flag()) {
             digestion -= 5;
         }
 

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -257,7 +257,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
         if (!has_resist_conf(creature)) {
             (void)bss.mod_confusion(randint0(4) + 4);
         }
-        if (!creature.free_act) {
+        if (!creature.has_free_act()) {
             (void)bss.mod_paralysis(randint0(4) + 4);
         }
         if (!has_resist_chaos(creature)) {

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -516,7 +516,7 @@ void PlayerType::on_death(std::string_view cause)
         const auto is_hallucinated = effects->hallucination().is_hallucinated();
         auto paralysis_state = "";
         if (effects->paralysis().is_paralyzed()) {
-            paralysis_state = this->free_act ? _("彫像状態で", " while being the statue") : _("麻痺状態で", " while paralyzed");
+            paralysis_state = this->has_free_act() ? _("彫像状態で", " while being the statue") : _("麻痺状態で", " while paralyzed");
         }
 
         const auto hallucintion_state = is_hallucinated ? _("幻覚に歪んだ", "hallucinatingly distorted ") : "";

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -331,7 +331,7 @@ bool trap_can_be_ignored(CreatureEntity &creature, FEAT_IDX feat)
         }
         break;
     case TrapType::TELEPORT:
-        if (creature.anti_tele) {
+        if (creature.has_anti_tele()) {
             return true;
         }
         break;
@@ -361,7 +361,7 @@ bool trap_can_be_ignored(CreatureEntity &creature, FEAT_IDX feat)
         }
         break;
     case TrapType::SLEEP:
-        if (creature.free_act) {
+        if (creature.has_free_act()) {
             return true;
         }
         break;

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -653,7 +653,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
                 msg_print(_("失敗！", "You cannot move to that place!"));
                 break;
             }
-            if (creature.anti_tele) {
+            if (creature.has_anti_tele()) {
                 msg_print(_("不思議な力がテレポートを防いだ！", "A mysterious force prevents you from teleporting!"));
                 break;
             }

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -151,7 +151,7 @@ void Chest::fire_trap(const Pos2D &pos, short item_idx)
     /* Paralyze */
     if (trap.has(ChestTrapType::PARALYZE)) {
         msg_print(_("突如吹き出した黄色いガスに包み込まれた！", "A puff of yellow gas surrounds you!"));
-        if (!this->creature_ptr->free_act) {
+        if (!this->creature_ptr->has_free_act()) {
             (void)BadStatusSetter(*this->creature_ptr).mod_paralysis(10 + randint1(20));
         }
     }
@@ -253,7 +253,7 @@ void Chest::fire_trap(const Pos2D &pos, short item_idx)
             }
 
             if (one_in_(4)) {
-                if (!this->creature_ptr->free_act) {
+                if (!this->creature_ptr->has_free_act()) {
                     (void)bss.mod_paralysis(2 + randint0(6));
                 } else {
                     (void)bss.mod_stun(10 + randint0(100));

--- a/src/spell-kind/blood-curse.cpp
+++ b/src/spell-kind/blood-curse.cpp
@@ -113,12 +113,12 @@ void blood_curse_to_enemy(CreatureEntity &creature, MONSTER_IDX m_idx)
         case 23:
         case 24:
         case 25:
-            if (creature.hold_exp && evaluate_percent(75)) {
+            if (creature.has_hold_exp() && evaluate_percent(75)) {
                 break;
             }
 
             msg_print(_("経験値が体から吸い取られた気がする！", "You feel your experience draining away..."));
-            if (creature.hold_exp) {
+            if (creature.has_hold_exp()) {
                 lose_exp(creature, creature.exp / 160);
             } else {
                 lose_exp(creature, creature.exp / 16);

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -193,11 +193,11 @@ bool activate_ty_curse(CreatureEntity &creature, bool stop_ty, int *count)
         case 19:
         case 20: {
             auto is_statue = stop_ty;
-            is_statue |= creature.free_act && (randint1(125) < creature.skill_sav);
+            is_statue |= creature.has_free_act() && (randint1(125) < creature.skill_sav);
             is_statue |= CreatureClass(creature).equals(PlayerClassType::BERSERKER);
             if (!is_statue) {
                 msg_print(_("彫像になった気分だ！", "You feel like a statue!"));
-                TIME_EFFECT turns = creature.free_act ? randint1(3) : randint1(13);
+                TIME_EFFECT turns = creature.has_free_act() ? randint1(3) : randint1(13);
                 (void)BadStatusSetter(creature).mod_paralysis(turns);
                 stop_ty = true;
             }

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -45,7 +45,7 @@
 bool teleport_swap(CreatureEntity &creature, const Direction &dir)
 {
     const auto pos = dir.get_target_position(creature.get_position());
-    if (creature.anti_tele) {
+    if (creature.has_anti_tele()) {
         msg_print(_("不思議な力がテレポートを防いだ！", "A mysterious force prevents you from teleporting!"));
         return false;
     }
@@ -282,7 +282,7 @@ bool teleport_player_aux(CreatureEntity &creature, POSITION dis, bool is_quantum
         return false;
     }
 
-    if (!is_quantum_effect && creature.anti_tele && !(mode & TELEPORT_NONMAGICAL)) {
+    if (!is_quantum_effect && creature.has_anti_tele() && !(mode & TELEPORT_NONMAGICAL)) {
         msg_print(_("不思議な力がテレポートを防いだ！", "A mysterious force prevents you from teleporting!"));
         return false;
     }
@@ -468,7 +468,7 @@ void teleport_player_away(MONSTER_IDX m_idx, CreatureEntity &creature, POSITION 
  */
 void teleport_player_to(CreatureEntity &creature, POSITION ny, POSITION nx, teleport_flags mode)
 {
-    if (creature.anti_tele && !(mode & TELEPORT_NONMAGICAL)) {
+    if (creature.has_anti_tele() && !(mode & TELEPORT_NONMAGICAL)) {
         msg_print(_("不思議な力がテレポートを防いだ！", "A mysterious force prevents you from teleporting!"));
         return;
     }

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -78,7 +78,7 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
         return;
     }
 
-    if ((m_idx <= 0) && creature.anti_tele) {
+    if ((m_idx <= 0) && creature.has_anti_tele()) {
         msg_print(_("不思議な力がテレポートを防いだ！", "A mysterious force prevents you from teleporting!"));
         return;
     }

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -189,7 +189,7 @@ void SpellHex::decrease_mana()
     }
 
     auto need_restart = this->check_restart();
-    if (this->creature.anti_magic) {
+    if (this->creature.has_anti_magic()) {
         this->stop_all_spells();
         return;
     }

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -34,7 +34,7 @@ void check_music(CreatureEntity &creature)
         return;
     }
 
-    if (creature.anti_magic) {
+    if (creature.has_anti_magic()) {
         stop_singing(creature);
         return;
     }

--- a/src/status/experience.cpp
+++ b/src/status/experience.cpp
@@ -76,12 +76,12 @@ bool drain_exp(CreatureEntity &creature, int32_t drain, int32_t slip, int hold_e
         return false;
     }
 
-    if (creature.hold_exp && evaluate_percent(hold_exp_prob)) {
+    if (creature.has_hold_exp() && evaluate_percent(hold_exp_prob)) {
         msg_print(_("しかし自己の経験値を守りきった！", "You keep hold of your experience!"));
         return false;
     }
 
-    if (creature.hold_exp) {
+    if (creature.has_hold_exp()) {
         msg_print(_("経験値を少し吸い取られた気がする！", "You feel your experience slipping away!"));
         lose_exp(creature, slip);
     } else {

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -922,6 +922,55 @@ public:
     {
         return this->levitation != 0;
     }
+    /*!
+     * @brief 麻痺耐性の有無
+     */
+    virtual bool has_free_act() const
+    {
+        return this->free_act != 0;
+    }
+    /*!
+     * @brief 反魔法能力の有無
+     */
+    virtual bool has_anti_magic() const
+    {
+        return this->anti_magic != 0;
+    }
+    /*!
+     * @brief テレポート阻害の有無
+     */
+    virtual bool has_anti_tele() const
+    {
+        return this->anti_tele != 0;
+    }
+    /*!
+     * @brief 自動再生能力の有無（フィールド値）
+     */
+    virtual bool has_regen_flag() const
+    {
+        return this->regenerate != 0;
+    }
+    /*!
+     * @brief 経験値吸収耐性の有無
+     */
+    virtual bool has_hold_exp() const
+    {
+        return this->hold_exp != 0;
+    }
+    /*!
+     * @brief 低速消化能力の有無
+     */
+    virtual bool has_slow_digest_flag() const
+    {
+        return this->slow_digest != 0;
+    }
+    /*!
+     * @brief 夜間視能力の有無
+     */
+    virtual bool has_see_nocto() const
+    {
+        return this->see_nocto != 0;
+    }
 
     /*!
      * @brief クリーチャーのコピーを返す

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -137,7 +137,7 @@ DisplaySymbolPair map_info(CreatureEntity &creature, const Pos2D &pos)
     const auto &world = AngbandWorld::get_instance();
     const auto is_wild_mode = world.is_wild_mode();
     const auto is_blind = creature.is_blind();
-    const auto has_nocto = creature.see_nocto != 0;
+    const auto has_nocto = creature.has_see_nocto() != 0;
     const auto is_darkened = !has_nocto && grid.is_darkened();
     const auto tag_unsafe = (view_unsafe_grids && (grid.info & CAVE_UNSAFE)) ? TerrainTag::UNDETECTED : TerrainTag::NONE;
     const auto *terrain_mimic_ptr = &grid.get_terrain(TerrainKind::MIMIC);

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -302,7 +302,7 @@ static int calculate_hp_regen_rate(CreatureEntity &creature)
     }
 
     // 再生能力
-    if (creature.regenerate) {
+    if (creature.has_regen_flag()) {
         regen_amount = regen_amount * 2;
     }
 
@@ -372,7 +372,7 @@ static int calculate_mp_regen_rate(CreatureEntity &creature)
     }
 
     // 再生能力
-    if (creature.regenerate) {
+    if (creature.has_regen_flag()) {
         regen_amount = regen_amount * 2;
     }
 


### PR DESCRIPTION
提案 2 の継続。以下の BIT_FLAGS にも virtual アクセサを追加し、
読取り side の call site を置換:

- free_act → has_free_act() (19 箇所)
- anti_magic → has_anti_magic() (18 箇所)
- anti_tele → has_anti_tele() (12 箇所)
- regenerate → has_regen_flag() (6 箇所)
- hold_exp → has_hold_exp() (8 箇所)
- slow_digest → has_slow_digest_flag() (4 箇所)
- see_nocto → has_see_nocto() (7 箇所)

命名は既存自由関数（has_regenerate(creature) 等）との混同を
避けるため、has_regen_flag / has_slow_digest_flag のように
フィールド値読取り用のサフィックスを付けた形を一部採用。

将来モンスター側で種族フラグから導出する形でオーバーライド可能。