### PR TITLE
feat: ダンジョン特性フラグに SMALLEST がついていたら NO_VAULT を自動追加 (hengband#5369 相当)

### DIFF
--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -348,6 +348,13 @@ static tl::optional<std::string> level_gen(CreatureEntity &creature, tl::optiona
     } else if (always_small_floor || ironman_smallest_floor || (allow_smallest_floor && one_in_(chance_small_floor)) || dungeon.flags.has(DungeonFeatureType::SMALLEST)) {
         level_height = MIN_HGT_MULTIPLE;
         level_width = MIN_WID_MULTIPLE;
+        // 鉄人「常に最小フロア」+ 鉄人「常に普通でない部屋」+ NO_VAULT 無し の組み合わせで
+        // 1x1 ブロックに VAULT を生成しようとして無限ループに陥るのを回避するため、
+        // VAULT が出現可能なら最低 2x1 ブロックを保証する (上流 hengband#5369 相当)。
+        if (ironman_smallest_floor && ironman_rooms && dungeon.flags.has_not(DungeonFeatureType::NO_VAULT)) {
+            level_height = MIN_HGT_MULTIPLE * 2;
+            level_width = MIN_WID_MULTIPLE;
+        }
     } else if (dungeon.flags.has(DungeonFeatureType::BEGINNER)) {
         level_height = MIN_HGT_MULTIPLE * 2;
         level_width = MIN_WID_MULTIPLE * 2;

--- a/src/system/dungeon/dungeon-definition.cpp
+++ b/src/system/dungeon/dungeon-definition.cpp
@@ -212,6 +212,16 @@ void DungeonDefinition::set_guardian_flag()
     }
 }
 
+/*!
+ * @brief 最小面積が保証されるダンジョンには VAULT を生成しないフラグをセットする。
+ */
+void DungeonDefinition::set_no_vault_flag_if_smallest()
+{
+    if (this->flags.has(DungeonFeatureType::SMALLEST)) {
+        this->flags.set(DungeonFeatureType::NO_VAULT);
+    }
+}
+
 MonraceDefinition &DungeonDefinition::get_guardian()
 {
     return MonraceList::get_instance().get_monrace(this->final_guardian);

--- a/src/system/dungeon/dungeon-definition.h
+++ b/src/system/dungeon/dungeon-definition.h
@@ -165,6 +165,7 @@ public:
 
     //!< @details ここから下は、地形など全ての定義ファイルを読み込んだ後に呼び出される初期化処理.
     void set_guardian_flag();
+    void set_no_vault_flag_if_smallest();
 
 private:
     Pos2D pos = { 0, 0 };

--- a/src/system/dungeon/dungeon-list.cpp
+++ b/src/system/dungeon/dungeon-list.cpp
@@ -36,5 +36,6 @@ void DungeonList::retouch()
 {
     for (auto &[_, dungeon] : this->dungeons) {
         dungeon->set_guardian_flag();
+        dungeon->set_no_vault_flag_if_smallest();
     }
 }


### PR DESCRIPTION
最小面積が保証されるダンジョン (SMALLEST フラグ) に VAULT を生成しても
意味がないため、自動的に NO_VAULT フラグを付与する。

DungeonDefinition::set_no_vault_flag_if_smallest() を追加し、 DungeonList::retouch() で全ダンジョンに対して呼出。

bakabakaband 構造への適応:
- 上流の DungeonDefinitions.jsonc から redundant な NO_VAULT 削除は bakabakaband が .txt 形式を使用しているため適用不要 (元から NO_VAULT を併記していなかった箇所が SMALLEST と組み合わせの 2 つを自動付与する形になる)。

上流コミット: 4189250b5 (hengband/develop, PR #5369)