### PR TITLE
refactor(creature): 装備集計系自由関数 10 種を virtual メソッド化

### DIFF
--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -142,7 +142,7 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
     const auto &monster = floor.get_monster(grid.m_idx);
 
     auto &terrain = grid.get_terrain();
-    auto p_can_kill_walls = has_kill_wall(creature);
+    auto p_can_kill_walls = creature.has_kill_wall();
     p_can_kill_walls &= terrain.flags.has(TerrainCharacteristics::CAN_DISINTEGRATE);
     p_can_kill_walls &= !p_can_enter || terrain.flags.has_not(TerrainCharacteristics::LOS);
     p_can_kill_walls &= terrain.flags.has_not(TerrainCharacteristics::PERMANENT);

--- a/src/combat/aura-counterattack.cpp
+++ b/src/combat/aura-counterattack.cpp
@@ -31,7 +31,7 @@
 
 static void aura_fire_by_monster_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    if (!has_sh_fire(creature) || !monap_ptr->alive || creature.is_dead()) {
+    if (!creature.has_sh_fire() || !monap_ptr->alive || creature.is_dead()) {
         return;
     }
 
@@ -56,7 +56,7 @@ static void aura_fire_by_monster_attack(CreatureEntity &creature, MonsterAttackP
 
 static void aura_elec_by_monster_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    if (!has_sh_elec(creature) || !monap_ptr->alive || creature.is_dead()) {
+    if (!creature.has_sh_elec() || !monap_ptr->alive || creature.is_dead()) {
         return;
     }
 
@@ -81,7 +81,7 @@ static void aura_elec_by_monster_attack(CreatureEntity &creature, MonsterAttackP
 
 static void aura_cold_by_monster_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
-    if (!has_sh_cold(creature) || !monap_ptr->alive || creature.is_dead()) {
+    if (!creature.has_sh_cold() || !monap_ptr->alive || creature.is_dead()) {
         return;
     }
 

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -70,7 +70,7 @@ bool EffectPlayerType::is_monster() const
  */
 static bool process_bolt_reflection(CreatureEntity &creature, EffectPlayerType *ep_ptr, project_func project)
 {
-    auto can_reflect = (has_reflect(creature)) != 0;
+    auto can_reflect = (creature.has_reflect()) != 0;
     can_reflect &= any_bits(ep_ptr->flag, PROJECT_REFLECTABLE);
     can_reflect &= !one_in_(10);
     if (!can_reflect) {

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -955,7 +955,7 @@ bool player_can_enter(CreatureEntity &creature, FEAT_IDX feature, BIT_FLAGS16 mo
     if (terrain.flags.has(TerrainCharacteristics::CAN_SWIM) && creature.has_can_swim()) {
         return true;
     }
-    if (terrain.flags.has(TerrainCharacteristics::CAN_PASS) && has_pass_wall(creature)) {
+    if (terrain.flags.has(TerrainCharacteristics::CAN_PASS) && creature.has_pass_wall()) {
         return true;
     }
 

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -382,12 +382,12 @@ void process_player_hp_mp(CreatureEntity &creature)
         auto should_damage = !creature.is_invulnerable();
         should_damage &= creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM) == 0;
         should_damage &= creature.get_timed_effect(CreatureTimedEffect::TIM_PASS_WALL) == 0;
-        should_damage &= (creature.hp > (creature.level / 5)) || !has_pass_wall(creature);
+        should_damage &= (creature.hp > (creature.level / 5)) || !creature.has_pass_wall();
         if (should_damage) {
             concptr dam_desc;
             cave_no_regen = true;
 
-            if (has_pass_wall(creature)) {
+            if (creature.has_pass_wall()) {
                 msg_print(_("体の分子が分解した気がする！", "Your molecules feel disrupted!"));
                 dam_desc = _("密度", "density");
             } else {

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -243,7 +243,7 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
     fis.e1 = INVEN_MAIN_HAND;
     fis.e2 = INVEN_TOTAL - 1;
     test_equipment_floor(creature, &fis, item_tester);
-    if (has_two_handed_weapons(creature) && !(fis.mode & IGNORE_BOTHHAND_SLOT)) {
+    if (creature.has_two_handed_weapons() && !(fis.mode & IGNORE_BOTHHAND_SLOT)) {
         fis.max_equip++;
     }
 
@@ -255,7 +255,7 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
         fis.e2--;
     }
 
-    if (fis.equip && has_two_handed_weapons(creature) && !(fis.mode & IGNORE_BOTHHAND_SLOT)) {
+    if (fis.equip && creature.has_two_handed_weapons() && !(fis.mode & IGNORE_BOTHHAND_SLOT)) {
         if (can_attack_with_main_hand(creature)) {
             if (fis.e2 < INVEN_SUB_HAND) {
                 fis.e2 = INVEN_SUB_HAND;

--- a/src/inventory/inventory-describer.cpp
+++ b/src/inventory/inventory-describer.cpp
@@ -23,7 +23,7 @@ concptr mention_use(CreatureEntity &creature, int i)
     case INVEN_MAIN_HAND:
         p = creature.heavy_wield[0]
                 ? "運搬中"
-                : ((has_two_handed_weapons(creature) && can_attack_with_main_hand(creature)) ? " 両手" : (left_hander ? " 左手" : " 右手"));
+                : ((creature.has_two_handed_weapons() && can_attack_with_main_hand(creature)) ? " 両手" : (left_hander ? " 左手" : " 右手"));
         break;
 #else
     case INVEN_MAIN_HAND:
@@ -35,7 +35,7 @@ concptr mention_use(CreatureEntity &creature, int i)
     case INVEN_SUB_HAND:
         p = creature.heavy_wield[1]
                 ? "運搬中"
-                : ((has_two_handed_weapons(creature) && can_attack_with_sub_hand(creature)) ? " 両手" : (left_hander ? " 右手" : " 左手"));
+                : ((creature.has_two_handed_weapons() && can_attack_with_sub_hand(creature)) ? " 両手" : (left_hander ? " 右手" : " 左手"));
         break;
 #else
     case INVEN_SUB_HAND:
@@ -100,8 +100,8 @@ concptr describe_use(CreatureEntity &creature, int i)
     case INVEN_MAIN_HAND:
         p = creature.heavy_wield[0]
                 ? "運搬中の"
-                : ((has_two_handed_weapons(creature) && can_attack_with_main_hand(creature)) ? "両手に装備している"
-                                                                                             : (left_hander ? "左手に装備している" : "右手に装備している"));
+                : ((creature.has_two_handed_weapons() && can_attack_with_main_hand(creature)) ? "両手に装備している"
+                                                                                              : (left_hander ? "左手に装備している" : "右手に装備している"));
         break;
 #else
     case INVEN_MAIN_HAND:
@@ -113,8 +113,8 @@ concptr describe_use(CreatureEntity &creature, int i)
     case INVEN_SUB_HAND:
         p = creature.heavy_wield[1]
                 ? "運搬中の"
-                : ((has_two_handed_weapons(creature) && can_attack_with_sub_hand(creature)) ? "両手に装備している"
-                                                                                            : (left_hander ? "右手に装備している" : "左手に装備している"));
+                : ((creature.has_two_handed_weapons() && can_attack_with_sub_hand(creature)) ? "両手に装備している"
+                                                                                             : (left_hander ? "右手に装備している" : "左手に装備している"));
         break;
 #else
     case INVEN_SUB_HAND:

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -482,7 +482,7 @@ static void dump_aux_equipment_inventory(CreatureEntity &creature, FILE *fff)
             auto item_name = describe_flavor(creature, *creature.inventory[i], 0);
             auto is_two_handed = ((i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(creature));
             is_two_handed |= ((i == INVEN_SUB_HAND) && can_attack_with_main_hand(creature));
-            if (is_two_handed && has_two_handed_weapons(creature)) {
+            if (is_two_handed && creature.has_two_handed_weapons()) {
                 item_name = _("(武器を両手持ち)", "(wielding with two-hands)");
             }
 

--- a/src/monster-floor/monster-direction.cpp
+++ b/src/monster-floor/monster-direction.cpp
@@ -83,7 +83,7 @@ static void decide_enemy_approch_direction(CreatureEntity &creature, MONSTER_IDX
             continue;
         }
 
-        const auto can_pass_wall = monrace.feature_flags.has(MonsterFeatureType::PASS_WALL) && (!monster_from.is_riding() || has_pass_wall(creature));
+        const auto can_pass_wall = monrace.feature_flags.has(MonsterFeatureType::PASS_WALL) && (!monster_from.is_riding() || creature.has_pass_wall());
         const auto can_kill_wall = monrace.feature_flags.has(MonsterFeatureType::KILL_WALL) && !monster_from.is_riding();
         const auto m_pos_from = monster_from.get_position();
         const auto m_pos_to = monster_to.get_position();

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -92,7 +92,7 @@ static bool process_wall(CreatureEntity &creature, turn_flags *turn_flags_ptr, c
     }
 
     turn_flags_ptr->do_move = true;
-    if ((monrace.feature_flags.has(Mft::PASS_WALL)) && (!turn_flags_ptr->is_riding_mon || has_pass_wall(creature)) && terrain.flags.has(Tc::CAN_PASS)) {
+    if ((monrace.feature_flags.has(Mft::PASS_WALL)) && (!turn_flags_ptr->is_riding_mon || creature.has_pass_wall()) && terrain.flags.has(Tc::CAN_PASS)) {
         turn_flags_ptr->did_pass_wall = true;
     }
 

--- a/src/monster/monster-info.cpp
+++ b/src/monster/monster-info.cpp
@@ -61,7 +61,7 @@ bool monster_can_cross_terrain(CreatureEntity &creature, FEAT_IDX feat, const Mo
         return true;
     }
     if (terrain.flags.has(TerrainCharacteristics::CAN_PASS)) {
-        if (monrace.feature_flags.has(MonsterFeatureType::PASS_WALL) && (!(mode & CEM_RIDING) || has_pass_wall(creature))) {
+        if (monrace.feature_flags.has(MonsterFeatureType::PASS_WALL) && (!(mode & CEM_RIDING) || creature.has_pass_wall())) {
             return true;
         }
     }

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -792,7 +792,7 @@ void update_smart_learn(CreatureEntity &creature, MONSTER_IDX m_idx, int what)
 
         break;
     case DRS_REFLECT:
-        if (has_reflect(creature)) {
+        if (creature.has_reflect()) {
             monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_REFLECT);
         }
 

--- a/src/mspell/high-resistance-checker.cpp
+++ b/src/mspell/high-resistance-checker.cpp
@@ -54,7 +54,7 @@ void add_cheat_remove_flags_others(CreatureEntity &creature, msr_type *msr_ptr)
         msr_ptr->smart_flags.set(MonsterSmartLearnType::RES_SHARD);
     }
 
-    if (has_reflect(creature)) {
+    if (creature.has_reflect()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::IMM_REFLECT);
     }
 

--- a/src/player-info/body-improvement-info.cpp
+++ b/src/player-info/body-improvement-info.cpp
@@ -85,7 +85,7 @@ void set_body_improvement_info_3(CreatureEntity &creature, self_info_type *self_
         self_ptr->info_list.emplace_back(_("あなたは自己の経験値をしっかりと維持する。", "You have a firm hold on your experience."));
     }
 
-    if (has_reflect(creature)) {
+    if (creature.has_reflect()) {
         self_ptr->info_list.emplace_back(_("あなたは矢の呪文を反射する。", "You reflect bolt spells."));
     }
 
@@ -93,7 +93,7 @@ void set_body_improvement_info_3(CreatureEntity &creature, self_info_type *self_
         self_ptr->info_list.emplace_back(_("あなたはより強く呪いに抵抗できる。", "You can resist curses powerfully."));
     }
 
-    if (has_sh_fire(creature)) {
+    if (creature.has_sh_fire()) {
         self_ptr->info_list.emplace_back(_("あなたは炎のオーラに包まれている。", "You are surrounded with a fiery aura."));
     }
 
@@ -101,7 +101,7 @@ void set_body_improvement_info_3(CreatureEntity &creature, self_info_type *self_
         self_ptr->info_list.emplace_back(_("あなたは身を焼く炎に包まれている。", "You are being damaged with fire."));
     }
 
-    if (has_sh_elec(creature)) {
+    if (creature.has_sh_elec()) {
         self_ptr->info_list.emplace_back(_("あなたは電気のオーラに包まれている。", "You are surrounded with an electricity aura."));
     }
 
@@ -109,7 +109,7 @@ void set_body_improvement_info_3(CreatureEntity &creature, self_info_type *self_
         self_ptr->info_list.emplace_back(_("あなたは身を焦がす電撃に包まれている。", "You are being damaged with electricity."));
     }
 
-    if (has_sh_cold(creature)) {
+    if (creature.has_sh_cold()) {
         self_ptr->info_list.emplace_back(_("あなたは冷気のオーラに包まれている。", "You are surrounded with an aura of coldness."));
     }
 

--- a/src/player/player-status-resist.cpp
+++ b/src/player/player-status-resist.cpp
@@ -513,7 +513,7 @@ PERCENTAGE calc_void_damage_rate(CreatureEntity &creature, rate_calc_type_mode m
 {
     (void)mode; // unused
     PERCENTAGE per = 100;
-    if (has_pass_wall(creature)) {
+    if (creature.has_pass_wall()) {
         per = per * 3 / 2;
     } else if (has_anti_tele(creature) != 0) {
         per *= 400;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -281,9 +281,9 @@ static void update_bonuses(CreatureEntity &creature)
     creature.esp_unique = has_esp_unique(creature);
     creature.telepathy = has_esp_telepathy(creature);
     creature.bless_blade = has_bless_blade(creature);
-    creature.easy_2weapon = has_easy2_weapon(creature);
-    creature.down_saving = has_down_saving(creature);
-    creature.yoiyami = has_no_ac(creature);
+    creature.easy_2weapon = creature.has_easy2_weapon();
+    creature.down_saving = creature.has_down_saving();
+    creature.yoiyami = creature.has_no_ac();
     creature.mighty_throw = has_mighty_throw(creature);
     creature.dec_mana = has_dec_mana(creature);
     creature.see_nocto = has_see_nocto(creature);
@@ -1461,7 +1461,7 @@ static int16_t calc_num_blow(CreatureEntity &creature, int i)
             div = ((o_ptr->weight < wgt) ? wgt : o_ptr->weight);
             str_index = (adj_str_blow[creature.stat_index[A_STR]] * mul / div);
 
-            if (has_two_handed_weapons(creature) && !has_disable_two_handed_bonus(creature, 0)) {
+            if (creature.has_two_handed_weapons() && !has_disable_two_handed_bonus(creature, 0)) {
                 str_index += pc.equals(PlayerClassType::WARRIOR) || pc.equals(PlayerClassType::BERSERKER) ? (creature.level / 23 + 1) : 1;
             }
             if (pc.equals(PlayerClassType::NINJA)) {
@@ -1901,7 +1901,7 @@ static bool is_riding_two_hands(CreatureEntity &creature)
         return false;
     }
 
-    if (has_two_handed_weapons(creature) || (empty_hands(creature, false) == EMPTY_HAND_NONE)) {
+    if (creature.has_two_handed_weapons() || (empty_hands(creature, false) == EMPTY_HAND_NONE)) {
         return true;
     }
 
@@ -2071,7 +2071,7 @@ static short calc_to_damage(CreatureEntity &creature, INVENTORY_IDX slot, bool i
         damage -= 2;
     } else if (pc.equals(PlayerClassType::BERSERKER)) {
         damage += creature.level / 6;
-        if (((calc_hand == PLAYER_HAND_MAIN) && !can_attack_with_sub_hand(creature)) || has_two_handed_weapons(creature)) {
+        if (((calc_hand == PLAYER_HAND_MAIN) && !can_attack_with_sub_hand(creature)) || creature.has_two_handed_weapons()) {
             damage += creature.level / 6;
         }
     } else if (pc.equals(PlayerClassType::SORCERER)) {
@@ -2308,7 +2308,7 @@ static short calc_to_hit(CreatureEntity &creature, INVENTORY_IDX slot, bool is_r
             hit -= 2;
         } else if (pc.equals(PlayerClassType::BERSERKER)) {
             hit += creature.level / 5;
-            if (((calc_hand == PLAYER_HAND_MAIN) && !can_attack_with_sub_hand(creature)) || has_two_handed_weapons(creature)) {
+            if (((calc_hand == PLAYER_HAND_MAIN) && !can_attack_with_sub_hand(creature)) || creature.has_two_handed_weapons()) {
                 hit += creature.level / 5;
             }
         } else if (pc.equals(PlayerClassType::SORCERER)) {
@@ -3090,7 +3090,7 @@ void stop_mouth(CreatureEntity &creature)
 int calc_weapon_weight_limit(CreatureEntity &creature)
 {
     auto weight = adj_str_hold[creature.stat_index[A_STR]];
-    if (has_two_handed_weapons(creature)) {
+    if (creature.has_two_handed_weapons()) {
         weight *= 2;
     }
 

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -133,7 +133,7 @@ void process_player_damage_dodged(CreatureEntity &creature, int m_idx)
 void process_hit_to_player(CreatureEntity &creature, std::span<const Pos2D> pos_collapses, int m_idx)
 {
     const auto has_hit = ranges::contains(pos_collapses, creature.get_position());
-    if (!has_hit || has_pass_wall(creature) || has_kill_wall(creature)) {
+    if (!has_hit || creature.has_pass_wall() || creature.has_kill_wall()) {
         return;
     }
 

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -1122,4 +1122,14 @@ BIT_FLAGS CreatureEntity::has_immune_acid() { return ::has_immune_acid(*this); }
 BIT_FLAGS CreatureEntity::has_immune_elec() { return ::has_immune_elec(*this); }
 BIT_FLAGS CreatureEntity::has_immune_dark() { return ::has_immune_dark(*this); }
 BIT_FLAGS CreatureEntity::has_immune_lite() { return ::has_immune_lite(*this); }
+bool CreatureEntity::has_pass_wall() { return ::has_pass_wall(*this); }
+bool CreatureEntity::has_kill_wall() { return ::has_kill_wall(*this); }
+BIT_FLAGS CreatureEntity::has_reflect() { return ::has_reflect(*this); }
+bool CreatureEntity::has_two_handed_weapons() { return ::has_two_handed_weapons(*this); }
+BIT_FLAGS CreatureEntity::has_sh_fire() { return ::has_sh_fire(*this); }
+BIT_FLAGS CreatureEntity::has_sh_elec() { return ::has_sh_elec(*this); }
+BIT_FLAGS CreatureEntity::has_sh_cold() { return ::has_sh_cold(*this); }
+BIT_FLAGS CreatureEntity::has_down_saving() { return ::has_down_saving(*this); }
+BIT_FLAGS CreatureEntity::has_no_ac() { return ::has_no_ac(*this); }
+BIT_FLAGS CreatureEntity::has_easy2_weapon() { return ::has_easy2_weapon(*this); }
 // clang-format on

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -871,6 +871,18 @@ public:
     virtual BIT_FLAGS has_immune_dark();
     virtual BIT_FLAGS has_immune_lite();
 
+    // その他の装備集計系 virtual メソッド (提案 4)。
+    virtual bool has_pass_wall();
+    virtual bool has_kill_wall();
+    virtual BIT_FLAGS has_reflect();
+    virtual bool has_two_handed_weapons();
+    virtual BIT_FLAGS has_sh_fire();
+    virtual BIT_FLAGS has_sh_elec();
+    virtual BIT_FLAGS has_sh_cold();
+    virtual BIT_FLAGS has_down_saving();
+    virtual BIT_FLAGS has_no_ac();
+    virtual BIT_FLAGS has_easy2_weapon();
+
     /*!
      * @brief 汎用テレパシーの有無を返す
      * @details プレイヤーは装備由来、モンスターは種族フラグ由来（将来）。

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -56,7 +56,7 @@ static void display_player_melee_bonus(CreatureEntity &creature, int hand, int h
     const auto buf = format("(%+d,%+d)", (int)show_tohit, (int)show_todam);
     if (!has_melee_weapon(creature, INVEN_MAIN_HAND) && !has_melee_weapon(creature, INVEN_SUB_HAND)) {
         display_player_one_line(ENTRY_BARE_HAND, buf, TERM_L_BLUE);
-    } else if (has_two_handed_weapons(creature)) {
+    } else if (creature.has_two_handed_weapons()) {
         display_player_one_line(ENTRY_TWO_HANDS, buf, TERM_L_BLUE);
     } else {
         display_player_one_line(hand_entry, buf, TERM_L_BLUE);

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -331,7 +331,7 @@ static void display_equipment(CreatureEntity &creature, const ItemTester &item_t
         std::string item_name;
         auto is_two_handed = (i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(creature);
         is_two_handed |= (i == INVEN_SUB_HAND) && can_attack_with_main_hand(creature);
-        if (is_two_handed && has_two_handed_weapons(creature)) {
+        if (is_two_handed && creature.has_two_handed_weapons()) {
             item_name = _("(武器を両手持ち)", "(wielding with two-hands)");
             attr = TERM_WHITE;
         } else {

--- a/src/window/main-window-equipments.cpp
+++ b/src/window/main-window-equipments.cpp
@@ -46,7 +46,7 @@ COMMAND_CODE show_equipment(CreatureEntity &creature, int target_item, BIT_FLAGS
         auto only_slot = !(creature.select_ring_slot ? is_ring_slot(i) : (item_tester.okay(&item) || any_bits(mode, USE_FULL)));
         auto is_any_hand = (i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(creature);
         is_any_hand |= (i == INVEN_SUB_HAND) && can_attack_with_main_hand(creature);
-        auto is_two_handed = is_any_hand && has_two_handed_weapons(creature);
+        auto is_two_handed = is_any_hand && creature.has_two_handed_weapons();
         only_slot &= !is_two_handed || any_bits(mode, IGNORE_BOTHHAND_SLOT);
         if (only_slot) {
             continue;


### PR DESCRIPTION
提案 4 の拡張。以下 10 関数を CreatureEntity の virtual メソッドに
追加し、call site を移行:

- has_pass_wall / has_kill_wall (壁通過・壁殺し)
- has_reflect (魔法反射)
- has_two_handed_weapons (両手持ち判定)
- has_sh_fire / has_sh_elec / has_sh_cold (オーラ系)
- has_down_saving / has_no_ac / has_easy2_weapon

22 ファイル、約 50 箇所の call site を creature.has_X() 形式に
置換。デフォルト実装は自由関数に委譲、将来モンスター側で
override 可能。