### PR TITLE
refactor(creature): 装備集計・フィールドアクセサ系にもモンスター経路追加

### DIFF
--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -1354,14 +1354,100 @@ BIT_FLAGS CreatureEntity::has_immune_lite()
     }
     return ::has_immune_lite(*this);
 }
-bool CreatureEntity::has_pass_wall() { return ::has_pass_wall(*this); }
-bool CreatureEntity::has_kill_wall() { return ::has_kill_wall(*this); }
-BIT_FLAGS CreatureEntity::has_reflect() { return ::has_reflect(*this); }
-bool CreatureEntity::has_two_handed_weapons() { return ::has_two_handed_weapons(*this); }
-BIT_FLAGS CreatureEntity::has_sh_fire() { return ::has_sh_fire(*this); }
-BIT_FLAGS CreatureEntity::has_sh_elec() { return ::has_sh_elec(*this); }
-BIT_FLAGS CreatureEntity::has_sh_cold() { return ::has_sh_cold(*this); }
-BIT_FLAGS CreatureEntity::has_down_saving() { return ::has_down_saving(*this); }
-BIT_FLAGS CreatureEntity::has_no_ac() { return ::has_no_ac(*this); }
-BIT_FLAGS CreatureEntity::has_easy2_weapon() { return ::has_easy2_weapon(*this); }
+
+// 装備集計系 virtual メソッドにもモンスター経路を実装。
+bool CreatureEntity::has_pass_wall()
+{
+    if (this->has_monster_profile()) {
+        return this->get_monrace().feature_flags.has(MonsterFeatureType::PASS_WALL);
+    }
+    return ::has_pass_wall(*this);
+}
+bool CreatureEntity::has_kill_wall()
+{
+    if (this->has_monster_profile()) {
+        return this->get_monrace().feature_flags.has(MonsterFeatureType::KILL_WALL);
+    }
+    return ::has_kill_wall(*this);
+}
+BIT_FLAGS CreatureEntity::has_reflect()
+{
+    if (this->has_monster_profile()) {
+        return this->get_monrace().misc_flags.has(MonsterMiscType::REFLECTING) ? static_cast<BIT_FLAGS>(FLAG_CAUSE_RACE) : 0U;
+    }
+    return ::has_reflect(*this);
+}
+bool CreatureEntity::has_two_handed_weapons()
+{
+    if (this->has_monster_profile()) {
+        return false;
+    }
+    return ::has_two_handed_weapons(*this);
+}
+BIT_FLAGS CreatureEntity::has_sh_fire()
+{
+    if (this->has_monster_profile()) {
+        return 0; // モンスターの炎オーラは別系統 (AuraType) で管理
+    }
+    return ::has_sh_fire(*this);
+}
+BIT_FLAGS CreatureEntity::has_sh_elec()
+{
+    if (this->has_monster_profile()) {
+        return 0;
+    }
+    return ::has_sh_elec(*this);
+}
+BIT_FLAGS CreatureEntity::has_sh_cold()
+{
+    if (this->has_monster_profile()) {
+        return 0;
+    }
+    return ::has_sh_cold(*this);
+}
+BIT_FLAGS CreatureEntity::has_down_saving()
+{
+    if (this->has_monster_profile()) {
+        return 0;
+    }
+    return ::has_down_saving(*this);
+}
+BIT_FLAGS CreatureEntity::has_no_ac()
+{
+    if (this->has_monster_profile()) {
+        return 0;
+    }
+    return ::has_no_ac(*this);
+}
+BIT_FLAGS CreatureEntity::has_easy2_weapon()
+{
+    if (this->has_monster_profile()) {
+        return 0;
+    }
+    return ::has_easy2_weapon(*this);
+}
+
+bool CreatureEntity::has_can_swim() const
+{
+    if (this->has_monster_profile()) {
+        return this->get_monrace().feature_flags.has(MonsterFeatureType::CAN_SWIM);
+    }
+    return this->can_swim;
+}
+
+bool CreatureEntity::has_levitation() const
+{
+    if (this->has_monster_profile()) {
+        return this->get_monrace().feature_flags.has(MonsterFeatureType::CAN_FLY);
+    }
+    return this->levitation != 0;
+}
+
+bool CreatureEntity::has_regen_flag() const
+{
+    if (this->has_monster_profile()) {
+        return this->get_monrace().misc_flags.has(MonsterMiscType::REGENERATE);
+    }
+    return this->regenerate != 0;
+}
 // clang-format on

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -971,18 +971,16 @@ public:
     }
     /*!
      * @brief 水中遊泳の可否
+     * @details プレイヤーは装備由来 (can_swim フィールド)、モンスターは
+     *          種族 feature_flags の CAN_SWIM から判定。
      */
-    virtual bool has_can_swim() const
-    {
-        return this->can_swim;
-    }
+    virtual bool has_can_swim() const;
     /*!
      * @brief 浮遊能力の有無
+     * @details プレイヤーは装備由来 (levitation フィールド)、モンスターは
+     *          種族 feature_flags の CAN_FLY から判定。
      */
-    virtual bool has_levitation() const
-    {
-        return this->levitation != 0;
-    }
+    virtual bool has_levitation() const;
     /*!
      * @brief 麻痺耐性の有無
      */
@@ -1006,11 +1004,9 @@ public:
     }
     /*!
      * @brief 自動再生能力の有無（フィールド値）
+     * @details プレイヤーは装備由来、モンスターは MonsterMiscType::REGENERATE。
      */
-    virtual bool has_regen_flag() const
-    {
-        return this->regenerate != 0;
-    }
+    virtual bool has_regen_flag() const;
     /*!
      * @brief 経験値吸収耐性の有無
      */


### PR DESCRIPTION
提案 1 (モンスター側 override) の継続:

- has_pass_wall: MonsterFeatureType::PASS_WALL
- has_kill_wall: MonsterFeatureType::KILL_WALL
- has_can_swim: MonsterFeatureType::CAN_SWIM (cpp 移設)
- has_levitation: MonsterFeatureType::CAN_FLY (cpp 移設)
- has_reflect: MonsterMiscType::REFLECTING
- has_regen_flag: MonsterMiscType::REGENERATE (cpp 移設)

その他の装備集計系 (has_two_handed_weapons / has_sh_fire / has_sh_elec / has_sh_cold / has_down_saving / has_no_ac / has_easy2_weapon) は モンスター側で対応概念がないため 0/false を返す。

has_can_swim / has_levitation / has_regen_flag はヘッダ inline から .cpp 実装に移設し、モンスター種族フラグ経由の実装を提供。