### PR TITLE
refactor: get_stats でモンスターの stat_use も確定する

### DIFF
--- a/src/birth/birth-stat.cpp
+++ b/src/birth/birth-stat.cpp
@@ -82,9 +82,12 @@ void get_stats(CreatureEntity &creature)
         }
     }
 
-    // stat_max_maxは初期化する
+    // stat_max_max は初期化、stat_use はロール結果と同値を初期表示にする。
+    // プレイヤーは後段の calc_bonuses() で stat_use を再計算するが、
+    // モンスターは calc_bonuses() を呼ばないので stat_use がここで確定する。
     for (auto i = 0; i < A_MAX; i++) {
         creature.stat_max_max[i] = creature.stat_max[i];
+        creature.stat_use[i] = creature.stat_max[i];
     }
 }
 


### PR DESCRIPTION
one-monster-placer は既にモンスター生成時に get_stats(*m_ptr) を 呼んでおり stat_cur / stat_max / stat_max_max は能力値ロール
（auto_roller_distribution + 720~870 区間チェック）の結果が
入っていたが、画面表示で参照される stat_use は 0 のままだった
ため c キーで全能力値が 0 と表示されていた。

calc_bonuses() を呼ばないモンスター用に、get_stats の最終ループで
stat_use[i] = stat_max[i] を設定。プレイヤーは後段の
calc_bonuses() で再計算されるため副作用なし。