### PR TITLE
refactor(creature): HALLUCINATION/CUT/POISON を CreatureTimedEffect に追加

### DIFF
--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -225,7 +225,7 @@ bool BadStatusSetter::set_poison(const TIME_EFFECT tmp_v)
 
 bool BadStatusSetter::mod_poison(const TIME_EFFECT tmp_v)
 {
-    return this->set_poison(this->creature.effects()->poison().current() + tmp_v);
+    return this->set_poison(this->creature.get_timed_effect(CreatureTimedEffect::POISON) + tmp_v);
 }
 
 /*!
@@ -397,7 +397,7 @@ bool BadStatusSetter::hallucination(const TIME_EFFECT tmp_v)
 
 bool BadStatusSetter::mod_hallucination(const TIME_EFFECT tmp_v)
 {
-    return this->hallucination(this->creature.effects()->hallucination().current() + tmp_v);
+    return this->hallucination(this->creature.get_timed_effect(CreatureTimedEffect::HALLUCINATION) + tmp_v);
 }
 
 /*!
@@ -528,7 +528,7 @@ bool BadStatusSetter::set_cut(const TIME_EFFECT tmp_v)
 
 bool BadStatusSetter::mod_cut(const TIME_EFFECT tmp_v)
 {
-    return this->set_cut(this->creature.effects()->cut().current() + tmp_v);
+    return this->set_cut(this->creature.get_timed_effect(CreatureTimedEffect::CUT) + tmp_v);
 }
 
 bool BadStatusSetter::process_stun_effect(const short v)

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -474,6 +474,12 @@ short CreatureEntity::get_timed_effect(CreatureTimedEffect effect) const
             return eff.paralysis().current();
         case CreatureTimedEffect::BLINDNESS:
             return eff.blindness().current();
+        case CreatureTimedEffect::HALLUCINATION:
+            return eff.hallucination().current();
+        case CreatureTimedEffect::CUT:
+            return eff.cut().current();
+        case CreatureTimedEffect::POISON:
+            return eff.poison().current();
         default:
             break;
         }
@@ -508,6 +514,15 @@ void CreatureEntity::set_timed_effect(CreatureTimedEffect effect, short value)
             return;
         case CreatureTimedEffect::BLINDNESS:
             eff.blindness().set(value);
+            return;
+        case CreatureTimedEffect::HALLUCINATION:
+            eff.hallucination().set(value);
+            return;
+        case CreatureTimedEffect::CUT:
+            eff.cut().set(value);
+            return;
+        case CreatureTimedEffect::POISON:
+            eff.poison().set(value);
             return;
         default:
             break;

--- a/src/system/creature-timed-effect-types.h
+++ b/src/system/creature-timed-effect-types.h
@@ -19,6 +19,9 @@ enum class CreatureTimedEffect {
     // --- プレイヤー専用：状態異常系 ---
     BLINDNESS, /*!< 盲目 / Blindness */
     PARALYSIS, /*!< 麻痺 / Paralysis */
+    HALLUCINATION, /*!< 幻覚 / Hallucination */
+    CUT, /*!< 切り傷 / Cut */
+    POISON, /*!< 毒 / Poison */
 
     // --- プレイヤー専用：戦闘バフ系 ---
     HERO, /*!< 士気高揚 / Heroism */


### PR DESCRIPTION
提案 5 の継続。これまで CreatureTimedEffect enum に存在せず TimedEffects オブジェクト経由でしかアクセスできなかった HALLUCINATION/CUT/POISON
を enum に追加し、get/set_timed_effect の switch 分岐に対応 case を 追加。プレイヤー時は引き続き TimedEffects オブジェクト経由で値が
管理される（PlayerHallucination 等の高機能 API を保つ）。

合わせて bad-status-setter.cpp の以下 3 箇所を get_timed_effect 経由に統一:
- mod_poison / mod_cut / mod_hallucination

これで CreatureTimedEffect 経由のアクセスがプレイヤー固有 7 効果
+ 共通効果 + HALLUCINATION/CUT/POISON まで網羅された統一 API として 利用できるようになった。