### PR TITLE
refactor(creature): スキル系と赤外線視に virtual アクセサ追加・移行

### DIFF
--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -83,7 +83,7 @@ static void decide_activation_level(ae_type *ae_ptr)
 
 static void decide_chance_fail(CreatureEntity &creature, ae_type *ae_ptr)
 {
-    ae_ptr->chance = creature.skill_dev;
+    ae_ptr->chance = creature.get_skill_device();
     if (creature.is_confused()) {
         ae_ptr->chance = ae_ptr->chance / 2;
     }

--- a/src/action/open-close-execution.cpp
+++ b/src/action/open-close-execution.cpp
@@ -61,7 +61,7 @@ bool exe_open(CreatureEntity &creature, POSITION y, POSITION x)
         return false;
     }
 
-    int i = creature.skill_dis;
+    int i = creature.get_skill_disarm();
     const auto effects = creature.effects();
     if (effects->blindness().is_blind() || no_lite(creature)) {
         i = i / 10;
@@ -164,7 +164,7 @@ bool easy_open_door(CreatureEntity &creature, const Pos2D &pos)
         constexpr auto fmt = _("%sはがっちりと閉じられているようだ。", "The %s appears to be stuck.");
         msg_format(fmt, grid.get_terrain(TerrainKind::MIMIC).name.data());
     } else if (terrain.power) {
-        auto power_disarm = creature.skill_dis;
+        auto power_disarm = creature.get_skill_disarm();
         const auto effects = creature.effects();
         if (effects->blindness().is_blind() || no_lite(creature)) {
             power_disarm = power_disarm / 10;
@@ -219,7 +219,7 @@ bool exe_disarm_chest(CreatureEntity &creature, POSITION y, POSITION x, OBJECT_I
     const Pos2D pos(y, x);
     auto *o_ptr = creature.get_floor()->o_list[o_idx].get();
     PlayerEnergy(creature).set_player_turn_energy(100);
-    int i = creature.skill_dis;
+    int i = creature.get_skill_disarm();
     const auto effects = creature.effects();
     if (effects->blindness().is_blind() || no_lite(creature)) {
         i = i / 10;
@@ -284,7 +284,7 @@ bool exe_disarm(CreatureEntity &creature, POSITION y, POSITION x, const Directio
     const auto &terrain = grid.get_terrain();
     const auto &name = terrain.name;
     int power = terrain.power;
-    int i = creature.skill_dis;
+    int i = creature.get_skill_disarm();
     PlayerEnergy(creature).set_player_turn_energy(100);
     auto effects = creature.effects();
     if (effects->blindness().is_blind() || no_lite(creature)) {

--- a/src/action/tunnel-execution.cpp
+++ b/src/action/tunnel-execution.cpp
@@ -77,7 +77,7 @@ bool exe_tunnel(CreatureEntity &creature, POSITION y, POSITION x)
             msg_print(_("そこは掘れない!", "You can't tunnel through that!"));
         }
     } else if (terrain.flags.has(TerrainCharacteristics::CAN_DIG)) {
-        if (creature.skill_dig > randint0(20 * power)) {
+        if (creature.get_skill_dig() > randint0(20 * power)) {
             sound(SoundKind::DIG_THROUGH);
             msg_format(_("%sをくずした。", "You have removed the %s."), name.data());
             cave_alter_feat(creature, y, x, TerrainCharacteristics::TUNNEL);
@@ -89,7 +89,7 @@ bool exe_tunnel(CreatureEntity &creature, POSITION y, POSITION x)
         }
     } else {
         bool tree = terrain_mimic.flags.has(TerrainCharacteristics::TREE);
-        if (creature.skill_dig > power + randint0(40 * power)) {
+        if (creature.get_skill_dig() > power + randint0(40 * power)) {
             sound(SoundKind::DIG_THROUGH);
             if (tree) {
                 msg_format(_("%sを切り払った。", "You have cleared away the %s."), name.data());

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -105,7 +105,7 @@ static void natural_attack(CreatureEntity &creature, MONSTER_IDX m_idx, PlayerMu
 
     const auto m_name = monster_desc(creature, monster, 0);
     int bonus = creature.to_h_m + (creature.level * 6 / 5);
-    int chance = (creature.skill_thn + (bonus * BTH_PLUS_ADJ));
+    int chance = (creature.get_skill_to_hit_melee() + (bonus * BTH_PLUS_ADJ));
 
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     bool is_hit = (monrace.kind_flags.has_not(MonsterKindType::QUANTUM)) || !randint0(2);
@@ -177,7 +177,7 @@ static void headbutt_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *f
         dice = Dice(4, 8); // より強力なダメージ
     }
 
-    int chance = (creature.skill_thn + (bonus * BTH_PLUS_ADJ));
+    int chance = (creature.get_skill_to_hit_melee() + (bonus * BTH_PLUS_ADJ));
 
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     creature.plus_incident_tree("HEADBUTT", 1);
@@ -269,7 +269,7 @@ static void bodyslam_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *f
         atk_desc = _("勇猛な体当たり", "heroic body slam");
     }
 
-    int chance = (creature.skill_thn + (bonus * BTH_PLUS_ADJ));
+    int chance = (creature.get_skill_to_hit_melee() + (bonus * BTH_PLUS_ADJ));
 
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     bool is_hit = (monrace.kind_flags.has_not(MonsterKindType::QUANTUM)) || !randint0(2);
@@ -673,7 +673,7 @@ static void enema_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *fear
     int bonus = creature.to_h_m + (creature.level * 6 / 5) + (creature.level + creature.stat_index[A_DEX]) / 3;
     ;
 
-    int chance = (creature.skill_thn + (bonus * BTH_PLUS_ADJ));
+    int chance = (creature.get_skill_to_hit_melee() + (bonus * BTH_PLUS_ADJ));
 
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     bool is_hit = (monrace.kind_flags.has_not(MonsterKindType::QUANTUM)) || !randint0(2);

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -425,7 +425,7 @@ void do_cmd_walk(CreatureEntity &creature, bool pickup)
             tmp = 1;
         }
 
-        if (((wild_level + 5) > (creature.level / 2)) && randint0(tmp) < (21 - creature.skill_stl)) {
+        if (((wild_level + 5) > (creature.level / 2)) && randint0(tmp) < (21 - creature.get_skill_stealth())) {
             // TODO: 広域マップの領域ごとのアライアンス情報を取得する機能が未実装のため、
             // 今回はデフォルトメッセージを使用。将来的にはアライアンス固有のメッセージを表示予定
             msg_print(_("襲撃だ！", "You are ambushed !"));

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -51,7 +51,7 @@ static bool exe_open_chest(CreatureEntity &creature, const Pos2D &pos, OBJECT_ID
     PlayerEnergy(creature).set_player_turn_energy(100);
     if (o_ptr->pval > 0) {
         flag = false;
-        int i = creature.skill_dis;
+        int i = creature.get_skill_disarm();
         const auto effects = creature.effects();
         if (effects->blindness().is_blind() || no_lite(creature)) {
             i = i / 10;

--- a/src/combat/attack-criticality.cpp
+++ b/src/combat/attack-criticality.cpp
@@ -50,7 +50,7 @@ std::tuple<int, std::string, SoundKind> apply_critical_norm_damage(int k, int ba
 int critical_norm(CreatureEntity &creature, WEIGHT weight, int plus, int dam, int16_t meichuu, combat_options mode, bool impact)
 {
     /* Extract "blow" power */
-    int i = (weight + (meichuu * 3 + plus * 5) + creature.skill_thn);
+    int i = (weight + (meichuu * 3 + plus * 5) + creature.get_skill_to_hit_melee());
 
     /* Chance */
     auto pow = CreatureClass(creature).equals(PlayerClassType::NINJA) ? 4444 : 5000;

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -533,13 +533,13 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
     constexpr auto xbow_magnification = 400;
     int chance;
     if (tval == ItemKindType::NONE) {
-        chance = (creature.skill_thb + ((weapon_exps[0] - median_skill_exp) / bow_magnification + bonus) * BTH_PLUS_ADJ);
+        chance = (creature.get_skill_to_hit_bow() + ((weapon_exps[0] - median_skill_exp) / bow_magnification + bonus) * BTH_PLUS_ADJ);
     } else {
         const auto sval = *j_ptr->bi_key.sval();
         if (j_ptr->is_cross_bow()) {
-            chance = (creature.skill_thb + (weapon_exps[sval] / xbow_magnification + bonus) * BTH_PLUS_ADJ);
+            chance = (creature.get_skill_to_hit_bow() + (weapon_exps[sval] / xbow_magnification + bonus) * BTH_PLUS_ADJ);
         } else {
-            chance = (creature.skill_thb + ((weapon_exps[sval] - median_skill_exp) / bow_magnification + bonus) * BTH_PLUS_ADJ);
+            chance = (creature.get_skill_to_hit_bow() + ((weapon_exps[sval] - median_skill_exp) / bow_magnification + bonus) * BTH_PLUS_ADJ);
         }
     }
 
@@ -1065,14 +1065,14 @@ int critical_shot(CreatureEntity &creature, WEIGHT weight, int plus_ammo, int pl
     constexpr auto xbow_magnification = 400;
     int power;
     if (tval == ItemKindType::NONE) {
-        power = creature.skill_thb + ((weapon_exps[0] - median_skill_exp) / bow_magnification + bonus) * BTH_PLUS_ADJ;
+        power = creature.get_skill_to_hit_bow() + ((weapon_exps[0] - median_skill_exp) / bow_magnification + bonus) * BTH_PLUS_ADJ;
     } else {
         const auto sval = *item.bi_key.sval();
         const auto weapon_exp = weapon_exps[sval];
         if (creature.tval_ammo == ItemKindType::BOLT) {
-            power = (creature.skill_thb + (weapon_exp / xbow_magnification + bonus) * BTH_PLUS_ADJ);
+            power = (creature.get_skill_to_hit_bow() + (weapon_exp / xbow_magnification + bonus) * BTH_PLUS_ADJ);
         } else {
-            power = creature.skill_thb + ((weapon_exp - median_skill_exp) / bow_magnification + bonus) * BTH_PLUS_ADJ;
+            power = creature.get_skill_to_hit_bow() + ((weapon_exp - median_skill_exp) / bow_magnification + bonus) * BTH_PLUS_ADJ;
         }
     }
 
@@ -1124,9 +1124,9 @@ int calc_crit_ratio_shot(CreatureEntity &creature, int plus_ammo, int plus_bow)
     const auto tval = j_ptr->bi_key.tval();
     const auto sval = *j_ptr->bi_key.sval();
     if (creature.tval_ammo == ItemKindType::BOLT) {
-        i = (creature.skill_thb + (creature.weapon_exp[tval][sval] / 400 + i) * BTH_PLUS_ADJ);
+        i = (creature.get_skill_to_hit_bow() + (creature.weapon_exp[tval][sval] / 400 + i) * BTH_PLUS_ADJ);
     } else {
-        i = (creature.skill_thb + ((creature.weapon_exp[tval][sval] - (PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER) / 2)) / 200 + i) * BTH_PLUS_ADJ);
+        i = (creature.get_skill_to_hit_bow() + ((creature.weapon_exp[tval][sval] - (PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER) / 2)) / 200 + i) * BTH_PLUS_ADJ);
     }
 
     CreatureClass pc(creature);
@@ -1207,7 +1207,7 @@ int calc_expect_crit(CreatureEntity &creature, WEIGHT weight, int plus, int dam,
         return dam;
     }
 
-    int i = (weight + (meichuu * 3 + plus * 5) + creature.skill_thn);
+    int i = (weight + (meichuu * 3 + plus * 5) + creature.get_skill_to_hit_melee());
     if (i < 0) {
         i = 0;
     }

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -284,7 +284,7 @@ static void effect_monster_domination_corrupted(CreatureEntity &creature, Effect
     msg_format(_("%s^の堕落した精神は攻撃を跳ね返した！",
                    (em_ptr->seen ? "%s^'s corrupted mind backlashes your attack!" : "%s^s corrupted mind backlashes your attack!")),
         em_ptr->m_name);
-    if (randint0(100 + em_ptr->r_ptr->level / 2) < creature.skill_sav) {
+    if (randint0(100 + em_ptr->r_ptr->level / 2) < creature.get_skill_save()) {
         msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
         return;
     }

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -150,7 +150,7 @@ static void effect_monster_psi_resist(CreatureEntity &creature, EffectMonster *e
     }
 
     /* プレイヤーの反射判定 */
-    if ((randint0(100 + em_ptr->r_ptr->level / 2) < creature.skill_sav) && !check_multishadow(creature)) {
+    if ((randint0(100 + em_ptr->r_ptr->level / 2) < creature.get_skill_save()) && !check_multishadow(creature)) {
         msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
         em_ptr->dam = 0;
         return;
@@ -243,7 +243,7 @@ static void effect_monster_psi_drain_resist(CreatureEntity &creature, EffectMons
     }
 
     /* プレイヤーの反射判定 */
-    if ((randint0(100 + em_ptr->r_ptr->level / 2) < creature.skill_sav) && !check_multishadow(creature)) {
+    if ((randint0(100 + em_ptr->r_ptr->level / 2) < creature.get_skill_save()) && !check_multishadow(creature)) {
         msg_print(_("あなたは効力を跳ね返した！", "You resist the effects!"));
         em_ptr->dam = 0;
         return;

--- a/src/effect/effect-player-curse.cpp
+++ b/src/effect/effect-player-curse.cpp
@@ -13,7 +13,7 @@
 
 void effect_player_curse_1(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 {
-    if ((randint0(100 + ep_ptr->rlev / 2) < creature.skill_sav) && !check_multishadow(creature)) {
+    if ((randint0(100 + ep_ptr->rlev / 2) < creature.get_skill_save()) && !check_multishadow(creature)) {
         msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
     } else {
         if (!check_multishadow(creature)) {
@@ -25,7 +25,7 @@ void effect_player_curse_1(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
 void effect_player_curse_2(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 {
-    if ((randint0(100 + ep_ptr->rlev / 2) < creature.skill_sav) && !check_multishadow(creature)) {
+    if ((randint0(100 + ep_ptr->rlev / 2) < creature.get_skill_save()) && !check_multishadow(creature)) {
         msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
     } else {
         if (!check_multishadow(creature)) {
@@ -37,7 +37,7 @@ void effect_player_curse_2(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
 void effect_player_curse_3(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 {
-    if ((randint0(100 + ep_ptr->rlev / 2) < creature.skill_sav) && !check_multishadow(creature)) {
+    if ((randint0(100 + ep_ptr->rlev / 2) < creature.get_skill_save()) && !check_multishadow(creature)) {
         msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
     } else {
         if (!check_multishadow(creature)) {
@@ -49,7 +49,7 @@ void effect_player_curse_3(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
 void effect_player_curse_4(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 {
-    if ((randint0(100 + ep_ptr->rlev / 2) < creature.skill_sav) && (ep_ptr->m_ptr->r_idx != MonraceId::KENSHIROU) && !check_multishadow(creature)) {
+    if ((randint0(100 + ep_ptr->rlev / 2) < creature.get_skill_save()) && (ep_ptr->m_ptr->r_idx != MonraceId::KENSHIROU) && !check_multishadow(creature)) {
         msg_print(_("しかし秘孔を跳ね返した！", "You resist the effects!"));
         return;
     }

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -633,7 +633,7 @@ void effect_player_icee(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
 void effect_player_hand_doom(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 {
-    if ((randint0(100 + ep_ptr->rlev / 2) < creature.skill_sav) && !check_multishadow(creature)) {
+    if ((randint0(100 + ep_ptr->rlev / 2) < creature.get_skill_save()) && !check_multishadow(creature)) {
         msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
     } else {
         if (!check_multishadow(creature)) {

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -73,7 +73,7 @@ void effect_player_drain_mana(CreatureEntity &creature, EffectPlayerType *ep_ptr
 
 void effect_player_mind_blast(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 {
-    if ((randint0(100 + ep_ptr->rlev / 2) < std::max<short>(5, creature.skill_sav)) && !check_multishadow(creature)) {
+    if ((randint0(100 + ep_ptr->rlev / 2) < std::max<short>(5, creature.get_skill_save())) && !check_multishadow(creature)) {
         msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
         return;
     }
@@ -105,7 +105,7 @@ void effect_player_mind_blast(CreatureEntity &creature, EffectPlayerType *ep_ptr
 
 void effect_player_brain_smash(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 {
-    if ((randint0(100 + ep_ptr->rlev / 2) < std::max<short>(5, creature.skill_sav)) && !check_multishadow(creature)) {
+    if ((randint0(100 + ep_ptr->rlev / 2) < std::max<short>(5, creature.get_skill_save())) && !check_multishadow(creature)) {
         msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
         return;
     }
@@ -141,10 +141,10 @@ void effect_player_brain_smash(CreatureEntity &creature, EffectPlayerType *ep_pt
 
     (void)bss.mod_deceleration(randint0(4) + 4, false);
 
-    while (randint0(100 + ep_ptr->rlev / 2) > (std::max<short>(5, creature.skill_sav))) {
+    while (randint0(100 + ep_ptr->rlev / 2) > (std::max<short>(5, creature.get_skill_save()))) {
         (void)do_dec_stat(creature, A_INT);
     }
-    while (randint0(100 + ep_ptr->rlev / 2) > (std::max<short>(5, creature.skill_sav))) {
+    while (randint0(100 + ep_ptr->rlev / 2) > (std::max<short>(5, creature.get_skill_save()))) {
         (void)do_dec_stat(creature, A_WIS);
     }
 

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -281,7 +281,7 @@ void update_dungeon_feeling(CreatureEntity &creature)
         return;
     }
 
-    const auto delay = std::max(10, 150 - creature.skill_fos) * (150 - floor.dun_level) * TURNS_PER_TICK / 100;
+    const auto delay = std::max(10, 150 - creature.get_skill_perception()) * (150 - floor.dun_level) * TURNS_PER_TICK / 100;
     const auto &world = AngbandWorld::get_instance();
     auto &df = DungeonFeeling::get_instance();
     if (world.game_turn < df.get_turns() + delay && !cheat_xtra) {

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -261,7 +261,7 @@ static void list_weapon(CreatureEntity &creature, const ItemEntity &item, TERM_L
 {
     const auto eff_dd = item.damage_dice.num + creature.damage_dice_bonus[0].num;
     const auto eff_ds = item.damage_dice.sides + creature.damage_dice_bonus[0].sides;
-    const auto hit_reliability = creature.skill_thn + (creature.to_h[0] + item.to_h) * BTH_PLUS_ADJ;
+    const auto hit_reliability = creature.get_skill_to_hit_melee() + (creature.to_h[0] + item.to_h) * BTH_PLUS_ADJ;
     const auto item_name = describe_flavor(creature, item, OD_NAME_ONLY);
     c_put_str(TERM_YELLOW, item_name, row, col);
     put_str(format(_("攻撃回数: %d", "Number of Blows: %d"), creature.num_blow[0]), row + 1, col);

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -207,7 +207,7 @@ void process_surprise_attack(CreatureEntity &creature, player_attack_type *pa_pt
         return;
     }
 
-    int tmp = creature.level * 6 + (creature.skill_stl + 10) * 4;
+    int tmp = creature.level * 6 + (creature.get_skill_stealth() + 10) * 4;
     if (creature.monlite && (pa_ptr->mode != HISSATSU_NYUSIN)) {
         tmp /= 3;
     }

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -464,7 +464,7 @@ int calc_attack_quality(CreatureEntity &creature, player_attack_type *pa_ptr)
 {
     auto *o_ptr = creature.inventory[INVEN_MAIN_HAND + pa_ptr->hand].get();
     int bonus = creature.to_h[pa_ptr->hand] + o_ptr->to_h;
-    int chance = (creature.skill_thn + (bonus * BTH_PLUS_ADJ));
+    int chance = (creature.get_skill_to_hit_melee() + (bonus * BTH_PLUS_ADJ));
     if (pa_ptr->mode == HISSATSU_IAI) {
         chance += 60;
     }

--- a/src/mind/mind-warrior.cpp
+++ b/src/mind/mind-warrior.cpp
@@ -23,7 +23,7 @@ bool hit_and_away(CreatureEntity &creature)
     const auto pos = creature.get_neighbor(dir);
     if (creature.get_floor()->get_grid(pos).has_monster()) {
         do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
-        if (randint0(creature.skill_dis) < 7) {
+        if (randint0(creature.get_skill_disarm()) < 7) {
             msg_print(_("うまく逃げられなかった。", "You failed to run away."));
         } else {
             teleport_player(creature, 30, TELEPORT_SPONTANEOUS);

--- a/src/monster-attack/monster-attack-status.cpp
+++ b/src/monster-attack/monster-attack-status.cpp
@@ -58,7 +58,7 @@ void process_terrify_attack(CreatureEntity &creature, MonsterAttackPlayer *monap
         return;
     }
 
-    if (randint0(100 + monrace.level / 2) < creature.skill_sav) {
+    if (randint0(100 + monrace.level / 2) < creature.get_skill_save()) {
         msg_print(_("しかし恐怖に侵されなかった！", "You stand your ground!"));
         monap_ptr->obvious = true;
         return;
@@ -82,7 +82,7 @@ void process_paralyze_attack(CreatureEntity &creature, MonsterAttackPlayer *mona
         return;
     }
 
-    if (randint0(100 + monrace.level / 2) < creature.skill_sav) {
+    if (randint0(100 + monrace.level / 2) < creature.get_skill_save()) {
         msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
         monap_ptr->obvious = true;
         return;

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -568,7 +568,7 @@ void process_sound(CreatureEntity &creature, MONSTER_IDX m_idx)
     const auto &monster = floor.get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
 
-    if (monster.get_monster_profile().ml || creature.skill_srh < randint1(100)) {
+    if (monster.get_monster_profile().ml || creature.get_skill_search() < randint1(100)) {
         return;
     }
     const auto m_name = std::string(_("それ", "It"));

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -321,7 +321,7 @@ bool process_stealth(CreatureEntity &creature, MONSTER_IDX m_idx)
 
     const auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
-    int tmp = creature.level * 6 + (creature.skill_stl + 10) * 4;
+    int tmp = creature.level * 6 + (creature.get_skill_stealth() + 10) * 4;
     if (creature.monlite) {
         tmp /= 3;
     }

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -288,7 +288,7 @@ void process_monsters_timed_effect(CreatureEntity &creature, CreatureTimedEffect
 
     /* Hack -- calculate the "player noise" */
     if (mte == CreatureTimedEffect::SLEEP_OR_PARALYSIS) {
-        csleep_noise = (1U << (30 - creature.skill_stl));
+        csleep_noise = (1U << (30 - creature.get_skill_stealth()));
     }
 
     /* Process the monsters (backwards) */

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -411,7 +411,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
 static bool check_cold_blood(CreatureEntity &creature, um_type *um_ptr, const POSITION distance)
 {
-    if (distance > creature.see_infra) {
+    if (distance > creature.get_infravision()) {
         return false;
     }
 

--- a/src/mspell/mspell-floor.cpp
+++ b/src/mspell/mspell-floor.cpp
@@ -330,7 +330,7 @@ MonsterSpellResult spell_RF6_TELE_LEVEL(CreatureEntity &creature, MONSTER_IDX m_
 
     if (target_type == MONSTER_TO_PLAYER) {
         resist = (has_resist_shard(creature) != 0);
-        saving_throw = (randint0(100 + rlev / 2) < creature.skill_sav);
+        saving_throw = (randint0(100 + rlev / 2) < creature.get_skill_save());
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^が何か奇妙な言葉をつぶやいた。", "%s^ mumbles strangely."),
             _("%s^があなたの足を指さした。", "%s^ gestures at your feet."), _("しかし効果がなかった！", "You are unaffected!"),

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -255,7 +255,7 @@ MonsterSpellResult spell_RF5_SCARE(MONSTER_IDX m_idx, CreatureEntity &creature, 
 
     if (target_type == MONSTER_TO_PLAYER) {
         resist = (has_resist_fear(creature) != 0);
-        saving_throw = (randint0(100 + rlev / 2) < creature.skill_sav);
+        saving_throw = (randint0(100 + rlev / 2) < creature.get_skill_save());
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^が何かをつぶやくと、恐ろしげな音が聞こえた。", "%s^ mumbles, and you hear scary noises."),
             _("%s^が恐ろしげな幻覚を作り出した。", "%s^ casts a fearful illusion."), _("しかし恐怖に侵されなかった。", "You refuse to be frightened."),
@@ -312,7 +312,7 @@ MonsterSpellResult spell_RF5_BLIND(MONSTER_IDX m_idx, CreatureEntity &creature, 
 
     if (target_type == MONSTER_TO_PLAYER) {
         resist = (has_resist_blind(creature) != 0);
-        saving_throw = (randint0(100 + rlev / 2) < creature.skill_sav);
+        saving_throw = (randint0(100 + rlev / 2) < creature.get_skill_save());
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
             _("%s^が呪文を唱えてあなたの目をくらました！", "%s^ casts a spell, burning your eyes!"), _("しかし効果がなかった！", "You are unaffected!"),
@@ -377,7 +377,7 @@ MonsterSpellResult spell_RF5_CONF(MONSTER_IDX m_idx, CreatureEntity &creature, M
 
     if (target_type == MONSTER_TO_PLAYER) {
         resist = (has_resist_conf(creature) != 0);
-        saving_throw = (randint0(100 + rlev / 2) < creature.skill_sav);
+        saving_throw = (randint0(100 + rlev / 2) < creature.get_skill_save());
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^が何かをつぶやくと、頭を悩ます音がした。", "%s^ mumbles, and you hear puzzling noises."),
             _("%s^が誘惑的な幻覚を作り出した。", "%s^ creates a mesmerising illusion."),
@@ -435,7 +435,7 @@ MonsterSpellResult spell_RF5_HOLD(MONSTER_IDX m_idx, CreatureEntity &creature, M
 
     if (target_type == MONSTER_TO_PLAYER) {
         resist = (creature.has_free_act() != 0);
-        saving_throw = (randint0(100 + rlev / 2) < creature.skill_sav);
+        saving_throw = (randint0(100 + rlev / 2) < creature.get_skill_save());
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
             _("%s^があなたの目をじっと見つめた！", "%s^ stares deep into your eyes!"), _("しかし効果がなかった！", "You are unaffected!"),
@@ -523,7 +523,7 @@ MonsterSpellResult spell_RF5_SLOW(MONSTER_IDX m_idx, CreatureEntity &creature, M
 
     if (target_type == MONSTER_TO_PLAYER) {
         resist = (has_resist_conf(creature) != 0);
-        saving_throw = (randint0(100 + rlev / 2) < creature.skill_sav);
+        saving_throw = (randint0(100 + rlev / 2) < creature.get_skill_save());
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^があなたの筋力を吸い取ろうとした！", "%s^ drains power from your muscles!"),
             _("%s^があなたの筋力を吸い取ろうとした！", "%s^ drains power from your muscles!"), _("しかし効果がなかった！", "You are unaffected!"),
@@ -690,7 +690,7 @@ MonsterSpellResult spell_RF6_FORGET(CreatureEntity &creature, MONSTER_IDX m_idx)
 
     msg_format(_("%s^があなたの記憶を消去しようとしている。", "%s^ tries to blank your mind."), m_name.data());
 
-    if (randint0(100 + rlev / 2) < creature.skill_sav) {
+    if (randint0(100 + rlev / 2) < creature.get_skill_save()) {
         msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
     } else if (lose_all_info(creature)) {
         msg_print(_("記憶が薄れてしまった。", "Your memories fade away."));

--- a/src/object-use/use-execution.cpp
+++ b/src/object-use/use-execution.cpp
@@ -62,7 +62,7 @@ void ObjectUseEntity::execute()
         item_level = 50 + (item_level - 50) / 2;
     }
 
-    auto chance = creature.skill_dev;
+    auto chance = creature.get_skill_device();
     if (creature.is_confused()) {
         chance = chance / 2;
     }

--- a/src/object-use/zaprod-execution.cpp
+++ b/src/object-use/zaprod-execution.cpp
@@ -64,7 +64,7 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX i_idx)
     }
 
     const auto item_level = o_ptr->get_baseitem_level();
-    auto chance = creature.skill_dev;
+    auto chance = creature.get_skill_device();
     if (creature.is_confused()) {
         chance = chance / 2;
     }

--- a/src/object-use/zapwand-execution.cpp
+++ b/src/object-use/zapwand-execution.cpp
@@ -65,7 +65,7 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX i_idx)
         item_level = 50 + (item_level - 50) / 2;
     }
 
-    auto chance = this->creature.skill_dev;
+    auto chance = this->creature.get_skill_device();
     if (this->creature.is_confused()) {
         chance = chance / 2;
     }

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -192,7 +192,7 @@ static void spell_damcalc(CreatureEntity &creature, const CreatureEntity &monste
 
     case AttributeType::MIND_BLAST:
     case AttributeType::BRAIN_SMASH:
-        if (100 + rlev / 2 <= std::max<short>(5, creature.skill_sav)) {
+        if (100 + rlev / 2 <= std::max<short>(5, creature.get_skill_save())) {
             dam = 0;
             ignore_wraith_form = true;
         }
@@ -203,7 +203,7 @@ static void spell_damcalc(CreatureEntity &creature, const CreatureEntity &monste
     case AttributeType::CAUSE_2:
     case AttributeType::CAUSE_3:
     case AttributeType::HAND_DOOM:
-        if (100 + rlev / 2 <= creature.skill_sav) {
+        if (100 + rlev / 2 <= creature.get_skill_save()) {
             dam = 0;
             ignore_wraith_form = true;
         }
@@ -211,7 +211,7 @@ static void spell_damcalc(CreatureEntity &creature, const CreatureEntity &monste
         break;
 
     case AttributeType::CAUSE_4:
-        if ((100 + rlev / 2 <= creature.skill_sav) && (monster.r_idx != MonraceId::KENSHIROU)) {
+        if ((100 + rlev / 2 <= creature.get_skill_save()) && (monster.r_idx != MonraceId::KENSHIROU)) {
             dam = 0;
             ignore_wraith_form = true;
         }

--- a/src/player-info/body-improvement-info.cpp
+++ b/src/player-info/body-improvement-info.cpp
@@ -53,7 +53,7 @@ void set_body_improvement_info_2(CreatureEntity &creature, self_info_type *self_
         self_ptr->info_list.emplace_back(_("あなたはすぐにこの世界を離れるだろう。", "You will soon be altered."));
     }
 
-    if (creature.see_infra) {
+    if (creature.get_infravision()) {
         self_ptr->info_list.emplace_back(_("あなたの瞳は赤外線に敏感である。", "Your eyes are sensitive to infrared light."));
     }
 

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -96,7 +96,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
             return;
         }
 
-        if (evaluate_percent(creature.skill_sav - power)) {
+        if (evaluate_percent(creature.get_skill_save() - power)) {
             return;
         }
 
@@ -142,7 +142,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
             power *= 2;
         }
 
-        if (evaluate_percent(creature.skill_sav * 100 / power)) {
+        if (evaluate_percent(creature.get_skill_save() * 100 / power)) {
             msg_format(_("夢の中で%sに追いかけられた。", "%s^ chases you through your dreams."), m_name.data());
             return;
         }
@@ -174,7 +174,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
     /* 過去の効果無効率再現のため5回saving_throw 実行 */
     auto save = true;
     for (auto i = 0; i < 5; i++) {
-        save &= evaluate_percent(creature.skill_sav - power);
+        save &= evaluate_percent(creature.get_skill_save() - power);
     }
 
     if (save) {

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -96,7 +96,7 @@ static void discover_hidden_things(CreatureEntity &creature, const Pos2D &pos)
  */
 void search(CreatureEntity &creature)
 {
-    PERCENTAGE chance = creature.skill_srh;
+    PERCENTAGE chance = creature.get_skill_search();
     const auto effects = creature.effects();
     if (effects->blindness().is_blind() || no_lite(creature)) {
         chance = chance / 10;
@@ -229,7 +229,7 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
             }
         }
 
-        if ((creature.skill_fos >= 50) || (0 == randint0(50 - creature.skill_fos))) {
+        if ((creature.get_skill_perception() >= 50) || (0 == randint0(50 - creature.get_skill_perception()))) {
             search(creature);
         }
 

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -193,7 +193,7 @@ bool activate_ty_curse(CreatureEntity &creature, bool stop_ty, int *count)
         case 19:
         case 20: {
             auto is_statue = stop_ty;
-            is_statue |= creature.has_free_act() && (randint1(125) < creature.skill_sav);
+            is_statue |= creature.has_free_act() && (randint1(125) < creature.get_skill_save());
             is_statue |= CreatureClass(creature).equals(PlayerClassType::BERSERKER);
             if (!is_statue) {
                 msg_print(_("彫像になった気分だ！", "You feel like a statue!"));

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -690,7 +690,7 @@ void apply_nexus(const CreatureEntity &attacker, CreatureEntity &creature)
     }
 
     case 6: {
-        if (evaluate_percent(creature.skill_sav)) {
+        if (evaluate_percent(creature.get_skill_save())) {
             msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
             break;
         }
@@ -700,7 +700,7 @@ void apply_nexus(const CreatureEntity &attacker, CreatureEntity &creature)
     }
 
     case 7: {
-        if (evaluate_percent(creature.skill_sav)) {
+        if (evaluate_percent(creature.get_skill_save())) {
             msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
             break;
         }

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1106,6 +1106,76 @@ public:
     {
         return this->pclass_ref;
     }
+    /*!
+     * @brief 赤外線視能力の強さ
+     */
+    virtual ACTION_SKILL_POWER get_infravision() const
+    {
+        return this->see_infra;
+    }
+    /*!
+     * @brief 解除能力スキル
+     */
+    virtual ACTION_SKILL_POWER get_skill_disarm() const
+    {
+        return this->skill_dis;
+    }
+    /*!
+     * @brief 魔道具使用スキル
+     */
+    virtual ACTION_SKILL_POWER get_skill_device() const
+    {
+        return this->skill_dev;
+    }
+    /*!
+     * @brief 魔法防御スキル
+     */
+    virtual ACTION_SKILL_POWER get_skill_save() const
+    {
+        return this->skill_sav;
+    }
+    /*!
+     * @brief 隠密スキル
+     */
+    virtual ACTION_SKILL_POWER get_skill_stealth() const
+    {
+        return this->skill_stl;
+    }
+    /*!
+     * @brief 知覚スキル
+     */
+    virtual ACTION_SKILL_POWER get_skill_search() const
+    {
+        return this->skill_srh;
+    }
+    /*!
+     * @brief 探索スキル
+     */
+    virtual ACTION_SKILL_POWER get_skill_perception() const
+    {
+        return this->skill_fos;
+    }
+    /*!
+     * @brief 打撃命中スキル
+     */
+    virtual ACTION_SKILL_POWER get_skill_to_hit_melee() const
+    {
+        return this->skill_thn;
+    }
+    /*!
+     * @brief 射撃命中スキル
+     */
+    virtual ACTION_SKILL_POWER get_skill_to_hit_bow() const
+    {
+        return this->skill_thb;
+    }
+    /*!
+     * @brief 掘削スキル
+     */
+    virtual ACTION_SKILL_POWER get_skill_dig() const
+    {
+        return this->skill_dig;
+    }
 
     /*!
      * @brief クリーチャーのコピーを返す

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -51,7 +51,7 @@ static void display_player_melee_bonus(CreatureEntity &creature, int hand, int h
         show_todam += o_ptr->to_d;
     }
 
-    show_tohit += creature.skill_thn / BTH_PLUS_ADJ;
+    show_tohit += creature.get_skill_to_hit_melee() / BTH_PLUS_ADJ;
 
     const auto buf = format("(%+d,%+d)", (int)show_tohit, (int)show_todam);
     if (!has_melee_weapon(creature, INVEN_MAIN_HAND) && !has_melee_weapon(creature, INVEN_SUB_HAND)) {
@@ -122,7 +122,7 @@ static void display_bow_hit_damage(CreatureEntity &creature)
         }
     }
 
-    show_tohit += creature.skill_thb / BTH_PLUS_ADJ;
+    show_tohit += creature.get_skill_to_hit_bow() / BTH_PLUS_ADJ;
     display_player_one_line(ENTRY_SHOOT_HIT_DAM, format("(%+d,%+d)", show_tohit, show_todam), TERM_L_BLUE);
 }
 

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -429,7 +429,7 @@ static int calculate_mp_regen_rate(CreatureEntity &creature)
  */
 static void display_first_page(CreatureEntity &creature, int xthb, int *damage, int shots, int shot_frac)
 {
-    int xthn = creature.skill_thn + (creature.to_h_m * BTH_PLUS_ADJ);
+    int xthn = creature.get_skill_to_hit_melee() + (creature.to_h_m * BTH_PLUS_ADJ);
 
     int muta_att = 0;
     if (creature.get_mutations().has(PlayerMutationType::HORNS)) {
@@ -450,13 +450,13 @@ static void display_first_page(CreatureEntity &creature, int xthb, int *damage, 
 
     int blows1 = can_attack_with_main_hand(creature) ? creature.num_blow[0] : 0;
     int blows2 = can_attack_with_sub_hand(creature) ? creature.num_blow[1] : 0;
-    int xdis = creature.skill_dis;
-    int xdev = creature.skill_dev;
-    int xsav = creature.skill_sav;
-    int xstl = creature.skill_stl;
-    int xsrh = creature.skill_srh;
-    int xfos = creature.skill_fos;
-    int xdig = creature.skill_dig;
+    int xdis = creature.get_skill_disarm();
+    int xdev = creature.get_skill_device();
+    int xsav = creature.get_skill_save();
+    int xstl = creature.get_skill_stealth();
+    int xsrh = creature.get_skill_search();
+    int xfos = creature.get_skill_perception();
+    int xdig = creature.get_skill_dig();
 
     auto sd = likert(xthn, 12);
     display_player_one_line(ENTRY_SKILL_FIGHT, sd.first, sd.second);
@@ -501,7 +501,7 @@ static void display_first_page(CreatureEntity &creature, int xthb, int *damage, 
     }
 
     display_player_one_line(ENTRY_AVG_DMG, desc, TERM_L_BLUE);
-    display_player_one_line(ENTRY_INFRA, format("%d feet", creature.see_infra * 10), TERM_WHITE);
+    display_player_one_line(ENTRY_INFRA, format("%d feet", creature.get_infravision() * 10), TERM_WHITE);
 
     // HP回復量/100ターンの計算
     int hp_regen_amount = calculate_hp_regen_rate(creature);
@@ -532,7 +532,7 @@ void display_player_various(CreatureEntity &creature)
     ItemEntity *o_ptr;
     o_ptr = creature.inventory[INVEN_BOW].get();
     int tmp = creature.to_h_b + o_ptr->to_h;
-    int xthb = creature.skill_thb + (tmp * BTH_PLUS_ADJ);
+    int xthb = creature.get_skill_to_hit_bow() + (tmp * BTH_PLUS_ADJ);
     int shots = 0;
     int shot_frac = 0;
     calc_shot_params(creature, o_ptr, &shots, &shot_frac);


### PR DESCRIPTION
提案 2 の継続。以下 10 フィールドに virtual アクセサを追加し、
読取り箇所を移行:

- see_infra → get_infravision()
- skill_dis → get_skill_disarm()
- skill_dev → get_skill_device()
- skill_sav → get_skill_save()
- skill_stl → get_skill_stealth()
- skill_srh → get_skill_search()
- skill_fos → get_skill_perception()
- skill_thn → get_skill_to_hit_melee()
- skill_thb → get_skill_to_hit_bow()
- skill_dig → get_skill_dig()

37 ファイル、読取り 80 箇所の置換。書込み (代入・save/load) は
直接参照のまま残置。将来モンスター種族定義から導出する形で
override 可能。

https://claude.ai/code/session_01Q6mCnU2BLa2WBs38WzM3y2