### PR TITLE
feat: HP/MP 自然回復計算をプレイヤー基準で CreatureEntity に統合

### DIFF
--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -116,7 +116,7 @@ void process_player_hp_mp(CreatureEntity &creature)
     const auto &terrain = grid.get_terrain();
     bool cave_no_regen = false;
     int upkeep_factor = 0;
-    int regen_amount = PY_REGEN_NORMAL;
+    int regen_amount = 0; // compute_regen_amount() で後段に確定
     if (terrain.flags.has(TerrainCharacteristics::RUNE_HEALING)) {
         hp_player(creature, 2 + creature.level / 6);
     }
@@ -395,35 +395,14 @@ void process_player_hp_mp(CreatureEntity &creature)
         }
     }
 
-    if (creature.food < PY_FOOD_WEAK) {
-        if (creature.food < PY_FOOD_STARVE) {
-            regen_amount = 0;
-        } else if (creature.food < PY_FOOD_FAINT) {
-            regen_amount = PY_REGEN_FAINT;
-        } else {
-            regen_amount = PY_REGEN_WEAK;
-        }
-    }
-
     CreatureClass pc(creature);
     if (pattern_effect(creature)) {
         cave_no_regen = true;
-    } else {
-        if (creature.has_regen_flag()) {
-            regen_amount = regen_amount * 2;
-        }
-
-        if (!pc.monk_stance_is(MonkStanceType::NONE) || !pc.samurai_stance_is(SamuraiStanceType::NONE)) {
-            regen_amount /= 2;
-        }
-        if (creature.get_cursed_flags().has(CurseTraitType::SLOW_REGEN)) {
-            regen_amount /= 5;
-        }
     }
 
-    if ((creature.action == ACTION_SEARCH) || (creature.action == ACTION_REST)) {
-        regen_amount = regen_amount * 2;
-    }
+    // 統一ヘルパでベースの regen_amount を算出
+    // (満腹度・再生種族・スタンス・呪い・行動・地形衛生・ミュータント体質まで反映済み)
+    regen_amount = compute_regen_amount(creature);
 
     upkeep_factor = calculate_upkeep(creature);
     if ((creature.action == ACTION_LEARN) || (creature.action == ACTION_HAYAGAKE) || pc.samurai_stance_is(SamuraiStanceType::KOUKIJIN)) {
@@ -448,26 +427,10 @@ void process_player_hp_mp(CreatureEntity &creature)
         }
     }
 
-    if (creature.is_poisoned()) {
-        regen_amount = 0;
-    }
-    if (creature.is_cut()) {
-        regen_amount = 0;
-    }
     if (cave_no_regen) {
         regen_amount = 0;
     }
 
-    // Apply hygiene-based regeneration modifier
-    if (regen_amount > 0 && terrain.hygiene != 0) {
-        const int hygiene_modifier = 100 + terrain.hygiene;
-        regen_amount = (regen_amount * hygiene_modifier) / 100;
-        if (regen_amount < 0) {
-            regen_amount = 0;
-        }
-    }
-
-    regen_amount = (regen_amount * creature.mutant_regenerate_mod) / 100;
     if ((creature.hp < creature.maxhp) && !cave_no_regen) {
         regenhp(creature, regen_amount);
     }

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -3,10 +3,13 @@
 #include "core/window-redrawer.h"
 #include "inventory/inventory-slot-types.h"
 #include "monster/monster-status.h"
+#include "object-enchant/trc-types.h"
 #include "player-base/player-class.h"
 #include "player-info/magic-eater-data-type.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player/attack-defense-types.h"
+#include "player/digestion-processor.h"
 #include "player/player-status-table.h"
 #include "player/special-defense-types.h"
 #include "system/creature-entity.h"
@@ -20,6 +23,82 @@
 
 /*!<広域マップ移動時の自然回復処理カウンタ（広域マップ1マス毎に20回処理を基本とする）*/
 int wild_regen = 20;
+
+/*!
+ * @brief 共通の自然回復量を算出する。プレイヤー基準の計算に揃え、モンスターでも同形で
+ *        評価できる係数 (regen_amount) を返す。
+ *
+ * - PY_REGEN_NORMAL を起点に、満腹度・スタンス・呪い・ミュータント体質などの
+ *   プレイヤー固有要因は is_player() ガードで適用する。
+ * - 再生種族フラグ (regen)・毒・切り傷・行動 (search/rest)・地形衛生は
+ *   モンスターでも同等のロジックで適用される。
+ * - regenhp() / regenmana() / 表示用 calculate_*_regen_rate() で同じ値を使うことで
+ *   プレイヤー・モンスター・c画面表示を一貫させる。
+ */
+int compute_regen_amount(CreatureEntity &creature)
+{
+    if (creature.is_player()) {
+        CreatureClass pc(creature);
+        if (pc.samurai_stance_is(SamuraiStanceType::KOUKIJIN)) {
+            return 0;
+        }
+        if (creature.action == ACTION_HAYAGAKE) {
+            return 0;
+        }
+    }
+
+    int regen_amount = PY_REGEN_NORMAL;
+
+    if (creature.is_player()) {
+        if (creature.food < PY_FOOD_WEAK) {
+            if (creature.food < PY_FOOD_STARVE) {
+                regen_amount = 0;
+            } else if (creature.food < PY_FOOD_FAINT) {
+                regen_amount = PY_REGEN_FAINT;
+            } else {
+                regen_amount = PY_REGEN_WEAK;
+            }
+        }
+    }
+
+    if (creature.is_poisoned() || creature.is_cut()) {
+        regen_amount = 0;
+    }
+
+    if (creature.has_regen_flag()) {
+        regen_amount = regen_amount * 2;
+    }
+
+    if (creature.is_player()) {
+        CreatureClass pc(creature);
+        if (!pc.monk_stance_is(MonkStanceType::NONE) || !pc.samurai_stance_is(SamuraiStanceType::NONE)) {
+            regen_amount /= 2;
+        }
+        if (creature.get_cursed_flags().has(CurseTraitType::SLOW_REGEN)) {
+            regen_amount /= 5;
+        }
+    }
+
+    if ((creature.action == ACTION_SEARCH) || (creature.action == ACTION_REST)) {
+        regen_amount = regen_amount * 2;
+    }
+
+    const auto &grid = creature.get_floor()->get_grid(creature.get_position());
+    const auto &terrain = grid.get_terrain();
+    if (regen_amount > 0 && terrain.hygiene != 0) {
+        const int hygiene_modifier = 100 + terrain.hygiene;
+        regen_amount = (regen_amount * hygiene_modifier) / 100;
+        if (regen_amount < 0) {
+            regen_amount = 0;
+        }
+    }
+
+    if (creature.is_player()) {
+        regen_amount = (regen_amount * creature.mutant_regenerate_mod) / 100;
+    }
+
+    return regen_amount;
+}
 
 /*!
  * @brief プレイヤーのHP自然回復処理 / Regenerate hit points -RAK-
@@ -166,49 +245,41 @@ void regenmagic(CreatureEntity &creature, int regen_amount)
 }
 
 /*!
- * @brief 100ゲームターン毎のモンスターのHP自然回復処理 / Regenerate the monsters (once per 100 game turns)
+ * @brief 100ゲームターン毎のモンスターのHP/MP自然回復処理 / Regenerate the monsters (once per 100 game turns)
  * @param creature クリーチャーへの参照
  * @note Should probably be done during monster turns.
+ * @details
+ * プレイヤー側 (process_player_hp_mp) と同じ compute_regen_amount() で
+ * regen_amount を算出し、regenhp() / regenmana() に流す。
+ * 本処理は 100 ターン毎、プレイヤー側は 10 ターン毎に走るため
+ * 1 回あたりの強度を 10 倍してプレイヤーの 10 ティック分を一度に補正する
+ * (1 ターン平均の回復速度はプレイヤー基準と一致)。
  */
 void regenerate_monsters(CreatureEntity &creature)
 {
+    constexpr int monster_regen_tick_scale = 10;
     auto &tracker = HealthBarTracker::get_instance();
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     for (short i = 1; i < creature.get_floor()->m_max; i++) {
         auto &monster = creature.get_floor()->get_monster(i);
-        const auto &monrace = monster.get_monrace();
         if (!monster.is_valid()) {
             continue;
         }
 
+        const auto regen_amount = compute_regen_amount(monster) * monster_regen_tick_scale;
+        if (regen_amount <= 0) {
+            continue;
+        }
+
+        const auto old_hp = monster.hp;
         if (monster.hp < monster.maxhp) {
-            int frac = monster.maxhp / 100;
-            if (!frac) {
-                if (one_in_(2)) {
-                    frac = 1;
-                }
-            }
+            regenhp(monster, regen_amount);
+        }
+        if (monster.csp < monster.msp) {
+            regenmana(monster, 0, regen_amount);
+        }
 
-            if (monrace.misc_flags.has(MonsterMiscType::REGENERATE)) {
-                frac *= 2;
-            }
-
-            // Apply hygiene-based regeneration modifier
-            const auto &grid = creature.get_floor()->get_grid(monster.get_position());
-            const auto &terrain = grid.get_terrain();
-            if (terrain.hygiene != 0) {
-                const int hygiene_modifier = 100 + terrain.hygiene;
-                frac = (frac * hygiene_modifier) / 100;
-                if (frac < 0) {
-                    frac = 0;
-                }
-            }
-
-            monster.hp += frac;
-            if (monster.hp > monster.maxhp) {
-                monster.hp = monster.maxhp;
-            }
-
+        if (old_hp != monster.hp) {
             tracker.set_flag_if_tracking(i);
             if (monster.is_riding()) {
                 rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);

--- a/src/hpmp/hp-mp-regenerator.h
+++ b/src/hpmp/hp-mp-regenerator.h
@@ -14,6 +14,18 @@
 extern int wild_regen;
 
 class CreatureEntity;
+
+/*!
+ * @brief 共通の自然回復量 (regen_amount) を算出する。
+ * @details
+ * プレイヤーの基準計算を CreatureEntity 上に統一したヘルパ。
+ * - 食料・スタンス・呪い・ミュータント体質等のプレイヤー固有要因は is_player() ガードで分岐
+ * - 再生種族フラグ・毒・切り傷・行動・地形衛生等は両者で共通に効く
+ * 戻り値は HP/MP 回復共通の係数 (1/2^16 単位) で、
+ * regenhp() / regenmana() / display 用 calculate_*_regen_rate() で同じ値を使う。
+ */
+int compute_regen_amount(CreatureEntity &creature);
+
 void regenhp(CreatureEntity &creature, int percent);
 void regenmana(CreatureEntity &creature, MANA_POINT upkeep_factor, MANA_POINT regen_amount);
 void regenmagic(CreatureEntity &creature, int regen_amount);

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -281,67 +281,8 @@ static void calc_two_hands(CreatureEntity &creature, int *damage, int *to_h)
  */
 static int calculate_hp_regen_rate(CreatureEntity &creature)
 {
-    CreatureClass pc(creature);
-    if (pc.samurai_stance_is(SamuraiStanceType::KOUKIJIN)) {
-        return 0;
-    }
-    if (creature.action == ACTION_HAYAGAKE) {
-        return 0;
-    }
-
-    int regen_amount = PY_REGEN_NORMAL;
-
-    // 満腹度による補正
-    if (creature.food < PY_FOOD_WEAK) {
-        if (creature.food < PY_FOOD_STARVE) {
-            regen_amount = 0;
-        } else if (creature.food < PY_FOOD_FAINT) {
-            regen_amount = PY_REGEN_FAINT;
-        } else {
-            regen_amount = PY_REGEN_WEAK;
-        }
-    }
-
-    // 毒・切り傷で回復しない
-    const auto effects = creature.effects();
-    if (effects->poison().is_poisoned() || effects->cut().is_cut()) {
-        regen_amount = 0;
-    }
-
-    // 再生能力
-    if (creature.has_regen_flag()) {
-        regen_amount = regen_amount * 2;
-    }
-
-    // 構え・型による補正
-    if (!pc.monk_stance_is(MonkStanceType::NONE) || !pc.samurai_stance_is(SamuraiStanceType::NONE)) {
-        regen_amount /= 2;
-    }
-
-    // 呪いによる補正
-    if (creature.get_cursed_flags().has(CurseTraitType::SLOW_REGEN)) {
-        regen_amount /= 5;
-    }
-
-    // 探索・休息中は2倍
-    if ((creature.action == ACTION_SEARCH) || (creature.action == ACTION_REST)) {
-        regen_amount = regen_amount * 2;
-    }
-
-    // 地形による衛生補正
-    const auto &floor = *creature.get_floor();
-    const auto &grid = floor.get_grid(creature.get_position());
-    const auto &terrain = grid.get_terrain();
-    if (regen_amount > 0 && terrain.hygiene != 0) {
-        const int hygiene_modifier = 100 + terrain.hygiene;
-        regen_amount = (regen_amount * hygiene_modifier) / 100;
-        if (regen_amount < 0) {
-            regen_amount = 0;
-        }
-    }
-
-    // ミュータント補正
-    regen_amount = (regen_amount * creature.mutant_regenerate_mod) / 100;
+    // プレイヤー基準の統一ヘルパ。モンスターでも同じ計算式が使える。
+    const int regen_amount = compute_regen_amount(creature);
 
     // 実際の回復量を計算 (10ターンごとに処理されるので1ターンあたりの量に変換)
     // percent = regen_amount は 1/2^16 単位なので、実際のHP回復量は:
@@ -359,50 +300,17 @@ static int calculate_hp_regen_rate(CreatureEntity &creature)
  */
 static int calculate_mp_regen_rate(CreatureEntity &creature)
 {
-    int regen_amount = PY_REGEN_NORMAL;
+    // プレイヤー基準の統一ヘルパ。モンスターでも同じ計算式が使える。
+    const int regen_amount = compute_regen_amount(creature);
 
-    // 満腹度による補正
-    if (creature.food < PY_FOOD_WEAK) {
-        if (creature.food < PY_FOOD_STARVE) {
-            regen_amount = 0;
-        } else if (creature.food < PY_FOOD_FAINT) {
-            regen_amount = PY_REGEN_FAINT;
-        } else {
-            regen_amount = PY_REGEN_WEAK;
-        }
-    }
-
-    // 毒で回復しない
-    const auto effects = creature.effects();
-    if (effects->poison().is_poisoned()) {
-        regen_amount = 0;
-    }
-
-    // 再生能力
-    if (creature.has_regen_flag()) {
-        regen_amount = regen_amount * 2;
-    }
-
-    // 構え・型による補正
-    CreatureClass pc(creature);
-    if (!pc.monk_stance_is(MonkStanceType::NONE) || !pc.samurai_stance_is(SamuraiStanceType::NONE)) {
-        regen_amount /= 2;
-    }
-
-    // 呪いによる補正
-    if (creature.get_cursed_flags().has(CurseTraitType::SLOW_REGEN)) {
-        regen_amount /= 5;
-    }
-
-    // 探索・休息中は2倍
-    if ((creature.action == ACTION_SEARCH) || (creature.action == ACTION_REST)) {
-        regen_amount = regen_amount * 2;
-    }
-
-    // ペットの維持コスト
+    // ペットの維持コスト (モンスターでも calculate_upkeep は flore m_list を巡回するが
+    // 通常モンスターはペットを持たないため 0 となる)
     int upkeep_factor = calculate_upkeep(creature);
-    if ((creature.action == ACTION_LEARN) || (creature.action == ACTION_HAYAGAKE) || pc.samurai_stance_is(SamuraiStanceType::KOUKIJIN)) {
-        upkeep_factor += 100;
+    if (creature.is_player()) {
+        CreatureClass pc(creature);
+        if ((creature.action == ACTION_LEARN) || (creature.action == ACTION_HAYAGAKE) || pc.samurai_stance_is(SamuraiStanceType::KOUKIJIN)) {
+            upkeep_factor += 100;
+        }
     }
 
     // 回復率を計算 (100分率)
@@ -716,6 +624,15 @@ static void display_monster_first_page(CreatureEntity &creature)
 
     sd = likert(skills.skill_dig, 4);
     display_player_one_line(ENTRY_SKILL_DIG, sd.first, sd.second);
+
+    // HP/MP 回復量はプレイヤーと共通の calculate_*_regen_rate() 経由で算出 (compute_regen_amount を共有)。
+    int hp_regen_amount = calculate_hp_regen_rate(creature);
+    std::string hp_regen_desc = format("%+d.%05d", hp_regen_amount / 100000, hp_regen_amount % 100000);
+    display_player_one_line(ENTRY_HP_REGEN, hp_regen_desc, TERM_L_BLUE);
+
+    int mp_regen_amount = calculate_mp_regen_rate(creature);
+    std::string mp_regen_desc = format("%+d.%05d", mp_regen_amount / 100000, mp_regen_amount % 100000);
+    display_player_one_line(ENTRY_MP_REGEN, mp_regen_desc, TERM_L_BLUE);
 }
 
 /*!


### PR DESCRIPTION
compute_regen_amount(CreatureEntity&) を hp-mp-regenerator に新設し、 プレイヤーの自然回復係数 (regen_amount) 算出ロジックを共通ヘルパに集約した。
モンスターでも同関数を呼び出せ、c画面表示・実回復処理ともに同じ計算式を使う。

主な経路:
- process_player_hp_mp (プレイヤー実回復): 旧来の食料/再生/スタンス/呪い/行動/ 地形衛生/ミュータント体質ロジックを compute_regen_amount() に置換。
- regenerate_monsters (モンスター実回復): 旧 maxhp/100 ベース簡易計算を撤去し、 プレイヤーと同形の compute_regen_amount() + regenhp() 経路に統一。 100ターン毎呼出のため 1 回あたり 10 倍してプレイヤー基準と等価な秒間量に揃える。
- calculate_hp_regen_rate / calculate_mp_regen_rate (c画面表示): 内部実装を 共通ヘルパに置換。これにより display_monster_first_page でも ENTRY_HP_REGEN / ENTRY_MP_REGEN を表示できる (モンスターcページ拡張)。

副次的にプレイヤーの MP 回復処理が毒・切り傷で 0 になる挙動が表示と整合。
(従来は表示は 0 だが実回復は継続する不整合があった)