### PR TITLE
refactor(creature): 基本元素耐性/免疫の call site を virtual メンバ経由に移行

### DIFF
--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -234,7 +234,7 @@ static bool run_test(CreatureEntity &creature)
                     notice = false;
                 } else if (find_ignore_stairs && terrain.flags.has(TerrainCharacteristics::STAIRS)) {
                     notice = false;
-                } else if (terrain.flags.has(TerrainCharacteristics::LAVA) && (has_immune_fire(creature) || creature.is_invulnerable())) {
+                } else if (terrain.flags.has(TerrainCharacteristics::LAVA) && (creature.has_immune_fire() || creature.is_invulnerable())) {
                     notice = false;
                 } else if (terrain.flags.has(TerrainCharacteristics::VOID) && creature.is_invulnerable()) {
                     notice = false;

--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -45,7 +45,7 @@ int travel_flow_cost(CreatureEntity &creature, const Pos2D &pos)
 
     if (terrain.flags.has(TerrainCharacteristics::LAVA)) {
         int lava = 2;
-        if (!has_resist_fire(creature)) {
+        if (!creature.has_resist_fire()) {
             lava *= 2;
         }
 

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -74,7 +74,7 @@ static bool exe_eat_junk_type_object(CreatureEntity &creature, ItemEntity *o_ptr
     if (o_ptr->bi_key.sval() == SV_JUNK_FECES || o_ptr->bi_key.sval() == SV_KMR_CURRY) {
         msg_print("ワーォ！貴方は糞を喰った！");
         msg_print("『涙が出るほどうめぇ……』");
-        if (!(has_resist_pois(creature) || is_oppose_pois(creature))) {
+        if (!(creature.has_resist_pois() || is_oppose_pois(creature))) {
             (void)BadStatusSetter(creature).mod_poison(10 + randint1(10));
         }
         creature.plus_incident_tree("EAT_FECES", 1);
@@ -84,7 +84,7 @@ static bool exe_eat_junk_type_object(CreatureEntity &creature, ItemEntity *o_ptr
     if (o_ptr->bi_key.sval() == SV_JUNK_VOMITTING) {
         msg_print("ワーォ！貴方はゲロを喰った！");
         msg_print("『涙が出るほどうめぇ……』");
-        if (!(has_resist_pois(creature) || is_oppose_pois(creature))) {
+        if (!(creature.has_resist_pois() || is_oppose_pois(creature))) {
             (void)BadStatusSetter(creature).mod_poison(10 + randint1(10));
         }
         creature.plus_incident_tree("EAT_FECES", 1);
@@ -198,7 +198,7 @@ static bool exe_eat_corpse_type_object(CreatureEntity &creature, ItemEntity *o_p
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::POISONOUS)) {
-        if (!(has_resist_pois(creature) || is_oppose_pois(creature))) {
+        if (!(creature.has_resist_pois() || is_oppose_pois(creature))) {
             (void)BadStatusSetter(creature).mod_poison(10 + randint1(15));
         }
     }
@@ -277,7 +277,7 @@ static bool exe_eat_food_type_object(CreatureEntity &creature, const BaseitemKey
     BadStatusSetter bss(creature);
     switch (bi_key.sval().value()) {
     case SV_FOOD_POISON:
-        if (!(has_resist_pois(creature) || is_oppose_pois(creature))) {
+        if (!(creature.has_resist_pois() || is_oppose_pois(creature))) {
             if (bss.mod_poison(randint0(10) + 10)) {
                 creature.plus_incident_tree("EAT_POISON", 1);
                 return true;

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -53,13 +53,13 @@ void effect_player_poison(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     ep_ptr->dam = ep_ptr->dam * calc_pois_damage_rate(creature) / 100;
 
-    if ((!(double_resist || has_resist_pois(creature))) && one_in_(CHANCE_ABILITY_SCORE_DECREASE) && !check_multishadow(creature)) {
+    if ((!(double_resist || creature.has_resist_pois())) && one_in_(CHANCE_ABILITY_SCORE_DECREASE) && !check_multishadow(creature)) {
         do_dec_stat(creature, A_CON);
     }
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 
-    if (!(double_resist || has_resist_pois(creature)) && !check_multishadow(creature)) {
+    if (!(double_resist || creature.has_resist_pois()) && !check_multishadow(creature)) {
         (void)BadStatusSetter(creature).mod_poison(randint0(ep_ptr->dam) + 10);
     }
 }
@@ -74,7 +74,7 @@ void effect_player_nuke(CreatureEntity &creature, EffectPlayerType *ep_ptr)
     ep_ptr->dam = ep_ptr->dam * calc_pois_damage_rate(creature) / 100;
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
-    if ((double_resist || has_resist_pois(creature)) || check_multishadow(creature)) {
+    if ((double_resist || creature.has_resist_pois()) || check_multishadow(creature)) {
         return;
     }
 
@@ -160,7 +160,7 @@ void effect_player_plasma(CreatureEntity &creature, EffectPlayerType *ep_ptr)
         (void)BadStatusSetter(creature).mod_stun(plus_stun);
     }
 
-    if (!(has_resist_fire(creature) || is_oppose_fire(creature) || has_immune_fire(creature))) {
+    if (!(creature.has_resist_fire() || is_oppose_fire(creature) || creature.has_immune_fire())) {
         inventory_damage(creature, BreakerAcid(), 3);
     }
 }
@@ -597,7 +597,7 @@ void effect_player_meteor(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
     if (!has_resist_shard(creature) || one_in_(13)) {
-        if (!has_immune_fire(creature)) {
+        if (!creature.has_immune_fire()) {
             inventory_damage(creature, BreakerFire(), 2);
         }
         inventory_damage(creature, BreakerCold(), 2);
@@ -624,8 +624,8 @@ void effect_player_icee(CreatureEntity &creature, EffectPlayerType *ep_ptr)
         (void)bss.mod_stun(randnum1<short>(15));
     }
 
-    if ((!(has_resist_cold(creature) || is_oppose_cold(creature))) || one_in_(12)) {
-        if (!has_immune_cold(creature)) {
+    if ((!(creature.has_resist_cold() || is_oppose_cold(creature))) || one_in_(12)) {
+        if (!creature.has_immune_cold()) {
             inventory_damage(creature, BreakerCold(), 3);
         }
     }

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -916,7 +916,7 @@ bool cave_player_teleportable_bold(CreatureEntity &creature, POSITION y, POSITIO
         }
     }
 
-    if (terrain.flags.has_not(TerrainCharacteristics::LAVA) || has_immune_fire(creature) || creature.is_invulnerable()) {
+    if (terrain.flags.has_not(TerrainCharacteristics::LAVA) || creature.has_immune_fire() || creature.is_invulnerable()) {
         return true;
     }
 

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -228,7 +228,7 @@ static void hit_trap_pit(CreatureEntity &creature, TrapType trap_feat_type)
         return;
     }
 
-    if (has_resist_pois(creature) || is_oppose_pois(creature)) {
+    if (creature.has_resist_pois() || is_oppose_pois(creature)) {
         msg_print(_("しかし毒の影響はなかった！", "The poison does not affect you!"));
         take_hit(creature, DAMAGE_NOESCAPE, dam, trap_name);
         return;
@@ -403,7 +403,7 @@ void hit_trap(CreatureEntity &creature, bool break_trap)
         break;
     case TrapType::POISON:
         msg_print(_("刺激的な緑色のガスに包み込まれた！", "A pungent green gas surrounds you!"));
-        if (has_resist_pois(creature) == 0) {
+        if (creature.has_resist_pois() == 0) {
             (void)BadStatusSetter(creature).mod_poison(randint0(20) + 10);
         }
 

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -163,7 +163,7 @@ void process_player_hp_mp(CreatureEntity &creature)
         }
     }
 
-    if (terrain.flags.has(TerrainCharacteristics::LAVA) && !creature.is_invulnerable() && !has_immune_fire(creature)) {
+    if (terrain.flags.has(TerrainCharacteristics::LAVA) && !creature.is_invulnerable() && !creature.has_immune_fire()) {
         constexpr auto mes_leviation = _("熱で火傷した！", "The heat burns you!");
         constexpr auto mes_normal = _("で火傷した！", "burns you!");
         if (deal_damege_by_feat(creature, grid, mes_leviation, mes_normal, calc_fire_damage_rate, nullptr)) {
@@ -172,7 +172,7 @@ void process_player_hp_mp(CreatureEntity &creature)
         }
     }
 
-    if (terrain.flags.has(TerrainCharacteristics::COLD_PUDDLE) && !creature.is_invulnerable() && !has_immune_cold(creature)) {
+    if (terrain.flags.has(TerrainCharacteristics::COLD_PUDDLE) && !creature.is_invulnerable() && !creature.has_immune_cold()) {
         constexpr auto mes_leviation = _("冷気に覆われた！", "The cold engulfs you!");
         constexpr auto mes_normal = _("に凍えた！", "frostbites you!");
         if (deal_damege_by_feat(creature, grid, mes_leviation, mes_normal, calc_cold_damage_rate, nullptr)) {
@@ -181,7 +181,7 @@ void process_player_hp_mp(CreatureEntity &creature)
         }
     }
 
-    if (terrain.flags.has(TerrainCharacteristics::ELEC_PUDDLE) && !creature.is_invulnerable() && !has_immune_elec(creature)) {
+    if (terrain.flags.has(TerrainCharacteristics::ELEC_PUDDLE) && !creature.is_invulnerable() && !creature.has_immune_elec()) {
         constexpr auto mes_leviation = _("電撃を受けた！", "The electricity shocks you!");
         constexpr auto mes_normal = _("に感電した！", "shocks you!");
         if (deal_damege_by_feat(creature, grid, mes_leviation, mes_normal, calc_elec_damage_rate, nullptr)) {
@@ -190,7 +190,7 @@ void process_player_hp_mp(CreatureEntity &creature)
         }
     }
 
-    if (terrain.flags.has(TerrainCharacteristics::ACID_PUDDLE) && !creature.is_invulnerable() && !has_immune_acid(creature)) {
+    if (terrain.flags.has(TerrainCharacteristics::ACID_PUDDLE) && !creature.is_invulnerable() && !creature.has_immune_acid()) {
         constexpr auto mes_leviation = _("酸が飛び散った！", "The acid melts you!");
         constexpr auto mes_normal = _("に溶かされた！", "melts you!");
         if (deal_damege_by_feat(creature, grid, mes_leviation, mes_normal, calc_acid_damage_rate, nullptr)) {
@@ -204,7 +204,7 @@ void process_player_hp_mp(CreatureEntity &creature)
         constexpr auto mes_normal = _("に毒された！", "poisons you!");
         if (deal_damege_by_feat(creature, grid, mes_leviation, mes_normal, calc_pois_damage_rate,
                 [](CreatureEntity &creature, int damage) {
-                    if (!has_resist_pois(creature)) {
+                    if (!creature.has_resist_pois()) {
                         (void)BadStatusSetter(creature).mod_poison(static_cast<TIME_EFFECT>(damage));
                     }
                 })) {
@@ -216,7 +216,7 @@ void process_player_hp_mp(CreatureEntity &creature)
     if (terrain.flags.has(TerrainCharacteristics::DUNG_POOL) && !creature.is_invulnerable()) {
         cave_no_regen = deal_damege_by_feat(creature, grid, _("糞が飛び散った！", "The feced scatter to you!"), _("に浸かった！", "tainted you!"),
             calc_acid_damage_rate, [](CreatureEntity &creature, int damage) {
-                if (!has_resist_pois(creature)) {
+                if (!creature.has_resist_pois()) {
                     (void)BadStatusSetter(creature).mod_poison(static_cast<TIME_EFFECT>(damage));
                 }
             });
@@ -262,13 +262,13 @@ void process_player_hp_mp(CreatureEntity &creature)
         sound(SoundKind::TERRAIN_DAMAGE);
     }
 
-    if (get_player_flags(creature, TR_SELF_FIRE) && !has_immune_fire(creature)) {
+    if (get_player_flags(creature, TR_SELF_FIRE) && !creature.has_immune_fire()) {
         int damage;
         damage = creature.level;
         if (race.tr_flags().has(TR_VUL_FIRE)) {
             damage += damage / 3;
         }
-        if (has_resist_fire(creature)) {
+        if (creature.has_resist_fire()) {
             damage = damage / 3;
         }
         if (is_oppose_fire(creature)) {
@@ -280,13 +280,13 @@ void process_player_hp_mp(CreatureEntity &creature)
         take_hit(creature, DAMAGE_NOESCAPE, damage, _("炎のオーラ", "Fire aura"));
     }
 
-    if (get_player_flags(creature, TR_SELF_ELEC) && !has_immune_elec(creature)) {
+    if (get_player_flags(creature, TR_SELF_ELEC) && !creature.has_immune_elec()) {
         int damage;
         damage = creature.level;
         if (race.tr_flags().has(TR_VUL_ELEC)) {
             damage += damage / 3;
         }
-        if (has_resist_elec(creature)) {
+        if (creature.has_resist_elec()) {
             damage = damage / 3;
         }
         if (is_oppose_elec(creature)) {
@@ -298,13 +298,13 @@ void process_player_hp_mp(CreatureEntity &creature)
         take_hit(creature, DAMAGE_NOESCAPE, damage, _("電気のオーラ", "Elec aura"));
     }
 
-    if (get_player_flags(creature, TR_SELF_COLD) && !has_immune_cold(creature)) {
+    if (get_player_flags(creature, TR_SELF_COLD) && !creature.has_immune_cold()) {
         int damage;
         damage = creature.level;
         if (race.tr_flags().has(TR_VUL_COLD)) {
             damage += damage / 3;
         }
-        if (has_resist_cold(creature)) {
+        if (creature.has_resist_cold()) {
             damage = damage / 3;
         }
         if (is_oppose_cold(creature)) {
@@ -319,12 +319,12 @@ void process_player_hp_mp(CreatureEntity &creature)
     if (creature.riding) {
         int damage;
         auto auras = floor.get_monster(creature.riding).get_monrace().aura_flags;
-        if (auras.has(MonsterAuraType::FIRE) && !has_immune_fire(creature)) {
+        if (auras.has(MonsterAuraType::FIRE) && !creature.has_immune_fire()) {
             damage = floor.get_monster(creature.riding).get_monrace().level / 2;
             if (race.tr_flags().has(TR_VUL_FIRE)) {
                 damage += damage / 3;
             }
-            if (has_resist_fire(creature)) {
+            if (creature.has_resist_fire()) {
                 damage = damage / 3;
             }
             if (is_oppose_fire(creature)) {
@@ -336,12 +336,12 @@ void process_player_hp_mp(CreatureEntity &creature)
             take_hit(creature, DAMAGE_NOESCAPE, damage, _("炎のオーラ", "Fire aura"));
         }
 
-        if (auras.has(MonsterAuraType::ELEC) && !has_immune_elec(creature)) {
+        if (auras.has(MonsterAuraType::ELEC) && !creature.has_immune_elec()) {
             damage = floor.get_monster(creature.riding).get_monrace().level / 2;
             if (race.tr_flags().has(TR_VUL_ELEC)) {
                 damage += damage / 3;
             }
-            if (has_resist_elec(creature)) {
+            if (creature.has_resist_elec()) {
                 damage = damage / 3;
             }
             if (is_oppose_elec(creature)) {
@@ -353,12 +353,12 @@ void process_player_hp_mp(CreatureEntity &creature)
             take_hit(creature, DAMAGE_NOESCAPE, damage, _("電気のオーラ", "Elec aura"));
         }
 
-        if (auras.has(MonsterAuraType::COLD) && !has_immune_cold(creature)) {
+        if (auras.has(MonsterAuraType::COLD) && !creature.has_immune_cold()) {
             damage = floor.get_monster(creature.riding).get_monrace().level / 2;
             if (race.tr_flags().has(TR_VUL_COLD)) {
                 damage += damage / 3;
             }
-            if (has_resist_cold(creature)) {
+            if (creature.has_resist_cold()) {
                 damage = damage / 3;
             }
             if (is_oppose_cold(creature)) {

--- a/src/monster-attack/monster-attack-lose.cpp
+++ b/src/monster-attack/monster-attack-lose.cpp
@@ -21,7 +21,7 @@
  */
 void calc_blow_disease(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    if (has_resist_pois(creature)) {
+    if (creature.has_resist_pois()) {
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 4) / 9;
     }
 
@@ -34,7 +34,7 @@ void calc_blow_disease(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
         return;
     }
 
-    if (!(has_resist_pois(creature) || is_oppose_pois(creature)) && BadStatusSetter(creature).mod_poison(randint1(monap_ptr->rlev) + 5)) {
+    if (!(creature.has_resist_pois() || is_oppose_pois(creature)) && BadStatusSetter(creature).mod_poison(randint1(monap_ptr->rlev) + 5)) {
         monap_ptr->obvious = true;
     }
 

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -49,7 +49,7 @@ static void calc_blow_poison(CreatureEntity &creature, MonsterAttackPlayer *mona
         return;
     }
 
-    if (!(has_resist_pois(creature) || is_oppose_pois(creature)) && !check_multishadow(creature) && BadStatusSetter(creature).mod_poison(randint1(monap_ptr->rlev) + 5)) {
+    if (!(creature.has_resist_pois() || is_oppose_pois(creature)) && !check_multishadow(creature) && BadStatusSetter(creature).mod_poison(randint1(monap_ptr->rlev) + 5)) {
         monap_ptr->obvious = true;
     }
 

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -648,7 +648,7 @@ void update_smart_learn(CreatureEntity &creature, MONSTER_IDX m_idx, int what)
 
     switch (what) {
     case DRS_ACID:
-        if (has_resist_acid(creature)) {
+        if (creature.has_resist_acid()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_ACID);
         }
 
@@ -656,13 +656,13 @@ void update_smart_learn(CreatureEntity &creature, MONSTER_IDX m_idx, int what)
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::OPP_ACID);
         }
 
-        if (has_immune_acid(creature)) {
+        if (creature.has_immune_acid()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_ACID);
         }
 
         break;
     case DRS_ELEC:
-        if (has_resist_elec(creature)) {
+        if (creature.has_resist_elec()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_ELEC);
         }
 
@@ -670,13 +670,13 @@ void update_smart_learn(CreatureEntity &creature, MONSTER_IDX m_idx, int what)
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::OPP_ELEC);
         }
 
-        if (has_immune_elec(creature)) {
+        if (creature.has_immune_elec()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_ELEC);
         }
 
         break;
     case DRS_FIRE:
-        if (has_resist_fire(creature)) {
+        if (creature.has_resist_fire()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_FIRE);
         }
 
@@ -684,13 +684,13 @@ void update_smart_learn(CreatureEntity &creature, MONSTER_IDX m_idx, int what)
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::OPP_FIRE);
         }
 
-        if (has_immune_fire(creature)) {
+        if (creature.has_immune_fire()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_FIRE);
         }
 
         break;
     case DRS_COLD:
-        if (has_resist_cold(creature)) {
+        if (creature.has_resist_cold()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_COLD);
         }
 
@@ -698,13 +698,13 @@ void update_smart_learn(CreatureEntity &creature, MONSTER_IDX m_idx, int what)
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::OPP_COLD);
         }
 
-        if (has_immune_cold(creature)) {
+        if (creature.has_immune_cold()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_COLD);
         }
 
         break;
     case DRS_POIS:
-        if (has_resist_pois(creature)) {
+        if (creature.has_resist_pois()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_POIS);
         }
 

--- a/src/mspell/element-resistance-checker.cpp
+++ b/src/mspell/element-resistance-checker.cpp
@@ -10,7 +10,7 @@
 
 void add_cheat_remove_flags_element(CreatureEntity &creature, msr_type *msr_ptr)
 {
-    if (has_resist_acid(creature)) {
+    if (creature.has_resist_acid()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_ACID);
     }
 
@@ -18,11 +18,11 @@ void add_cheat_remove_flags_element(CreatureEntity &creature, msr_type *msr_ptr)
         msr_ptr->smart_flags.set(MonsterSmartLearnType::OPP_ACID);
     }
 
-    if (has_immune_acid(creature)) {
+    if (creature.has_immune_acid()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::IMM_ACID);
     }
 
-    if (has_resist_elec(creature)) {
+    if (creature.has_resist_elec()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_ELEC);
     }
 
@@ -30,11 +30,11 @@ void add_cheat_remove_flags_element(CreatureEntity &creature, msr_type *msr_ptr)
         msr_ptr->smart_flags.set(MonsterSmartLearnType::OPP_ELEC);
     }
 
-    if (has_immune_elec(creature)) {
+    if (creature.has_immune_elec()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::IMM_ELEC);
     }
 
-    if (has_resist_fire(creature)) {
+    if (creature.has_resist_fire()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_FIRE);
     }
 
@@ -42,11 +42,11 @@ void add_cheat_remove_flags_element(CreatureEntity &creature, msr_type *msr_ptr)
         msr_ptr->smart_flags.set(MonsterSmartLearnType::OPP_FIRE);
     }
 
-    if (has_immune_fire(creature)) {
+    if (creature.has_immune_fire()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::IMM_FIRE);
     }
 
-    if (has_resist_cold(creature)) {
+    if (creature.has_resist_cold()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_COLD);
     }
 
@@ -54,11 +54,11 @@ void add_cheat_remove_flags_element(CreatureEntity &creature, msr_type *msr_ptr)
         msr_ptr->smart_flags.set(MonsterSmartLearnType::OPP_COLD);
     }
 
-    if (has_immune_cold(creature)) {
+    if (creature.has_immune_cold()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::IMM_COLD);
     }
 
-    if (has_resist_pois(creature)) {
+    if (creature.has_resist_pois()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_POIS);
     }
 

--- a/src/mspell/mspell-judgement.cpp
+++ b/src/mspell/mspell-judgement.cpp
@@ -260,7 +260,7 @@ bool dispel_check(CreatureEntity &creature, MONSTER_IDX m_idx)
     const auto &monster = floor_ref.get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     if (monrace.ability_flags.has(MonsterAbilityType::BR_ACID)) {
-        if (!has_immune_acid(creature) && (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ACID) || music_singing(creature, MUSIC_RESIST))) {
+        if (!creature.has_immune_acid() && (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ACID) || music_singing(creature, MUSIC_RESIST))) {
             return true;
         }
 
@@ -271,7 +271,7 @@ bool dispel_check(CreatureEntity &creature, MONSTER_IDX m_idx)
 
     if (monrace.ability_flags.has(MonsterAbilityType::BR_FIRE)) {
         if (!(CreatureRace(&creature).equals(PlayerRaceType::BALROG) && creature.level > 44)) {
-            if (!has_immune_fire(creature) && (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE) || music_singing(creature, MUSIC_RESIST))) {
+            if (!creature.has_immune_fire() && (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE) || music_singing(creature, MUSIC_RESIST))) {
                 return true;
             }
 
@@ -282,7 +282,7 @@ bool dispel_check(CreatureEntity &creature, MONSTER_IDX m_idx)
     }
 
     if (monrace.ability_flags.has(MonsterAbilityType::BR_ELEC)) {
-        if (!has_immune_elec(creature) && (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ELEC) || music_singing(creature, MUSIC_RESIST))) {
+        if (!creature.has_immune_elec() && (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ELEC) || music_singing(creature, MUSIC_RESIST))) {
             return true;
         }
 
@@ -292,7 +292,7 @@ bool dispel_check(CreatureEntity &creature, MONSTER_IDX m_idx)
     }
 
     if (monrace.ability_flags.has(MonsterAbilityType::BR_COLD)) {
-        if (!has_immune_cold(creature) && (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD) || music_singing(creature, MUSIC_RESIST))) {
+        if (!creature.has_immune_cold() && (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD) || music_singing(creature, MUSIC_RESIST))) {
             return true;
         }
 

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -65,7 +65,7 @@ static void spell_damcalc(CreatureEntity &creature, const CreatureEntity &monste
     /* Vulnerability, resistance and immunity */
     switch (typ) {
     case AttributeType::ELEC:
-        if (has_immune_elec(creature)) {
+        if (creature.has_immune_elec()) {
             ignore_wraith_form = true;
         }
         dam = dam * calc_elec_damage_rate(creature) / 100;
@@ -76,7 +76,7 @@ static void spell_damcalc(CreatureEntity &creature, const CreatureEntity &monste
         break;
 
     case AttributeType::ACID:
-        if (has_immune_acid(creature)) {
+        if (creature.has_immune_acid()) {
             ignore_wraith_form = true;
         }
         dam = dam * calc_acid_damage_rate(creature) / 100;
@@ -84,14 +84,14 @@ static void spell_damcalc(CreatureEntity &creature, const CreatureEntity &monste
 
     case AttributeType::COLD:
     case AttributeType::ICE:
-        if (has_immune_cold(creature)) {
+        if (creature.has_immune_cold()) {
             ignore_wraith_form = true;
         }
         dam = dam * calc_cold_damage_rate(creature) / 100;
         break;
 
     case AttributeType::FIRE:
-        if (has_immune_fire(creature)) {
+        if (creature.has_immune_fire()) {
             ignore_wraith_form = true;
         }
         dam = dam * calc_fire_damage_rate(creature) / 100;

--- a/src/player-info/resistance-info.cpp
+++ b/src/player-info/resistance-info.cpp
@@ -10,57 +10,57 @@ void set_element_resistance_info(CreatureEntity &creature, self_info_type *self_
 {
     const auto race_tr_flags = CreatureRace(&creature).tr_flags();
 
-    if (has_immune_acid(creature)) {
+    if (creature.has_immune_acid()) {
         self_ptr->info_list.emplace_back(_("あなたは酸に対する完全なる免疫を持っている。", "You are completely immune to acid."));
-    } else if (has_resist_acid(creature) && is_oppose_acid(creature)) {
+    } else if (creature.has_resist_acid() && is_oppose_acid(creature)) {
         self_ptr->info_list.emplace_back(_("あなたは酸への強力な耐性を持っている。", "You resist acid exceptionally well."));
-    } else if (has_resist_acid(creature) || is_oppose_acid(creature)) {
+    } else if (creature.has_resist_acid() || is_oppose_acid(creature)) {
         self_ptr->info_list.emplace_back(_("あなたは酸への耐性を持っている。", "You are resistant to acid."));
     }
 
-    if (race_tr_flags.has(TR_VUL_ACID) && !has_immune_acid(creature)) {
+    if (race_tr_flags.has(TR_VUL_ACID) && !creature.has_immune_acid()) {
         self_ptr->info_list.emplace_back(_("あなたは酸に弱い。", "You are susceptible to damage from acid."));
     }
 
-    if (has_immune_elec(creature)) {
+    if (creature.has_immune_elec()) {
         self_ptr->info_list.emplace_back(_("あなたは電撃に対する完全なる免疫を持っている。", "You are completely immune to lightning."));
-    } else if (has_resist_elec(creature) && is_oppose_elec(creature)) {
+    } else if (creature.has_resist_elec() && is_oppose_elec(creature)) {
         self_ptr->info_list.emplace_back(_("あなたは電撃への強力な耐性を持っている。", "You resist lightning exceptionally well."));
-    } else if (has_resist_elec(creature) || is_oppose_elec(creature)) {
+    } else if (creature.has_resist_elec() || is_oppose_elec(creature)) {
         self_ptr->info_list.emplace_back(_("あなたは電撃への耐性を持っている。", "You are resistant to lightning."));
     }
 
-    if (race_tr_flags.has(TR_VUL_ELEC) && !has_immune_elec(creature)) {
+    if (race_tr_flags.has(TR_VUL_ELEC) && !creature.has_immune_elec()) {
         self_ptr->info_list.emplace_back(_("あなたは電撃に弱い。", "You are susceptible to damage from lightning."));
     }
 
-    if (has_immune_fire(creature)) {
+    if (creature.has_immune_fire()) {
         self_ptr->info_list.emplace_back(_("あなたは火に対する完全なる免疫を持っている。", "You are completely immune to fire."));
-    } else if (has_resist_fire(creature) && is_oppose_fire(creature)) {
+    } else if (creature.has_resist_fire() && is_oppose_fire(creature)) {
         self_ptr->info_list.emplace_back(_("あなたは火への強力な耐性を持っている。", "You resist fire exceptionally well."));
-    } else if (has_resist_fire(creature) || is_oppose_fire(creature)) {
+    } else if (creature.has_resist_fire() || is_oppose_fire(creature)) {
         self_ptr->info_list.emplace_back(_("あなたは火への耐性を持っている。", "You are resistant to fire."));
     }
 
-    if (race_tr_flags.has(TR_VUL_FIRE) && !has_immune_fire(creature)) {
+    if (race_tr_flags.has(TR_VUL_FIRE) && !creature.has_immune_fire()) {
         self_ptr->info_list.emplace_back(_("あなたは火に弱い。", "You are susceptible to damage from fire."));
     }
 
-    if (has_immune_cold(creature)) {
+    if (creature.has_immune_cold()) {
         self_ptr->info_list.emplace_back(_("あなたは冷気に対する完全なる免疫を持っている。", "You are completely immune to cold."));
-    } else if (has_resist_cold(creature) && is_oppose_cold(creature)) {
+    } else if (creature.has_resist_cold() && is_oppose_cold(creature)) {
         self_ptr->info_list.emplace_back(_("あなたは冷気への強力な耐性を持っている。", "You resist cold exceptionally well."));
-    } else if (has_resist_cold(creature) || is_oppose_cold(creature)) {
+    } else if (creature.has_resist_cold() || is_oppose_cold(creature)) {
         self_ptr->info_list.emplace_back(_("あなたは冷気への耐性を持っている。", "You are resistant to cold."));
     }
 
-    if (race_tr_flags.has(TR_VUL_COLD) && !has_immune_cold(creature)) {
+    if (race_tr_flags.has(TR_VUL_COLD) && !creature.has_immune_cold()) {
         self_ptr->info_list.emplace_back(_("あなたは冷気に弱い。", "You are susceptible to damage from cold."));
     }
 
-    if (has_resist_pois(creature) && is_oppose_pois(creature)) {
+    if (creature.has_resist_pois() && is_oppose_pois(creature)) {
         self_ptr->info_list.emplace_back(_("あなたは毒への強力な耐性を持っている。", "You resist poison exceptionally well."));
-    } else if (has_resist_pois(creature) || is_oppose_pois(creature)) {
+    } else if (creature.has_resist_pois() || is_oppose_pois(creature)) {
         self_ptr->info_list.emplace_back(_("あなたは毒への耐性を持っている。", "You are resistant to poison."));
     }
 }

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -154,7 +154,7 @@ int acid_dam(CreatureEntity &creature, int dam, std::string_view kb_str, bool au
     }
 
     if (aura || !check_multishadow(creature)) {
-        if ((!(double_resist || has_resist_acid(creature))) && one_in_(CHANCE_ABILITY_SCORE_DECREASE)) {
+        if ((!(double_resist || creature.has_resist_acid())) && one_in_(CHANCE_ABILITY_SCORE_DECREASE)) {
             (void)do_dec_stat(creature, A_CHR);
         }
 
@@ -164,7 +164,7 @@ int acid_dam(CreatureEntity &creature, int dam, std::string_view kb_str, bool au
     }
 
     int get_damage = take_hit(creature, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str);
-    if (!aura && !(double_resist && has_resist_acid(creature))) {
+    if (!aura && !(double_resist && creature.has_resist_acid())) {
         inventory_damage(creature, BreakerAcid(), inv);
     }
 
@@ -194,13 +194,13 @@ int elec_dam(CreatureEntity &creature, int dam, std::string_view kb_str, bool au
     }
 
     if (aura || !check_multishadow(creature)) {
-        if ((!(double_resist || has_resist_elec(creature))) && one_in_(CHANCE_ABILITY_SCORE_DECREASE)) {
+        if ((!(double_resist || creature.has_resist_elec())) && one_in_(CHANCE_ABILITY_SCORE_DECREASE)) {
             (void)do_dec_stat(creature, A_DEX);
         }
     }
 
     int get_damage = take_hit(creature, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str);
-    if (!aura && !(double_resist && has_resist_elec(creature))) {
+    if (!aura && !(double_resist && creature.has_resist_elec())) {
         inventory_damage(creature, BreakerElec(), inv);
     }
 
@@ -224,19 +224,19 @@ int fire_dam(CreatureEntity &creature, int dam, std::string_view kb_str, bool au
     bool double_resist = is_oppose_fire(creature);
 
     /* Totally immune */
-    if (has_immune_fire(creature) || (dam <= 0)) {
+    if (creature.has_immune_fire() || (dam <= 0)) {
         return 0;
     }
 
     dam = dam * calc_fire_damage_rate(creature) / 100;
     if (aura || !check_multishadow(creature)) {
-        if ((!(double_resist || has_resist_fire(creature))) && one_in_(CHANCE_ABILITY_SCORE_DECREASE)) {
+        if ((!(double_resist || creature.has_resist_fire())) && one_in_(CHANCE_ABILITY_SCORE_DECREASE)) {
             (void)do_dec_stat(creature, A_STR);
         }
     }
 
     int get_damage = take_hit(creature, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str);
-    if (!aura && !(double_resist && has_resist_fire(creature))) {
+    if (!aura && !(double_resist && creature.has_resist_fire())) {
         inventory_damage(creature, BreakerFire(), inv);
     }
 
@@ -258,19 +258,19 @@ int cold_dam(CreatureEntity &creature, int dam, std::string_view kb_str, bool au
     int inv = (dam < 30) ? 1 : (dam < 60) ? 2
                                           : 3;
     bool double_resist = is_oppose_cold(creature);
-    if (has_immune_cold(creature) || (dam <= 0)) {
+    if (creature.has_immune_cold() || (dam <= 0)) {
         return 0;
     }
 
     dam = dam * calc_cold_damage_rate(creature) / 100;
     if (aura || !check_multishadow(creature)) {
-        if ((!(double_resist || has_resist_cold(creature))) && one_in_(CHANCE_ABILITY_SCORE_DECREASE)) {
+        if ((!(double_resist || creature.has_resist_cold())) && one_in_(CHANCE_ABILITY_SCORE_DECREASE)) {
             (void)do_dec_stat(creature, A_STR);
         }
     }
 
     int get_damage = take_hit(creature, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str);
-    if (!aura && !(double_resist && has_resist_cold(creature))) {
+    if (!aura && !(double_resist && creature.has_resist_cold())) {
         inventory_damage(creature, BreakerCold(), inv);
     }
 
@@ -742,9 +742,9 @@ void touch_zap_player(const CreatureEntity &source, CreatureEntity &creature)
     constexpr auto fire_mes = _("突然とても熱くなった！", "You are suddenly very hot!");
     constexpr auto cold_mes = _("突然とても寒くなった！", "You are suddenly very cold!");
     constexpr auto elec_mes = _("電撃をくらった！", "You get zapped!");
-    process_aura_damage(source, creature, has_immune_fire(creature) != 0, MonsterAuraType::FIRE, fire_dam, fire_mes);
-    process_aura_damage(source, creature, has_immune_cold(creature) != 0, MonsterAuraType::COLD, cold_dam, cold_mes);
-    process_aura_damage(source, creature, has_immune_elec(creature) != 0, MonsterAuraType::ELEC, elec_dam, elec_mes);
+    process_aura_damage(source, creature, creature.has_immune_fire() != 0, MonsterAuraType::FIRE, fire_dam, fire_mes);
+    process_aura_damage(source, creature, creature.has_immune_cold() != 0, MonsterAuraType::COLD, cold_dam, cold_mes);
+    process_aura_damage(source, creature, creature.has_immune_elec() != 0, MonsterAuraType::ELEC, elec_dam, elec_mes);
 }
 
 /*!

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -336,12 +336,12 @@ bool trap_can_be_ignored(CreatureEntity &creature, FEAT_IDX feat)
         }
         break;
     case TrapType::FIRE:
-        if (has_immune_fire(creature)) {
+        if (creature.has_immune_fire()) {
             return true;
         }
         break;
     case TrapType::ACID:
-        if (has_immune_acid(creature)) {
+        if (creature.has_immune_acid()) {
             return true;
         }
         break;
@@ -356,7 +356,7 @@ bool trap_can_be_ignored(CreatureEntity &creature, FEAT_IDX feat)
         }
         break;
     case TrapType::POISON:
-        if (has_resist_pois(creature)) {
+        if (creature.has_resist_pois()) {
             return true;
         }
         break;

--- a/src/player/player-status-resist.cpp
+++ b/src/player/player-status-resist.cpp
@@ -57,11 +57,11 @@ PERCENTAGE calc_acid_damage_rate(CreatureEntity &creature)
 {
     PERCENTAGE per = 100;
 
-    if (has_immune_acid(creature)) {
+    if (creature.has_immune_acid()) {
         return 0;
     }
 
-    BIT_FLAGS flags = has_vuln_acid(creature);
+    BIT_FLAGS flags = creature.has_vuln_acid();
 
     for (BIT_FLAGS check_flag = 0x01U; check_flag < FLAG_CAUSE_MAX; check_flag <<= 1) {
         if (any_bits(flags, check_flag)) {
@@ -73,7 +73,7 @@ PERCENTAGE calc_acid_damage_rate(CreatureEntity &creature)
         }
     }
 
-    if (has_resist_acid(creature)) {
+    if (creature.has_resist_acid()) {
         per = (per + 2) / 3;
     }
     if (is_oppose_acid(creature)) {
@@ -90,11 +90,11 @@ PERCENTAGE calc_elec_damage_rate(CreatureEntity &creature)
 {
     PERCENTAGE per = 100;
 
-    if (has_immune_elec(creature)) {
+    if (creature.has_immune_elec()) {
         return 0;
     }
 
-    BIT_FLAGS flags = has_vuln_elec(creature);
+    BIT_FLAGS flags = creature.has_vuln_elec();
     for (BIT_FLAGS check_flag = 0x01U; check_flag < FLAG_CAUSE_MAX; check_flag <<= 1) {
         if (any_bits(flags, check_flag)) {
             if (check_flag == FLAG_CAUSE_MUTATION) {
@@ -105,7 +105,7 @@ PERCENTAGE calc_elec_damage_rate(CreatureEntity &creature)
         }
     }
 
-    if (has_resist_elec(creature)) {
+    if (creature.has_resist_elec()) {
         per = (per + 2) / 3;
     }
     if (is_oppose_elec(creature)) {
@@ -121,7 +121,7 @@ PERCENTAGE calc_elec_damage_rate(CreatureEntity &creature)
 PERCENTAGE calc_fire_damage_rate(CreatureEntity &creature)
 {
     PERCENTAGE per = 100;
-    BIT_FLAGS flags = has_vuln_fire(creature);
+    BIT_FLAGS flags = creature.has_vuln_fire();
     for (BIT_FLAGS check_flag = 0x01U; check_flag < FLAG_CAUSE_MAX; check_flag <<= 1) {
         if (any_bits(flags, check_flag)) {
             if (check_flag == FLAG_CAUSE_MUTATION) {
@@ -133,7 +133,7 @@ PERCENTAGE calc_fire_damage_rate(CreatureEntity &creature)
     }
 
     /* Resist the damage */
-    if (has_resist_fire(creature)) {
+    if (creature.has_resist_fire()) {
         per = (per + 2) / 3;
     }
     if (is_oppose_fire(creature)) {
@@ -157,7 +157,7 @@ PERCENTAGE calc_plasma_damage_rate(CreatureEntity &creature)
 PERCENTAGE calc_cold_damage_rate(CreatureEntity &creature)
 {
     PERCENTAGE per = 100;
-    BIT_FLAGS flags = has_vuln_cold(creature);
+    BIT_FLAGS flags = creature.has_vuln_cold();
     for (BIT_FLAGS check_flag = 0x01U; check_flag < FLAG_CAUSE_MAX; check_flag <<= 1) {
         if (any_bits(flags, check_flag)) {
             if (check_flag == FLAG_CAUSE_MUTATION) {
@@ -168,7 +168,7 @@ PERCENTAGE calc_cold_damage_rate(CreatureEntity &creature)
         }
     }
 
-    if (has_resist_cold(creature)) {
+    if (creature.has_resist_cold()) {
         per = (per + 2) / 3;
     }
     if (is_oppose_cold(creature)) {
@@ -184,7 +184,7 @@ PERCENTAGE calc_cold_damage_rate(CreatureEntity &creature)
 PERCENTAGE calc_pois_damage_rate(CreatureEntity &creature)
 {
     PERCENTAGE per = 100;
-    if (has_resist_pois(creature)) {
+    if (creature.has_resist_pois()) {
         per = (per + 2) / 3;
     }
     if (is_oppose_pois(creature)) {
@@ -200,7 +200,7 @@ PERCENTAGE calc_pois_damage_rate(CreatureEntity &creature)
 PERCENTAGE calc_nuke_damage_rate(CreatureEntity &creature)
 {
     PERCENTAGE per = 100;
-    if (has_resist_pois(creature)) {
+    if (creature.has_resist_pois()) {
         per = (2 * per + 2) / 5;
     }
     if (is_oppose_pois(creature)) {

--- a/src/player/temporary-resistances.cpp
+++ b/src/player/temporary-resistances.cpp
@@ -28,16 +28,16 @@ void tim_player_flags(CreatureEntity &creature, TrFlags &flags)
 
     flags.clear();
 
-    if (is_oppose_acid(creature) && none_bits(has_immune_acid(creature), (race_class_flag | tmp_effect_flag))) {
+    if (is_oppose_acid(creature) && none_bits(creature.has_immune_acid(), (race_class_flag | tmp_effect_flag))) {
         flags.set(TR_RES_ACID);
     }
-    if (is_oppose_elec(creature) && none_bits(has_immune_elec(creature), (race_class_flag | tmp_effect_flag))) {
+    if (is_oppose_elec(creature) && none_bits(creature.has_immune_elec(), (race_class_flag | tmp_effect_flag))) {
         flags.set(TR_RES_ELEC);
     }
-    if (is_oppose_fire(creature) && none_bits(has_immune_fire(creature), (race_class_flag | tmp_effect_flag))) {
+    if (is_oppose_fire(creature) && none_bits(creature.has_immune_fire(), (race_class_flag | tmp_effect_flag))) {
         flags.set(TR_RES_FIRE);
     }
-    if (is_oppose_cold(creature) && none_bits(has_immune_cold(creature), (race_class_flag | tmp_effect_flag))) {
+    if (is_oppose_cold(creature) && none_bits(creature.has_immune_cold(), (race_class_flag | tmp_effect_flag))) {
         flags.set(TR_RES_COLD);
     }
     if (is_oppose_pois(creature)) {

--- a/src/specific-object/death-scythe.cpp
+++ b/src/specific-object/death-scythe.cpp
@@ -90,23 +90,23 @@ static void compensate_death_scythe_reflection_magnification(CreatureEntity &cre
         *magnification = 20;
     }
 
-    if (!(has_resist_acid(creature) || is_oppose_acid(creature) || has_immune_acid(creature)) && (*magnification < 25)) {
+    if (!(creature.has_resist_acid() || is_oppose_acid(creature) || creature.has_immune_acid()) && (*magnification < 25)) {
         *magnification = 25;
     }
 
-    if (!(has_resist_elec(creature) || is_oppose_elec(creature) || has_immune_elec(creature)) && (*magnification < 25)) {
+    if (!(creature.has_resist_elec() || is_oppose_elec(creature) || creature.has_immune_elec()) && (*magnification < 25)) {
         *magnification = 25;
     }
 
-    if (!(has_resist_fire(creature) || is_oppose_fire(creature) || has_immune_fire(creature)) && (*magnification < 25)) {
+    if (!(creature.has_resist_fire() || is_oppose_fire(creature) || creature.has_immune_fire()) && (*magnification < 25)) {
         *magnification = 25;
     }
 
-    if (!(has_resist_cold(creature) || is_oppose_cold(creature) || has_immune_cold(creature)) && (*magnification < 25)) {
+    if (!(creature.has_resist_cold() || is_oppose_cold(creature) || creature.has_immune_cold()) && (*magnification < 25)) {
         *magnification = 25;
     }
 
-    if (!(has_resist_pois(creature) || is_oppose_pois(creature)) && (*magnification < 25)) {
+    if (!(creature.has_resist_pois() || is_oppose_pois(creature)) && (*magnification < 25)) {
         *magnification = 25;
     }
 


### PR DESCRIPTION
提案 4 の継続。以下 13 関数の call site を自由関数呼出から
virtual メンバ呼出形式に置換:

- has_resist_fire/cold/elec/acid/pois
- has_vuln_fire/cold/elec/acid
- has_immune_fire/cold/elec/acid

19 ファイル、118 箇所の置換。将来モンスターが種族フラグ由来の
耐性を持つ場合、MonsterProfile 側で override 可能。自由関数本体
(player-status-flags.cpp) は現状保持。