### PR TITLE
refactor(creature): race/personality/pclass_ref ポインタに virtual アクセサ追加

### DIFF
--- a/src/autopick/autopick-editor-command.cpp
+++ b/src/autopick/autopick-editor-command.cpp
@@ -528,7 +528,7 @@ ape_quittance do_editor_command(CreatureEntity &creature, text_body_type *tb, in
             break;
         }
         const auto expression = format("?:[AND [EQU $RACE %s] [EQU $CLASS %s] [GEQ $LEVEL %02d]]",
-            creature.race->title.en_string().data(), (*creature.pclass_ref).title.en_string().data(),
+            creature.get_race_info()->title.en_string().data(), (*creature.get_class_info()).title.en_string().data(),
             creature.level);
         tb->cx = 0;
         insert_return_code(tb);

--- a/src/birth/auto-roller.cpp
+++ b/src/birth/auto-roller.cpp
@@ -171,14 +171,14 @@ static void decide_initial_stat(CreatureEntity &creature, int *cval)
  */
 static std::string cursor_of_adjusted_stat(CreatureEntity &creature, const int *cval, int cs)
 {
-    auto j = creature.race->r_adj[cs] + (*creature.pclass_ref).c_adj[cs] + (*creature.personality).a_adj[cs];
+    auto j = creature.get_race_info()->r_adj[cs] + (*creature.get_class_info()).c_adj[cs] + (*creature.get_personality_info()).a_adj[cs];
     auto m = adjust_stat(170, j); // 17.0 の新形式
     auto maxv = format("%4.1f", m / 10.0);
 
     m = adjust_stat(cval[cs], j);
     auto inp = format("%4.1f", m / 10.0);
 
-    return format("%6s     %4.1f   %+3d  %+3d  %+3d  =  %6s  %6s", stat_names[cs], cval[cs] / 10.0, creature.race->r_adj[cs], (*creature.pclass_ref).c_adj[cs], (*creature.personality).a_adj[cs], inp.data(), maxv.data());
+    return format("%6s     %4.1f   %+3d  %+3d  %+3d  =  %6s  %6s", stat_names[cs], cval[cs] / 10.0, creature.get_race_info()->r_adj[cs], (*creature.get_class_info()).c_adj[cs], (*creature.get_personality_info()).a_adj[cs], inp.data(), maxv.data());
 }
 
 /*!
@@ -368,11 +368,11 @@ bool get_chara_limits(CreatureEntity &creature, chara_limit_type *chara_limit_pt
 
     int max_percent, min_percent;
     if (creature.psex == SEX_MALE) {
-        max_percent = (int)(creature.race->m_b_ht + creature.race->m_m_ht * 4 - 1) * 100 / (int)(creature.race->m_b_ht);
-        min_percent = (int)(creature.race->m_b_ht - creature.race->m_m_ht * 4 + 1) * 100 / (int)(creature.race->m_b_ht);
+        max_percent = (int)(creature.get_race_info()->m_b_ht + creature.get_race_info()->m_m_ht * 4 - 1) * 100 / (int)(creature.get_race_info()->m_b_ht);
+        min_percent = (int)(creature.get_race_info()->m_b_ht - creature.get_race_info()->m_m_ht * 4 + 1) * 100 / (int)(creature.get_race_info()->m_b_ht);
     } else {
-        max_percent = (int)(creature.race->f_b_ht + creature.race->f_m_ht * 4 - 1) * 100 / (int)(creature.race->f_b_ht);
-        min_percent = (int)(creature.race->f_b_ht - creature.race->f_m_ht * 4 + 1) * 100 / (int)(creature.race->f_b_ht);
+        max_percent = (int)(creature.get_race_info()->f_b_ht + creature.get_race_info()->f_m_ht * 4 - 1) * 100 / (int)(creature.get_race_info()->f_b_ht);
+        min_percent = (int)(creature.get_race_info()->f_b_ht - creature.get_race_info()->f_m_ht * 4 + 1) * 100 / (int)(creature.get_race_info()->f_b_ht);
     }
 
     put_str(_("体格/地位の最小値/最大値を設定して下さい。", "Set minimum/maximum attribute."), 10, 10);
@@ -384,38 +384,38 @@ bool get_chara_limits(CreatureEntity &creature, chara_limit_type *chara_limit_pt
         int m;
         switch (i) {
         case 0: /* Minimum age */
-            m = creature.race->b_age + 1;
+            m = creature.get_race_info()->b_age + 1;
             break;
         case 1: /* Maximum age */
-            m = creature.race->b_age + creature.race->m_age;
+            m = creature.get_race_info()->b_age + creature.get_race_info()->m_age;
             break;
 
         case 2: /* Minimum height */
             if (creature.psex == SEX_MALE) {
-                m = creature.race->m_b_ht - creature.race->m_m_ht * 4 + 1;
+                m = creature.get_race_info()->m_b_ht - creature.get_race_info()->m_m_ht * 4 + 1;
             } else {
-                m = creature.race->f_b_ht - creature.race->f_m_ht * 4 + 1;
+                m = creature.get_race_info()->f_b_ht - creature.get_race_info()->f_m_ht * 4 + 1;
             }
             break;
         case 3: /* Maximum height */
             if (creature.psex == SEX_MALE) {
-                m = creature.race->m_b_ht + creature.race->m_m_ht * 4 - 1;
+                m = creature.get_race_info()->m_b_ht + creature.get_race_info()->m_m_ht * 4 - 1;
             } else {
-                m = creature.race->f_b_ht + creature.race->f_m_ht * 4 - 1;
+                m = creature.get_race_info()->f_b_ht + creature.get_race_info()->f_m_ht * 4 - 1;
             }
             break;
         case 4: /* Minimum weight */
             if (creature.psex == SEX_MALE) {
-                m = (creature.race->m_b_wt * min_percent / 100) - (creature.race->m_m_wt * min_percent / 75) + 1;
+                m = (creature.get_race_info()->m_b_wt * min_percent / 100) - (creature.get_race_info()->m_m_wt * min_percent / 75) + 1;
             } else {
-                m = (creature.race->f_b_wt * min_percent / 100) - (creature.race->f_m_wt * min_percent / 75) + 1;
+                m = (creature.get_race_info()->f_b_wt * min_percent / 100) - (creature.get_race_info()->f_m_wt * min_percent / 75) + 1;
             }
             break;
         case 5: /* Maximum weight */
             if (creature.psex == SEX_MALE) {
-                m = (creature.race->m_b_wt * max_percent / 100) + (creature.race->m_m_wt * max_percent / 75) - 1;
+                m = (creature.get_race_info()->m_b_wt * max_percent / 100) + (creature.get_race_info()->m_m_wt * max_percent / 75) - 1;
             } else {
-                m = (creature.race->f_b_wt * max_percent / 100) + (creature.race->f_m_wt * max_percent / 75) - 1;
+                m = (creature.get_race_info()->f_b_wt * max_percent / 100) + (creature.get_race_info()->f_m_wt * max_percent / 75) - 1;
             }
             break;
         case 6: /* Minimum prestige */

--- a/src/birth/birth-body-spec.cpp
+++ b/src/birth/birth-body-spec.cpp
@@ -22,14 +22,14 @@ void get_height_weight(CreatureEntity &creature)
     int deviation;
     switch (creature.psex) {
     case SEX_MALE:
-        creature.ht = randnor(creature.race->m_b_ht, creature.race->m_m_ht);
-        deviation = (int)(creature.ht) * 100 / (int)(creature.race->m_b_ht);
-        creature.wt = randnor((int)(creature.race->m_b_wt) * deviation / 100, (int)(creature.race->m_m_wt) * deviation / 300);
+        creature.ht = randnor(creature.get_race_info()->m_b_ht, creature.get_race_info()->m_m_ht);
+        deviation = (int)(creature.ht) * 100 / (int)(creature.get_race_info()->m_b_ht);
+        creature.wt = randnor((int)(creature.get_race_info()->m_b_wt) * deviation / 100, (int)(creature.get_race_info()->m_m_wt) * deviation / 300);
         return;
     case SEX_FEMALE:
-        creature.ht = randnor(creature.race->f_b_ht, creature.race->f_m_ht);
-        deviation = (int)(creature.ht) * 100 / (int)(creature.race->f_b_ht);
-        creature.wt = randnor((int)(creature.race->f_b_wt) * deviation / 100, (int)(creature.race->f_m_wt) * deviation / 300);
+        creature.ht = randnor(creature.get_race_info()->f_b_ht, creature.get_race_info()->f_m_ht);
+        deviation = (int)(creature.ht) * 100 / (int)(creature.get_race_info()->f_b_ht);
+        creature.wt = randnor((int)(creature.get_race_info()->f_b_wt) * deviation / 100, (int)(creature.get_race_info()->f_m_wt) * deviation / 300);
         return;
     default:
         return;
@@ -42,7 +42,7 @@ void get_height_weight(CreatureEntity &creature)
  */
 void get_ahw(CreatureEntity &creature)
 {
-    creature.age = creature.race->b_age + randint1(creature.race->m_age);
+    creature.age = creature.get_race_info()->b_age + randint1(creature.get_race_info()->m_age);
     get_height_weight(creature);
 }
 

--- a/src/birth/birth-select-class.cpp
+++ b/src/birth/birth-select-class.cpp
@@ -25,7 +25,7 @@ static std::string birth_class_label(CreatureEntity &creature, int cs, concptr s
     ss << sym[cs] << p2;
     const auto pclass = i2enum<PlayerClassType>(cs);
     const auto title = class_info.at(pclass).title;
-    if (!(creature.race->choice & (1UL << cs))) {
+    if (!(creature.get_race_info()->choice & (1UL << cs))) {
         ss << '(' << title << ')';
     } else {
         ss << title;
@@ -220,6 +220,6 @@ bool get_player_class(CreatureEntity &creature)
     cp_ptr = &class_info.at(creature.pclass);
     creature.pclass_ref = &class_info.at(creature.pclass);
     mp_ptr = &class_magics_info[enum2i(creature.pclass)];
-    c_put_str(TERM_L_BLUE, creature.pclass_ref->title, 5, 15);
+    c_put_str(TERM_L_BLUE, creature.get_class_info()->title, 5, 15);
     return true;
 }

--- a/src/birth/birth-select-race.cpp
+++ b/src/birth/birth-select-race.cpp
@@ -71,23 +71,23 @@ static std::string display_race_stat(CreatureEntity &creature, int cs, int *os, 
         put_str("                                   ", 6, 40);
     } else {
         creature.race = &race_info[cs];
-        c_put_str(TERM_L_BLUE, creature.race->title, 3, 40);
+        c_put_str(TERM_L_BLUE, creature.get_race_info()->title, 3, 40);
         put_str(_("腕力 知能 賢さ 器用 耐久 魅力 経験 ", "Str  Int  Wis  Dex  Con  Chr   EXP "), 4, 40);
-        put_str(_("の種族修正", ": Race modification"), 3, 40 + creature.race->title->length());
+        put_str(_("の種族修正", ": Race modification"), 3, 40 + creature.get_race_info()->title->length());
 
-        const auto stats = format("%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", creature.race->r_adj[0], creature.race->r_adj[1], creature.race->r_adj[2], creature.race->r_adj[3], creature.race->r_adj[4], creature.race->r_adj[5], (creature.race->r_exp - 100));
+        const auto stats = format("%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", creature.get_race_info()->r_adj[0], creature.get_race_info()->r_adj[1], creature.get_race_info()->r_adj[2], creature.get_race_info()->r_adj[3], creature.get_race_info()->r_adj[4], creature.get_race_info()->r_adj[5], (creature.get_race_info()->r_exp - 100));
         c_put_str(TERM_L_BLUE, stats, 5, 40);
 
         put_str("HD ", 6, 40);
-        const auto hd = format("%2d", creature.race->r_mhp);
+        const auto hd = format("%2d", creature.get_race_info()->r_mhp);
         c_put_str(TERM_L_BLUE, hd, 6, 43);
 
         put_str(_("隠密", "Stealth"), 6, 47);
-        const auto stealth = format("%+2d", creature.race->r_stl);
+        const auto stealth = format("%+2d", creature.get_race_info()->r_stl);
         c_put_str(TERM_L_BLUE, stealth, 6, _(52, 55));
 
         put_str(_("赤外線視力", "Infra"), 6, _(56, 59));
-        const auto infra = format(_("%%2dft", "%%2dft"), 10 * creature.race->infra);
+        const auto infra = format(_("%%2dft", "%%2dft"), 10 * creature.get_race_info()->infra);
         c_put_str(TERM_L_BLUE, infra, 6, _(67, 65));
     }
 
@@ -203,6 +203,6 @@ bool get_player_race(CreatureEntity &creature)
 
     creature.prace = i2enum<PlayerRaceType>(k);
     creature.race = &race_info[k];
-    c_put_str(TERM_L_BLUE, creature.race->title, 4, 15);
+    c_put_str(TERM_L_BLUE, creature.get_race_info()->title, 4, 15);
     return true;
 }

--- a/src/birth/birth-stat.cpp
+++ b/src/birth/birth-stat.cpp
@@ -123,11 +123,11 @@ void get_money_for_creature(CreatureEntity &creature)
  */
 uint16_t get_expfact(CreatureEntity &creature)
 {
-    uint16_t expfact = creature.race->r_exp;
+    uint16_t expfact = creature.get_race_info()->r_exp;
 
     CreatureRace pr(&creature);
     if (!pr.equals(PlayerRaceType::ANDROID)) {
-        expfact += (*creature.pclass_ref).c_exp;
+        expfact += (*creature.get_class_info()).c_exp;
     }
 
     auto is_race_gaining_additional_speed = pr.equals(PlayerRaceType::KLACKON) || pr.equals(PlayerRaceType::SPRITE);
@@ -180,8 +180,8 @@ void get_extra(CreatureEntity &creature, bool roll_hitdie)
     // 武術スタイルの初期設定
     creature.martial_arts_style = MartialArtsStyleType::TRADITIONAL;
 
-    const auto r_mhp = is_sorcerer ? creature.race->r_mhp / 2 : creature.race->r_mhp;
-    creature.hit_dice = Dice(1, r_mhp + (*creature.pclass_ref).c_mhp + (*creature.personality).a_mhp);
+    const auto r_mhp = is_sorcerer ? creature.get_race_info()->r_mhp / 2 : creature.get_race_info()->r_mhp;
+    creature.hit_dice = Dice(1, r_mhp + (*creature.get_class_info()).c_mhp + (*creature.get_personality_info()).a_mhp);
     if (roll_hitdie) {
         roll_hitdice(creature, SPOP_NO_UPDATE);
     }

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -299,7 +299,7 @@ static void display_initial_options(CreatureEntity &creature)
     const auto expfact_mod = static_cast<int>(get_expfact(creature)) - 100;
     int16_t adj[A_MAX]{};
     for (int i = 0; i < A_MAX; i++) {
-        adj[i] = creature.race->r_adj[i] + (*creature.pclass_ref).c_adj[i] + (*creature.personality).a_adj[i];
+        adj[i] = creature.get_race_info()->r_adj[i] + (*creature.get_class_info()).c_adj[i] + (*creature.get_personality_info()).a_adj[i];
     }
 
     put_str("                                   ", 3, 40);
@@ -309,7 +309,7 @@ static void display_initial_options(CreatureEntity &creature)
     c_put_str(TERM_L_BLUE, stats, 5, 40);
 
     put_str("HD ", 6, 40);
-    const auto hd = format("%2d", creature.race->r_mhp + (*creature.pclass_ref).c_mhp + (*creature.personality).a_mhp);
+    const auto hd = format("%2d", creature.get_race_info()->r_mhp + (*creature.get_class_info()).c_mhp + (*creature.get_personality_info()).a_mhp);
     c_put_str(TERM_L_BLUE, hd, 6, 43);
 
     put_str(_("隠密", "Stealth"), 6, 47);
@@ -317,12 +317,12 @@ static void display_initial_options(CreatureEntity &creature)
     if (CreatureClass(creature).equals(PlayerClassType::BERSERKER)) {
         stealth = "xx";
     } else {
-        stealth = format("%+2d", creature.race->r_stl + (*creature.pclass_ref).c_stl + (*creature.personality).a_stl);
+        stealth = format("%+2d", creature.get_race_info()->r_stl + (*creature.get_class_info()).c_stl + (*creature.get_personality_info()).a_stl);
     }
     c_put_str(TERM_L_BLUE, stealth, 6, _(52, 55));
 
     put_str(_("赤外線視力", "Infra"), 6, _(56, 59));
-    const auto infra = format(_("%%2dft", "%%2dft"), 10 * creature.race->infra);
+    const auto infra = format(_("%%2dft", "%%2dft"), 10 * creature.get_race_info()->infra);
     c_put_str(TERM_L_BLUE, infra, 6, _(67, 65));
 
     clear_from(10);
@@ -355,7 +355,7 @@ static void display_auto_roller_success_rate(CreatureEntity &creature, const int
 
     for (int i = 0; i < A_MAX; i++) {
         put_str(stat_names[i], 3 + i, col + 8);
-        int j = creature.race->r_adj[i] + (*creature.pclass_ref).c_adj[i] + (*creature.personality).a_adj[i];
+        int j = creature.get_race_info()->r_adj[i] + (*creature.get_class_info()).c_adj[i] + (*creature.get_personality_info()).a_adj[i];
         int m = adjust_stat(stat_limit[i], j);
         c_put_str(TERM_L_BLUE, cnv_stat(m), 3 + i, col + 13);
     }

--- a/src/cmd-io/cmd-diary.cpp
+++ b/src/cmd-io/cmd-diary.cpp
@@ -30,9 +30,9 @@ static void display_diary(CreatureEntity &creature)
     const auto choice = Rand_external(subtitle_candidates.size());
     const auto &subtitle = subtitle_candidates[choice];
 #ifdef JP
-    const auto diary_title = format("「%s%s%sの伝説 -%s-」", (*creature.personality).title.data(), (*creature.personality).no ? "の" : "", creature.name.data(), subtitle.data());
+    const auto diary_title = format("「%s%s%sの伝説 -%s-」", (*creature.get_personality_info()).title.data(), (*creature.get_personality_info()).no ? "の" : "", creature.name.data(), subtitle.data());
 #else
-    const auto diary_title = format("Legend of %s %s '%s'", (*creature.personality).title.data(), creature.name.data(), subtitle.data());
+    const auto diary_title = format("Legend of %s %s '%s'", (*creature.get_personality_info()).title.data(), creature.name.data(), subtitle.data());
 #endif
 
     std::stringstream ss;

--- a/src/info-reader/fixed-map-parser.cpp
+++ b/src/info-reader/fixed-map-parser.cpp
@@ -173,9 +173,9 @@ static std::string parse_fixed_map_expression(CreatureEntity &creature, char **s
             v = "OFF";
         }
     } else if (streq(b + 1, "RACE")) {
-        v = creature.race->title.en_string();
+        v = creature.get_race_info()->title.en_string();
     } else if (streq(b + 1, "CLASS")) {
-        v = (*creature.pclass_ref).title.en_string();
+        v = (*creature.get_class_info()).title.en_string();
     } else if (streq(b + 1, "REALM1")) {
         v = PlayerRealm(creature).realm1().get_name().en_string();
     } else if (streq(b + 1, "REALM2")) {

--- a/src/io-dump/player-status-dump-json.cpp
+++ b/src/io-dump/player-status-dump-json.cpp
@@ -61,10 +61,10 @@ static void add_basic_info_to_json(nlohmann::json &j, CreatureEntity &creature)
     j["basic"]["prestige"] = creature.prestige;
 
     if (creature.race != nullptr) {
-        j["basic"]["race"] = localized_to_utf8_safe(creature.race->title);
+        j["basic"]["race"] = localized_to_utf8_safe(creature.get_race_info()->title);
     }
     if (creature.pclass_ref != nullptr) {
-        j["basic"]["class"] = localized_to_utf8_safe(creature.pclass_ref->title);
+        j["basic"]["class"] = localized_to_utf8_safe(creature.get_class_info()->title);
     }
 
     // モンスターはプレイヤー固有の性別・性格・魔法領域・変身形態を持たない

--- a/src/io/pref-file-expressor.cpp
+++ b/src/io/pref-file-expressor.cpp
@@ -163,9 +163,9 @@ std::string process_pref_file_expr(CreatureEntity &creature, char **sp, char *fp
             v = "OFF";
         }
     } else if (streq(b + 1, "RACE")) {
-        v = creature.race->title.en_string();
+        v = creature.get_race_info()->title.en_string();
     } else if (streq(b + 1, "CLASS")) {
-        v = (*creature.pclass_ref).title.en_string();
+        v = (*creature.get_class_info()).title.en_string();
     } else if (streq(b + 1, "PLAYER")) {
         static char tmp_player_name[64];
         const char *pn = creature.name.c_str();

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -280,8 +280,8 @@ void load_all_pref_files(CreatureEntity &creature)
     process_pref_file(creature, "user.prf");
     process_pref_file(creature, format("user-%s.prf", ANGBAND_SYS));
     constexpr auto fmt = "%s.prf";
-    process_pref_file(creature, format(fmt, creature.race->title.data()));
-    process_pref_file(creature, format(fmt, (*creature.pclass_ref).title.data()));
+    process_pref_file(creature, format(fmt, creature.get_race_info()->title.data()));
+    process_pref_file(creature, format(fmt, (*creature.get_class_info()).title.data()));
     process_pref_file(creature, format(fmt, creature.base_name.data()));
     PlayerRealm pr(creature);
     if (pr.realm1().is_available()) {

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -237,8 +237,8 @@ std::string make_screen_dump(CreatureEntity &creature)
 bool report_score(CreatureEntity &creature)
 {
     std::stringstream score_ss;
-    std::string personality_desc = (*creature.personality).title.string();
-    personality_desc.append(_((*creature.personality).no ? "の" : "", " "));
+    std::string personality_desc = (*creature.get_personality_info()).title.string();
+    personality_desc.append(_((*creature.get_personality_info()).no ? "の" : "", " "));
 
     PlayerRealm pr(creature);
     const auto &realm1_name = CreatureClass(creature).equals(PlayerClassType::ELEMENTALIST) ? get_element_title(creature.element_realm) : pr.realm1().get_name().string();
@@ -253,8 +253,8 @@ bool report_score(CreatureEntity &creature)
     const auto &igd = InnerGameData::get_instance();
     score_ss << fmt::format("turns: {}\n", igd.get_real_turns(AngbandWorld::get_instance().game_turn))
              << fmt::format("sex: {}\n", enum2i(creature.psex))
-             << fmt::format("race: {}\n", creature.race->title)
-             << fmt::format("class: {}\n", (*creature.pclass_ref).title)
+             << fmt::format("race: {}\n", creature.get_race_info()->title)
+             << fmt::format("class: {}\n", (*creature.get_class_info()).title)
              << fmt::format("seikaku: {}\n", personality_desc)
              << fmt::format("realm1: {}\n", realm1_name)
              << fmt::format("realm2: {}\n", pr.realm2().get_name())

--- a/src/pet/pet-util.cpp
+++ b/src/pet/pet-util.cpp
@@ -105,7 +105,7 @@ PERCENTAGE calculate_upkeep(CreatureEntity &creature)
         return 0;
     }
 
-    int upkeep_factor = (total_friend_levels - (creature.level * 80 / ((*creature.pclass_ref).pet_upkeep_div)));
+    int upkeep_factor = (total_friend_levels - (creature.level * 80 / ((*creature.get_class_info()).pet_upkeep_div)));
     if (upkeep_factor < 0) {
         upkeep_factor = 0;
     }

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -420,7 +420,7 @@ static void update_max_hitpoints(CreatureEntity &creature)
     auto is_sorcerer = pc.equals(PlayerClassType::SORCERER);
     if (creature.get_mimic_form() != MimicKindType::NONE) {
         auto r_mhp = mimic_info.at(creature.get_mimic_form()).r_mhp;
-        const auto mimic_hit_dice = Dice(1, (is_sorcerer ? r_mhp / 2 : r_mhp) + (*creature.pclass_ref).c_mhp + (*creature.personality).a_mhp);
+        const auto mimic_hit_dice = Dice(1, (is_sorcerer ? r_mhp / 2 : r_mhp) + (*creature.get_class_info()).c_mhp + (*creature.get_personality_info()).a_mhp);
         mhp = mhp * mimic_hit_dice.maxroll() / creature.hit_dice.maxroll();
     }
 
@@ -714,7 +714,7 @@ static void update_max_mana(CreatureEntity &creature)
     if (pc.equals(PlayerClassType::SAMURAI)) {
         msp = (adj_mag_mana[creature.stat_index[mp_ptr->spell_stat]] + 10) * 2;
         if (msp) {
-            msp += (msp * creature.race->r_adj[mp_ptr->spell_stat] / 20);
+            msp += (msp * creature.get_race_info()->r_adj[mp_ptr->spell_stat] / 20);
         }
     } else {
         msp = adj_mag_mana[creature.stat_index[mp_ptr->spell_stat]] * (levels + 3) / 4;
@@ -722,7 +722,7 @@ static void update_max_mana(CreatureEntity &creature)
             msp++;
         }
         if (msp) {
-            msp += (msp * creature.race->r_adj[mp_ptr->spell_stat] / 20);
+            msp += (msp * creature.get_race_info()->r_adj[mp_ptr->spell_stat] / 20);
         }
         if (msp && (creature.ppersonality == PERSONALITY_MUNCHKIN)) {
             msp += msp / 2;
@@ -1038,7 +1038,7 @@ static ACTION_SKILL_POWER calc_disarming(CreatureEntity &creature)
     const auto &player_personality = personality_info[creature.ppersonality];
 
     pow = tmp_race_ptr->r_dis + player_class.c_dis + player_personality.a_dis;
-    pow += (((*creature.pclass_ref).x_dis * creature.level / 10) + ((*creature.personality).a_dis * creature.level / 50));
+    pow += (((*creature.get_class_info()).x_dis * creature.level / 10) + ((*creature.get_personality_info()).a_dis * creature.level / 50));
     pow += adj_dex_dis[creature.stat_index[A_DEX]];
     pow += adj_int_dis[creature.stat_index[A_INT]];
     return pow;
@@ -1070,7 +1070,7 @@ static ACTION_SKILL_POWER calc_device_ability(CreatureEntity &creature)
     const auto &player_personality = personality_info[creature.ppersonality];
 
     pow = tmp_race_ptr->r_dev + player_class.c_dev + player_personality.a_dev;
-    pow += ((player_class.x_dev * creature.level / 10) + ((*creature.personality).a_dev * creature.level / 50));
+    pow += ((player_class.x_dev * creature.level / 10) + ((*creature.get_personality_info()).a_dev * creature.level / 50));
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         ItemEntity *o_ptr;
@@ -1126,7 +1126,7 @@ static ACTION_SKILL_POWER calc_saving_throw(CreatureEntity &creature)
     const auto &player_personality = personality_info[creature.ppersonality];
 
     pow = tmp_race_ptr->r_sav + player_class.c_sav + player_personality.a_sav;
-    pow += (((*creature.pclass_ref).x_sav * creature.level / 10) + ((*creature.personality).a_sav * creature.level / 50));
+    pow += (((*creature.get_class_info()).x_sav * creature.level / 10) + ((*creature.get_personality_info()).a_sav * creature.level / 50));
 
     if (creature.get_mutations().has(PlayerMutationType::MAGIC_RES)) {
         pow += (15 + (creature.level / 5));

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -231,7 +231,7 @@ void print_tomb(CreatureEntity &creature)
 
     show_tomb_line(p, GRAVE_PLAYER_TITLE_ROW);
 
-    show_tomb_line((*creature.pclass_ref).title, GRAVE_PLAYER_CLASS_ROW);
+    show_tomb_line((*creature.get_class_info()).title, GRAVE_PLAYER_CLASS_ROW);
 
     show_basic_params(creature);
 

--- a/src/status/shape-changer.cpp
+++ b/src/status/shape-changer.cpp
@@ -72,7 +72,7 @@ void change_race(CreatureEntity &creature, PlayerRaceType new_race, concptr effe
 
     creature.prace = new_race;
     creature.race = &race_info[enum2i(creature.prace)];
-    creature.expfact = creature.race->r_exp + (*creature.pclass_ref).c_exp;
+    creature.expfact = creature.get_race_info()->r_exp + (*creature.get_class_info()).c_exp;
 
     CreatureClass pc(creature);
     bool is_special_class = pc.equals(PlayerClassType::MONK);
@@ -87,8 +87,8 @@ void change_race(CreatureEntity &creature, PlayerRaceType new_race, concptr effe
 
     get_height_weight(creature);
 
-    const auto r_mhp = pc.equals(PlayerClassType::SORCERER) ? creature.race->r_mhp / 2 : creature.race->r_mhp;
-    creature.hit_dice = Dice(1, r_mhp + (*creature.pclass_ref).c_mhp + (*creature.personality).a_mhp);
+    const auto r_mhp = pc.equals(PlayerClassType::SORCERER) ? creature.get_race_info()->r_mhp / 2 : creature.get_race_info()->r_mhp;
+    creature.hit_dice = Dice(1, r_mhp + (*creature.get_class_info()).c_mhp + (*creature.get_personality_info()).a_mhp);
 
     roll_hitdice(creature, SPOP_NONE);
     check_experience(creature);

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1082,6 +1082,30 @@ public:
     {
         return this->cursed_special;
     }
+    /*!
+     * @brief 種族情報ポインタ
+     * @details プレイヤー時は race_info[] の該当エントリへのポインタ、
+     *          モンスター時は nullptr。将来モンスター側でも種族情報を
+     *          返す形に override できる。
+     */
+    virtual const player_race_info *get_race_info() const
+    {
+        return this->race;
+    }
+    /*!
+     * @brief 性格情報ポインタ
+     */
+    virtual const player_personality *get_personality_info() const
+    {
+        return this->personality;
+    }
+    /*!
+     * @brief 職業情報ポインタ
+     */
+    virtual const player_class_info *get_class_info() const
+    {
+        return this->pclass_ref;
+    }
 
     /*!
      * @brief クリーチャーのコピーを返す

--- a/src/view/display-birth.cpp
+++ b/src/view/display-birth.cpp
@@ -22,7 +22,7 @@ void birth_put_stats(CreatureEntity &creature)
 
     const int col = 22;
     for (int i = 0; i < A_MAX; i++) {
-        int j = creature.race->r_adj[i] + (*creature.pclass_ref).c_adj[i] + (*creature.personality).a_adj[i];
+        int j = creature.get_race_info()->r_adj[i] + (*creature.get_class_info()).c_adj[i] + (*creature.get_personality_info()).a_adj[i];
         int m = adjust_stat(creature.stat_max[i], j);
         c_put_str(TERM_L_GREEN, cnv_stat(m), 3 + i, col + 24);
     }

--- a/src/view/display-player-misc-info.cpp
+++ b/src/view/display-player-misc-info.cpp
@@ -19,7 +19,7 @@ void display_player_name(CreatureEntity &creature, bool name_only)
 {
     std::stringstream ss;
     if (!name_only && creature.personality != nullptr) {
-        ss << (*creature.personality).title << _((*creature.personality).no == 1 ? "の" : "", " ");
+        ss << (*creature.get_personality_info()).title << _((*creature.get_personality_info()).no == 1 ? "の" : "", " ");
     }
     // 無名モンスター（または匿名プレイヤー）の場合は「名無し」表記へフォールバック
     if (creature.name.empty()) {
@@ -55,8 +55,8 @@ void display_player_misc_info(CreatureEntity &creature)
     put_str(_("職業  :", "Class :"), 5, 1);
 
     c_put_str(TERM_L_BLUE, creature.get_sex_info().title, 3, 9);
-    c_put_str(TERM_L_BLUE, (creature.get_mimic_form() != MimicKindType::NONE ? mimic_info.at(creature.get_mimic_form()).title : creature.race->title), 4, 9);
-    c_put_str(TERM_L_BLUE, (*creature.pclass_ref).title, 5, 9);
+    c_put_str(TERM_L_BLUE, (creature.get_mimic_form() != MimicKindType::NONE ? mimic_info.at(creature.get_mimic_form()).title : creature.get_race_info()->title), 4, 9);
+    c_put_str(TERM_L_BLUE, (*creature.get_class_info()).title, 5, 9);
 
     put_str(_("レベル:", "Level :"), 6, 1);
     put_str(_("ＨＰ  :", "Hits  :"), 7, 1);

--- a/src/view/display-player-stat-info.cpp
+++ b/src/view/display-player-stat-info.cpp
@@ -109,9 +109,9 @@ static void display_basic_stat_value(CreatureEntity &creature, int stat_num, int
 {
     c_put_str(TERM_L_BLUE, format("%3d", r_adj), row + stat_num + 1, stat_col + 13);
 
-    c_put_str(TERM_L_BLUE, format("%3d", (int)(*creature.pclass_ref).c_adj[stat_num]), row + stat_num + 1, stat_col + 16);
+    c_put_str(TERM_L_BLUE, format("%3d", (int)(*creature.get_class_info()).c_adj[stat_num]), row + stat_num + 1, stat_col + 16);
 
-    c_put_str(TERM_L_BLUE, format("%3d", (int)(*creature.personality).a_adj[stat_num]), row + stat_num + 1, stat_col + 19);
+    c_put_str(TERM_L_BLUE, format("%3d", (int)(*creature.get_personality_info()).a_adj[stat_num]), row + stat_num + 1, stat_col + 19);
 
     c_put_str(TERM_L_BLUE, format("%3d", (int)e_adj), row + stat_num + 1, stat_col + 22);
 
@@ -131,12 +131,12 @@ static void display_basic_stat_value(CreatureEntity &creature, int stat_num, int
 static void process_stats(CreatureEntity &creature, int row, int stat_col)
 {
     for (int i = 0; i < A_MAX; i++) {
-        int r_adj = creature.get_mimic_form() != MimicKindType::NONE ? mimic_info.at(creature.get_mimic_form()).r_adj[i] : creature.race->r_adj[i];
+        int r_adj = creature.get_mimic_form() != MimicKindType::NONE ? mimic_info.at(creature.get_mimic_form()).r_adj[i] : creature.get_race_info()->r_adj[i];
         int e_adj = calc_basic_stat(creature, i);
         r_adj += compensate_special_race(creature, i);
         e_adj -= r_adj;
-        e_adj -= (*creature.pclass_ref).c_adj[i];
-        e_adj -= (*creature.personality).a_adj[i];
+        e_adj -= (*creature.get_class_info()).c_adj[i];
+        e_adj -= (*creature.get_personality_info()).a_adj[i];
 
         display_basic_stat_name(creature, i, row, stat_col);
         if (creature.stat_max[i] == creature.stat_max_max[i]) {

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -95,10 +95,10 @@ static void display_player_basic_info(CreatureEntity &creature)
     display_player_name(creature);
     display_player_one_line(ENTRY_SEX, creature.get_sex_info().title, TERM_L_BLUE);
     if (creature.race != nullptr) {
-        display_player_one_line(ENTRY_RACE, (creature.get_mimic_form() != MimicKindType::NONE ? mimic_info.at(creature.get_mimic_form()).title : creature.race->title), TERM_L_BLUE);
+        display_player_one_line(ENTRY_RACE, (creature.get_mimic_form() != MimicKindType::NONE ? mimic_info.at(creature.get_mimic_form()).title : creature.get_race_info()->title), TERM_L_BLUE);
     }
     if (creature.pclass_ref != nullptr) {
-        display_player_one_line(ENTRY_CLASS, (*creature.pclass_ref).title, TERM_L_BLUE);
+        display_player_one_line(ENTRY_CLASS, (*creature.get_class_info()).title, TERM_L_BLUE);
     }
 }
 

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -250,7 +250,7 @@ void print_depth(CreatureEntity &creature)
 void print_frame_basic(CreatureEntity &creature)
 {
     const auto &title = creature.get_mimic_form() == MimicKindType::NONE
-                            ? creature.race->title
+                            ? creature.get_race_info()->title
                             : mimic_info.at(creature.get_mimic_form()).title;
     print_field(title, ROW_RACE, COL_RACE);
     print_title(creature);


### PR DESCRIPTION
提案 2 の継続。プレイヤー情報ポインタに const ポインタ返し virtual
アクセサを追加:

- get_race_info() : race
- get_personality_info() : personality
- get_class_info() : pclass_ref

読取り用途 call site 55 箇所超を置換:
- creature.race->X → creature.get_race_info()->X
- (*creature.personality).X → (*creature.get_personality_info()).X
- (*creature.pclass_ref).X → (*creature.get_class_info()).X

モンスターでは nullptr を返すが既存プレイヤー経路ではこれらを
前提としており安全。将来モンスター側でも何らかの種族/職業情報を
持たせる際は virtual で override 可能。