### PR TITLE
data: 耐電のアミュレットを追加 (hengband#5349 相当)

### DIFF
--- a/lib/edit/BaseitemDefinitions.jsonc
+++ b/lib/edit/BaseitemDefinitions.jsonc
@@ -27724,5 +27724,35 @@
         "en": "",
       },
     },
+    {
+      "id": 828,
+      "name": {
+        "ja": "耐電",
+        "en": "Resist Elec",
+      },
+      "flavor_name": {
+        "ja": "竜骨の",
+        "en": "Dragonbone",
+      },
+      "symbol": {
+        "character": "\"",
+        "color": "Light Blue",
+      },
+      "itemkind": {
+        "type_value": 40,
+        "subtype_value": 31,
+      },
+      "parameter_value": 0,
+      "level": 12,
+      "weight": 2,
+      "cost": 300,
+      "allocations": [
+        {
+          "depth": 12,
+          "rarity": 1,
+        },
+      ],
+      "flags": ["RES_ELEC", "IGNORE_ELEC"],
+    },
   ],
 }


### PR DESCRIPTION
竜骨の耐電アミュレット (RES_ELEC, IGNORE_ELEC) をベースアイテムに追加。
上流の id 683 は bakabakaband 既存アイテム (伸縮性のあるボクサー型のパンツ) と衝突するため、末尾に id 828 として追加。subtype_value=31 は上流と一致。

上流コミット: 82115fa92 (hengband/develop, PR #5349)