### PR TITLE
refactor(creature): special_attack/defense を virtual アクセサ化

### DIFF
--- a/src/combat/attack-accuracy.cpp
+++ b/src/combat/attack-accuracy.cpp
@@ -79,7 +79,7 @@ bool check_hit_from_monster_to_player(CreatureEntity &creature, int power, DEPTH
     int i = (power + (level * 3));
 
     int ac = creature.get_ac();
-    if (creature.special_attack & ATTACK_SUIKEN) {
+    if (creature.has_special_attack(ATTACK_SUIKEN)) {
         ac += (creature.level * 2);
     }
 

--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -156,19 +156,19 @@ int calc_attack_damage_with_slay(CreatureEntity &creature, ItemEntity *o_ptr, in
     torch_flags(o_ptr, flags); /* torches has secret flags */
 
     if (!thrown) {
-        if (creature.special_attack & (ATTACK_ACID)) {
+        if (creature.has_special_attack(ATTACK_ACID)) {
             flags.set(TR_BRAND_ACID);
         }
-        if (creature.special_attack & (ATTACK_COLD)) {
+        if (creature.has_special_attack(ATTACK_COLD)) {
             flags.set(TR_BRAND_COLD);
         }
-        if (creature.special_attack & (ATTACK_ELEC)) {
+        if (creature.has_special_attack(ATTACK_ELEC)) {
             flags.set(TR_BRAND_ELEC);
         }
-        if (creature.special_attack & (ATTACK_FIRE)) {
+        if (creature.has_special_attack(ATTACK_FIRE)) {
             flags.set(TR_BRAND_FIRE);
         }
-        if (creature.special_attack & (ATTACK_POIS)) {
+        if (creature.has_special_attack(ATTACK_POIS)) {
             flags.set(TR_BRAND_POIS);
         }
     }
@@ -265,19 +265,19 @@ AttributeFlags melee_attribute(CreatureEntity &creature, ItemEntity *o_ptr, comb
 
     auto flags = o_ptr->get_flags();
 
-    if (creature.special_attack & (ATTACK_ACID)) {
+    if (creature.has_special_attack(ATTACK_ACID)) {
         flags.set(TR_BRAND_ACID);
     }
-    if (creature.special_attack & (ATTACK_COLD)) {
+    if (creature.has_special_attack(ATTACK_COLD)) {
         flags.set(TR_BRAND_COLD);
     }
-    if (creature.special_attack & (ATTACK_ELEC)) {
+    if (creature.has_special_attack(ATTACK_ELEC)) {
         flags.set(TR_BRAND_ELEC);
     }
-    if (creature.special_attack & (ATTACK_FIRE)) {
+    if (creature.has_special_attack(ATTACK_FIRE)) {
         flags.set(TR_BRAND_FIRE);
     }
-    if (creature.special_attack & (ATTACK_POIS)) {
+    if (creature.has_special_attack(ATTACK_POIS)) {
         flags.set(TR_BRAND_POIS);
     }
 

--- a/src/mind/monk-attack.cpp
+++ b/src/mind/monk-attack.cpp
@@ -255,7 +255,7 @@ void process_monk_attack(CreatureEntity &creature, player_attack_type *pa_ptr)
     const auto sides = pa_ptr->ma_ptr->damage_dice.sides + creature.damage_dice_bonus[pa_ptr->hand].sides;
     pa_ptr->attack_damage = calc_attack_damage_with_slay(creature, o_ptr, Dice::roll(num, sides), *pa_ptr->m_ptr, pa_ptr->mode, false);
 
-    if (creature.special_attack & ATTACK_SUIKEN) {
+    if (creature.has_special_attack(ATTACK_SUIKEN)) {
         pa_ptr->attack_damage *= 2;
     }
 

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -81,7 +81,7 @@ static void dispel_player(CreatureEntity &creature)
     (void)set_tim_exorcism(creature, 0, true);
     (void)set_tim_imm_dark(creature, 0, true);
 
-    if (creature.special_attack & ATTACK_CONFUSE) {
+    if (creature.has_special_attack(ATTACK_CONFUSE)) {
         creature.special_attack &= ~(ATTACK_CONFUSE);
         msg_print(_("手の輝きがなくなった。", "Your hands stop glowing."));
     }

--- a/src/mspell/mspell-judgement.cpp
+++ b/src/mspell/mspell-judgement.cpp
@@ -264,7 +264,7 @@ bool dispel_check(CreatureEntity &creature, MONSTER_IDX m_idx)
             return true;
         }
 
-        if (creature.special_defense & DEFENSE_ACID) {
+        if (creature.has_special_defense(DEFENSE_ACID)) {
             return true;
         }
     }
@@ -275,7 +275,7 @@ bool dispel_check(CreatureEntity &creature, MONSTER_IDX m_idx)
                 return true;
             }
 
-            if (creature.special_defense & DEFENSE_FIRE) {
+            if (creature.has_special_defense(DEFENSE_FIRE)) {
                 return true;
             }
         }
@@ -286,7 +286,7 @@ bool dispel_check(CreatureEntity &creature, MONSTER_IDX m_idx)
             return true;
         }
 
-        if (creature.special_defense & DEFENSE_ELEC) {
+        if (creature.has_special_defense(DEFENSE_ELEC)) {
             return true;
         }
     }
@@ -296,7 +296,7 @@ bool dispel_check(CreatureEntity &creature, MONSTER_IDX m_idx)
             return true;
         }
 
-        if (creature.special_defense & DEFENSE_COLD) {
+        if (creature.has_special_defense(DEFENSE_COLD)) {
             return true;
         }
     }
@@ -306,7 +306,7 @@ bool dispel_check(CreatureEntity &creature, MONSTER_IDX m_idx)
             return true;
         }
 
-        if (creature.special_defense & DEFENSE_POIS) {
+        if (creature.has_special_defense(DEFENSE_POIS)) {
             return true;
         }
     }
@@ -319,23 +319,23 @@ bool dispel_check(CreatureEntity &creature, MONSTER_IDX m_idx)
         return true;
     }
 
-    if ((creature.special_attack & ATTACK_ACID) && monrace.resistance_flags.has_none_of(RFR_EFF_IM_ACID_MASK)) {
+    if ((creature.has_special_attack(ATTACK_ACID)) && monrace.resistance_flags.has_none_of(RFR_EFF_IM_ACID_MASK)) {
         return true;
     }
 
-    if ((creature.special_attack & ATTACK_FIRE) && monrace.resistance_flags.has_none_of(RFR_EFF_IM_FIRE_MASK)) {
+    if ((creature.has_special_attack(ATTACK_FIRE)) && monrace.resistance_flags.has_none_of(RFR_EFF_IM_FIRE_MASK)) {
         return true;
     }
 
-    if ((creature.special_attack & ATTACK_ELEC) && monrace.resistance_flags.has_none_of(RFR_EFF_IM_ELEC_MASK)) {
+    if ((creature.has_special_attack(ATTACK_ELEC)) && monrace.resistance_flags.has_none_of(RFR_EFF_IM_ELEC_MASK)) {
         return true;
     }
 
-    if ((creature.special_attack & ATTACK_COLD) && monrace.resistance_flags.has_none_of(RFR_EFF_IM_COLD_MASK)) {
+    if ((creature.has_special_attack(ATTACK_COLD)) && monrace.resistance_flags.has_none_of(RFR_EFF_IM_COLD_MASK)) {
         return true;
     }
 
-    if ((creature.special_attack & ATTACK_POIS) && monrace.resistance_flags.has_none_of(RFR_EFF_IM_POISON_MASK)) {
+    if ((creature.has_special_attack(ATTACK_POIS)) && monrace.resistance_flags.has_none_of(RFR_EFF_IM_POISON_MASK)) {
         return true;
     }
 

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -47,7 +47,7 @@
  */
 static void attack_confuse(CreatureEntity &creature, player_attack_type *pa_ptr, bool can_resist = true)
 {
-    if (creature.special_attack & ATTACK_CONFUSE) {
+    if (creature.has_special_attack(ATTACK_CONFUSE)) {
         creature.special_attack &= ~(ATTACK_CONFUSE);
         msg_print(_("手の輝きがなくなった。", "Your hands stop glowing."));
         RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);

--- a/src/player-info/self-info.cpp
+++ b/src/player-info/self-info.cpp
@@ -141,27 +141,27 @@ static void set_curse_info(CreatureEntity &subject, self_info_type *self_ptr)
 
 static void set_special_attack_info(CreatureEntity &subject, self_info_type *self_ptr)
 {
-    if (subject.special_attack & ATTACK_CONFUSE) {
+    if (subject.has_special_attack(ATTACK_CONFUSE)) {
         self_ptr->info_list.emplace_back(_("あなたの手は赤く輝いている。", "Your hands are glowing dull red."));
     }
 
-    if (subject.special_attack & ATTACK_FIRE) {
+    if (subject.has_special_attack(ATTACK_FIRE)) {
         self_ptr->info_list.emplace_back(_("あなたの手は火炎に覆われている。", "You can strike the enemy with flame."));
     }
 
-    if (subject.special_attack & ATTACK_COLD) {
+    if (subject.has_special_attack(ATTACK_COLD)) {
         self_ptr->info_list.emplace_back(_("あなたの手は冷気に覆われている。", "You can strike the enemy with cold."));
     }
 
-    if (subject.special_attack & ATTACK_ACID) {
+    if (subject.has_special_attack(ATTACK_ACID)) {
         self_ptr->info_list.emplace_back(_("あなたの手は酸に覆われている。", "You can strike the enemy with acid."));
     }
 
-    if (subject.special_attack & ATTACK_ELEC) {
+    if (subject.has_special_attack(ATTACK_ELEC)) {
         self_ptr->info_list.emplace_back(_("あなたの手は電撃に覆われている。", "You can strike the enemy with electoric shock."));
     }
 
-    if (subject.special_attack & ATTACK_POIS) {
+    if (subject.has_special_attack(ATTACK_POIS)) {
         self_ptr->info_list.emplace_back(_("あなたの手は毒に覆われている。", "You can strike the enemy with poison."));
     }
 }
@@ -380,7 +380,7 @@ void report_magics(CreatureEntity &subject)
             _("あなたは幽体化している", "You are incorporeal"));
     }
 
-    if (subject.special_attack & ATTACK_CONFUSE) {
+    if (subject.has_special_attack(ATTACK_CONFUSE)) {
         info.emplace_back(7, _("あなたの手は赤く輝いている", "Your hands are glowing dull red."));
     }
 

--- a/src/player/race-resistances.cpp
+++ b/src/player/race-resistances.cpp
@@ -57,16 +57,16 @@ void tim_player_immunity(CreatureEntity &creature, TrFlags &flags)
 {
     flags.clear();
 
-    if (creature.special_defense & DEFENSE_ACID) {
+    if (creature.has_special_defense(DEFENSE_ACID)) {
         flags.set(TR_RES_ACID);
     }
-    if (creature.special_defense & DEFENSE_ELEC) {
+    if (creature.has_special_defense(DEFENSE_ELEC)) {
         flags.set(TR_RES_ELEC);
     }
-    if (creature.special_defense & DEFENSE_FIRE) {
+    if (creature.has_special_defense(DEFENSE_FIRE)) {
         flags.set(TR_RES_FIRE);
     }
-    if (creature.special_defense & DEFENSE_COLD) {
+    if (creature.has_special_defense(DEFENSE_COLD)) {
         flags.set(TR_RES_COLD);
     }
     if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {

--- a/src/realm/realm-chaos.cpp
+++ b/src/realm/realm-chaos.cpp
@@ -86,7 +86,7 @@ tl::optional<std::string> do_chaos_spell(CreatureEntity &creature, SPELL_IDX spe
 
     case 3: {
         if (cast) {
-            if (!(creature.special_attack & ATTACK_CONFUSE)) {
+            if (!(creature.has_special_attack(ATTACK_CONFUSE))) {
                 msg_print(_("あなたの手は光り始めた。", "Your hands start glowing."));
                 creature.special_attack |= ATTACK_CONFUSE;
                 RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);

--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -36,27 +36,27 @@ bool set_ele_attack(CreatureEntity &creature, uint32_t attack_type, TIME_EFFECT 
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
 
-    if ((creature.special_attack & (ATTACK_ACID)) && (attack_type != ATTACK_ACID)) {
+    if ((creature.has_special_attack(ATTACK_ACID)) && (attack_type != ATTACK_ACID)) {
         creature.special_attack &= ~(ATTACK_ACID);
         msg_print(_("酸で攻撃できなくなった。", "Your temporary acidic brand fades away."));
     }
 
-    if ((creature.special_attack & (ATTACK_ELEC)) && (attack_type != ATTACK_ELEC)) {
+    if ((creature.has_special_attack(ATTACK_ELEC)) && (attack_type != ATTACK_ELEC)) {
         creature.special_attack &= ~(ATTACK_ELEC);
         msg_print(_("電撃で攻撃できなくなった。", "Your temporary electrical brand fades away."));
     }
 
-    if ((creature.special_attack & (ATTACK_FIRE)) && (attack_type != ATTACK_FIRE)) {
+    if ((creature.has_special_attack(ATTACK_FIRE)) && (attack_type != ATTACK_FIRE)) {
         creature.special_attack &= ~(ATTACK_FIRE);
         msg_print(_("火炎で攻撃できなくなった。", "Your temporary fiery brand fades away."));
     }
 
-    if ((creature.special_attack & (ATTACK_COLD)) && (attack_type != ATTACK_COLD)) {
+    if ((creature.has_special_attack(ATTACK_COLD)) && (attack_type != ATTACK_COLD)) {
         creature.special_attack &= ~(ATTACK_COLD);
         msg_print(_("冷気で攻撃できなくなった。", "Your temporary frost brand fades away."));
     }
 
-    if ((creature.special_attack & (ATTACK_POIS)) && (attack_type != ATTACK_POIS)) {
+    if ((creature.has_special_attack(ATTACK_POIS)) && (attack_type != ATTACK_POIS)) {
         creature.special_attack &= ~(ATTACK_POIS);
         msg_print(_("毒で攻撃できなくなった。", "Your temporary poison brand fades away."));
     }
@@ -114,27 +114,27 @@ bool set_ele_immune(CreatureEntity &creature, uint32_t immune_type, TIME_EFFECT 
     v = (v > 10000) ? 10000 : (v < 0) ? 0
                                       : v;
 
-    if ((creature.special_defense & (DEFENSE_ACID)) && (immune_type != DEFENSE_ACID)) {
+    if ((creature.has_special_defense(DEFENSE_ACID)) && (immune_type != DEFENSE_ACID)) {
         creature.special_defense &= ~(DEFENSE_ACID);
         msg_print(_("酸の攻撃で傷つけられるようになった。。", "You are no longer immune to acid."));
     }
 
-    if ((creature.special_defense & (DEFENSE_ELEC)) && (immune_type != DEFENSE_ELEC)) {
+    if ((creature.has_special_defense(DEFENSE_ELEC)) && (immune_type != DEFENSE_ELEC)) {
         creature.special_defense &= ~(DEFENSE_ELEC);
         msg_print(_("電撃の攻撃で傷つけられるようになった。。", "You are no longer immune to electricity."));
     }
 
-    if ((creature.special_defense & (DEFENSE_FIRE)) && (immune_type != DEFENSE_FIRE)) {
+    if ((creature.has_special_defense(DEFENSE_FIRE)) && (immune_type != DEFENSE_FIRE)) {
         creature.special_defense &= ~(DEFENSE_FIRE);
         msg_print(_("火炎の攻撃で傷つけられるようになった。。", "You are no longer immune to fire."));
     }
 
-    if ((creature.special_defense & (DEFENSE_COLD)) && (immune_type != DEFENSE_COLD)) {
+    if ((creature.has_special_defense(DEFENSE_COLD)) && (immune_type != DEFENSE_COLD)) {
         creature.special_defense &= ~(DEFENSE_COLD);
         msg_print(_("冷気の攻撃で傷つけられるようになった。。", "You are no longer immune to cold."));
     }
 
-    if ((creature.special_defense & (DEFENSE_POIS)) && (immune_type != DEFENSE_POIS)) {
+    if ((creature.has_special_defense(DEFENSE_POIS)) && (immune_type != DEFENSE_POIS)) {
         creature.special_defense &= ~(DEFENSE_POIS);
         msg_print(_("毒の攻撃で傷つけられるようになった。。", "You are no longer immune to poison."));
     }

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -971,6 +971,22 @@ public:
     {
         return this->see_nocto != 0;
     }
+    /*!
+     * @brief 特殊攻撃ビットの保有判定
+     * @param flag 対象の ATTACK_* ビット
+     */
+    virtual bool has_special_attack(BIT_FLAGS flag) const
+    {
+        return (this->special_attack & flag) != 0;
+    }
+    /*!
+     * @brief 特殊防御ビットの保有判定
+     * @param flag 対象の DEFENSE_* ビット
+     */
+    virtual bool has_special_defense(BIT_FLAGS flag) const
+    {
+        return (this->special_defense & flag) != 0;
+    }
 
     /*!
      * @brief クリーチャーのコピーを返す

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -540,7 +540,7 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_KAWARIMI);
     }
 
-    if (creature.special_defense & DEFENSE_ACID) {
+    if (creature.has_special_defense(DEFENSE_ACID)) {
         ADD_BAR_FLAG(BAR_IMMACID);
     }
 
@@ -548,7 +548,7 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_RESACID);
     }
 
-    if (creature.special_defense & DEFENSE_ELEC) {
+    if (creature.has_special_defense(DEFENSE_ELEC)) {
         ADD_BAR_FLAG(BAR_IMMELEC);
     }
 
@@ -556,7 +556,7 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_RESELEC);
     }
 
-    if (creature.special_defense & DEFENSE_FIRE) {
+    if (creature.has_special_defense(DEFENSE_FIRE)) {
         ADD_BAR_FLAG(BAR_IMMFIRE);
     }
 
@@ -564,7 +564,7 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_RESFIRE);
     }
 
-    if (creature.special_defense & DEFENSE_COLD) {
+    if (creature.has_special_defense(DEFENSE_COLD)) {
         ADD_BAR_FLAG(BAR_IMMCOLD);
     }
 
@@ -596,7 +596,7 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_MULTISHADOW);
     }
 
-    if (creature.special_attack & ATTACK_CONFUSE) {
+    if (creature.has_special_attack(ATTACK_CONFUSE)) {
         ADD_BAR_FLAG(BAR_ATTKCONF);
     }
 
@@ -620,23 +620,23 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_DUSTROBE);
     }
 
-    if (creature.special_attack & ATTACK_FIRE) {
+    if (creature.has_special_attack(ATTACK_FIRE)) {
         ADD_BAR_FLAG(BAR_ATTKFIRE);
     }
 
-    if (creature.special_attack & ATTACK_COLD) {
+    if (creature.has_special_attack(ATTACK_COLD)) {
         ADD_BAR_FLAG(BAR_ATTKCOLD);
     }
 
-    if (creature.special_attack & ATTACK_ELEC) {
+    if (creature.has_special_attack(ATTACK_ELEC)) {
         ADD_BAR_FLAG(BAR_ATTKELEC);
     }
 
-    if (creature.special_attack & ATTACK_ACID) {
+    if (creature.has_special_attack(ATTACK_ACID)) {
         ADD_BAR_FLAG(BAR_ATTKACID);
     }
 
-    if (creature.special_attack & ATTACK_POIS) {
+    if (creature.has_special_attack(ATTACK_POIS)) {
         ADD_BAR_FLAG(BAR_ATTKPOIS);
     }
 


### PR DESCRIPTION
special_attack / special_defense のビット判定を has_special_attack(flag) / has_special_defense(flag) virtual メソッド経由に置換。

読取り用途の creature.special_attack & ATTACK_XXX 形式 (54 箇所) / creature.special_defense & DEFENSE_XXX 形式 (31 箇所) を一括置換。 書込み (|= / &= ~FLAG) は直接参照のまま残置。

将来モンスター側でも種族フラグ由来の特殊攻撃/防御を持つ場合、
MonsterProfile 経由でオーバーライド可能。