### PR TITLE
refactor(creature): 残存 BIT_FLAGS 9 種の virtual アクセサ化

### DIFF
--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -315,7 +315,7 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
         return;
     }
 
-    if (creature.warning && (!process_warning(creature, pos.x, pos.y))) {
+    if (creature.has_warning_flag() && (!process_warning(creature, pos.x, pos.y))) {
         energy.set_player_turn_energy(25);
         return;
     }

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -547,7 +547,7 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
     auto tmul = j_ptr->get_arrow_magnification();
 
     /* Get extra "power" from "extra might" */
-    if (creature.xtra_might) {
+    if (creature.has_xtra_might()) {
         tmul++;
     }
 
@@ -1282,7 +1282,7 @@ uint32_t calc_expect_dice(
     CreatureEntity &creature, uint32_t dam, int16_t to_h, ItemEntity *o_ptr)
 {
     auto flags = o_ptr->get_flags_known();
-    bool impact = creature.impact != 0;
+    bool impact = creature.has_impact_flag() != 0;
 
     int vorpal_mult = 1;
     int vorpal_div = 1;

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -87,7 +87,7 @@ static void compare_weapon_aux(CreatureEntity &creature, ItemEntity *o_ptr, int 
         dokubari = true;
     }
 
-    bool impact = flags.has(TR_IMPACT) || (creature.impact != 0);
+    bool impact = flags.has(TR_IMPACT) || (creature.has_impact_flag() != 0);
     mindam = calc_expect_crit(creature, o_ptr->weight, o_ptr->to_h, mindice, creature.to_h[0], dokubari, impact);
     maxdam = calc_expect_crit(creature, o_ptr->weight, o_ptr->to_h, maxdice, creature.to_h[0], dokubari, impact);
     show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("会心:", "Critical:"), TERM_L_RED);

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -180,7 +180,7 @@ static bool check_procection_rune(CreatureEntity &creature, MonraceId monrace_id
 
 static void warn_unique_generation(CreatureEntity &creature, MonraceId r_idx)
 {
-    if (!creature.warning || !AngbandWorld::get_instance().character_dungeon) {
+    if (!creature.has_warning_flag() || !AngbandWorld::get_instance().character_dungeon) {
         return;
     }
 

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -110,7 +110,7 @@ void ObjectThrowEntity::calc_throw_range()
     distribute_charges(this->o_ptr, this->q_ptr, 1);
     this->q_ptr->number = 1;
     this->o_name = describe_flavor(creature, *this->q_ptr, OD_OMIT_PREFIX);
-    if (creature.mighty_throw) {
+    if (creature.has_mighty_throw()) {
         this->mult += 3;
     }
 

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -31,7 +31,7 @@ ItemEntity *choose_warning_item(CreatureEntity &creature)
 {
 
     /* Paranoia -- Player has no warning ability */
-    if (!creature.warning) {
+    if (!creature.has_warning_flag()) {
         return nullptr;
     }
 

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -271,7 +271,7 @@ static int magical_brand_extra_dice(player_attack_type *pa_ptr)
  */
 static bool does_equip_cause_earthquake(CreatureEntity &creature, player_attack_type *pa_ptr)
 {
-    if (!creature.earthquake) {
+    if (!creature.has_earthquake_flag()) {
         return false;
     }
 

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -89,7 +89,7 @@ void update_lite_radius(CreatureEntity &creature)
         creature.cur_lite += o_ptr->get_lite_radius();
     }
 
-    if (creature.cur_lite <= 0 && creature.lite) {
+    if (creature.cur_lite <= 0 && creature.has_lite_flag()) {
         creature.cur_lite++;
     }
 

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -37,13 +37,13 @@ MANA_POINT mod_need_mana(CreatureEntity &creature, MANA_POINT need_mana, SPELL_I
 #define DEC_MANA_DIV 3
     if (PlayerRealm::is_magic(realm) || PlayerRealm::is_technic(realm)) {
         need_mana = need_mana * (MANA_CONST + PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT) - PlayerSkill(creature).exp_of_spell(realm, spell_id)) + (MANA_CONST - 1);
-        need_mana *= creature.dec_mana ? DEC_MANA_DIV : MANA_DIV;
+        need_mana *= creature.has_dec_mana() ? DEC_MANA_DIV : MANA_DIV;
         need_mana /= MANA_CONST * MANA_DIV;
         if (need_mana < 1) {
             need_mana = 1;
         }
     } else {
-        if (creature.dec_mana) {
+        if (creature.has_dec_mana()) {
             need_mana = (need_mana + 1) * DEC_MANA_DIV / MANA_DIV;
         }
     }
@@ -68,15 +68,15 @@ PERCENTAGE mod_spell_chance_1(CreatureEntity &creature, PERCENTAGE chance)
 {
     chance += creature.to_m_chance;
 
-    if (creature.hard_spell) {
+    if (creature.has_hard_spell()) {
         chance += 20;
     }
 
-    if (creature.dec_mana && creature.easy_spell) {
+    if (creature.has_dec_mana() && creature.has_easy_spell()) {
         chance -= 4;
-    } else if (creature.easy_spell) {
+    } else if (creature.has_easy_spell()) {
         chance -= 3;
-    } else if (creature.dec_mana) {
+    } else if (creature.has_dec_mana()) {
         chance -= 2;
     }
 
@@ -97,10 +97,10 @@ PERCENTAGE mod_spell_chance_1(CreatureEntity &creature, PERCENTAGE chance)
  */
 PERCENTAGE mod_spell_chance_2(CreatureEntity &creature, PERCENTAGE chance)
 {
-    if (creature.dec_mana) {
+    if (creature.has_dec_mana()) {
         chance--;
     }
-    if (creature.hard_spell) {
+    if (creature.has_hard_spell()) {
         chance += 5;
     }
     return std::max(chance, 0);

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -987,6 +987,69 @@ public:
     {
         return (this->special_defense & flag) != 0;
     }
+    /*!
+     * @brief 光源能力の有無 (フィールド値)
+     */
+    virtual bool has_lite_flag() const
+    {
+        return this->lite != 0;
+    }
+    /*!
+     * @brief 警告能力の有無
+     */
+    virtual bool has_warning_flag() const
+    {
+        return this->warning != 0;
+    }
+    /*!
+     * @brief 衝撃付与攻撃の有無 (装備起因)
+     */
+    virtual bool has_impact_flag() const
+    {
+        return this->impact != 0;
+    }
+    /*!
+     * @brief 地震付与攻撃の有無 (装備起因)
+     */
+    virtual bool has_earthquake_flag() const
+    {
+        return this->earthquake != 0;
+    }
+    /*!
+     * @brief 魔法消費軽減能力の有無
+     */
+    virtual bool has_dec_mana() const
+    {
+        return this->dec_mana != 0;
+    }
+    /*!
+     * @brief 易しい呪文能力の有無
+     */
+    virtual bool has_easy_spell() const
+    {
+        return this->easy_spell != 0;
+    }
+    /*!
+     * @brief 難しい呪文フラグの有無
+     */
+    virtual bool has_hard_spell() const
+    {
+        return this->hard_spell != 0;
+    }
+    /*!
+     * @brief 強力投擲能力の有無
+     */
+    virtual bool has_mighty_throw() const
+    {
+        return this->mighty_throw != 0;
+    }
+    /*!
+     * @brief 追加威力弓能力の有無
+     */
+    virtual bool has_xtra_might() const
+    {
+        return this->xtra_might != 0;
+    }
 
     /*!
      * @brief クリーチャーのコピーを返す

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -135,7 +135,7 @@ static void display_shoot_magnification(CreatureEntity &creature)
     int tmul = 0;
     if (creature.inventory[INVEN_BOW]->is_valid()) {
         tmul = creature.inventory[INVEN_BOW]->get_arrow_magnification();
-        if (creature.xtra_might) {
+        if (creature.has_xtra_might()) {
             tmul++;
         }
 

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -108,7 +108,7 @@ static bool calc_weapon_damage_limit(CreatureEntity &creature, int hand, int *da
     } else {
         *basedam = monk_ave_damage[level][0];
     }
-    bool impact = creature.impact != 0;
+    bool impact = creature.has_impact_flag() != 0;
     WEIGHT weight = creature.level * calc_monk_attack_weight(creature);
     int to_h = creature.level * 7 / 10; // 命中計算が煩雑なのでおよその値を使用する
 


### PR DESCRIPTION
提案 2 の継続。以下 9 フィールドに virtual アクセサを追加し、
読取り箇所を置換:

- lite → has_lite_flag()
- warning → has_warning_flag()
- impact → has_impact_flag()
- earthquake → has_earthquake_flag()
- dec_mana → has_dec_mana()
- easy_spell → has_easy_spell()
- hard_spell → has_hard_spell()
- mighty_throw → has_mighty_throw()
- xtra_might → has_xtra_might()

一部 (player-attack.cpp) の earthquake/impact は FLAG_CAUSE_* ビットマスクとして使用するため直接フィールド参照のまま。
命名は既存自由関数 has_lite/has_impact/has_earthquake との
混同を避けるため _flag サフィックスを付加。