### PR TITLE
refactor(creature): ppersonality に NONE 値を追加しモンスター初期化を明確化

### DIFF
--- a/src/player/player-personality-types.h
+++ b/src/player/player-personality-types.h
@@ -1,6 +1,7 @@
 #pragma once
 
 enum player_personality_type {
+    PERSONALITY_NONE = -1,
     PERSONALITY_ORDINARY = 0,
     PERSONALITY_MIGHTY = 1,
     PERSONALITY_SHREWD = 2,

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -22,6 +22,7 @@
 #include "player-info/race-types.h"
 #include "player-info/sniper-data-type.h"
 #include "player-info/spell-hex-data-type.h"
+#include "player/player-personality.h"
 #include "player/player-status-flags.h"
 #include "player/race-info-table.h"
 #include "realm/realm-song-numbers.h"
@@ -183,6 +184,16 @@ const player_sex_type &CreatureEntity::get_sex_info() const
     default:
         return sex_info[SEX_ASEXUAL];
     }
+}
+
+const player_personality *CreatureEntity::get_personality_info() const
+{
+    if (this->personality) {
+        return this->personality;
+    }
+
+    static const player_personality null_personality{};
+    return &null_personality;
 }
 
 bool CreatureEntity::has_living_flag(bool is_appearance) const
@@ -1137,6 +1148,7 @@ void CreatureEntity::init_monster_profile()
     // 対応する MonsterProfile 側の設定値からここに反映させる。
     this->prace = PlayerRaceType::NONE;
     this->pclass = PlayerClassType::NONE;
+    this->ppersonality = PERSONALITY_NONE;
     this->realm1 = RealmType::NONE;
     this->realm2 = RealmType::NONE;
     this->element_realm = ElementRealmType::NONE;

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1180,10 +1180,8 @@ public:
     /*!
      * @brief 性格情報ポインタ
      */
-    virtual const player_personality *get_personality_info() const
-    {
-        return this->personality;
-    }
+    virtual const player_personality *get_personality_info() const;
+
     /*!
      * @brief 職業情報ポインタ
      */


### PR DESCRIPTION
player_personality_type に PERSONALITY_NONE = -1 を追加し、モンスター
生成時 (init_monster_profile) に ppersonality を明示的に NONE に
初期化するようにした。prace / pclass と同様のパターン。

get_personality_info() を out-of-line 化し、personality ポインタが
null の場合（モンスター等）にゼロ初期化された静的インスタンスを
返すことで、呼出元の配列範囲外アクセスを防止。