### PR TITLE
merge: Visual Studio 2026 対応（hengband#5335 相当）

### DIFF
--- a/.github/workflows/build-test-with-msvc.yml
+++ b/.github/workflows/build-test-with-msvc.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
 
     steps:
       - uses: actions/checkout@v4

--- a/VisualStudio/Bakabakaband.sln
+++ b/VisualStudio/Bakabakaband.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31903.59
+# Visual Studio Version 18
+VisualStudioVersion = 18.5.11716.220 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{82CF9010-9443-4FFF-ADF0-0D3E81C732CC}"
 	ProjectSection(SolutionItems) = preProject

--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
@@ -3,19 +3,19 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
@@ -45,24 +45,24 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -122,6 +122,9 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <CompileAsManaged>false</CompileAsManaged>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -161,6 +164,9 @@
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <CompileAsManaged>false</CompileAsManaged>
       <ConformanceMode>true</ConformanceMode>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -193,6 +199,9 @@
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <CompileAsManaged>false</CompileAsManaged>
       <ConformanceMode>true</ConformanceMode>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -234,6 +243,9 @@
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <CompileAsManaged>false</CompileAsManaged>
       <ConformanceMode>true</ConformanceMode>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
     </ClCompile>
     <Link>
       <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/alliance/alliance-soukaiya.h
+++ b/src/alliance/alliance-soukaiya.h
@@ -6,6 +6,8 @@ class AllianceSoukaiya : public Alliance {
 public:
     using Alliance::Alliance;
     AllianceSoukaiya() = delete;
+    AllianceSoukaiya(const AllianceSoukaiya &) = default;
+    AllianceSoukaiya(AllianceSoukaiya &&) = default;
     AllianceSoukaiya &operator=(const AllianceSoukaiya &) = delete;
     AllianceSoukaiya &operator=(AllianceSoukaiya &&) = delete;
     virtual ~AllianceSoukaiya() = default;

--- a/src/alliance/alliance-soukaiya.h
+++ b/src/alliance/alliance-soukaiya.h
@@ -6,8 +6,6 @@ class AllianceSoukaiya : public Alliance {
 public:
     using Alliance::Alliance;
     AllianceSoukaiya() = delete;
-    AllianceSoukaiya(const AllianceSoukaiya &) = delete;
-    AllianceSoukaiya(AllianceSoukaiya &&) = delete;
     AllianceSoukaiya &operator=(const AllianceSoukaiya &) = delete;
     AllianceSoukaiya &operator=(AllianceSoukaiya &&) = delete;
     virtual ~AllianceSoukaiya() = default;

--- a/src/alliance/alliance-soukaiya.h
+++ b/src/alliance/alliance-soukaiya.h
@@ -5,6 +5,11 @@
 class AllianceSoukaiya : public Alliance {
 public:
     using Alliance::Alliance;
+    AllianceSoukaiya() = delete;
+    AllianceSoukaiya(const AllianceSoukaiya &) = delete;
+    AllianceSoukaiya(AllianceSoukaiya &&) = delete;
+    AllianceSoukaiya &operator=(const AllianceSoukaiya &) = delete;
+    AllianceSoukaiya &operator=(AllianceSoukaiya &&) = delete;
     virtual ~AllianceSoukaiya() = default;
     int calcImpressionPoint(const CreatureEntity &creature) const override;
     bool isAnnihilated() override;

--- a/src/avatar/avatar-changer.h
+++ b/src/avatar/avatar-changer.h
@@ -6,6 +6,10 @@ class CreatureEntity;
 class AvatarChanger {
 public:
     AvatarChanger(CreatureEntity &creature, const CreatureEntity &target);
+    AvatarChanger(const AvatarChanger &) = delete;
+    AvatarChanger(AvatarChanger &&) = delete;
+    AvatarChanger &operator=(const AvatarChanger &) = delete;
+    AvatarChanger &operator=(AvatarChanger &&) = delete;
     virtual ~AvatarChanger() = default;
     void change_virtue();
 

--- a/src/avatar/avatar-changer.h
+++ b/src/avatar/avatar-changer.h
@@ -6,8 +6,6 @@ class CreatureEntity;
 class AvatarChanger {
 public:
     AvatarChanger(CreatureEntity &creature, const CreatureEntity &target);
-    AvatarChanger(const AvatarChanger &) = delete;
-    AvatarChanger(AvatarChanger &&) = delete;
     AvatarChanger &operator=(const AvatarChanger &) = delete;
     AvatarChanger &operator=(AvatarChanger &&) = delete;
     virtual ~AvatarChanger() = default;

--- a/src/avatar/avatar-changer.h
+++ b/src/avatar/avatar-changer.h
@@ -6,6 +6,8 @@ class CreatureEntity;
 class AvatarChanger {
 public:
     AvatarChanger(CreatureEntity &creature, const CreatureEntity &target);
+    AvatarChanger(const AvatarChanger &) = default;
+    AvatarChanger(AvatarChanger &&) = default;
     AvatarChanger &operator=(const AvatarChanger &) = delete;
     AvatarChanger &operator=(AvatarChanger &&) = delete;
     virtual ~AvatarChanger() = default;

--- a/src/birth/birth-select-patron.cpp
+++ b/src/birth/birth-select-patron.cpp
@@ -167,7 +167,7 @@ bool get_player_patron(CreatureEntity &creature)
         return false;
     }
 
-    creature.patron = k;
+    creature.patron = static_cast<int16_t>(k);
     display_player_name(creature);
     return true;
 }

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -155,18 +155,18 @@ void player_outfit(CreatureEntity &creature)
 {
 
     const auto &baseitems = BaseitemList::get_instance();
-    ItemEntity item;
+    ItemEntity parchment;
     decide_initial_items(creature);
 
     // アンナタールの羊皮紙
-    item.generate(baseitems.lookup_baseitem_id({ ItemKindType::READING_MATTER, 0 }));
-    item.number = 1;
-    add_outfit(creature, item);
+    parchment.generate(baseitems.lookup_baseitem_id({ ItemKindType::READING_MATTER, 0 }));
+    parchment.number = 1;
+    add_outfit(creature, parchment);
 
     // メルコールの羊皮紙
-    item.generate(baseitems.lookup_baseitem_id({ ItemKindType::READING_MATTER, 3 }));
-    item.number = 1;
-    add_outfit(creature, item);
+    parchment.generate(baseitems.lookup_baseitem_id({ ItemKindType::READING_MATTER, 3 }));
+    parchment.number = 1;
+    add_outfit(creature, parchment);
 
     CreatureClass pc(creature);
     CreatureRace pr(&creature);

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -109,7 +109,7 @@ static void natural_attack(CreatureEntity &creature, MONSTER_IDX m_idx, PlayerMu
 
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     bool is_hit = (monrace.kind_flags.has_not(MonsterKindType::QUANTUM)) || !randint0(2);
-    is_hit &= test_hit_norm(creature, chance, monster.get_ac(), monster.get_monster_profile().ml);
+    is_hit &= test_hit_norm(creature, chance, static_cast<ARMOUR_CLASS>(monster.get_ac()), monster.get_monster_profile().ml);
     if (!is_hit) {
         sound(SoundKind::MISS);
         msg_format(_("ミス！ %sにかわされた。", "You miss %s."), m_name.data());
@@ -182,7 +182,7 @@ static void headbutt_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *f
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     creature.plus_incident_tree("HEADBUTT", 1);
     bool is_hit = (monrace.kind_flags.has_not(MonsterKindType::QUANTUM)) || !randint0(2);
-    is_hit &= test_hit_norm(creature, chance, monster.get_ac(), monster.get_monster_profile().ml);
+    is_hit &= test_hit_norm(creature, chance, static_cast<ARMOUR_CLASS>(monster.get_ac()), monster.get_monster_profile().ml);
 
     if (!is_hit) {
         sound(SoundKind::MISS);
@@ -273,7 +273,7 @@ static void bodyslam_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *f
 
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     bool is_hit = (monrace.kind_flags.has_not(MonsterKindType::QUANTUM)) || !randint0(2);
-    is_hit &= test_hit_norm(creature, chance, monster.get_ac(), monster.get_monster_profile().ml);
+    is_hit &= test_hit_norm(creature, chance, static_cast<ARMOUR_CLASS>(monster.get_ac()), monster.get_monster_profile().ml);
 
     if (!is_hit) {
         sound(SoundKind::MISS);
@@ -677,7 +677,7 @@ static void enema_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *fear
 
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     bool is_hit = (monrace.kind_flags.has_not(MonsterKindType::QUANTUM)) || !randint0(2);
-    is_hit &= test_hit_norm(creature, chance, monster.get_ac(), monster.get_monster_profile().ml);
+    is_hit &= test_hit_norm(creature, chance, static_cast<ARMOUR_CLASS>(monster.get_ac()), monster.get_monster_profile().ml);
 
     if (!is_hit) {
         sound(SoundKind::MISS);

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -156,7 +156,7 @@ static int damage;
  */
 static std::string mane_info(CreatureEntity &creature, MonsterAbilityType power, int dam)
 {
-    PLAYER_LEVEL plev = creature.get_level();
+    PLAYER_LEVEL plev = static_cast<PLAYER_LEVEL>(creature.get_level());
 
     const auto power_int = enum2i(power);
     using Mat = MonsterAbilityType;
@@ -211,7 +211,7 @@ static int get_mane_power(CreatureEntity &creature, int *sn, bool baigaesi)
     TERM_LEN y = 1;
     TERM_LEN x = 18;
     PERCENTAGE minfail = 0;
-    PLAYER_LEVEL plev = creature.get_level();
+    PLAYER_LEVEL plev = static_cast<PLAYER_LEVEL>(creature.get_level());
     PERCENTAGE chance = 0;
     char choice;
     concptr p = _("能力", "power");
@@ -364,7 +364,7 @@ static int get_mane_power(CreatureEntity &creature, int *sn, bool baigaesi)
  */
 static bool use_mane(CreatureEntity &creature, MonsterAbilityType spell)
 {
-    PLAYER_LEVEL plev = creature.get_level();
+    PLAYER_LEVEL plev = static_cast<PLAYER_LEVEL>(creature.get_level());
     BIT_FLAGS mode = (PM_ALLOW_GROUP | PM_FORCE_PET);
     BIT_FLAGS u_mode = 0L;
 
@@ -1192,7 +1192,7 @@ bool do_cmd_mane(CreatureEntity &creature, bool baigaesi)
     int n = 0;
     PERCENTAGE chance;
     PERCENTAGE minfail = 0;
-    PLAYER_LEVEL plev = creature.get_level();
+    PLAYER_LEVEL plev = static_cast<PLAYER_LEVEL>(creature.get_level());
     monster_power spell;
     bool cast;
 

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -671,7 +671,7 @@ void do_cmd_pet(CreatureEntity &creature)
     {
         /* Check pets (backwards) */
         for (pet_ctr = creature.get_floor()->m_max - 1; pet_ctr >= 1; pet_ctr--) {
-            const auto &m_ref = creature.get_floor()->get_monster(pet_ctr);
+            const auto &m_ref = creature.get_floor()->get_monster(static_cast<MONSTER_IDX>(pet_ctr));
             if (m_ref.is_pet()) {
                 break;
             }
@@ -744,7 +744,7 @@ void do_cmd_pet(CreatureEntity &creature)
         if (creature.pet_extra_flags & PF_PICKUP_ITEMS) {
             creature.pet_extra_flags &= ~(PF_PICKUP_ITEMS);
             for (pet_ctr = creature.get_floor()->m_max - 1; pet_ctr >= 1; pet_ctr--) {
-                auto &monster = creature.get_floor()->get_monster(pet_ctr);
+                auto &monster = creature.get_floor()->get_monster(static_cast<MONSTER_IDX>(pet_ctr));
                 if (monster.is_pet()) {
                     monster_drop_carried_objects(creature, monster);
                 }

--- a/src/cmd-io/cmd-text-command.cpp
+++ b/src/cmd-io/cmd-text-command.cpp
@@ -53,8 +53,8 @@ static std::string normalize_string(const std::string &str)
 {
     std::string result;
     for (char c : str) {
-        if (!std::isspace(c)) {
-            result += std::tolower(c);
+        if (!std::isspace(static_cast<unsigned char>(c))) {
+            result += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
         }
     }
     return result;

--- a/src/combat/attack-accuracy.cpp
+++ b/src/combat/attack-accuracy.cpp
@@ -140,7 +140,7 @@ static bool decide_attack_hit(CreatureEntity &creature, player_attack_type *pa_p
     } else if (CreatureClass(creature).equals(PlayerClassType::NINJA) && ((pa_ptr->backstab || pa_ptr->surprise_attack) && !monrace.resistance_flags.has(MonsterResistanceType::RESIST_ALL))) {
         success_hit = true;
     } else {
-        success_hit = test_hit_norm(creature, chance, pa_ptr->m_ptr->get_ac(), pa_ptr->m_ptr->get_monster_profile().ml);
+        success_hit = test_hit_norm(creature, chance, static_cast<ARMOUR_CLASS>(pa_ptr->m_ptr->get_ac()), pa_ptr->m_ptr->get_monster_profile().ml);
     }
 
     if ((pa_ptr->mode == HISSATSU_MAJIN) && one_in_(2)) {

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -1022,7 +1022,7 @@ bool test_hit_fire(CreatureEntity &creature, int chance, CreatureEntity &target,
         return false;
     }
 
-    ac = target.get_ac();
+    ac = static_cast<ARMOUR_CLASS>(target.get_ac());
     ac = ac * (8 - sniper_concent) / 8;
 
     if (target.r_idx == MonraceId::GOEMON && !target.is_asleep()) {

--- a/src/core/object-compressor.cpp
+++ b/src/core/object-compressor.cpp
@@ -22,6 +22,10 @@ public:
         , distance_threshold(5 * (20 - try_count))
     {
     }
+    ItemCompactionChecker(const ItemCompactionChecker &) = delete;
+    ItemCompactionChecker(ItemCompactionChecker &&) = delete;
+    ItemCompactionChecker &operator=(const ItemCompactionChecker &) = delete;
+    ItemCompactionChecker &operator=(ItemCompactionChecker &&) = delete;
 
     bool can_delete_for_compaction(const ItemEntity &item) const
     {

--- a/src/core/object-compressor.cpp
+++ b/src/core/object-compressor.cpp
@@ -22,6 +22,8 @@ public:
         , distance_threshold(5 * (20 - try_count))
     {
     }
+    ItemCompactionChecker(const ItemCompactionChecker &) = default;
+    ItemCompactionChecker(ItemCompactionChecker &&) = default;
     ItemCompactionChecker &operator=(const ItemCompactionChecker &) = delete;
     ItemCompactionChecker &operator=(ItemCompactionChecker &&) = delete;
 

--- a/src/core/object-compressor.cpp
+++ b/src/core/object-compressor.cpp
@@ -22,8 +22,6 @@ public:
         , distance_threshold(5 * (20 - try_count))
     {
     }
-    ItemCompactionChecker(const ItemCompactionChecker &) = delete;
-    ItemCompactionChecker(ItemCompactionChecker &&) = delete;
     ItemCompactionChecker &operator=(const ItemCompactionChecker &) = delete;
     ItemCompactionChecker &operator=(ItemCompactionChecker &&) = delete;
 

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -137,7 +137,7 @@ void process_player(CreatureEntity &creature)
         WorldTurnProcessor(creature).print_cheat_position();
 
     } else if (!(load && creature.energy_need <= 0)) {
-        creature.energy_need -= speed_to_energy(creature.get_speed());
+        creature.energy_need -= speed_to_energy(static_cast<byte>(creature.get_speed()));
     }
 
     if (creature.energy_need > 0) {
@@ -439,7 +439,7 @@ void process_player(CreatureEntity &creature)
 void process_upkeep_with_speed(CreatureEntity &creature)
 {
     if (!load && creature.enchant_energy_need > 0 && !creature.leaving) {
-        creature.enchant_energy_need -= speed_to_energy(creature.get_speed());
+        creature.enchant_energy_need -= speed_to_energy(static_cast<byte>(creature.get_speed()));
     }
 
     if (creature.enchant_energy_need > 0) {

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -441,7 +441,7 @@ static void effect_monster_captured(CreatureEntity &creature, EffectMonster *em_
     msg_format(_("%sを捕えた！", "You capture %s^!"), em_ptr->m_name);
     auto cap_mon_ptr = tmp_cap_mon_ptr.value();
     cap_mon_ptr->r_idx = em_ptr->m_ptr->r_idx;
-    cap_mon_ptr->speed = em_ptr->m_ptr->speed;
+    cap_mon_ptr->speed = static_cast<byte>(em_ptr->m_ptr->speed);
     cap_mon_ptr->current_hp = static_cast<short>(em_ptr->m_ptr->hp);
     cap_mon_ptr->max_hp = static_cast<short>(em_ptr->m_ptr->max_maxhp);
     cap_mon_ptr->name = em_ptr->m_ptr->name;

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -698,7 +698,7 @@ void apply_vestige_terrain_replacement(CreatureEntity &creature)
         // 4%の確率で地形を差し替え
         if (one_in_(replacement_chance)) {
             const auto terrain = rand_choice(replaceable_terrain_ids);
-            set_terrain_id_to_grid(creature, pos, terrain);
+            set_terrain_id_to_grid(creature, pos, static_cast<short>(terrain));
             replacement_count++;
         }
     }

--- a/src/floor/object-scanner.cpp
+++ b/src/floor/object-scanner.cpp
@@ -86,10 +86,10 @@ static std::string prepare_label_string_floor(const FloorType &floor, const std:
 COMMAND_CODE show_floor_items(CreatureEntity &creature, int target_item, POSITION y, POSITION x, TERM_LEN *min_width, const ItemTester &item_tester)
 {
     const Pos2D pos(y, x);
-    constexpr auto max_items = 23; //!< @todo 1マスに落ちているアイテムの最大数. ヘッダに移したい.
+    constexpr size_t max_items = 23; //!< @todo 1マスに落ちているアイテムの最大数. ヘッダに移したい.
     COMMAND_CODE m;
     int j, l;
-    COMMAND_CODE out_index[max_items]{};
+    short out_index[max_items]{};
     TERM_COLOR out_color[max_items]{};
     std::array<std::string, max_items> descriptions{};
     COMMAND_CODE target_item_label = 0;
@@ -102,7 +102,7 @@ COMMAND_CODE show_floor_items(CreatureEntity &creature, int target_item, POSITIO
     for (size_t i = 0; (i < floor_item_index.size()) && (i < max_items); i++) {
         const auto &item = *floor.o_list[floor_item_index[i]];
         const auto item_name = describe_flavor(creature, item, 0);
-        out_index[k] = i;
+        out_index[k] = static_cast<short>(i);
         const auto tval = item.bi_key.tval();
         out_color[k] = tval_to_attr[enum2i(tval) & 0x7F];
         descriptions[k] = item_name;

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -862,7 +862,7 @@ bool change_wild_mode(CreatureEntity &creature, bool encount)
     bool has_pet = false;
     PlayerEnergy energy(creature);
     for (int i = 1; i < creature.get_floor()->m_max; i++) {
-        const auto &monster = creature.get_floor()->get_monster(i);
+        const auto &monster = creature.get_floor()->get_monster(static_cast<MONSTER_IDX>(i));
         if (!monster.is_valid()) {
             continue;
         }

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -170,7 +170,7 @@ static int check_hit_from_monster_to_player(CreatureEntity &creature, int power)
     }
 
     /* Total armor */
-    ac = creature.get_ac();
+    ac = static_cast<ARMOUR_CLASS>(creature.get_ac());
 
     /* Power competes against Armor */
     if (randint1(power) > ((ac * 3) / 4)) {
@@ -465,8 +465,8 @@ void hit_trap(CreatureEntity &creature, bool break_trap)
 
                 /* Let them fight each other */
                 if (evil_idx && good_idx) {
-                    auto &monster_evil = floor.get_monster(evil_idx);
-                    auto &monster_good = floor.get_monster(good_idx);
+                    auto &monster_evil = floor.get_monster(static_cast<MONSTER_IDX>(evil_idx));
+                    auto &monster_good = floor.get_monster(static_cast<MONSTER_IDX>(good_idx));
                     monster_evil.set_target(monster_good.get_position());
                     monster_good.set_target(monster_evil.get_position());
                 }

--- a/src/info-reader/vault-reader.cpp
+++ b/src/info-reader/vault-reader.cpp
@@ -94,7 +94,7 @@ errr parse_vaults_info(std::string_view buf, angband_header *)
                     }
                     if (v_ptr->place_monster_list.count(c) == 0) {
                         try {
-                            std::stoi(s_tokens[1]);
+                            (void)std::stoi(s_tokens[1]);
                             info_set_value(v_ptr->place_monster_list[c], s_tokens[1]);
                             break;
                         } catch (const std::invalid_argument &) {

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -754,13 +754,13 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
         case '8':
         case '9': {
             if (command_wrk != USE_FLOOR) {
-                const auto i_idx = get_tag(creature, fis.which, command_wrk, item_tester);
-                if (!i_idx) {
+                const auto tag_opt = get_tag(creature, fis.which, command_wrk, item_tester);
+                if (!tag_opt) {
                     bell();
                     break;
                 }
 
-                fis.k = *i_idx;
+                fis.k = *tag_opt;
                 if ((fis.k < INVEN_MAIN_HAND) ? !fis.inven : !fis.equip) {
                     bell();
                     break;
@@ -804,11 +804,11 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
             bool tag_not_found = false;
 
             if (command_wrk != USE_FLOOR) {
-                const auto i_idx = get_tag(creature, fis.which, command_wrk, item_tester);
-                if (!i_idx) {
+                const auto tag_opt = get_tag(creature, fis.which, command_wrk, item_tester);
+                if (!tag_opt) {
                     tag_not_found = true;
                 } else {
-                    fis.k = *i_idx;
+                    fis.k = *tag_opt;
                     if ((fis.k < INVEN_MAIN_HAND) ? !fis.inven : !fis.equip) {
                         tag_not_found = true;
                     }
@@ -847,14 +847,15 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
                         fis.k = label_to_equipment(creature, which);
                     }
                 } else if (command_wrk == USE_FLOOR) {
+                    const auto floor_item_index_size = static_cast<short>(fis.floor_item_index.size());
                     if (which == '(') {
                         fis.k = 0;
                     } else if (which == ')') {
-                        fis.k = fis.floor_item_index.size() - 1;
+                        fis.k = floor_item_index_size - 1;
                     } else {
                         fis.k = islower(which) ? A2I(which) : -1;
                     }
-                    if (fis.k < 0 || fis.k >= static_cast<short>(fis.floor_item_index.size()) || fis.k >= 23) {
+                    if (fis.k < 0 || fis.k >= floor_item_index_size || fis.k >= 23) {
                         bell();
                         break;
                     }

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -62,7 +62,7 @@ static void dump_aux_pet(CreatureEntity &creature, FILE *fff)
     auto pet = false;
     auto pet_settings = false;
     for (auto i = floor.m_max - 1; i >= 1; i--) {
-        const auto &monster = floor.get_monster(i);
+        const auto &monster = floor.get_monster(static_cast<MONSTER_IDX>(i));
         if (!monster.is_valid()) {
             continue;
         }

--- a/src/knowledge/knowledge-incident.cpp
+++ b/src/knowledge/knowledge-incident.cpp
@@ -237,7 +237,7 @@ void do_cmd_knowledge_incident(CreatureEntity &creature)
                     // アイテムを再構成
                     ItemEntity item;
                     item.bi_key = BaseitemKey(static_cast<ItemKindType>(tval), sval);
-                    item.pval = pval;
+                    item.pval = static_cast<PARAMETER_VALUE>(pval);
                     item.mark_as_known();
 
                     auto item_name = describe_flavor(creature, item, 0);

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -161,7 +161,7 @@ void do_cmd_knowledge_pets(CreatureEntity &creature)
 
     int t_friends = 0;
     for (int i = creature.get_floor()->m_max - 1; i >= 1; i--) {
-        const auto &monster = creature.get_floor()->get_monster(i);
+        const auto &monster = creature.get_floor()->get_monster(static_cast<MONSTER_IDX>(i));
         if (!monster.is_valid() || !monster.is_pet()) {
             continue;
         }

--- a/src/melee/melee-spell.cpp
+++ b/src/melee/melee-spell.cpp
@@ -36,7 +36,7 @@ static bool try_melee_spell(CreatureEntity &creature, melee_spell_type *ms_ptr)
 
     disturb(creature, true, true);
     if (ms_ptr->see_m) {
-        msg_format(_(" %s^は呢文を唱えようとしたが失敗した。", "%s^ tries to cast a spell, but fails."), ms_ptr->m_name.data());
+        msg_format(_(" %s^は呪文を唱えようとしたが失敗した。", "%s^ tries to cast a spell, but fails."), ms_ptr->m_name.data());
     }
 
     return true;

--- a/src/melee/melee-util.cpp
+++ b/src/melee/melee-util.cpp
@@ -32,7 +32,7 @@ mam_type *initialize_mam_type(CreatureEntity &creature, mam_type *mam_ptr, MONST
     mam_ptr->touched = false;
 
     const auto &monrace = mam_ptr->m_ptr->get_monrace();
-    mam_ptr->ac = mam_ptr->t_ptr->get_ac();
+    mam_ptr->ac = static_cast<ARMOUR_CLASS>(mam_ptr->t_ptr->get_ac());
     mam_ptr->rlev = ((monrace.level >= 1) ? monrace.level : 1);
     mam_ptr->blinked = false;
     mam_ptr->power = 0;

--- a/src/mind/mind-chaos-warrior.cpp
+++ b/src/mind/mind-chaos-warrior.cpp
@@ -83,7 +83,7 @@ void acquire_hafted_weapon(CreatureEntity &creature)
         item.pval = 1;
         item.to_h = 3 + randint1(18);
         item.to_d = 3 + randint1(18);
-        item.to_a = randint1(5);
+        item.to_a = static_cast<ARMOUR_CLASS>(randint1(5));
 
         switch (randint1(21)) {
         case 1:

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -167,7 +167,7 @@ bool MonsterAttackPlayer::process_monster_blows()
         }
 
         // フレーバーの打撃は必中扱い。それ以外は通常の命中判定を行う。
-        this->ac = creature.get_ac();
+        this->ac = static_cast<ARMOUR_CLASS>(creature.get_ac());
         bool hit;
         if (this->effect == RaceBlowEffectType::FLAVOR) {
             hit = true;

--- a/src/monster-floor/monster-direction.cpp
+++ b/src/monster-floor/monster-direction.cpp
@@ -69,7 +69,7 @@ static void decide_enemy_approch_direction(CreatureEntity &creature, MONSTER_IDX
         }
 
         const auto t_idx = dummy;
-        const auto &monster_to = floor.get_monster(t_idx);
+        const auto &monster_to = floor.get_monster(static_cast<MONSTER_IDX>(t_idx));
         if (&monster_to == &monster_from) {
             continue;
         }

--- a/src/monster-floor/monster-lite.cpp
+++ b/src/monster-floor/monster-lite.cpp
@@ -157,7 +157,7 @@ void update_mon_lite(CreatureEntity &creature)
     const auto p_pos = creature.get_position();
     if (!world.timewalk_m_idx) {
         for (auto i = 1; i < floor.m_max; i++) {
-            const auto &monster = floor.get_monster(i);
+            const auto &monster = floor.get_monster(static_cast<MONSTER_IDX>(i));
             const auto &monrace = monster.get_monrace();
             if (!monster.is_valid() || (Grid::calc_distance(p_pos, monster.get_position()) > dis_lim)) {
                 continue;

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -101,7 +101,7 @@ void wipe_monsters_list(CreatureEntity &creature)
     auto &monraces = MonraceList::get_instance();
     auto &floor = *creature.get_floor();
     for (auto i = floor.m_max - 1; i >= 1; i--) {
-        auto &monster = floor.get_monster(i);
+        auto &monster = floor.get_monster(static_cast<MONSTER_IDX>(i));
         if (!monster.is_valid()) {
             continue;
         }

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -100,7 +100,7 @@ static tl::optional<bool> final_summon(CreatureEntity &creature, MonsterDeath *m
         }
 
         BIT_FLAGS mode = dead_mode(md_ptr);
-        const auto summon_src = md_ptr->m_ptr->is_pet() ? -1 : md_ptr->m_idx;
+        const short summon_src = md_ptr->m_ptr->is_pet() ? -1 : md_ptr->m_idx;
         if (summon_named_creature(creature, summon_src, m_pos.y, m_pos.x, summon_data.id, mode) && player_can_see_bold(creature, m_pos.y, m_pos.x)) {
             notice = true;
         }

--- a/src/monster/monster-compaction.cpp
+++ b/src/monster/monster-compaction.cpp
@@ -65,7 +65,7 @@ static void compact_monsters_aux(CreatureEntity &creature, MONSTER_IDX i1, MONST
 
     if (monster.is_pet()) {
         for (int i = 1; i < floor.m_max; i++) {
-            CreatureEntity *m2_ptr = &floor.get_monster(i);
+            CreatureEntity *m2_ptr = &floor.get_monster(static_cast<MONSTER_IDX>(i));
 
             if (m2_ptr->get_monster_profile().parent_m_idx == i1) {
                 m2_ptr->get_monster_profile().parent_m_idx = i2;

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -128,7 +128,6 @@ bool MonsterDamageProcessor::mon_take_hit(std::string_view note)
 
 bool MonsterDamageProcessor::genocide_patron()
 {
-    auto &creature = this->creature;
     const auto &monster = creature.get_floor()->get_monster(this->m_idx);
     if (!monster.is_valid()) {
         this->m_idx = 0;
@@ -143,7 +142,6 @@ bool MonsterDamageProcessor::genocide_patron()
 
 bool MonsterDamageProcessor::process_dead_exp_virtue(std::string_view note, const CreatureEntity &exp_target)
 {
-    auto &creature = this->creature;
     auto &monster = creature.get_floor()->get_monster(this->m_idx);
     auto &monrace = monster.get_real_monrace();
     if (monster.hp >= 0) {
@@ -180,7 +178,6 @@ bool MonsterDamageProcessor::process_dead_exp_virtue(std::string_view note, cons
  */
 void MonsterDamageProcessor::death_special_flag_monster()
 {
-    auto &creature = this->creature;
     auto &monster = creature.get_floor()->get_monster(this->m_idx);
     auto monrace_id = monster.r_idx;
     auto &monrace = monster.get_monrace();
@@ -216,7 +213,6 @@ void MonsterDamageProcessor::death_special_flag_monster()
 
 void MonsterDamageProcessor::increase_kill_numbers()
 {
-    auto &creature = this->creature;
     auto &monster = creature.get_floor()->get_monster(this->m_idx);
     auto &monrace = monster.get_real_monrace();
     monrace.increment_akills();
@@ -320,7 +316,6 @@ void MonsterDamageProcessor::death_choasians(std::string_view m_name)
 
 void MonsterDamageProcessor::dying_scream(std::string_view m_name)
 {
-    auto &creature = this->creature;
     const auto &monster = creature.get_floor()->get_monster(this->m_idx);
     const auto &r_ref = monster.get_real_monrace();
     if (r_ref.speak_flags.has_none_of({ MonsterSpeakType::SPEAK_ALL, MonsterSpeakType::SPEAK_DEATH })) {
@@ -390,7 +385,6 @@ void MonsterDamageProcessor::show_explosion_message(std::string_view died_mes, s
 
 void MonsterDamageProcessor::show_bounty_message(std::string_view m_name)
 {
-    auto &creature = this->creature;
     auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(this->m_idx);
     const auto &monrace = monster.get_real_monrace();
@@ -421,7 +415,6 @@ void MonsterDamageProcessor::show_bounty_message(std::string_view m_name)
  */
 void MonsterDamageProcessor::get_exp_from_mon(const CreatureEntity &target, int exp_dam)
 {
-    auto &creature = this->creature;
     const auto &monrace = target.get_monrace();
     if (!target.is_valid() || target.is_pet() || AngbandSystem::get_instance().is_phase_out()) {
         return;
@@ -486,7 +479,6 @@ void MonsterDamageProcessor::get_exp_from_mon(const CreatureEntity &target, int 
 
 void MonsterDamageProcessor::set_redraw()
 {
-    auto &creature = this->creature;
     auto &monster = creature.get_floor()->get_monster(this->m_idx);
     HealthBarTracker::get_instance().set_flag_if_tracking(this->m_idx);
     if (monster.is_riding()) {
@@ -496,7 +488,6 @@ void MonsterDamageProcessor::set_redraw()
 
 void MonsterDamageProcessor::add_monster_fear()
 {
-    auto &creature = this->creature;
     const auto &monster = creature.get_floor()->get_monster(this->m_idx);
     if (monster.is_fearful() && (this->dam > 0)) {
         auto fear_remining = monster.get_remaining_fear() - randint1(this->dam);
@@ -528,7 +519,6 @@ void MonsterDamageProcessor::add_monster_fear()
  */
 void MonsterDamageProcessor::process_masochist_reaction()
 {
-    auto &creature = this->creature;
     auto &monster = creature.get_floor()->get_monster(this->m_idx);
     const auto &monrace = monster.get_monrace();
 
@@ -558,7 +548,6 @@ void MonsterDamageProcessor::process_masochist_reaction()
  */
 void MonsterDamageProcessor::process_sadist_reaction()
 {
-    auto &creature = this->creature;
     auto &monster = creature.get_floor()->get_monster(this->m_idx);
     const auto &monrace = monster.get_monrace();
 
@@ -586,7 +575,6 @@ void MonsterDamageProcessor::process_sadist_reaction()
  */
 bool MonsterDamageProcessor::check_and_process_hp_transform()
 {
-    auto &creature = this->creature;
     auto &monster = creature.get_floor()->get_monster(this->m_idx);
 
     // 変身条件のチェック

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -425,7 +425,7 @@ void MonsterDamageProcessor::get_exp_from_mon(const CreatureEntity &target, int 
      * - Varying speed effects
      * - Get a fraction in proportion of damage point
      */
-    auto new_exp = monrace.level * speed_to_energy(target.speed) * exp_dam;
+    auto new_exp = monrace.level * speed_to_energy(static_cast<byte>(target.speed)) * exp_dam;
     auto new_exp_frac = 0U;
     auto div_h = 0;
     auto div_l = (uint)((creature.max_plv + 2) * speed_to_energy(monrace.speed));

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -432,7 +432,7 @@ void MonsterDamageProcessor::get_exp_from_mon(const CreatureEntity &target, int 
 
     /* Use (average maxhp * 2) as a denominator */
     int compensation = monrace.misc_flags.has(MonsterMiscType::FORCE_MAXHP) ? monrace.hit_dice.maxroll() * 2 : monrace.hit_dice.floored_expected_value_multiplied_by(2);
-    s64b_mul(&div_h, &div_l, 0, (ironman_nightmare ? 2 : 1) * compensation);
+    s64b_mul(&div_h, &div_l, 0, static_cast<uint32_t>((ironman_nightmare ? 2 : 1) * compensation));
 
     /* Special penalty in the wilderness */
     if (!this->creature.get_floor()->is_underground()) {

--- a/src/monster/monster-damage.h
+++ b/src/monster/monster-damage.h
@@ -14,6 +14,10 @@ class MonsterDamageProcessor {
 public:
     MonsterDamageProcessor(CreatureEntity &creature, MONSTER_IDX m_idx, int dam, bool *fear, AttributeType type);
     MonsterDamageProcessor(CreatureEntity &creature, MONSTER_IDX m_idx, int dam, bool *fear, AttributeFlags attribute_flags);
+    MonsterDamageProcessor(const MonsterDamageProcessor &) = delete;
+    MonsterDamageProcessor(MonsterDamageProcessor &&) = delete;
+    MonsterDamageProcessor &operator=(const MonsterDamageProcessor &) = delete;
+    MonsterDamageProcessor &operator=(MonsterDamageProcessor &&) = delete;
     virtual ~MonsterDamageProcessor() = default;
     bool mon_take_hit(std::string_view note);
 

--- a/src/monster/monster-damage.h
+++ b/src/monster/monster-damage.h
@@ -14,6 +14,8 @@ class MonsterDamageProcessor {
 public:
     MonsterDamageProcessor(CreatureEntity &creature, MONSTER_IDX m_idx, int dam, bool *fear, AttributeType type);
     MonsterDamageProcessor(CreatureEntity &creature, MONSTER_IDX m_idx, int dam, bool *fear, AttributeFlags attribute_flags);
+    MonsterDamageProcessor(const MonsterDamageProcessor &) = default;
+    MonsterDamageProcessor(MonsterDamageProcessor &&) = default;
     MonsterDamageProcessor &operator=(const MonsterDamageProcessor &) = delete;
     MonsterDamageProcessor &operator=(MonsterDamageProcessor &&) = delete;
     virtual ~MonsterDamageProcessor() = default;

--- a/src/monster/monster-damage.h
+++ b/src/monster/monster-damage.h
@@ -14,8 +14,6 @@ class MonsterDamageProcessor {
 public:
     MonsterDamageProcessor(CreatureEntity &creature, MONSTER_IDX m_idx, int dam, bool *fear, AttributeType type);
     MonsterDamageProcessor(CreatureEntity &creature, MONSTER_IDX m_idx, int dam, bool *fear, AttributeFlags attribute_flags);
-    MonsterDamageProcessor(const MonsterDamageProcessor &) = delete;
-    MonsterDamageProcessor(MonsterDamageProcessor &&) = delete;
     MonsterDamageProcessor &operator=(const MonsterDamageProcessor &) = delete;
     MonsterDamageProcessor &operator=(MonsterDamageProcessor &&) = delete;
     virtual ~MonsterDamageProcessor() = default;

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -403,8 +403,8 @@ bool vanish_summoned_children(CreatureEntity &creature, MONSTER_IDX m_idx, bool 
     }
 
     if (record_named_pet && monster.is_named_pet()) {
-        const auto m_name = monster_desc(creature, monster, MD_INDEF_VISIBLE);
-        exe_write_diary(floor, DiaryKind::NAMED_PET, RECORD_NAMED_PET_LOSE_PARENT, m_name);
+        const auto pet_name = monster_desc(creature, monster, MD_INDEF_VISIBLE);
+        exe_write_diary(floor, DiaryKind::NAMED_PET, RECORD_NAMED_PET_LOSE_PARENT, pet_name);
     }
 
     delete_monster_idx(creature, m_idx);

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -149,7 +149,7 @@ static void process_monsters_timed_effect_aux(CreatureEntity &creature, MONSTER_
         auto d = (cdis < MAX_MONSTER_SENSING / 2) ? (MAX_MONSTER_SENSING / cdis) : 1;
 
         /* Hack -- amount of "waking" is affected by speed of player */
-        d = (d * speed_to_energy(creature.get_speed())) / 10;
+        d = (d * speed_to_energy(static_cast<byte>(creature.get_speed()))) / 10;
         if (d < 0) {
             d = 1;
         }

--- a/src/monster/monster-timed-effects.h
+++ b/src/monster/monster-timed-effects.h
@@ -10,7 +10,7 @@
  * @details CreatureTimedEffect のうちモンスター側で扱う 7 種。
  * プレイヤー専用効果（HERO/BLESSED 等）はここに含まれない。
  */
-constexpr std::array<CreatureTimedEffect, 7> MONSTER_TIMED_EFFECT_LIST = {
+constexpr std::array<CreatureTimedEffect, 7> MONSTER_TIMED_EFFECT_LIST = { {
     CreatureTimedEffect::SLEEP_OR_PARALYSIS,
     CreatureTimedEffect::ACCELERATION,
     CreatureTimedEffect::DECELERATION,
@@ -18,6 +18,6 @@ constexpr std::array<CreatureTimedEffect, 7> MONSTER_TIMED_EFFECT_LIST = {
     CreatureTimedEffect::CONFUSION,
     CreatureTimedEffect::FEAR,
     CreatureTimedEffect::INVULNERABILITY,
-};
+} };
 
 extern const std::map<CreatureTimedEffect, std::string> effect_type_to_label;

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -458,7 +458,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
     if (creature.get_mutations().has(PlayerMutationType::WARNING) && one_in_(1000)) {
         int danger_amount = 0;
         for (auto m_idx = 0; m_idx < creature.get_floor()->m_max; m_idx++) {
-            const auto &monster = creature.get_floor()->get_monster(m_idx);
+            const auto &monster = creature.get_floor()->get_monster(static_cast<MONSTER_IDX>(m_idx));
             const auto &monrace = monster.get_monrace();
             if (!monster.is_valid()) {
                 continue;

--- a/src/object-activation/activation-charm.cpp
+++ b/src/object-activation/activation-charm.cpp
@@ -13,7 +13,7 @@ bool activate_charm_directional(CreatureEntity &creature, SpellFunc spell, int p
         return false;
     }
 
-    (void)spell(creature, dir, power);
+    (void)spell(creature, dir, static_cast<PLAYER_LEVEL>(power));
     return true;
 }
 }

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -165,7 +165,7 @@ bool activate_unique_detection(CreatureEntity &creature)
 {
     msg_print(_("奇妙な場所が頭の中に浮かんだ．．．", "Some strange places show up in your mind. And you see ..."));
     for (int i = creature.get_floor()->m_max - 1; i >= 1; i--) {
-        const auto &monster = creature.get_floor()->get_monster(i);
+        const auto &monster = creature.get_floor()->get_monster(static_cast<MONSTER_IDX>(i));
         if (!monster.is_valid()) {
             continue;
         }

--- a/src/object-enchant/item-magic-applier.h
+++ b/src/object-enchant/item-magic-applier.h
@@ -8,6 +8,10 @@ class CreatureEntity;
 class ItemMagicApplier {
 public:
     ItemMagicApplier(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH lev, BIT_FLAGS mode);
+    ItemMagicApplier(const ItemMagicApplier &) = delete;
+    ItemMagicApplier(ItemMagicApplier &&) = delete;
+    ItemMagicApplier &operator=(const ItemMagicApplier &) = delete;
+    ItemMagicApplier &operator=(ItemMagicApplier &&) = delete;
     void execute();
 
 private:

--- a/src/object-enchant/item-magic-applier.h
+++ b/src/object-enchant/item-magic-applier.h
@@ -8,6 +8,8 @@ class CreatureEntity;
 class ItemMagicApplier {
 public:
     ItemMagicApplier(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH lev, BIT_FLAGS mode);
+    ItemMagicApplier(const ItemMagicApplier &) = default;
+    ItemMagicApplier(ItemMagicApplier &&) = default;
     ItemMagicApplier &operator=(const ItemMagicApplier &) = delete;
     ItemMagicApplier &operator=(ItemMagicApplier &&) = delete;
     void execute();

--- a/src/object-enchant/item-magic-applier.h
+++ b/src/object-enchant/item-magic-applier.h
@@ -8,8 +8,6 @@ class CreatureEntity;
 class ItemMagicApplier {
 public:
     ItemMagicApplier(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH lev, BIT_FLAGS mode);
-    ItemMagicApplier(const ItemMagicApplier &) = delete;
-    ItemMagicApplier(ItemMagicApplier &&) = delete;
     ItemMagicApplier &operator=(const ItemMagicApplier &) = delete;
     ItemMagicApplier &operator=(ItemMagicApplier &&) = delete;
     void execute();

--- a/src/object-enchant/others/apply-magic-amulet.h
+++ b/src/object-enchant/others/apply-magic-amulet.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class AmuletEnchanter : public EnchanterBase {
 public:
     AmuletEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    AmuletEnchanter(const AmuletEnchanter &) = delete;
-    AmuletEnchanter(AmuletEnchanter &&) = delete;
     AmuletEnchanter &operator=(const AmuletEnchanter &) = delete;
     AmuletEnchanter &operator=(AmuletEnchanter &&) = delete;
     virtual ~AmuletEnchanter() = default;

--- a/src/object-enchant/others/apply-magic-amulet.h
+++ b/src/object-enchant/others/apply-magic-amulet.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class AmuletEnchanter : public EnchanterBase {
 public:
     AmuletEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    AmuletEnchanter(const AmuletEnchanter &) = default;
+    AmuletEnchanter(AmuletEnchanter &&) = default;
     AmuletEnchanter &operator=(const AmuletEnchanter &) = delete;
     AmuletEnchanter &operator=(AmuletEnchanter &&) = delete;
     virtual ~AmuletEnchanter() = default;

--- a/src/object-enchant/others/apply-magic-amulet.h
+++ b/src/object-enchant/others/apply-magic-amulet.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class AmuletEnchanter : public EnchanterBase {
 public:
     AmuletEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    AmuletEnchanter(const AmuletEnchanter &) = delete;
+    AmuletEnchanter(AmuletEnchanter &&) = delete;
+    AmuletEnchanter &operator=(const AmuletEnchanter &) = delete;
+    AmuletEnchanter &operator=(AmuletEnchanter &&) = delete;
     virtual ~AmuletEnchanter() = default;
     void apply_magic() override;
 

--- a/src/object-enchant/others/apply-magic-lite.h
+++ b/src/object-enchant/others/apply-magic-lite.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class LiteEnchanter : public EnchanterBase {
 public:
     LiteEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, int power);
-    LiteEnchanter(const LiteEnchanter &) = delete;
-    LiteEnchanter(LiteEnchanter &&) = delete;
     LiteEnchanter &operator=(const LiteEnchanter &) = delete;
     LiteEnchanter &operator=(LiteEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/others/apply-magic-lite.h
+++ b/src/object-enchant/others/apply-magic-lite.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class LiteEnchanter : public EnchanterBase {
 public:
     LiteEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, int power);
+    LiteEnchanter(const LiteEnchanter &) = default;
+    LiteEnchanter(LiteEnchanter &&) = default;
     LiteEnchanter &operator=(const LiteEnchanter &) = delete;
     LiteEnchanter &operator=(LiteEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/others/apply-magic-lite.h
+++ b/src/object-enchant/others/apply-magic-lite.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class LiteEnchanter : public EnchanterBase {
 public:
     LiteEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, int power);
+    LiteEnchanter(const LiteEnchanter &) = delete;
+    LiteEnchanter(LiteEnchanter &&) = delete;
+    LiteEnchanter &operator=(const LiteEnchanter &) = delete;
+    LiteEnchanter &operator=(LiteEnchanter &&) = delete;
     void apply_magic() override;
 
 protected:

--- a/src/object-enchant/others/apply-magic-others.h
+++ b/src/object-enchant/others/apply-magic-others.h
@@ -7,6 +7,10 @@ class ItemEntity;
 class OtherItemsEnchanter : public EnchanterBase {
 public:
     OtherItemsEnchanter(CreatureEntity &creature, ItemEntity *o_ptr);
+    OtherItemsEnchanter(const OtherItemsEnchanter &) = delete;
+    OtherItemsEnchanter(OtherItemsEnchanter &&) = delete;
+    OtherItemsEnchanter &operator=(const OtherItemsEnchanter &) = delete;
+    OtherItemsEnchanter &operator=(OtherItemsEnchanter &&) = delete;
     void apply_magic() override;
 
     void sval_enchant() override{};

--- a/src/object-enchant/others/apply-magic-others.h
+++ b/src/object-enchant/others/apply-magic-others.h
@@ -7,6 +7,8 @@ class ItemEntity;
 class OtherItemsEnchanter : public EnchanterBase {
 public:
     OtherItemsEnchanter(CreatureEntity &creature, ItemEntity *o_ptr);
+    OtherItemsEnchanter(const OtherItemsEnchanter &) = default;
+    OtherItemsEnchanter(OtherItemsEnchanter &&) = default;
     OtherItemsEnchanter &operator=(const OtherItemsEnchanter &) = delete;
     OtherItemsEnchanter &operator=(OtherItemsEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/others/apply-magic-others.h
+++ b/src/object-enchant/others/apply-magic-others.h
@@ -7,8 +7,6 @@ class ItemEntity;
 class OtherItemsEnchanter : public EnchanterBase {
 public:
     OtherItemsEnchanter(CreatureEntity &creature, ItemEntity *o_ptr);
-    OtherItemsEnchanter(const OtherItemsEnchanter &) = delete;
-    OtherItemsEnchanter(OtherItemsEnchanter &&) = delete;
     OtherItemsEnchanter &operator=(const OtherItemsEnchanter &) = delete;
     OtherItemsEnchanter &operator=(OtherItemsEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/others/apply-magic-ring.h
+++ b/src/object-enchant/others/apply-magic-ring.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class RingEnchanter : public EnchanterBase {
 public:
     RingEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    RingEnchanter(const RingEnchanter &) = default;
+    RingEnchanter(RingEnchanter &&) = default;
     RingEnchanter &operator=(const RingEnchanter &) = delete;
     RingEnchanter &operator=(RingEnchanter &&) = delete;
     virtual ~RingEnchanter() = default;

--- a/src/object-enchant/others/apply-magic-ring.h
+++ b/src/object-enchant/others/apply-magic-ring.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class RingEnchanter : public EnchanterBase {
 public:
     RingEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    RingEnchanter(const RingEnchanter &) = delete;
+    RingEnchanter(RingEnchanter &&) = delete;
+    RingEnchanter &operator=(const RingEnchanter &) = delete;
+    RingEnchanter &operator=(RingEnchanter &&) = delete;
     virtual ~RingEnchanter() = default;
     void apply_magic() override;
 

--- a/src/object-enchant/others/apply-magic-ring.h
+++ b/src/object-enchant/others/apply-magic-ring.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class RingEnchanter : public EnchanterBase {
 public:
     RingEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    RingEnchanter(const RingEnchanter &) = delete;
-    RingEnchanter(RingEnchanter &&) = delete;
     RingEnchanter &operator=(const RingEnchanter &) = delete;
     RingEnchanter &operator=(RingEnchanter &&) = delete;
     virtual ~RingEnchanter() = default;

--- a/src/object-enchant/protector/apply-magic-armor.h
+++ b/src/object-enchant/protector/apply-magic-armor.h
@@ -7,6 +7,10 @@ class CreatureEntity;
 class ItemEntity;
 class ArmorEnchanter : public AbstractProtectorEnchanter {
 public:
+    ArmorEnchanter(const ArmorEnchanter &) = delete;
+    ArmorEnchanter(ArmorEnchanter &&) = delete;
+    ArmorEnchanter &operator=(const ArmorEnchanter &) = delete;
+    ArmorEnchanter &operator=(ArmorEnchanter &&) = delete;
     virtual ~ArmorEnchanter() = default;
 
 protected:

--- a/src/object-enchant/protector/apply-magic-armor.h
+++ b/src/object-enchant/protector/apply-magic-armor.h
@@ -7,6 +7,8 @@ class CreatureEntity;
 class ItemEntity;
 class ArmorEnchanter : public AbstractProtectorEnchanter {
 public:
+    ArmorEnchanter(const ArmorEnchanter &) = default;
+    ArmorEnchanter(ArmorEnchanter &&) = default;
     ArmorEnchanter &operator=(const ArmorEnchanter &) = delete;
     ArmorEnchanter &operator=(ArmorEnchanter &&) = delete;
     virtual ~ArmorEnchanter() = default;

--- a/src/object-enchant/protector/apply-magic-armor.h
+++ b/src/object-enchant/protector/apply-magic-armor.h
@@ -7,8 +7,6 @@ class CreatureEntity;
 class ItemEntity;
 class ArmorEnchanter : public AbstractProtectorEnchanter {
 public:
-    ArmorEnchanter(const ArmorEnchanter &) = delete;
-    ArmorEnchanter(ArmorEnchanter &&) = delete;
     ArmorEnchanter &operator=(const ArmorEnchanter &) = delete;
     ArmorEnchanter &operator=(ArmorEnchanter &&) = delete;
     virtual ~ArmorEnchanter() = default;

--- a/src/object-enchant/protector/apply-magic-boots.h
+++ b/src/object-enchant/protector/apply-magic-boots.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class BootsEnchanter : public AbstractProtectorEnchanter {
 public:
     BootsEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    BootsEnchanter(const BootsEnchanter &) = delete;
-    BootsEnchanter(BootsEnchanter &&) = delete;
     BootsEnchanter &operator=(const BootsEnchanter &) = delete;
     BootsEnchanter &operator=(BootsEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-boots.h
+++ b/src/object-enchant/protector/apply-magic-boots.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class BootsEnchanter : public AbstractProtectorEnchanter {
 public:
     BootsEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    BootsEnchanter(const BootsEnchanter &) = default;
+    BootsEnchanter(BootsEnchanter &&) = default;
     BootsEnchanter &operator=(const BootsEnchanter &) = delete;
     BootsEnchanter &operator=(BootsEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-boots.h
+++ b/src/object-enchant/protector/apply-magic-boots.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class BootsEnchanter : public AbstractProtectorEnchanter {
 public:
     BootsEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    BootsEnchanter(const BootsEnchanter &) = delete;
+    BootsEnchanter(BootsEnchanter &&) = delete;
+    BootsEnchanter &operator=(const BootsEnchanter &) = delete;
+    BootsEnchanter &operator=(BootsEnchanter &&) = delete;
     void apply_magic() override;
 
 protected:

--- a/src/object-enchant/protector/apply-magic-cloak.h
+++ b/src/object-enchant/protector/apply-magic-cloak.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class CloakEnchanter : public AbstractProtectorEnchanter {
 public:
     CloakEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    CloakEnchanter(const CloakEnchanter &) = default;
+    CloakEnchanter(CloakEnchanter &&) = default;
     CloakEnchanter &operator=(const CloakEnchanter &) = delete;
     CloakEnchanter &operator=(CloakEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-cloak.h
+++ b/src/object-enchant/protector/apply-magic-cloak.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class CloakEnchanter : public AbstractProtectorEnchanter {
 public:
     CloakEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    CloakEnchanter(const CloakEnchanter &) = delete;
+    CloakEnchanter(CloakEnchanter &&) = delete;
+    CloakEnchanter &operator=(const CloakEnchanter &) = delete;
+    CloakEnchanter &operator=(CloakEnchanter &&) = delete;
     void apply_magic() override;
 
 protected:

--- a/src/object-enchant/protector/apply-magic-cloak.h
+++ b/src/object-enchant/protector/apply-magic-cloak.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class CloakEnchanter : public AbstractProtectorEnchanter {
 public:
     CloakEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    CloakEnchanter(const CloakEnchanter &) = delete;
-    CloakEnchanter(CloakEnchanter &&) = delete;
     CloakEnchanter &operator=(const CloakEnchanter &) = delete;
     CloakEnchanter &operator=(CloakEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-crown.h
+++ b/src/object-enchant/protector/apply-magic-crown.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class CrownEnchanter : public AbstractProtectorEnchanter {
 public:
     CrownEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    CrownEnchanter(const CrownEnchanter &) = delete;
+    CrownEnchanter(CrownEnchanter &&) = delete;
+    CrownEnchanter &operator=(const CrownEnchanter &) = delete;
+    CrownEnchanter &operator=(CrownEnchanter &&) = delete;
     void apply_magic() override;
 
 protected:

--- a/src/object-enchant/protector/apply-magic-crown.h
+++ b/src/object-enchant/protector/apply-magic-crown.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class CrownEnchanter : public AbstractProtectorEnchanter {
 public:
     CrownEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    CrownEnchanter(const CrownEnchanter &) = delete;
-    CrownEnchanter(CrownEnchanter &&) = delete;
     CrownEnchanter &operator=(const CrownEnchanter &) = delete;
     CrownEnchanter &operator=(CrownEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-crown.h
+++ b/src/object-enchant/protector/apply-magic-crown.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class CrownEnchanter : public AbstractProtectorEnchanter {
 public:
     CrownEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    CrownEnchanter(const CrownEnchanter &) = default;
+    CrownEnchanter(CrownEnchanter &&) = default;
     CrownEnchanter &operator=(const CrownEnchanter &) = delete;
     CrownEnchanter &operator=(CrownEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-dragon-armor.h
+++ b/src/object-enchant/protector/apply-magic-dragon-armor.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class DragonArmorEnchanter : public AbstractProtectorEnchanter {
 public:
     DragonArmorEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    DragonArmorEnchanter(const DragonArmorEnchanter &) = default;
+    DragonArmorEnchanter(DragonArmorEnchanter &&) = default;
     DragonArmorEnchanter &operator=(const DragonArmorEnchanter &) = delete;
     DragonArmorEnchanter &operator=(DragonArmorEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-dragon-armor.h
+++ b/src/object-enchant/protector/apply-magic-dragon-armor.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class DragonArmorEnchanter : public AbstractProtectorEnchanter {
 public:
     DragonArmorEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    DragonArmorEnchanter(const DragonArmorEnchanter &) = delete;
-    DragonArmorEnchanter(DragonArmorEnchanter &&) = delete;
     DragonArmorEnchanter &operator=(const DragonArmorEnchanter &) = delete;
     DragonArmorEnchanter &operator=(DragonArmorEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-dragon-armor.h
+++ b/src/object-enchant/protector/apply-magic-dragon-armor.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class DragonArmorEnchanter : public AbstractProtectorEnchanter {
 public:
     DragonArmorEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    DragonArmorEnchanter(const DragonArmorEnchanter &) = delete;
+    DragonArmorEnchanter(DragonArmorEnchanter &&) = delete;
+    DragonArmorEnchanter &operator=(const DragonArmorEnchanter &) = delete;
+    DragonArmorEnchanter &operator=(DragonArmorEnchanter &&) = delete;
     void apply_magic() override;
 
 protected:

--- a/src/object-enchant/protector/apply-magic-gloves.h
+++ b/src/object-enchant/protector/apply-magic-gloves.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class GlovesEnchanter : public AbstractProtectorEnchanter {
 public:
     GlovesEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    GlovesEnchanter(const GlovesEnchanter &) = default;
+    GlovesEnchanter(GlovesEnchanter &&) = default;
     GlovesEnchanter &operator=(const GlovesEnchanter &) = delete;
     GlovesEnchanter &operator=(GlovesEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-gloves.h
+++ b/src/object-enchant/protector/apply-magic-gloves.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class GlovesEnchanter : public AbstractProtectorEnchanter {
 public:
     GlovesEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    GlovesEnchanter(const GlovesEnchanter &) = delete;
-    GlovesEnchanter(GlovesEnchanter &&) = delete;
     GlovesEnchanter &operator=(const GlovesEnchanter &) = delete;
     GlovesEnchanter &operator=(GlovesEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-gloves.h
+++ b/src/object-enchant/protector/apply-magic-gloves.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class GlovesEnchanter : public AbstractProtectorEnchanter {
 public:
     GlovesEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    GlovesEnchanter(const GlovesEnchanter &) = delete;
+    GlovesEnchanter(GlovesEnchanter &&) = delete;
+    GlovesEnchanter &operator=(const GlovesEnchanter &) = delete;
+    GlovesEnchanter &operator=(GlovesEnchanter &&) = delete;
     void apply_magic() override;
 
 protected:

--- a/src/object-enchant/protector/apply-magic-hard-armor.h
+++ b/src/object-enchant/protector/apply-magic-hard-armor.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class HardArmorEnchanter : public ArmorEnchanter {
 public:
     HardArmorEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    HardArmorEnchanter(const HardArmorEnchanter &) = default;
+    HardArmorEnchanter(HardArmorEnchanter &&) = default;
     HardArmorEnchanter &operator=(const HardArmorEnchanter &) = delete;
     HardArmorEnchanter &operator=(HardArmorEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-hard-armor.h
+++ b/src/object-enchant/protector/apply-magic-hard-armor.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class HardArmorEnchanter : public ArmorEnchanter {
 public:
     HardArmorEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    HardArmorEnchanter(const HardArmorEnchanter &) = delete;
+    HardArmorEnchanter(HardArmorEnchanter &&) = delete;
+    HardArmorEnchanter &operator=(const HardArmorEnchanter &) = delete;
+    HardArmorEnchanter &operator=(HardArmorEnchanter &&) = delete;
     void apply_magic() override;
 
 protected:

--- a/src/object-enchant/protector/apply-magic-hard-armor.h
+++ b/src/object-enchant/protector/apply-magic-hard-armor.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class HardArmorEnchanter : public ArmorEnchanter {
 public:
     HardArmorEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    HardArmorEnchanter(const HardArmorEnchanter &) = delete;
-    HardArmorEnchanter(HardArmorEnchanter &&) = delete;
     HardArmorEnchanter &operator=(const HardArmorEnchanter &) = delete;
     HardArmorEnchanter &operator=(HardArmorEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-helm.h
+++ b/src/object-enchant/protector/apply-magic-helm.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class HelmEnchanter : public AbstractProtectorEnchanter {
 public:
     HelmEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    HelmEnchanter(const HelmEnchanter &) = delete;
-    HelmEnchanter(HelmEnchanter &&) = delete;
     HelmEnchanter &operator=(const HelmEnchanter &) = delete;
     HelmEnchanter &operator=(HelmEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-helm.h
+++ b/src/object-enchant/protector/apply-magic-helm.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class HelmEnchanter : public AbstractProtectorEnchanter {
 public:
     HelmEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    HelmEnchanter(const HelmEnchanter &) = delete;
+    HelmEnchanter(HelmEnchanter &&) = delete;
+    HelmEnchanter &operator=(const HelmEnchanter &) = delete;
+    HelmEnchanter &operator=(HelmEnchanter &&) = delete;
     void apply_magic() override;
 
 protected:

--- a/src/object-enchant/protector/apply-magic-helm.h
+++ b/src/object-enchant/protector/apply-magic-helm.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class HelmEnchanter : public AbstractProtectorEnchanter {
 public:
     HelmEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    HelmEnchanter(const HelmEnchanter &) = default;
+    HelmEnchanter(HelmEnchanter &&) = default;
     HelmEnchanter &operator=(const HelmEnchanter &) = delete;
     HelmEnchanter &operator=(HelmEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-shield.h
+++ b/src/object-enchant/protector/apply-magic-shield.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class ShieldEnchanter : public AbstractProtectorEnchanter {
 public:
     ShieldEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    ShieldEnchanter(const ShieldEnchanter &) = delete;
+    ShieldEnchanter(ShieldEnchanter &&) = delete;
+    ShieldEnchanter &operator=(const ShieldEnchanter &) = delete;
+    ShieldEnchanter &operator=(ShieldEnchanter &&) = delete;
     void apply_magic() override;
 
 protected:

--- a/src/object-enchant/protector/apply-magic-shield.h
+++ b/src/object-enchant/protector/apply-magic-shield.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class ShieldEnchanter : public AbstractProtectorEnchanter {
 public:
     ShieldEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    ShieldEnchanter(const ShieldEnchanter &) = default;
+    ShieldEnchanter(ShieldEnchanter &&) = default;
     ShieldEnchanter &operator=(const ShieldEnchanter &) = delete;
     ShieldEnchanter &operator=(ShieldEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-shield.h
+++ b/src/object-enchant/protector/apply-magic-shield.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class ShieldEnchanter : public AbstractProtectorEnchanter {
 public:
     ShieldEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    ShieldEnchanter(const ShieldEnchanter &) = delete;
-    ShieldEnchanter(ShieldEnchanter &&) = delete;
     ShieldEnchanter &operator=(const ShieldEnchanter &) = delete;
     ShieldEnchanter &operator=(ShieldEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-soft-armor.h
+++ b/src/object-enchant/protector/apply-magic-soft-armor.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class SoftArmorEnchanter : public ArmorEnchanter {
 public:
     SoftArmorEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    SoftArmorEnchanter(const SoftArmorEnchanter &) = delete;
-    SoftArmorEnchanter(SoftArmorEnchanter &&) = delete;
     SoftArmorEnchanter &operator=(const SoftArmorEnchanter &) = delete;
     SoftArmorEnchanter &operator=(SoftArmorEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-soft-armor.h
+++ b/src/object-enchant/protector/apply-magic-soft-armor.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class SoftArmorEnchanter : public ArmorEnchanter {
 public:
     SoftArmorEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    SoftArmorEnchanter(const SoftArmorEnchanter &) = default;
+    SoftArmorEnchanter(SoftArmorEnchanter &&) = default;
     SoftArmorEnchanter &operator=(const SoftArmorEnchanter &) = delete;
     SoftArmorEnchanter &operator=(SoftArmorEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/protector/apply-magic-soft-armor.h
+++ b/src/object-enchant/protector/apply-magic-soft-armor.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class SoftArmorEnchanter : public ArmorEnchanter {
 public:
     SoftArmorEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    SoftArmorEnchanter(const SoftArmorEnchanter &) = delete;
+    SoftArmorEnchanter(SoftArmorEnchanter &&) = delete;
+    SoftArmorEnchanter &operator=(const SoftArmorEnchanter &) = delete;
+    SoftArmorEnchanter &operator=(SoftArmorEnchanter &&) = delete;
     void apply_magic() override;
 
 protected:

--- a/src/object-enchant/weapon/apply-magic-arrow.h
+++ b/src/object-enchant/weapon/apply-magic-arrow.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class ArrowEnchanter : public AbstractWeaponEnchanter {
 public:
     ArrowEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    ArrowEnchanter(const ArrowEnchanter &) = default;
+    ArrowEnchanter(ArrowEnchanter &&) = default;
     ArrowEnchanter &operator=(const ArrowEnchanter &) = delete;
     ArrowEnchanter &operator=(ArrowEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/weapon/apply-magic-arrow.h
+++ b/src/object-enchant/weapon/apply-magic-arrow.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class ArrowEnchanter : public AbstractWeaponEnchanter {
 public:
     ArrowEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    ArrowEnchanter(const ArrowEnchanter &) = delete;
-    ArrowEnchanter(ArrowEnchanter &&) = delete;
     ArrowEnchanter &operator=(const ArrowEnchanter &) = delete;
     ArrowEnchanter &operator=(ArrowEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/weapon/apply-magic-arrow.h
+++ b/src/object-enchant/weapon/apply-magic-arrow.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class ArrowEnchanter : public AbstractWeaponEnchanter {
 public:
     ArrowEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    ArrowEnchanter(const ArrowEnchanter &) = delete;
+    ArrowEnchanter(ArrowEnchanter &&) = delete;
+    ArrowEnchanter &operator=(const ArrowEnchanter &) = delete;
+    ArrowEnchanter &operator=(ArrowEnchanter &&) = delete;
     void apply_magic() override;
 
 protected:

--- a/src/object-enchant/weapon/apply-magic-bow.h
+++ b/src/object-enchant/weapon/apply-magic-bow.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class BowEnchanter : public AbstractWeaponEnchanter {
 public:
     BowEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    BowEnchanter(const BowEnchanter &) = delete;
-    BowEnchanter(BowEnchanter &&) = delete;
     BowEnchanter &operator=(const BowEnchanter &) = delete;
     BowEnchanter &operator=(BowEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/weapon/apply-magic-bow.h
+++ b/src/object-enchant/weapon/apply-magic-bow.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class BowEnchanter : public AbstractWeaponEnchanter {
 public:
     BowEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    BowEnchanter(const BowEnchanter &) = delete;
+    BowEnchanter(BowEnchanter &&) = delete;
+    BowEnchanter &operator=(const BowEnchanter &) = delete;
+    BowEnchanter &operator=(BowEnchanter &&) = delete;
     void apply_magic() override;
 
 protected:

--- a/src/object-enchant/weapon/apply-magic-bow.h
+++ b/src/object-enchant/weapon/apply-magic-bow.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class BowEnchanter : public AbstractWeaponEnchanter {
 public:
     BowEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    BowEnchanter(const BowEnchanter &) = default;
+    BowEnchanter(BowEnchanter &&) = default;
     BowEnchanter &operator=(const BowEnchanter &) = delete;
     BowEnchanter &operator=(BowEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/weapon/apply-magic-digging.h
+++ b/src/object-enchant/weapon/apply-magic-digging.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class DiggingEnchanter : public AbstractWeaponEnchanter {
 public:
     DiggingEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    DiggingEnchanter(const DiggingEnchanter &) = delete;
+    DiggingEnchanter(DiggingEnchanter &&) = delete;
+    DiggingEnchanter &operator=(const DiggingEnchanter &) = delete;
+    DiggingEnchanter &operator=(DiggingEnchanter &&) = delete;
     void apply_magic() override;
 
 protected:

--- a/src/object-enchant/weapon/apply-magic-digging.h
+++ b/src/object-enchant/weapon/apply-magic-digging.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class DiggingEnchanter : public AbstractWeaponEnchanter {
 public:
     DiggingEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    DiggingEnchanter(const DiggingEnchanter &) = default;
+    DiggingEnchanter(DiggingEnchanter &&) = default;
     DiggingEnchanter &operator=(const DiggingEnchanter &) = delete;
     DiggingEnchanter &operator=(DiggingEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/weapon/apply-magic-digging.h
+++ b/src/object-enchant/weapon/apply-magic-digging.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class DiggingEnchanter : public AbstractWeaponEnchanter {
 public:
     DiggingEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    DiggingEnchanter(const DiggingEnchanter &) = delete;
-    DiggingEnchanter(DiggingEnchanter &&) = delete;
     DiggingEnchanter &operator=(const DiggingEnchanter &) = delete;
     DiggingEnchanter &operator=(DiggingEnchanter &&) = delete;
     void apply_magic() override;

--- a/src/object-enchant/weapon/apply-magic-hafted.h
+++ b/src/object-enchant/weapon/apply-magic-hafted.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class HaftedEnchanter : public MeleeWeaponEnchanter {
 public:
     HaftedEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    HaftedEnchanter(const HaftedEnchanter &) = delete;
-    HaftedEnchanter(HaftedEnchanter &&) = delete;
     HaftedEnchanter &operator=(const HaftedEnchanter &) = delete;
     HaftedEnchanter &operator=(HaftedEnchanter &&) = delete;
 

--- a/src/object-enchant/weapon/apply-magic-hafted.h
+++ b/src/object-enchant/weapon/apply-magic-hafted.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class HaftedEnchanter : public MeleeWeaponEnchanter {
 public:
     HaftedEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    HaftedEnchanter(const HaftedEnchanter &) = default;
+    HaftedEnchanter(HaftedEnchanter &&) = default;
     HaftedEnchanter &operator=(const HaftedEnchanter &) = delete;
     HaftedEnchanter &operator=(HaftedEnchanter &&) = delete;
 

--- a/src/object-enchant/weapon/apply-magic-hafted.h
+++ b/src/object-enchant/weapon/apply-magic-hafted.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class HaftedEnchanter : public MeleeWeaponEnchanter {
 public:
     HaftedEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    HaftedEnchanter(const HaftedEnchanter &) = delete;
+    HaftedEnchanter(HaftedEnchanter &&) = delete;
+    HaftedEnchanter &operator=(const HaftedEnchanter &) = delete;
+    HaftedEnchanter &operator=(HaftedEnchanter &&) = delete;
 
     void apply_magic() override;
 

--- a/src/object-enchant/weapon/apply-magic-polearm.h
+++ b/src/object-enchant/weapon/apply-magic-polearm.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class PolearmEnchanter : public MeleeWeaponEnchanter {
 public:
     PolearmEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    PolearmEnchanter(const PolearmEnchanter &) = default;
+    PolearmEnchanter(PolearmEnchanter &&) = default;
     PolearmEnchanter &operator=(const PolearmEnchanter &) = delete;
     PolearmEnchanter &operator=(PolearmEnchanter &&) = delete;
 

--- a/src/object-enchant/weapon/apply-magic-polearm.h
+++ b/src/object-enchant/weapon/apply-magic-polearm.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class PolearmEnchanter : public MeleeWeaponEnchanter {
 public:
     PolearmEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    PolearmEnchanter(const PolearmEnchanter &) = delete;
-    PolearmEnchanter(PolearmEnchanter &&) = delete;
     PolearmEnchanter &operator=(const PolearmEnchanter &) = delete;
     PolearmEnchanter &operator=(PolearmEnchanter &&) = delete;
 

--- a/src/object-enchant/weapon/apply-magic-polearm.h
+++ b/src/object-enchant/weapon/apply-magic-polearm.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class PolearmEnchanter : public MeleeWeaponEnchanter {
 public:
     PolearmEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    PolearmEnchanter(const PolearmEnchanter &) = delete;
+    PolearmEnchanter(PolearmEnchanter &&) = delete;
+    PolearmEnchanter &operator=(const PolearmEnchanter &) = delete;
+    PolearmEnchanter &operator=(PolearmEnchanter &&) = delete;
 
     void apply_magic() override;
 

--- a/src/object-enchant/weapon/apply-magic-sword.h
+++ b/src/object-enchant/weapon/apply-magic-sword.h
@@ -8,8 +8,6 @@ class ItemEntity;
 class SwordEnchanter : public MeleeWeaponEnchanter {
 public:
     SwordEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
-    SwordEnchanter(const SwordEnchanter &) = delete;
-    SwordEnchanter(SwordEnchanter &&) = delete;
     SwordEnchanter &operator=(const SwordEnchanter &) = delete;
     SwordEnchanter &operator=(SwordEnchanter &&) = delete;
 

--- a/src/object-enchant/weapon/apply-magic-sword.h
+++ b/src/object-enchant/weapon/apply-magic-sword.h
@@ -8,6 +8,10 @@ class ItemEntity;
 class SwordEnchanter : public MeleeWeaponEnchanter {
 public:
     SwordEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    SwordEnchanter(const SwordEnchanter &) = delete;
+    SwordEnchanter(SwordEnchanter &&) = delete;
+    SwordEnchanter &operator=(const SwordEnchanter &) = delete;
+    SwordEnchanter &operator=(SwordEnchanter &&) = delete;
 
     void apply_magic() override;
 

--- a/src/object-enchant/weapon/apply-magic-sword.h
+++ b/src/object-enchant/weapon/apply-magic-sword.h
@@ -8,6 +8,8 @@ class ItemEntity;
 class SwordEnchanter : public MeleeWeaponEnchanter {
 public:
     SwordEnchanter(CreatureEntity &creature, ItemEntity *o_ptr, DEPTH level, int power);
+    SwordEnchanter(const SwordEnchanter &) = default;
+    SwordEnchanter(SwordEnchanter &&) = default;
     SwordEnchanter &operator=(const SwordEnchanter &) = delete;
     SwordEnchanter &operator=(SwordEnchanter &&) = delete;
 

--- a/src/object-enchant/weapon/melee-weapon-enchanter.h
+++ b/src/object-enchant/weapon/melee-weapon-enchanter.h
@@ -7,6 +7,10 @@ class CreatureEntity;
 class ItemEntity;
 class MeleeWeaponEnchanter : public AbstractWeaponEnchanter {
 public:
+    MeleeWeaponEnchanter(const MeleeWeaponEnchanter &) = delete;
+    MeleeWeaponEnchanter(MeleeWeaponEnchanter &&) = delete;
+    MeleeWeaponEnchanter &operator=(const MeleeWeaponEnchanter &) = delete;
+    MeleeWeaponEnchanter &operator=(MeleeWeaponEnchanter &&) = delete;
     virtual ~MeleeWeaponEnchanter() = default;
 
     void apply_magic() override;

--- a/src/object-enchant/weapon/melee-weapon-enchanter.h
+++ b/src/object-enchant/weapon/melee-weapon-enchanter.h
@@ -7,8 +7,6 @@ class CreatureEntity;
 class ItemEntity;
 class MeleeWeaponEnchanter : public AbstractWeaponEnchanter {
 public:
-    MeleeWeaponEnchanter(const MeleeWeaponEnchanter &) = delete;
-    MeleeWeaponEnchanter(MeleeWeaponEnchanter &&) = delete;
     MeleeWeaponEnchanter &operator=(const MeleeWeaponEnchanter &) = delete;
     MeleeWeaponEnchanter &operator=(MeleeWeaponEnchanter &&) = delete;
     virtual ~MeleeWeaponEnchanter() = default;

--- a/src/object-enchant/weapon/melee-weapon-enchanter.h
+++ b/src/object-enchant/weapon/melee-weapon-enchanter.h
@@ -7,6 +7,8 @@ class CreatureEntity;
 class ItemEntity;
 class MeleeWeaponEnchanter : public AbstractWeaponEnchanter {
 public:
+    MeleeWeaponEnchanter(const MeleeWeaponEnchanter &) = default;
+    MeleeWeaponEnchanter(MeleeWeaponEnchanter &&) = default;
     MeleeWeaponEnchanter &operator=(const MeleeWeaponEnchanter &) = delete;
     MeleeWeaponEnchanter &operator=(MeleeWeaponEnchanter &&) = delete;
     virtual ~MeleeWeaponEnchanter() = default;

--- a/src/object-use/item-use-checker.h
+++ b/src/object-use/item-use-checker.h
@@ -6,6 +6,8 @@ class CreatureEntity;
 class ItemUseChecker {
 public:
     ItemUseChecker(CreatureEntity &creature);
+    ItemUseChecker(const ItemUseChecker &) = default;
+    ItemUseChecker(ItemUseChecker &&) = default;
     ItemUseChecker &operator=(const ItemUseChecker &) = delete;
     ItemUseChecker &operator=(ItemUseChecker &&) = delete;
     virtual ~ItemUseChecker() = default;

--- a/src/object-use/item-use-checker.h
+++ b/src/object-use/item-use-checker.h
@@ -6,8 +6,6 @@ class CreatureEntity;
 class ItemUseChecker {
 public:
     ItemUseChecker(CreatureEntity &creature);
-    ItemUseChecker(const ItemUseChecker &) = delete;
-    ItemUseChecker(ItemUseChecker &&) = delete;
     ItemUseChecker &operator=(const ItemUseChecker &) = delete;
     ItemUseChecker &operator=(ItemUseChecker &&) = delete;
     virtual ~ItemUseChecker() = default;

--- a/src/object-use/item-use-checker.h
+++ b/src/object-use/item-use-checker.h
@@ -6,6 +6,10 @@ class CreatureEntity;
 class ItemUseChecker {
 public:
     ItemUseChecker(CreatureEntity &creature);
+    ItemUseChecker(const ItemUseChecker &) = delete;
+    ItemUseChecker(ItemUseChecker &&) = delete;
+    ItemUseChecker &operator=(const ItemUseChecker &) = delete;
+    ItemUseChecker &operator=(ItemUseChecker &&) = delete;
     virtual ~ItemUseChecker() = default;
 
     bool check_stun(std::string_view mes) const;

--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -621,7 +621,7 @@ bool QuaffEffects::mesudachi()
     for (int i = 0; i < 10; i++) {
         skill_gain += randint1(10);
     }
-    this->creature.skill_exp[PlayerSkillKindType::ASSHOLE] += skill_gain;
+    this->creature.skill_exp[PlayerSkillKindType::ASSHOLE] += static_cast<SUB_EXP>(skill_gain);
     msg_format(_("尻の穴技能が%d向上した！", "Your asshole skill increased by %d!"), skill_gain);
 
     // 1/36の確率で性別が女になる（両性の場合は無効）

--- a/src/object-use/quaff/quaff-effects.h
+++ b/src/object-use/quaff/quaff-effects.h
@@ -5,6 +5,10 @@ class ItemEntity;
 class QuaffEffects {
 public:
     QuaffEffects(CreatureEntity &creature);
+    QuaffEffects(const QuaffEffects &) = delete;
+    QuaffEffects(QuaffEffects &&) = delete;
+    QuaffEffects &operator=(const QuaffEffects &) = delete;
+    QuaffEffects &operator=(QuaffEffects &&) = delete;
 
     bool influence(const ItemEntity &item, const bool is_rectal);
 

--- a/src/object-use/quaff/quaff-effects.h
+++ b/src/object-use/quaff/quaff-effects.h
@@ -5,8 +5,6 @@ class ItemEntity;
 class QuaffEffects {
 public:
     QuaffEffects(CreatureEntity &creature);
-    QuaffEffects(const QuaffEffects &) = delete;
-    QuaffEffects(QuaffEffects &&) = delete;
     QuaffEffects &operator=(const QuaffEffects &) = delete;
     QuaffEffects &operator=(QuaffEffects &&) = delete;
 

--- a/src/object-use/quaff/quaff-effects.h
+++ b/src/object-use/quaff/quaff-effects.h
@@ -5,6 +5,8 @@ class ItemEntity;
 class QuaffEffects {
 public:
     QuaffEffects(CreatureEntity &creature);
+    QuaffEffects(const QuaffEffects &) = default;
+    QuaffEffects(QuaffEffects &&) = default;
     QuaffEffects &operator=(const QuaffEffects &) = delete;
     QuaffEffects &operator=(QuaffEffects &&) = delete;
 

--- a/src/object-use/quaff/quaff-execution.h
+++ b/src/object-use/quaff/quaff-execution.h
@@ -7,6 +7,8 @@ class ItemEntity;
 class ObjectQuaffEntity {
 public:
     ObjectQuaffEntity(CreatureEntity &creature);
+    ObjectQuaffEntity(const ObjectQuaffEntity &) = default;
+    ObjectQuaffEntity(ObjectQuaffEntity &&) = default;
     ObjectQuaffEntity &operator=(const ObjectQuaffEntity &) = delete;
     ObjectQuaffEntity &operator=(ObjectQuaffEntity &&) = delete;
     virtual ~ObjectQuaffEntity() = default;

--- a/src/object-use/quaff/quaff-execution.h
+++ b/src/object-use/quaff/quaff-execution.h
@@ -7,8 +7,6 @@ class ItemEntity;
 class ObjectQuaffEntity {
 public:
     ObjectQuaffEntity(CreatureEntity &creature);
-    ObjectQuaffEntity(const ObjectQuaffEntity &) = delete;
-    ObjectQuaffEntity(ObjectQuaffEntity &&) = delete;
     ObjectQuaffEntity &operator=(const ObjectQuaffEntity &) = delete;
     ObjectQuaffEntity &operator=(ObjectQuaffEntity &&) = delete;
     virtual ~ObjectQuaffEntity() = default;

--- a/src/object-use/quaff/quaff-execution.h
+++ b/src/object-use/quaff/quaff-execution.h
@@ -7,6 +7,10 @@ class ItemEntity;
 class ObjectQuaffEntity {
 public:
     ObjectQuaffEntity(CreatureEntity &creature);
+    ObjectQuaffEntity(const ObjectQuaffEntity &) = delete;
+    ObjectQuaffEntity(ObjectQuaffEntity &&) = delete;
+    ObjectQuaffEntity &operator=(const ObjectQuaffEntity &) = delete;
+    ObjectQuaffEntity &operator=(ObjectQuaffEntity &&) = delete;
     virtual ~ObjectQuaffEntity() = default;
 
     void execute(INVENTORY_IDX i_idx, bool is_rectal = false);

--- a/src/object-use/read/parchment-read-executor.h
+++ b/src/object-use/read/parchment-read-executor.h
@@ -7,8 +7,6 @@ class ItemEntity;
 class ParchmentReadExecutor : public ReadExecutorBase {
 public:
     ParchmentReadExecutor(CreatureEntity &creature, ItemEntity *o_ptr);
-    ParchmentReadExecutor(const ParchmentReadExecutor &) = delete;
-    ParchmentReadExecutor(ParchmentReadExecutor &&) = delete;
     ParchmentReadExecutor &operator=(const ParchmentReadExecutor &) = delete;
     ParchmentReadExecutor &operator=(ParchmentReadExecutor &&) = delete;
     bool read() override;

--- a/src/object-use/read/parchment-read-executor.h
+++ b/src/object-use/read/parchment-read-executor.h
@@ -7,6 +7,10 @@ class ItemEntity;
 class ParchmentReadExecutor : public ReadExecutorBase {
 public:
     ParchmentReadExecutor(CreatureEntity &creature, ItemEntity *o_ptr);
+    ParchmentReadExecutor(const ParchmentReadExecutor &) = delete;
+    ParchmentReadExecutor(ParchmentReadExecutor &&) = delete;
+    ParchmentReadExecutor &operator=(const ParchmentReadExecutor &) = delete;
+    ParchmentReadExecutor &operator=(ParchmentReadExecutor &&) = delete;
     bool read() override;
     bool is_identified() const override;
 

--- a/src/object-use/read/parchment-read-executor.h
+++ b/src/object-use/read/parchment-read-executor.h
@@ -7,6 +7,8 @@ class ItemEntity;
 class ParchmentReadExecutor : public ReadExecutorBase {
 public:
     ParchmentReadExecutor(CreatureEntity &creature, ItemEntity *o_ptr);
+    ParchmentReadExecutor(const ParchmentReadExecutor &) = default;
+    ParchmentReadExecutor(ParchmentReadExecutor &&) = default;
     ParchmentReadExecutor &operator=(const ParchmentReadExecutor &) = delete;
     ParchmentReadExecutor &operator=(ParchmentReadExecutor &&) = delete;
     bool read() override;

--- a/src/object-use/read/read-execution.h
+++ b/src/object-use/read/read-execution.h
@@ -7,6 +7,8 @@ class ItemEntity;
 class ObjectReadEntity {
 public:
     ObjectReadEntity(CreatureEntity &creature, INVENTORY_IDX i_idx);
+    ObjectReadEntity(const ObjectReadEntity &) = default;
+    ObjectReadEntity(ObjectReadEntity &&) = default;
     ObjectReadEntity &operator=(const ObjectReadEntity &) = delete;
     ObjectReadEntity &operator=(ObjectReadEntity &&) = delete;
     virtual ~ObjectReadEntity() = default;

--- a/src/object-use/read/read-execution.h
+++ b/src/object-use/read/read-execution.h
@@ -7,8 +7,6 @@ class ItemEntity;
 class ObjectReadEntity {
 public:
     ObjectReadEntity(CreatureEntity &creature, INVENTORY_IDX i_idx);
-    ObjectReadEntity(const ObjectReadEntity &) = delete;
-    ObjectReadEntity(ObjectReadEntity &&) = delete;
     ObjectReadEntity &operator=(const ObjectReadEntity &) = delete;
     ObjectReadEntity &operator=(ObjectReadEntity &&) = delete;
     virtual ~ObjectReadEntity() = default;

--- a/src/object-use/read/read-execution.h
+++ b/src/object-use/read/read-execution.h
@@ -7,6 +7,10 @@ class ItemEntity;
 class ObjectReadEntity {
 public:
     ObjectReadEntity(CreatureEntity &creature, INVENTORY_IDX i_idx);
+    ObjectReadEntity(const ObjectReadEntity &) = delete;
+    ObjectReadEntity(ObjectReadEntity &&) = delete;
+    ObjectReadEntity &operator=(const ObjectReadEntity &) = delete;
+    ObjectReadEntity &operator=(ObjectReadEntity &&) = delete;
     virtual ~ObjectReadEntity() = default;
 
     void execute(bool known);

--- a/src/object-use/read/scroll-read-executor.h
+++ b/src/object-use/read/scroll-read-executor.h
@@ -7,6 +7,8 @@ class ItemEntity;
 class ScrollReadExecutor : public ReadExecutorBase {
 public:
     ScrollReadExecutor(CreatureEntity &creature, ItemEntity *o_ptr, bool known);
+    ScrollReadExecutor(const ScrollReadExecutor &) = default;
+    ScrollReadExecutor(ScrollReadExecutor &&) = default;
     ScrollReadExecutor &operator=(const ScrollReadExecutor &) = delete;
     ScrollReadExecutor &operator=(ScrollReadExecutor &&) = delete;
     bool is_identified() const override;

--- a/src/object-use/read/scroll-read-executor.h
+++ b/src/object-use/read/scroll-read-executor.h
@@ -7,8 +7,6 @@ class ItemEntity;
 class ScrollReadExecutor : public ReadExecutorBase {
 public:
     ScrollReadExecutor(CreatureEntity &creature, ItemEntity *o_ptr, bool known);
-    ScrollReadExecutor(const ScrollReadExecutor &) = delete;
-    ScrollReadExecutor(ScrollReadExecutor &&) = delete;
     ScrollReadExecutor &operator=(const ScrollReadExecutor &) = delete;
     ScrollReadExecutor &operator=(ScrollReadExecutor &&) = delete;
     bool is_identified() const override;

--- a/src/object-use/read/scroll-read-executor.h
+++ b/src/object-use/read/scroll-read-executor.h
@@ -7,6 +7,10 @@ class ItemEntity;
 class ScrollReadExecutor : public ReadExecutorBase {
 public:
     ScrollReadExecutor(CreatureEntity &creature, ItemEntity *o_ptr, bool known);
+    ScrollReadExecutor(const ScrollReadExecutor &) = delete;
+    ScrollReadExecutor(ScrollReadExecutor &&) = delete;
+    ScrollReadExecutor &operator=(const ScrollReadExecutor &) = delete;
+    ScrollReadExecutor &operator=(ScrollReadExecutor &&) = delete;
     bool is_identified() const override;
     bool read() override;
 

--- a/src/object-use/zapwand-execution.h
+++ b/src/object-use/zapwand-execution.h
@@ -6,6 +6,8 @@ class CreatureEntity;
 class ObjectZapWandEntity {
 public:
     ObjectZapWandEntity(CreatureEntity &creature);
+    ObjectZapWandEntity(const ObjectZapWandEntity &) = default;
+    ObjectZapWandEntity(ObjectZapWandEntity &&) = default;
     ObjectZapWandEntity &operator=(const ObjectZapWandEntity &) = delete;
     ObjectZapWandEntity &operator=(ObjectZapWandEntity &&) = delete;
     virtual ~ObjectZapWandEntity() = default;

--- a/src/object-use/zapwand-execution.h
+++ b/src/object-use/zapwand-execution.h
@@ -6,6 +6,10 @@ class CreatureEntity;
 class ObjectZapWandEntity {
 public:
     ObjectZapWandEntity(CreatureEntity &creature);
+    ObjectZapWandEntity(const ObjectZapWandEntity &) = delete;
+    ObjectZapWandEntity(ObjectZapWandEntity &&) = delete;
+    ObjectZapWandEntity &operator=(const ObjectZapWandEntity &) = delete;
+    ObjectZapWandEntity &operator=(ObjectZapWandEntity &&) = delete;
     virtual ~ObjectZapWandEntity() = default;
 
     void execute(INVENTORY_IDX i_idx);

--- a/src/object-use/zapwand-execution.h
+++ b/src/object-use/zapwand-execution.h
@@ -6,8 +6,6 @@ class CreatureEntity;
 class ObjectZapWandEntity {
 public:
     ObjectZapWandEntity(CreatureEntity &creature);
-    ObjectZapWandEntity(const ObjectZapWandEntity &) = delete;
-    ObjectZapWandEntity(ObjectZapWandEntity &&) = delete;
     ObjectZapWandEntity &operator=(const ObjectZapWandEntity &) = delete;
     ObjectZapWandEntity &operator=(ObjectZapWandEntity &&) = delete;
     virtual ~ObjectZapWandEntity() = default;

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -267,7 +267,7 @@ static int blow_damcalc(const CreatureEntity &monster, CreatureEntity &creature,
         return dam;
     }
 
-    ARMOUR_CLASS ac = creature.get_ac();
+    ARMOUR_CLASS ac = static_cast<ARMOUR_CLASS>(creature.get_ac());
     bool check_wraith_form = true;
     switch (blow.effect) {
     case RaceBlowEffectType::SUPERHURT: {

--- a/src/pet/pet-util.cpp
+++ b/src/pet/pet-util.cpp
@@ -69,7 +69,7 @@ PERCENTAGE calculate_upkeep(CreatureEntity &creature)
     DEPTH total_friend_levels = 0;
     total_friends = 0;
     for (auto m_idx = creature.get_floor()->m_max - 1; m_idx >= 1; m_idx--) {
-        const auto &monster = creature.get_floor()->get_monster(m_idx);
+        const auto &monster = creature.get_floor()->get_monster(static_cast<MONSTER_IDX>(m_idx));
         if (!monster.is_valid()) {
             continue;
         }

--- a/src/player-ability/player-charisma.h
+++ b/src/player-ability/player-charisma.h
@@ -6,6 +6,10 @@ class CreatureEntity;
 class PlayerCharisma : public PlayerBasicStatistics {
 public:
     PlayerCharisma(CreatureEntity &creature);
+    PlayerCharisma(const PlayerCharisma &) = delete;
+    PlayerCharisma(PlayerCharisma &&) = delete;
+    PlayerCharisma &operator=(const PlayerCharisma &) = delete;
+    PlayerCharisma &operator=(PlayerCharisma &&) = delete;
 
     BIT_FLAGS get_all_flags() override;
     BIT_FLAGS get_bad_flags() override;

--- a/src/player-ability/player-charisma.h
+++ b/src/player-ability/player-charisma.h
@@ -6,8 +6,6 @@ class CreatureEntity;
 class PlayerCharisma : public PlayerBasicStatistics {
 public:
     PlayerCharisma(CreatureEntity &creature);
-    PlayerCharisma(const PlayerCharisma &) = delete;
-    PlayerCharisma(PlayerCharisma &&) = delete;
     PlayerCharisma &operator=(const PlayerCharisma &) = delete;
     PlayerCharisma &operator=(PlayerCharisma &&) = delete;
 

--- a/src/player-ability/player-charisma.h
+++ b/src/player-ability/player-charisma.h
@@ -6,6 +6,8 @@ class CreatureEntity;
 class PlayerCharisma : public PlayerBasicStatistics {
 public:
     PlayerCharisma(CreatureEntity &creature);
+    PlayerCharisma(const PlayerCharisma &) = default;
+    PlayerCharisma(PlayerCharisma &&) = default;
     PlayerCharisma &operator=(const PlayerCharisma &) = delete;
     PlayerCharisma &operator=(PlayerCharisma &&) = delete;
 

--- a/src/player-ability/player-constitution.h
+++ b/src/player-ability/player-constitution.h
@@ -6,6 +6,8 @@ class CreatureEntity;
 class PlayerConstitution : public PlayerBasicStatistics {
 public:
     PlayerConstitution(CreatureEntity &creature);
+    PlayerConstitution(const PlayerConstitution &) = default;
+    PlayerConstitution(PlayerConstitution &&) = default;
     PlayerConstitution &operator=(const PlayerConstitution &) = delete;
     PlayerConstitution &operator=(PlayerConstitution &&) = delete;
 

--- a/src/player-ability/player-constitution.h
+++ b/src/player-ability/player-constitution.h
@@ -6,8 +6,6 @@ class CreatureEntity;
 class PlayerConstitution : public PlayerBasicStatistics {
 public:
     PlayerConstitution(CreatureEntity &creature);
-    PlayerConstitution(const PlayerConstitution &) = delete;
-    PlayerConstitution(PlayerConstitution &&) = delete;
     PlayerConstitution &operator=(const PlayerConstitution &) = delete;
     PlayerConstitution &operator=(PlayerConstitution &&) = delete;
 

--- a/src/player-ability/player-constitution.h
+++ b/src/player-ability/player-constitution.h
@@ -6,6 +6,10 @@ class CreatureEntity;
 class PlayerConstitution : public PlayerBasicStatistics {
 public:
     PlayerConstitution(CreatureEntity &creature);
+    PlayerConstitution(const PlayerConstitution &) = delete;
+    PlayerConstitution(PlayerConstitution &&) = delete;
+    PlayerConstitution &operator=(const PlayerConstitution &) = delete;
+    PlayerConstitution &operator=(PlayerConstitution &&) = delete;
 
 protected:
     void set_locals() override;

--- a/src/player-ability/player-dexterity.h
+++ b/src/player-ability/player-dexterity.h
@@ -6,6 +6,8 @@ class CreatureEntity;
 class PlayerDexterity : public PlayerBasicStatistics {
 public:
     PlayerDexterity(CreatureEntity &creature);
+    PlayerDexterity(const PlayerDexterity &) = default;
+    PlayerDexterity(PlayerDexterity &&) = default;
     PlayerDexterity &operator=(const PlayerDexterity &) = delete;
     PlayerDexterity &operator=(PlayerDexterity &&) = delete;
 

--- a/src/player-ability/player-dexterity.h
+++ b/src/player-ability/player-dexterity.h
@@ -6,6 +6,10 @@ class CreatureEntity;
 class PlayerDexterity : public PlayerBasicStatistics {
 public:
     PlayerDexterity(CreatureEntity &creature);
+    PlayerDexterity(const PlayerDexterity &) = delete;
+    PlayerDexterity(PlayerDexterity &&) = delete;
+    PlayerDexterity &operator=(const PlayerDexterity &) = delete;
+    PlayerDexterity &operator=(PlayerDexterity &&) = delete;
 
 protected:
     void set_locals() override;

--- a/src/player-ability/player-dexterity.h
+++ b/src/player-ability/player-dexterity.h
@@ -6,8 +6,6 @@ class CreatureEntity;
 class PlayerDexterity : public PlayerBasicStatistics {
 public:
     PlayerDexterity(CreatureEntity &creature);
-    PlayerDexterity(const PlayerDexterity &) = delete;
-    PlayerDexterity(PlayerDexterity &&) = delete;
     PlayerDexterity &operator=(const PlayerDexterity &) = delete;
     PlayerDexterity &operator=(PlayerDexterity &&) = delete;
 

--- a/src/player-ability/player-intelligence.h
+++ b/src/player-ability/player-intelligence.h
@@ -6,6 +6,8 @@ class CreatureEntity;
 class PlayerIntelligence : public PlayerBasicStatistics {
 public:
     PlayerIntelligence(CreatureEntity &creature);
+    PlayerIntelligence(const PlayerIntelligence &) = default;
+    PlayerIntelligence(PlayerIntelligence &&) = default;
     PlayerIntelligence &operator=(const PlayerIntelligence &) = delete;
     PlayerIntelligence &operator=(PlayerIntelligence &&) = delete;
 

--- a/src/player-ability/player-intelligence.h
+++ b/src/player-ability/player-intelligence.h
@@ -6,8 +6,6 @@ class CreatureEntity;
 class PlayerIntelligence : public PlayerBasicStatistics {
 public:
     PlayerIntelligence(CreatureEntity &creature);
-    PlayerIntelligence(const PlayerIntelligence &) = delete;
-    PlayerIntelligence(PlayerIntelligence &&) = delete;
     PlayerIntelligence &operator=(const PlayerIntelligence &) = delete;
     PlayerIntelligence &operator=(PlayerIntelligence &&) = delete;
 

--- a/src/player-ability/player-intelligence.h
+++ b/src/player-ability/player-intelligence.h
@@ -6,6 +6,10 @@ class CreatureEntity;
 class PlayerIntelligence : public PlayerBasicStatistics {
 public:
     PlayerIntelligence(CreatureEntity &creature);
+    PlayerIntelligence(const PlayerIntelligence &) = delete;
+    PlayerIntelligence(PlayerIntelligence &&) = delete;
+    PlayerIntelligence &operator=(const PlayerIntelligence &) = delete;
+    PlayerIntelligence &operator=(PlayerIntelligence &&) = delete;
 
 protected:
     void set_locals() override;

--- a/src/player-ability/player-strength.h
+++ b/src/player-ability/player-strength.h
@@ -6,6 +6,8 @@ class CreatureEntity;
 class PlayerStrength : public PlayerBasicStatistics {
 public:
     PlayerStrength(CreatureEntity &creature);
+    PlayerStrength(const PlayerStrength &) = default;
+    PlayerStrength(PlayerStrength &&) = default;
     PlayerStrength &operator=(const PlayerStrength &) = delete;
     PlayerStrength &operator=(PlayerStrength &&) = delete;
 

--- a/src/player-ability/player-strength.h
+++ b/src/player-ability/player-strength.h
@@ -6,6 +6,10 @@ class CreatureEntity;
 class PlayerStrength : public PlayerBasicStatistics {
 public:
     PlayerStrength(CreatureEntity &creature);
+    PlayerStrength(const PlayerStrength &) = delete;
+    PlayerStrength(PlayerStrength &&) = delete;
+    PlayerStrength &operator=(const PlayerStrength &) = delete;
+    PlayerStrength &operator=(PlayerStrength &&) = delete;
 
 protected:
     void set_locals() override;

--- a/src/player-ability/player-strength.h
+++ b/src/player-ability/player-strength.h
@@ -6,8 +6,6 @@ class CreatureEntity;
 class PlayerStrength : public PlayerBasicStatistics {
 public:
     PlayerStrength(CreatureEntity &creature);
-    PlayerStrength(const PlayerStrength &) = delete;
-    PlayerStrength(PlayerStrength &&) = delete;
     PlayerStrength &operator=(const PlayerStrength &) = delete;
     PlayerStrength &operator=(PlayerStrength &&) = delete;
 

--- a/src/player-ability/player-wisdom.h
+++ b/src/player-ability/player-wisdom.h
@@ -6,6 +6,8 @@ class CreatureEntity;
 class PlayerWisdom : public PlayerBasicStatistics {
 public:
     PlayerWisdom(CreatureEntity &creature);
+    PlayerWisdom(const PlayerWisdom &) = default;
+    PlayerWisdom(PlayerWisdom &&) = default;
     PlayerWisdom &operator=(const PlayerWisdom &) = delete;
     PlayerWisdom &operator=(PlayerWisdom &&) = delete;
 

--- a/src/player-ability/player-wisdom.h
+++ b/src/player-ability/player-wisdom.h
@@ -6,8 +6,6 @@ class CreatureEntity;
 class PlayerWisdom : public PlayerBasicStatistics {
 public:
     PlayerWisdom(CreatureEntity &creature);
-    PlayerWisdom(const PlayerWisdom &) = delete;
-    PlayerWisdom(PlayerWisdom &&) = delete;
     PlayerWisdom &operator=(const PlayerWisdom &) = delete;
     PlayerWisdom &operator=(PlayerWisdom &&) = delete;
 

--- a/src/player-ability/player-wisdom.h
+++ b/src/player-ability/player-wisdom.h
@@ -6,6 +6,10 @@ class CreatureEntity;
 class PlayerWisdom : public PlayerBasicStatistics {
 public:
     PlayerWisdom(CreatureEntity &creature);
+    PlayerWisdom(const PlayerWisdom &) = delete;
+    PlayerWisdom(PlayerWisdom &&) = delete;
+    PlayerWisdom &operator=(const PlayerWisdom &) = delete;
+    PlayerWisdom &operator=(PlayerWisdom &&) = delete;
 
 protected:
     void set_locals() override;

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -42,7 +42,6 @@ bool CreatureClass::equals(PlayerClassType type) const
     if (!this->creature.is_player()) {
         return false;
     }
-    auto &creature = this->creature;
     return creature.pclass == type;
 }
 
@@ -54,7 +53,6 @@ TrFlags CreatureClass::tr_flags() const
     if (!this->creature.is_player()) {
         return TrFlags();
     }
-    auto &creature = this->creature;
 
     TrFlags flags;
     const auto plev = creature.level;
@@ -234,7 +232,6 @@ TrFlags CreatureClass::stance_tr_flags() const
     if (!this->creature.is_player()) {
         return TrFlags();
     }
-    auto &creature = this->creature;
 
     TrFlags flags;
 
@@ -284,7 +281,6 @@ bool CreatureClass::has_stun_immunity() const
     if (!this->creature.is_player()) {
         return false;
     }
-    auto &creature = this->creature;
     return this->equals(PlayerClassType::BERSERKER) && (creature.level > 34);
 }
 
@@ -293,7 +289,6 @@ bool CreatureClass::has_poison_resistance() const
     if (!this->creature.is_player()) {
         return false;
     }
-    auto &creature = this->creature;
     return this->equals(PlayerClassType::NINJA) && (creature.level > 44);
 }
 
@@ -411,7 +406,6 @@ bool CreatureClass::lose_balance()
     if (!this->creature.is_player()) {
         return false;
     }
-    auto &creature = this->creature;
     if (creature.pclass != PlayerClassType::SAMURAI) {
         return false;
     }
@@ -516,7 +510,6 @@ void CreatureClass::init_specific_data()
     if (!this->creature.is_player()) {
         return;
     }
-    auto &creature = this->creature;
 
     switch (creature.pclass) {
     case PlayerClassType::SMITH:
@@ -567,7 +560,6 @@ bool CreatureClass::has_ninja_speed() const
     if (!this->creature.is_player()) {
         return false;
     }
-    auto &creature = this->creature;
 
     auto has_ninja_speed_main = !creature.inventory[INVEN_MAIN_HAND]->is_valid();
     has_ninja_speed_main |= can_attack_with_main_hand(creature);

--- a/src/player-base/player-class.h
+++ b/src/player-base/player-class.h
@@ -13,6 +13,8 @@ enum class PlayerClassType : short;
 class CreatureClass {
 public:
     CreatureClass(CreatureEntity &creature);
+    CreatureClass(const CreatureClass &) = default;
+    CreatureClass(CreatureClass &&) = default;
     CreatureClass &operator=(const CreatureClass &) = delete;
     CreatureClass &operator=(CreatureClass &&) = delete;
     virtual ~CreatureClass() = default;

--- a/src/player-base/player-class.h
+++ b/src/player-base/player-class.h
@@ -13,8 +13,6 @@ enum class PlayerClassType : short;
 class CreatureClass {
 public:
     CreatureClass(CreatureEntity &creature);
-    CreatureClass(const CreatureClass &) = delete;
-    CreatureClass(CreatureClass &&) = delete;
     CreatureClass &operator=(const CreatureClass &) = delete;
     CreatureClass &operator=(CreatureClass &&) = delete;
     virtual ~CreatureClass() = default;

--- a/src/player-base/player-class.h
+++ b/src/player-base/player-class.h
@@ -13,6 +13,10 @@ enum class PlayerClassType : short;
 class CreatureClass {
 public:
     CreatureClass(CreatureEntity &creature);
+    CreatureClass(const CreatureClass &) = delete;
+    CreatureClass(CreatureClass &&) = delete;
+    CreatureClass &operator=(const CreatureClass &) = delete;
+    CreatureClass &operator=(CreatureClass &&) = delete;
     virtual ~CreatureClass() = default;
 
     bool equals(PlayerClassType type) const;

--- a/src/player-status/player-basic-statistics.h
+++ b/src/player-status/player-basic-statistics.h
@@ -6,8 +6,6 @@
 class CreatureEntity;
 class PlayerBasicStatistics : public PlayerStatusBase {
 public:
-    PlayerBasicStatistics(const PlayerBasicStatistics &) = delete;
-    PlayerBasicStatistics(PlayerBasicStatistics &&) = delete;
     PlayerBasicStatistics &operator=(const PlayerBasicStatistics &) = delete;
     PlayerBasicStatistics &operator=(PlayerBasicStatistics &&) = delete;
 

--- a/src/player-status/player-basic-statistics.h
+++ b/src/player-status/player-basic-statistics.h
@@ -6,6 +6,8 @@
 class CreatureEntity;
 class PlayerBasicStatistics : public PlayerStatusBase {
 public:
+    PlayerBasicStatistics(const PlayerBasicStatistics &) = default;
+    PlayerBasicStatistics(PlayerBasicStatistics &&) = default;
     PlayerBasicStatistics &operator=(const PlayerBasicStatistics &) = delete;
     PlayerBasicStatistics &operator=(PlayerBasicStatistics &&) = delete;
 

--- a/src/player-status/player-basic-statistics.h
+++ b/src/player-status/player-basic-statistics.h
@@ -6,6 +6,11 @@
 class CreatureEntity;
 class PlayerBasicStatistics : public PlayerStatusBase {
 public:
+    PlayerBasicStatistics(const PlayerBasicStatistics &) = delete;
+    PlayerBasicStatistics(PlayerBasicStatistics &&) = delete;
+    PlayerBasicStatistics &operator=(const PlayerBasicStatistics &) = delete;
+    PlayerBasicStatistics &operator=(PlayerBasicStatistics &&) = delete;
+
     void update_value();
     int16_t modification_value();
     int16_t get_value() override;

--- a/src/player-status/player-infravision.h
+++ b/src/player-status/player-infravision.h
@@ -5,6 +5,10 @@ class CreatureEntity;
 class PlayerInfravision : public PlayerStatusBase {
 public:
     PlayerInfravision(CreatureEntity &creature);
+    PlayerInfravision(const PlayerInfravision &) = delete;
+    PlayerInfravision(PlayerInfravision &&) = delete;
+    PlayerInfravision &operator=(const PlayerInfravision &) = delete;
+    PlayerInfravision &operator=(PlayerInfravision &&) = delete;
 
 protected:
     void set_locals() override;

--- a/src/player-status/player-infravision.h
+++ b/src/player-status/player-infravision.h
@@ -5,8 +5,6 @@ class CreatureEntity;
 class PlayerInfravision : public PlayerStatusBase {
 public:
     PlayerInfravision(CreatureEntity &creature);
-    PlayerInfravision(const PlayerInfravision &) = delete;
-    PlayerInfravision(PlayerInfravision &&) = delete;
     PlayerInfravision &operator=(const PlayerInfravision &) = delete;
     PlayerInfravision &operator=(PlayerInfravision &&) = delete;
 

--- a/src/player-status/player-infravision.h
+++ b/src/player-status/player-infravision.h
@@ -5,6 +5,8 @@ class CreatureEntity;
 class PlayerInfravision : public PlayerStatusBase {
 public:
     PlayerInfravision(CreatureEntity &creature);
+    PlayerInfravision(const PlayerInfravision &) = default;
+    PlayerInfravision(PlayerInfravision &&) = default;
     PlayerInfravision &operator=(const PlayerInfravision &) = delete;
     PlayerInfravision &operator=(PlayerInfravision &&) = delete;
 

--- a/src/player-status/player-speed.cpp
+++ b/src/player-status/player-speed.cpp
@@ -276,7 +276,7 @@ int16_t PlayerSpeed::mutation_bonus()
 int16_t PlayerSpeed::riding_bonus()
 {
     const auto &monster = (&this->creature)->get_floor()->get_monster(this->creature.riding);
-    int16_t speed = monster.speed;
+    int16_t speed = static_cast<int16_t>(monster.speed);
     int16_t bonus = 0;
     if (!this->creature.riding) {
         return 0;

--- a/src/player-status/player-speed.h
+++ b/src/player-status/player-speed.h
@@ -5,6 +5,8 @@ class CreatureEntity;
 class PlayerSpeed : public PlayerStatusBase {
 public:
     PlayerSpeed(CreatureEntity &creature);
+    PlayerSpeed(const PlayerSpeed &) = default;
+    PlayerSpeed(PlayerSpeed &&) = default;
     PlayerSpeed &operator=(const PlayerSpeed &) = delete;
     PlayerSpeed &operator=(PlayerSpeed &&) = delete;
 

--- a/src/player-status/player-speed.h
+++ b/src/player-status/player-speed.h
@@ -5,8 +5,6 @@ class CreatureEntity;
 class PlayerSpeed : public PlayerStatusBase {
 public:
     PlayerSpeed(CreatureEntity &creature);
-    PlayerSpeed(const PlayerSpeed &) = delete;
-    PlayerSpeed(PlayerSpeed &&) = delete;
     PlayerSpeed &operator=(const PlayerSpeed &) = delete;
     PlayerSpeed &operator=(PlayerSpeed &&) = delete;
 

--- a/src/player-status/player-speed.h
+++ b/src/player-status/player-speed.h
@@ -5,6 +5,10 @@ class CreatureEntity;
 class PlayerSpeed : public PlayerStatusBase {
 public:
     PlayerSpeed(CreatureEntity &creature);
+    PlayerSpeed(const PlayerSpeed &) = delete;
+    PlayerSpeed(PlayerSpeed &&) = delete;
+    PlayerSpeed &operator=(const PlayerSpeed &) = delete;
+    PlayerSpeed &operator=(PlayerSpeed &&) = delete;
 
 protected:
     void set_locals() override;

--- a/src/player-status/player-status-base.h
+++ b/src/player-status/player-status-base.h
@@ -5,8 +5,6 @@
 class CreatureEntity;
 class PlayerStatusBase {
 public:
-    PlayerStatusBase(const PlayerStatusBase &) = delete;
-    PlayerStatusBase(PlayerStatusBase &&) = delete;
     PlayerStatusBase &operator=(const PlayerStatusBase &) = delete;
     PlayerStatusBase &operator=(PlayerStatusBase &&) = delete;
 

--- a/src/player-status/player-status-base.h
+++ b/src/player-status/player-status-base.h
@@ -5,6 +5,8 @@
 class CreatureEntity;
 class PlayerStatusBase {
 public:
+    PlayerStatusBase(const PlayerStatusBase &) = default;
+    PlayerStatusBase(PlayerStatusBase &&) = default;
     PlayerStatusBase &operator=(const PlayerStatusBase &) = delete;
     PlayerStatusBase &operator=(PlayerStatusBase &&) = delete;
 

--- a/src/player-status/player-status-base.h
+++ b/src/player-status/player-status-base.h
@@ -5,6 +5,11 @@
 class CreatureEntity;
 class PlayerStatusBase {
 public:
+    PlayerStatusBase(const PlayerStatusBase &) = delete;
+    PlayerStatusBase(PlayerStatusBase &&) = delete;
+    PlayerStatusBase &operator=(const PlayerStatusBase &) = delete;
+    PlayerStatusBase &operator=(PlayerStatusBase &&) = delete;
+
     virtual ~PlayerStatusBase() = default;
     virtual int16_t get_value();
     virtual BIT_FLAGS get_all_flags();

--- a/src/player-status/player-stealth.h
+++ b/src/player-status/player-stealth.h
@@ -5,8 +5,6 @@ class CreatureEntity;
 class PlayerStealth : public PlayerStatusBase {
 public:
     PlayerStealth(CreatureEntity &creature);
-    PlayerStealth(const PlayerStealth &) = delete;
-    PlayerStealth(PlayerStealth &&) = delete;
     PlayerStealth &operator=(const PlayerStealth &) = delete;
     PlayerStealth &operator=(PlayerStealth &&) = delete;
 

--- a/src/player-status/player-stealth.h
+++ b/src/player-status/player-stealth.h
@@ -5,6 +5,10 @@ class CreatureEntity;
 class PlayerStealth : public PlayerStatusBase {
 public:
     PlayerStealth(CreatureEntity &creature);
+    PlayerStealth(const PlayerStealth &) = delete;
+    PlayerStealth(PlayerStealth &&) = delete;
+    PlayerStealth &operator=(const PlayerStealth &) = delete;
+    PlayerStealth &operator=(PlayerStealth &&) = delete;
 
     BIT_FLAGS get_bad_flags() override;
 

--- a/src/player-status/player-stealth.h
+++ b/src/player-status/player-stealth.h
@@ -5,6 +5,8 @@ class CreatureEntity;
 class PlayerStealth : public PlayerStatusBase {
 public:
     PlayerStealth(CreatureEntity &creature);
+    PlayerStealth(const PlayerStealth &) = default;
+    PlayerStealth(PlayerStealth &&) = default;
     PlayerStealth &operator=(const PlayerStealth &) = delete;
     PlayerStealth &operator=(PlayerStealth &&) = delete;
 

--- a/src/player/digestion-processor.cpp
+++ b/src/player/digestion-processor.cpp
@@ -33,7 +33,7 @@ void starve_player(CreatureEntity &creature)
     if (creature.food >= PY_FOOD_MAX) {
         (void)set_food(creature, creature.food - 100);
     } else if (AngbandWorld::get_instance().game_turn % (TURNS_PER_TICK * 5) == 0) {
-        int digestion = speed_to_energy(creature.get_speed());
+        int digestion = speed_to_energy(static_cast<byte>(creature.get_speed()));
         if (creature.has_regen_flag()) {
             digestion += 20;
         }

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -560,9 +560,9 @@ void PlayerType::on_death(std::string_view cause)
     DeathRecord death_record;
     death_record.game_turn = world.game_turn;
     const auto [day, hour, min] = world.extract_date_time(this->prace);
-    death_record.day = day;
-    death_record.hour = hour;
-    death_record.min = min;
+    death_record.day = static_cast<int16_t>(day);
+    death_record.hour = static_cast<int16_t>(hour);
+    death_record.min = static_cast<int16_t>(min);
     death_record.player_level = this->level;
     death_record.cause = this->died_from;
     death_record.killer_monrace_id = this->killer_monrace_id;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -258,7 +258,7 @@ static void update_bonuses(CreatureEntity &creature)
     BIT_FLAGS old_esp_unique = creature.esp_unique;
     BIT_FLAGS old_see_inv = creature.see_inv;
     BIT_FLAGS old_mighty_throw = creature.mighty_throw;
-    int16_t old_speed = creature.get_speed();
+    int16_t old_speed = static_cast<int16_t>(creature.get_speed());
 
     ARMOUR_CLASS old_dis_ac = creature.dis_ac;
     ARMOUR_CLASS old_dis_to_a = creature.dis_to_a;
@@ -1662,7 +1662,7 @@ static ARMOUR_CLASS calc_base_ac(CreatureEntity &creature)
         // 装備がより軽いほどボーナスが大きくなる（最大で2倍）
         auto weight_ratio = (300 - equipment_weight) / 300.0;
         evasion_bonus = static_cast<int>(evasion_bonus * (1.0 + weight_ratio));
-        ac += evasion_bonus;
+        ac += static_cast<ARMOUR_CLASS>(evasion_bonus);
     }
 
     return ac;

--- a/src/racial/race-racial-command-setter.cpp
+++ b/src/racial/race-racial-command-setter.cpp
@@ -372,13 +372,13 @@ void set_race_racial_command(CreatureEntity &creature, rc_type *rc_ptr)
 
     // 性格ベースのレイシャル能力
     if (creature.ppersonality == PERSONALITY_MESUGAKI) {
-        rpi_type rpi(_("社会的抹殺", "Social Genocide"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2 + 30);
-        rpi.text = _("男性の人間モンスターを社会的に抹殺するボルトを放つ。", "Fires a bolt that socially eliminates male human monsters.");
-        rpi.min_level = 1;
-        rpi.cost = 10;
-        rpi.stat = A_CHR;
-        rpi.fail = 5;
-        rc_ptr->add_power(rpi, RC_IDX_RACE_1);
+        rpi_type rpi_personality(_("社会的抹殺", "Social Genocide"));
+        rpi_personality.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2 + 30);
+        rpi_personality.text = _("男性の人間モンスターを社会的に抹殺するボルトを放つ。", "Fires a bolt that socially eliminates male human monsters.");
+        rpi_personality.min_level = 1;
+        rpi_personality.cost = 10;
+        rpi_personality.stat = A_CHR;
+        rpi_personality.fail = 5;
+        rc_ptr->add_power(rpi_personality, RC_IDX_RACE_1);
     }
 }

--- a/src/save/alliance-writer.cpp
+++ b/src/save/alliance-writer.cpp
@@ -14,7 +14,7 @@ void wr_alliance_base_power()
 
     // 各アライアンスのIDとbase_power、natural_recoveryを書き込む
     for (const auto &[alliance_type, alliance_ptr] : alliance_list) {
-        wr_s16b(enum2i(alliance_type));
+        wr_s16b(static_cast<int16_t>(enum2i(alliance_type)));
         wr_s64b(alliance_ptr->base_power);
         wr_s64b(alliance_ptr->natural_recovery);
     }

--- a/src/save/item-writer.cpp
+++ b/src/save/item-writer.cpp
@@ -211,7 +211,7 @@ static void write_item_info(const ItemEntity &item, const BIT_FLAGS flags)
     }
 
     if (any_bits(flags, SaveDataItemFlagType::XTRA5)) {
-        wr_s16b(item.captured_monster_max_hp);
+        wr_s16b(static_cast<int16_t>(item.captured_monster_max_hp));
     }
 
     if (any_bits(flags, SaveDataItemFlagType::FEELING)) {

--- a/src/save/monster-writer.cpp
+++ b/src/save/monster-writer.cpp
@@ -232,7 +232,7 @@ void MonsterWriter::write_monster_info(uint32_t flags) const
 
     if (any_bits(flags, SaveDataMonsterFlagType::TRANSFORM)) {
         wr_s16b(static_cast<int16_t>(enum2i(this->monster.get_monster_profile().transform_r_idx)));
-        wr_byte(this->monster.get_monster_profile().transform_hp_threshold);
+        wr_byte(static_cast<byte>(this->monster.get_monster_profile().transform_hp_threshold));
         wr_byte(this->monster.get_monster_profile().has_transformed ? 1 : 0);
     }
 

--- a/src/save/monster-writer.cpp
+++ b/src/save/monster-writer.cpp
@@ -223,7 +223,7 @@ void MonsterWriter::write_monster_info(uint32_t flags) const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::RACE)) {
-        wr_byte(enum2i(this->monster.prace));
+        wr_byte(static_cast<byte>(enum2i(this->monster.prace)));
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::CLASS)) {
@@ -231,7 +231,7 @@ void MonsterWriter::write_monster_info(uint32_t flags) const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::TRANSFORM)) {
-        wr_s16b(enum2i(this->monster.get_monster_profile().transform_r_idx));
+        wr_s16b(static_cast<int16_t>(enum2i(this->monster.get_monster_profile().transform_r_idx)));
         wr_byte(this->monster.get_monster_profile().transform_hp_threshold);
         wr_byte(this->monster.get_monster_profile().has_transformed ? 1 : 0);
     }

--- a/src/smith/object-smith.h
+++ b/src/smith/object-smith.h
@@ -28,6 +28,10 @@ public:
     using DrainEssenceResult = std::vector<std::tuple<SmithEssenceType, int>>;
 
     Smith(CreatureEntity &creature);
+    Smith(const Smith &) = delete;
+    Smith(Smith &&) = delete;
+    Smith &operator=(const Smith &) = delete;
+    Smith &operator=(Smith &&) = delete;
 
     static const std::vector<SmithEssenceType> &get_essence_list();
     static concptr get_essence_name(SmithEssenceType essence);

--- a/src/smith/object-smith.h
+++ b/src/smith/object-smith.h
@@ -28,8 +28,6 @@ public:
     using DrainEssenceResult = std::vector<std::tuple<SmithEssenceType, int>>;
 
     Smith(CreatureEntity &creature);
-    Smith(const Smith &) = delete;
-    Smith(Smith &&) = delete;
     Smith &operator=(const Smith &) = delete;
     Smith &operator=(Smith &&) = delete;
 

--- a/src/smith/object-smith.h
+++ b/src/smith/object-smith.h
@@ -28,6 +28,8 @@ public:
     using DrainEssenceResult = std::vector<std::tuple<SmithEssenceType, int>>;
 
     Smith(CreatureEntity &creature);
+    Smith(const Smith &) = default;
+    Smith(Smith &&) = default;
     Smith &operator=(const Smith &) = delete;
     Smith &operator=(Smith &&) = delete;
 

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -75,11 +75,11 @@ void Chest::open(bool scatter, const Pos2D &pos, short item_idx)
         if (small && one_in_(4)) {
             item_inner_chest = floor.make_gold();
         } else {
-            auto item = make_object(*this->creature_ptr, mode);
-            if (!item) {
+            auto item_inner_chest_opt = make_object(*this->creature_ptr, mode);
+            if (!item_inner_chest_opt) {
                 continue;
             }
-            item_inner_chest = std::move(*item);
+            item_inner_chest = std::move(*item_inner_chest_opt);
         }
 
         if (!scatter) {

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -97,7 +97,7 @@ std::string build_killer_on_earthquake(CreatureEntity &creature, int m_idx)
         return _("地震", "an earthquake");
     }
 
-    const auto &monster = creature.get_floor()->get_monster(m_idx);
+    const auto &monster = creature.get_floor()->get_monster(static_cast<MONSTER_IDX>(m_idx));
     const auto m_name = monster_desc(creature, monster, MD_WRONGDOER_NAME);
     return format(_("%sの起こした地震", "an earthquake caused by %s"), m_name.data());
 }

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -367,7 +367,6 @@ void SpellHex::interrupt_spelling()
  */
 void SpellHex::eyes_on_eyes(MONSTER_IDX m_idx, int dam)
 {
-    auto &creature = this->creature;
     const auto is_eyeeye_finished = (this->creature.get_timed_effect(CreatureTimedEffect::TIM_EYEEYE) == 0) && !this->is_spelling_specific(HEX_EYE_FOR_EYE);
     if (is_eyeeye_finished || (dam == 0) || this->creature.is_dead()) {
         return;

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -17,6 +17,8 @@ struct spell_hex_data_type;
 class SpellHex {
 public:
     SpellHex(CreatureEntity &creature);
+    SpellHex(const SpellHex &) = default;
+    SpellHex(SpellHex &&) = default;
     SpellHex &operator=(const SpellHex &) = delete;
     SpellHex &operator=(SpellHex &&) = delete;
     virtual ~SpellHex() = default;

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -17,6 +17,10 @@ struct spell_hex_data_type;
 class SpellHex {
 public:
     SpellHex(CreatureEntity &creature);
+    SpellHex(const SpellHex &) = delete;
+    SpellHex(SpellHex &&) = delete;
+    SpellHex &operator=(const SpellHex &) = delete;
+    SpellHex &operator=(SpellHex &&) = delete;
     virtual ~SpellHex() = default;
 
     bool stop_spells_with_selection();

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -17,8 +17,6 @@ struct spell_hex_data_type;
 class SpellHex {
 public:
     SpellHex(CreatureEntity &creature);
-    SpellHex(const SpellHex &) = delete;
-    SpellHex(SpellHex &&) = delete;
     SpellHex &operator=(const SpellHex &) = delete;
     SpellHex &operator=(SpellHex &&) = delete;
     virtual ~SpellHex() = default;

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -99,6 +99,8 @@ struct AmusementRewardItemVisitor {
         , flag(flag)
     {
     }
+    AmusementRewardItemVisitor(const AmusementRewardItemVisitor &) = default;
+    AmusementRewardItemVisitor(AmusementRewardItemVisitor &&) = default;
     AmusementRewardItemVisitor &operator=(const AmusementRewardItemVisitor &) = delete;
     AmusementRewardItemVisitor &operator=(AmusementRewardItemVisitor &&) = delete;
 

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -99,8 +99,6 @@ struct AmusementRewardItemVisitor {
         , flag(flag)
     {
     }
-    AmusementRewardItemVisitor(const AmusementRewardItemVisitor &) = delete;
-    AmusementRewardItemVisitor(AmusementRewardItemVisitor &&) = delete;
     AmusementRewardItemVisitor &operator=(const AmusementRewardItemVisitor &) = delete;
     AmusementRewardItemVisitor &operator=(AmusementRewardItemVisitor &&) = delete;
 

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -99,6 +99,10 @@ struct AmusementRewardItemVisitor {
         , flag(flag)
     {
     }
+    AmusementRewardItemVisitor(const AmusementRewardItemVisitor &) = delete;
+    AmusementRewardItemVisitor(AmusementRewardItemVisitor &&) = delete;
+    AmusementRewardItemVisitor &operator=(const AmusementRewardItemVisitor &) = delete;
+    AmusementRewardItemVisitor &operator=(AmusementRewardItemVisitor &&) = delete;
 
     tl::optional<ItemEntity> operator()(const FixedArtifactId &fa_id) const
     {

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -334,7 +334,7 @@ void mitokohmon(CreatureEntity &creature)
         const auto &floor = *creature.get_floor();
         const auto p_pos = creature.get_position();
         for (auto i = floor.m_max - 1; i > 0; i--) {
-            const auto &monster = floor.get_monster(i);
+            const auto &monster = floor.get_monster(static_cast<MONSTER_IDX>(i));
             if (!monster.is_valid()) {
                 continue;
             }

--- a/src/status/bad-status-setter.h
+++ b/src/status/bad-status-setter.h
@@ -14,8 +14,6 @@ class CreatureEntity;
 class BadStatusSetter {
 public:
     BadStatusSetter(CreatureEntity &creature);
-    BadStatusSetter(const BadStatusSetter &) = delete;
-    BadStatusSetter(BadStatusSetter &&) = delete;
     BadStatusSetter &operator=(const BadStatusSetter &) = delete;
     BadStatusSetter &operator=(BadStatusSetter &&) = delete;
     ~BadStatusSetter() = default;

--- a/src/status/bad-status-setter.h
+++ b/src/status/bad-status-setter.h
@@ -14,6 +14,8 @@ class CreatureEntity;
 class BadStatusSetter {
 public:
     BadStatusSetter(CreatureEntity &creature);
+    BadStatusSetter(const BadStatusSetter &) = default;
+    BadStatusSetter(BadStatusSetter &&) = default;
     BadStatusSetter &operator=(const BadStatusSetter &) = delete;
     BadStatusSetter &operator=(BadStatusSetter &&) = delete;
     ~BadStatusSetter() = default;

--- a/src/status/bad-status-setter.h
+++ b/src/status/bad-status-setter.h
@@ -14,6 +14,10 @@ class CreatureEntity;
 class BadStatusSetter {
 public:
     BadStatusSetter(CreatureEntity &creature);
+    BadStatusSetter(const BadStatusSetter &) = delete;
+    BadStatusSetter(BadStatusSetter &&) = delete;
+    BadStatusSetter &operator=(const BadStatusSetter &) = delete;
+    BadStatusSetter &operator=(BadStatusSetter &&) = delete;
     ~BadStatusSetter() = default;
 
     bool set_blindness(const TIME_EFFECT tmp_v);

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -153,8 +153,6 @@ public:
         , tokens(tokens)
     {
     }
-    ProcessRumor(const ProcessRumor &) = delete;
-    ProcessRumor(ProcessRumor &&) = delete;
     ProcessRumor &operator=(const ProcessRumor &) = delete;
     ProcessRumor &operator=(ProcessRumor &&) = delete;
 

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -153,6 +153,10 @@ public:
         , tokens(tokens)
     {
     }
+    ProcessRumor(const ProcessRumor &) = delete;
+    ProcessRumor(ProcessRumor &&) = delete;
+    ProcessRumor &operator=(const ProcessRumor &) = delete;
+    ProcessRumor &operator=(ProcessRumor &&) = delete;
 
     void operator()(const ArtifactRumor &artifact_rumor)
     {

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -195,9 +195,8 @@ public:
         this->print_rumor(town_name);
 
         const uint32_t visit = (1U << (town_rumor.t_idx - 1));
-        auto &creature = this->creature;
-        if ((town_rumor.t_idx != SECRET_TOWN) && !(creature.visit & visit)) {
-            creature.visit |= visit;
+        if ((town_rumor.t_idx != SECRET_TOWN) && !(this->creature.visit & visit)) {
+            this->creature.visit |= visit;
             msg_erase();
             msg_print(_("{}に行ったことがある気がする。", "You feel you have been to {}."), town_name);
         }

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -153,6 +153,8 @@ public:
         , tokens(tokens)
     {
     }
+    ProcessRumor(const ProcessRumor &) = default;
+    ProcessRumor(ProcessRumor &&) = default;
     ProcessRumor &operator=(const ProcessRumor &) = delete;
     ProcessRumor &operator=(ProcessRumor &&) = delete;
 

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -376,12 +376,12 @@ void store_maintenance(CreatureEntity &creature, int town_num, StoreSaleType sto
     }
 
     const int level = store_level(store_num);
-    const int store_max_keep = (store_num == StoreSaleType::BLACK) ? STORE_MAX_KEEP * (level + 60) / 20 : STORE_MAX_KEEP;
-    const int store_min_keep = (store_num == StoreSaleType::BLACK) ? STORE_MIN_KEEP * (level + 60) / 20 : STORE_MIN_KEEP;
-    const int store_turnover = (store_num == StoreSaleType::BLACK) ? STORE_TURNOVER * (level + 60) / 20 : STORE_TURNOVER;
+    const short store_max_keep = (store_num == StoreSaleType::BLACK) ? STORE_MAX_KEEP * (level + 60) / 20 : STORE_MAX_KEEP;
+    const short store_min_keep = (store_num == StoreSaleType::BLACK) ? STORE_MIN_KEEP * (level + 60) / 20 : STORE_MIN_KEEP;
+    const short store_turnover = (store_num == StoreSaleType::BLACK) ? STORE_TURNOVER * (level + 60) / 20 : STORE_TURNOVER;
     chance = (store_num == StoreSaleType::BLACK) ? chance * (level + 60) / 20 : chance;
 
-    INVENTORY_IDX j = st_ptr->stock_num;
+    auto j = st_ptr->stock_num;
     int remain = store_turnover + std::max(0, j - store_max_keep);
     int turn_over = 1;
     for (int i = 0; i < chance; i++) {

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -1052,30 +1052,30 @@ tl::optional<std::string> CreatureEntity::get_pain_message(std::string_view mons
 
 byte CreatureEntity::get_temporary_speed() const
 {
-    auto speed = this->speed;
+    auto current_speed = this->speed;
     if (ironman_nightmare) {
-        speed += 5;
+        current_speed += 5;
     }
 
     if (this->is_accelerated()) {
-        speed += 10;
+        current_speed += 10;
     }
 
     if (this->is_decelerated()) {
-        speed -= 10;
+        current_speed -= 10;
     }
 
     if (this->has_monster_profile()) {
         if (this->get_monster_profile().mflag2.has(MonsterConstantFlagType::FAT)) {
-            speed -= 5;
+            current_speed -= 5;
         }
 
         if (this->get_monster_profile().mflag2.has(MonsterConstantFlagType::FRENZY)) {
-            speed += 10;
+            current_speed += 10;
         }
     }
 
-    return speed;
+    return current_speed;
 }
 
 int CreatureEntity::calc_life_rating() const
@@ -1109,20 +1109,20 @@ void CreatureEntity::set_individual_speed(bool force_fixed_speed)
     }
 
     const auto &monrace = this->get_monrace();
-    auto speed = monrace.speed;
+    auto new_speed = monrace.speed;
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) && !force_fixed_speed) {
         /* Allow some small variation per monster */
         int i = speed_to_energy(monrace.speed) / (one_in_(4) ? 3 : 10);
         if (i) {
-            speed += static_cast<uint8_t>(rand_spread(0, i));
+            new_speed += static_cast<uint8_t>(rand_spread(0, i));
         }
     }
 
-    if (speed > STANDARD_SPEED + 99) {
-        speed = STANDARD_SPEED + 99;
+    if (new_speed > STANDARD_SPEED + 99) {
+        new_speed = STANDARD_SPEED + 99;
     }
 
-    this->speed = speed;
+    this->speed = new_speed;
 }
 
 bool CreatureEntity::can_ring_boss_call_nazgul() const

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -1075,7 +1075,7 @@ byte CreatureEntity::get_temporary_speed() const
         }
     }
 
-    return current_speed;
+    return static_cast<byte>(current_speed);
 }
 
 int CreatureEntity::calc_life_rating() const

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -1028,9 +1028,9 @@ void MonraceDefinition::decrement_mob_numbers()
     }
 }
 
-void MonraceDefinition::emplace_final_summon(MonraceId id, int probability, int min_num, int max_num, int radius)
+void MonraceDefinition::emplace_final_summon(MonraceId id, int probability, int min_summon_num, int max_summon_num, int radius)
 {
-    this->final_summons.emplace_back(MonsterSummon(id, probability, min_num, max_num, radius));
+    this->final_summons.emplace_back(MonsterSummon(id, probability, min_summon_num, max_summon_num, radius));
 }
 
 const std::vector<MonsterSummon> &MonraceDefinition::get_final_summons() const

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -285,7 +285,7 @@ public:
     void increment_tkills();
 
     void decrement_mob_numbers();
-    void emplace_final_summon(MonraceId id, int probability, int min_num, int max_num, int radius);
+    void emplace_final_summon(MonraceId id, int probability, int min_summon_num, int max_summon_num, int radius);
     const std::vector<MonsterSummon> &get_final_summons() const;
 
 private:

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -34,6 +34,10 @@
 class TargetSetter {
 public:
     TargetSetter(CreatureEntity &creature, target_type mode);
+    TargetSetter(const TargetSetter &) = delete;
+    TargetSetter(TargetSetter &&) = delete;
+    TargetSetter &operator=(const TargetSetter &) = delete;
+    TargetSetter &operator=(TargetSetter &&) = delete;
     void sweep_target_grids();
     const Target &get_target() const
     {

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -34,6 +34,8 @@
 class TargetSetter {
 public:
     TargetSetter(CreatureEntity &creature, target_type mode);
+    TargetSetter(const TargetSetter &) = default;
+    TargetSetter(TargetSetter &&) = default;
     TargetSetter &operator=(const TargetSetter &) = delete;
     TargetSetter &operator=(TargetSetter &&) = delete;
     void sweep_target_grids();

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -34,8 +34,6 @@
 class TargetSetter {
 public:
     TargetSetter(CreatureEntity &creature, target_type mode);
-    TargetSetter(const TargetSetter &) = delete;
-    TargetSetter(TargetSetter &&) = delete;
     TargetSetter &operator=(const TargetSetter &) = delete;
     TargetSetter &operator=(TargetSetter &&) = delete;
     void sweep_target_grids();

--- a/src/view/display-lore-attacks.cpp
+++ b/src/view/display-lore-attacks.cpp
@@ -157,10 +157,10 @@ void display_monster_melee_summary_line(lore_type *lore_ptr)
     }
 
     // lore_ptr の作業領域(p/q/色)を壊さないよう退避
-    const char *saved_p = lore_ptr->p;
-    const char *saved_q = lore_ptr->q;
-    const int saved_pc = lore_ptr->pc;
-    const int saved_qc = lore_ptr->qc;
+    const auto *saved_p = lore_ptr->p;
+    const auto *saved_q = lore_ptr->q;
+    const auto saved_pc = lore_ptr->pc;
+    const auto saved_qc = lore_ptr->qc;
 
     const int max_attack_numbers = 4;
     bool any = false;

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -286,7 +286,7 @@ static void print_health_monster_in_arena_for_wizard(CreatureEntity &creature)
 
         term_putstr(col - 2, row + row_offset, 12, TERM_WHITE, "      /     ");
 
-        auto &monster = creature.get_floor()->get_monster(monster_list_index);
+        auto &monster = creature.get_floor()->get_monster(static_cast<MONSTER_IDX>(monster_list_index));
         if (monster.is_valid()) {
             const auto &monrace = monster.get_monrace();
             const auto &symbol_config = monrace.symbol_config;

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -206,7 +206,7 @@ void WorldTurnProcessor::process_monster_arena()
 
 void WorldTurnProcessor::process_monster_arena_winner(int win_m_idx)
 {
-    const auto &monster = this->creature.get_floor()->get_monster(win_m_idx);
+    const auto &monster = this->creature.get_floor()->get_monster(static_cast<MONSTER_IDX>(win_m_idx));
     const auto m_name = monster_desc(this->creature, monster, 0);
     msg_format(_("%sが勝利した！", "%s won!"), m_name.data());
     msg_erase();

--- a/src/world/world-turn-processor.h
+++ b/src/world/world-turn-processor.h
@@ -4,8 +4,6 @@ class CreatureEntity;
 class WorldTurnProcessor {
 public:
     WorldTurnProcessor(CreatureEntity &creature);
-    WorldTurnProcessor(const WorldTurnProcessor &) = delete;
-    WorldTurnProcessor(WorldTurnProcessor &&) = delete;
     WorldTurnProcessor &operator=(const WorldTurnProcessor &) = delete;
     WorldTurnProcessor &operator=(WorldTurnProcessor &&) = delete;
     virtual ~WorldTurnProcessor() = default;

--- a/src/world/world-turn-processor.h
+++ b/src/world/world-turn-processor.h
@@ -4,6 +4,10 @@ class CreatureEntity;
 class WorldTurnProcessor {
 public:
     WorldTurnProcessor(CreatureEntity &creature);
+    WorldTurnProcessor(const WorldTurnProcessor &) = delete;
+    WorldTurnProcessor(WorldTurnProcessor &&) = delete;
+    WorldTurnProcessor &operator=(const WorldTurnProcessor &) = delete;
+    WorldTurnProcessor &operator=(WorldTurnProcessor &&) = delete;
     virtual ~WorldTurnProcessor() = default;
     void process_world();
     void print_time();

--- a/src/world/world-turn-processor.h
+++ b/src/world/world-turn-processor.h
@@ -4,6 +4,8 @@ class CreatureEntity;
 class WorldTurnProcessor {
 public:
     WorldTurnProcessor(CreatureEntity &creature);
+    WorldTurnProcessor(const WorldTurnProcessor &) = default;
+    WorldTurnProcessor(WorldTurnProcessor &&) = default;
     WorldTurnProcessor &operator=(const WorldTurnProcessor &) = delete;
     WorldTurnProcessor &operator=(WorldTurnProcessor &&) = delete;
     virtual ~WorldTurnProcessor() = default;


### PR DESCRIPTION
変愚蛮怒 PR #5335 の内容を bakabakaband に適応してマージ。

- VS ソリューション/プロジェクト: VS Version 17→18, PlatformToolset v143→v145, 外部ヘッダ警告抑制オプション追加
- GitHub Actions CI: runs-on を windows-2025-vs2026 に更新
- VS2026 コンパイル警告修正 (7ファイル):
  - object-scanner: constexpr size_t, short out_index, static_cast
  - floor-item-getter: 変数名リネーム (i_idx→tag_opt), size narrow cast
  - special-death-switcher: summon_src を const short に
  - chest: 変数名シャドウイング回避 (item→item_inner_chest_opt)
  - store: store_max_keep 等を const short に
  - monrace-definition: パラメータ名 min_num/max_num→min_summon_num/max_summon_num
  - display-lore-attacks: const auto 推論に変更

上流コミット: c416f9229, e3f84c2c8, e1aa58e53 (hengband/develop)
Refs: #8266