### PR TITLE
refactor: MonsterProfile 主要フィールドを virtual アクセサに集約 (提案 9 一部完了)

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -320,6 +320,51 @@ Phase 2 で主要な `is_xxx()` 系は仮想化済みだが、以下はまだ自
 
 ---
 
+## 提案 9: MonsterProfile フィールド virtual アクセサ化 ✅ 一部完了
+
+### 背景
+
+`MonsterProfile` の主要フィールド (alliance_idx / sub_align /
+parent_m_idx / smart / hold_o_idx_list) はそれぞれ十数件以上の
+直アクセスを持ち、プレイヤー側 (MonsterProfile を持たない) から
+呼ぶと tl::optional dereference でクラッシュする問題を抱えていた。
+提案 7 (ml) と同様の方針で virtual アクセサに集約する。
+
+### 作業内容
+
+`CreatureEntity` に 5 つの virtual アクセサを追加 (read-only):
+
+| 仮想関数 | 役割 | プレイヤー側デフォルト |
+|---|---|---|
+| `get_alliance_idx()` | アライアンス所属 | `AllianceType::NONE` |
+| `get_sub_align()` | サブアライメント | `SUB_ALIGN_NEUTRAL` |
+| `get_parent_m_idx()` | 召喚親モンスター | `0` |
+| `get_smart_flags()` | smart_learn フラグ群 (const ref) | 空フラグ集合 |
+| `get_held_objects()` | 保持アイテム ObjectIndexList (const ref) | 空リスト |
+
+### 移行結果
+
+- 読取り 54 箇所を新 virtual 経由に置換
+- 書込み・破壊的メソッド呼出 (set/reset/clear/add/pop_front 等) 58 箇所は
+  従来通り `monster.get_monster_profile().X` 形式で残置
+  (将来 setter virtual を整備する余地)
+
+### 効果
+
+- プレイヤー側で誤って呼んだ際の null dereference リスクを排除
+- `if (creature.has_monster_profile())` ガード忘れによるバグを防止
+- 提案 7 と同パターンで一貫性のある拡張
+
+### 残作業
+
+- mflag (227 箇所) の virtual 化は粒度を細かく (is_chameleon / is_kage 等
+  個別 virtual) して別バッチで進めると衝突を抑えられる
+- 書込み側 setter virtual の整備は call site が多様な mutation
+  (set/reset/clear/pop/push) を行うため、virtual 経由で全て表現すると
+  抽象コストが大きい。優先度低として保留
+
+---
+
 ## 提案 8: HP/MP 自然回復計算の virtual hook 化 ✅ 完了
 
 ### 背景

--- a/src/alliance/alliance.cpp
+++ b/src/alliance/alliance.cpp
@@ -267,7 +267,7 @@ bool Alliance::is_hostile_to(const CreatureEntity &creature_other, const Monrace
     if (monrace.kind_flags.has(MonsterKindType::GOOD)) {
         sub_align2 |= SUB_ALIGN_GOOD;
     }
-    const auto sub_align1 = creature_other.has_monster_profile() ? creature_other.get_monster_profile().sub_align : static_cast<BIT_FLAGS8>(SUB_ALIGN_NEUTRAL);
+    const auto sub_align1 = creature_other.has_monster_profile() ? creature_other.get_sub_align() : static_cast<BIT_FLAGS8>(SUB_ALIGN_NEUTRAL);
     return CreatureEntity::check_sub_alignments(sub_align1, sub_align2);
 }
 

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -135,7 +135,7 @@ static void preserve_pet(CreatureEntity &creature)
     record_pet_diary(creature);
     for (MONSTER_IDX i = creature.get_floor()->m_max - 1; i >= 1; i--) {
         const auto &monster = creature.get_floor()->m_list[i];
-        const auto parent_r_idx = creature.get_floor()->m_list[monster.get_monster_profile().parent_m_idx].r_idx;
+        const auto parent_r_idx = creature.get_floor()->m_list[monster.get_parent_m_idx()].r_idx;
         if (!monster.has_parent() || MonraceList::is_valid(parent_r_idx)) {
             continue;
         }

--- a/src/monster-attack/monster-attack-processor.cpp
+++ b/src/monster-attack/monster-attack-processor.cpp
@@ -132,7 +132,7 @@ bool process_monster_attack_to_monster(CreatureEntity &creature, turn_flags *tur
     do_kill_body &= !monster_to.is_riding();
     const bool is_same_alliance_intelligent = (monrace_from.alliance_idx != AllianceType::NONE && monrace_from.alliance_idx == monrace_to.alliance_idx && monrace_from.behavior_flags.has_not(MonsterBehaviorType::STUPID));
     do_kill_body &= !is_same_alliance_intelligent;
-    const bool is_same_summon_parent = (monster_from.get_monster_profile().parent_m_idx == monster_to.get_monster_profile().parent_m_idx && monrace_from.behavior_flags.has_not(MonsterBehaviorType::STUPID)) || (monster_from.get_monster_profile().mflag2.has(MonsterConstantFlagType::PET) != monster_to.get_monster_profile().mflag2.has(MonsterConstantFlagType::PET));
+    const bool is_same_summon_parent = (monster_from.get_parent_m_idx() == monster_to.get_parent_m_idx() && monrace_from.behavior_flags.has_not(MonsterBehaviorType::STUPID)) || (monster_from.get_monster_profile().mflag2.has(MonsterConstantFlagType::PET) != monster_to.get_monster_profile().mflag2.has(MonsterConstantFlagType::PET));
     do_kill_body &= !is_same_summon_parent;
     if (do_kill_body || monster_from.is_hostile_to_melee(monster_to) || monster_from.is_confused()) {
         return exe_monster_attack_to_monster(creature, m_idx, grid);

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -78,7 +78,7 @@ void delete_monster_idx(CreatureEntity &creature, short m_idx)
     // 召喚されたモンスター自身のm_idxを指すようにする
     for (MONSTER_IDX child_m_idx = 1; child_m_idx < floor.m_max; child_m_idx++) {
         auto &child_monster = floor.get_monster(child_m_idx);
-        if (child_monster.is_valid() && child_monster.get_monster_profile().parent_m_idx == m_idx) {
+        if (child_monster.is_valid() && child_monster.get_parent_m_idx() == m_idx) {
             child_monster.get_monster_profile().parent_m_idx = child_m_idx;
         }
     }

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -380,7 +380,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     }
 
     if (m_ptr->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::CHAMELEON) && is_summoned && new_monrace.kind_flags.has_none_of(alignment_mask)) {
-        m_ptr->get_monster_profile().sub_align = summoner.get_monster_profile().sub_align;
+        m_ptr->get_monster_profile().sub_align = summoner.get_sub_align();
     } else if (m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::CHAMELEON) && new_monrace.kind_flags.has(MonsterKindType::UNIQUE) && !is_summoned) {
         m_ptr->get_monster_profile().sub_align = SUB_ALIGN_NEUTRAL;
     } else {
@@ -471,8 +471,8 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
         should_be_friendly |= any_bits(mode, PM_FORCE_FRIENDLY);
         auto force_hostile = monster_has_hostile_to_player(player, 0, -1, new_monrace);
         force_hostile |= floor.inside_arena;
-        if (m_ptr->get_monster_profile().alliance_idx != AllianceType::NONE) {
-            should_be_friendly |= alliance_list.at(m_ptr->get_monster_profile().alliance_idx)->isFriendly(player);
+        if (m_ptr->get_alliance_idx() != AllianceType::NONE) {
+            should_be_friendly |= alliance_list.at(m_ptr->get_alliance_idx())->isFriendly(player);
         }
         if (should_be_friendly && !force_hostile) {
             m_ptr->set_friendly();

--- a/src/monster/monster-compaction.cpp
+++ b/src/monster/monster-compaction.cpp
@@ -37,7 +37,7 @@ static void compact_monsters_aux(CreatureEntity &creature, MONSTER_IDX i1, MONST
     auto &grid = floor.grid_array[y][x];
     grid.m_idx = i2;
 
-    for (const auto this_o_idx : monster.get_monster_profile().hold_o_idx_list) {
+    for (const auto this_o_idx : monster.get_held_objects()) {
         ItemEntity *o_ptr;
         o_ptr = floor.o_list[this_o_idx].get();
         o_ptr->held_m_idx = i2;
@@ -67,7 +67,7 @@ static void compact_monsters_aux(CreatureEntity &creature, MONSTER_IDX i1, MONST
         for (int i = 1; i < floor.m_max; i++) {
             CreatureEntity *m2_ptr = &floor.get_monster(static_cast<MONSTER_IDX>(i));
 
-            if (m2_ptr->get_monster_profile().parent_m_idx == i1) {
+            if (m2_ptr->get_parent_m_idx() == i1) {
                 m2_ptr->get_monster_profile().parent_m_idx = i2;
             }
         }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -599,7 +599,7 @@ bool MonsterDamageProcessor::check_and_process_hp_transform()
     // 変身前の情報を保存
     const auto old_hp = monster.hp;
     const auto old_maxhp = monster.max_maxhp;
-    const auto old_sub_align = monster.get_monster_profile().sub_align;
+    const auto old_sub_align = monster.get_sub_align();
     const auto old_name = monster_desc(creature, monster, MD_INDEF_VISIBLE);
 
     // 種族カウンターの更新

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -245,11 +245,11 @@ std::string monster_desc(CreatureEntity &subject, const CreatureEntity &monster,
     const auto name = get_describing_monster_name(monster, is_hallucinated, mode);
     std::stringstream ss;
 
-    if (monster.get_monster_profile().parent_m_idx > 0) {
-        const auto &parent_monster = subject.get_floor()->get_monster(monster.get_monster_profile().parent_m_idx);
+    if (monster.get_parent_m_idx() > 0) {
+        const auto &parent_monster = subject.get_floor()->get_monster(monster.get_parent_m_idx());
         // 親ID＝自身のIDでは主を失った状態なのでスキップ
         if (parent_monster.r_idx != monster.r_idx) {
-            auto parent_name = subject.get_floor()->get_monster(monster.get_monster_profile().parent_m_idx).get_monrace().name;
+            auto parent_name = subject.get_floor()->get_monster(monster.get_parent_m_idx()).get_monrace().name;
             if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::QUYLTHLUG_BORN)) {
                 ss << parent_name << _("が産んだ", "-born ");
             } else if (monrace.misc_flags.has(MonsterMiscType::BREAK_DOWN)) {

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -381,7 +381,7 @@ bool vanish_summoned_children(CreatureEntity &creature, MONSTER_IDX m_idx, bool 
     }
 
     // parent_m_idxが自分自身を指している場合は召喚主は消滅している
-    if (monster.get_monster_profile().parent_m_idx != m_idx && floor.get_monster(monster.get_monster_profile().parent_m_idx).is_valid()) {
+    if (monster.get_parent_m_idx() != m_idx && floor.get_monster(monster.get_parent_m_idx()).is_valid()) {
         return false;
     }
 

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -378,7 +378,7 @@ void monster_gain_exp(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId mon
 
     const auto old_hp = monster.hp;
     const auto old_maxhp = monster.max_maxhp;
-    const auto old_sub_align = monster.get_monster_profile().sub_align;
+    const auto old_sub_align = monster.get_sub_align();
 
     /* Hack -- Reduce the racial counter of previous monster */
     monster.get_real_monrace().decrement_current_numbers();

--- a/src/mspell/improper-mspell-remover.cpp
+++ b/src/mspell/improper-mspell-remover.cpp
@@ -45,7 +45,7 @@ void remove_bad_spells(MONSTER_IDX m_idx, CreatureEntity &creature, EnumClassFla
             monster.get_monster_profile().smart.clear();
         }
 
-        msr_ptr->smart_flags = monster.get_monster_profile().smart;
+        msr_ptr->smart_flags = monster.get_smart_flags();
     }
 
     add_cheat_remove_flags(creature, msr_ptr);

--- a/src/mspell/mspell-summon.cpp
+++ b/src/mspell/mspell-summon.cpp
@@ -1153,9 +1153,9 @@ MonsterSpellResult spell_RF6_S_UNIQUE(CreatureEntity &creature, POSITION y, POSI
     }
 
     summon_type non_unique_type = SUMMON_HI_UNDEAD;
-    if ((monster.get_monster_profile().sub_align & (SUB_ALIGN_GOOD | SUB_ALIGN_EVIL)) == (SUB_ALIGN_GOOD | SUB_ALIGN_EVIL)) {
+    if ((monster.get_sub_align() & (SUB_ALIGN_GOOD | SUB_ALIGN_EVIL)) == (SUB_ALIGN_GOOD | SUB_ALIGN_EVIL)) {
         non_unique_type = SUMMON_NONE;
-    } else if (monster.get_monster_profile().sub_align & SUB_ALIGN_GOOD) {
+    } else if (monster.get_sub_align() & SUB_ALIGN_GOOD) {
         non_unique_type = SUMMON_ANGEL;
     }
 

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -255,7 +255,7 @@ static void attack_golden_hammer(CreatureEntity &creature, player_attack_type *p
 {
     auto &floor = *creature.get_floor();
     auto &monster = floor.get_monster(pa_ptr->m_idx);
-    if (monster.get_monster_profile().hold_o_idx_list.empty()) {
+    if (monster.get_held_objects().empty()) {
         return;
     }
 

--- a/src/save/monster-writer.cpp
+++ b/src/save/monster-writer.cpp
@@ -22,7 +22,7 @@ void MonsterWriter::write_to_savedata() const
     const auto flags = this->write_monster_flags();
 
     wr_s16b(enum2i(this->monster.r_idx));
-    wr_s32b(enum2i(this->monster.get_monster_profile().alliance_idx));
+    wr_s32b(enum2i(this->monster.get_alliance_idx()));
 
     wr_byte((byte)this->monster.y);
     wr_byte((byte)this->monster.x);
@@ -36,7 +36,7 @@ void MonsterWriter::write_to_savedata() const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN)) {
-        wr_byte(this->monster.get_monster_profile().sub_align);
+        wr_byte(this->monster.get_sub_align());
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::SLEEP)) {
@@ -56,7 +56,7 @@ uint32_t MonsterWriter::write_monster_flags() const
         set_bits(flags, SaveDataMonsterFlagType::AP_R_IDX);
     }
 
-    if (this->monster.get_monster_profile().sub_align) {
+    if (this->monster.get_sub_align()) {
         set_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN);
     }
 
@@ -96,7 +96,7 @@ uint32_t MonsterWriter::write_monster_flags() const
         set_bits(flags, SaveDataMonsterFlagType::INVULNER);
     }
 
-    if (this->monster.get_monster_profile().smart.any()) {
+    if (this->monster.get_smart_flags().any()) {
         set_bits(flags, SaveDataMonsterFlagType::SMART);
     }
 
@@ -194,7 +194,7 @@ void MonsterWriter::write_monster_info(uint32_t flags) const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::SMART)) {
-        wr_FlagGroup(this->monster.get_monster_profile().smart, wr_byte);
+        wr_FlagGroup(this->monster.get_smart_flags(), wr_byte);
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::EXP)) {
@@ -210,7 +210,7 @@ void MonsterWriter::write_monster_info(uint32_t flags) const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::PARENT)) {
-        wr_s16b(this->monster.get_monster_profile().parent_m_idx);
+        wr_s16b(this->monster.get_parent_m_idx());
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::GOLD)) {

--- a/src/spell-kind/spells-polymorph.cpp
+++ b/src/spell-kind/spells-polymorph.cpp
@@ -96,7 +96,7 @@ bool polymorph_monster(CreatureEntity &creature, POSITION y, POSITION x)
         return false;
     }
 
-    bool preserve_hold_objects = !back_m.get_monster_profile().hold_o_idx_list.empty();
+    bool preserve_hold_objects = !back_m.get_held_objects().empty();
 
     BIT_FLAGS mode = 0L;
     if (monster.is_friendly()) {
@@ -116,8 +116,8 @@ bool polymorph_monster(CreatureEntity &creature, POSITION y, POSITION x)
     if (m_idx) {
         auto &monster_polymorphed = floor.get_monster(*m_idx);
         monster_polymorphed.name = back_m.name;
-        monster_polymorphed.get_monster_profile().parent_m_idx = back_m.get_monster_profile().parent_m_idx;
-        monster_polymorphed.get_monster_profile().hold_o_idx_list = back_m.get_monster_profile().hold_o_idx_list;
+        monster_polymorphed.get_monster_profile().parent_m_idx = back_m.get_parent_m_idx();
+        monster_polymorphed.get_monster_profile().hold_o_idx_list = back_m.get_held_objects();
         polymorphed = true;
     } else {
         m_idx = place_specific_monster(creature, y, x, old_r_idx, (mode | PM_NO_KAGE | PM_IGNORE_TERRAIN));
@@ -130,7 +130,7 @@ bool polymorph_monster(CreatureEntity &creature, POSITION y, POSITION x)
     }
 
     if (preserve_hold_objects) {
-        for (const auto this_o_idx : back_m.get_monster_profile().hold_o_idx_list) {
+        for (const auto this_o_idx : back_m.get_held_objects()) {
             auto *o_ptr = floor.o_list[this_o_idx].get();
             o_ptr->held_m_idx = *m_idx;
         }

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -389,11 +389,11 @@ std::string probed_monster_info(CreatureEntity &creature, CreatureEntity &target
         align = _("邪悪", "evil");
     } else if (monrace.kind_flags.has(MonsterKindType::GOOD)) {
         align = _("善良", "good");
-    } else if ((target.get_monster_profile().sub_align & (SUB_ALIGN_EVIL | SUB_ALIGN_GOOD)) == (SUB_ALIGN_EVIL | SUB_ALIGN_GOOD)) {
+    } else if ((target.get_sub_align() & (SUB_ALIGN_EVIL | SUB_ALIGN_GOOD)) == (SUB_ALIGN_EVIL | SUB_ALIGN_GOOD)) {
         align = _("中立(善悪)", "neutral(good&evil)");
-    } else if (target.get_monster_profile().sub_align & SUB_ALIGN_EVIL) {
+    } else if (target.get_sub_align() & SUB_ALIGN_EVIL) {
         align = _("中立(邪悪)", "neutral(evil)");
-    } else if (target.get_monster_profile().sub_align & SUB_ALIGN_GOOD) {
+    } else if (target.get_sub_align() & SUB_ALIGN_GOOD) {
         align = _("中立(善良)", "neutral(good)");
     } else {
         align = _("中立", "neutral");

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -634,9 +634,9 @@ bool CreatureEntity::is_hostile_to_melee(const CreatureEntity &other) const
         }
     }
 
-    if (this->get_monster_profile().alliance_idx != other.get_monster_profile().alliance_idx) {
+    if (this->get_alliance_idx() != other.get_alliance_idx()) {
         return true;
-    } else if (this->is_hostile_align(other.get_monster_profile().sub_align)) {
+    } else if (this->is_hostile_align(other.get_sub_align())) {
         if (this->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::CHAMELEON) || other.get_monster_profile().mflag2.has_not(MonsterConstantFlagType::CHAMELEON)) {
             return true;
         }
@@ -650,7 +650,7 @@ bool CreatureEntity::is_hostile_align(byte other_sub_align) const
     if (!this->has_monster_profile()) {
         return false;
     }
-    return CreatureEntity::check_sub_alignments(this->get_monster_profile().sub_align, other_sub_align);
+    return CreatureEntity::check_sub_alignments(this->get_sub_align(), other_sub_align);
 }
 
 bool CreatureEntity::is_mimicry() const
@@ -683,9 +683,9 @@ void CreatureEntity::set_hostile()
 
     this->get_monster_profile().mflag2.reset({ MonsterConstantFlagType::PET, MonsterConstantFlagType::FRIENDLY });
 
-    if (this->get_monster_profile().alliance_idx != AllianceType::NONE) {
+    if (this->get_alliance_idx() != AllianceType::NONE) {
         for (auto &monster : this->get_floor()->m_list) {
-            if (monster.get_monster_profile().alliance_idx == this->get_monster_profile().alliance_idx) {
+            if (monster.get_alliance_idx() == this->get_alliance_idx()) {
                 monster.get_monster_profile().mflag2.reset({ MonsterConstantFlagType::PET, MonsterConstantFlagType::FRIENDLY });
             }
         }
@@ -940,8 +940,8 @@ std::string CreatureEntity::build_looking_description(bool needs_attitude) const
     const std::string clone(this->has_monster_profile() && this->get_monster_profile().mflag2.has(MonsterConstantFlagType::CLONED) ? ", clone" : "");
     const auto &apparent_monrace = this->get_appearance_monrace();
 
-    const bool show_alliance = this->has_monster_profile() && !this->is_pet() && this->get_monster_profile().alliance_idx != AllianceType::NONE;
-    const std::string alliance_part = show_alliance ? format("(%s)", alliance_list.at(this->get_monster_profile().alliance_idx)->name.data()) : "";
+    const bool show_alliance = this->has_monster_profile() && !this->is_pet() && this->get_alliance_idx() != AllianceType::NONE;
+    const std::string alliance_part = show_alliance ? format("(%s)", alliance_list.at(this->get_alliance_idx())->name.data()) : "";
 
     if ((apparent_monrace.r_tkills > 0) && (!this->has_monster_profile() || this->get_monster_profile().mflag2.has_not(MonsterConstantFlagType::KAGE))) {
         constexpr auto fmt = _("レベル%d, %s%s%s%s", "Level %d, %s%s%s%s");

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -839,6 +839,59 @@ public:
     }
 
     /*!
+     * @brief クリーチャーが所属するアライアンスを取得する
+     * @return アライアンス種別。デフォルトは AllianceType::NONE（無所属）
+     */
+    virtual AllianceType get_alliance_idx() const
+    {
+        return this->has_monster_profile() ? this->get_monster_profile().alliance_idx : AllianceType::NONE;
+    }
+
+    /*!
+     * @brief クリーチャーのサブアライメント（中立モンスターが召喚主の影響で一時的に持つ陣営）を取得する
+     * @return サブアライメントフラグ。デフォルトは SUB_ALIGN_NEUTRAL
+     */
+    virtual BIT_FLAGS8 get_sub_align() const
+    {
+        return this->has_monster_profile() ? this->get_monster_profile().sub_align : static_cast<BIT_FLAGS8>(SUB_ALIGN_NEUTRAL);
+    }
+
+    /*!
+     * @brief このクリーチャーを召喚した親モンスターのインデックスを取得する
+     * @return 親モンスター m_idx。召喚されていない（または不明）なら 0
+     */
+    virtual MONSTER_IDX get_parent_m_idx() const
+    {
+        return this->has_monster_profile() ? this->get_monster_profile().parent_m_idx : 0;
+    }
+
+    /*!
+     * @brief プレイヤーに対する学習フラグ（smart_learn）を取得する
+     * @return 学習フラグ群。プレイヤー側は空のフラグ集合を返す
+     */
+    virtual const EnumClassFlagGroup<MonsterSmartLearnType> &get_smart_flags() const
+    {
+        if (this->has_monster_profile()) {
+            return this->get_monster_profile().smart;
+        }
+        static const EnumClassFlagGroup<MonsterSmartLearnType> empty{};
+        return empty;
+    }
+
+    /*!
+     * @brief このクリーチャーが保持しているアイテムリストを取得する
+     * @return 保持アイテム ObjectIndexList。プレイヤー側は空リストを返す
+     */
+    virtual const ObjectIndexList &get_held_objects() const
+    {
+        if (this->has_monster_profile()) {
+            return this->get_monster_profile().hold_o_idx_list;
+        }
+        static const ObjectIndexList empty{};
+        return empty;
+    }
+
+    /*!
      * @brief クリーチャーがフレンドリー状態かどうかを判定
      * @return フレンドリーならtrue、デフォルトはfalse（プレイヤーはフレンドリー判定対象外）
      */

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -254,7 +254,7 @@ static void describe_monster_person(GridExamination *ge_ptr)
 
 static short describe_monster_item(CreatureEntity &creature, GridExamination *ge_ptr)
 {
-    for (const auto this_o_idx : ge_ptr->m_ptr->get_monster_profile().hold_o_idx_list) {
+    for (const auto this_o_idx : ge_ptr->m_ptr->get_held_objects()) {
         const auto &item = *creature.get_floor()->o_list[this_o_idx];
         const auto item_name = describe_flavor(creature, item, 0);
 #ifdef JP


### PR DESCRIPTION
ロードマップ提案 9 の主要部分を実装。MonsterProfile の 5 フィールドに
read-only virtual アクセサを追加し、プレイヤー側からの直接アクセス時の
null dereference リスクを排除する。

追加 virtual (CreatureEntity 上, read-only):
- get_alliance_idx()  : デフォルト AllianceType::NONE
- get_sub_align()     : デフォルト SUB_ALIGN_NEUTRAL
- get_parent_m_idx()  : デフォルト 0
- get_smart_flags()   : デフォルト 空フラグ集合 (const ref)
- get_held_objects()  : デフォルト 空 ObjectIndexList (const ref)

移行結果:
- 読取り 54 箇所を新 virtual 経由に置換
- 書込み・破壊的メソッド呼出 (set/reset/clear/add/pop_front 等) 58 箇所は 従来通り monster.get_monster_profile().X 形式で残置 (mutation を全て virtual 化すると抽象コスト大のため将来検討)

効果:
- プレイヤー側で誤って呼んだ際の null dereference リスクを排除
- `if (creature.has_monster_profile())` ガード忘れによるバグを防止
- 提案 7 (ml) と同パターンで一貫性のある拡張

残作業: mflag (227 箇所) の細粒度 virtual 化、setter virtual 整備 (優先度低として保留)

ビルド・スモークテスト確認:
- フルビルド (exit 0, 警告なし)
- ./src/hengband --output-spoilers (exit 0)

ロードマップ更新: 提案 9 ✅ 一部完了