### PR TITLE
feat: UNIQUE モンスターの creature.name に種族名をセット

### DIFF
--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -402,7 +402,13 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     }
 
     m_ptr->reset_target();
-    m_ptr->name.clear();
+    // UNIQUE モンスターはペットでなくとも creature.name に種族名を保持し、
+    // ペットの個体名と同じ変数 (CreatureEntity::name) で名前を扱えるようにする。
+    if (new_monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
+        m_ptr->name = new_monrace.name.string();
+    } else {
+        m_ptr->name.clear();
+    }
     m_ptr->exp = 0;
 
     if (is_summoned) {

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -327,7 +327,9 @@ std::string monster_desc(CreatureEntity &subject, const CreatureEntity &monster,
         ss << describe_non_pet(subject, monster, name, mode);
     }
 
-    if (monster.is_named()) {
+    // UNIQUE モンスターは生成時に creature.name = monrace.name が入っているため、
+    // 種族名と一致する場合は「called」表記を抑止して "X called X" の重複を防ぐ。
+    if (monster.is_named() && monster.name != monster.get_monrace().name.string()) {
         ss << _("「", " called ") << monster.name << _("」", "");
     }
 


### PR DESCRIPTION
ペットのニックネームと同じ CreatureEntity::name 変数で
UNIQUE モンスターの個体名を扱えるようにする。
place_monster_one で UNIQUE 判定時のみ name = monrace.name とし、 それ以外は従来通り空文字列にクリアする。

monster_desc では monster.name が monrace 名と一致する場合は
「called」表記を抑止し、UNIQUE 表示が "X called X" にならないようにする。 do_name_pet は元から UNIQUE を除外しているため、UNIQUE 個体名は
常に種族名と一致する。