### PR TITLE
refactor(creature): has_resist_*/has_immune_*/has_vuln_* を virtual メソッド化

### DIFF
--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -18,6 +18,7 @@
 #include "player-info/race-types.h"
 #include "player-info/sniper-data-type.h"
 #include "player-info/spell-hex-data-type.h"
+#include "player/player-status-flags.h"
 #include "player/race-info-table.h"
 #include "realm/realm-song-numbers.h"
 #include "realm/realm-types.h"
@@ -1083,3 +1084,42 @@ void CreatureEntity::wipe()
         this->init_monster_profile();
     }
 }
+
+// 耐性系 virtual メソッドのデフォルト実装。
+// player-status-flags の自由関数に委譲する形で、プレイヤー用の集計
+// ロジック（装備・職業・種族・時限効果）をそのまま活用。将来
+// モンスター側で MonsterProfile / MonraceDefinition 由来の耐性を
+// 返す形にオーバーライド可能。
+
+// clang-format off
+BIT_FLAGS CreatureEntity::has_resist_fire() { return ::has_resist_fire(*this); }
+BIT_FLAGS CreatureEntity::has_resist_cold() { return ::has_resist_cold(*this); }
+BIT_FLAGS CreatureEntity::has_resist_elec() { return ::has_resist_elec(*this); }
+BIT_FLAGS CreatureEntity::has_resist_acid() { return ::has_resist_acid(*this); }
+BIT_FLAGS CreatureEntity::has_resist_pois() { return ::has_resist_pois(*this); }
+BIT_FLAGS CreatureEntity::has_resist_conf() { return ::has_resist_conf(*this); }
+BIT_FLAGS CreatureEntity::has_resist_sound() { return ::has_resist_sound(*this); }
+BIT_FLAGS CreatureEntity::has_resist_lite() { return ::has_resist_lite(*this); }
+BIT_FLAGS CreatureEntity::has_resist_dark() { return ::has_resist_dark(*this); }
+BIT_FLAGS CreatureEntity::has_resist_chaos() { return ::has_resist_chaos(*this); }
+BIT_FLAGS CreatureEntity::has_resist_disen() { return ::has_resist_disen(*this); }
+BIT_FLAGS CreatureEntity::has_resist_shard() { return ::has_resist_shard(*this); }
+BIT_FLAGS CreatureEntity::has_resist_blind() { return ::has_resist_blind(*this); }
+BIT_FLAGS CreatureEntity::has_resist_neth() { return ::has_resist_neth(*this); }
+BIT_FLAGS CreatureEntity::has_resist_time() { return ::has_resist_time(*this); }
+BIT_FLAGS CreatureEntity::has_resist_water() { return ::has_resist_water(*this); }
+BIT_FLAGS CreatureEntity::has_resist_fear() { return ::has_resist_fear(*this); }
+BIT_FLAGS CreatureEntity::has_resist_curse() { return ::has_resist_curse(*this); }
+BIT_FLAGS CreatureEntity::has_vuln_curse() { return ::has_vuln_curse(*this); }
+BIT_FLAGS CreatureEntity::has_vuln_acid() { return ::has_vuln_acid(*this); }
+BIT_FLAGS CreatureEntity::has_vuln_elec() { return ::has_vuln_elec(*this); }
+BIT_FLAGS CreatureEntity::has_vuln_fire() { return ::has_vuln_fire(*this); }
+BIT_FLAGS CreatureEntity::has_vuln_cold() { return ::has_vuln_cold(*this); }
+BIT_FLAGS CreatureEntity::has_vuln_lite() { return ::has_vuln_lite(*this); }
+BIT_FLAGS CreatureEntity::has_immune_fire() { return ::has_immune_fire(*this); }
+BIT_FLAGS CreatureEntity::has_immune_cold() { return ::has_immune_cold(*this); }
+BIT_FLAGS CreatureEntity::has_immune_acid() { return ::has_immune_acid(*this); }
+BIT_FLAGS CreatureEntity::has_immune_elec() { return ::has_immune_elec(*this); }
+BIT_FLAGS CreatureEntity::has_immune_dark() { return ::has_immune_dark(*this); }
+BIT_FLAGS CreatureEntity::has_immune_lite() { return ::has_immune_lite(*this); }
+// clang-format on

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -836,6 +836,41 @@ public:
     virtual bool is_time_limit_esp() const;
     virtual bool is_time_limit_stealth() const;
 
+    // 耐性系 virtual メソッド (提案 4)。
+    // プレイヤーは装備・職業・種族・時限効果から集計、モンスターは
+    // 将来 MonsterProfile / MonraceDefinition 経由で override 可能。
+    // 戻り値は BIT_FLAGS_CAUSE_* のビット集合（0 なら非耐性）。
+    virtual BIT_FLAGS has_resist_fire();
+    virtual BIT_FLAGS has_resist_cold();
+    virtual BIT_FLAGS has_resist_elec();
+    virtual BIT_FLAGS has_resist_acid();
+    virtual BIT_FLAGS has_resist_pois();
+    virtual BIT_FLAGS has_resist_conf();
+    virtual BIT_FLAGS has_resist_sound();
+    virtual BIT_FLAGS has_resist_lite();
+    virtual BIT_FLAGS has_resist_dark();
+    virtual BIT_FLAGS has_resist_chaos();
+    virtual BIT_FLAGS has_resist_disen();
+    virtual BIT_FLAGS has_resist_shard();
+    virtual BIT_FLAGS has_resist_blind();
+    virtual BIT_FLAGS has_resist_neth();
+    virtual BIT_FLAGS has_resist_time();
+    virtual BIT_FLAGS has_resist_water();
+    virtual BIT_FLAGS has_resist_fear();
+    virtual BIT_FLAGS has_resist_curse();
+    virtual BIT_FLAGS has_vuln_curse();
+    virtual BIT_FLAGS has_vuln_acid();
+    virtual BIT_FLAGS has_vuln_elec();
+    virtual BIT_FLAGS has_vuln_fire();
+    virtual BIT_FLAGS has_vuln_cold();
+    virtual BIT_FLAGS has_vuln_lite();
+    virtual BIT_FLAGS has_immune_fire();
+    virtual BIT_FLAGS has_immune_cold();
+    virtual BIT_FLAGS has_immune_acid();
+    virtual BIT_FLAGS has_immune_elec();
+    virtual BIT_FLAGS has_immune_dark();
+    virtual BIT_FLAGS has_immune_lite();
+
     /*!
      * @brief 汎用テレパシーの有無を返す
      * @details プレイヤーは装備由来、モンスターは種族フラグ由来（将来）。


### PR DESCRIPTION
提案 4 の第一歩。30 種の耐性/免疫/弱点系自由関数に対応する
virtual メソッドを CreatureEntity に追加:

- has_resist_fire / cold / elec / acid / pois / conf / sound / lite / dark / chaos / disen / shard / blind / neth / time / water / fear / curse
- has_vuln_curse / acid / elec / fire / cold / lite
- has_immune_fire / cold / acid / elec / dark / lite

デフォルト実装は既存自由関数 (player-status-flags) に委譲。
将来モンスター側で MonsterProfile / MonraceDefinition 経由で
override 可能にする土台を整備。call site の creature.has_resist_fire() 形式への移行は後続コミットで段階的に実施。

https://claude.ai/code/session_01Q6mCnU2BLa2WBs38WzM3y2