### PR TITLE
refactor: モンスターステータス画面の未定義値を「なし」「----」表記に統一

### DIFF
--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -96,9 +96,13 @@ static void display_player_basic_info(CreatureEntity &creature)
     display_player_one_line(ENTRY_SEX, creature.get_sex_info().title, TERM_L_BLUE);
     if (creature.race != nullptr) {
         display_player_one_line(ENTRY_RACE, (creature.get_mimic_form() != MimicKindType::NONE ? mimic_info.at(creature.get_mimic_form()).title : creature.get_race_info()->title), TERM_L_BLUE);
+    } else {
+        display_player_one_line(ENTRY_RACE, _("なし", "None"), TERM_SLATE);
     }
     if (creature.pclass_ref != nullptr) {
         display_player_one_line(ENTRY_CLASS, (*creature.get_class_info()).title, TERM_L_BLUE);
+    } else {
+        display_player_one_line(ENTRY_CLASS, _("なし", "None"), TERM_SLATE);
     }
 }
 
@@ -110,6 +114,7 @@ static void display_magic_realms(CreatureEntity &creature)
 {
     PlayerRealm pr(creature);
     if (!pr.realm1().is_available() && creature.element_realm == ElementRealmType::NONE) {
+        display_player_one_line(ENTRY_REALM, _("なし", "None"), TERM_SLATE);
         return;
     }
 
@@ -136,37 +141,56 @@ static void display_magic_realms(CreatureEntity &creature)
 static void display_phisique(CreatureEntity &creature)
 {
     const auto is_player = creature.is_player();
+    constexpr auto unset_numeric = "----";
 #ifdef JP
     if (is_player) {
         display_player_one_line(ENTRY_AGE, format("%d才", (int)creature.age), TERM_L_BLUE);
+    } else {
+        display_player_one_line(ENTRY_AGE, unset_numeric, TERM_SLATE);
     }
     if (is_player || creature.ht > 0) {
         display_player_one_line(ENTRY_HEIGHT, format("%dcm", inch_to_cm(creature.ht)), TERM_L_BLUE);
+    } else {
+        display_player_one_line(ENTRY_HEIGHT, unset_numeric, TERM_SLATE);
     }
     if (is_player || creature.wt > 0) {
         display_player_one_line(ENTRY_WEIGHT, format("%dkg", lb_to_kg(creature.wt)), TERM_L_BLUE);
+    } else {
+        display_player_one_line(ENTRY_WEIGHT, unset_numeric, TERM_SLATE);
     }
     if (is_player) {
         display_player_one_line(ENTRY_SOCIAL, format("%d  ", (int)creature.prestige), TERM_L_BLUE);
+    } else {
+        display_player_one_line(ENTRY_SOCIAL, unset_numeric, TERM_SLATE);
     }
 #else
     if (is_player) {
         display_player_one_line(ENTRY_AGE, format("%d", (int)creature.age), TERM_L_BLUE);
+    } else {
+        display_player_one_line(ENTRY_AGE, unset_numeric, TERM_SLATE);
     }
     if (is_player || creature.ht > 0) {
         display_player_one_line(ENTRY_HEIGHT, format("%d", (int)creature.ht), TERM_L_BLUE);
+    } else {
+        display_player_one_line(ENTRY_HEIGHT, unset_numeric, TERM_SLATE);
     }
     if (is_player || creature.wt > 0) {
         display_player_one_line(ENTRY_WEIGHT, format("%d", (int)creature.wt), TERM_L_BLUE);
+    } else {
+        display_player_one_line(ENTRY_WEIGHT, unset_numeric, TERM_SLATE);
     }
     if (is_player) {
         display_player_one_line(ENTRY_SOCIAL, format("%d", (int)creature.prestige), TERM_L_BLUE);
+    } else {
+        display_player_one_line(ENTRY_SOCIAL, unset_numeric, TERM_SLATE);
     }
 #endif
     std::string alg = PlayerAlignment(creature).get_alignment_description();
     display_player_one_line(ENTRY_ALIGN, format("%s", alg.data()), TERM_L_BLUE);
     if (is_player) {
         display_player_one_line(ENTRY_DEATH_COUNT, format("%d  ", (int)creature.death_count), TERM_L_BLUE);
+    } else {
+        display_player_one_line(ENTRY_DEATH_COUNT, unset_numeric, TERM_SLATE);
     }
 }
 
@@ -328,6 +352,8 @@ tl::optional<int> display_player(CreatureEntity &creature, const int tmp_mode)
     display_magic_realms(creature);
     if (CreatureClass(creature).equals(PlayerClassType::CHAOS_WARRIOR) || (creature.get_mutations().has(PlayerMutationType::CHAOS_GIFT))) {
         display_player_one_line(ENTRY_PATRON, patron_list[creature.patron].name, TERM_L_BLUE);
+    } else {
+        display_player_one_line(ENTRY_PATRON, _("なし", "None"), TERM_SLATE);
     }
 
     // 実際の種族と見かけの種族を表示

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -38,7 +38,7 @@ void print_title(CreatureEntity &creature)
     std::string p;
     const auto &world = AngbandWorld::get_instance();
     if (!creature.is_player()) {
-        // モンスター閲覧時は職業称号を持たないため空欄
+        p = _("なし", "None");
     } else if (world.wizard) {
         p = _("［ウィザード］", "[=-WIZARD-=]");
     } else if (world.total_winner) {
@@ -256,6 +256,7 @@ void print_depth(CreatureEntity &creature)
 void print_frame_basic(CreatureEntity &creature)
 {
     // モンスター時 race_info は nullptr なので種族名は monrace.name を使う。
+    // どちらも取れない場合は「なし」表記。
     std::string_view title;
     if (creature.get_mimic_form() != MimicKindType::NONE) {
         title = mimic_info.at(creature.get_mimic_form()).title;
@@ -263,6 +264,8 @@ void print_frame_basic(CreatureEntity &creature)
         title = race_info->title;
     } else if (creature.has_monster_profile()) {
         title = creature.get_monrace().name;
+    } else {
+        title = _("なし", "None");
     }
     print_field(title, ROW_RACE, COL_RACE);
     print_title(creature);


### PR DESCRIPTION
cキーでモンスターのステータスを閲覧した際、プレイヤー専用の項目
（種族・職業・魔法領域・カオスパトロン・年齢/身長/体重/威信/死亡回数）
が空欄で表示されていたのを、enum 系は「なし」、数値系は「----」と
明示するよう統一。

view/display-player.cpp:
- display_player_basic_info: race/class が nullptr のとき「なし」(TERM_SLATE)
- display_magic_realms: 魔法領域なしのとき「なし」
- display_phisique: モンスターの age/height/weight/social/death_count に 「----」(TERM_SLATE) を表示
- ENTRY_PATRON: 非カオス系プレイヤー/モンスターに「なし」

window/main-window-left-frame.cpp (ゲーム画面左フレーム):
- print_frame_basic: 種族名取得不能なら「なし」
- print_title: モンスター閲覧時の称号を「なし」に明示