### PR TITLE
[Fix] 射撃を行うとクラッシュする (hengband#5346)

### DIFF
--- a/src/cmd-action/cmd-shoot.cpp
+++ b/src/cmd-action/cmd-shoot.cpp
@@ -56,13 +56,13 @@ void do_cmd_fire(CreatureEntity &creature, SPELL_IDX snipe_type)
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
     constexpr auto q = _("どれを撃ちますか? ", "Fire which item? ");
     constexpr auto s = _("発射されるアイテムがありません。", "You have nothing to fire.");
-    const auto &[item, i_idx] = choose_item(creature, q, s, USE_INVEN | USE_FLOOR, TvalItemTester(creature.tval_ammo));
-    if (!item) {
+    const auto &[ammo, ammo_idx] = choose_item(creature, q, s, USE_INVEN | USE_FLOOR, TvalItemTester(creature.tval_ammo));
+    if (!ammo) {
         flush();
         return;
     }
 
-    exe_fire(creature, i_idx, item.get(), snipe_type);
+    exe_fire(creature, ammo_idx, bow_ptr, snipe_type);
     if (!creature.is_fired || !CreatureClass(creature).equals(PlayerClassType::SNIPER)) {
         return;
     }


### PR DESCRIPTION
変愚蛮怒 PR #5346 を bakabakaband に反映。

cf79c57 のリファクタリングで射撃武器への参照ポインタを渡すべきところ
射撃する矢弾の参照ポインタを渡すように誤って修正したことが原因。
元の通り射撃武器への参照ポインタを渡すようにするとともに、射撃武器と
矢弾で両方 item という名称を使っているのが間違いを引き起こした原因なので
bow と ammo という具体的な種別を示す変数名に変更する。

上流コミット: 62e4e3037 (hengband/develop)

bakabakaband 側適応:
- 上流の `item_ptr` → `bow_ptr` 改名は bakabakaband 側で既適用済み
- `choose_item()` 戻り値の `item` / `i_idx` を `ammo` / `ammo_idx` に改名
- `exe_fire(creature, ammo_idx, bow_ptr, snipe_type)` で矢弾の代わりに 射撃武器を渡すように修正

ビルド・スモークテスト確認:
- フルビルド (exit 0, 警告なし)
- ./src/hengband --output-spoilers (exit 0)

備考: 同じバグ修正バッチで検討した他 3 件 (#5322 / #5324 / #5331) は
bakabakaband に既反映済みのため本マージでは対象外:
- #5322: move_monster_to() 統合は earlier session で完了
- #5324: MESSAGE_REFLECT/TIMESTART の use_name: false 設定は HEAD で 既に DEFAULT セクション後段に配置済み
- #5331: 素手+強撃 int overflow 修正は ed0311ee5 で既マージ済み