### PR TITLE
refactor: DungeonList の non-const getter を削除 (hengband#5358 相当)

### DIFF
--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -289,7 +289,7 @@ void do_cmd_go_down(CreatureEntity &creature)
             return;
         }
 
-        auto dungeon = DungeonList::get_instance().get_dungeon(dungeon_id);
+        const auto &dungeon = DungeonList::get_instance().get_dungeon(dungeon_id);
         if (dungeon.min_plev > creature.level) {
             msg_print(_("あなたは弾き返された。このダンジョンに入るだけの力が備わっていないようだ。", "You are repelled. You lack the strength to enter this dungeon."));
             return;

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -18,8 +18,8 @@
 
 static void rd_hengband_dungeons()
 {
-    const int dungeons_size = DungeonList::get_instance().size();
     const auto &dungeons = DungeonList::get_instance();
+    const int dungeons_size = dungeons.size();
     auto &records = DungeonRecords::get_instance();
     const int max = rd_byte();
     for (auto i = 0; i < max; i++) {

--- a/src/system/dungeon/dungeon-list.cpp
+++ b/src/system/dungeon/dungeon-list.cpp
@@ -14,22 +14,12 @@ DungeonList &DungeonList::get_instance()
     return instance;
 }
 
-DungeonDefinition &DungeonList::get_dungeon(DungeonId dungeon_id)
-{
-    return *this->dungeons.at(dungeon_id);
-}
-
 const DungeonDefinition &DungeonList::get_dungeon(DungeonId dungeon_id) const
 {
     return *this->dungeons.at(dungeon_id);
 }
 
-std::shared_ptr<DungeonDefinition> DungeonList::get_dungeon_shared(DungeonId dungeon_id)
-{
-    return this->dungeons.at(dungeon_id);
-}
-
-std::shared_ptr<const DungeonDefinition> DungeonList::get_dungeon_shared(DungeonId dungeon_id) const
+const std::shared_ptr<const DungeonDefinition> DungeonList::get_dungeon_shared(DungeonId dungeon_id) const
 {
     return this->dungeons.at(dungeon_id);
 }

--- a/src/system/dungeon/dungeon-list.h
+++ b/src/system/dungeon/dungeon-list.h
@@ -21,10 +21,8 @@ public:
     ~DungeonList() = default;
 
     static DungeonList &get_instance();
-    DungeonDefinition &get_dungeon(DungeonId dungeon_id);
     const DungeonDefinition &get_dungeon(DungeonId dungeon_id) const;
-    std::shared_ptr<DungeonDefinition> get_dungeon_shared(DungeonId dungeon_id);
-    std::shared_ptr<const DungeonDefinition> get_dungeon_shared(DungeonId dungeon_id) const;
+    const std::shared_ptr<const DungeonDefinition> get_dungeon_shared(DungeonId dungeon_id) const;
     void emplace(DungeonId dungeon_id, DungeonDefinition &&definition);
     void retouch();
 


### PR DESCRIPTION
DungeonDefinition は定義ファイルとして完成済みで、ロード後に外部から
変更を許可する必要がないため、DungeonList::get_dungeon() および
get_dungeon_shared() の non-const オーバーロードを削除。

bakabakaband 側の追加対応:
- cmd-action/cmd-move.cpp: get_dungeon() の戻り値を auto から const auto & に変更 (上流は同箇所で既に参照取得していたが bakabakaband ではコピー取得していた)。

上流コミット: 07c2643c5 (hengband/develop, PR #5358)