### PR TITLE
fix: 地形を照らした時の色補正が正しくなかった (hengband#5370 相当)

### DIFF
--- a/src/info-reader/terrain-reader.cpp
+++ b/src/info-reader/terrain-reader.cpp
@@ -78,6 +78,7 @@ static errr set_terrain_symbol(const nlohmann::json &symbol_obj, TerrainType &te
     const bool lit = lit_obj.get<bool>();
     if (lit) {
         terrain.reset_lighting(false);
+        return PARSE_ERROR_NONE;
     }
 
     for (int j = F_LIT_NS_BEGIN; j < F_LIT_MAX; j++) {


### PR DESCRIPTION
JSON から地形情報を読み込む際、LIT フラグ付きの terrain.reset_lighting(false) 呼出後に F_LIT_NS_BEGIN〜F_LIT_MAX のループでデフォルト色に上書きされていた バグを修正。lit=true の場合は早期 return する。

bakabakaband 側の TerrainDefinitions.jsonc は既に「Dark Gray」で正しい色を 使用していたため、上流の data 修正部分 (d3757196d) は適用不要。C++ 修正のみ。

上流コミット: 8d4c281e1 (PR #5370 part 1/2)