### PR TITLE
feat: モンスター近接攻撃に装備武器の命中ボーナス to_h を反映 (フェーズ B-2c)

### DIFF
--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -172,7 +172,23 @@ bool MonsterAttackPlayer::process_monster_blows()
         if (this->effect == RaceBlowEffectType::FLAVOR) {
             hit = true;
         } else {
-            const int power = mbe_info[enum2i(this->effect)].power;
+            int power = mbe_info[enum2i(this->effect)].power;
+            // [フェーズ B-2c] 武器による命中ボーナス (B-2b の damage 加算と同じく
+            // HIT/PUNCH/SLASH/STING の打撃でのみ MAIN_HAND の to_h を加算)
+            switch (this->method) {
+            case RaceBlowMethodType::HIT:
+            case RaceBlowMethodType::PUNCH:
+            case RaceBlowMethodType::SLASH:
+            case RaceBlowMethodType::STING: {
+                const auto &weapon = *this->m_ptr->inventory[INVEN_MAIN_HAND];
+                if (weapon.is_valid()) {
+                    power += weapon.to_h;
+                }
+                break;
+            }
+            default:
+                break;
+            }
             hit = check_hit_from_monster_to_player(creature, power, this->rlev, this->m_ptr->get_remaining_stun());
         }
 


### PR DESCRIPTION
フェーズ B-2b (ダメージボーナス) の対となる命中ボーナスの実装。
モンスター装備の武器が持つ命中補正 (item.to_h) を、武器を振るう種別の
打撃 (HIT/PUNCH/SLASH/STING) の命中判定に加算する。

変更点 (src/monster-attack/monster-attack-player.cpp):
- MonsterAttackPlayer::process_monster_blows() の命中判定前に 武器 to_h を power に加算 (HIT/PUNCH/SLASH/STING のみ)
- check_hit_from_monster_to_player() のシグネチャは変更せず、 power を呼出側で調整する形で最小変更

ゲームプレイ影響:
- B-2b と合わせて、武器を装備したモンスターの近接攻撃が完全に強化される (命中 + ダメージ)
- +X+Y のような武器ボーナスがそのまま反映される
- 二刀流 (INVEN_SUB_HAND) は引き続き未対応 (主武器のみ)

未実装で次の検討対象:
- 二刀流対応 (副武器の to_h/to_d/dice 加算)
- 防具側のバフ (TR_AGGRAVATE 等の負の効果)
- C-1 本格実装 (杖/ロッド/巻物の自己使用)
- B-3: 装備フラグキャッシュ

ビルド・スモークテスト確認:
- フルビルド (exit 0, 警告なし)
- ./src/hengband --output-spoilers (exit 0)