### PR TITLE
refactor: 配列フィールドに virtual インデックスアクセサを追加 (提案 10 一部完了)

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -320,6 +320,49 @@ Phase 2 で主要な `is_xxx()` 系は仮想化済みだが、以下はまだ自
 
 ---
 
+## 提案 10: 配列フィールド virtual インデックスアクセサ ✅ 一部完了
+
+### 背景
+
+`spell_exp[64]` (固定配列) / `weapon_exp` / `weapon_exp_max` /
+`skill_exp` (`std::map`) はプレイヤーの熟練度システム用フィールドだが
+`CreatureEntity` 直下に存在するため、モンスターからもアクセス可能な
+構造になっている。直アクセスのみで virtual がなく、将来モンスターに
+熟練度概念を導入する際の拡張点が無かった。
+
+### 作業内容
+
+`CreatureEntity` に 3 つの read-only virtual インデックサを追加:
+
+| 仮想関数 | 役割 | デフォルト動作 |
+|---|---|---|
+| `get_spell_exp(int idx)` | 呪文熟練度 | `spell_exp[idx]` を返す |
+| `get_skill_exp(PlayerSkillKindType)` | スキル熟練度 | map に存在すれば値、無ければ 0 |
+| `get_weapon_exp(ItemKindType, int sval)` | 武器熟練度 | map に存在すれば値、無ければ 0 |
+
+### 移行結果
+
+- 読取り 31 箇所 (spell_exp 4, skill_exp 22, weapon_exp 5) を新 virtual 経由に置換
+- 書込み・参照取得 (`auto &exp = ...`)・複合代入 16 箇所は従来通り
+  直接配列アクセス形式で残置 (mutation/reference 取得には virtual が
+  対応できないため)
+
+### 効果
+
+- 読取りパスがプレイヤー・モンスター共通の API を通る
+- 将来モンスターに `get_X_exp()` を override させて種族別/個体別の
+  熟練度ロジックを導入可能
+
+### 残作業
+
+- 書込み setter virtual 整備は呼び出しパターン (集計加算/上限クランプ/
+  `auto &` 経由 in-place 変更) が多様で抽象コストが大きく、優先度低
+  として保留
+- 配列全体走査 (`for (auto &exp : creature.weapon_exp[tval])`) は
+  span 経由の virtual 化も検討余地あり
+
+---
+
 ## 提案 9: MonsterProfile フィールド virtual アクセサ化 ✅ 一部完了
 
 ### 背景

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -441,7 +441,7 @@ bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_opti
     }
 
     if (can_attack_with_main_hand(creature) && can_attack_with_sub_hand(creature)) {
-        if (((creature.skill_exp[PlayerSkillKindType::TWO_WEAPON] - 1000) / 200) < monrace.level) {
+        if (((creature.get_skill_exp(PlayerSkillKindType::TWO_WEAPON) - 1000) / 200) < monrace.level) {
             PlayerSkill(creature).gain_two_weapon_skill_exp();
         }
     }

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -257,7 +257,7 @@ bool do_cmd_riding(CreatureEntity &creature, bool force)
 
             return false;
         }
-        if (monster.get_monrace().level > randint1((creature.skill_exp[PlayerSkillKindType::RIDING] / 50 + creature.level / 2 + 20))) {
+        if (monster.get_monrace().level > randint1((creature.get_skill_exp(PlayerSkillKindType::RIDING) / 50 + creature.level / 2 + 20))) {
             msg_print(_("うまく乗れなかった。", "You failed to ride."));
             PlayerEnergy(creature).set_player_turn_energy(100);
             return false;

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -822,7 +822,7 @@ void do_cmd_study(CreatureEntity &creature)
 
     if (realm_status.is_learned(spell % 32)) {
         auto max_exp = PlayerSkill::spell_exp_at((spell < 32) ? PlayerSkillRank::MASTER : PlayerSkillRank::EXPERT);
-        const auto old_exp = creature.spell_exp[spell];
+        const auto old_exp = creature.get_spell_exp(spell);
         const auto &realm = increment ? pr.realm2() : pr.realm1();
         const auto &spell_name = realm.get_spell_name(spell % 32);
 

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -1125,9 +1125,9 @@ int calc_crit_ratio_shot(CreatureEntity &creature, int plus_ammo, int plus_bow)
     const auto tval = j_ptr->bi_key.tval();
     const auto sval = *j_ptr->bi_key.sval();
     if (creature.tval_ammo == ItemKindType::BOLT) {
-        i = (creature.get_skill_to_hit_bow() + (creature.weapon_exp[tval][sval] / 400 + i) * BTH_PLUS_ADJ);
+        i = (creature.get_skill_to_hit_bow() + (creature.get_weapon_exp(tval, sval) / 400 + i) * BTH_PLUS_ADJ);
     } else {
-        i = (creature.get_skill_to_hit_bow() + ((creature.weapon_exp[tval][sval] - (PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER) / 2)) / 200 + i) * BTH_PLUS_ADJ);
+        i = (creature.get_skill_to_hit_bow() + ((creature.get_weapon_exp(tval, sval) - (PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER) / 2)) / 200 + i) * BTH_PLUS_ADJ);
     }
 
     CreatureClass pc(creature);

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -192,7 +192,7 @@ void process_player(CreatureEntity &creature)
 
         if (monster.is_stunned()) {
             if (set_monster_stunned(*creature.get_floor(), creature.riding,
-                    (randint0(monrace.level) < creature.skill_exp[PlayerSkillKindType::RIDING]) ? 0 : (monster.get_remaining_stun() - 1))) {
+                    (randint0(monrace.level) < creature.get_skill_exp(PlayerSkillKindType::RIDING)) ? 0 : (monster.get_remaining_stun() - 1))) {
                 const auto m_name = monster_desc(creature, monster, 0);
                 msg_format(_("%s^を朦朧状態から立ち直らせた。", "%s^ is no longer stunned."), m_name.data());
             }
@@ -200,7 +200,7 @@ void process_player(CreatureEntity &creature)
 
         if (monster.is_confused()) {
             if (set_monster_confused(*creature.get_floor(), creature.riding,
-                    (randint0(monrace.level) < creature.skill_exp[PlayerSkillKindType::RIDING]) ? 0 : (monster.get_remaining_confusion() - 1))) {
+                    (randint0(monrace.level) < creature.get_skill_exp(PlayerSkillKindType::RIDING)) ? 0 : (monster.get_remaining_confusion() - 1))) {
                 const auto m_name = monster_desc(creature, monster, 0);
                 msg_format(_("%s^を混乱状態から立ち直らせた。", "%s^ is no longer confused."), m_name.data());
             }
@@ -208,7 +208,7 @@ void process_player(CreatureEntity &creature)
 
         if (monster.is_fearful()) {
             if (set_monster_monfear(*creature.get_floor(), creature.riding,
-                    (randint0(monrace.level) < creature.skill_exp[PlayerSkillKindType::RIDING]) ? 0 : (monster.get_remaining_fear() - 1))) {
+                    (randint0(monrace.level) < creature.get_skill_exp(PlayerSkillKindType::RIDING)) ? 0 : (monster.get_remaining_fear() - 1))) {
                 const auto m_name = monster_desc(creature, monster, 0);
                 msg_format(_("%s^を恐怖から立ち直らせた。", "%s^ is no longer fearful."), m_name.data());
             }

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -45,7 +45,7 @@ void do_cmd_knowledge_weapon_exp(CreatureEntity &creature)
                     continue;
                 }
 
-                SUB_EXP weapon_exp = creature.weapon_exp[tval][num];
+                SUB_EXP weapon_exp = creature.get_weapon_exp(tval, num);
                 SUB_EXP weapon_max = creature.weapon_exp_max[tval][num];
                 fprintf(fff, "%-25s ", baseitem.stripped_name().data());
                 if (show_actual_value) {
@@ -94,7 +94,7 @@ void do_cmd_knowledge_spell_exp(CreatureEntity &creature)
             if (spell.slevel >= 99) {
                 continue;
             }
-            SUB_EXP spell_exp = creature.spell_exp[i];
+            SUB_EXP spell_exp = creature.get_spell_exp(i);
             auto skill_rank = PlayerSkill::spell_skill_rank(spell_exp);
             const auto &spell_name = pr.realm1().get_spell_name(i);
             fprintf(fff, "%-25s ", spell_name.data());
@@ -131,7 +131,7 @@ void do_cmd_knowledge_spell_exp(CreatureEntity &creature)
                 continue;
             }
 
-            SUB_EXP spell_exp = creature.spell_exp[i + 32];
+            SUB_EXP spell_exp = creature.get_spell_exp(i + 32);
             auto skill_rank = PlayerSkill::spell_skill_rank(spell_exp);
             const auto spell_name = pr.realm2().get_spell_name(i);
             fprintf(fff, "%-25s ", spell_name.data());
@@ -169,7 +169,7 @@ void do_cmd_knowledge_skill_exp(CreatureEntity &creature)
     }
 
     for (auto i : PLAYER_SKILL_KIND_TYPE_RANGE) {
-        SUB_EXP skill_exp = creature.skill_exp[i];
+        SUB_EXP skill_exp = creature.get_skill_exp(i);
         SUB_EXP skill_max = class_skills_info[enum2i(creature.pclass)].s_max[i];
         fprintf(fff, "%-20s ", PlayerSkill::skill_name(i));
         if (show_actual_value) {

--- a/src/mind/mind-cavalry.cpp
+++ b/src/mind/mind-cavalry.cpp
@@ -51,7 +51,7 @@ bool rodeo(CreatureEntity &creature)
     if (rlev > 60) {
         rlev = 60 + (rlev - 60) / 2;
     }
-    if ((randint1(creature.skill_exp[PlayerSkillKindType::RIDING] / 120 + creature.level * 2 / 3) > rlev) && one_in_(2) &&
+    if ((randint1(creature.get_skill_exp(PlayerSkillKindType::RIDING) / 120 + creature.level * 2 / 3) > rlev) && one_in_(2) &&
         !creature.get_floor()->inside_arena && !AngbandSystem::get_instance().is_phase_out() && monrace.misc_flags.has_not(MonsterMiscType::GUARDIAN) && monrace.misc_flags.has_not(MonsterMiscType::QUESTOR) &&
         (rlev < creature.level * 3 / 2 + randint0(creature.level / 5))) {
         msg_format(_("%sを手なずけた。", "You tame %s."), m_name.data());

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -481,7 +481,7 @@ void MonsterAttackPlayer::gain_armor_exp()
         return;
     }
 
-    auto cur = creature.skill_exp[PlayerSkillKindType::SHIELD];
+    auto cur = creature.get_skill_exp(PlayerSkillKindType::SHIELD);
     auto max = class_skills_info[enum2i(creature.pclass)].s_max[PlayerSkillKindType::SHIELD];
     if (cur >= max) {
         return;

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -475,7 +475,7 @@ void process_angar(CreatureEntity &creature, MONSTER_IDX m_idx, bool see_m)
 
     /* When riding a hostile alignment pet */
     if (monster.is_riding()) {
-        if (abs(creature.alignment / 10) < randint0(creature.skill_exp[PlayerSkillKindType::RIDING])) {
+        if (abs(creature.alignment / 10) < randint0(creature.get_skill_exp(PlayerSkillKindType::RIDING))) {
             return;
         }
 

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -59,7 +59,7 @@ static bool calc_fall_off_possibility(CreatureEntity &creature, const int dam, c
         return true;
     }
 
-    auto cur = creature.skill_exp[PlayerSkillKindType::RIDING];
+    auto cur = creature.get_skill_exp(PlayerSkillKindType::RIDING);
 
     int fall_off_level = monrace.level;
     if (creature.riding_ryoute) {

--- a/src/player-status/player-speed.cpp
+++ b/src/player-status/player-speed.cpp
@@ -283,7 +283,7 @@ int16_t PlayerSpeed::riding_bonus()
     }
 
     if (monster.speed > STANDARD_SPEED) {
-        const auto skill_exp = this->creature.skill_exp[PlayerSkillKindType::RIDING];
+        const auto skill_exp = this->creature.get_skill_exp(PlayerSkillKindType::RIDING);
         bonus = (int16_t)((speed - STANDARD_SPEED) * (skill_exp * 3 + this->creature.level * 160L - 10000L) / (22000L));
         if (bonus < 0) {
             bonus = 0;
@@ -292,7 +292,7 @@ int16_t PlayerSpeed::riding_bonus()
         bonus = speed - 110;
     }
 
-    bonus += (this->creature.skill_exp[PlayerSkillKindType::RIDING] + this->creature.level * 160L) / 3200;
+    bonus += (this->creature.get_skill_exp(PlayerSkillKindType::RIDING) + this->creature.level * 160L) / 3200;
     if (monster.is_accelerated()) {
         bonus += 10;
     }

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1639,13 +1639,13 @@ static ARMOUR_CLASS calc_base_ac(CreatureEntity &creature)
     const auto o_ptr_mh = creature.inventory[INVEN_MAIN_HAND].get();
     const auto o_ptr_sh = creature.inventory[INVEN_SUB_HAND].get();
     if (o_ptr_mh->is_protector() || o_ptr_sh->is_protector()) {
-        ac += creature.skill_exp[PlayerSkillKindType::SHIELD] * (1 + creature.level / 22) / 2000;
+        ac += creature.get_skill_exp(PlayerSkillKindType::SHIELD) * (1 + creature.level / 22) / 2000;
     }
 
     // 装甲技能による防御力ボーナス（鎧装備時）
     const auto o_ptr_body = creature.inventory[INVEN_BODY].get();
     if (o_ptr_body->is_valid() && (o_ptr_body->bi_key.tval() == ItemKindType::HARD_ARMOR)) {
-        ac += creature.skill_exp[PlayerSkillKindType::ARMOR] * (1 + creature.level / 25) / 2500;
+        ac += creature.get_skill_exp(PlayerSkillKindType::ARMOR) * (1 + creature.level / 25) / 2500;
     }
 
     // 回避技能による防御力ボーナス（軽装備時）
@@ -1658,7 +1658,7 @@ static ARMOUR_CLASS calc_base_ac(CreatureEntity &creature)
 
     // 装備重量が軽い（300ポンド以下）時に回避技能ボーナス
     if (equipment_weight <= 300) {
-        auto evasion_bonus = creature.skill_exp[PlayerSkillKindType::EVASION] * (1 + creature.level / 20) / 3000;
+        auto evasion_bonus = creature.get_skill_exp(PlayerSkillKindType::EVASION) * (1 + creature.level / 20) / 3000;
         // 装備がより軽いほどボーナスが大きくなる（最大で2倍）
         auto weight_ratio = (300 - equipment_weight) / 300.0;
         evasion_bonus = static_cast<int>(evasion_bonus * (1.0 + weight_ratio));
@@ -1868,7 +1868,7 @@ int16_t calc_double_weapon_penalty(CreatureEntity &creature, INVENTORY_IDX slot)
     if (has_melee_weapon(creature, INVEN_MAIN_HAND) && has_melee_weapon(creature, INVEN_SUB_HAND)) {
         const auto flags = creature.inventory[INVEN_SUB_HAND]->get_flags();
 
-        penalty = ((100 - creature.skill_exp[PlayerSkillKindType::TWO_WEAPON] / 160) - (130 - creature.inventory[slot]->weight) / 8);
+        penalty = ((100 - creature.get_skill_exp(PlayerSkillKindType::TWO_WEAPON) / 160) - (130 - creature.inventory[slot]->weight) / 8);
         if (set_quick_and_tiny(creature) || set_icing_and_twinkle(creature) || set_anubis_and_chariot(creature)) {
             penalty = penalty / 2 - 5;
         }
@@ -1932,7 +1932,7 @@ static int16_t calc_riding_bow_penalty(CreatureEntity &creature)
             penalty = 5;
         }
     } else {
-        penalty = floor.get_monster(creature.riding).get_monrace().level - creature.skill_exp[PlayerSkillKindType::RIDING] / 80;
+        penalty = floor.get_monster(creature.riding).get_monrace().level - creature.get_skill_exp(PlayerSkillKindType::RIDING) / 80;
         penalty += 30;
         if (penalty < 30) {
             penalty = 30;
@@ -2243,7 +2243,7 @@ static short calc_to_hit(CreatureEntity &creature, INVENTORY_IDX slot, bool is_r
             }
             [[fallthrough]];
         case MELEE_TYPE_BAREHAND_TWO:
-            hit += (creature.skill_exp[PlayerSkillKindType::MARTIAL_ARTS] - PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER)) / 200;
+            hit += (creature.get_skill_exp(PlayerSkillKindType::MARTIAL_ARTS) - PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER)) / 200;
             break;
 
         default:
@@ -2265,7 +2265,7 @@ static short calc_to_hit(CreatureEntity &creature, INVENTORY_IDX slot, bool is_r
         /* Traind bonuses */
         const auto tval = o_ptr->bi_key.tval();
         const auto sval = *o_ptr->bi_key.sval();
-        hit += (creature.weapon_exp[tval][sval] - PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER)) / 200;
+        hit += (creature.get_weapon_exp(tval, sval) - PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER)) / 200;
 
         /* Weight penalty */
         if (calc_weapon_weight_limit(creature) < o_ptr->weight / 10) {
@@ -2291,7 +2291,7 @@ static short calc_to_hit(CreatureEntity &creature, INVENTORY_IDX slot, bool is_r
                 if (CreatureClass(creature).is_tamer()) {
                     penalty = 5;
                 } else {
-                    penalty = creature.get_floor()->get_monster(creature.riding).get_monrace().level - creature.skill_exp[PlayerSkillKindType::RIDING] / 80;
+                    penalty = creature.get_floor()->get_monster(creature.riding).get_monrace().level - creature.get_skill_exp(PlayerSkillKindType::RIDING) / 80;
                     penalty += 30;
                     if (penalty < 30) {
                         penalty = 30;

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -106,17 +106,17 @@ void wr_player(CreatureEntity &creature)
     wr_s16b(creature.level);
 
     for (int i = 0; i < 64; i++) {
-        wr_s16b(creature.spell_exp[i]);
+        wr_s16b(creature.get_spell_exp(i));
     }
 
     for (auto tval : TV_WEAPON_RANGE) {
         for (int j = 0; j < 64; j++) {
-            wr_s16b(creature.weapon_exp[tval][j]);
+            wr_s16b(creature.get_weapon_exp(tval, j));
         }
     }
 
     for (auto i : PLAYER_SKILL_KIND_TYPE_RANGE) {
-        wr_s16b(creature.skill_exp[i]);
+        wr_s16b(creature.get_skill_exp(i));
     }
     for (auto i = 0U; i < MAX_SKILLS - PLAYER_SKILL_KIND_TYPE_RANGE.size(); ++i) {
         // resreved skills

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -129,7 +129,7 @@ PERCENTAGE spell_chance(CreatureEntity &creature, SPELL_IDX spell_id, RealmType 
     chance -= 3 * (adj_mag_stat[creature.stat_index[mp_ptr->spell_stat]] - 1);
     if (creature.riding) {
         const auto &riding_monrace = creature.get_floor()->get_monster(creature.riding).get_monrace();
-        chance += (std::max(riding_monrace.level - creature.skill_exp[PlayerSkillKindType::RIDING] / 100 - 10, 0));
+        chance += (std::max(riding_monrace.level - creature.get_skill_exp(PlayerSkillKindType::RIDING) / 100 - 10, 0));
     }
 
     MANA_POINT need_mana = mod_need_mana(creature, spell.smana, spell_id, use_realm);

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -892,6 +892,40 @@ public:
     }
 
     /*!
+     * @brief 指定インデックスの呪文熟練度を取得する
+     * @param spell_idx 呪文インデックス (0..63)
+     * @return SUB_EXP 値。プレイヤーは spell_exp[spell_idx]、モンスターは default 実装で
+     *         同フィールドを参照 (現状は意味を持たないが将来モンスター呪文熟練を導入する余地)
+     */
+    virtual SUB_EXP get_spell_exp(int spell_idx) const
+    {
+        return this->spell_exp[spell_idx];
+    }
+
+    /*!
+     * @brief 指定スキル種別のスキル熟練度を取得する
+     * @param skill スキル種別
+     * @return SUB_EXP 値。プレイヤーは skill_exp に存在すれば返し、無ければ 0。
+     */
+    virtual SUB_EXP get_skill_exp(PlayerSkillKindType skill) const
+    {
+        const auto it = this->skill_exp.find(skill);
+        return (it != this->skill_exp.end()) ? it->second : 0;
+    }
+
+    /*!
+     * @brief 指定武器種別・サブ種別の武器熟練度を取得する
+     * @param tval ItemKindType
+     * @param sval サブ種別 (0..63)
+     * @return SUB_EXP 値。プレイヤーは weapon_exp[tval][sval]、なければ 0
+     */
+    virtual SUB_EXP get_weapon_exp(ItemKindType tval, int sval) const
+    {
+        const auto it = this->weapon_exp.find(tval);
+        return (it != this->weapon_exp.end()) ? it->second[sval] : 0;
+    }
+
+    /*!
      * @brief クリーチャーがフレンドリー状態かどうかを判定
      * @return フレンドリーならtrue、デフォルトはfalse（プレイヤーはフレンドリー判定対象外）
      */

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -361,7 +361,7 @@ void wiz_change_status(CreatureEntity &creature)
     for (auto j : PLAYER_SKILL_KIND_TYPE_RANGE) {
         creature.skill_exp[j] = *proficiency;
         auto short_pclass = enum2i(creature.pclass);
-        if (creature.skill_exp[j] > class_skills_info[short_pclass].s_max[j]) {
+        if (creature.get_skill_exp(j) > class_skills_info[short_pclass].s_max[j]) {
             creature.skill_exp[j] = class_skills_info[short_pclass].s_max[j];
         }
     }


### PR DESCRIPTION
ロードマップ提案 10 の主要部分を実装。プレイヤー熟練度系フィールド
(spell_exp / skill_exp / weapon_exp) に read-only virtual インデックサを 追加し、読取りパスをプレイヤー・モンスター共通 API に集約する。

追加 virtual (CreatureEntity 上, read-only):
- get_spell_exp(int spell_idx)              : 呪文熟練度 (spell_exp[idx])
- get_skill_exp(PlayerSkillKindType skill)  : スキル熟練度 (map lookup, 無ければ 0)
- get_weapon_exp(ItemKindType tval, int sval) : 武器熟練度 (map lookup, 無ければ 0)

移行結果:
- 読取り 31 箇所 (spell_exp 4 / skill_exp 22 / weapon_exp 5) を新 virtual 経由に置換
- 書込み・参照取得・複合代入 16 箇所は従来通り直接配列アクセス形式で残置 (mutation/reference 取得は virtual で表現できないため)

効果:
- 読取りパスがプレイヤー・モンスター共通の API 経由
- 将来モンスターに get_X_exp() を override させて種族別/個体別の 熟練度ロジックを導入可能

残作業:
- setter virtual 整備は call site の mutation パターン (集計加算/ 上限クランプ/参照経由 in-place 変更) が多様で抽象コスト大、保留
- 配列全体走査の virtual 化 (span 経由) も検討余地あり

ビルド・スモークテスト確認:
- フルビルド (exit 0, 警告なし)
- ./src/hengband --output-spoilers (exit 0)

ロードマップ更新: 提案 10 ✅ 一部完了