### PR TITLE
refactor(creature): TimedEffects 高機能 API を CreatureEntity virtual メソッ…

### DIFF
--- a/src/action/racial-execution.cpp
+++ b/src/action/racial-execution.cpp
@@ -17,7 +17,6 @@
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
 #include "term/screen-processor.h"
-#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!
@@ -56,9 +55,8 @@ PERCENTAGE racial_chance(CreatureEntity &creature, rpi_type *rpi_ptr)
         return 100;
     }
 
-    const auto &player_stun = creature.effects()->stun();
-    if (player_stun.is_stunned()) {
-        difficulty += player_stun.current();
+    if (creature.is_stunned()) {
+        difficulty += creature.get_remaining_stun();
     } else if (creature.level > rpi_ptr->min_level) {
         PERCENTAGE lev_adj = (PERCENTAGE)((creature.level - rpi_ptr->min_level) / 3);
         if (lev_adj > 10) {
@@ -98,9 +96,8 @@ static void adjust_racial_power_difficulty(CreatureEntity &creature, rpi_type *r
         return;
     }
 
-    const auto &player_stun = creature.effects()->stun();
-    if (player_stun.is_stunned()) {
-        *difficulty += player_stun.current();
+    if (creature.is_stunned()) {
+        *difficulty += creature.get_remaining_stun();
     } else if (creature.level > rpi_ptr->min_level) {
         int lev_adj = ((creature.level - rpi_ptr->min_level) / 3);
         if (lev_adj > 10) {

--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -16,7 +16,6 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/terrain/terrain-definition.h"
-#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 #include <queue>
 #include <vector>
@@ -129,8 +128,7 @@ Direction decide_travel_step_dir(CreatureEntity &creature, const Direction &prev
         return Direction::none();
     }
 
-    const auto &blindness = creature.effects()->blindness();
-    if (blindness.is_blind() || no_lite(creature)) {
+    if (creature.is_blind() || no_lite(creature)) {
         msg_print(_("目が見えない！", "You cannot see!"));
         return Direction::none();
     }

--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -25,7 +25,6 @@
 #include "system/creature-entity.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
-#include "timed-effect/timed-effects.h"
 #include "util/enum-converter.h"
 #include "util/flag-group.h"
 #include "util/int-char-converter.h"
@@ -269,7 +268,7 @@ int calculate_blue_magic_failure_probability(CreatureEntity &creature, const mon
         chance = minfail;
     }
 
-    chance += creature.effects()->stun().get_magic_chance_penalty();
+    chance += creature.get_stun_magic_chance_penalty();
     if (chance > 95) {
         chance = 95;
     }

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -62,7 +62,6 @@
 #include "target/target-types.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"
-#include "timed-effect/timed-effects.h"
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
@@ -293,7 +292,7 @@ static int get_mane_power(CreatureEntity &creature, int *sn, bool baigaesi)
                         chance = minfail;
                     }
 
-                    chance += creature.effects()->stun().get_magic_chance_penalty();
+                    chance += creature.get_stun_magic_chance_penalty();
                     if (chance > 95) {
                         chance = 95;
                     }
@@ -1239,7 +1238,7 @@ bool do_cmd_mane(CreatureEntity &creature, bool baigaesi)
         chance = minfail;
     }
 
-    chance += creature.effects()->stun().get_magic_chance_penalty();
+    chance += creature.get_stun_magic_chance_penalty();
     if (chance > 95) {
         chance = 95;
     }

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -49,7 +49,6 @@
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
-#include "timed-effect/timed-effects.h"
 #include "util/enum-converter.h"
 #include "view/display-messages.h"
 #include "view/display-util.h"
@@ -189,7 +188,7 @@ static void decide_mind_chance(CreatureEntity &creature, cm_type *cm_ptr)
         cm_ptr->chance = cm_ptr->minfail;
     }
 
-    cm_ptr->chance += creature.effects()->stun().get_magic_chance_penalty();
+    cm_ptr->chance += creature.get_stun_magic_chance_penalty();
     if (cm_ptr->use_mind != MindKindType::KI) {
         return;
     }

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -79,7 +79,6 @@
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "term/z-form.h"
-#include "timed-effect/timed-effects.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include "view/display-util.h"
@@ -273,7 +272,7 @@ static tl::optional<BaseitemKey> select_magic_eater(CreatureEntity &creature, bo
                 }
                 chance = mod_spell_chance_1(creature, chance);
                 chance = std::max<int>(chance, adj_mag_fail[creature.stat_index[mp_ptr->spell_stat]]);
-                chance += creature.effects()->stun().get_magic_chance_penalty();
+                chance += creature.get_stun_magic_chance_penalty();
                 if (chance > 95) {
                     chance = 95;
                 }
@@ -514,7 +513,7 @@ bool do_cmd_magic_eater(CreatureEntity &creature, bool only_browse, bool powerfu
     }
     chance = mod_spell_chance_1(creature, chance);
     chance = std::max<int>(chance, adj_mag_fail[creature.stat_index[mp_ptr->spell_stat]]);
-    chance += creature.effects()->stun().get_magic_chance_penalty();
+    chance += creature.get_stun_magic_chance_penalty();
     if (chance > 95) {
         chance = 95;
     }

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -38,7 +38,6 @@
 #include "system/monrace/monrace-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "system/terrain/terrain-definition.h"
-#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -118,21 +117,18 @@ void process_player_hp_mp(CreatureEntity &creature)
     bool cave_no_regen = false;
     int upkeep_factor = 0;
     int regen_amount = PY_REGEN_NORMAL;
-    const auto effects = creature.effects();
     if (terrain.flags.has(TerrainCharacteristics::RUNE_HEALING)) {
         hp_player(creature, 2 + creature.level / 6);
     }
 
-    const auto &player_poison = effects->poison();
-    if (player_poison.is_poisoned() && !creature.is_invulnerable()) {
+    if (creature.is_poisoned() && !creature.is_invulnerable()) {
         if (take_hit(creature, DAMAGE_NOESCAPE, 1, _("毒", "poison")) > 0) {
             sound(SoundKind::DAMAGE_OVER_TIME);
         }
     }
 
-    const auto &player_cut = effects->cut();
-    if (player_cut.is_cut() && !creature.is_invulnerable()) {
-        const auto dam = player_cut.get_damage();
+    if (creature.is_cut() && !creature.is_invulnerable()) {
+        const auto dam = creature.get_cut_damage_per_turn();
         if (take_hit(creature, DAMAGE_NOESCAPE, dam, _("致命傷", "a mortal wound")) > 0) {
             sound(SoundKind::DAMAGE_OVER_TIME);
         }
@@ -452,10 +448,10 @@ void process_player_hp_mp(CreatureEntity &creature)
         }
     }
 
-    if (player_poison.is_poisoned()) {
+    if (creature.is_poisoned()) {
         regen_amount = 0;
     }
-    if (player_cut.is_cut()) {
+    if (creature.is_cut()) {
         regen_amount = 0;
     }
     if (cave_no_regen) {

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -54,7 +54,7 @@
 #include "target/grid-selector.h"
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
-#include "timed-effect/timed-effects.h"
+#include "term/term-color-types.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include "view/display-util.h"
@@ -652,7 +652,7 @@ static PERCENTAGE decide_element_chance(CreatureEntity &creature, mind_type spel
         chance = minfail;
     }
 
-    chance += creature.effects()->stun().get_magic_chance_penalty();
+    chance += creature.get_stun_magic_chance_penalty();
     if (heavy_armor(creature)) {
         chance += 5;
     }

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -19,7 +19,6 @@
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"
-#include "timed-effect/timed-effects.h"
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 
@@ -302,7 +301,7 @@ void MindPowerGetter::calculate_mind_chance(bool has_weapon_main, bool has_weapo
         this->chance = minfail;
     }
 
-    this->chance += this->creature_ptr->effects()->stun().get_magic_chance_penalty();
+    this->chance += this->creature_ptr->get_stun_magic_chance_penalty();
     add_ki_chance();
     if (this->chance > 95) {
         this->chance = 95;

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -34,7 +34,6 @@
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"
-#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
@@ -272,9 +271,8 @@ static void hissatsu_lightning_eagle(CreatureEntity &creature, samurai_slaying_t
  */
 static void hissatsu_bloody_maelstroem(CreatureEntity &creature, samurai_slaying_type *samurai_slaying_ptr)
 {
-    const auto &player_cut = creature.effects()->cut();
-    if ((samurai_slaying_ptr->mode == HISSATSU_SEKIRYUKA) && player_cut.is_cut() && samurai_slaying_ptr->m_ptr->has_living_flag()) {
-        auto tmp = std::min<short>(100, std::max<short>(10, player_cut.current() / 10));
+    if ((samurai_slaying_ptr->mode == HISSATSU_SEKIRYUKA) && creature.is_cut() && samurai_slaying_ptr->m_ptr->has_living_flag()) {
+        auto tmp = std::min<short>(100, std::max<short>(10, creature.get_remaining_cut() / 10));
         if (samurai_slaying_ptr->mult < tmp) {
             samurai_slaying_ptr->mult = tmp;
         }
@@ -378,13 +376,12 @@ bool choose_samurai_stance(CreatureEntity &creature)
         return false;
     }
 
-    const auto effects = creature.effects();
-    if (effects->stun().is_stunned()) {
+    if (creature.is_stunned()) {
         msg_print(_("意識がはっきりとしない。", "You are not clear-headed"));
         return false;
     }
 
-    if (effects->fear().is_fearful()) {
+    if (creature.is_fearful()) {
         msg_print(_("体が震えて構えられない！", "You are trembling with fear!"));
         return false;
     }

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -282,7 +282,7 @@ bool MonsterAttackPlayer::effect_protecion_from_evil()
 {
     auto &creature = *this->creature_ptr;
     auto &monrace = this->m_ptr->get_monrace();
-    auto is_protected = creature.effects()->protection().is_protected();
+    auto is_protected = creature.is_protected_from_evil();
     is_protected &= monrace.kind_flags.has(MonsterKindType::EVIL);
     is_protected &= (randint0(100) + creature.level - this->rlev) > 50;
     if (!is_protected) {

--- a/src/object-use/item-use-checker.cpp
+++ b/src/object-use/item-use-checker.cpp
@@ -1,6 +1,5 @@
 #include "object-use/item-use-checker.h"
 #include "system/creature-entity.h"
-#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 ItemUseChecker::ItemUseChecker(CreatureEntity &creature)
@@ -10,7 +9,7 @@ ItemUseChecker::ItemUseChecker(CreatureEntity &creature)
 
 bool ItemUseChecker::check_stun(std::string_view mes) const
 {
-    const auto penalty = this->creature.effects()->stun().get_item_chance_penalty();
+    const auto penalty = this->creature.get_stun_item_chance_penalty();
     if (penalty >= randint1(100)) {
         msg_print(mes);
         return false;

--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -39,7 +39,6 @@
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
 #include "system/redrawing-flags-updater.h"
-#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "util/dice.h"
 #include "view/display-messages.h"
@@ -119,7 +118,7 @@ bool QuaffEffects::influence(const ItemEntity &item, const bool is_rectal)
     case SV_POTION_DETECT_INVIS:
         return set_tim_invis(this->creature, this->creature.get_timed_effect(CreatureTimedEffect::TIM_INVIS) + 12 + randint1(12), false);
     case SV_POTION_SLOW_POISON:
-        return BadStatusSetter(this->creature).set_poison(this->creature.effects()->poison().current() / 2);
+        return BadStatusSetter(this->creature).set_poison(this->creature.get_remaining_poison() / 2);
     case SV_POTION_CURE_POISON:
         return BadStatusSetter(this->creature).set_poison(0);
     case SV_POTION_BOLDNESS:

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -103,7 +103,6 @@
 #include "system/services/dungeon-service.h"
 #include "system/terrain/terrain-definition.h"
 #include "term/screen-processor.h"
-#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
 #include "util/string-processor.h"
@@ -2064,7 +2063,7 @@ static short calc_to_damage(CreatureEntity &creature, INVENTORY_IDX slot, bool i
         damage += 3 + (creature.level / 5);
     }
 
-    damage -= creature.effects()->stun().get_damage_penalty();
+    damage -= creature.get_stun_damage_penalty();
     CreatureClass pc(creature);
     const auto tval = o_ptr->bi_key.tval();
     if (pc.equals(PlayerClassType::PRIEST) && (o_ptr->get_flags().has_not(TR_BLESSED)) && ((tval == ItemKindType::SWORD) || (tval == ItemKindType::POLEARM))) {
@@ -2221,7 +2220,7 @@ static short calc_to_hit(CreatureEntity &creature, INVENTORY_IDX slot, bool is_r
         hit += 12;
     }
 
-    hit -= creature.effects()->stun().get_damage_penalty();
+    hit -= creature.get_stun_damage_penalty();
     player_hand calc_hand = PLAYER_HAND_OTHER;
     if (slot == INVEN_MAIN_HAND) {
         calc_hand = PLAYER_HAND_MAIN;
@@ -2456,7 +2455,7 @@ static int16_t calc_to_hit_bow(CreatureEntity &creature, bool is_real_value)
         }
     }
 
-    pow -= creature.effects()->stun().get_damage_penalty();
+    pow -= creature.get_stun_damage_penalty();
     if (creature.is_blessed()) {
         pow += 10;
     }
@@ -2539,7 +2538,7 @@ static int16_t calc_to_damage_misc(CreatureEntity &creature)
         to_dam += 3 + (creature.level / 5);
     }
 
-    to_dam -= creature.effects()->stun().get_damage_penalty();
+    to_dam -= creature.get_stun_damage_penalty();
     to_dam += ((int)(adj_str_td[creature.stat_index[A_STR]]) - 128);
     return to_dam;
 }
@@ -2577,7 +2576,7 @@ static int16_t calc_to_hit_misc(CreatureEntity &creature)
         to_hit += 12;
     }
 
-    to_hit -= creature.effects()->stun().get_damage_penalty();
+    to_hit -= creature.get_stun_damage_penalty();
     to_hit += ((int)(adj_dex_th[creature.stat_index[A_DEX]]) - 128);
     to_hit += ((int)(adj_str_th[creature.stat_index[A_STR]]) - 128);
 

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -48,7 +48,6 @@
 #include "target/projection-path-calculator.h"
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
-#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -417,7 +416,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
 
     case 19:
         if (cast) {
-            const auto current_cut = creature.effects()->cut().current();
+            const auto current_cut = creature.get_remaining_cut();
             short new_cut = current_cut < 300 ? current_cut + 300 : current_cut * 2;
             (void)BadStatusSetter(creature).set_cut(new_cut);
             const auto &floor = *creature.get_floor();

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -15,7 +15,6 @@
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "term/z-form.h"
-#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
@@ -190,7 +189,7 @@ PERCENTAGE spell_chance(CreatureEntity &creature, SPELL_IDX spell_id, RealmType 
         chance = minfail;
     }
 
-    chance += creature.effects()->stun().get_magic_chance_penalty();
+    chance += creature.get_stun_magic_chance_penalty();
     if (chance > 95) {
         chance = 95;
     }

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -48,7 +48,6 @@
 #include "system/item-entity.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/target-getter.h"
-#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 
@@ -407,7 +406,7 @@ bool cure_serious_wounds(CreatureEntity &creature, int pow)
         ident = true;
     }
 
-    if (bss.set_cut((creature.effects()->cut().current() / 2) - 50)) {
+    if (bss.set_cut((creature.get_remaining_cut() / 2) - 50)) {
         ident = true;
     }
 

--- a/src/status/shape-changer.cpp
+++ b/src/status/shape-changer.cpp
@@ -23,7 +23,6 @@
 #include "status/base-status.h"
 #include "system/creature-entity.h"
 #include "system/redrawing-flags-updater.h"
-#include "timed-effect/timed-effects.h"
 #include "util/enum-converter.h"
 #include "view/display-messages.h"
 
@@ -32,8 +31,7 @@ void do_poly_wounds(CreatureEntity &creature)
     int16_t hit_p = (creature.maxhp - creature.hp);
     auto change = static_cast<TIME_EFFECT>(Dice::roll(creature.level, 5));
     auto nasty_effect = one_in_(5);
-    const auto &player_cut = creature.effects()->cut();
-    if (!player_cut.is_cut() && (hit_p == 0) && !nasty_effect) {
+    if (!creature.is_cut() && (hit_p == 0) && !nasty_effect) {
         return;
     }
 

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -431,6 +431,43 @@ bool CreatureEntity::is_poisoned() const
     return this->get_timed_effect(CreatureTimedEffect::POISON) > 0;
 }
 
+bool CreatureEntity::is_protected_from_evil() const
+{
+    return this->effects()->protection().is_protected();
+}
+
+int CreatureEntity::get_stun_magic_chance_penalty() const
+{
+    return this->effects()->stun().get_magic_chance_penalty();
+}
+
+int CreatureEntity::get_stun_item_chance_penalty() const
+{
+    return this->effects()->stun().get_item_chance_penalty();
+}
+
+short CreatureEntity::get_stun_damage_penalty() const
+{
+    return this->effects()->stun().get_damage_penalty();
+}
+
+std::pair<TERM_COLOR, std::string> CreatureEntity::get_stun_expr() const
+{
+    const auto [color, text] = this->effects()->stun().get_expr();
+    return { color, std::string(text) };
+}
+
+std::pair<TERM_COLOR, std::string> CreatureEntity::get_cut_expr() const
+{
+    const auto [color, text] = this->effects()->cut().get_expr();
+    return { color, text };
+}
+
+int CreatureEntity::get_cut_damage_per_turn() const
+{
+    return this->effects()->cut().get_damage();
+}
+
 bool CreatureEntity::is_blessed() const
 {
     if (this->get_timed_effect(CreatureTimedEffect::BLESSED) > 0) {

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <string_view>
 #include <tl/optional.hpp>
+#include <utility>
 #include <vector>
 
 constexpr int MONSTER_MAXHP = 10000000; //!< モンスターの最大HP
@@ -598,6 +599,21 @@ public:
         return this->get_timed_effect(CreatureTimedEffect::OPPOSE_POIS);
     }
 
+    short get_remaining_cut() const
+    {
+        return this->get_timed_effect(CreatureTimedEffect::CUT);
+    }
+
+    short get_remaining_poison() const
+    {
+        return this->get_timed_effect(CreatureTimedEffect::POISON);
+    }
+
+    short get_remaining_blindness() const
+    {
+        return this->get_timed_effect(CreatureTimedEffect::BLINDNESS);
+    }
+
     tl::optional<std::string> get_pain_message(std::string_view monster_name, int damage) const;
 
     /*!
@@ -680,6 +696,15 @@ public:
      * @return 毒に侵されていればtrue
      */
     virtual bool is_poisoned() const;
+
+    virtual bool is_protected_from_evil() const;
+
+    virtual int get_stun_magic_chance_penalty() const;
+    virtual int get_stun_item_chance_penalty() const;
+    virtual short get_stun_damage_penalty() const;
+    virtual std::pair<TERM_COLOR, std::string> get_stun_expr() const;
+    virtual std::pair<TERM_COLOR, std::string> get_cut_expr() const;
+    virtual int get_cut_damage_per_turn() const;
 
     /*!
      * @brief クリーチャーが加速しているかどうかを判定

--- a/src/window/display-sub-window-spells.cpp
+++ b/src/window/display-sub-window-spells.cpp
@@ -15,8 +15,6 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
-#include "timed-effect/player-stun.h"
-#include "timed-effect/timed-effects.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 
@@ -116,8 +114,7 @@ static void display_spell_list(CreatureEntity &creature)
                 chance = minfail;
             }
 
-            auto player_stun = creature.effects()->stun();
-            chance += player_stun->get_magic_chance_penalty();
+            chance += creature.get_stun_magic_chance_penalty();
             if (chance > 95) {
                 chance = 95;
             }

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -36,7 +36,6 @@
 #include "target/target-preparation.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
-#include "timed-effect/timed-effects.h"
 #include "tracking/lore-tracker.h"
 #include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
@@ -799,7 +798,7 @@ static void display_spell_list(CreatureEntity &creature)
                 chance = minfail;
             }
 
-            chance += creature.effects()->stun().get_magic_chance_penalty();
+            chance += creature.get_stun_magic_chance_penalty();
             if (chance > 95) {
                 chance = 95;
             }

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -24,7 +24,6 @@
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "term/z-form.h"
-#include "timed-effect/timed-effects.h"
 #include "view/status-bars-table.h"
 #include "window/main-window-row-column.h"
 #include "world/world.h"
@@ -73,13 +72,12 @@ void print_stat(CreatureEntity &creature, int stat)
  */
 void print_cut(CreatureEntity &creature)
 {
-    const auto &player_cut = creature.effects()->cut();
-    if (!player_cut.is_cut()) {
+    if (!creature.is_cut()) {
         put_str("            ", ROW_CUT, COL_CUT);
         return;
     }
 
-    auto [color, stat] = player_cut.get_expr();
+    auto [color, stat] = creature.get_cut_expr();
     c_put_str(color, stat, ROW_CUT, COL_CUT);
 }
 
@@ -89,13 +87,12 @@ void print_cut(CreatureEntity &creature)
  */
 void print_stun(CreatureEntity &creature)
 {
-    const auto &player_stun = creature.effects()->stun();
-    if (!player_stun.is_stunned()) {
+    if (!creature.is_stunned()) {
         put_str("            ", ROW_STUN, COL_STUN);
         return;
     }
 
-    const auto &[color, stat] = player_stun.get_expr();
+    const auto &[color, stat] = creature.get_stun_expr();
     c_put_str(color, stat, ROW_STUN, COL_STUN);
 }
 
@@ -444,12 +441,11 @@ void print_status(CreatureEntity &creature)
     const auto max_col_statbar = wid + MAX_COL_STATBAR;
     term_erase(0, row_statbar, max_col_statbar);
     BIT_FLAGS bar_flags[3]{};
-    auto effects = creature.effects();
     if (creature.get_timed_effect(CreatureTimedEffect::TSUYOSHI)) {
         ADD_BAR_FLAG(BAR_TSUYOSHI);
     }
 
-    if (effects->hallucination().is_hallucinated()) {
+    if (creature.is_hallucinated()) {
         ADD_BAR_FLAG(BAR_HALLUCINATION);
     }
 
@@ -457,15 +453,15 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_BLINDNESS);
     }
 
-    if (effects->paralysis().is_paralyzed()) {
+    if (creature.is_paralyzed()) {
         ADD_BAR_FLAG(BAR_PARALYZE);
     }
 
-    if (effects->confusion().is_confused()) {
+    if (creature.is_confused()) {
         ADD_BAR_FLAG(BAR_CONFUSE);
     }
 
-    if (effects->poison().is_poisoned()) {
+    if (creature.is_poisoned()) {
         ADD_BAR_FLAG(BAR_POISONED);
     }
 
@@ -491,7 +487,7 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_INFRAVISION);
     }
 
-    if (effects->protection().is_protected()) {
+    if (creature.is_protected_from_evil()) {
         ADD_BAR_FLAG(BAR_PROTEVIL);
     }
 
@@ -584,7 +580,7 @@ void print_status(CreatureEntity &creature)
         ADD_BAR_FLAG(BAR_ALTER);
     }
 
-    if (effects->fear().is_fearful()) {
+    if (creature.is_fearful()) {
         ADD_BAR_FLAG(BAR_AFRAID);
     }
 


### PR DESCRIPTION
…ドに昇格

effects()->stun().get_magic_chance_penalty() 等の高機能 API 呼出を CreatureEntity の virtual メソッドとして提供し、外部コードから
TimedEffects オブジェクトへの直接アクセスを不要にした。

新規 virtual メソッド:
- get_stun_magic_chance_penalty() / get_stun_item_chance_penalty()
- get_stun_damage_penalty() / get_stun_expr() / get_cut_expr()
- get_cut_damage_per_turn() / is_protected_from_evil()

新規 inline ヘルパ:
- get_remaining_cut() / get_remaining_poison() / get_remaining_blindness()

27 箇所の effects()-> 直接呼出を virtual メソッド / 既存 is_*() / get_remaining_*() に移行し、不要になった timed-effect ヘッダの
インクルードを 17 ファイルから削除。