### PR TITLE
feat: バフ解除の効果音定義および再生処理を追加 (hengband#5344 相当)

### DIFF
--- a/src/main/sound-definitions-table.cpp
+++ b/src/main/sound-definitions-table.cpp
@@ -38,6 +38,7 @@ const std::map<SoundKind, std::string> sound_names = {
     { SoundKind::BUY, "buy" },
     { SoundKind::SELL, "sell" },
     { SoundKind::WARN, "warn" },
+    { SoundKind::BUFF_EXPIRE, "buff_expire" },
     { SoundKind::ROCKET, "rocket" },
     { SoundKind::N_KILL, "n_kill" },
     { SoundKind::U_KILL, "u_kill" },

--- a/src/main/sound-definitions-table.h
+++ b/src/main/sound-definitions-table.h
@@ -40,6 +40,7 @@ enum class SoundKind {
     BUY,
     SELL,
     WARN,
+    BUFF_EXPIRE,
     ROCKET, /*!< (unused) Somebody's shooting rockets */
     N_KILL, /*!< The player kills a non-living/undead monster */
     U_KILL, /*!< (unused) The player kills a unique*/

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -8,6 +8,8 @@
 #include "floor/geometry.h"
 #include "game-option/disturbance-options.h"
 #include "grid/grid.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "mind/mind-magic-resistance.h"
 #include "mind/mind-numbers.h"
 #include "monster-floor/monster-summon.h"
@@ -124,6 +126,7 @@ void set_lightspeed(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::LIGHTSPEED)) {
             msg_print(_("動きの素早さがなくなったようだ。", "You feel yourself slow down."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/mind/mind-magic-resistance.cpp
+++ b/src/mind/mind-magic-resistance.cpp
@@ -3,6 +3,8 @@
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "system/creature-entity.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
@@ -36,6 +38,7 @@ bool set_resist_magic(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::RESIST_MAGIC)) {
             msg_print(_("魔法に弱くなった。", "You are no longer protected from magic."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -22,6 +22,8 @@
 #include "grid/grid.h"
 #include "io/cursor.h"
 #include "io/screen-util.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "mind/mind-magic-resistance.h"
 #include "mind/mind-numbers.h"
 #include "pet/pet-util.h"
@@ -271,6 +273,7 @@ bool set_multishadow(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::MULTISHADOW)) {
             msg_print(_("幻影が消えた。", "Your Shadow disappears."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -319,6 +322,7 @@ bool set_dustrobe(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::DUSTROBE)) {
             msg_print(_("鏡のオーラが消えた。", "The mirror shards disappear."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/racial/racial-kutar.cpp
+++ b/src/racial/racial-kutar.cpp
@@ -3,6 +3,8 @@
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "system/creature-entity.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
@@ -35,6 +37,7 @@ bool set_leveling(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TSUBURERU)) {
             msg_print(_("もう横に伸びていない。", "Your body returns to normal."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -3,6 +3,8 @@
 #include "effect/effect-characteristics.h"
 #include "effect/effect-processor.h"
 #include "hpmp/hp-mp-processor.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "player-info/class-info.h"
 #include "player/attack-defense-types.h"
 #include "player/player-status.h"
@@ -107,6 +109,7 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         if (stop) {
             if (!creature.get_timed_effect(CreatureTimedEffect::BLESSED)) {
                 msg_print(_("高潔な気分が消え失せた。", "The prayer has expired."));
+                sound(SoundKind::BUFF_EXPIRE);
             }
         }
 
@@ -249,6 +252,7 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         if (stop) {
             if (!creature.get_timed_effect(CreatureTimedEffect::HERO)) {
                 msg_print(_("ヒーローの気分が消え失せた。", "The heroism wears off."));
+                sound(SoundKind::BUFF_EXPIRE);
                 RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::HP);
             }
         }
@@ -384,6 +388,7 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         if (stop) {
             if (!creature.get_timed_effect(CreatureTimedEffect::TIM_STEALTH)) {
                 msg_print(_("姿がはっきりと見えるようになった。", "You are no longer hidden."));
+                sound(SoundKind::BUFF_EXPIRE);
             }
         }
 
@@ -510,24 +515,42 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         }
 
         if (stop) {
+            auto sound_played = false;
             if (!creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ACID)) {
                 msg_print(_("酸への耐性が薄れた気がする。", "You feel less resistant to acid."));
+                sound(SoundKind::BUFF_EXPIRE);
+                sound_played = true;
             }
 
             if (!creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ELEC)) {
                 msg_print(_("電撃への耐性が薄れた気がする。", "You feel less resistant to elec."));
+                if (!sound_played) {
+                    sound(SoundKind::BUFF_EXPIRE);
+                    sound_played = true;
+                }
             }
 
             if (!creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE)) {
                 msg_print(_("火への耐性が薄れた気がする。", "You feel less resistant to fire."));
+                if (!sound_played) {
+                    sound(SoundKind::BUFF_EXPIRE);
+                    sound_played = true;
+                }
             }
 
             if (!creature.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD)) {
                 msg_print(_("冷気への耐性が薄れた気がする。", "You feel less resistant to cold."));
+                if (!sound_played) {
+                    sound(SoundKind::BUFF_EXPIRE);
+                    sound_played = true;
+                }
             }
 
             if (!creature.get_timed_effect(CreatureTimedEffect::OPPOSE_POIS)) {
                 msg_print(_("毒への耐性が薄れた気がする。", "You feel less resistant to pois."));
+                if (!sound_played) {
+                    sound(SoundKind::BUFF_EXPIRE);
+                }
             }
         }
 
@@ -547,6 +570,7 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         if (stop) {
             if (!creature.is_fast()) {
                 msg_print(_("動きの素早さがなくなったようだ。", "You feel yourself slow down."));
+                sound(SoundKind::BUFF_EXPIRE);
             }
         }
 
@@ -741,13 +765,19 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         }
 
         if (stop) {
+            auto sound_played = false;
             if (!creature.get_timed_effect(CreatureTimedEffect::HERO)) {
                 msg_print(_("ヒーローの気分が消え失せた。", "The heroism wears off."));
+                sound(SoundKind::BUFF_EXPIRE);
+                sound_played = true;
                 RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::HP);
             }
 
             if (!creature.is_fast()) {
                 msg_print(_("動きの素早さがなくなったようだ。", "You feel yourself slow down."));
+                if (!sound_played) {
+                    sound(SoundKind::BUFF_EXPIRE);
+                }
             }
         }
 
@@ -846,6 +876,7 @@ tl::optional<std::string> do_music_spell(CreatureEntity &creature, SPELL_IDX spe
         if (stop) {
             if (!creature.get_timed_effect(CreatureTimedEffect::INVULNERABILITY)) {
                 msg_print(_("無敵ではなくなった。", "The invulnerability wears off."));
+                sound(SoundKind::BUFF_EXPIRE);
                 auto &rfu = RedrawingFlagsUpdater::get_instance();
                 rfu.set_flag(MainWindowRedrawingFlag::MAP);
                 rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);

--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -9,6 +9,8 @@
 #include "game-option/disturbance-options.h"
 #include "inventory/inventory-slot-types.h"
 #include "io/input-key-acceptor.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "object-enchant/object-ego.h"
 #include "object/item-use-flags.h"
 #include "player-info/equipment-info.h"
@@ -39,26 +41,31 @@ bool set_ele_attack(CreatureEntity &creature, uint32_t attack_type, TIME_EFFECT 
     if ((creature.has_special_attack(ATTACK_ACID)) && (attack_type != ATTACK_ACID)) {
         creature.special_attack &= ~(ATTACK_ACID);
         msg_print(_("酸で攻撃できなくなった。", "Your temporary acidic brand fades away."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_attack(ATTACK_ELEC)) && (attack_type != ATTACK_ELEC)) {
         creature.special_attack &= ~(ATTACK_ELEC);
         msg_print(_("電撃で攻撃できなくなった。", "Your temporary electrical brand fades away."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_attack(ATTACK_FIRE)) && (attack_type != ATTACK_FIRE)) {
         creature.special_attack &= ~(ATTACK_FIRE);
         msg_print(_("火炎で攻撃できなくなった。", "Your temporary fiery brand fades away."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_attack(ATTACK_COLD)) && (attack_type != ATTACK_COLD)) {
         creature.special_attack &= ~(ATTACK_COLD);
         msg_print(_("冷気で攻撃できなくなった。", "Your temporary frost brand fades away."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_attack(ATTACK_POIS)) && (attack_type != ATTACK_POIS)) {
         creature.special_attack &= ~(ATTACK_POIS);
         msg_print(_("毒で攻撃できなくなった。", "Your temporary poison brand fades away."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((v) && (attack_type)) {
@@ -117,26 +124,31 @@ bool set_ele_immune(CreatureEntity &creature, uint32_t immune_type, TIME_EFFECT 
     if ((creature.has_special_defense(DEFENSE_ACID)) && (immune_type != DEFENSE_ACID)) {
         creature.special_defense &= ~(DEFENSE_ACID);
         msg_print(_("酸の攻撃で傷つけられるようになった。。", "You are no longer immune to acid."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_defense(DEFENSE_ELEC)) && (immune_type != DEFENSE_ELEC)) {
         creature.special_defense &= ~(DEFENSE_ELEC);
         msg_print(_("電撃の攻撃で傷つけられるようになった。。", "You are no longer immune to electricity."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_defense(DEFENSE_FIRE)) && (immune_type != DEFENSE_FIRE)) {
         creature.special_defense &= ~(DEFENSE_FIRE);
         msg_print(_("火炎の攻撃で傷つけられるようになった。。", "You are no longer immune to fire."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_defense(DEFENSE_COLD)) && (immune_type != DEFENSE_COLD)) {
         creature.special_defense &= ~(DEFENSE_COLD);
         msg_print(_("冷気の攻撃で傷つけられるようになった。。", "You are no longer immune to cold."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_defense(DEFENSE_POIS)) && (immune_type != DEFENSE_POIS)) {
         creature.special_defense &= ~(DEFENSE_POIS);
         msg_print(_("毒の攻撃で傷つけられるようになった。。", "You are no longer immune to poison."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((v) && (immune_type)) {

--- a/src/spell-realm/spells-crusade.cpp
+++ b/src/spell-realm/spells-crusade.cpp
@@ -11,6 +11,8 @@
 #include "effect/effect-characteristics.h"
 #include "effect/effect-processor.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "player-info/race-info.h"
 #include "spell-kind/spells-detection.h"
 #include "spell-kind/spells-floor.h"
@@ -55,6 +57,7 @@ bool set_tim_sh_holy(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_SH_HOLY)) {
             msg_print(_("聖なるオーラが消えた。", "The holy aura disappeared."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -106,6 +109,7 @@ bool set_tim_eyeeye(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_EYEEYE)) {
             msg_print(_("懲罰を執行することができなくなった。", "You lost your aura of retribution."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/spell-realm/spells-demon.cpp
+++ b/src/spell-realm/spells-demon.cpp
@@ -3,6 +3,8 @@
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "system/creature-entity.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
@@ -35,6 +37,7 @@ bool set_tim_sh_fire(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_SH_FIRE)) {
             msg_print(_("炎のオーラが消えた。", "The fiery aura disappeared."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -4,6 +4,8 @@
 #include "core/stuff-handler.h"
 #include "core/window-redrawer.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "player-base/player-class.h"
 #include "player-info/bard-data-type.h"
 #include "player/attack-defense-types.h"
@@ -110,6 +112,7 @@ bool set_tim_stealth(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_STEALTH) && !music_singing(creature, MUSIC_STEALTH)) {
             msg_print(_("足音が大きくなった。", "You no longer walk silently."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/status/body-improvement.cpp
+++ b/src/status/body-improvement.cpp
@@ -6,6 +6,8 @@
 #include "core/stuff-handler.h"
 #include "core/window-redrawer.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "realm/realm-song-numbers.h"
 #include "spell-realm/spells-song.h"
 #include "system/creature-entity.h"
@@ -58,6 +60,7 @@ void BodyImprovement::set_protection(short v, bool is_decrease)
     } else {
         if (is_protected) {
             msg_print(_("邪悪なる存在から守られている感じがなくなった。", "You no longer feel safe from evil."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -116,6 +119,7 @@ bool set_invuln(CreatureEntity &creature, short v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::INVULNERABILITY) && !music_singing(creature, MUSIC_INVULN)) {
             msg_print(_("無敵ではなくなった。", "The invulnerability wears off."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
             rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
@@ -168,6 +172,7 @@ bool set_tim_regen(CreatureEntity &creature, short v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_REGEN)) {
             msg_print(_("素早く回復する感じがなくなった。", "You feel you are no longer regenerating quickly."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -216,6 +221,7 @@ bool set_tim_reflect(CreatureEntity &creature, short v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_REFLECT)) {
             msg_print(_("体の表面が滑かでなくなった。", "Your body is no longer smooth."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -264,6 +270,7 @@ bool set_pass_wall(CreatureEntity &creature, short v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_PASS_WALL)) {
             msg_print(_("体が物質化した。", "You are no longer ethereal."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -312,6 +319,7 @@ bool set_tim_emission(CreatureEntity &creature, short v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_EMISSION)) {
             msg_print(_("体の光が消え去った。", "Your body stopped emitting light."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -360,6 +368,7 @@ bool set_tim_exorcism(CreatureEntity &creature, short v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_EXORCISM)) {
             msg_print(_("浄化の力を失った。", "You are no longer exorcist."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -6,6 +6,8 @@
 #include "core/stuff-handler.h"
 #include "core/window-redrawer.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "monster/monster-status-setter.h"
 #include "player-base/player-class.h"
 #include "player-info/class-info.h"
@@ -147,6 +149,7 @@ bool set_acceleration(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
             is_singing |= music_singing(creature, MUSIC_SHERO);
             if (!is_singing) {
                 msg_print(_("動きの素早さがなくなったようだ。", "You feel yourself slow down."));
+                sound(SoundKind::BUFF_EXPIRE);
                 notice = true;
             }
         }
@@ -198,6 +201,7 @@ bool set_shield(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::SHIELD)) {
             msg_print(_("肌が元に戻った。", "Your skin returns to normal."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -246,6 +250,7 @@ bool set_magicdef(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::MAGICDEF)) {
             msg_print(_("魔法の防御力が元に戻った。", "You feel less resistant to magic."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -294,6 +299,7 @@ bool set_blessed(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::BLESSED) && !music_singing(creature, MUSIC_BLESS)) {
             msg_print(_("高潔な気分が消え失せた。", "The prayer has expired."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -342,6 +348,7 @@ bool set_hero(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::HERO) && !music_singing(creature, MUSIC_HERO) && !music_singing(creature, MUSIC_SHERO)) {
             msg_print(_("ヒーローの気分が消え失せた。", "The heroism wears off."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -398,6 +405,7 @@ bool set_mimic(CreatureEntity &creature, TIME_EFFECT v, MimicKindType mimic_race
     else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC)) {
             msg_print(_("変身が解けた。", "You are no longer transformed."));
+            sound(SoundKind::BUFF_EXPIRE);
             if (creature.get_mimic_form() == MimicKindType::DEMON) {
                 set_oppose_fire(creature, 0, true);
             }
@@ -463,6 +471,7 @@ bool set_berserk(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::BERSERK)) {
+            sound(SoundKind::BUFF_EXPIRE);
             msg_print(_("野蛮な気持ちが消え失せた。", "You feel less berserk."));
             notice = true;
         }
@@ -528,6 +537,7 @@ bool set_wraith_form(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
             msg_print(_("不透明になった感じがする。", "You feel opaque."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
             rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
@@ -578,6 +588,7 @@ bool set_tsuyoshi(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TSUYOSHI)) {
+            sound(SoundKind::BUFF_EXPIRE);
             msg_print(_("肉体が急速にしぼんでいった。", "Your body has quickly shriveled."));
 
             (void)dec_stat(creature, A_CON, 20, true);

--- a/src/status/element-resistance.cpp
+++ b/src/status/element-resistance.cpp
@@ -3,6 +3,8 @@
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/race-info.h"
@@ -42,6 +44,7 @@ bool set_oppose_acid(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
         if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ACID) && !music_singing(creature, MUSIC_RESIST) &&
             !CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU)) {
             msg_print(_("酸への耐性が薄れた気がする。", "You feel less resistant to acid."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -89,6 +92,7 @@ bool set_oppose_elec(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
         if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_ELEC) && !music_singing(creature, MUSIC_RESIST) &&
             !CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU)) {
             msg_print(_("電撃への耐性が薄れた気がする。", "You feel less resistant to electricity."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -138,6 +142,7 @@ bool set_oppose_fire(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
         if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE) && !music_singing(creature, MUSIC_RESIST) &&
             !CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU)) {
             msg_print(_("火への耐性が薄れた気がする。", "You feel less resistant to fire."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -184,6 +189,7 @@ bool set_oppose_cold(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
         if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD) && !music_singing(creature, MUSIC_RESIST) &&
             !CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU)) {
             msg_print(_("冷気への耐性が薄れた気がする。", "You feel less resistant to cold."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -234,6 +240,7 @@ bool set_oppose_pois(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
         if (creature.get_timed_effect(CreatureTimedEffect::OPPOSE_POIS) && !music_singing(creature, MUSIC_RESIST) &&
             !pc.samurai_stance_is(SamuraiStanceType::MUSOU)) {
             msg_print(_("毒への耐性が薄れた気がする。", "You feel less resistant to poison."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/status/sight-setter.cpp
+++ b/src/status/sight-setter.cpp
@@ -2,6 +2,8 @@
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "realm/realm-song-numbers.h"
 #include "spell-realm/spells-song.h"
 #include "system/creature-entity.h"
@@ -57,6 +59,7 @@ bool set_tim_esp(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_ESP) && !music_singing(creature, MUSIC_MIND)) {
             msg_print(_("意識は元に戻った。", "Your consciousness contracts again."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -93,6 +96,7 @@ bool set_tim_invis(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_INVIS)) {
             msg_print(_("目の敏感さがなくなったようだ。", "Your eyes feel less sensitive."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -129,6 +133,7 @@ bool set_tim_infra(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_INFRA)) {
             msg_print(_("目の輝きがなくなった。", "Your eyes stop tingling."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/status/temporary-resistance.cpp
+++ b/src/status/temporary-resistance.cpp
@@ -3,6 +3,8 @@
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "system/creature-entity.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
@@ -35,6 +37,7 @@ bool set_tim_levitation(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_LEVITATION)) {
             msg_print(_("もう宙に浮かべなくなった。", "You stop flying."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -77,6 +80,7 @@ bool set_ultimate_res(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE)) {
             msg_print(_("あらゆることに対する耐性が薄れた気がする。", "You feel less resistant"));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -121,6 +125,7 @@ bool set_tim_res_nether(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_NETHER)) {
             msg_print(_("地獄の力に対する耐性が薄れた気がする。", "You feel less nether-resistant"));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -162,6 +167,7 @@ bool set_tim_res_lite(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_LITE)) {
             msg_print(_("閃光の力に対する耐性が薄れた気がする。", "You feel less lite-resistant"));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -203,6 +209,7 @@ bool set_tim_res_dark(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_DARK)) {
             msg_print(_("暗黒の力に対する耐性が薄れた気がする。", "You feel less dark-resistant"));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -243,6 +250,7 @@ bool set_tim_res_fear(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_FEAR)) {
             msg_print(_("恐怖の力に対する耐性が薄れた気がする。", "You feel less fear-resistant"));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -281,6 +289,7 @@ bool set_tim_res_time(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_RES_TIME)) {
             msg_print(_("時間逆転の力に対する耐性が薄れた気がする。", "You feel less time-resistant"));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -321,6 +330,7 @@ bool set_tim_imm_dark(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_IMM_DARK)) {
             msg_print(_("暗黒の力に対する完全な耐性を喪った気がする。", "You feel lose dark-immunity"));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }


### PR DESCRIPTION
SoundKind::BUFF_EXPIRE を追加し、プレイヤーにかかる時間経過で
解除されうる良性の状態変化 (歌によるものを含む) について
sound(SoundKind::BUFF_EXPIRE) の再生を仕込む。
時止め・変わり身・超隠密・混乱打撃・帰還・現実変容からの解除は対象外。

bakabakaband 構造への適応:
- player_ptr->X (TIME_EFFECT 直接フィールド) → creature.get_timed_effect(...)
- player_ptr->mimic_form → creature.get_mimic_form()
- include 競合 (system/creature-entity.h vs system/player-type-definition.h) は bakabakaband 側 (creature-entity.h) を採用

上流コミット: 575146f51 (hengband/develop, PR #5344)