### PR TITLE
refactor: HP/MP 自然回復計算を virtual hook 化 (提案 8)

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -320,6 +320,42 @@ Phase 2 で主要な `is_xxx()` 系は仮想化済みだが、以下はまだ自
 
 ---
 
+## 提案 8: HP/MP 自然回復計算の virtual hook 化 ✅ 完了
+
+### 背景
+
+`compute_regen_amount(CreatureEntity &)` 内に `if (creature.is_player())`
+分岐が 4 箇所あり、満腹度・スタンス・呪い・ミュータント体質のプレイヤー
+固有処理が直書きされていた。モンスター回復計算 `regenerate_monsters()`
+からも同関数が呼ばれており、is_player() ガードで適切にスキップされていたが、
+将来モンスターに同等の概念を持たせる際の拡張点が定義されていなかった。
+
+### 作業内容
+
+`CreatureEntity` に 4 つの virtual hook を追加:
+
+| 仮想関数 | 役割 | デフォルト | PlayerType override |
+|---|---|---|---|
+| `should_skip_natural_regen()` | 完全停止判定 | false | KOUKIJIN 構え or HAYAGAKE 行動なら true |
+| `get_base_natural_regen_amount()` | ベース量取得 | `PY_REGEN_NORMAL` | 満腹度に応じて NORMAL/WEAK/FAINT/0 |
+| `apply_state_regen_modifier(int)` | 構え・呪い補正 | identity | 僧/侍構え `/2`、SLOW_REGEN 呪い `/5` |
+| `apply_creature_specific_regen_modifier(int)` | 最終固有補正 | identity | `mutant_regenerate_mod` 適用 |
+
+### 効果
+
+- `compute_regen_amount()` から `is_player()` 分岐 4 箇所を排除
+- プレイヤー固有処理が `PlayerType` 内に集約され、モンスターの hook 上書きで
+  個体差・種族別回復補正を導入できる下地が整備
+- 関数本体はベース量算出 → 状態補正 → 行動/地形補正 → 最終補正の流れが
+  読み取りやすくなる
+
+### 計算結果の同等性
+
+各 virtual のデフォルト・override 順序は元の is_player ガード順を保持しているため、
+プレイヤー・モンスターの数値結果は完全一致 (回帰なし)。
+
+---
+
 ## 提案 7: モンスター可視判定 (`ml`) の virtual アクセサ化 ✅ 完了
 
 ### 背景

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -17,6 +17,7 @@
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
+#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "system/terrain/terrain-definition.h"
 #include "tracking/health-bar-tracker.h"
@@ -28,38 +29,21 @@ int wild_regen = 20;
  * @brief 共通の自然回復量を算出する。プレイヤー基準の計算に揃え、モンスターでも同形で
  *        評価できる係数 (regen_amount) を返す。
  *
- * - PY_REGEN_NORMAL を起点に、満腹度・スタンス・呪い・ミュータント体質などの
- *   プレイヤー固有要因は is_player() ガードで適用する。
- * - 再生種族フラグ (regen)・毒・切り傷・行動 (search/rest)・地形衛生は
- *   モンスターでも同等のロジックで適用される。
+ * - 構え・行動による完全停止判定は should_skip_natural_regen() (virtual)
+ * - ベース回復量は get_base_natural_regen_amount() (virtual)。プレイヤーは満腹度に応じた値を返す
+ * - 構え・呪いによる減衰は apply_state_regen_modifier() (virtual)
+ * - ミュータント体質等のクリーチャー固有要因は apply_creature_specific_regen_modifier() (virtual)
+ * - 毒・切り傷・再生種族フラグ・行動 (search/rest)・地形衛生はプレイヤー・モンスター共通で適用
  * - regenhp() / regenmana() / 表示用 calculate_*_regen_rate() で同じ値を使うことで
  *   プレイヤー・モンスター・c画面表示を一貫させる。
  */
 int compute_regen_amount(CreatureEntity &creature)
 {
-    if (creature.is_player()) {
-        CreatureClass pc(creature);
-        if (pc.samurai_stance_is(SamuraiStanceType::KOUKIJIN)) {
-            return 0;
-        }
-        if (creature.action == ACTION_HAYAGAKE) {
-            return 0;
-        }
+    if (creature.should_skip_natural_regen()) {
+        return 0;
     }
 
-    int regen_amount = PY_REGEN_NORMAL;
-
-    if (creature.is_player()) {
-        if (creature.food < PY_FOOD_WEAK) {
-            if (creature.food < PY_FOOD_STARVE) {
-                regen_amount = 0;
-            } else if (creature.food < PY_FOOD_FAINT) {
-                regen_amount = PY_REGEN_FAINT;
-            } else {
-                regen_amount = PY_REGEN_WEAK;
-            }
-        }
-    }
+    int regen_amount = creature.get_base_natural_regen_amount();
 
     if (creature.is_poisoned() || creature.is_cut()) {
         regen_amount = 0;
@@ -69,15 +53,7 @@ int compute_regen_amount(CreatureEntity &creature)
         regen_amount = regen_amount * 2;
     }
 
-    if (creature.is_player()) {
-        CreatureClass pc(creature);
-        if (!pc.monk_stance_is(MonkStanceType::NONE) || !pc.samurai_stance_is(SamuraiStanceType::NONE)) {
-            regen_amount /= 2;
-        }
-        if (creature.get_cursed_flags().has(CurseTraitType::SLOW_REGEN)) {
-            regen_amount /= 5;
-        }
-    }
+    regen_amount = creature.apply_state_regen_modifier(regen_amount);
 
     if ((creature.action == ACTION_SEARCH) || (creature.action == ACTION_REST)) {
         regen_amount = regen_amount * 2;
@@ -93,11 +69,47 @@ int compute_regen_amount(CreatureEntity &creature)
         }
     }
 
-    if (creature.is_player()) {
-        regen_amount = (regen_amount * creature.mutant_regenerate_mod) / 100;
-    }
+    return creature.apply_creature_specific_regen_modifier(regen_amount);
+}
 
-    return regen_amount;
+bool PlayerType::should_skip_natural_regen() const
+{
+    CreatureClass pc(const_cast<PlayerType &>(*this));
+    if (pc.samurai_stance_is(SamuraiStanceType::KOUKIJIN)) {
+        return true;
+    }
+    return this->action == ACTION_HAYAGAKE;
+}
+
+int PlayerType::get_base_natural_regen_amount() const
+{
+    if (this->food >= PY_FOOD_WEAK) {
+        return PY_REGEN_NORMAL;
+    }
+    if (this->food < PY_FOOD_STARVE) {
+        return 0;
+    }
+    if (this->food < PY_FOOD_FAINT) {
+        return PY_REGEN_FAINT;
+    }
+    return PY_REGEN_WEAK;
+}
+
+int PlayerType::apply_state_regen_modifier(int amount) const
+{
+    CreatureClass pc(const_cast<PlayerType &>(*this));
+    if (!pc.monk_stance_is(MonkStanceType::NONE) || !pc.samurai_stance_is(SamuraiStanceType::NONE)) {
+        amount /= 2;
+    }
+    if (this->get_cursed_flags().has(CurseTraitType::SLOW_REGEN)) {
+        amount /= 5;
+    }
+    return amount;
+}
+
+int PlayerType::apply_creature_specific_regen_modifier(int amount) const
+{
+    return (amount * this->mutant_regenerate_mod) / 100;
 }
 
 /*!

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -2,6 +2,7 @@
 #include "core/speed-table.h"
 #include "floor/geometry.h"
 #include "game-option/birth-options.h"
+#include "hpmp/hp-mp-regenerator.h"
 #include "inventory/inventory-slot-types.h"
 #include "market/arena-entry.h"
 #include "mind/mind-elementalist.h"
@@ -588,6 +589,11 @@ void CreatureEntity::set_timed_effect(CreatureTimedEffect effect, short value)
         }
     }
     this->timed_effects_map[effect] = value;
+}
+
+int CreatureEntity::get_base_natural_regen_amount() const
+{
+    return PY_REGEN_NORMAL;
 }
 
 void CreatureEntity::make_lore_treasure(int num_item, int num_gold) const

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -501,6 +501,45 @@ public:
      */
     virtual void set_timed_effect(CreatureTimedEffect effect, short value);
 
+    /*!
+     * @brief 自然回復をスキップすべき状態か（侍 KOUKIJIN 構え・早駆け中等）を判定
+     * @return スキップすべきなら true。デフォルトは false（モンスターは常に回復対象）
+     * @details PlayerType でオーバーライドし、KOUKIJIN 構え・HAYAGAKE 行動を判定する
+     */
+    virtual bool should_skip_natural_regen() const
+    {
+        return false;
+    }
+
+    /*!
+     * @brief 自然回復ベース量を取得（満腹度等の影響を反映）
+     * @return ベース回復量。デフォルトは PY_REGEN_NORMAL
+     * @details PlayerType でオーバーライドし、PY_FOOD_WEAK / FAINT / STARVE による減衰を適用する
+     */
+    virtual int get_base_natural_regen_amount() const;
+
+    /*!
+     * @brief 構え・呪いによる回復量補正を適用
+     * @param amount 補正前の回復量
+     * @return 補正後の回復量。デフォルトは引数をそのまま返す
+     * @details PlayerType でオーバーライドし、僧/侍構え・SLOW_REGEN 呪いによる減衰を適用する
+     */
+    virtual int apply_state_regen_modifier(int amount) const
+    {
+        return amount;
+    }
+
+    /*!
+     * @brief クリーチャー固有要因による最終回復量補正を適用
+     * @param amount 補正前の回復量
+     * @return 補正後の回復量。デフォルトは引数をそのまま返す
+     * @details PlayerType でオーバーライドし、ミュータント体質 (mutant_regenerate_mod) による補正を適用する
+     */
+    virtual int apply_creature_specific_regen_modifier(int amount) const
+    {
+        return amount;
+    }
+
     short get_remaining_sleep() const
     {
         return this->get_timed_effect(CreatureTimedEffect::SLEEP_OR_PARALYSIS);

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -16,6 +16,11 @@ public:
     void on_death(std::string_view cause) override;
     bool calc_damage_reduction(int &damage, int damage_type) override;
 
+    bool should_skip_natural_regen() const override;
+    int get_base_natural_regen_amount() const override;
+    int apply_state_regen_modifier(int amount) const override;
+    int apply_creature_specific_regen_modifier(int amount) const override;
+
     void wipe() override;
 
     /*!


### PR DESCRIPTION
ロードマップ提案 8 を実装。compute_regen_amount() 内の
is_player() ガード分岐 4 箇所を CreatureEntity 上の virtual hook に 集約し、満腹度・スタンス・呪い・ミュータント体質のプレイヤー固有
処理を PlayerType 側 override にまとめる。

追加 virtual:
- should_skip_natural_regen()       : 完全停止判定 (KOUKIJIN/HAYAGAKE)
- get_base_natural_regen_amount()   : 満腹度反映ベース量
- apply_state_regen_modifier(int)   : 構え/呪い補正
- apply_creature_specific_regen_modifier(int) : ミュータント体質等

デフォルト実装はモンスター意味論 (素通し) に揃え、PlayerType で
従来のプレイヤー固有処理を override で再現。各補正の適用順序は
元コードを保持しているため数値結果は完全一致 (回帰なし)。

効果:
- compute_regen_amount() から is_player() 分岐 4 箇所を排除
- プレイヤー固有処理を PlayerType 内に集約し可読性向上
- 将来モンスターの個体差・種族別回復補正を hook 上書きで導入できる

ビルド・スモークテスト確認:
- フルビルド (exit 0, 警告なし)
- ./src/hengband --output-spoilers (exit 0)

ロードマップ更新: 提案 8 ✅ 完了