### PR TITLE
refactor(creature): 残るフィールドアクセサに override 追加と意図明確化

### DIFF
--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -5,6 +5,7 @@
 #include "inventory/inventory-slot-types.h"
 #include "market/arena-entry.h"
 #include "mind/mind-elementalist.h"
+#include "monster-race/race-brightness-flags.h"
 #include "monster-race/race-feature-flags.h"
 #include "monster-race/race-flags-resistance.h"
 #include "monster-race/race-kind-flags.h"
@@ -1449,5 +1450,23 @@ bool CreatureEntity::has_regen_flag() const
         return this->get_monrace().misc_flags.has(MonsterMiscType::REGENERATE);
     }
     return this->regenerate != 0;
+}
+
+bool CreatureEntity::has_lite_flag() const
+{
+    if (this->has_monster_profile()) {
+        const auto &flags = this->get_monrace().brightness_flags;
+        return flags.has_any_of({ MonsterBrightnessType::HAS_LITE_1, MonsterBrightnessType::HAS_LITE_2,
+            MonsterBrightnessType::SELF_LITE_1, MonsterBrightnessType::SELF_LITE_2 });
+    }
+    return this->lite != 0;
+}
+
+bool CreatureEntity::has_anti_tele() const
+{
+    if (this->has_monster_profile()) {
+        return this->get_monrace().resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT);
+    }
+    return this->anti_tele != 0;
 }
 // clang-format on

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -897,8 +897,8 @@ public:
 
     /*!
      * @brief 汎用テレパシーの有無を返す
-     * @details プレイヤーは装備由来、モンスターは種族フラグ由来（将来）。
-     *          デフォルト実装は BIT_FLAGS フィールドを参照する。
+     * @details プレイヤーは装備由来 (telepathy フィールドを player-status.cpp が更新)。
+     *          モンスター側は対応概念なし（モンスターの感知は別経路）のため常に false。
      */
     virtual bool has_telepathy() const
     {
@@ -963,7 +963,8 @@ public:
 
     /*!
      * @brief 透明視認の可否
-     * @details プレイヤーは装備由来、モンスターは種族フラグ由来（将来）。
+     * @details プレイヤーは装備由来 (see_inv フィールド)。モンスター側は
+     *          対応フラグなし（透明モンスターの認知は AI 側で別判定）。
      */
     virtual bool can_see_invisible() const
     {
@@ -983,6 +984,9 @@ public:
     virtual bool has_levitation() const;
     /*!
      * @brief 麻痺耐性の有無
+     * @details プレイヤーは装備由来。モンスターは状態耐性が個別フラグ
+     *          (NO_SLEEP / NO_STUN) で表現されるためこの統一値での
+     *          単純な対応は持たず、現状 false 相当を返す。
      */
     virtual bool has_free_act() const
     {
@@ -990,6 +994,7 @@ public:
     }
     /*!
      * @brief 反魔法能力の有無
+     * @details プレイヤーは装備由来。モンスター側に対応フラグなし。
      */
     virtual bool has_anti_magic() const
     {
@@ -997,11 +1002,9 @@ public:
     }
     /*!
      * @brief テレポート阻害の有無
+     * @details プレイヤーは装備由来、モンスターは MonsterResistanceType::RESIST_TELEPORT。
      */
-    virtual bool has_anti_tele() const
-    {
-        return this->anti_tele != 0;
-    }
+    virtual bool has_anti_tele() const;
     /*!
      * @brief 自動再生能力の有無（フィールド値）
      * @details プレイヤーは装備由来、モンスターは MonsterMiscType::REGENERATE。
@@ -1046,11 +1049,10 @@ public:
     }
     /*!
      * @brief 光源能力の有無 (フィールド値)
+     * @details プレイヤーは装備由来 (lite フィールド)、モンスターは
+     *          MonsterBrightnessType::HAS_LITE_1/2 / SELF_LITE_1/2 から判定。
      */
-    virtual bool has_lite_flag() const
-    {
-        return this->lite != 0;
-    }
+    virtual bool has_lite_flag() const;
     /*!
      * @brief 警告能力の有無
      */


### PR DESCRIPTION
提案 B-1 対応。フィールド書込みがプレイヤー専用 (player-status.cpp)
のため、モンスターでは値が常に 0 で意味ある応答にならない問題に対処:

- has_lite_flag(): モンスターは MonsterBrightnessType::HAS_LITE_1/2 / SELF_LITE_1/2 から判定 (.cpp 移設)
- has_anti_tele(): モンスターは MonsterResistanceType::RESIST_TELEPORT から判定 (.cpp 移設)

その他 (has_telepathy / can_see_invisible / has_free_act / has_anti_magic) はモンスター側に対応フラグがないため動作上 false
相当のままだが、doxygen コメントで「モンスター側未対応」と明記し
誤解を防ぐよう改善。