### PR TITLE
refactor: psex に SEX_NONE 追加 / get_psex() & get_ppersonality() virtua…

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -74,7 +74,13 @@ ESP 系 BIT_FLAGS 等）が残存している。モンスターでも将来運�
 
 - ✅ モンスター生成時に `prace` / `pclass` / `realm1` / `realm2` /
   `element_realm` を NONE に明示初期化（`init_monster_profile()`）
-- 🚧 残り: `ppersonality` / `psex` 用の NONE 値追加、virtual アクセサ整備
+- ✅ `ppersonality` の NONE 値 (`PERSONALITY_NONE`) を `init_monster_profile()`
+  で初期化
+- ✅ `player_sex` enum に `SEX_NONE = 4` を追加 (sex_info に「未設定」エントリ
+  も追加)。`init_monster_profile()` で `psex = SEX_NONE` に初期化し、
+  `get_sex_info()` は範囲外の値を SEX_NONE にフォールバック
+- ✅ virtual アクセサ `get_psex()` / `get_ppersonality()` を `CreatureEntity`
+  に追加 (将来モンスター固有のオーバーライド余地を確保)
 
 ---
 

--- a/src/player/player-sex.cpp
+++ b/src/player/player-sex.cpp
@@ -15,7 +15,9 @@ const player_sex_type *sp_ptr;
  *      Winner
  * </pre>
  * 配列の並びは player_sex enum (SEX_FEMALE=0, SEX_MALE=1,
- * SEX_BISEXUAL=2, SEX_ASEXUAL=3) と必ず一致させること。
+ * SEX_BISEXUAL=2, SEX_ASEXUAL=3, SEX_NONE=4) と必ず一致させること。
+ * SEX_NONE はモンスター生成過程の中間値で、UI 表示等では明示的に
+ * 「未設定」として扱う。
  */
 const player_sex_type sex_info[MAX_SEXES] = {
     {
@@ -33,5 +35,9 @@ const player_sex_type sex_info[MAX_SEXES] = {
     {
         { "無性", "Asexual" },
         { "ロード", "Lord" },
+    },
+    {
+        { "未設定", "Unset" },
+        { "未設定", "Unset" },
     },
 };

--- a/src/player/player-sex.h
+++ b/src/player/player-sex.h
@@ -8,7 +8,8 @@ enum player_sex : byte {
     SEX_MALE = 1,
     SEX_BISEXUAL = 2,
     SEX_ASEXUAL = 3,
-    MAX_SEXES = 4, /*!< 性別の定義最大数 / Maximum number of player "sex" types (see "table.c", etc) */
+    SEX_NONE = 4, /*!< 未設定 (主にモンスター生成途中の中間値) / Unset (transient state during monster generation) */
+    MAX_SEXES = 5, /*!< 性別の定義最大数 / Maximum number of "sex" types (see "table.c", etc) */
 };
 
 struct player_sex_type {

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -173,7 +173,9 @@ const player_sex_type &CreatureEntity::get_sex_info() const
 {
     // モンスターの psex は one_monster_placer で kind_flags MALE/FEMALE
     // から計算済み。プレイヤーは birth で選択済み。両者ともそのまま参照する。
-    return sex_info[this->psex];
+    // SEX_NONE は生成途中等の中間値として末尾エントリ ("未設定") を返す。
+    const auto psex_safe = (this->psex < MAX_SEXES) ? this->psex : SEX_NONE;
+    return sex_info[psex_safe];
 }
 
 const player_personality *CreatureEntity::get_personality_info() const
@@ -1136,9 +1138,12 @@ void CreatureEntity::init_monster_profile()
     // モンスターに対して意味をなさないため、明示的に無効値に初期化する。
     // 将来モンスターにも種族・職業・魔法領域を持たせて運用する際は、
     // 対応する MonsterProfile 側の設定値からここに反映させる。
+    // psex は one_monster_placer で kind_flags MALE/FEMALE から再設定されるが、
+    // ここで SEX_NONE に明示初期化することで生成途中の中間状態を区別可能にする。
     this->prace = PlayerRaceType::NONE;
     this->pclass = PlayerClassType::NONE;
     this->ppersonality = PERSONALITY_NONE;
+    this->psex = SEX_NONE;
     this->realm1 = RealmType::NONE;
     this->realm2 = RealmType::NONE;
     this->element_realm = ElementRealmType::NONE;

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -364,6 +364,28 @@ public:
      */
     const player_sex_type &get_sex_info() const;
 
+    /*!
+     * @brief 性別 enum を取得する
+     * @return psex (player_sex)
+     * @details モンスターは生成途中で SEX_NONE → kind_flags MALE/FEMALE から
+     * 確定値に置換される。プレイヤーは birth で確定済み。
+     */
+    virtual player_sex get_psex() const
+    {
+        return this->psex;
+    }
+
+    /*!
+     * @brief 性格 enum を取得する
+     * @return ppersonality (player_personality_type)
+     * @details モンスターは init_monster_profile() で PERSONALITY_NONE に
+     * 初期化されており、種族側に性格設定が無い限り NONE のまま。
+     */
+    virtual player_personality_type get_ppersonality() const
+    {
+        return this->ppersonality;
+    }
+
     bool has_living_flag(bool is_appearance = false) const;
     bool has_demon_flag(bool is_appearance = false) const;
     bool has_undead_flag(bool is_appearance = false) const;


### PR DESCRIPTION
…l アクセサ

CreatureEntity 統合リファクタリング (提案 1) の残タスク:

- player_sex enum に SEX_NONE = 4 を追加 (MAX_SEXES = 5) sex_info に "未設定" / "Unset" エントリを追加。 この値はモンスター生成途中の中間状態を表現するセンチネルで、 one_monster_placer が kind_flags MALE/FEMALE から確定値を設定する。
- CreatureEntity::init_monster_profile() で psex = SEX_NONE に明示初期化。 既存の prace/pclass/ppersonality/realm1/realm2/element_realm の NONE 初期化と 整合させる。
- CreatureEntity::get_sex_info() を範囲ガード付きに変更 (psex が MAX_SEXES 以上ならフォールバックとして SEX_NONE を返す)
- virtual アクセサ get_psex() / get_ppersonality() を追加。将来モンスター固有の オーバーライド余地を確保。

docs/creature-entity-refactoring-roadmap.md の提案 1 進捗も更新。