### PR TITLE
refactor(creature): 残存 immune/vuln の call site を virtual メンバ経由に移行

### DIFF
--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -459,7 +459,7 @@ void effect_player_dark(CreatureEntity &creature, EffectPlayerType *ep_ptr)
 
     auto go_blind = !is_blind;
     go_blind &= !creature.has_resist_blind();
-    go_blind &= !(creature.has_resist_dark() || has_immune_dark(creature));
+    go_blind &= !(creature.has_resist_dark() || creature.has_immune_dark());
     go_blind &= !check_multishadow(creature);
 
     if (go_blind) {

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -726,7 +726,7 @@ void update_smart_learn(CreatureEntity &creature, MONSTER_IDX m_idx, int what)
 
         break;
     case DRS_DARK:
-        if (creature.has_resist_dark() || has_immune_dark(creature)) {
+        if (creature.has_resist_dark() || creature.has_immune_dark()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_DARK);
         }
 

--- a/src/mspell/high-resistance-checker.cpp
+++ b/src/mspell/high-resistance-checker.cpp
@@ -118,7 +118,7 @@ static void check_dark_resistance(CreatureEntity &creature, msr_type *msr_ptr)
         return;
     }
 
-    if (has_immune_dark(creature)) {
+    if (creature.has_immune_dark()) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BR_DARK);
         msr_ptr->ability_flags.reset(MonsterAbilityType::BA_DARK);
         return;

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -114,7 +114,7 @@ static void spell_damcalc(CreatureEntity &creature, const CreatureEntity &monste
 
     case AttributeType::DARK:
         dam = dam * calc_dark_damage_rate(creature, CALC_MAX) / 100;
-        if (has_immune_dark(creature) || creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
+        if (creature.has_immune_dark() || creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
             ignore_wraith_form = true;
         }
         break;

--- a/src/player-info/resistance-info.cpp
+++ b/src/player-info/resistance-info.cpp
@@ -71,11 +71,11 @@ void set_high_resistance_info(CreatureEntity &creature, self_info_type *self_ptr
         self_ptr->info_list.emplace_back(_("あなたは閃光への耐性を持っている。", "You are resistant to bright light."));
     }
 
-    if (has_vuln_lite(creature)) {
+    if (creature.has_vuln_lite()) {
         self_ptr->info_list.emplace_back(_("あなたは閃光に弱い。", "You are susceptible to damage from bright light."));
     }
 
-    if (has_immune_dark(creature) || creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
+    if (creature.has_immune_dark() || creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
         self_ptr->info_list.emplace_back(_("あなたは暗黒に対する完全なる免疫を持っている。", "You are completely immune to darkness."));
     } else if (creature.has_resist_dark()) {
         self_ptr->info_list.emplace_back(_("あなたは暗黒への耐性を持っている。", "You are resistant to darkness."));

--- a/src/player/player-status-resist.cpp
+++ b/src/player/player-status-resist.cpp
@@ -246,7 +246,7 @@ PERCENTAGE calc_lite_damage_rate(CreatureEntity &creature, rate_calc_type_mode m
 {
     PERCENTAGE per = 100;
 
-    if (has_immune_lite(creature)) {
+    if (creature.has_immune_lite()) {
         return 0;
     }
 
@@ -282,7 +282,7 @@ PERCENTAGE calc_dark_damage_rate(CreatureEntity &creature, rate_calc_type_mode m
 {
     PERCENTAGE per = 100;
 
-    if (has_immune_dark(creature)) {
+    if (creature.has_immune_dark()) {
         return 0;
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1142,7 +1142,7 @@ static ACTION_SKILL_POWER calc_saving_throw(CreatureEntity &creature)
 
     pow += adj_wis_sav[creature.stat_index[A_WIS]];
 
-    if (has_vuln_curse(creature)) {
+    if (creature.has_vuln_curse()) {
         pow -= 10;
     }
 


### PR DESCRIPTION
提案 4 の継続。以下 4 種の残存 call site を移行:

- has_immune_dark / has_immune_lite
- has_vuln_lite / has_vuln_curse

7 ファイル。これで creature 引数を取る has_resist_*/has_immune_*/ has_vuln_* の自由関数形式呼出は全て virtual メンバ経由に置換済み。