### PR TITLE
refactor(creature): has_resist_nexus を virtual 化対象に追加

### DIFF
--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -1228,6 +1228,13 @@ BIT_FLAGS CreatureEntity::has_resist_shard()
     }
     return ::has_resist_shard(*this);
 }
+BIT_FLAGS CreatureEntity::has_resist_nexus()
+{
+    if (this->has_monster_profile()) {
+        return monster_race_flag_cause(*this, MonsterResistanceType::RESIST_NEXUS);
+    }
+    return ::has_resist_nexus(*this);
+}
 BIT_FLAGS CreatureEntity::has_resist_blind()
 {
     if (this->has_monster_profile()) {

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -864,6 +864,7 @@ public:
     virtual BIT_FLAGS has_resist_chaos();
     virtual BIT_FLAGS has_resist_disen();
     virtual BIT_FLAGS has_resist_shard();
+    virtual BIT_FLAGS has_resist_nexus();
     virtual BIT_FLAGS has_resist_blind();
     virtual BIT_FLAGS has_resist_neth();
     virtual BIT_FLAGS has_resist_time();


### PR DESCRIPTION
提案 A-1 対応。他の耐性系 virtual メソッドから漏れていた
has_resist_nexus を CreatureEntity に追加。

- プレイヤー時: player-status-flags 自由関数に委譲 (既存実装)
- モンスター時: MonsterResistanceType::RESIST_NEXUS から判定

外部 call site は 0 (self-info 等で将来使う可能性のみ) だが、他
耐性系 29 種との完全性のため追加。内部 (player-status-flags.cpp
自身) の呼出 1 箇所はそのまま維持。