### PR TITLE
refactor: MonsterProfile::ml を virtual is_visible_on_map() に集約 (提案 7)

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -320,6 +320,38 @@ Phase 2 で主要な `is_xxx()` 系は仮想化済みだが、以下はまだ自
 
 ---
 
+## 提案 7: モンスター可視判定 (`ml`) の virtual アクセサ化 ✅ 完了
+
+### 背景
+
+`MonsterProfile::ml` (bool) はプレイヤーから見えるかを保持する一時変数で、
+全コードベース 119 箇所で `monster.get_monster_profile().ml` の形で
+直接アクセスされていた。MonsterProfile を持たないクリーチャー
+(=プレイヤー) でアクセスすると `tl::optional` の dereference でクラッシュ
+するため、慣用句的に呼び側で `has_monster_profile()` ガードや
+`ternary` で `false` フォールバックを書く必要があった。
+
+### 作業内容
+
+- `CreatureEntity` に virtual `is_visible_on_map()` を追加
+  (デフォルト実装: `monster_profile ? ml : false`)
+- 同 virtual `set_visible_on_map(bool)` を追加
+  (デフォルト実装: monster_profile があれば書込み、なければ no-op)
+- 既存呼び側を sed 一括移行: 読取り 113 箇所、書込み 6 箇所、
+  43 ファイルに渡って `is_visible_on_map()` / `set_visible_on_map(...)`
+  形式へ置換
+- `is_seen()` (geometry.cpp) と `is_original_ap_and_seen()`
+  (monster-info.cpp) の `has_monster_profile()` ガードは
+  virtual 内部で吸収されるようになったため削除
+
+### 効果
+
+- 119 箇所の直接アクセスを virtual 経由に集約
+- ガード忘れ・null dereference リスクの恒久的排除
+- 将来モンスターに「視認状態」概念を追加するときの拡張ポイント確保
+
+---
+
 ## 推奨実施順序
 
 1. **提案 1** - プレイヤー専用フィールドのクリーチャー共通化（初期値・アクセサ整備）

--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -149,20 +149,20 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
     std::string m_name;
     bool can_move = true;
     bool do_past = false;
-    if (grid.has_monster() && (monster.get_monster_profile().ml || p_can_enter || p_can_kill_walls)) {
+    if (grid.has_monster() && (monster.is_visible_on_map() || p_can_enter || p_can_kill_walls)) {
         const auto &monrace = monster.get_monrace();
         const auto effects = creature.effects();
         const auto is_stunned = effects->stun().is_stunned();
         auto can_cast = !effects->confusion().is_confused();
         const auto is_hallucinated = effects->hallucination().is_hallucinated();
         can_cast &= !is_hallucinated;
-        can_cast &= monster.get_monster_profile().ml;
+        can_cast &= monster.is_visible_on_map();
         can_cast &= !is_stunned;
         can_cast &= creature.get_mutations().has_not(PlayerMutationType::BERS_RAGE) || !creature.is_shero();
         if (!monster.is_hostile() && can_cast && pattern_seq(creature, pos) && (p_can_enter || p_can_kill_walls)) {
             (void)set_monster_csleep(*creature.get_floor(), grid.m_idx, 0);
             m_name = monster_desc(creature, monster, 0);
-            if (monster.get_monster_profile().ml) {
+            if (monster.is_visible_on_map()) {
                 if (!is_hallucinated) {
                     LoreTracker::get_instance().set_trackee(monster.ap_r_idx);
                 }

--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -213,7 +213,7 @@ static bool run_test(CreatureEntity &creature)
         const auto &grid = floor.get_grid(pos);
         if (grid.has_monster()) {
             const auto &monster = floor.get_monster(grid.m_idx);
-            if (monster.get_monster_profile().ml) {
+            if (monster.is_visible_on_map()) {
                 return true;
             }
         }

--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -158,7 +158,7 @@ Direction decide_travel_step_dir(CreatureEntity &creature, const Direction &prev
         const auto &grid = floor.get_grid(pos);
         if (grid.has_monster()) {
             const auto &monster = floor.get_monster(grid.m_idx);
-            if (monster.get_monster_profile().ml) {
+            if (monster.is_visible_on_map()) {
                 return Direction::none();
             }
         }

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -109,7 +109,7 @@ static void natural_attack(CreatureEntity &creature, MONSTER_IDX m_idx, PlayerMu
 
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     bool is_hit = (monrace.kind_flags.has_not(MonsterKindType::QUANTUM)) || !randint0(2);
-    is_hit &= test_hit_norm(creature, chance, static_cast<ARMOUR_CLASS>(monster.get_ac()), monster.get_monster_profile().ml);
+    is_hit &= test_hit_norm(creature, chance, static_cast<ARMOUR_CLASS>(monster.get_ac()), monster.is_visible_on_map());
     if (!is_hit) {
         sound(SoundKind::MISS);
         msg_format(_("ミス！ %sにかわされた。", "You miss %s."), m_name.data());
@@ -182,7 +182,7 @@ static void headbutt_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *f
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     creature.plus_incident_tree("HEADBUTT", 1);
     bool is_hit = (monrace.kind_flags.has_not(MonsterKindType::QUANTUM)) || !randint0(2);
-    is_hit &= test_hit_norm(creature, chance, static_cast<ARMOUR_CLASS>(monster.get_ac()), monster.get_monster_profile().ml);
+    is_hit &= test_hit_norm(creature, chance, static_cast<ARMOUR_CLASS>(monster.get_ac()), monster.is_visible_on_map());
 
     if (!is_hit) {
         sound(SoundKind::MISS);
@@ -273,7 +273,7 @@ static void bodyslam_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *f
 
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     bool is_hit = (monrace.kind_flags.has_not(MonsterKindType::QUANTUM)) || !randint0(2);
-    is_hit &= test_hit_norm(creature, chance, static_cast<ARMOUR_CLASS>(monster.get_ac()), monster.get_monster_profile().ml);
+    is_hit &= test_hit_norm(creature, chance, static_cast<ARMOUR_CLASS>(monster.get_ac()), monster.is_visible_on_map());
 
     if (!is_hit) {
         sound(SoundKind::MISS);
@@ -374,7 +374,7 @@ bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_opti
     const auto m_name = monster_desc(creature, monster, 0);
     const auto effects = creature.effects();
     const auto is_hallucinated = effects->hallucination().is_hallucinated();
-    if (monster.get_monster_profile().ml) {
+    if (monster.is_visible_on_map()) {
         if (!is_hallucinated) {
             LoreTracker::get_instance().set_trackee(monster.ap_r_idx);
         }
@@ -384,7 +384,7 @@ bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_opti
 
     const auto is_confused = effects->confusion().is_confused();
     const auto is_stunned = effects->stun().is_stunned();
-    if (monster.is_female() && !(is_stunned || is_confused || is_hallucinated || !monster.get_monster_profile().ml)) {
+    if (monster.is_female() && !(is_stunned || is_confused || is_hallucinated || !monster.is_visible_on_map())) {
         if (creature.is_wielding(FixedArtifactId::ZANTETSU)) {
             sound(SoundKind::ATTACK_FAILED);
             msg_print(_("拙者、おなごは斬れぬ！", "I can not attack women!"));
@@ -398,7 +398,7 @@ bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_opti
         return false;
     }
 
-    if (!monster.is_hostile() && !(is_stunned || is_confused || is_hallucinated || creature.is_shero() || !monster.get_monster_profile().ml)) {
+    if (!monster.is_hostile() && !(is_stunned || is_confused || is_hallucinated || creature.is_shero() || !monster.is_visible_on_map())) {
         if (creature.is_wielding(FixedArtifactId::STORMBRINGER)) {
             msg_format(_("黒い刃は強欲に%sを攻撃した！", "Your black blade greedily attacks %s!"), m_name.data());
             chg_virtue(creature, Virtue::INDIVIDUALISM, 1);
@@ -419,7 +419,7 @@ bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_opti
     }
 
     if (effects->fear().is_fearful()) {
-        if (monster.get_monster_profile().ml) {
+        if (monster.is_visible_on_map()) {
             sound(SoundKind::ATTACK_FAILED);
             msg_format(_("恐くて%sを攻撃できない！", "You are too fearful to attack %s!"), m_name.data());
         } else {
@@ -470,7 +470,7 @@ bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_opti
         }
     }
 
-    if (fear && monster.get_monster_profile().ml && !mdeath) {
+    if (fear && monster.is_visible_on_map() && !mdeath) {
         // 1/20の確率で恐怖せず狂乱状態になる
         if (one_in_(20)) {
             auto &current_monster = floor.get_monster(grid.m_idx);
@@ -546,7 +546,7 @@ bool do_cmd_headbutt(CreatureEntity &creature)
     // 敵対的でないモンスターへの確認
     const auto is_stunned = effects->stun().is_stunned();
     const auto is_hallucinated = effects->hallucination().is_hallucinated();
-    if (!monster.is_hostile() && !(is_stunned || is_confused || is_hallucinated || creature.is_shero() || !monster.get_monster_profile().ml)) {
+    if (!monster.is_hostile() && !(is_stunned || is_confused || is_hallucinated || creature.is_shero() || !monster.is_visible_on_map())) {
         if (!CreatureClass(creature).equals(PlayerClassType::BERSERKER)) {
             if (!input_check(_("本当に頭突きしますか？", "Really headbutt it? "))) {
                 msg_format(_("%sへの頭突きを止めた。", "You stop to avoid headbutting %s."), m_name.data());
@@ -565,7 +565,7 @@ bool do_cmd_headbutt(CreatureEntity &creature)
     msg_format(_("%sに向かって勢いよく頭突きした！", "You charge forward with a powerful headbutt at %s!"), m_name.data());
     headbutt_attack(creature, grid.m_idx, &fear, &mdeath);
 
-    if (fear && monster.get_monster_profile().ml && !mdeath) {
+    if (fear && monster.is_visible_on_map() && !mdeath) {
         // 1/20の確率で恐怖せず狂乱状態になる
         if (one_in_(20)) {
             auto &current_monster = floor.get_monster(grid.m_idx);
@@ -637,7 +637,7 @@ void do_cmd_body_slam(CreatureEntity &creature)
     msg_format(_("%sに向かって全力で体当たりを仕掛けた！", "You charge at %s with a full body slam!"), m_name.data());
     bodyslam_attack(creature, m_idx, &fear, &mdeath);
 
-    if (fear && monster.get_monster_profile().ml && !mdeath) {
+    if (fear && monster.is_visible_on_map() && !mdeath) {
         // 1/20の確率で恐怖せず狂乱状態になる
         if (one_in_(20)) {
             auto &current_monster = floor.get_monster(m_idx);
@@ -677,7 +677,7 @@ static void enema_attack(CreatureEntity &creature, MONSTER_IDX m_idx, bool *fear
 
     creature.plus_incident_tree("ATTACK_EXE_COUNT", 1);
     bool is_hit = (monrace.kind_flags.has_not(MonsterKindType::QUANTUM)) || !randint0(2);
-    is_hit &= test_hit_norm(creature, chance, static_cast<ARMOUR_CLASS>(monster.get_ac()), monster.get_monster_profile().ml);
+    is_hit &= test_hit_norm(creature, chance, static_cast<ARMOUR_CLASS>(monster.get_ac()), monster.is_visible_on_map());
 
     if (!is_hit) {
         sound(SoundKind::MISS);
@@ -778,7 +778,7 @@ void do_cmd_enema(CreatureEntity &creature)
     msg_format(_("%sに向かって全力で浣腸を仕掛けた！", "You charge at %s with a full enema!"), m_name.data());
     enema_attack(creature, m_idx, &fear, &mdeath);
 
-    if (fear && monster.get_monster_profile().ml && !mdeath) {
+    if (fear && monster.is_visible_on_map() && !mdeath) {
         // 1/20の確率で恐怖せず狂乱状態になる
         if (one_in_(20)) {
             auto &current_monster = floor.get_monster(m_idx);

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -102,7 +102,7 @@ void do_cmd_pet_dismiss(CreatureEntity &creature)
             handle_stuff(creature);
             constexpr auto mes = _("%sを放しますか？ [Yes/No/Unnamed (%d体)]", "Dismiss %s? [Yes/No/Unnamed (%d remain)]");
             msg_format(mes, friend_name.data(), num_pet_index - i);
-            if (monster.get_monster_profile().ml) {
+            if (monster.is_visible_on_map()) {
                 move_cursor_relative(monster.y, monster.x);
             }
 
@@ -226,7 +226,7 @@ bool do_cmd_riding(CreatureEntity &creature, bool force)
 
         const auto &monster = creature.get_floor()->get_monster(grid.m_idx);
 
-        if (!grid.has_monster() || !monster.get_monster_profile().ml) {
+        if (!grid.has_monster() || !monster.is_visible_on_map()) {
             msg_print(_("その場所にはモンスターはいません。", "There is no monster here."));
             return false;
         }
@@ -692,7 +692,7 @@ void do_cmd_pet(CreatureEntity &creature)
             creature.pet_t_m_idx = 0;
         } else {
             const auto &grid = creature.get_floor()->get_grid(*pos);
-            if (grid.has_monster() && (creature.get_floor()->get_monster(grid.m_idx).get_monster_profile().ml)) {
+            if (grid.has_monster() && (creature.get_floor()->get_monster(grid.m_idx).is_visible_on_map())) {
                 creature.pet_t_m_idx = creature.get_floor()->get_grid(*pos).m_idx;
                 creature.pet_follow_distance = PET_DESTROY_DIST;
             } else {

--- a/src/combat/attack-accuracy.cpp
+++ b/src/combat/attack-accuracy.cpp
@@ -140,7 +140,7 @@ static bool decide_attack_hit(CreatureEntity &creature, player_attack_type *pa_p
     } else if (CreatureClass(creature).equals(PlayerClassType::NINJA) && ((pa_ptr->backstab || pa_ptr->surprise_attack) && !monrace.resistance_flags.has(MonsterResistanceType::RESIST_ALL))) {
         success_hit = true;
     } else {
-        success_hit = test_hit_norm(creature, chance, static_cast<ARMOUR_CLASS>(pa_ptr->m_ptr->get_ac()), pa_ptr->m_ptr->get_monster_profile().ml);
+        success_hit = test_hit_norm(creature, chance, static_cast<ARMOUR_CLASS>(pa_ptr->m_ptr->get_ac()), pa_ptr->m_ptr->is_visible_on_map());
     }
 
     if ((pa_ptr->mode == HISSATSU_MAJIN) && one_in_(2)) {

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -743,7 +743,7 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
                 auto &monrace = monster.get_monrace();
 
                 /* Check the visibility */
-                auto visible = monster.get_monster_profile().ml;
+                auto visible = monster.is_visible_on_map();
 
                 /* Note the collision */
                 hit_body = true;
@@ -766,7 +766,7 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
                 }
 
                 /* Did we hit it (penalize range) */
-                if (test_hit_fire(creature, chance - cur_dis, monster, monster.get_monster_profile().ml, item_name.data())) {
+                if (test_hit_fire(creature, chance - cur_dis, monster, monster.is_visible_on_map(), item_name.data())) {
                     bool fear = false;
                     auto tdam = tdam_base; //!< @note 実際に与えるダメージ
                     auto base_dam = tdam; //!< @note 補正前の与えるダメージ(無傷、全ての耐性など)
@@ -787,7 +787,7 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
 
                         msg_format(_("%sが%sに命中した。", "The %s hits %s."), item_name.data(), m_name.data());
 
-                        if (monster.get_monster_profile().ml) {
+                        if (monster.is_visible_on_map()) {
                             if (!creature.is_hallucinated()) {
                                 tracker.set_trackee(monster.ap_r_idx);
                             }
@@ -875,7 +875,7 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
                             anger_monster(creature, monster);
                         }
 
-                        if (fear && monster.get_monster_profile().ml) {
+                        if (fear && monster.is_visible_on_map()) {
                             sound(SoundKind::FLEE);
                             msg_format(_("%s^は恐怖して逃げ出した！", "%s^ flees in terror!"), m_name.data());
                         }

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -348,7 +348,7 @@ void process_player(CreatureEntity &creature)
                 const auto &monrace = monster.get_appearance_monrace();
 
                 // モンスターのシンボル/カラーの更新
-                if (monster.get_monster_profile().ml && monrace.visual_flags.has_any_of({ MonsterVisualType::MULTI_COLOR, MonsterVisualType::SHAPECHANGER })) {
+                if (monster.is_visible_on_map() && monrace.visual_flags.has_any_of({ MonsterVisualType::MULTI_COLOR, MonsterVisualType::SHAPECHANGER })) {
                     lite_spot(creature, monster.get_position());
                 }
 
@@ -369,7 +369,7 @@ void process_player(CreatureEntity &creature)
                         monster.get_monster_profile().mflag2.reset(MonsterConstantFlagType::SHOW);
                     } else {
                         monster.get_monster_profile().mflag2.reset(MonsterConstantFlagType::MARK);
-                        monster.get_monster_profile().ml = false;
+                        monster.set_visible_on_map(false);
                         update_monster(creature, m_idx, false);
                         HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
                         if (monster.is_riding()) {

--- a/src/effect/effect-monster-util.cpp
+++ b/src/effect/effect-monster-util.cpp
@@ -44,7 +44,7 @@ EffectMonster::EffectMonster(CreatureEntity &creature, MONSTER_IDX src_idx, POSI
     this->m_ptr = &floor.get_monster(this->g_ptr->m_idx);
     this->m_caster_ptr = this->is_monster() ? &floor.get_monster(this->src_idx) : nullptr;
     this->r_ptr = &this->m_ptr->get_monrace();
-    this->seen = this->m_ptr->get_monster_profile().ml;
+    this->seen = this->m_ptr->is_visible_on_map();
     this->seen_msg = is_seen(creature, *this->m_ptr);
     this->slept = this->m_ptr->is_asleep();
     this->known = (Grid::calc_distance(creature.get_position(), this->m_ptr->get_position()) <= MAX_PLAYER_SIGHT) || AngbandSystem::get_instance().is_phase_out();

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -180,7 +180,7 @@ static ProcessResult exe_affect_monster_by_effect(CreatureEntity &creature, Effe
  */
 static void effect_damage_killed_pet(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    bool sad = em_ptr->m_ptr->is_pet() && !(em_ptr->m_ptr->get_monster_profile().ml);
+    bool sad = em_ptr->m_ptr->is_pet() && !(em_ptr->m_ptr->is_visible_on_map());
     if (em_ptr->known && !em_ptr->note.empty()) {
         angband_strcpy(em_ptr->m_name, monster_desc(creature, *em_ptr->m_ptr, MD_TRUE_NAME), sizeof(em_ptr->m_name));
         if (em_ptr->see_s_msg) {

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -64,7 +64,7 @@ void effect_player_drain_mana(CreatureEntity &creature, EffectPlayerType *ep_ptr
         rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
-    if (ep_ptr->m_ptr->get_monster_profile().ml) {
+    if (ep_ptr->m_ptr->is_visible_on_map()) {
         msg_format(_("%s^は気分が良さそうだ。", "%s^ appears healthier."), ep_ptr->m_name.data());
     }
 

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -288,7 +288,7 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
                     }
 
                     if (is_seen(creature, monster)) {
-                        const auto m_name = monster.get_monster_profile().ml ? monster_desc(creature, monster, 0) : std::string(_("それ", "It"));
+                        const auto m_name = monster.is_visible_on_map() ? monster_desc(creature, monster, 0) : std::string(_("それ", "It"));
                         sound(SoundKind::REFLECT);
                         const auto reflect_message = monrace.get_message(m_name, MonsterMessageType::MESSAGE_REFLECT);
                         if (reflect_message) {
@@ -381,7 +381,7 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
             const auto &grid = floor.get_grid(pos_project);
             if (grid.has_monster()) {
                 auto &monster = floor.get_monster(grid.m_idx);
-                if (monster.get_monster_profile().ml) {
+                if (monster.is_visible_on_map()) {
                     if (!creature.is_hallucinated()) {
                         tracker.set_trackee(monster.ap_r_idx);
                     }

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -124,7 +124,7 @@ static MonraceDefinition &set_pet_params(CreatureEntity &creature, const int cur
     monster.y = cy;
     monster.x = cx;
     monster.set_floor(creature.get_floor());
-    monster.get_monster_profile().ml = true;
+    monster.set_visible_on_map(true);
     monster.set_timed_effect(CreatureTimedEffect::SLEEP_OR_PARALYSIS, 0);
     monster.get_monster_profile().hold_o_idx_list.clear();
     monster.reset_target();

--- a/src/floor/geometry.cpp
+++ b/src/floor/geometry.cpp
@@ -140,6 +140,5 @@ bool is_seen(CreatureEntity &creature, const CreatureEntity &target)
     const auto p_pos = creature.get_position();
     const auto t_pos = target.get_position();
     is_inside_view |= player_can_see_bold(creature, t_pos.y, t_pos.x) && projectable(*creature.get_floor(), p_pos, t_pos);
-    const auto ml = target.has_monster_profile() ? target.get_monster_profile().ml : false;
-    return ml && is_inside_view;
+    return target.is_visible_on_map() && is_inside_view;
 }

--- a/src/io/cursor.cpp
+++ b/src/io/cursor.cpp
@@ -51,7 +51,7 @@ void print_path(CreatureEntity &creature, POSITION y, POSITION x)
         const auto &grid = floor.get_grid(pos_path);
         if (panel_contains(pos_path)) {
             DisplaySymbolPair symbol_pair({ default_color, '\0' }, { default_color, '*' });
-            if (grid.has_monster() && floor.get_monster(grid.m_idx).get_monster_profile().ml) {
+            if (grid.has_monster() && floor.get_monster(grid.m_idx).is_visible_on_map()) {
                 symbol_pair = map_info(creature, pos_path);
                 auto &symbol_foreground = symbol_pair.symbol_foreground;
                 if (!symbol_foreground.is_ascii_graphics()) {

--- a/src/melee/melee-postprocess.cpp
+++ b/src/melee/melee-postprocess.cpp
@@ -75,7 +75,7 @@ mam_pp_type::mam_pp_type(CreatureEntity &creature, MONSTER_IDX m_idx, int dam, b
 
 static void prepare_redraw(mam_pp_type *mam_pp_ptr)
 {
-    if (!mam_pp_ptr->m_ptr->get_monster_profile().ml) {
+    if (!mam_pp_ptr->m_ptr->is_visible_on_map()) {
         return;
     }
 

--- a/src/melee/melee-spell.cpp
+++ b/src/melee/melee-spell.cpp
@@ -58,7 +58,7 @@ static bool disturb_melee_spell(CreatureEntity &creature, melee_spell_type *ms_p
 static void process_special_melee_spell(CreatureEntity &creature, melee_spell_type *ms_ptr)
 {
     CreatureClass pc(creature);
-    bool is_special_magic = ms_ptr->m_ptr->get_monster_profile().ml;
+    bool is_special_magic = ms_ptr->m_ptr->is_visible_on_map();
     is_special_magic &= ms_ptr->maneable;
     is_special_magic &= AngbandWorld::get_instance().timewalk_m_idx == 0;
     is_special_magic &= !creature.is_blind();

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -95,7 +95,7 @@ static void aura_fire_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
         msg_format(_("%s^は突然熱くなった！", "%s^ is suddenly very hot!"), mam_ptr->m_name);
     }
 
-    if (mam_ptr->m_ptr->get_monster_profile().ml && is_original_ap_and_seen(creature, *mam_ptr->t_ptr)) {
+    if (mam_ptr->m_ptr->is_visible_on_map() && is_original_ap_and_seen(creature, *mam_ptr->t_ptr)) {
         monrace_target.aura_flags.set(MonsterAuraType::FIRE);
     }
 
@@ -122,7 +122,7 @@ static void aura_cold_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
         msg_format(_("%s^は突然寒くなった！", "%s^ is suddenly very cold!"), mam_ptr->m_name);
     }
 
-    if (monster.get_monster_profile().ml && is_original_ap_and_seen(creature, *mam_ptr->t_ptr)) {
+    if (monster.is_visible_on_map() && is_original_ap_and_seen(creature, *mam_ptr->t_ptr)) {
         monrace_target.aura_flags.set(MonsterAuraType::COLD);
     }
 
@@ -149,7 +149,7 @@ static void aura_elec_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
         msg_format(_("%s^は電撃を食らった！", "%s^ gets zapped!"), mam_ptr->m_name);
     }
 
-    if (monster.get_monster_profile().ml && is_original_ap_and_seen(creature, *mam_ptr->t_ptr)) {
+    if (monster.is_visible_on_map() && is_original_ap_and_seen(creature, *mam_ptr->t_ptr)) {
         monrace_target.aura_flags.set(MonsterAuraType::ELEC);
     }
 
@@ -178,7 +178,7 @@ static bool check_same_monster(CreatureEntity &creature, mam_type *mam_ptr)
 
 static void redraw_health_bar(mam_type *mam_ptr)
 {
-    if (!mam_ptr->t_ptr->get_monster_profile().ml) {
+    if (!mam_ptr->t_ptr->is_visible_on_map()) {
         return;
     }
 

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -165,9 +165,9 @@ bool rush_attack(CreatureEntity &creature, bool *mdeath)
         const auto &monster = floor.get_monster(grid_new.m_idx);
         if (tm_idx != grid_new.m_idx) {
 #ifdef JP
-            msg_format("%s%sが立ちふさがっている！", tm_idx > 0 ? "別の" : "", monster.get_monster_profile().ml ? "モンスター" : "何か");
+            msg_format("%s%sが立ちふさがっている！", tm_idx > 0 ? "別の" : "", monster.is_visible_on_map() ? "モンスター" : "何か");
 #else
-            msg_format("There is %s in the way!", monster.get_monster_profile().ml ? (tm_idx > 0 ? "another monster" : "a monster") : "someone");
+            msg_format("There is %s in the way!", monster.is_visible_on_map() ? (tm_idx > 0 ? "another monster" : "a monster") : "someone");
 #endif
         } else if (!creature.is_located_at(p_pos_new)) {
             const auto m_name = monster_desc(creature, monster, 0);
@@ -219,13 +219,13 @@ void process_surprise_attack(CreatureEntity &creature, player_attack_type *pa_pt
     }
 
     auto ninja_data = CreatureClass(creature).get_specific_data<ninja_data_type>();
-    if (pa_ptr->m_ptr->is_asleep() && pa_ptr->m_ptr->get_monster_profile().ml) {
+    if (pa_ptr->m_ptr->is_asleep() && pa_ptr->m_ptr->is_visible_on_map()) {
         /* Can't backstab creatures that we can't see, right? */
         pa_ptr->backstab = true;
     } else if ((ninja_data && ninja_data->s_stealth) && (randint0(tmp) > (monrace.level + 20)) &&
-               pa_ptr->m_ptr->get_monster_profile().ml && !monrace.resistance_flags.has(MonsterResistanceType::RESIST_ALL)) {
+               pa_ptr->m_ptr->is_visible_on_map() && !monrace.resistance_flags.has(MonsterResistanceType::RESIST_ALL)) {
         pa_ptr->surprise_attack = true;
-    } else if (pa_ptr->m_ptr->is_fearful() && pa_ptr->m_ptr->get_monster_profile().ml) {
+    } else if (pa_ptr->m_ptr->is_fearful() && pa_ptr->m_ptr->is_visible_on_map()) {
         pa_ptr->stab_fleeing = true;
     }
 }

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -520,7 +520,7 @@ void mineuchi(CreatureEntity &creature, player_attack_type *pa_ptr)
 void musou_counterattack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
     const auto is_musou = CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU);
-    if ((!creature.counter && !is_musou) || !monap_ptr->alive || creature.is_dead() || !monap_ptr->m_ptr->get_monster_profile().ml || (creature.csp <= 7)) {
+    if ((!creature.counter && !is_musou) || !monap_ptr->alive || creature.is_dead() || !monap_ptr->m_ptr->is_visible_on_map() || (creature.csp <= 7)) {
         return;
     }
 

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -453,7 +453,7 @@ void MonsterAttackPlayer::process_monster_attack_evasion()
 void MonsterAttackPlayer::describe_attack_evasion()
 {
     auto &creature = *this->creature_ptr;
-    if (!this->m_ptr->get_monster_profile().ml) {
+    if (!this->m_ptr->is_visible_on_map()) {
         return;
     }
 
@@ -558,7 +558,7 @@ void MonsterAttackPlayer::postprocess_monster_blows()
         monrace.r_deaths++;
     }
 
-    if (this->m_ptr->get_monster_profile().ml && this->fear && this->alive && !creature.is_dead()) {
+    if (this->m_ptr->is_visible_on_map() && this->fear && this->alive && !creature.is_dead()) {
         sound(SoundKind::FLEE);
         msg_format(_("%s^は恐怖で逃げ出した！", "%s^ flees in terror!"), this->m_name);
     }
@@ -601,7 +601,7 @@ void MonsterAttackPlayer::process_sadist_reaction()
         // 一時的な攻撃力上昇（怒り状態付与）
         this->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::ANGER);
 
-        if (this->m_ptr->get_monster_profile().ml) {
+        if (this->m_ptr->is_visible_on_map()) {
             msg_format(_("%s^は他者の苦痛に興奮している！", "%s^ gets excited by others' pain!"), this->m_name);
         }
     }

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -295,7 +295,7 @@ void process_drain_life(MonsterAttackPlayer *monap_ptr, const bool resist_drain)
         RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
-    if (monap_ptr->m_ptr->get_monster_profile().ml && did_heal) {
+    if (monap_ptr->m_ptr->is_visible_on_map() && did_heal) {
         msg_format(_("%sは体力を回復したようだ。", "%s^ appears healthier."), monap_ptr->m_name);
     }
 }

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -336,7 +336,7 @@ static void drop_items_golds(CreatureEntity &creature, MonsterDeath *md_ptr, int
     }
 
     floor.object_level = floor.base_level;
-    auto visible = md_ptr->m_ptr->get_monster_profile().ml && !creature.is_hallucinated();
+    auto visible = md_ptr->m_ptr->is_visible_on_map() && !creature.is_hallucinated();
     visible |= (md_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE));
     if (visible && (dump_item || dump_gold)) {
         md_ptr->m_ptr->make_lore_treasure(dump_item, dump_gold);

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -481,7 +481,7 @@ bool process_monster_movement(CreatureEntity &creature, turn_flags *turn_flags_p
         const auto can_see = disturb_near && monster.get_monster_profile().mflag.has(MonsterTemporaryFlagType::VIEW) && is_projectable;
         const auto is_high_level = disturb_high && (apparent_monrace.r_tkills > 0) && (apparent_monrace.level >= creature.level);
         const auto is_unknown_level = disturb_unknown && (apparent_monrace.r_tkills == 0);
-        if (monster.get_monster_profile().ml && (disturb_move || can_see || is_high_level || is_unknown_level)) {
+        if (monster.is_visible_on_map() && (disturb_move || can_see || is_high_level || is_unknown_level)) {
             if (monster.is_hostile()) {
                 disturb(creature, false, true);
             }
@@ -568,7 +568,7 @@ void process_sound(CreatureEntity &creature, MONSTER_IDX m_idx)
     const auto &monster = floor.get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
 
-    if (monster.get_monster_profile().ml || creature.get_skill_search() < randint1(100)) {
+    if (monster.is_visible_on_map() || creature.get_skill_search() < randint1(100)) {
         return;
     }
     const auto m_name = std::string(_("それ", "It"));
@@ -623,7 +623,7 @@ void process_speak(CreatureEntity &creature, MONSTER_IDX m_idx, POSITION oy, POS
         return;
     }
 
-    const auto m_name = monster.get_monster_profile().ml ? monster_desc(creature, monster, 0) : std::string(_("それ", "It"));
+    const auto m_name = monster.is_visible_on_map() ? monster_desc(creature, monster, 0) : std::string(_("それ", "It"));
     const auto message_type = get_speak_type(monster);
     if (!message_type) {
         return;

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -134,7 +134,7 @@ static void monster_pickup_object(CreatureEntity &creature, turn_flags *turn_fla
     if (is_unpickable_object) {
         if (turn_flags_ptr->do_take && monrace.behavior_flags.has(MonsterBehaviorType::STUPID)) {
             turn_flags_ptr->did_take_item = true;
-            if (monster.get_monster_profile().ml && player_can_see_bold(creature, ny, nx)) {
+            if (monster.is_visible_on_map() && player_can_see_bold(creature, ny, nx)) {
                 msg_format(_("%s^は%sを拾おうとしたが、だめだった。", "%s^ tries to pick up %s, but fails."), m_name.data(), o_name.data());
             }
         }

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -462,7 +462,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     // 所持金を初期化（能力値に基づいて計算）
     get_money_for_creature(*m_ptr);
 
-    m_ptr->get_monster_profile().ml = false;
+    m_ptr->set_visible_on_map(false);
     if (any_bits(mode, PM_FORCE_PET)) {
         set_pet(player, *m_ptr);
     } else {

--- a/src/monster-floor/quantum-effect.cpp
+++ b/src/monster-floor/quantum-effect.cpp
@@ -31,7 +31,7 @@ static void vanish_nonunique(CreatureEntity &creature, MONSTER_IDX m_idx, bool s
 
     monster_death(creature, m_idx, false, AttributeType::QUANTUM_VANISH);
     delete_monster_idx(creature, m_idx);
-    if (monster.is_pet() && !(monster.get_monster_profile().ml)) {
+    if (monster.is_pet() && !(monster.is_visible_on_map())) {
         msg_print(_("少しの間悲しい気分になった。", "You feel sad for a moment."));
     }
 }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -236,7 +236,7 @@ void MonsterDamageProcessor::increase_kill_numbers()
     }
 
     const auto is_hallucinated = creature.is_hallucinated();
-    if (((monster.get_monster_profile().ml == 0) || is_hallucinated) && monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {
+    if ((!monster.is_visible_on_map() || is_hallucinated) && monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {
         return;
     }
 
@@ -343,7 +343,7 @@ void MonsterDamageProcessor::show_kill_message(std::string_view note, std::strin
         return;
     }
 
-    if (!monster.get_monster_profile().ml) {
+    if (!monster.is_visible_on_map()) {
         auto mes = this->creature.is_echizen() ? _("せっかくだから%sを殺した。", "Because it's time, you have killed %s.")
                                                : _("%sを殺した。", "You have killed %s.");
         msg_format(mes, m_name.data());
@@ -535,7 +535,7 @@ void MonsterDamageProcessor::process_masochist_reaction()
             auto heal_amount = randint1(this->dam / 4 + 1);
             monster.hp = std::min(monster.hp + heal_amount, monster.maxhp);
 
-            if (monster.get_monster_profile().ml) {
+            if (monster.is_visible_on_map()) {
                 msg_format(_("%s^は苦痛に悦んでいる！", "%s^ seems to enjoy the pain!"), monster.get_monrace().name.data());
             }
         }
@@ -563,7 +563,7 @@ void MonsterDamageProcessor::process_sadist_reaction()
         // 一時的な加速効果付与（興奮状態）
         (void)set_monster_fast(*creature.get_floor(), this->m_idx, monster.get_remaining_acceleration() + 100);
 
-        if (monster.get_monster_profile().ml) {
+        if (monster.is_visible_on_map()) {
             msg_format(_("%s^は他者の苦痛に興奮している！", "%s^ gets excited by others' pain!"), monster.get_monrace().name.data());
         }
     }
@@ -633,7 +633,7 @@ bool MonsterDamageProcessor::check_and_process_hp_transform()
     monster.get_monster_profile().sub_align = old_sub_align;
 
     // メッセージ表示
-    if (monster.get_monster_profile().ml) {
+    if (monster.is_visible_on_map()) {
         const auto new_name = monster_desc(creature, monster, MD_INDEF_VISIBLE);
         msg_format(_("％sは％sに変身した！", "％s^ transforms into ％s!"),
             old_name.data(), new_name.data());

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -91,7 +91,7 @@ static std::string get_monster_personal_pronoun(const int kind, const BIT_FLAGS 
 
 static tl::optional<std::string> decide_monster_personal_pronoun(const CreatureEntity &monster, const BIT_FLAGS mode)
 {
-    const auto seen = any_bits(mode, MD_ASSUME_VISIBLE) || (none_bits(mode, MD_ASSUME_HIDDEN) && monster.get_monster_profile().ml);
+    const auto seen = any_bits(mode, MD_ASSUME_VISIBLE) || (none_bits(mode, MD_ASSUME_HIDDEN) && monster.is_visible_on_map());
     const auto pron = (seen && any_bits(mode, MD_PRON_VISIBLE)) || (!seen && any_bits(mode, MD_PRON_HIDDEN));
     if (seen && !pron) {
         return tl::nullopt;

--- a/src/monster/monster-info.cpp
+++ b/src/monster/monster-info.cpp
@@ -247,7 +247,7 @@ bool monster_has_hostile_sub_align(uint8_t sub_align, const MonraceDefinition &m
 
 bool is_original_ap_and_seen(CreatureEntity &subject, const CreatureEntity &creature)
 {
-    return creature.has_monster_profile() && creature.get_monster_profile().ml && !subject.is_hallucinated() && creature.is_original_ap();
+    return creature.is_visible_on_map() && !subject.is_hallucinated() && creature.is_original_ap();
 }
 
 /*!

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -300,7 +300,7 @@ void process_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
         return;
     }
 
-    if (monster.get_monster_profile().ml) {
+    if (monster.is_visible_on_map()) {
         chg_virtue(creature, Virtue::COMPASSION, -1);
     }
 }
@@ -435,7 +435,7 @@ bool awake_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
     }
 
     (void)set_monster_csleep(*creature.get_floor(), m_idx, 0);
-    if (monster.get_monster_profile().ml) {
+    if (monster.is_visible_on_map()) {
         const auto m_name = monster_desc(creature, monster, 0);
         msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());
     }
@@ -555,7 +555,7 @@ void process_special(CreatureEntity &creature, MONSTER_IDX m_idx)
 
     for (int k = 0; k < A_MAX; k++) {
         if (auto summoned_m_idx = summon_specific(creature, monster.y, monster.x, rlev, SUMMON_MOLD, (PM_ALLOW_GROUP | p_mode), m_idx)) {
-            if (creature.get_floor()->get_monster(*summoned_m_idx).get_monster_profile().ml) {
+            if (creature.get_floor()->get_monster(*summoned_m_idx).is_visible_on_map()) {
                 count++;
             }
         }
@@ -605,10 +605,10 @@ bool decide_monster_multiplication(CreatureEntity &creature, MONSTER_IDX m_idx, 
     constexpr auto chance_reproduction = 8;
     if ((k < 4) && (!k || !randint0(k * chance_reproduction))) {
         if (auto multiplied_m_idx = multiply_monster(creature, m_idx, monrace.idx, false, (monster.is_pet() ? PM_FORCE_PET : 0))) {
-            if (creature.get_floor()->get_monster(*multiplied_m_idx).get_monster_profile().ml && is_original_ap_and_seen(creature, monster)) {
+            if (creature.get_floor()->get_monster(*multiplied_m_idx).is_visible_on_map() && is_original_ap_and_seen(creature, monster)) {
                 monrace.r_misc_flags.set(MonsterMiscType::MULTIPLY);
             }
-            if (floor.get_monster(*multiplied_m_idx).get_monster_profile().ml && is_original_ap_and_seen(creature, monster)) {
+            if (floor.get_monster(*multiplied_m_idx).is_visible_on_map() && is_original_ap_and_seen(creature, monster)) {
                 monrace.r_misc_flags.set(MonsterMiscType::MULTIPLY);
             }
             return true;
@@ -726,7 +726,7 @@ bool process_monster_spawn_monster(CreatureEntity &creature, MONSTER_IDX m_idx, 
         if (randint1(deno) <= num) {
             if (multiply_monster(creature, m_idx, idx, false, (m_ptr->is_pet() ? PM_FORCE_PET : 0))) {
                 auto &monster = creature.get_floor()->get_monster(m_idx);
-                if (monster.get_monster_profile().ml && is_original_ap_and_seen(creature, *m_ptr)) {
+                if (monster.is_visible_on_map() && is_original_ap_and_seen(creature, *m_ptr)) {
                     r_ptr->misc_flags.set(MonsterMiscType::MULTIPLY);
                 }
                 return true;
@@ -949,7 +949,7 @@ void sweep_monster_process(CreatureEntity &creature)
                 pow *= 3;
             }
             if (r_ptr.level < randint0(pow)) {
-                if (monster.get_monster_profile().ml) {
+                if (monster.is_visible_on_map()) {
                     msg_format(_("%sは%sに絡めとられて動けなかった！", "%s wes entangled in the %s and could not move!"), m_name.data(), f_ptr.name.data());
                 }
                 if (r_ptr.kind_flags.has(MonsterKindType::HENTAI)) {

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -91,7 +91,7 @@ bool set_monster_csleep(FloorType &floor, MONSTER_IDX m_idx, int v)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (monster.get_monster_profile().ml) {
+    if (monster.is_visible_on_map()) {
         HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
         if (monster.is_riding()) {
             rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
@@ -274,7 +274,7 @@ bool set_monster_monfear(FloorType &floor, MONSTER_IDX m_idx, int v)
         return false;
     }
 
-    if (monster.get_monster_profile().ml) {
+    if (monster.is_visible_on_map()) {
         HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
         if (monster.is_riding()) {
             RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
@@ -318,7 +318,7 @@ bool set_monster_invulner(FloorType &floor, MONSTER_IDX m_idx, int v, bool energ
         return false;
     }
 
-    if (monster.get_monster_profile().ml) {
+    if (monster.is_visible_on_map()) {
         HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
         if (monster.is_riding()) {
             RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -170,7 +170,7 @@ static void process_monsters_timed_effect_aux(CreatureEntity &creature, MONSTER_
         }
 
         /* Notice the "waking up" */
-        if (monster.get_monster_profile().ml) {
+        if (monster.is_visible_on_map()) {
             const auto m_name = monster_desc(creature, monster, 0);
             msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());
         }
@@ -310,19 +310,19 @@ void dispel_monster_status(CreatureEntity &creature, MONSTER_IDX m_idx)
     const auto &monster = floor.get_monster(m_idx);
     const auto m_name = monster_desc(creature, monster, 0);
     if (set_monster_invulner(floor, m_idx, 0, true)) {
-        if (monster.get_monster_profile().ml) {
+        if (monster.is_visible_on_map()) {
             msg_format(_("%sはもう無敵ではない。", "%s^ is no longer invulnerable."), m_name.data());
         }
     }
 
     if (set_monster_fast(floor, m_idx, 0)) {
-        if (monster.get_monster_profile().ml) {
+        if (monster.is_visible_on_map()) {
             msg_format(_("%sはもう加速されていない。", "%s^ is no longer fast."), m_name.data());
         }
     }
 
     if (set_monster_slow(floor, m_idx, 0)) {
-        if (monster.get_monster_profile().ml) {
+        if (monster.is_visible_on_map()) {
             msg_format(_("%sはもう減速されていない。", "%s^ is no longer slow."), m_name.data());
         }
     }
@@ -421,7 +421,7 @@ void monster_gain_exp(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId mon
     }
 
     monster.exp = 0;
-    if (monster.is_pet() || monster.get_monster_profile().ml) {
+    if (monster.is_pet() || monster.is_visible_on_map()) {
         const auto is_hallucinated = creature.is_hallucinated();
         if (!ignore_unview || player_can_see_bold(creature, monster.y, monster.x)) {
             if (is_hallucinated) {

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -503,11 +503,11 @@ static void decide_sight_invisible_monster(CreatureEntity &creature, um_type *um
 static void update_invisible_monster(CreatureEntity &creature, um_type *um_ptr, MONSTER_IDX m_idx)
 {
     auto &monster = *um_ptr->m_ptr;
-    if (monster.get_monster_profile().ml) {
+    if (monster.is_visible_on_map()) {
         return;
     }
 
-    monster.get_monster_profile().ml = true;
+    monster.set_visible_on_map(true);
     lite_spot(creature, um_ptr->get_position());
 
     HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
@@ -544,11 +544,11 @@ static void update_invisible_monster(CreatureEntity &creature, um_type *um_ptr, 
 
 static void update_visible_monster(CreatureEntity &creature, um_type *um_ptr, MONSTER_IDX m_idx)
 {
-    if (!um_ptr->m_ptr->get_monster_profile().ml) {
+    if (!um_ptr->m_ptr->is_visible_on_map()) {
         return;
     }
 
-    um_ptr->m_ptr->get_monster_profile().ml = false;
+    um_ptr->m_ptr->set_visible_on_map(false);
     lite_spot(creature, um_ptr->get_position());
 
     HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -262,7 +262,7 @@ static bool check_thrown_mspell(CreatureEntity &creature, msa_type *msa_ptr)
 
 static void check_mspell_imitation(CreatureEntity &creature, msa_type *msa_ptr)
 {
-    const auto seen = (!creature.is_blind() && msa_ptr->m_ptr->get_monster_profile().ml);
+    const auto seen = (!creature.is_blind() && msa_ptr->m_ptr->is_visible_on_map());
     const auto can_imitate = creature.get_floor()->has_los_at({ msa_ptr->m_ptr->y, msa_ptr->m_ptr->x });
     CreatureClass pc(creature);
     if (!seen || !can_imitate || (AngbandWorld::get_instance().timewalk_m_idx != 0) || !pc.equals(PlayerClassType::IMITATOR)) {

--- a/src/mspell/mspell-learn-checker.cpp
+++ b/src/mspell/mspell-learn-checker.cpp
@@ -16,7 +16,7 @@ bool spell_learnable(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
     const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
-    const auto seen = (!creature.is_blind() && monster.get_monster_profile().ml);
+    const auto seen = (!creature.is_blind() && monster.is_visible_on_map());
     const auto maneable = floor.has_los_at({ monster.y, monster.x });
     return seen && maneable && (AngbandWorld::get_instance().timewalk_m_idx == 0);
 }

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -172,7 +172,7 @@ MonsterSpellResult spell_RF5_DRAIN_MANA(CreatureEntity &creature, POSITION y, PO
 MonsterSpellResult spell_RF5_MIND_BLAST(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
     const auto &monster = creature.get_floor()->get_monster(m_idx);
-    bool seen = (!creature.is_blind() && monster.get_monster_profile().ml);
+    bool seen = (!creature.is_blind() && monster.is_visible_on_map());
     const auto m_name = monster_name(creature, m_idx);
     const auto t_name = monster_name(creature, t_idx);
 
@@ -210,7 +210,7 @@ MonsterSpellResult spell_RF5_MIND_BLAST(CreatureEntity &creature, POSITION y, PO
 MonsterSpellResult spell_RF5_BRAIN_SMASH(CreatureEntity &creature, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
     const auto &monster = creature.get_floor()->get_monster(m_idx);
-    bool seen = (!creature.is_blind() && monster.get_monster_profile().ml);
+    bool seen = (!creature.is_blind() && monster.is_visible_on_map());
     const auto m_name = monster_name(creature, m_idx);
     const auto t_name = monster_name(creature, t_idx);
 
@@ -585,7 +585,7 @@ MonsterSpellResult spell_RF6_HEAL(CreatureEntity &creature, MONSTER_IDX m_idx, M
     auto &monster = floor.get_monster(m_idx);
     DEPTH rlev = monster_level_idx(floor, m_idx);
     const auto is_blind = creature.is_blind();
-    const auto seen = (!is_blind && monster.get_monster_profile().ml);
+    const auto seen = (!is_blind && monster.is_visible_on_map());
     const auto m_poss = monster_desc(creature, monster, MD_PRON_VISIBLE | MD_POSSESSIVE);
 
     msg.to_player_true = _("%s^が何かをつぶやいた。", "%s^ mumbles.");
@@ -643,14 +643,14 @@ MonsterSpellResult spell_RF6_HEAL(CreatureEntity &creature, MONSTER_IDX m_idx, M
 MonsterSpellResult spell_RF6_INVULNER(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
     const auto &monster = creature.get_floor()->get_monster(m_idx);
-    bool seen = (!creature.is_blind() && monster.get_monster_profile().ml);
+    bool seen = (!creature.is_blind() && monster.is_visible_on_map());
     mspell_cast_msg msg(_("%s^が何かを力強くつぶやいた。", "%s^ mumbles powerfully."),
         _("%s^が何かを力強くつぶやいた。", "%s^ mumbles powerfully."), _("%sは無傷の球の呪文を唱えた。", "%s^ casts a Globe of Invulnerability."),
         _("%sは無傷の球の呪文を唱えた。", "%s^ casts a Globe of Invulnerability."));
 
     monspell_message_base(creature, m_idx, t_idx, msg, !seen, target_type);
 
-    if (monster.get_monster_profile().ml) {
+    if (monster.is_visible_on_map()) {
         MonraceId r_idx = monster.r_idx;
         const auto m_name = monster_desc(creature, monster, MD_NONE);
         switch (r_idx) {

--- a/src/mutation/mutation-techniques.cpp
+++ b/src/mutation/mutation-techniques.cpp
@@ -45,7 +45,7 @@ bool eat_rock(CreatureEntity &creature)
     } else if (grid.has_monster()) {
         const auto &monster = creature.get_floor()->get_monster(grid.m_idx);
         msg_print(_("何かが邪魔しています！", "There's something in the way!"));
-        if (!monster.get_monster_profile().ml || !monster.is_pet()) {
+        if (!monster.is_visible_on_map() || !monster.is_pet()) {
             do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
         }
     } else if (terrain.flags.has(TerrainCharacteristics::TREE)) {

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -449,7 +449,7 @@ void ObjectThrowEntity::attack_racial_power()
     }
 
     auto &monster = *this->hit_monster->m_ptr;
-    if (!test_hit_fire(creature, this->chance - this->cur_dis, monster, monster.get_monster_profile().ml, this->o_name)) {
+    if (!test_hit_fire(creature, this->chance - this->cur_dis, monster, monster.is_visible_on_map(), this->o_name)) {
         return;
     }
 
@@ -478,7 +478,7 @@ void ObjectThrowEntity::attack_racial_power()
         anger_monster(creature, monster);
     }
 
-    if (fear && monster.get_monster_profile().ml) {
+    if (fear && monster.is_visible_on_map()) {
         sound(SoundKind::FLEE);
         msg_format(_("%s^は恐怖して逃げ出した！", "%s^ flees in terror!"), this->hit_monster->m_name.data());
     }
@@ -491,7 +491,7 @@ void ObjectThrowEntity::display_attack_racial_power()
         return;
     }
 
-    if (!this->hit_monster->m_ptr->get_monster_profile().ml) {
+    if (!this->hit_monster->m_ptr->is_visible_on_map()) {
         msg_format(_("%sが敵を捕捉した。", "The %s finds a mark."), this->o_name.data());
         return;
     }

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -612,7 +612,7 @@ void massacre(CreatureEntity &creature)
         const auto pos = creature.get_neighbor(d);
         const auto &grid = floor.get_grid(pos);
         const auto &monster = floor.get_monster(grid.m_idx);
-        if (grid.has_monster() && (monster.get_monster_profile().ml || floor.has_terrain_characteristics(pos, TerrainCharacteristics::PROJECTION))) {
+        if (grid.has_monster() && (monster.is_visible_on_map() || floor.has_terrain_characteristics(pos, TerrainCharacteristics::PROJECTION))) {
             do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
         }
     }

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -80,7 +80,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
             return;
         }
 
-        if (!monster.get_monster_profile().ml) {
+        if (!monster.is_visible_on_map()) {
             return;
         }
 

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -425,7 +425,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
                 const auto pos_ddd = pos + d.vec();
                 const auto &grid = floor.get_grid(pos_ddd);
                 const auto &monster = floor.get_monster(grid.m_idx);
-                if (!grid.has_monster() || (!monster.get_monster_profile().ml && !floor.has_terrain_characteristics(pos_ddd, TerrainCharacteristics::PROJECTION))) {
+                if (!grid.has_monster() || (!monster.is_visible_on_map() && !floor.has_terrain_characteristics(pos_ddd, TerrainCharacteristics::PROJECTION))) {
                     continue;
                 }
 

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -294,7 +294,7 @@ void SpellsMirrorMaster::project_seeker_ray(int target_x, int target_y, int dam)
             }
             const auto &grid = floor.grid_array[project_m_y][project_m_x];
             const auto &monster = floor.get_monster(grid.m_idx);
-            if (project_m_n == 1 && grid.has_monster() && monster.get_monster_profile().ml) {
+            if (project_m_n == 1 && grid.has_monster() && monster.is_visible_on_map()) {
                 if (!this->creature_ptr->is_hallucinated()) {
                     tracker.set_trackee(monster.ap_r_idx);
                 }
@@ -394,7 +394,7 @@ static bool activate_super_ray_effect(CreatureEntity &creature, int y, int x, in
     const auto &floor = *creature.get_floor();
     const auto &grid = floor.grid_array[project_m_y][project_m_x];
     const auto &monster = floor.get_monster(grid.m_idx);
-    if (project_m_n == 1 && grid.has_monster() && monster.get_monster_profile().ml) {
+    if (project_m_n == 1 && grid.has_monster() && monster.is_visible_on_map()) {
         if (!creature.is_hallucinated()) {
             LoreTracker::get_instance().set_trackee(monster.ap_r_idx);
         }

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -156,7 +156,7 @@ bool fetch_monster(CreatureEntity &creature)
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
     }
 
-    if (monster.get_monster_profile().ml) {
+    if (monster.is_visible_on_map()) {
         if (!creature.is_hallucinated()) {
             LoreTracker::get_instance().set_trackee(monster.ap_r_idx);
         }

--- a/src/spell-kind/spells-genocide.cpp
+++ b/src/spell-kind/spells-genocide.cpp
@@ -81,7 +81,7 @@ bool genocide_aux(CreatureEntity &creature, MONSTER_IDX m_idx, int power, bool p
 
         if (monster.is_asleep()) {
             (void)set_monster_csleep(*creature.get_floor(), m_idx, 0);
-            if (monster.get_monster_profile().ml) {
+            if (monster.is_visible_on_map()) {
                 msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());
             }
         }

--- a/src/spell-kind/spells-lite.cpp
+++ b/src/spell-kind/spells-lite.cpp
@@ -61,7 +61,7 @@ static void cave_temp_room_lite(CreatureEntity &creature, const std::vector<Pos2
 
             if (monster.is_asleep() && evaluate_percent(chance)) {
                 (void)set_monster_csleep(*creature.get_floor(), grid.m_idx, 0);
-                if (monster.get_monster_profile().ml) {
+                if (monster.is_visible_on_map()) {
                     const auto m_name = monster_desc(creature, monster, 0);
                     msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());
                 }

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -450,7 +450,7 @@ bool probing(CreatureEntity &creature)
         if (!floor.has_los_at({ monster.y, monster.x })) {
             continue;
         }
-        if (!monster.get_monster_profile().ml) {
+        if (!monster.is_visible_on_map()) {
             continue;
         }
 

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -514,7 +514,7 @@ void teleport_away_followable(CreatureEntity &creature, MONSTER_IDX m_idx)
     const auto &floor = *creature.get_floor();
     const auto &monster = floor.get_monster(m_idx);
     const auto old_m_pos = monster.get_position();
-    bool old_ml = monster.get_monster_profile().ml;
+    bool old_ml = monster.is_visible_on_map();
     const auto old_cdis = Grid::calc_distance(creature.get_position(), old_m_pos);
 
     teleport_away(creature, m_idx, MAX_PLAYER_SIGHT * 2 + 5, TELEPORT_SPONTANEOUS);

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -143,7 +143,7 @@ bool vanish_dungeon(CreatureEntity &creature)
         const auto &monster = floor.get_monster(grid.m_idx);
         if (grid.has_monster() && monster.is_asleep()) {
             (void)set_monster_csleep(floor, grid.m_idx, 0);
-            if (monster.get_monster_profile().ml) {
+            if (monster.is_visible_on_map()) {
                 const auto m_name = monster_desc(creature, monster, 0);
                 msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());
             }

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -954,7 +954,7 @@ std::string CreatureEntity::build_damage_description() const
 
     const auto is_living = this->has_living_flag(true);
     const auto damage_ratio = this->maxhp > 0 ? 100L * this->hp / this->maxhp : 0;
-    if (!this->get_monster_profile().ml) {
+    if (!this->is_visible_on_map()) {
         return _("損傷具合不明", "damage unknown");
     }
 
@@ -1044,7 +1044,7 @@ tl::optional<std::string> CreatureEntity::get_pain_message(std::string_view mons
     }
 
     auto &monrace = this->get_monrace();
-    return MonsterPainDescriber(monrace.idx, monrace.symbol_definition.character, monster_name).describe(this->hp, damage, this->get_monster_profile().ml);
+    return MonsterPainDescriber(monrace.idx, monrace.symbol_definition.character, monster_name).describe(this->hp, damage, this->is_visible_on_map());
 }
 
 byte CreatureEntity::get_temporary_speed() const

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -776,6 +776,30 @@ public:
     }
 
     /*!
+     * @brief クリーチャーがマップ上で視認可能（プレイヤーから見える）かどうかを判定
+     * @return 視認可能ならtrue
+     * @details モンスターは MonsterProfile::ml の値、プレイヤーや MonsterProfile を
+     *          持たないクリーチャーは false（プレイヤー自身を「視認対象」として
+     *          扱わないことで既存の `is_seen()` 等の意味論を維持）
+     */
+    virtual bool is_visible_on_map() const
+    {
+        return this->has_monster_profile() && this->get_monster_profile().ml;
+    }
+
+    /*!
+     * @brief クリーチャーのマップ上視認状態を設定する
+     * @param value 視認状態
+     * @details モンスターのみ意味を持つ。プレイヤーには無効。
+     */
+    virtual void set_visible_on_map(bool value)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().ml = value;
+        }
+    }
+
+    /*!
      * @brief クリーチャーがフレンドリー状態かどうかを判定
      * @return フレンドリーならtrue、デフォルトはfalse（プレイヤーはフレンドリー判定対象外）
      */

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -286,7 +286,7 @@ static bool within_char_util(const short input)
 
 static short describe_grid(CreatureEntity &creature, GridExamination *ge_ptr)
 {
-    if (!ge_ptr->g_ptr->has_monster() || !creature.get_floor()->get_monster(ge_ptr->g_ptr->m_idx).get_monster_profile().ml) {
+    if (!ge_ptr->g_ptr->has_monster() || !creature.get_floor()->get_monster(ge_ptr->g_ptr->m_idx).is_visible_on_map()) {
         return CONTINUOUS_DESCRIPTION;
     }
 

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -42,7 +42,7 @@ bool target_able(CreatureEntity &creature, MONSTER_IDX m_idx)
         return false;
     }
 
-    if (!monster.get_monster_profile().ml) {
+    if (!monster.is_visible_on_map()) {
         return false;
     }
 
@@ -79,7 +79,7 @@ static bool target_set_accept(CreatureEntity &creature, const Pos2D &pos)
     const auto &grid = floor.get_grid(pos);
     if (grid.has_monster()) {
         auto &monster = floor.get_monster(grid.m_idx);
-        if (monster.get_monster_profile().ml) {
+        if (monster.is_visible_on_map()) {
             return true;
         }
     }
@@ -179,7 +179,7 @@ void target_sensing_monsters_prepare(CreatureEntity &creature, std::vector<MONST
 
     for (MONSTER_IDX i = 1; i < creature.get_floor()->m_max; i++) {
         const auto &monster = creature.get_floor()->m_list[i];
-        if (!monster.is_valid() || !monster.get_monster_profile().ml || monster.is_pet()) {
+        if (!monster.is_valid() || !monster.is_visible_on_map() || monster.is_pet()) {
             continue;
         }
 

--- a/src/target/target-sorter.cpp
+++ b/src/target/target-sorter.cpp
@@ -39,8 +39,8 @@ bool TargetSorter::compare_importance(const FloorType &floor, const Pos2D &pos_a
         return false;
     }
 
-    const auto can_see_grid1 = grid1.has_monster() && monster_a.get_monster_profile().ml;
-    const auto can_see_grid2 = grid2.has_monster() && monster_b.get_monster_profile().ml;
+    const auto can_see_grid1 = grid1.has_monster() && monster_a.is_visible_on_map();
+    const auto can_see_grid2 = grid2.has_monster() && monster_b.is_visible_on_map();
     if (can_see_grid1 && !can_see_grid2) {
         return true;
     }

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -255,7 +255,7 @@ DisplaySymbolPair map_info(CreatureEntity &creature, const Pos2D &pos)
     }
 
     const auto &monster = floor.get_monster(grid.m_idx);
-    if (!monster.get_monster_profile().ml) {
+    if (!monster.is_visible_on_map()) {
         symbol_pair.symbol_foreground = set_term_color(creature, pos, symbol_pair.symbol_foreground);
         return symbol_pair;
     }

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -222,7 +222,7 @@ static void print_pet_list_oneline(CreatureEntity &creature, const CreatureEntit
     const auto &monrace = monster.get_appearance_monrace();
     const auto name = monster_desc(creature, monster, MD_ASSUME_VISIBLE | MD_INDEF_VISIBLE | MD_NO_OWNER);
     const auto &[bar_color, bar_len] = monster.get_hp_bar_data();
-    const auto is_visible = monster.get_monster_profile().ml && !creature.is_hallucinated();
+    const auto is_visible = monster.is_visible_on_map() && !creature.is_hallucinated();
 
     term_erase(0, y);
     if (is_visible) {
@@ -535,7 +535,7 @@ static bool is_seeing_monster_on(const FloorType &floor, const Grid &grid)
     }
 
     const auto &monster = floor.get_monster(grid.m_idx);
-    return monster.is_valid() && monster.get_monster_profile().ml;
+    return monster.is_valid() && monster.is_visible_on_map();
 }
 
 /*!

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -405,7 +405,7 @@ void print_health(CreatureEntity &creature, bool riding)
 
     const auto &monster = creature.get_floor()->get_monster(monster_idx.value());
 
-    if ((!monster.get_monster_profile().ml) || (creature.is_hallucinated()) || monster.is_dead()) {
+    if ((!monster.is_visible_on_map()) || (creature.is_hallucinated()) || monster.is_dead()) {
         term_putstr(col, row, max_width, TERM_WHITE, "[----------]");
         return;
     }


### PR DESCRIPTION
ロードマップ提案 7 を実装。MonsterProfile::ml (bool) はプレイヤーから
モンスターを視認できるかを保持するが、これまでは全コードベース 119 箇所で
`monster.get_monster_profile().ml` の直接アクセスを行っていた。
MonsterProfile を持たないプレイヤー側でこのアクセサを呼ぶと
tl::optional の dereference でクラッシュするため、呼び側で
has_monster_profile() ガードや ternary フォールバックを書く必要があり、 ガード忘れによる null dereference リスクが恒常的に存在した。

変更内容:
- CreatureEntity に virtual `is_visible_on_map()` を追加 (デフォルト実装: monster_profile があれば ml、なければ false)
- CreatureEntity に virtual `set_visible_on_map(bool)` を追加 (デフォルト実装: monster_profile があれば書込み、なければ no-op)
- 既存呼び側を sed 一括移行: 読取り 113 / 書込み 6 / 43 ファイル 対応で、`is_visible_on_map()` / `set_visible_on_map(...)` 形式へ
- `is_seen()` (floor/geometry.cpp) と `is_original_ap_and_seen()` (monster/monster-info.cpp) の has_monster_profile() ガードは virtual 内部で吸収されるため削除

効果:
- 119 箇所の直接アクセスを virtual 経由に集約
- ガード忘れ・null dereference リスクの恒久的排除
- 将来モンスターに「視認状態」概念を追加するときの拡張ポイント確保

ビルド・スモークテスト確認:
- フルビルド (exit 0, 警告なし)
- ./src/hengband --output-spoilers (exit 0)