### PR TITLE
refactor: ref_item() の戻り値を std::shared_ptr<ItemEntity> に変更 (hengband#…

### DIFF
--- a/src/autopick/autopick.cpp
+++ b/src/autopick/autopick.cpp
@@ -40,14 +40,14 @@
  */
 static void autopick_delayed_alter_aux(CreatureEntity &creature, INVENTORY_IDX i_idx)
 {
-    const auto *o_ptr = ref_item(creature, i_idx);
-    if (!o_ptr->is_valid() || o_ptr->marked.has_not(OmType::AUTODESTROY)) {
+    const auto &item = ref_item(creature, i_idx);
+    if (!item->is_valid() || item->marked.has_not(OmType::AUTODESTROY)) {
         return;
     }
 
-    const auto item_name = describe_flavor(creature, *o_ptr, 0);
+    const auto item_name = describe_flavor(creature, *item, 0);
     if (i_idx >= 0) {
-        inven_item_increase(creature, i_idx, -(o_ptr->number));
+        inven_item_increase(creature, i_idx, -(item->number));
         inven_item_optimize(creature, i_idx);
     } else {
         delete_object_idx(creature, 0 - i_idx);
@@ -87,12 +87,11 @@ void autopick_delayed_alter(CreatureEntity &creature)
  */
 void autopick_alter_item(CreatureEntity &creature, INVENTORY_IDX i_idx, bool destroy)
 {
-    ItemEntity *o_ptr;
-    o_ptr = ref_item(creature, i_idx);
-    int idx = find_autopick_list(creature, o_ptr);
-    auto_inscribe_item(o_ptr, idx);
+    auto item = ref_item(creature, i_idx);
+    int idx = find_autopick_list(creature, item.get());
+    auto_inscribe_item(item.get(), idx);
     if (destroy && i_idx <= INVEN_PACK) {
-        auto_destroy_item(creature, o_ptr, idx);
+        auto_destroy_item(creature, item.get(), idx);
     }
 }
 

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -549,28 +549,28 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
         (void)spell_hex.stop_all_spells();
     }
 
-    auto *o_ptr = ref_item(creature, i_idx);
+    auto item = ref_item(creature, i_idx);
 
     sound(SoundKind::EAT);
 
     PlayerEnergy(creature).set_player_turn_energy(100);
-    const auto level = o_ptr->get_baseitem_level();
+    const auto level = item->get_baseitem_level();
 
     /* 基本食い物でないものを喰う判定 */
     bool ate = false;
 
-    ate = exe_eat_soul(creature, o_ptr);
+    ate = exe_eat_soul(creature, item.get());
 
     if (!ate) {
-        ate = exe_eat_corpse_type_object(creature, o_ptr);
+        ate = exe_eat_corpse_type_object(creature, item.get());
     }
 
     if (!ate) {
-        ate = exe_eat_junk_type_object(creature, o_ptr);
+        ate = exe_eat_junk_type_object(creature, item.get());
     }
 
     /* Identity not known yet */
-    const auto &bi_key = o_ptr->bi_key;
+    const auto &bi_key = item->bi_key;
     const auto ident = exe_eat_food_type_object(creature, bi_key);
 
     /*
@@ -588,7 +588,7 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
     }
 
     rfu.reset_flags(flags_srf);
-    if (!(o_ptr->is_aware())) {
+    if (!(item->is_aware())) {
         chg_virtue(creature, Virtue::KNOWLEDGE, -1);
         chg_virtue(creature, Virtue::PATIENCE, -1);
         chg_virtue(creature, Virtue::CHANCE, 1);
@@ -597,12 +597,12 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
     /* We have tried it */
     const auto tval = bi_key.tval();
     if (tval == ItemKindType::FOOD) {
-        o_ptr->mark_as_tried();
+        item->mark_as_tried();
     }
 
     /* The creature is now aware of the object */
-    if (ident && !o_ptr->is_aware()) {
-        object_aware(creature, *o_ptr);
+    if (ident && !item->is_aware()) {
+        object_aware(creature, *item);
         gain_exp(creature, (level + (creature.level >> 1)) / creature.level);
     }
 
@@ -614,7 +614,7 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
     rfu.set_flags(flags_swrf);
 
     /* Undeads drain recharge of magic device */
-    if (exe_eat_charge_of_magic_device(creature, o_ptr, i_idx)) {
+    if (exe_eat_charge_of_magic_device(creature, item.get(), i_idx)) {
         rfu.set_flags(flags_srf);
         return;
     }
@@ -623,8 +623,8 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
 
     /* Balrogs change humanoid corpses to energy */
     if (food_type == PlayerRaceFoodType::CORPSE) {
-        if (o_ptr->is_corpse() && o_ptr->get_monrace().is_human()) {
-            const auto item_name = describe_flavor(creature, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        if (item->is_corpse() && item->get_monrace().is_human()) {
+            const auto item_name = describe_flavor(creature, *item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
             msg_format(_("%sは燃え上り灰になった。精力を吸収した気がする。", "%s^ is burnt to ashes.  You absorb its vitality!"), item_name.data());
             (void)set_food(creature, PY_FOOD_MAX - 1);
 
@@ -637,11 +637,11 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
     if (CreatureRace(&creature).equals(PlayerRaceType::SKELETON)) {
         const auto sval = bi_key.sval();
         if ((sval != SV_FOOD_WAYBREAD) && (sval >= SV_FOOD_BISCUIT)) {
-            ItemEntity item(bi_key);
+            ItemEntity item_skeleton(bi_key);
             msg_print(_("食べ物がアゴを素通りして落ちた！", "The food falls through your jaws!"));
 
             /* Drop the object from heaven */
-            (void)drop_near(creature, item, creature.get_position());
+            (void)drop_near(creature, item_skeleton, creature.get_position());
             ate = true;
         } else {
             msg_print(_("食べ物がアゴを素通りして落ち、消えた！", "The food falls through your jaws and vanishes!"));
@@ -649,7 +649,7 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
         }
     } else if (food_type == PlayerRaceFoodType::BLOOD) {
         /* Vampires are filled only by bloods, so reduced nutritional benefit */
-        (void)set_food(creature, creature.food + (o_ptr->pval / 10));
+        (void)set_food(creature, creature.food + (item->pval / 10));
         msg_print(_("あなたのような者にとって食糧など僅かな栄養にしかならない。", "Mere victuals hold scant sustenance for a being such as yourself."));
 
         if (creature.food < PY_FOOD_ALERT) {
@@ -660,11 +660,11 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
 
     } else if (food_type == PlayerRaceFoodType::WATER) {
         msg_print(_("動物の食物はあなたにとってほとんど栄養にならない。", "The food of animals is poor sustenance for you."));
-        set_food(creature, creature.food + ((o_ptr->pval) / 20));
+        set_food(creature, creature.food + ((item->pval) / 20));
         ate = true;
     } else if (food_type != PlayerRaceFoodType::RATION) {
         msg_print(_("生者の食物はあなたにとってほとんど栄養にならない。", "The food of mortals is poor sustenance for you."));
-        set_food(creature, creature.food + ((o_ptr->pval) / 20));
+        set_food(creature, creature.food + ((item->pval) / 20));
         ate = true;
     } else {
         if (bi_key == BaseitemKey(ItemKindType::FOOD, SV_FOOD_WAYBREAD)) {
@@ -673,7 +673,7 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
             ate = true;
         } else if (bi_key.tval() == ItemKindType::FOOD) {
             /* Food can feed the creature */
-            (void)set_food(creature, creature.food + o_ptr->pval);
+            (void)set_food(creature, creature.food + item->pval);
             ate = true;
         }
     }
@@ -686,11 +686,11 @@ void exe_eat_food(CreatureEntity &creature, INVENTORY_IDX i_idx)
     creature.plus_incident_tree("EAT", 1);
 
     // 死体を食べた場合は詳細情報を記録
-    if (o_ptr->bi_key.tval() == ItemKindType::MONSTER_REMAINS && o_ptr->bi_key.sval() == SV_CORPSE) {
+    if (item->bi_key.tval() == ItemKindType::MONSTER_REMAINS && item->bi_key.sval() == SV_CORPSE) {
         auto incident_key = format("EAT/CORPSE/%d/%d/%d",
-            static_cast<int>(o_ptr->bi_key.tval()),
-            o_ptr->bi_key.sval().value_or(0),
-            o_ptr->pval);
+            static_cast<int>(item->bi_key.tval()),
+            item->bi_key.sval().value_or(0),
+            item->pval);
         creature.plus_incident_tree(incident_key, 1);
     }
 

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -583,5 +583,5 @@ ItemEntity *choose_object(CreatureEntity &creature, short *initial_i_idx, concpt
         return nullptr;
     }
 
-    return ref_item(creature, *i_idx);
+    return ref_item(creature, *i_idx).get(); //!< @todo ダングリングポインタになる可能性があるので戻り値自体をstd::shared_ptr<ItemEntity>にする.
 }

--- a/src/object-activation/activation-util.cpp
+++ b/src/object-activation/activation-util.cpp
@@ -5,7 +5,8 @@
 
 ae_type *initialize_ae_type(CreatureEntity &player, ae_type *ae_ptr, const INVENTORY_IDX i_idx)
 {
-    ae_ptr->o_ptr = ref_item(player, i_idx);
+    auto item = ref_item(player, i_idx);
+    ae_ptr->o_ptr = item.get();
     ae_ptr->lev = ae_ptr->o_ptr->get_baseitem_level();
     ae_ptr->broken = 0;
     return ae_ptr;

--- a/src/object-use/read/read-execution.cpp
+++ b/src/object-use/read/read-execution.cpp
@@ -43,7 +43,7 @@ ObjectReadEntity::ObjectReadEntity(CreatureEntity &creature, INVENTORY_IDX i_idx
  */
 void ObjectReadEntity::execute(bool known)
 {
-    auto *o_ptr = ref_item(this->creature, this->i_idx);
+    auto item = ref_item(this->creature, this->i_idx);
     PlayerEnergy(this->creature).set_player_turn_energy(100);
     if (!this->can_read()) {
         return;
@@ -58,7 +58,7 @@ void ObjectReadEntity::execute(bool known)
         (void)SpellHex(this->creature).stop_all_spells();
     }
 
-    auto executor = ReadExecutorFactory::create(this->creature, o_ptr, known);
+    auto executor = ReadExecutorFactory::create(this->creature, item.get(), known);
     auto used_up = executor->read();
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     using Srf = StatusRecalculatingFlag;
@@ -68,9 +68,9 @@ void ObjectReadEntity::execute(bool known)
     }
 
     rfu.reset_flags(flags_srf);
-    this->change_virtue_as_read(*o_ptr);
-    o_ptr->mark_as_tried();
-    this->gain_exp_from_item_use(o_ptr, executor->is_identified());
+    this->change_virtue_as_read(*item);
+    item->mark_as_tried();
+    this->gain_exp_from_item_use(item.get(), executor->is_identified());
     static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,

--- a/src/object-use/use-execution.cpp
+++ b/src/object-use/use-execution.cpp
@@ -46,8 +46,8 @@ void ObjectUseEntity::execute()
 {
     auto &creature = *this->creature_ptr;
     auto use_charge = true;
-    auto *o_ptr = ref_item(creature, this->i_idx);
-    if ((this->i_idx < 0) && (o_ptr->number > 1)) {
+    auto item = ref_item(creature, this->i_idx);
+    if ((this->i_idx < 0) && (item->number > 1)) {
         msg_print(_("まずは杖を拾わなければ。", "You must first pick up the staffs."));
         return;
     }
@@ -57,7 +57,7 @@ void ObjectUseEntity::execute()
         return;
     }
 
-    auto item_level = o_ptr->get_baseitem_level();
+    auto item_level = item->get_baseitem_level();
     if (item_level > 50) {
         item_level = 50 + (item_level - 50) / 2;
     }
@@ -82,13 +82,13 @@ void ObjectUseEntity::execute()
         return;
     }
 
-    if (o_ptr->pval <= 0) {
+    if (item->pval <= 0) {
         if (flush_failure) {
             flush();
         }
 
         msg_print(_("この杖にはもう魔力が残っていない。", "The staff has no charges left."));
-        o_ptr->ident |= IDENT_EMPTY;
+        item->ident |= IDENT_EMPTY;
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         static constexpr auto flags = {
             StatusRecalculatingFlag::COMBINATION,
@@ -100,8 +100,8 @@ void ObjectUseEntity::execute()
     }
 
     sound(SoundKind::ZAP);
-    auto ident = staff_effect(creature, *o_ptr->bi_key.sval(), &use_charge, false, false, o_ptr->is_aware());
-    if (!(o_ptr->is_aware())) {
+    auto ident = staff_effect(creature, *item->bi_key.sval(), &use_charge, false, false, item->is_aware());
+    if (!(item->is_aware())) {
         chg_virtue(creature, Virtue::PATIENCE, -1);
         chg_virtue(creature, Virtue::CHANCE, 1);
         chg_virtue(creature, Virtue::KNOWLEDGE, -1);
@@ -115,9 +115,9 @@ void ObjectUseEntity::execute()
     }
 
     rfu.reset_flags(flags_srf);
-    o_ptr->mark_as_tried();
-    if (ident && !o_ptr->is_aware()) {
-        object_aware(creature, *o_ptr);
+    item->mark_as_tried();
+    if (ident && !item->is_aware()) {
+        object_aware(creature, *item);
         gain_exp(creature, (item_level + (creature.level >> 1)) / creature.level);
     }
 
@@ -134,12 +134,12 @@ void ObjectUseEntity::execute()
         return;
     }
 
-    o_ptr->pval--;
-    if ((this->i_idx >= 0) && (o_ptr->number > 1)) {
-        auto used_item = o_ptr->clone();
+    item->pval--;
+    if ((this->i_idx >= 0) && (item->number > 1)) {
+        auto used_item = item->clone();
         used_item.number = 1;
-        o_ptr->pval++;
-        o_ptr->number--;
+        item->pval++;
+        item->number--;
         this->i_idx = store_item_to_inventory(creature, &used_item);
         msg_print(_("杖をまとめなおした。", "You unstack your staff."));
     }

--- a/src/object-use/zaprod-execution.cpp
+++ b/src/object-use/zaprod-execution.cpp
@@ -44,14 +44,14 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX i_idx)
 {
     auto &creature = *this->creature_ptr;
     auto use_charge = true;
-    auto *o_ptr = ref_item(creature, i_idx);
-    if ((i_idx < 0) && (o_ptr->number > 1)) {
+    auto item = ref_item(creature, i_idx);
+    if ((i_idx < 0) && (item->number > 1)) {
         msg_print(_("まずはロッドを拾わなければ。", "You must first pick up the rods."));
         return;
     }
 
     auto dir = Direction::none();
-    if (o_ptr->is_aiming_rod() || !o_ptr->is_aware()) {
+    if (item->is_aiming_rod() || !item->is_aware()) {
         dir = get_aim_dir(creature);
         if (!dir) {
             return;
@@ -63,7 +63,7 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX i_idx)
         return;
     }
 
-    const auto item_level = o_ptr->get_baseitem_level();
+    const auto item_level = item->get_baseitem_level();
     auto chance = creature.get_skill_device();
     if (creature.is_confused()) {
         chance = chance / 2;
@@ -103,15 +103,15 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX i_idx)
         return;
     }
 
-    const auto base_pval = o_ptr->get_baseitem_pval();
-    if ((o_ptr->number == 1) && (o_ptr->timeout)) {
+    const auto base_pval = item->get_baseitem_pval();
+    if ((item->number == 1) && (item->timeout)) {
         if (flush_failure) {
             flush();
         }
 
         msg_print(_("このロッドはまだ魔力を充填している最中だ。", "The rod is still charging."));
         return;
-    } else if ((o_ptr->number > 1) && (o_ptr->timeout > base_pval * (o_ptr->number - 1))) {
+    } else if ((item->number > 1) && (item->timeout > base_pval * (item->number - 1))) {
         if (flush_failure) {
             flush();
         }
@@ -121,9 +121,9 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX i_idx)
     }
 
     sound(SoundKind::ZAP);
-    auto ident = rod_effect(creature, *o_ptr->bi_key.sval(), dir, &use_charge, false);
+    auto ident = rod_effect(creature, *item->bi_key.sval(), dir, &use_charge, false);
     if (use_charge) {
-        o_ptr->timeout += base_pval;
+        item->timeout += base_pval;
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
@@ -132,15 +132,15 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX i_idx)
         StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
-    if (!(o_ptr->is_aware())) {
+    if (!(item->is_aware())) {
         chg_virtue(creature, Virtue::PATIENCE, -1);
         chg_virtue(creature, Virtue::CHANCE, 1);
         chg_virtue(creature, Virtue::KNOWLEDGE, -1);
     }
 
-    o_ptr->mark_as_tried();
-    if ((ident != 0) && !o_ptr->is_aware()) {
-        object_aware(creature, *o_ptr);
+    item->mark_as_tried();
+    if ((ident != 0) && !item->is_aware()) {
+        object_aware(creature, *item);
         gain_exp(creature, (item_level + (creature.level >> 1)) / creature.level);
     }
 

--- a/src/object-use/zapwand-execution.cpp
+++ b/src/object-use/zapwand-execution.cpp
@@ -37,14 +37,14 @@ ObjectZapWandEntity::ObjectZapWandEntity(CreatureEntity &creature)
 void ObjectZapWandEntity::execute(INVENTORY_IDX i_idx)
 {
     auto old_target_pet = target_pet;
-    auto *o_ptr = ref_item(this->creature, i_idx);
-    if ((i_idx < 0) && (o_ptr->number > 1)) {
+    auto item = ref_item(this->creature, i_idx);
+    if ((i_idx < 0) && (item->number > 1)) {
         msg_print(_("まずは魔法棒を拾わなければ。", "You must first pick up the wands."));
         return;
     }
 
-    const auto sval = o_ptr->bi_key.sval();
-    if (o_ptr->is_aware() && (sval == SV_WAND_HEAL_MONSTER || sval == SV_WAND_HASTE_MONSTER)) {
+    const auto sval = item->bi_key.sval();
+    if (item->is_aware() && (sval == SV_WAND_HEAL_MONSTER || sval == SV_WAND_HASTE_MONSTER)) {
         target_pet = true;
     }
 
@@ -60,7 +60,7 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX i_idx)
         return;
     }
 
-    auto item_level = o_ptr->get_baseitem_level();
+    auto item_level = item->get_baseitem_level();
     if (item_level > 50) {
         item_level = 50 + (item_level - 50) / 2;
     }
@@ -86,13 +86,13 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX i_idx)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (o_ptr->pval <= 0) {
+    if (item->pval <= 0) {
         if (flush_failure) {
             flush();
         }
 
         msg_print(_("この魔法棒にはもう魔力が残っていない。", "The wand has no charges left."));
-        o_ptr->ident |= IDENT_EMPTY;
+        item->ident |= IDENT_EMPTY;
         static constexpr auto flags = {
             StatusRecalculatingFlag::COMBINATION,
             StatusRecalculatingFlag::REORDER,
@@ -111,15 +111,15 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX i_idx)
     }
 
     rfu.reset_flags(flags_srf);
-    if (!o_ptr->is_aware()) {
+    if (!item->is_aware()) {
         chg_virtue(this->creature, Virtue::PATIENCE, -1);
         chg_virtue(this->creature, Virtue::CHANCE, 1);
         chg_virtue(this->creature, Virtue::KNOWLEDGE, -1);
     }
 
-    o_ptr->mark_as_tried();
-    if (ident && !o_ptr->is_aware()) {
-        object_aware(this->creature, *o_ptr);
+    item->mark_as_tried();
+    if (ident && !item->is_aware()) {
+        object_aware(this->creature, *item);
         gain_exp(this->creature, (item_level + (this->creature.level >> 1)) / this->creature.level);
     }
 
@@ -132,7 +132,7 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX i_idx)
     };
     rfu.set_flags(flags_swrf);
     rfu.set_flags(flags_srf);
-    o_ptr->pval--;
+    item->pval--;
     if (i_idx >= 0) {
         inven_item_charges(*this->creature.inventory[i_idx]);
         return;

--- a/src/object/object-info.cpp
+++ b/src/object/object-info.cpp
@@ -91,7 +91,7 @@ char index_to_label(int i)
  * @param o_ptr 名称を取得する元のオブジェクト構造体参照ポインタ
  * @return 対応する装備部位ID
  */
-int16_t wield_slot(CreatureEntity &creature, const ItemEntity *o_ptr)
+short wield_slot(CreatureEntity &creature, const ItemEntity *o_ptr)
 {
     switch (o_ptr->bi_key.tval()) {
     case ItemKindType::DIGGING:
@@ -180,8 +180,16 @@ bool check_book_realm(CreatureEntity &creature, const BaseitemKey &bi_key)
     return pr.realm1().equals(book_realm) || pr.realm2().equals(book_realm);
 }
 
-ItemEntity *ref_item(CreatureEntity &creature, INVENTORY_IDX i_idx)
+/*!
+ * @brief 所持品IDからアイテムを返す
+ * @param creature クリーチャーへの参照
+ * @param i_idx 所持品ID
+ * @return 対応するアイテムへの shared_ptr
+ * @details 返り値をshared_ptrとして保持せず".get()"で取得した生ポインタや"*"で取得した参照を保持し続けてはいけない.
+ * アイテムがインベントリや床から削除された際にダングリングポインタになる可能性がある.
+ */
+std::shared_ptr<ItemEntity> ref_item(CreatureEntity &creature, short i_idx)
 {
     auto &floor = *creature.get_floor();
-    return i_idx >= 0 ? creature.inventory[i_idx].get() : floor.o_list[0 - i_idx].get();
+    return i_idx >= 0 ? creature.inventory[i_idx] : floor.o_list[0 - i_idx];
 }

--- a/src/object/object-info.h
+++ b/src/object/object-info.h
@@ -1,14 +1,12 @@
 #pragma once
 
-#include "object/tval-types.h"
-#include "system/angband.h"
+#include <memory>
 
 class BaseitemKey;
 class CreatureEntity;
 class ItemEntity;
-class CreatureEntity;
 char index_to_label(int i);
-int16_t wield_slot(CreatureEntity &creature, const ItemEntity *o_ptr);
+short wield_slot(CreatureEntity &creature, const ItemEntity *o_ptr);
 bool check_book_realm(CreatureEntity &creature, const BaseitemKey &bi_key);
-ItemEntity *ref_item(CreatureEntity &creature, INVENTORY_IDX i_idx);
+std::shared_ptr<ItemEntity> ref_item(CreatureEntity &creature, short i_idx);
 std::string activation_explanation(const ItemEntity *o_ptr);


### PR DESCRIPTION
…5339 part 1/5)

ref_item() の戻り値型を `ItemEntity *` から `std::shared_ptr<ItemEntity>` に変更し、 所有関係を明確化する。inventory[i] / floor.o_list[i] が既に shared_ptr 保持のため .get() を使わずそのまま返却できる。

呼出側は autopick / cmd-eat / object-activation / read-execution / use-execution / zaprod-execution / zapwand-execution の各 ref_item() 受け側を `auto *o_ptr = ref_item(...)` から `auto item = ref_item(...)` に変え、 ItemEntity* を要求する API には `item.get()` を渡す。

floor-object.cpp::choose_object() は依然 ItemEntity* を返すため、 `ref_item(...).get()` で互換維持 (PR #5339 part 4/5 で shared_ptr に置換予定)。

bakabakaband 構造への適応:
- 上流の PlayerType * → CreatureEntity & は既に適用済み
- wield_slot() の戻り値型を int16_t から short に揃える (上流に合わせる cosmetic)

上流コミット: 198dc653b (hengband/develop, PR #5339 commit 1/5)