### PR TITLE
refactor(creature): 高級耐性の call site を virtual メンバ経由に移行

### DIFF
--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -285,7 +285,7 @@ static bool exe_eat_food_type_object(CreatureEntity &creature, const BaseitemKey
         }
         break;
     case SV_FOOD_BLINDNESS:
-        if (!has_resist_blind(creature)) {
+        if (!creature.has_resist_blind()) {
             if (bss.mod_blindness(randint0(200) + 200)) {
                 creature.plus_incident_tree("EAT_POISON", 1);
                 return true;
@@ -293,7 +293,7 @@ static bool exe_eat_food_type_object(CreatureEntity &creature, const BaseitemKey
         }
         break;
     case SV_FOOD_PARANOIA:
-        if (!has_resist_fear(creature)) {
+        if (!creature.has_resist_fear()) {
             if (bss.mod_fear(randint0(10) + 10)) {
                 creature.plus_incident_tree("EAT_POISON", 1);
                 return true;
@@ -301,7 +301,7 @@ static bool exe_eat_food_type_object(CreatureEntity &creature, const BaseitemKey
         }
         break;
     case SV_FOOD_CONFUSION:
-        if (!has_resist_conf(creature)) {
+        if (!creature.has_resist_conf()) {
             if (bss.mod_confusion(randint0(10) + 10)) {
                 creature.plus_incident_tree("EAT_POISON", 1);
                 return true;
@@ -309,7 +309,7 @@ static bool exe_eat_food_type_object(CreatureEntity &creature, const BaseitemKey
         }
         break;
     case SV_FOOD_HALLUCINATION:
-        if (!has_resist_chaos(creature)) {
+        if (!creature.has_resist_chaos()) {
             if (bss.mod_hallucination(randint0(250) + 250)) {
                 creature.plus_incident_tree("EAT_POISON", 1);
                 return true;

--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -65,7 +65,7 @@ int staff_effect(CreatureEntity &creature, int sval, bool *use_charge, bool powe
     BadStatusSetter bss(creature);
     switch (sval) {
     case SV_STAFF_DARKNESS:
-        if (!has_resist_blind(creature) && !has_resist_dark(creature)) {
+        if (!creature.has_resist_blind() && !creature.has_resist_dark()) {
             if (bss.mod_blindness(3 + randint1(5))) {
                 ident = true;
             }

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -155,7 +155,7 @@ void effect_player_plasma(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 
-    if (!has_resist_sound(creature) && !check_multishadow(creature)) {
+    if (!creature.has_resist_sound() && !check_multishadow(creature)) {
         const auto plus_stun = randnum1<short>((ep_ptr->dam > 40) ? 35 : (ep_ptr->dam * 3 / 4 + 5));
         (void)BadStatusSetter(creature).mod_stun(plus_stun);
     }
@@ -191,7 +191,7 @@ void effect_player_nether(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     ep_ptr->dam = ep_ptr->dam * calc_nether_damage_rate(creature, CALC_RAND) / 100;
 
-    if (!has_resist_neth(creature) && !evaded) {
+    if (!creature.has_resist_neth() && !evaded) {
         drain_exp(creature, 200 + (creature.exp / 100), 200 + (creature.exp / 1000), 75);
     }
 
@@ -218,14 +218,14 @@ void effect_player_water(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     ep_ptr->dam = ep_ptr->dam * calc_water_damage_rate(creature, CALC_RAND) / 100;
 
-    BIT_FLAGS has_res_water = has_resist_water(creature);
+    BIT_FLAGS has_res_water = creature.has_resist_water();
     BadStatusSetter bss(creature);
     if (!check_multishadow(creature)) {
-        if (!has_resist_sound(creature) && !has_res_water) {
+        if (!creature.has_resist_sound() && !has_res_water) {
             (void)bss.mod_stun(randnum1<short>(40));
         }
 
-        if (!has_resist_conf(creature) && !has_res_water) {
+        if (!creature.has_resist_conf() && !has_res_water) {
             (void)bss.mod_confusion(randint1(5) + 5);
         }
 
@@ -250,22 +250,22 @@ void effect_player_chaos(CreatureEntity &creature, EffectPlayerType *ep_ptr)
     }
 
     BadStatusSetter bss(creature);
-    if (!has_resist_conf(creature) && !has_resist_chaos(creature)) {
+    if (!creature.has_resist_conf() && !creature.has_resist_chaos()) {
         (void)bss.mod_confusion(randint0(20) + 10);
     }
 
-    if (!has_resist_chaos(creature)) {
+    if (!creature.has_resist_chaos()) {
         (void)bss.mod_hallucination(randnum1<short>(10));
         if (one_in_(3)) {
             msg_print(_("あなたの身体はカオスの力で捻じ曲げられた！", "Your body is twisted by chaos!"));
             (void)gain_mutation(creature, 0);
         }
     }
-    if (!has_resist_neth(creature) && !has_resist_chaos(creature)) {
+    if (!creature.has_resist_neth() && !creature.has_resist_chaos()) {
         drain_exp(creature, 5000 + (creature.exp / 100), 500 + (creature.exp / 1000), 75);
     }
 
-    if (!has_resist_chaos(creature) || one_in_(9)) {
+    if (!creature.has_resist_chaos() || one_in_(9)) {
         inventory_damage(creature, BreakerElec(), 2);
         inventory_damage(creature, BreakerFire(), 2);
     }
@@ -281,11 +281,11 @@ void effect_player_shards(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     ep_ptr->dam = ep_ptr->dam * calc_shards_damage_rate(creature, CALC_RAND) / 100;
 
-    if (!has_resist_shard(creature) && !check_multishadow(creature)) {
+    if (!creature.has_resist_shard() && !check_multishadow(creature)) {
         (void)BadStatusSetter(creature).mod_cut(static_cast<TIME_EFFECT>(ep_ptr->dam));
     }
 
-    if (!has_resist_shard(creature) || one_in_(13)) {
+    if (!creature.has_resist_shard() || one_in_(13)) {
         inventory_damage(creature, BreakerCold(), 2);
     }
 
@@ -300,12 +300,12 @@ void effect_player_sound(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     ep_ptr->dam = ep_ptr->dam * calc_sound_damage_rate(creature, CALC_RAND) / 100;
 
-    if (!has_resist_sound(creature) && !check_multishadow(creature)) {
+    if (!creature.has_resist_sound() && !check_multishadow(creature)) {
         const auto plus_stun = randnum1<short>((ep_ptr->dam > 90) ? 35 : (ep_ptr->dam / 3 + 5));
         (void)BadStatusSetter(creature).mod_stun(plus_stun);
     }
 
-    if (!has_resist_sound(creature) || one_in_(13)) {
+    if (!creature.has_resist_sound() || one_in_(13)) {
         inventory_damage(creature, BreakerCold(), 2);
     }
 
@@ -320,7 +320,7 @@ void effect_player_confusion(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     ep_ptr->dam = ep_ptr->dam * calc_conf_damage_rate(creature, CALC_RAND) / 100;
     BadStatusSetter bss(creature);
-    if (!has_resist_conf(creature) && !check_multishadow(creature)) {
+    if (!creature.has_resist_conf() && !check_multishadow(creature)) {
         (void)bss.mod_confusion(randint1(20) + 10);
     }
 
@@ -335,7 +335,7 @@ void effect_player_disenchant(CreatureEntity &creature, EffectPlayerType *ep_ptr
 
     ep_ptr->dam = ep_ptr->dam * calc_disenchant_damage_rate(creature, CALC_RAND) / 100;
 
-    if (!has_resist_disen(creature) && !check_multishadow(creature)) {
+    if (!creature.has_resist_disen() && !check_multishadow(creature)) {
         (void)apply_disenchant(creature, 0);
     }
 
@@ -350,7 +350,7 @@ void effect_player_nexus(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     ep_ptr->dam = ep_ptr->dam * calc_nexus_damage_rate(creature, CALC_RAND) / 100;
 
-    if (!has_resist_shard(creature) && !check_multishadow(creature)) {
+    if (!creature.has_resist_shard() && !check_multishadow(creature)) {
         apply_nexus(*ep_ptr->m_ptr, creature);
     }
 
@@ -362,7 +362,7 @@ void effect_player_force(CreatureEntity &creature, EffectPlayerType *ep_ptr)
     if (creature.is_blind()) {
         msg_print(_("運動エネルギーで攻撃された！", "You are hit by kinetic force!"));
     }
-    if (!has_resist_sound(creature) && !check_multishadow(creature)) {
+    if (!creature.has_resist_sound() && !check_multishadow(creature)) {
         (void)BadStatusSetter(creature).mod_stun(randnum1<short>(20));
     }
 
@@ -376,16 +376,16 @@ void effect_player_rocket(CreatureEntity &creature, EffectPlayerType *ep_ptr)
     }
 
     BadStatusSetter bss(creature);
-    if (!has_resist_sound(creature) && !check_multishadow(creature)) {
+    if (!creature.has_resist_sound() && !check_multishadow(creature)) {
         (void)bss.mod_stun(randnum1<short>(20));
     }
 
     ep_ptr->dam = ep_ptr->dam * calc_rocket_damage_rate(creature, CALC_RAND) / 100;
-    if (!has_resist_shard(creature) && !check_multishadow(creature)) {
+    if (!creature.has_resist_shard() && !check_multishadow(creature)) {
         (void)bss.mod_cut((ep_ptr->dam / 2));
     }
 
-    if (!has_resist_shard(creature) || one_in_(12)) {
+    if (!creature.has_resist_shard() || one_in_(12)) {
         inventory_damage(creature, BreakerCold(), 3);
     }
 
@@ -412,7 +412,7 @@ void effect_player_lite(CreatureEntity &creature, EffectPlayerType *ep_ptr)
         msg_print(_("何かで攻撃された！", "You are hit by something!"));
     }
 
-    if (!is_blind && !has_resist_lite(creature) && !has_resist_blind(creature) && !check_multishadow(creature)) {
+    if (!is_blind && !creature.has_resist_lite() && !creature.has_resist_blind() && !check_multishadow(creature)) {
         (void)BadStatusSetter(creature).mod_blindness(randint1(5) + 2);
     }
 
@@ -458,8 +458,8 @@ void effect_player_dark(CreatureEntity &creature, EffectPlayerType *ep_ptr)
     ep_ptr->dam = ep_ptr->dam * calc_dark_damage_rate(creature, CALC_RAND) / 100;
 
     auto go_blind = !is_blind;
-    go_blind &= !has_resist_blind(creature);
-    go_blind &= !(has_resist_dark(creature) || has_immune_dark(creature));
+    go_blind &= !creature.has_resist_blind();
+    go_blind &= !(creature.has_resist_dark() || has_immune_dark(creature));
     go_blind &= !check_multishadow(creature);
 
     if (go_blind) {
@@ -512,13 +512,13 @@ void effect_player_time(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     bool evaded = check_multishadow(creature);
 
-    if (has_resist_time(creature) && !evaded) {
+    if (creature.has_resist_time() && !evaded) {
         msg_print(_("時間が通り過ぎていく気がする。", "You feel as if time is passing you by."));
     }
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 
-    if (!has_resist_time(creature) && !evaded) {
+    if (!creature.has_resist_time() && !evaded) {
         effect_player_time_addition(creature);
     }
 }
@@ -538,7 +538,7 @@ void effect_player_gravity(CreatureEntity &creature, EffectPlayerType *ep_ptr)
             (void)bss.mod_deceleration(randint0(4) + 4, false);
         }
 
-        if (!(has_resist_sound(creature) || creature.has_levitation())) {
+        if (!(creature.has_resist_sound() || creature.has_levitation())) {
             const auto plus_stun = randnum1<short>((ep_ptr->dam > 90) ? 35 : (ep_ptr->dam / 3 + 5));
             (void)bss.mod_stun(plus_stun);
         }
@@ -596,7 +596,7 @@ void effect_player_meteor(CreatureEntity &creature, EffectPlayerType *ep_ptr)
     }
 
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
-    if (!has_resist_shard(creature) || one_in_(13)) {
+    if (!creature.has_resist_shard() || one_in_(13)) {
         if (!creature.has_immune_fire()) {
             inventory_damage(creature, BreakerFire(), 2);
         }
@@ -616,11 +616,11 @@ void effect_player_icee(CreatureEntity &creature, EffectPlayerType *ep_ptr)
     }
 
     BadStatusSetter bss(creature);
-    if (!has_resist_shard(creature)) {
+    if (!creature.has_resist_shard()) {
         (void)bss.mod_cut(static_cast<TIME_EFFECT>(Dice::roll(5, 8)));
     }
 
-    if (!has_resist_sound(creature)) {
+    if (!creature.has_resist_sound()) {
         (void)bss.mod_stun(randnum1<short>(15));
     }
 
@@ -686,15 +686,15 @@ void effect_player_abyss(CreatureEntity &creature, EffectPlayerType *ep_ptr)
     }
 
     msg_print(_("深淵から何かがあなたを覗き込んでいる！", "Something gazes at you from the abyss!"));
-    if (!has_resist_chaos(creature)) {
+    if (!creature.has_resist_chaos()) {
         (void)bss.mod_hallucination(randnum1<short>(10));
     }
 
-    if (!has_resist_conf(creature)) {
+    if (!creature.has_resist_conf()) {
         (void)bss.mod_confusion(randnum1<short>(10));
     }
 
-    if (!has_resist_fear(creature)) {
+    if (!creature.has_resist_fear()) {
         (void)bss.mod_fear(randnum1<short>(10));
     }
     ep_ptr->get_damage = take_hit(creature, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -85,11 +85,11 @@ void effect_player_mind_blast(CreatureEntity &creature, EffectPlayerType *ep_ptr
 
     msg_print(_("霊的エネルギーで精神が攻撃された。", "Your mind is blasted by psionic energy."));
     BadStatusSetter bss(creature);
-    if (!has_resist_conf(creature)) {
+    if (!creature.has_resist_conf()) {
         (void)bss.mod_confusion(randint0(4) + 4);
     }
 
-    if (!has_resist_chaos(creature) && one_in_(3)) {
+    if (!creature.has_resist_chaos() && one_in_(3)) {
         (void)bss.mod_hallucination(randint0(250) + 150);
     }
 
@@ -127,11 +127,11 @@ void effect_player_brain_smash(CreatureEntity &creature, EffectPlayerType *ep_pt
     }
 
     BadStatusSetter bss(creature);
-    if (!has_resist_blind(creature)) {
+    if (!creature.has_resist_blind()) {
         (void)bss.mod_blindness(8 + randint0(8));
     }
 
-    if (!has_resist_conf(creature)) {
+    if (!creature.has_resist_conf()) {
         (void)bss.mod_confusion(randint0(4) + 4);
     }
 
@@ -148,7 +148,7 @@ void effect_player_brain_smash(CreatureEntity &creature, EffectPlayerType *ep_pt
         (void)do_dec_stat(creature, A_WIS);
     }
 
-    if (!has_resist_chaos(creature)) {
+    if (!creature.has_resist_chaos()) {
         (void)bss.mod_hallucination(randint0(250) + 150);
     }
 }

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -389,14 +389,14 @@ void hit_trap(CreatureEntity &creature, bool break_trap)
         break;
     case TrapType::BLIND:
         msg_print(_("黒いガスに包み込まれた！", "A black gas surrounds you!"));
-        if (has_resist_blind(creature) == 0) {
+        if (creature.has_resist_blind() == 0) {
             (void)BadStatusSetter(creature).mod_blindness(randint0(50) + 25);
         }
 
         break;
     case TrapType::CONFUSE:
         msg_print(_("きらめくガスに包み込まれた！", "A gas of scintillating colors surrounds you!"));
-        if (has_resist_conf(creature) == 0) {
+        if (creature.has_resist_conf() == 0) {
             (void)BadStatusSetter(creature).mod_confusion(randint0(20) + 10);
         }
 

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -140,7 +140,7 @@ void process_player_hp_mp(CreatureEntity &creature)
 
     const CreatureRace race(&creature);
     if (race.life() == PlayerRaceLifeType::UNDEAD && race.tr_flags().has(TR_VUL_LITE)) {
-        if (!floor.is_underground() && !has_resist_lite(creature) && !creature.is_invulnerable() && AngbandWorld::get_instance().is_daytime()) {
+        if (!floor.is_underground() && !creature.has_resist_lite() && !creature.is_invulnerable() && AngbandWorld::get_instance().is_daytime()) {
             if ((floor.grid_array[creature.y][creature.x].info & (CAVE_GLOW | CAVE_MNDK)) == CAVE_GLOW) {
                 msg_print(_("日光があなたのアンデッドの肉体を焼き焦がした！", "The sun's rays scorch your undead flesh!"));
                 take_hit(creature, DAMAGE_NOESCAPE, 1, _("日光", "sunlight"));
@@ -150,7 +150,7 @@ void process_player_hp_mp(CreatureEntity &creature)
 
         const auto &item = *creature.inventory[INVEN_LITE];
         const auto flags = item.get_flags();
-        if ((creature.inventory[INVEN_LITE]->bi_key.tval() != ItemKindType::NONE) && flags.has_not(TR_DARK_SOURCE) && !has_resist_lite(creature)) {
+        if ((creature.inventory[INVEN_LITE]->bi_key.tval() != ItemKindType::NONE) && flags.has_not(TR_DARK_SOURCE) && !creature.has_resist_lite()) {
             const auto item_name = describe_flavor(creature, item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
             msg_format(_("%sがあなたのアンデッドの肉体を焼き焦がした！", "The %s scorches your undead flesh!"), item_name.data());
             cave_no_regen = true;
@@ -223,7 +223,7 @@ void process_player_hp_mp(CreatureEntity &creature)
     }
 
     const auto can_drown = terrain.flags.has_all_of({ TerrainCharacteristics::WATER, TerrainCharacteristics::DEEP });
-    if (can_drown && !creature.has_levitation() && !creature.has_can_swim() && !has_resist_water(creature)) {
+    if (can_drown && !creature.has_levitation() && !creature.has_can_swim() && !creature.has_resist_water()) {
         if (calc_inventory_weight(creature) > calc_weight_limit(creature)) {
             msg_print(_("溺れている！", "You are drowning!"));
             take_hit(creature, DAMAGE_NOESCAPE, randint1(creature.level), _("溺れ", "drowning"));

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -380,7 +380,7 @@ static void curse_cowardice(CreatureEntity &creature)
         duration *= 2;
     }
 
-    if (!one_in_(chance) || (has_resist_fear(creature) != 0)) {
+    if (!one_in_(chance) || (creature.has_resist_fear() != 0)) {
         return;
     }
 
@@ -520,7 +520,7 @@ static void occur_curse_effects(CreatureEntity &creature)
 void execute_cursed_items_effect(CreatureEntity &creature)
 {
     occur_curse_effects(creature);
-    if (!one_in_(999) || creature.has_anti_magic() || (one_in_(2) && has_resist_curse(creature))) {
+    if (!one_in_(999) || creature.has_anti_magic() || (one_in_(2) && creature.has_resist_curse())) {
         return;
     }
 

--- a/src/monster-attack/monster-attack-status.cpp
+++ b/src/monster-attack/monster-attack-status.cpp
@@ -22,7 +22,7 @@
 
 void process_blind_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    if (has_resist_blind(creature) || check_multishadow(creature)) {
+    if (creature.has_resist_blind() || check_multishadow(creature)) {
         return;
     }
 
@@ -52,7 +52,7 @@ void process_terrify_attack(CreatureEntity &creature, MonsterAttackPlayer *monap
     }
 
     const auto &monrace = monap_ptr->m_ptr->get_monrace();
-    if (has_resist_fear(creature)) {
+    if (creature.has_resist_fear()) {
         msg_print(_("しかし恐怖に侵されなかった！", "You stand your ground!"));
         monap_ptr->obvious = true;
         return;
@@ -123,7 +123,7 @@ void process_lose_all_attack(CreatureEntity &creature, MonsterAttackPlayer *mona
 
 void process_stun_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    if (has_resist_sound(creature) || check_multishadow(creature)) {
+    if (creature.has_resist_sound() || check_multishadow(creature)) {
         return;
     }
 
@@ -161,7 +161,7 @@ void process_groin_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_p
 
 void process_monster_attack_time(CreatureEntity &creature)
 {
-    if (has_resist_time(creature) || check_multishadow(creature)) {
+    if (creature.has_resist_time() || check_multishadow(creature)) {
         return;
     }
 

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -69,12 +69,12 @@ static void calc_blow_disenchant(CreatureEntity &creature, MonsterAttackPlayer *
         return;
     }
 
-    if (!has_resist_disen(creature) && !check_multishadow(creature) && apply_disenchant(creature, 0)) {
+    if (!creature.has_resist_disen() && !check_multishadow(creature) && apply_disenchant(creature, 0)) {
         update_creature(creature);
         monap_ptr->obvious = true;
     }
 
-    if (has_resist_disen(creature)) {
+    if (creature.has_resist_disen()) {
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 4) / 9;
     }
 
@@ -131,7 +131,7 @@ static void calc_blow_un_power(CreatureEntity &creature, MonsterAttackPlayer *mo
  */
 static void calc_blow_blind(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    if (has_resist_blind(creature)) {
+    if (creature.has_resist_blind()) {
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 3) / 8;
     }
 
@@ -155,7 +155,7 @@ static void calc_blow_confusion(CreatureEntity &creature, MonsterAttackPlayer *m
         return;
     }
 
-    if (has_resist_conf(creature)) {
+    if (creature.has_resist_conf()) {
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 3) / 8;
     }
 
@@ -164,7 +164,7 @@ static void calc_blow_confusion(CreatureEntity &creature, MonsterAttackPlayer *m
         return;
     }
 
-    if (!has_resist_conf(creature) && !check_multishadow(creature) && BadStatusSetter(creature).mod_confusion(3 + randint1(monap_ptr->rlev))) {
+    if (!creature.has_resist_conf() && !check_multishadow(creature) && BadStatusSetter(creature).mod_confusion(3 + randint1(monap_ptr->rlev))) {
         monap_ptr->obvious = true;
     }
 
@@ -178,7 +178,7 @@ static void calc_blow_confusion(CreatureEntity &creature, MonsterAttackPlayer *m
  */
 static void calc_blow_fear(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    if (has_resist_fear(creature)) {
+    if (creature.has_resist_fear()) {
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 3) / 8;
     }
 
@@ -225,7 +225,7 @@ static void calc_blow_drain_exp(CreatureEntity &creature, MonsterAttackPlayer *m
         damage_ratio -= 75;
     }
 
-    if (has_resist_neth(creature)) {
+    if (creature.has_resist_neth()) {
         damage_ratio -= 75;
     }
 
@@ -250,7 +250,7 @@ static void calc_blow_time(CreatureEntity &creature, MonsterAttackPlayer *monap_
     }
 
     process_monster_attack_time(creature);
-    if (has_resist_time(creature)) {
+    if (creature.has_resist_time()) {
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 4) / 9;
     }
 
@@ -542,7 +542,7 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
         monap_ptr->damage = monap_ptr->damage * calc_chaos_damage_rate(creature, CALC_RAND) / 100;
         monap_ptr->get_damage += take_hit(creature, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, monap_ptr->m_ptr->r_idx);
 
-        const auto has_chaos_resist = has_resist_chaos(creature);
+        const auto has_chaos_resist = creature.has_resist_chaos();
 
         if (!has_chaos_resist) {
             monap_ptr->obvious = true;
@@ -578,7 +578,7 @@ void switch_monster_blow_to_player(CreatureEntity &creature, MonsterAttackPlayer
             }
             monap_ptr->obvious = true;
 
-            if (!has_chaos_resist && !has_resist_conf(creature) && !check_multishadow(creature) && BadStatusSetter(creature).mod_confusion(3 + randint1(monap_ptr->rlev))) {
+            if (!has_chaos_resist && !creature.has_resist_conf() && !check_multishadow(creature) && BadStatusSetter(creature).mod_confusion(3 + randint1(monap_ptr->rlev))) {
                 monap_ptr->obvious = true;
             }
             break;

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -356,7 +356,7 @@ bool set_monster_timewalk(CreatureEntity &creature, MONSTER_IDX m_idx, int num, 
         msg_erase();
     }
 
-    if (has_resist_time(creature)) {
+    if (creature.has_resist_time()) {
         msg_print(_("しかし、あなたは時を止める力を打ち消した！", "But, you have countered power of time stop!"));
         return false;
     }

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -714,67 +714,67 @@ void update_smart_learn(CreatureEntity &creature, MONSTER_IDX m_idx, int what)
 
         break;
     case DRS_NETH:
-        if (has_resist_neth(creature)) {
+        if (creature.has_resist_neth()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_NETH);
         }
 
         break;
     case DRS_LITE:
-        if (has_resist_lite(creature)) {
+        if (creature.has_resist_lite()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_LITE);
         }
 
         break;
     case DRS_DARK:
-        if (has_resist_dark(creature) || has_immune_dark(creature)) {
+        if (creature.has_resist_dark() || has_immune_dark(creature)) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_DARK);
         }
 
         break;
     case DRS_FEAR:
-        if (has_resist_fear(creature)) {
+        if (creature.has_resist_fear()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_FEAR);
         }
 
         break;
     case DRS_CONF:
-        if (has_resist_conf(creature)) {
+        if (creature.has_resist_conf()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_CONF);
         }
 
         break;
     case DRS_CHAOS:
-        if (has_resist_chaos(creature)) {
+        if (creature.has_resist_chaos()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_CHAOS);
         }
 
         break;
     case DRS_DISEN:
-        if (has_resist_disen(creature)) {
+        if (creature.has_resist_disen()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_DISEN);
         }
 
         break;
     case DRS_BLIND:
-        if (has_resist_blind(creature)) {
+        if (creature.has_resist_blind()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_BLIND);
         }
 
         break;
     case DRS_NEXUS:
-        if (has_resist_shard(creature)) {
+        if (creature.has_resist_shard()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_NEXUS);
         }
 
         break;
     case DRS_SOUND:
-        if (has_resist_sound(creature)) {
+        if (creature.has_resist_sound()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_SOUND);
         }
 
         break;
     case DRS_SHARD:
-        if (has_resist_shard(creature)) {
+        if (creature.has_resist_shard()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_SHARD);
         }
 

--- a/src/mspell/high-resistance-checker.cpp
+++ b/src/mspell/high-resistance-checker.cpp
@@ -10,47 +10,47 @@
 
 void add_cheat_remove_flags_others(CreatureEntity &creature, msr_type *msr_ptr)
 {
-    if (has_resist_neth(creature)) {
+    if (creature.has_resist_neth()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_NETH);
     }
 
-    if (has_resist_lite(creature)) {
+    if (creature.has_resist_lite()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_LITE);
     }
 
-    if (has_resist_dark(creature)) {
+    if (creature.has_resist_dark()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_DARK);
     }
 
-    if (has_resist_fear(creature)) {
+    if (creature.has_resist_fear()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_FEAR);
     }
 
-    if (has_resist_conf(creature)) {
+    if (creature.has_resist_conf()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_CONF);
     }
 
-    if (has_resist_chaos(creature)) {
+    if (creature.has_resist_chaos()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_CHAOS);
     }
 
-    if (has_resist_disen(creature)) {
+    if (creature.has_resist_disen()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_DISEN);
     }
 
-    if (has_resist_blind(creature)) {
+    if (creature.has_resist_blind()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_BLIND);
     }
 
-    if (has_resist_shard(creature)) {
+    if (creature.has_resist_shard()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_NEXUS);
     }
 
-    if (has_resist_sound(creature)) {
+    if (creature.has_resist_sound()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_SOUND);
     }
 
-    if (has_resist_shard(creature)) {
+    if (creature.has_resist_shard()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_SHARD);
     }
 

--- a/src/mspell/mspell-floor.cpp
+++ b/src/mspell/mspell-floor.cpp
@@ -329,7 +329,7 @@ MonsterSpellResult spell_RF6_TELE_LEVEL(CreatureEntity &creature, MONSTER_IDX m_
     bool resist, saving_throw;
 
     if (target_type == MONSTER_TO_PLAYER) {
-        resist = (has_resist_shard(creature) != 0);
+        resist = (creature.has_resist_shard() != 0);
         saving_throw = (randint0(100 + rlev / 2) < creature.get_skill_save());
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^が何か奇妙な言葉をつぶやいた。", "%s^ mumbles strangely."),

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -254,7 +254,7 @@ MonsterSpellResult spell_RF5_SCARE(MONSTER_IDX m_idx, CreatureEntity &creature, 
     bool resist, saving_throw;
 
     if (target_type == MONSTER_TO_PLAYER) {
-        resist = (has_resist_fear(creature) != 0);
+        resist = (creature.has_resist_fear() != 0);
         saving_throw = (randint0(100 + rlev / 2) < creature.get_skill_save());
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^が何かをつぶやくと、恐ろしげな音が聞こえた。", "%s^ mumbles, and you hear scary noises."),
@@ -311,7 +311,7 @@ MonsterSpellResult spell_RF5_BLIND(MONSTER_IDX m_idx, CreatureEntity &creature, 
     bool resist, saving_throw;
 
     if (target_type == MONSTER_TO_PLAYER) {
-        resist = (has_resist_blind(creature) != 0);
+        resist = (creature.has_resist_blind() != 0);
         saving_throw = (randint0(100 + rlev / 2) < creature.get_skill_save());
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
@@ -376,7 +376,7 @@ MonsterSpellResult spell_RF5_CONF(MONSTER_IDX m_idx, CreatureEntity &creature, M
     bool resist, saving_throw;
 
     if (target_type == MONSTER_TO_PLAYER) {
-        resist = (has_resist_conf(creature) != 0);
+        resist = (creature.has_resist_conf() != 0);
         saving_throw = (randint0(100 + rlev / 2) < creature.get_skill_save());
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^が何かをつぶやくと、頭を悩ます音がした。", "%s^ mumbles, and you hear puzzling noises."),
@@ -522,7 +522,7 @@ MonsterSpellResult spell_RF5_SLOW(MONSTER_IDX m_idx, CreatureEntity &creature, M
     bool resist, saving_throw;
 
     if (target_type == MONSTER_TO_PLAYER) {
-        resist = (has_resist_conf(creature) != 0);
+        resist = (creature.has_resist_conf() != 0);
         saving_throw = (randint0(100 + rlev / 2) < creature.get_skill_save());
 
         mspell_cast_msg_bad_status_to_player msg(_("%s^があなたの筋力を吸い取ろうとした！", "%s^ drains power from your muscles!"),

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -115,7 +115,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
     }
 
     if (creature.get_mutations().has(PlayerMutationType::COWARDICE) && (randint1(3000) == 13)) {
-        if (!has_resist_fear(creature)) {
+        if (!creature.has_resist_fear()) {
             disturb(creature, false, true);
             msg_print(_("とても暗い... とても恐い！", "It's so dark... so scary!"));
             (void)bss.mod_fear(13 + randint1(26));
@@ -123,7 +123,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
     }
 
     if (creature.get_mutations().has(PlayerMutationType::RTELEPORT) && (randint1(5000) == 88)) {
-        if (!has_resist_shard(creature) && creature.get_mutations().has_not(PlayerMutationType::VTELEPORT) && !creature.has_anti_tele()) {
+        if (!creature.has_resist_shard() && creature.get_mutations().has_not(PlayerMutationType::VTELEPORT) && !creature.has_anti_tele()) {
             disturb(creature, false, true);
             msg_print(_("あなたの位置は突然ひじょうに不確定になった...", "Your position suddenly seems very uncertain..."));
             msg_erase();
@@ -132,17 +132,17 @@ void process_world_aux_mutation(CreatureEntity &creature)
     }
 
     if (creature.get_mutations().has(PlayerMutationType::ALCOHOL) && (randint1(6400) == 321)) {
-        if (!has_resist_conf(creature) && !has_resist_chaos(creature)) {
+        if (!creature.has_resist_conf() && !creature.has_resist_chaos()) {
             disturb(creature, false, true);
             RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::EXTRA);
             msg_print(_("いひきがもーろーとひてきたきがふる...ヒック！", "You feel a SSSCHtupor cOmINg over yOu... *HIC*!"));
         }
 
-        if (!has_resist_conf(creature)) {
+        if (!creature.has_resist_conf()) {
             (void)bss.mod_confusion(randint0(20) + 15);
         }
 
-        if (!has_resist_chaos(creature)) {
+        if (!creature.has_resist_chaos()) {
             if (one_in_(20)) {
                 msg_erase();
                 if (one_in_(3)) {
@@ -164,7 +164,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
     }
 
     if (creature.get_mutations().has(PlayerMutationType::HALLU) && (randint1(6400) == 42)) {
-        if (!has_resist_chaos(creature)) {
+        if (!creature.has_resist_chaos()) {
             disturb(creature, false, true);
             RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::EXTRA);
             (void)bss.mod_hallucination(randint0(50) + 20);

--- a/src/player-info/body-improvement-info.cpp
+++ b/src/player-info/body-improvement-info.cpp
@@ -89,7 +89,7 @@ void set_body_improvement_info_3(CreatureEntity &creature, self_info_type *self_
         self_ptr->info_list.emplace_back(_("あなたは矢の呪文を反射する。", "You reflect bolt spells."));
     }
 
-    if (has_resist_curse(creature)) {
+    if (creature.has_resist_curse()) {
         self_ptr->info_list.emplace_back(_("あなたはより強く呪いに抵抗できる。", "You can resist curses powerfully."));
     }
 
@@ -157,15 +157,15 @@ void set_body_improvement_info_3(CreatureEntity &creature, self_info_type *self_
 /*!< @todo 並び順の都合で連番を付ける。まとめても良いならまとめてしまう予定 */
 void set_body_improvement_info_4(CreatureEntity &creature, self_info_type *self_ptr)
 {
-    if (has_resist_fear(creature)) {
+    if (creature.has_resist_fear()) {
         self_ptr->info_list.emplace_back(_("あなたは全く恐怖を感じない。", "You are completely fearless."));
     }
 
-    if (has_resist_blind(creature)) {
+    if (creature.has_resist_blind()) {
         self_ptr->info_list.emplace_back(_("あなたの目は盲目への耐性を持っている。", "Your eyes are resistant to blindness."));
     }
 
-    if (has_resist_time(creature)) {
+    if (creature.has_resist_time()) {
         self_ptr->info_list.emplace_back(_("あなたは時間逆転への耐性を持っている。", "You are resistant to time."));
     }
 }

--- a/src/player-info/resistance-info.cpp
+++ b/src/player-info/resistance-info.cpp
@@ -67,7 +67,7 @@ void set_element_resistance_info(CreatureEntity &creature, self_info_type *self_
 
 void set_high_resistance_info(CreatureEntity &creature, self_info_type *self_ptr)
 {
-    if (has_resist_lite(creature)) {
+    if (creature.has_resist_lite()) {
         self_ptr->info_list.emplace_back(_("あなたは閃光への耐性を持っている。", "You are resistant to bright light."));
     }
 
@@ -77,37 +77,37 @@ void set_high_resistance_info(CreatureEntity &creature, self_info_type *self_ptr
 
     if (has_immune_dark(creature) || creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
         self_ptr->info_list.emplace_back(_("あなたは暗黒に対する完全なる免疫を持っている。", "You are completely immune to darkness."));
-    } else if (has_resist_dark(creature)) {
+    } else if (creature.has_resist_dark()) {
         self_ptr->info_list.emplace_back(_("あなたは暗黒への耐性を持っている。", "You are resistant to darkness."));
     }
 
-    if (has_resist_conf(creature)) {
+    if (creature.has_resist_conf()) {
         self_ptr->info_list.emplace_back(_("あなたは混乱への耐性を持っている。", "You are resistant to confusion."));
     }
 
-    if (has_resist_sound(creature)) {
+    if (creature.has_resist_sound()) {
         self_ptr->info_list.emplace_back(_("あなたは音波の衝撃への耐性を持っている。", "You are resistant to sonic attacks."));
     }
 
-    if (has_resist_disen(creature)) {
+    if (creature.has_resist_disen()) {
         self_ptr->info_list.emplace_back(_("あなたは劣化への耐性を持っている。", "You are resistant to disenchantment."));
     }
 
-    if (has_resist_chaos(creature)) {
+    if (creature.has_resist_chaos()) {
         self_ptr->info_list.emplace_back(_("あなたはカオスの力への耐性を持っている。", "You are resistant to chaos."));
     }
 
-    if (has_resist_shard(creature)) {
+    if (creature.has_resist_shard()) {
         self_ptr->info_list.emplace_back(_("あなたは破片の攻撃への耐性を持っている。", "You are resistant to blasts of shards."));
     }
 
-    if (has_resist_shard(creature)) {
+    if (creature.has_resist_shard()) {
         self_ptr->info_list.emplace_back(_("あなたは因果混乱の攻撃への耐性を持っている。", "You are resistant to nexus attacks."));
     }
 
     if (CreatureRace(&creature).equals(PlayerRaceType::SPECTRE)) {
         self_ptr->info_list.emplace_back(_("あなたは地獄の力を吸収できる。", "You can drain nether forces."));
-    } else if (has_resist_neth(creature)) {
+    } else if (creature.has_resist_neth()) {
         self_ptr->info_list.emplace_back(_("あなたは地獄の力への耐性を持っている。", "You are resistant to nether forces."));
     }
 }

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -201,7 +201,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
         break;
     }
     case 2: {
-        if (creature.get_mutations().has_not(PlayerMutationType::COWARDICE) && !has_resist_fear(creature)) {
+        if (creature.get_mutations().has_not(PlayerMutationType::COWARDICE) && !creature.has_resist_fear()) {
             msg_print(_("あなたはパラノイアになった！", "You become paranoid!"));
             if (creature.get_mutations().has(PlayerMutationType::FEARLESS)) {
                 msg_print(_("あなたはもう恐れ知らずではなくなった。", "You are no longer fearless."));
@@ -214,7 +214,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
         break;
     }
     case 3: {
-        if (creature.get_mutations().has_not(PlayerMutationType::HALLU) && !has_resist_chaos(creature)) {
+        if (creature.get_mutations().has_not(PlayerMutationType::HALLU) && !creature.has_resist_chaos()) {
             msg_print(_("幻覚をひき起こす精神錯乱に陥った！", "You are afflicted by a hallucinatory insanity!"));
             creature.muta.set(PlayerMutationType::HALLU);
         }
@@ -222,7 +222,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
         break;
     }
     case 4: {
-        if (creature.get_mutations().has_not(PlayerMutationType::BERS_RAGE) && !has_resist_conf(creature)) {
+        if (creature.get_mutations().has_not(PlayerMutationType::BERS_RAGE) && !creature.has_resist_conf()) {
             msg_print(_("激烈な感情の発作におそわれるようになった！", "You become subject to fits of berserk rage!"));
             creature.muta.set(PlayerMutationType::BERS_RAGE);
         }
@@ -238,11 +238,11 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
     case 11:
     case 12: {
         BadStatusSetter bss(creature);
-        if (!has_resist_conf(creature)) {
+        if (!creature.has_resist_conf()) {
             (void)bss.mod_confusion(randint0(4) + 4);
         }
 
-        if (!has_resist_chaos(creature) && one_in_(3)) {
+        if (!creature.has_resist_chaos() && one_in_(3)) {
             (void)bss.mod_hallucination(randint0(250) + 150);
         }
 
@@ -254,13 +254,13 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
     case 14:
     case 15: {
         BadStatusSetter bss(creature);
-        if (!has_resist_conf(creature)) {
+        if (!creature.has_resist_conf()) {
             (void)bss.mod_confusion(randint0(4) + 4);
         }
         if (!creature.has_free_act()) {
             (void)bss.mod_paralysis(randint0(4) + 4);
         }
-        if (!has_resist_chaos(creature)) {
+        if (!creature.has_resist_chaos()) {
             (void)bss.mod_hallucination(randint0(250) + 150);
         }
 

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -346,12 +346,12 @@ bool trap_can_be_ignored(CreatureEntity &creature, FEAT_IDX feat)
         }
         break;
     case TrapType::BLIND:
-        if (has_resist_blind(creature)) {
+        if (creature.has_resist_blind()) {
             return true;
         }
         break;
     case TrapType::CONFUSE:
-        if (has_resist_conf(creature)) {
+        if (creature.has_resist_conf()) {
             return true;
         }
         break;

--- a/src/player/player-status-resist.cpp
+++ b/src/player/player-status-resist.cpp
@@ -263,7 +263,7 @@ PERCENTAGE calc_lite_damage_rate(CreatureEntity &creature, rate_calc_type_mode m
         }
     }
 
-    if (has_resist_lite(creature)) {
+    if (creature.has_resist_lite()) {
         per *= 400;
         per /= randrate(4, 7, mode);
     }
@@ -286,7 +286,7 @@ PERCENTAGE calc_dark_damage_rate(CreatureEntity &creature, rate_calc_type_mode m
         return 0;
     }
 
-    if (has_resist_dark(creature)) {
+    if (creature.has_resist_dark()) {
         per *= 400;
         per /= randrate(4, 7, mode);
     }
@@ -301,7 +301,7 @@ PERCENTAGE calc_shards_damage_rate(CreatureEntity &creature, rate_calc_type_mode
 {
     PERCENTAGE per = 100;
 
-    if (has_resist_shard(creature)) {
+    if (creature.has_resist_shard()) {
         per *= 600;
         per /= randrate(4, 7, mode);
     }
@@ -316,7 +316,7 @@ PERCENTAGE calc_sound_damage_rate(CreatureEntity &creature, rate_calc_type_mode 
 {
     PERCENTAGE per = 100;
 
-    if (has_resist_sound(creature)) {
+    if (creature.has_resist_sound()) {
         per *= 500;
         per /= randrate(4, 7, mode);
     }
@@ -331,7 +331,7 @@ PERCENTAGE calc_conf_damage_rate(CreatureEntity &creature, rate_calc_type_mode m
 {
     PERCENTAGE per = 100;
 
-    if (has_resist_conf(creature)) {
+    if (creature.has_resist_conf()) {
         per *= 500;
         per /= randrate(4, 7, mode);
     }
@@ -354,7 +354,7 @@ PERCENTAGE calc_chaos_damage_rate(CreatureEntity &creature, rate_calc_type_mode 
 {
     PERCENTAGE per = 100;
 
-    if (has_resist_chaos(creature)) {
+    if (creature.has_resist_chaos()) {
         per *= 600;
         per /= randrate(4, 7, mode);
     }
@@ -369,7 +369,7 @@ PERCENTAGE calc_disenchant_damage_rate(CreatureEntity &creature, rate_calc_type_
 {
     PERCENTAGE per = 100;
 
-    if (has_resist_disen(creature)) {
+    if (creature.has_resist_disen()) {
         per *= 600;
         per /= randrate(4, 7, mode);
     }
@@ -384,7 +384,7 @@ PERCENTAGE calc_nexus_damage_rate(CreatureEntity &creature, rate_calc_type_mode 
 {
     PERCENTAGE per = 100;
 
-    if (has_resist_disen(creature)) {
+    if (creature.has_resist_disen()) {
         per *= 600;
         per /= randrate(4, 7, mode);
     }
@@ -400,7 +400,7 @@ PERCENTAGE calc_rocket_damage_rate(CreatureEntity &creature, rate_calc_type_mode
     (void)mode; // unused
     PERCENTAGE per = 100;
 
-    if (has_resist_shard(creature)) {
+    if (creature.has_resist_shard()) {
         per /= 2;
     }
 
@@ -414,7 +414,7 @@ PERCENTAGE calc_nether_damage_rate(CreatureEntity &creature, rate_calc_type_mode
 {
     PERCENTAGE per = 100;
 
-    if (has_resist_neth(creature)) {
+    if (creature.has_resist_neth()) {
         if (!CreatureRace(&creature).equals(PlayerRaceType::SPECTRE)) {
             per *= 6;
         }
@@ -433,7 +433,7 @@ PERCENTAGE calc_time_damage_rate(CreatureEntity &creature, rate_calc_type_mode m
     (void)mode; // unused
     PERCENTAGE per = 100;
 
-    if (has_resist_time(creature)) {
+    if (creature.has_resist_time()) {
         per *= 400;
         per /= randrate(4, 7, mode);
     }
@@ -449,7 +449,7 @@ PERCENTAGE calc_water_damage_rate(CreatureEntity &creature, rate_calc_type_mode 
     (void)mode; // unused
     PERCENTAGE per = 100;
 
-    if (has_resist_water(creature)) {
+    if (creature.has_resist_water()) {
         per *= 400;
         per /= randrate(4, 7, mode);
     }
@@ -532,7 +532,7 @@ PERCENTAGE calc_abyss_damage_rate(CreatureEntity &creature, rate_calc_type_mode 
     (void)mode; // unused
     PERCENTAGE per = 100;
 
-    if (has_resist_dark(creature) != 0) {
+    if (creature.has_resist_dark() != 0) {
         per *= 400;
         per /= randrate(4, 7, mode);
     } else if ((has_levitation(creature) == 0) && (has_anti_tele(creature) != 0)) {

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1132,7 +1132,7 @@ static ACTION_SKILL_POWER calc_saving_throw(CreatureEntity &creature)
         pow += (15 + (creature.level / 5));
     }
 
-    if (has_resist_curse(creature)) {
+    if (creature.has_resist_curse()) {
         pow += 30;
     }
 

--- a/src/realm/realm-nature.cpp
+++ b/src/realm/realm-nature.cpp
@@ -123,7 +123,7 @@ tl::optional<std::string> do_nature_spell(CreatureEntity &creature, SPELL_IDX sp
             lite_area(creature, dice.roll(), rad);
 
             CreatureRace race(&creature);
-            if (race.life() == PlayerRaceLifeType::UNDEAD && race.tr_flags().has(TR_VUL_LITE) && !has_resist_lite(creature)) {
+            if (race.life() == PlayerRaceLifeType::UNDEAD && race.tr_flags().has(TR_VUL_LITE) && !creature.has_resist_lite()) {
                 msg_print(_("日の光があなたの肉体を焦がした！", "The daylight scorches your flesh!"));
                 take_hit(creature, DAMAGE_NOESCAPE, Dice::roll(2, 2), _("日の光", "daylight"));
             }
@@ -450,7 +450,7 @@ tl::optional<std::string> do_nature_spell(CreatureEntity &creature, SPELL_IDX sp
             wiz_lite(creature, false);
 
             CreatureRace race(&creature);
-            if (race.life() == PlayerRaceLifeType::UNDEAD && race.tr_flags().has(TR_VUL_LITE) && !has_resist_lite(creature)) {
+            if (race.life() == PlayerRaceLifeType::UNDEAD && race.tr_flags().has(TR_VUL_LITE) && !creature.has_resist_lite()) {
                 msg_print(_("日光があなたの肉体を焦がした！", "The sunlight scorches your flesh!"));
                 take_hit(creature, DAMAGE_NOESCAPE, 50, _("日光", "sunlight"));
             }

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -444,7 +444,7 @@ bool destroy_area(CreatureEntity &creature, const POSITION y1, const POSITION x1
 
     if (flag) {
         msg_print(_("燃えるような閃光が発生した！", "There is a searing blast of light!"));
-        if (!has_resist_blind(creature) && !has_resist_lite(creature)) {
+        if (!creature.has_resist_blind() && !creature.has_resist_lite()) {
             (void)BadStatusSetter(creature).mod_blindness(10 + randint1(10));
         }
     }


### PR DESCRIPTION
提案 4 の継続。以下 13 種の高級耐性 call site を自由関数呼出から
virtual メンバ呼出形式に置換:

- has_resist_conf/sound/lite/dark/chaos/disen/shard/blind/neth/ time/water/fear/curse

23 ファイル、136 箇所の置換。自由関数本体は現状保持、将来
モンスター側で override 可能な土台は継続整備中。