### PR TITLE
merge: 素手+強撃のダメージ表示式の int overflow を修正（hengband#5331 相当）

### DIFF
--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -63,6 +63,7 @@
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "wizard/wizard-messages.h"
+#include <cstdint>
 
 /*!
  * @brief 矢弾の属性を定義する
@@ -1212,19 +1213,19 @@ int calc_expect_crit(CreatureEntity &creature, WEIGHT weight, int plus, int dam,
         i = 0;
     }
 
-    auto num = 0;
+    int64_t num = 0;
 
     if (impact) {
         // 強撃クリティカル(クリティカル強度: weight + d650 + d650)のときの期待値
-        auto sum = 0;
+        int64_t sum = 0;
         for (auto d = 2; d <= CRITICAL_DIE_SIDES * 2; ++d) { // d650 + d650 で出る 2～1300 について計算する
-            const auto count = (d <= CRITICAL_DIE_SIDES + 1) ? (d - 1) : (CRITICAL_DIE_SIDES * 2 - d + 1); // d650 + d650 で出る 650*650 通りのうちdが出るパターンの数
+            const int64_t count = (d <= CRITICAL_DIE_SIDES + 1) ? (d - 1) : (CRITICAL_DIE_SIDES * 2 - d + 1); // d650 + d650 で出る 650*650 通りのうちdが出るパターンの数
             sum += std::get<0>(apply_critical_norm_damage(weight + d, dam, mult)) * count;
         }
         num = sum / (CRITICAL_DIE_SIDES * CRITICAL_DIE_SIDES);
     } else {
         // 通常クリティカル(クリティカル強度: weight + d650)のときの期待値
-        auto sum = 0;
+        int64_t sum = 0;
         for (auto d = 1; d <= CRITICAL_DIE_SIDES; ++d) {
             sum += std::get<0>(apply_critical_norm_damage(weight + d, dam, mult));
         }


### PR DESCRIPTION
変愚蛮怒 PR #5331 の内容を bakabakaband に適応してマージ。

calc_expect_crit() で素手+強撃時のクリティカル期待値を計算する際、
中間変数 sum/count/num が int 範囲を超えるケースがあったため
int64_t に拡張して overflow を防止。

上流コミット: 5cd5fde8b73c (hengband/develop)
Refs: #8265