### PR TITLE
feat: モンスター近接攻撃の二刀流対応 (フェーズ B-2 拡張)

### DIFF
--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -168,26 +168,39 @@ bool MonsterAttackPlayer::process_monster_blows()
 
         // フレーバーの打撃は必中扱い。それ以外は通常の命中判定を行う。
         this->ac = static_cast<ARMOUR_CLASS>(creature.get_ac());
+
+        // [フェーズ B-2 二刀流対応] HIT/PUNCH/SLASH/STING の物理打撃で、
+        // MAIN/SUB の双方が有効な武器なら blow index で交互に使用、
+        // 片方のみなら一貫してそちらを使用、武器なしなら slot < 0
+        this->weapon_slot_for_blow = -1;
+        switch (this->method) {
+        case RaceBlowMethodType::HIT:
+        case RaceBlowMethodType::PUNCH:
+        case RaceBlowMethodType::SLASH:
+        case RaceBlowMethodType::STING: {
+            const bool main_valid = this->m_ptr->inventory[INVEN_MAIN_HAND]->is_valid() && this->m_ptr->inventory[INVEN_MAIN_HAND]->is_melee_weapon();
+            const bool sub_valid = this->m_ptr->inventory[INVEN_SUB_HAND]->is_valid() && this->m_ptr->inventory[INVEN_SUB_HAND]->is_melee_weapon();
+            if (main_valid && sub_valid) {
+                this->weapon_slot_for_blow = (ap_cnt % 2 == 0) ? INVEN_MAIN_HAND : INVEN_SUB_HAND;
+            } else if (main_valid) {
+                this->weapon_slot_for_blow = INVEN_MAIN_HAND;
+            } else if (sub_valid) {
+                this->weapon_slot_for_blow = INVEN_SUB_HAND;
+            }
+            break;
+        }
+        default:
+            break;
+        }
+
         bool hit;
         if (this->effect == RaceBlowEffectType::FLAVOR) {
             hit = true;
         } else {
             int power = mbe_info[enum2i(this->effect)].power;
-            // [フェーズ B-2c] 武器による命中ボーナス (B-2b の damage 加算と同じく
-            // HIT/PUNCH/SLASH/STING の打撃でのみ MAIN_HAND の to_h を加算)
-            switch (this->method) {
-            case RaceBlowMethodType::HIT:
-            case RaceBlowMethodType::PUNCH:
-            case RaceBlowMethodType::SLASH:
-            case RaceBlowMethodType::STING: {
-                const auto &weapon = *this->m_ptr->inventory[INVEN_MAIN_HAND];
-                if (weapon.is_valid()) {
-                    power += weapon.to_h;
-                }
-                break;
-            }
-            default:
-                break;
+            // [フェーズ B-2c / 二刀流対応] 武器による命中ボーナス
+            if (this->weapon_slot_for_blow >= 0) {
+                power += this->m_ptr->inventory[this->weapon_slot_for_blow]->to_h;
             }
             hit = check_hit_from_monster_to_player(creature, power, this->rlev, this->m_ptr->get_remaining_stun());
         }
@@ -280,24 +293,12 @@ bool MonsterAttackPlayer::process_monster_attack_hit()
         this->damage = 0;
     }
 
-    // [フェーズ B-2b] 装備武器によるダメージボーナス
-    // 武器を持って振るう種別の打撃 (HIT/PUNCH/SLASH/STING) のみ、
-    // INVEN_MAIN_HAND の武器ダメージ (dice + to_d) を加算する
-    if (!this->explode) {
-        switch (this->method) {
-        case RaceBlowMethodType::HIT:
-        case RaceBlowMethodType::PUNCH:
-        case RaceBlowMethodType::SLASH:
-        case RaceBlowMethodType::STING: {
-            const auto &weapon = *this->m_ptr->inventory[INVEN_MAIN_HAND];
-            if (weapon.is_valid()) {
-                this->damage += weapon.damage_dice.roll() + weapon.to_d;
-            }
-            break;
-        }
-        default:
-            break;
-        }
+    // [フェーズ B-2b / 二刀流対応] 装備武器によるダメージボーナス
+    // weapon_slot_for_blow は process_monster_blows() で設定され、
+    // 物理打撃 (HIT/PUNCH/SLASH/STING) かつ武器装備時のみ有効
+    if (!this->explode && this->weapon_slot_for_blow >= 0) {
+        const auto &weapon = *this->m_ptr->inventory[this->weapon_slot_for_blow];
+        this->damage += weapon.damage_dice.roll() + weapon.to_d;
     }
 
     switch_monster_blow_to_player(creature, this);

--- a/src/monster-attack/monster-attack-player.h
+++ b/src/monster-attack/monster-attack-player.h
@@ -36,6 +36,7 @@ public:
     ARMOUR_CLASS ac = 0;
     bool alive = true;
     bool fear = false;
+    short weapon_slot_for_blow = -1; //!< [フェーズ B-2 二刀流] 当該打撃で使用する武器スロット (-1 = 武器なし)
 
     void make_attack_normal();
 


### PR DESCRIPTION
INVEN_MAIN_HAND のみだった武器ボーナス適用を SUB_HAND まで拡張。
モンスターが両手に近接武器を装備していれば、blow index ごとに
交互にどちらかの武器を使うようになる。

変更点:
- src/monster-attack/monster-attack-player.h: MonsterAttackPlayer に short weapon_slot_for_blow = -1 メンバを追加 (現在の打撃で使用する武器スロット、-1 = 武器なし)
- src/monster-attack/monster-attack-player.cpp: process_monster_blows() で物理打撃 (HIT/PUNCH/SLASH/STING) のたびに weapon_slot_for_blow を以下のロジックで決定:
   - MAIN/SUB 両方 melee weapon → ap_cnt%2==0 で MAIN, 奇数で SUB
   - MAIN のみ → MAIN
   - SUB のみ → SUB
   - 武器なし → -1 命中ボーナス (B-2c) とダメージボーナス (B-2b) の両方が weapon_slot_for_blow を参照するように変更。重複コードを排除。

ゲームプレイ影響:
- 「両手に剣」のモンスターは打撃ごとに別々の武器を使い、両方の to_h/to_d/dice が活用される (4 連 HIT のモンスターなら 2 回ずつ MAIN/SUB)
- 盾/CAPTURE 等の SUB 装備は is_melee_weapon() で除外され、ペナルティ なし (盾は AC 経路で別途反映)
- 単純なペナルティ (二刀流による命中減) は player と異なり未実装。 monster の attack 経路を player の細分化に合わせる際に再検討予定

ビルド・スモークテスト確認:
- フルビルド (exit 0, 警告なし)
- ./src/hengband --output-spoilers (exit 0)