### PR TITLE
refactor: PlayerType 具象型を使わない 18 ファイルから不要な include を削除

### DIFF
--- a/src/birth/birth-select-class.cpp
+++ b/src/birth/birth-select-class.cpp
@@ -4,7 +4,6 @@
 #include "player-info/class-info.h"
 #include "player-info/race-info.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "term/z-form.h"

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -34,7 +34,6 @@
 #include "player/player-status.h"
 #include "player/process-name.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -14,7 +14,6 @@
 #include "player/process-name.h"
 #include "player/race-info-table.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "util/enum-converter.h"

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -46,7 +46,6 @@
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "util/enum-converter.h"

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -40,7 +40,6 @@
 #include "system/floor/floor-info.h"
 #include "system/floor/wilderness-grid.h"
 #include "system/grid-type-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "system/services/dungeon-service.h"
 #include "system/terrain/terrain-definition.h"

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -60,7 +60,6 @@
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -74,7 +74,6 @@
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"

--- a/src/combat/aura-counterattack.cpp
+++ b/src/combat/aura-counterattack.cpp
@@ -26,7 +26,6 @@
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 static void aura_fire_by_monster_attack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)

--- a/src/core/game-closer.cpp
+++ b/src/core/game-closer.cpp
@@ -25,7 +25,6 @@
 #include "save/save.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
-#include "system/player-type-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "util/angband-files.h"

--- a/src/flavor/tval-description-switcher.cpp
+++ b/src/flavor/tval-description-switcher.cpp
@@ -14,7 +14,6 @@
 #include "system/baseitem/baseitem-list.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "util/bit-flags-calculator.h"

--- a/src/io-dump/dump-util.cpp
+++ b/src/io-dump/dump-util.cpp
@@ -2,7 +2,6 @@
 #include "floor/geometry.h"
 #include "game-option/keymap-directory-getter.h"
 #include "game-option/special-options.h"
-#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -90,7 +90,6 @@
 #include "system/dungeon/dungeon-definition.h"
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "util/int-char-converter.h"

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -43,7 +43,6 @@
 #include "system/angband-exceptions.h"
 #include "system/angband-system.h"
 #include "system/angband-version.h"
-#include "system/player-type-definition.h"
 #include "system/system-variables.h"
 #include "util/angband-files.h"
 #include "util/enum-converter.h"

--- a/src/melee/melee-postprocess.cpp
+++ b/src/melee/melee-postprocess.cpp
@@ -37,7 +37,6 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "tracking/health-bar-tracker.h"
 #include "util/bit-flags-calculator.h"

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -15,7 +15,6 @@
 #include "player-info/equipment-info.h"
 #include "player/player-status-table.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -30,7 +30,6 @@
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
-#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"

--- a/src/monster-attack/monster-attack-describer.cpp
+++ b/src/monster-attack/monster-attack-describer.cpp
@@ -13,7 +13,6 @@
 #include "system/angband.h"
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
-#include "system/player-type-definition.h"
 
 static void show_jaian_song(MonsterAttackPlayer *monap_ptr)
 {

--- a/src/monster-attack/monster-attack-lose.cpp
+++ b/src/monster-attack/monster-attack-lose.cpp
@@ -10,7 +10,6 @@
 #include "status/base-status.h"
 #include "status/element-resistance.h"
 #include "system/creature-entity.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 /*!


### PR DESCRIPTION
PlayerType を直接参照せず CreatureEntity & のみで動作するファイルから