### PR TITLE
refactor(creature): is_cut() / is_poisoned() を virtual 化

### DIFF
--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -110,7 +110,7 @@ bool pattern_effect(CreatureEntity &creature)
         return false;
     }
 
-    const auto is_cut = creature.effects()->cut().is_cut();
+    const auto is_cut = creature.is_cut();
     if ((CreatureRace(&creature).equals(PlayerRaceType::AMBERITE)) && is_cut && one_in_(10)) {
         wreck_the_pattern(creature);
     }

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -387,7 +387,7 @@ static void apply_damage_bonus(CreatureEntity &creature, player_attack_type *pa_
         pa_ptr->attack_damage = 0;
     }
 
-    auto is_cut = creature.effects()->cut().is_cut();
+    auto is_cut = creature.is_cut();
     if ((pa_ptr->mode == HISSATSU_SEKIRYUKA) && !is_cut) {
         pa_ptr->attack_damage /= 2;
     }

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -417,6 +417,16 @@ bool CreatureEntity::is_paralyzed() const
     return this->get_timed_effect(CreatureTimedEffect::PARALYSIS) > 0;
 }
 
+bool CreatureEntity::is_cut() const
+{
+    return this->get_timed_effect(CreatureTimedEffect::CUT) > 0;
+}
+
+bool CreatureEntity::is_poisoned() const
+{
+    return this->get_timed_effect(CreatureTimedEffect::POISON) > 0;
+}
+
 bool CreatureEntity::is_blessed() const
 {
     if (this->get_timed_effect(CreatureTimedEffect::BLESSED) > 0) {

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -670,6 +670,18 @@ public:
     virtual bool is_paralyzed() const;
 
     /*!
+     * @brief クリーチャーが切り傷状態かどうかを判定
+     * @return 切り傷を受けていればtrue
+     */
+    virtual bool is_cut() const;
+
+    /*!
+     * @brief クリーチャーが毒状態かどうかを判定
+     * @return 毒に侵されていればtrue
+     */
+    virtual bool is_poisoned() const;
+
+    /*!
      * @brief クリーチャーが加速しているかどうかを判定
      * @return 加速中ならtrue
      */


### PR DESCRIPTION
提案 5 の継続。HALLUCINATION/CUT/POISON を CreatureTimedEffect に 追加したのに合わせ、is_cut() / is_poisoned() virtual メソッドも
CreatureEntity に追加 (既存の is_blind / is_paralyzed 等と同様の デフォルト実装: get_timed_effect(XXX) > 0)。

効果 API が揃ったので、pattern-walk.cpp / player-attack.cpp の creature.effects()->cut().is_cut() の直接呼出を creature.is_cut() 経由に置換。これで基本的な状態判定はすべて CreatureEntity の
virtual メソッドで統一された。