### PR TITLE
build: schema_files に CreaturePartyDefinitions.schema.json を追加 (hengb…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,7 @@ schema_files = \
 	schema/ArtifactDefinitions.schema.json \
 	schema/BaseitemDefinitions.schema.json \
 	schema/ClassMagicDefinitions.schema.json \
+	schema/CreaturePartyDefinitions.schema.json \
 	schema/MonraceDefinitions.schema.json \
 	schema/MonsterMessages.schema.json \
 	schema/SpellDefinitions.schema.json


### PR DESCRIPTION
…and#5361 相当)

bakabakaband には schema/CreaturePartyDefinitions.schema.json が存在するが Makefile.am の schema_files に列挙されておらず make dist で配布されない状態だった。 上流 #5361 が同様の問題で TerrainDefinitions.schema.json を schema_files に 追加したのに合わせ、bakabakaband 固有の漏れを修正する。
TerrainDefinitions.schema.json は bakabakaband に存在しないため上流そのままは 適用しない (#5353/#5357 をマージする段階でアップストリームと整合させる予定)。

上流コミット: ff8e5fcff (hengband/develop, PR #5361)