### PR TITLE
refactor(creature): ESP 系 virtual の実装を 1 行化してコメント整理

### DIFF
--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -904,6 +904,8 @@ public:
     {
         return this->telepathy != 0;
     }
+    // 種別 ESP 群: プレイヤーは装備由来 (esp_* フィールドを player-status.cpp が更新)。
+    // モンスター側に対応概念なしのため、フィールド初期値 0 で常に false を返す。
     virtual bool has_esp_animal() const
     {
         return this->esp_animal != 0;


### PR DESCRIPTION
has_esp_animal/nasty/homo/undead/demon/orc/troll/giant/dragon/ human/evil/good/nonliving/unique を 1 行 inline に圧縮し、 グループヘッダとして「モンスター側未対応、フィールド初期値 0 で
常に false」の意図を明記。機能変化なし、可読性向上のみ。