### PR TITLE
fix: 耐電のアミュレットの subtype を 31 → 30 に修正 (hengband#5371 相当)

### DIFF
--- a/lib/edit/BaseitemDefinitions.jsonc
+++ b/lib/edit/BaseitemDefinitions.jsonc
@@ -27740,7 +27740,7 @@
       },
       "itemkind": {
         "type_value": 40,
-        "subtype_value": 31,
+        "subtype_value": 30,
       },
       "parameter_value": 0,
       "level": 12,


### PR DESCRIPTION
前セッションの #5349 取り込み時 (commit 4ebec34a5) で subtype_value=31 にしたが、 これは上流の元バグを引き継いだもの。bakabakaband のアミュレット sval は
0-29 が使用済み (24 までは sv-amulet-types.h に enum 定義あり、25-29 は INSTA_ART で番号のみ使用)。次の空き slot は 30 のため subtype を 30 に修正。

上流コミット: 4c6d4ef98 (PR #5371) と同等の対応。