### PR TITLE
feat: モンスター 6 能力値補正を JSON で設定可能化

### DIFF
--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -197,6 +197,50 @@ static errr set_mon_speed(const nlohmann::json &speed_data, MonraceDefinition &m
 }
 
 /*!
+ * @brief JSON Objectからモンスターの能力値補正をセットする
+ * @param stat_data 能力値補正情報の格納された JSON Object
+ * @param monrace 保管先のモンスター種族構造体
+ * @return エラーコード
+ * @details
+ * "stat_modifiers": { "STR": 5, "INT": -2, "WIS": 0, "DEX": 3, "CON": 4, "CHR": -1 }
+ * 各値は表示単位 (1 = 内部 10 単位 = +1.0) で記述する。
+ * 指定されていないキーは tl::nullopt のままとなり、生成時に補正されない。
+ */
+static errr set_mon_stat_modifiers(const nlohmann::json &stat_data, MonraceDefinition &monrace)
+{
+    if (stat_data.is_null()) {
+        return PARSE_ERROR_NONE;
+    }
+    if (!stat_data.is_object()) {
+        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    }
+
+    constexpr std::array<std::pair<std::string_view, int>, A_MAX> stat_keys = { {
+        { "STR", A_STR },
+        { "INT", A_INT },
+        { "WIS", A_WIS },
+        { "DEX", A_DEX },
+        { "CON", A_CON },
+        { "CHR", A_CHR },
+    } };
+
+    for (const auto &[key, idx] : stat_keys) {
+        const auto key_str = std::string(key);
+        if (!stat_data.contains(key_str)) {
+            continue;
+        }
+        int modifier = 0;
+        if (auto err = info_set_integer(stat_data[key_str], modifier, true, Range(-40, 40))) {
+            return err;
+        }
+        // 表示単位 (1.0) → 内部 10 単位
+        monrace.stat_modifiers[idx] = modifier * 10;
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
+/*!
  * @brief JSON Objectからモンスターの進化をセットする
  * @param evolve_data 進化情報の格納されたJSON Object
  * @param monrace 保管先のモンスター種族構造体
@@ -1238,6 +1282,11 @@ errr parse_monraces_info(nlohmann::json &mon_data, angband_header *)
     err = info_set_integer(mon_data["start_hp_percentage"], monrace.cur_hp_per, false, Range(0, 99));
     if (err) {
         msg_format(_("モンスター初期体力読込失敗。ID: '%d'。", "Failed to load monster starting HP. ID: '%d'."), error_idx);
+        return err;
+    }
+    err = set_mon_stat_modifiers(mon_data["stat_modifiers"], monrace);
+    if (err) {
+        msg_format(_("モンスター能力値補正読込失敗。ID: '%d'。", "Failed to load monster stat modifiers. ID: '%d'."), error_idx);
         return err;
     }
     err = info_set_integer(mon_data["mob"], monrace.mob_num, false, Range(0, 9999999));

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -45,6 +45,7 @@
 #include "view/display-messages.h"
 #include "wizard/wizard-messages.h"
 #include "world/world.h"
+#include <algorithm>
 #include <range/v3/algorithm.hpp>
 #include <time.h>
 
@@ -286,6 +287,24 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     }
 
     const auto &new_monrace = m_ptr->get_monrace();
+    // 種族側で能力値補正が指定されていれば、ロール結果に加算する。
+    // 補正値は内部 10 単位 (表示 1.0 = 10) で格納されており、tl::nullopt の能力値は補正しない。
+    constexpr short stat_min = 30;
+    constexpr short stat_max = 400;
+    for (auto stat = 0; stat < A_MAX; ++stat) {
+        const auto &mod = new_monrace.stat_modifiers[stat];
+        if (!mod.has_value()) {
+            continue;
+        }
+        auto adjusted = static_cast<int>(m_ptr->stat_max[stat]) + *mod;
+        adjusted = std::clamp(adjusted, static_cast<int>(stat_min), static_cast<int>(stat_max));
+        m_ptr->stat_max[stat] = static_cast<short>(adjusted);
+        m_ptr->stat_cur[stat] = static_cast<short>(adjusted);
+        if (m_ptr->stat_max_max[stat] < m_ptr->stat_max[stat]) {
+            m_ptr->stat_max_max[stat] = m_ptr->stat_max[stat];
+        }
+        m_ptr->stat_use[stat] = m_ptr->stat_max[stat];
+    }
     const auto is_summoned = summoner_m_idx.has_value();
     const CreatureEntity &summoner = floor.m_list[summoner_m_idx.value_or(0)];
 

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -21,10 +21,12 @@
 #include "monster-race/race-special-flags.h"
 #include "monster-race/race-visual-flags.h"
 #include "monster-race/race-wilderness-flags.h"
+#include "player-ability/player-ability-types.h"
 #include "system/angband.h"
 #include "util/dice.h"
 #include "util/flag-group.h"
 #include "view/display-symbol.h"
+#include <array>
 #include <string>
 #include <string_view>
 #include <tl/optional.hpp>
@@ -191,6 +193,10 @@ public:
     REAL_TIME defeat_time{}; //!< 倒した時間(ユニーク用) / time at which defeated this race
     PERCENTAGE cur_hp_per{}; //!< 生成時現在HP率(%)
     AllianceType alliance_idx = AllianceType::NONE;
+    //! 6 能力値 (STR/INT/WIS/DEX/CON/CHR) の生成時補正値 (内部 10 単位 = 表示 1.0 単位)。
+    //! 値が無い (tl::nullopt) 場合はダイスロールの結果をそのまま使う。
+    //! 値がある場合は get_stats() で振った結果に加算する。
+    std::array<tl::optional<int>, A_MAX> stat_modifiers{};
 
     bool is_valid() const;
     bool is_male() const;


### PR DESCRIPTION
MonraceDefinition::stat_modifiers (std::array<tl::optional<int>, A_MAX>) を追加し、 JSON 側で "stat_modifiers": { "STR": 5, "INT": -2, ... } のように能力値補正を記述 できるようにした。値は表示単位 (1 = +1.0 = 内部 10 単位)。

place_monster_one では get_stats() でランダムロール後、stat_modifiers が セットされている能力値のみ加算する。指定されない能力値は従来通りロール結果を
そのまま使用する。stat_max/stat_cur/stat_use および必要に応じて stat_max_max も補正値で更新し、最終的に [30, 400] にクランプする。