### PR TITLE
chore: check-cpp-format.sh を clang-format-15 必須かつ install 既存時 skip に改善

### DIFF
--- a/.github/scripts/check-cpp-format.sh
+++ b/.github/scripts/check-cpp-format.sh
@@ -1,7 +1,27 @@
 #!/bin/sh
 
-sudo apt-get update >/dev/null
-sudo apt-get install clang-format-15 >/dev/null
+# 上流 (hengband) CI と format 出力を一致させるため、必ず clang-format-15 を使用する。
+# clang-format-18 等の他バージョンは「&noexcept」のスペーシング等で出力差が出るため
+# fallback には用いない (CI とローカルで diff が出るのを防ぐ)。
+#
+# clang-format-15 が未導入の環境では明示的に install する。CI (Ubuntu 24.04) では
+# 標準では未インストールだが、universe リポジトリ経由で入手可能。
+if ! command -v clang-format-15 >/dev/null 2>&1; then
+    if command -v sudo >/dev/null 2>&1; then
+        sudo apt-get update >/dev/null
+        sudo apt-get install -y clang-format-15 >/dev/null
+    else
+        apt-get update >/dev/null
+        apt-get install -y clang-format-15 >/dev/null
+    fi
+fi
+
+if ! command -v clang-format-15 >/dev/null 2>&1; then
+    echo "clang-format-15 is required but could not be installed."
+    echo "Please install clang-format-15 manually (e.g. via 'apt-get install clang-format-15')."
+    echo "Note: clang-format-18 や generic clang-format は出力差があるため使用不可。"
+    exit 1
+fi
 
 SRC_FILES=$(find src/ -type f -regextype posix-egrep -regex ".*\.(cpp|h)" -not -path "src/external-lib/*")
 


### PR DESCRIPTION
変更内容:
- clang-format-15 が既にインストール済みなら apt-get install を skip (CI でも dev 環境でも余計な install を回避)
- sudo が利用不能な環境 (Docker 等) では sudo 抜きで apt-get を実行
- インストール失敗時はエラーメッセージで状況を明示

clang-format-18 や generic clang-format への fallback は実装しない: 両バージョン間で出力差 (例: `&noexcept` vs `& noexcept` のスペーシング) があるため、CI の clang-format-15 とローカル環境の出力が乖離してしまう。
ローカル開発でも上流 hengband CI と同じ -15 を使用することが必須。