### PR TITLE
fix: モンスターのステータス表示時のクラッシュを防止

### DIFF
--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -37,7 +37,9 @@ void print_title(CreatureEntity &creature)
 {
     std::string p;
     const auto &world = AngbandWorld::get_instance();
-    if (world.wizard) {
+    if (!creature.is_player()) {
+        // モンスター閲覧時は職業称号を持たないため空欄
+    } else if (world.wizard) {
         p = _("［ウィザード］", "[=-WIZARD-=]");
     } else if (world.total_winner) {
         if (world.is_player_true_winner()) {
@@ -75,7 +77,11 @@ void print_exp(CreatureEntity &creature)
     std::string out_val;
 
     CreatureRace pr(&creature);
-    if ((!exp_need) || pr.equals(PlayerRaceType::ANDROID)) {
+    if (!creature.is_player()) {
+        // モンスターは player_exp 表に該当エントリを持たないため、
+        // 現在経験値のみ表示する。
+        out_val = format("%8d", creature.exp);
+    } else if ((!exp_need) || pr.equals(PlayerRaceType::ANDROID)) {
         out_val = format("%8d", creature.exp);
     } else {
         if (creature.level >= PY_MAX_LEVEL) {
@@ -249,9 +255,15 @@ void print_depth(CreatureEntity &creature)
  */
 void print_frame_basic(CreatureEntity &creature)
 {
-    const auto &title = creature.get_mimic_form() == MimicKindType::NONE
-                            ? creature.get_race_info()->title
-                            : mimic_info.at(creature.get_mimic_form()).title;
+    // モンスター時 race_info は nullptr なので種族名は monrace.name を使う。
+    std::string_view title;
+    if (creature.get_mimic_form() != MimicKindType::NONE) {
+        title = mimic_info.at(creature.get_mimic_form()).title;
+    } else if (const auto *race_info = creature.get_race_info(); race_info != nullptr) {
+        title = race_info->title;
+    } else if (creature.has_monster_profile()) {
+        title = creature.get_monrace().name;
+    }
     print_field(title, ROW_RACE, COL_RACE);
     print_title(creature);
     print_level(creature);


### PR DESCRIPTION
target-describer の 'c' キーで do_cmd_player_status(monster) を 呼ぶと、続く redraw_stuff -> print_frame_basic 内で以下が
プレイヤー専用前提のままだったため LocalizedString コンバート時に
クラッシュしていた:

- print_frame_basic 行 252-255: creature.get_race_info() は モンスターでは nullptr を返すため title 参照が UB。 mimic / race_info / monrace.name の三段階フォールバックに変更。
- print_title: world.wizard / world.total_winner 以外の経路で player_titles.at(creature.pclass).at((creature.level - 1) / 5) にアクセスしてレベル 0 や非プレイヤー pclass で out_of_range 例外。 is_player() ガードで非プレイヤー時はタイトル空欄に。
- print_exp: player_exp[creature.level - 1] が level == 0 で -1 添字となるため、is_player() ガードでモンスター時は exp のみ シンプル表示に切替。