### PR TITLE
refactor(status): mod_* 系の値読取りを get_timed_effect() に統一

### DIFF
--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -104,7 +104,7 @@ bool BadStatusSetter::set_blindness(const TIME_EFFECT tmp_v)
 
 bool BadStatusSetter::mod_blindness(const TIME_EFFECT tmp_v)
 {
-    return this->set_blindness(this->creature.effects()->blindness().current() + tmp_v);
+    return this->set_blindness(this->creature.get_timed_effect(CreatureTimedEffect::BLINDNESS) + tmp_v);
 }
 
 /*!
@@ -179,7 +179,7 @@ bool BadStatusSetter::set_confusion(const TIME_EFFECT tmp_v)
 
 bool BadStatusSetter::mod_confusion(const TIME_EFFECT tmp_v)
 {
-    return this->set_confusion(this->creature.effects()->confusion().current() + tmp_v);
+    return this->set_confusion(this->creature.get_timed_effect(CreatureTimedEffect::CONFUSION) + tmp_v);
 }
 
 /*!
@@ -276,7 +276,7 @@ bool BadStatusSetter::set_fear(const TIME_EFFECT tmp_v)
 
 bool BadStatusSetter::mod_fear(const TIME_EFFECT tmp_v)
 {
-    return this->set_fear(this->creature.effects()->fear().current() + tmp_v);
+    return this->set_fear(this->creature.get_timed_effect(CreatureTimedEffect::FEAR) + tmp_v);
 }
 
 /*!
@@ -330,7 +330,7 @@ bool BadStatusSetter::set_paralysis(const TIME_EFFECT tmp_v)
 
 bool BadStatusSetter::mod_paralysis(const TIME_EFFECT tmp_v)
 {
-    return this->set_paralysis(this->creature.effects()->paralysis().current() + tmp_v);
+    return this->set_paralysis(this->creature.get_timed_effect(CreatureTimedEffect::PARALYSIS) + tmp_v);
 }
 
 /*!
@@ -448,7 +448,7 @@ bool BadStatusSetter::set_deceleration(const TIME_EFFECT tmp_v, bool do_dec)
 
 bool BadStatusSetter::mod_deceleration(const TIME_EFFECT tmp_v, bool do_dec)
 {
-    return this->set_deceleration(this->creature.effects()->deceleration().current() + tmp_v, do_dec);
+    return this->set_deceleration(this->creature.get_timed_effect(CreatureTimedEffect::DECELERATION) + tmp_v, do_dec);
 }
 
 /*!
@@ -488,7 +488,7 @@ bool BadStatusSetter::set_stun(const TIME_EFFECT tmp_v)
 
 bool BadStatusSetter::mod_stun(const TIME_EFFECT tmp_v)
 {
-    return this->set_stun(this->creature.effects()->stun().current() + tmp_v);
+    return this->set_stun(this->creature.get_timed_effect(CreatureTimedEffect::STUN) + tmp_v);
 }
 
 /*!

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -167,7 +167,7 @@ bool set_acceleration(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
 
 bool mod_acceleration(CreatureEntity &creature, const TIME_EFFECT v, const bool do_dec)
 {
-    return set_acceleration(creature, creature.effects()->acceleration().current() + v, do_dec);
+    return set_acceleration(creature, creature.get_timed_effect(CreatureTimedEffect::ACCELERATION) + v, do_dec);
 }
 
 /*!


### PR DESCRIPTION
提案 5 の継続。bad-status-setter.cpp / buff-setter.cpp で TimedEffects オブジェクト経由で current() を呼んで値を取得していた
箇所のうち、純粋な値取得 7 箇所を CreatureEntity::get_timed_effect() 経由に置換:

- mod_blindness / mod_confusion / mod_fear / mod_paralysis / mod_stun / mod_deceleration
- mod_acceleration

PlayerStun::get_rank() 等の高機能 API を呼ぶ箇所、および書込み
(set) や HALLUCINATION/CUT/POISON (CreatureTimedEffect 未対応) は現状維持。