### PR TITLE
refactor: MP/SP 表示を常時表示化（モンスター・非魔法職問わず）

### DIFF
--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -310,12 +310,11 @@ static void display_playtime_in_game(CreatureEntity &creature)
         display_player_one_line(ENTRY_HP, format("%4d/%4d", creature.hp, creature.maxhp), TERM_RED);
     }
 
-    // MP を持たないクリーチャー（多くのモンスター等）は SP 行を描画しない
+    // SP は常に表示する。msp <= 0 のクリーチャー（多くのモンスター等）は
+    // 生成時に msp/csp とも 0 で初期化済みのため 0/0 と表示する。
     if (creature.msp <= 0) {
-        return;
-    }
-
-    if (creature.csp >= creature.msp) {
+        display_player_one_line(ENTRY_SP, format("%4d/%4d", creature.csp, creature.msp), TERM_SLATE);
+    } else if (creature.csp >= creature.msp) {
         display_player_one_line(ENTRY_SP, format("%4d/%4d", creature.csp, creature.msp), TERM_L_GREEN);
     } else if (creature.csp > (creature.msp * mana_warn) / 10) {
         display_player_one_line(ENTRY_SP, format("%4d/%4d", creature.csp, creature.msp), TERM_YELLOW);

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -149,20 +149,21 @@ void print_hp(CreatureEntity &creature)
 }
 
 /*!
- * @brief プレイヤーのMPを表示する / Prints players max/cur spell points
+ * @brief MPを表示する / Prints max/cur spell points
  * @param creature クリーチャーへの参照
+ * @details プレイヤー職業や msp の値に関わらず常に表示する。
+ * モンスターは生成時に msp/csp とも 0 で初期化されるため 0/0 と表示される。
  */
 void print_sp(CreatureEntity &creature)
 {
     char tmp[32];
     byte color;
-    if ((mp_ptr->spell_book == ItemKindType::NONE) && mp_ptr->spell_first == SPELL_FIRST_NO_SPELL) {
-        return;
-    }
 
     put_str(_("MP", "SP"), ROW_CURSP, COL_CURSP);
     sprintf(tmp, "%4ld", (long int)creature.csp);
-    if (creature.csp >= creature.msp) {
+    if (creature.msp <= 0) {
+        color = TERM_SLATE;
+    } else if (creature.csp >= creature.msp) {
         color = TERM_L_GREEN;
     } else if (creature.csp > (creature.msp * mana_warn) / 10) {
         color = TERM_YELLOW;
@@ -173,7 +174,7 @@ void print_sp(CreatureEntity &creature)
     c_put_str(color, format("%4d", creature.csp), ROW_CURSP, COL_CURSP + 3);
     put_str("/", ROW_CURSP, COL_CURSP + 7);
     sprintf(tmp, "%4ld", (long int)creature.msp);
-    color = TERM_L_GREEN;
+    color = (creature.msp <= 0) ? TERM_SLATE : TERM_L_GREEN;
     c_put_str(color, format("%4d", creature.msp), ROW_CURSP, COL_CURSP + 8);
 }
 


### PR DESCRIPTION
CreatureEntity::msp/csp は両者で値型としてのフィールドを既に持って
おり、モンスター生成時の wipe() で 0 初期化されている。表示側の
早期 return を撤去して常時表示する仕様に変更。

- main-window-left-frame.cpp print_sp: mp_ptr->spell_book ベースの 早期 return を削除。msp <= 0 のとき TERM_SLATE で 0/0 を表示。
- view/display-player-middle.cpp: 同様に msp <= 0 早期 return を 撤去し ENTRY_SP 行を必ず描画する。msp == 0 は TERM_SLATE。

これにより c キーで非魔法職プレイヤーやモンスターを閲覧したとき
SP 行が空欄になることを防ぎ、MP の概念を全クリーチャー共通に揃える。