### PR TITLE
refactor: TimedEffects::protection() を CreatureTimedEffect 統一 API へ統合

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -276,9 +276,10 @@ Phase 2 で主要な `is_xxx()` 系は仮想化済みだが、以下はまだ自
 - ✅ 基底クラス `CreatureEntity::get_timed_effect` / `set_timed_effect` に
   TimedEffects オブジェクト優先の分岐ロジックを集約。`PlayerType` 側の
   オーバーライドを廃止し、プレイヤー・モンスターで API 経路を統一
-- ✅ `CreatureTimedEffect` enum に `HALLUCINATION` / `CUT` / `POISON`
-  を追加し、これまで TimedEffects オブジェクト経由でのみアクセス
-  できた効果も `get/set_timed_effect()` 統一 API からアクセス可能に
+- ✅ `CreatureTimedEffect` enum に `HALLUCINATION` / `CUT` / `POISON` /
+  `PROTECTION` を追加し、これまで TimedEffects オブジェクト経由でのみ
+  アクセスできた効果も `get/set_timed_effect()` 統一 API からアクセス可能に
+  (TimedEffects オブジェクトが持つ 11 効果すべてが enum 統合済み)
 - ✅ `is_cut()` / `is_poisoned()` を virtual メソッド化 (既存
   `is_blind()` / `is_paralyzed()` 等と同等のデフォルト実装)
 - ✅ `bad-status-setter.cpp` / `buff-setter.cpp` / `cmd-inn.cpp`

--- a/src/status/body-improvement.cpp
+++ b/src/status/body-improvement.cpp
@@ -27,7 +27,7 @@ bool BodyImprovement::has_effect() const
 
 void BodyImprovement::mod_protection(short v, bool is_decrease)
 {
-    this->set_protection(this->creature_ptr->effects()->protection().current() + v, is_decrease);
+    this->set_protection(this->creature_ptr->get_timed_effect(CreatureTimedEffect::PROTECTION) + v, is_decrease);
 }
 
 /*!

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -534,6 +534,8 @@ short CreatureEntity::get_timed_effect(CreatureTimedEffect effect) const
             return eff.cut().current();
         case CreatureTimedEffect::POISON:
             return eff.poison().current();
+        case CreatureTimedEffect::PROTECTION:
+            return eff.protection().current();
         default:
             break;
         }
@@ -577,6 +579,9 @@ void CreatureEntity::set_timed_effect(CreatureTimedEffect effect, short value)
             return;
         case CreatureTimedEffect::POISON:
             eff.poison().set(value);
+            return;
+        case CreatureTimedEffect::PROTECTION:
+            eff.protection().set(value);
             return;
         default:
             break;

--- a/src/system/creature-timed-effect-types.h
+++ b/src/system/creature-timed-effect-types.h
@@ -22,6 +22,7 @@ enum class CreatureTimedEffect {
     HALLUCINATION, /*!< 幻覚 / Hallucination */
     CUT, /*!< 切り傷 / Cut */
     POISON, /*!< 毒 / Poison */
+    PROTECTION, /*!< 対邪悪結界 / Protection from Evil */
 
     // --- プレイヤー専用：戦闘バフ系 ---
     HERO, /*!< 士気高揚 / Heroism */


### PR DESCRIPTION
提案 5 の進捗継続。現在 TimedEffects オブジェクトが持つ 11 効果のうち、
PROTECTION のみが CreatureTimedEffect enum 未統合だった。本コミットで 最後のひとつとなる PROTECTION を統一 API へ取り込み、TimedEffects 上の 全効果が `get_timed_effect()` / `set_timed_effect()` 経由でアクセスできる 状態になる。

変更点:
- `CreatureTimedEffect::PROTECTION` を enum に追加
- `CreatureEntity::get/set_timed_effect()` の dispatcher へ `eff.protection().current()` / `.set()` を経路追加
- `BodyImprovement::mod_protection()` の単純な `current()` 読取り 1 件を `creature.get_timed_effect(CreatureTimedEffect::PROTECTION)` に置換 (`is_protected()` / `is_larger_than()` 等の高機能 API を呼ぶ箇所は 従来通り `effects()->protection()` 経由のまま)

ビルド・スモークテスト確認:
- フルビルド (exit 0, 警告なし)
- ./src/hengband --output-spoilers (exit 0)