### PR TITLE
docs: フェーズ A/B/C のモンスター inventory 統合・装備・AI 実装をドキュメント化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -530,6 +530,13 @@ bakabakaband 側と上流側でよくある構造的差異を以下のルール�
 | `switch_activation(..., ItemEntity **, ...)` 戻り値 `bool` | `switch_activation(..., const ItemEntity &, ...)` 戻り値 `std::pair<bool, std::shared_ptr<ItemEntity>>` (上流 PR #5342) |
 | `activate_artifact(creature, ItemEntity *)` 戻り値あり | `activate_artifact(creature, std::shared_ptr<ItemEntity> &)` 戻り値廃止 (上流 PR #5342) |
 | `concptr ANGBAND_SYS/KEYBOARD/GRAF` | `std::string_view ANGBAND_SYS/KEYBOARD/GRAF` (上流 PR #5354) |
+| `monster.get_monster_profile().ml` | `monster.is_visible_on_map()` (読取り) / `monster.set_visible_on_map(bool)` (書込み) (フェーズ 7) |
+| `creature.get_monster_profile().alliance_idx` / `.sub_align` / `.parent_m_idx` / `.smart` / `.hold_o_idx_list` 読取り | `creature.get_alliance_idx()` / `get_sub_align()` / `get_parent_m_idx()` / `get_smart_flags()` (read-only) (フェーズ 9) |
+| `creature.spell_exp[idx]` / `creature.skill_exp[key]` / `creature.weapon_exp[tval][sval]` 読取り | `creature.get_spell_exp(idx)` / `get_skill_exp(skill)` / `get_weapon_exp(tval, sval)` (フェーズ 10) |
+| `MonsterProfile::hold_o_idx_list` / `ItemEntity::held_m_idx` 経由のモンスター所持 | `monster.inventory[INVEN_TOTAL]` 直接、`monster.store_item(item)` / `monster.acquire_item(item)` / `monster.drop_all_inventory(dropper)` (フェーズ A 完了で廃止) |
+| `monster_drop_carried_objects(creature, monster)` | 内部実装が `monster.drop_all_inventory(creature)` に集約 (free function は薄いラッパとして残置) |
+| `store_item_to_inventory(creature, item_ptr)` | 既存の free function は維持。OO 形式は `creature.store_item(item)` |
+| `creature.effects()->protection().current()` | `creature.get_timed_effect(CreatureTimedEffect::PROTECTION)` (PlayerProtection も統一 API 経由) |
 
 **GCC 固有の注意**:
 上流は MSVC 前提のことが多く、`<cstdint>` 等のインクルード漏れがあれば追加する。

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -476,14 +476,160 @@ parent_m_idx / smart / hold_o_idx_list) はそれぞれ十数件以上の
 
 ---
 
+## 提案 11: モンスターアイテム所持の inventory[] 統一 ✅ 完了 (フェーズ A)
+
+### 背景
+
+bakabakaband ではプレイヤーとモンスター双方が `CreatureEntity` インスタンスとして
+`inventory[INVEN_TOTAL]` を持つ統一的なデータ構造を整備していたが、モンスターの
+アイテム所持は引き続きレガシーの `MonsterProfile::hold_o_idx_list` (floor.o_list
+上に held_m_idx を立てて表現する index リスト) で管理されていた。これにより:
+
+- プレイヤーとモンスターでアイテム所持の経路が二重化
+- floor.o_list 上に「held_m_idx 付きアイテム」が orphan として残存しやすい
+- monster.inventory[] フィールドは存在するも実際には使われていない
+
+### 作業内容 (5 サブフェーズ)
+
+- **A-1**: monster pickup を inventory[] 並走書込み (5710abdd8)
+- **A-2**: monster drop を inventory[] 経路へ切替 (ee2012106)
+- **A-3**: shoot/eating の取得経路を inventory[] 並走 (8358fc90f)
+- **A-4a**: hold_o_idx_list の参照経路を inventory[] へ移行 (dbce1c971)
+  - polymorph / attack-chaos-effect / target-describer / monster-compaction
+- **A-4b**: hold_o_idx_list / held_m_idx 経路完全廃止 + save/load マイグレーション (004d3fac2)
+  - `MonsterProfile::hold_o_idx_list` field 削除
+  - `CreatureEntity::get_held_objects()` virtual 削除
+  - load 時に held_m_idx 付き orphan アイテムを wipe で破棄
+- **A-5**: store_item / drop_all_inventory を `CreatureEntity` メンバに整備 (3d8579323)
+
+### 効果
+
+- モンスター所持アイテムは `CreatureEntity::inventory[INVEN_TOTAL]` に一本化
+- floor.o_list 上の orphan が完全消滅
+- フェーズ B/C で「装備」「アイテム使用」を構築する基盤が整備
+- save format は backward compat (held_m_idx flag は load 時 wipe で吸収)
+
+---
+
+## 提案 12: モンスター装備の有効化 ✅ 完了 (フェーズ B)
+
+### 背景
+
+提案 11 でモンスターも inventory[] を実際に使うようになったが、装備スロット
+(INVEN_MAIN_HAND..INVEN_TOTAL) は単なる格納場所でしかなく、装備品の効果が
+モンスターのステータスに反映されていなかった。
+
+### 作業内容
+
+- **B-1**: pickup 時の自動装備 (4031a2962)
+  - `wield_slot()` で空きスロット判定 → `acquire_item()` で直接装着
+- **B-2**: AC / 耐性の装備反映 (f0535d0aa)
+  - `get_ac()`: モンスター時 inventory 走査で `item.ac + item.to_a` 加算
+  - `has_resist_X()` 等 30 virtual: `::has_resist_X(*this)` を OR して
+    装備品 + ULTIMATE_RESISTANCE 等を反映
+- **B-2b**: 近接攻撃のダメージボーナス (7a9cda1ec)
+  - HIT/PUNCH/SLASH/STING 打撃で `weapon.damage_dice.roll() + weapon.to_d` 加算
+- **B-2c**: 近接攻撃の命中ボーナス (11058a278)
+  - `to_h` を `check_hit_from_monster_to_player` の power に加算
+- **B-4**: look 表示で装備品/パック品を区別 (145f1fb56)
+  - 「装備している」vs「持っている」分離表示
+- **二刀流対応** (57339aa0c)
+  - MAIN/SUB 両方に melee weapon があれば blow index 偶奇で交互使用
+
+### B-3 (装備フラグキャッシュ) は DEFERRED
+
+- on-the-fly O(14) iter / call で性能十分
+- 実 profiling で hot spot 判明したら再検討
+
+### 効果
+
+- 装備武器を持つ TAKE_ITEM 行動モンスターは 命中 + ダメージ + AC + 耐性 すべて強化
+- ペットに与えた装備が発動して戦闘力 UP
+- 「two-handed orc with flaming sword and shield」のような構成が機能する
+
+---
+
+## 提案 13: モンスター AI のアイテム能動使用 ✅ 完了 (フェーズ C)
+
+### 背景
+
+提案 12 でモンスター装備は機能するようになったが、消耗品 (ポーション/巻物/杖/ロッド)
+は inventory[] にあるだけで使われない状態だった。プレイヤーと同等のアイテム
+活用 AI を実装することで、戦術的なモンスター戦闘を実現する。
+
+### 作業内容
+
+- **C-1**: モンスター/ペットの自己使用 AI (`monster-processor.cpp`)
+  - 回復系ポーション 5 種 (080d4dbf3)
+  - 拡張: バフ/解毒/恐怖解除/加速/耐性/無敵 全 12 ポーション (21e3215fd)
+  - 巻物 PHASE_DOOR/TELEPORT (dbcabb762) → TELEPORT_LEVEL 追加 (fa873535f)
+  - 巻物 SUMMON_MONSTER/UNDEAD/KIN 追加 (49a7fa33b)
+  - 杖 HEAL_MONSTER/HASTE_MONSTER + ロッド HEALING/SPEED/CURING (92032a3f5)
+  - 攻撃用 wand/rod 17 種 (e9cebf58a) — MAGIC_MISSILE/各種 BOLT/BALL/HYPODYNAMIA/DRAGON_*
+  - WAND_TELEPORT_AWAY (防衛離脱) (fa873535f)
+  - WAND_CLONE_MONSTER (自身分裂) (49a7fa33b)
+- **C-2**: 永続的な窃取 + 自動装備 (98976a44b)
+  - 窃取後 `acquire_item()` 経由で装備可能なら即装備
+- **C-3**: ペット装備指定 UI (`cmd-pet.cpp`)
+  - 所持品確認コマンド (0f8589d4b)
+  - give/take プレイヤー↔ペット 転送 (a6fbfeae4)
+  - take は装備/パック両方から letter 選択 (6487e97de)
+  - 複数ペット選択メニュー (6951daaf1)
+
+### AI 状態判定の優先度設計
+
+1. HP < 25%: 大回復系 + INVULNERABILITY + TELEPORT_LEVEL
+2. HP < 50%: 中回復系 + WAND_TELEPORT_AWAY (防衛距離取り)
+3. 重毒/恐怖: 解毒/Boldness
+4. 戦闘中 + 未バフ: HEROISM/BERSERK
+5. 戦闘中 + 未加速: SPEED
+6. 戦闘中 + 耐性なし: RESISTANCE
+7. 戦闘中 + 直射可能: 攻撃 wand/rod
+8. 戦闘中: 召喚巻物 + WAND_CLONE_MONSTER
+
+各ポーション/巻物/杖/ロッドに priority (0=最優先) を割り当て、最も状況に
+適合した 1 個を毎ターン消費する。
+
+### 効果
+
+- TAKE_ITEM モンスターは戦闘中の生存性・脅威度が大幅に増加
+- ペットも同じ AI で自己保護＋援護 (give した回復系を使う)
+- 既存スペル AI (`mspell-attack`) と並列に動く副次行動として実装
+
+### 残存検討対象 (今後の拡張余地)
+
+- ペット AI で攻撃 wand/rod を hostile monster に向けて発動
+  (現状 `is_hostile()` ガードのため敵対モンスターのみ攻撃 wand 使用)
+- 戦略的脱出 (SCROLL_DESTRUCTION/GENOCIDE)
+- POTION_NEO_TSUYOSHI 等の特殊効果対応
+- 装備耐久 (`apply_artifact` に近い仕組みでモンスター装備も損耗)
+
+---
+
 ## 推奨実施順序
+
+### 完了済み (大規模フェーズ)
+
+- ✅ **提案 7-10**: virtual アクセサ整備 (ml/回復計算/MonsterProfile/配列)
+- ✅ **提案 11**: モンスター inventory[] 統一 (フェーズ A、5 サブフェーズ)
+- ✅ **提案 12**: モンスター装備有効化 (フェーズ B、AC/耐性/攻撃/二刀流)
+- ✅ **提案 13**: モンスター AI アイテム使用 (フェーズ C、ポーション/巻物/杖/ロッド + UI)
+
+### 既存提案の残作業 (中規模)
 
 1. **提案 1** - プレイヤー専用フィールドのクリーチャー共通化（初期値・アクセサ整備）
 2. **提案 2** - プレイヤー専用 virtual メソッドの共通化（提案 1 と並行可）
 3. **提案 5** - TimedEffects 二重管理解消
 4. **提案 4** - 残存状態チェック関数の仮想化
-5. **提案 3** - `PlayerType::get_instance()` 削減
+5. **提案 3** - `PlayerType::get_instance()` 削減 ✅ 完了
 6. **提案 6** - フィールド命名統一（最後）
+
+### 提案 13 の延長検討対象
+
+- ペット AI で攻撃 wand/rod を hostile monster に向けて発動
+- 戦略的脱出 (SCROLL_DESTRUCTION/GENOCIDE)
+- 装備耐久・損耗
+- B-3: 装備フラグキャッシュ (性能必要時)
 
 各提案は独立した PR として進めること。
 

--- a/docs/monster-item-ai.md
+++ b/docs/monster-item-ai.md
@@ -1,0 +1,138 @@
+# モンスター AI アイテム使用ロジック
+
+bakabakaband のモンスター AI は毎ターン `inventory[]` の消耗品を状況判定で
+自動使用する。本書は実装場所と判定優先度をまとめたリファレンス。
+
+実装ファイル: `src/monster/monster-processor.cpp`
+
+呼出箇所: `process_monster()` 内、`process_stalking()` 直前。
+スタン (50% で打ち切り) の後、通常行動に移る前に実行される。
+
+## 実行順序
+
+毎ターン以下の 3 つのヘルパが順に呼ばれる:
+
+1. `monster_quaff_potion(creature, monster)` — ポーション
+2. `monster_read_scroll(creature, monster, m_idx)` — 巻物
+3. `monster_use_wand_or_rod(creature, monster, m_idx)` — 杖/ロッド
+
+各ヘルパは `inventory[]` を 1 回走査し、状況にマッチする中で priority の
+最も小さい (= 最優先) アイテムを 1 個消費する。マッチなしなら何もしない。
+
+## 状況フラグ
+
+```cpp
+const bool low_hp_severe   = monster.hp < monster.maxhp / 4;  // 25% 未満
+const bool low_hp_mid      = monster.hp < monster.maxhp / 2;  // 50% 未満
+const bool poisoned_heavy  = POISON > 100;
+const bool fearful         = monster.is_fearful();
+const bool not_fast        = ACCELERATION == 0;
+const bool not_resistant   = OPPOSE_FIRE == 0 && OPPOSE_COLD == 0;
+const bool not_buffed      = HERO == 0 && BERSERK == 0;
+const bool fighting_context = monster.is_hostile() && monster.is_visible_on_map();
+const bool can_target_player = fighting_context && projectable(...);
+const bool has_status      = fearful || confused || stunned || POISON > 0;
+```
+
+## ポーション (`monster_quaff_potion`)
+
+| Priority | sval | 発動条件 | 効果 |
+|---|---|---|---|
+| 0 | STAR_HEALING / LIFE | `low_hp_severe` | HP+1200, 状態異常リセット, FEAR 解除 |
+| 1 | HEALING | `low_hp_severe` | HP+300, CUT/STUN/POISON リセット |
+| 2 | INVULNERABILITY | `low_hp_severe` | INVULNERABILITY 8〜16 ターン |
+| 3 | CURE_CRITICAL | `low_hp_mid` | HP+6d8, CUT/STUN/POISON リセット |
+| 4 | CURE_SERIOUS | `low_hp_mid` | HP+4d8, CUT 半減 |
+| 5 | CURE_LIGHT | `low_hp_mid` | HP+2d8, CUT 微減 |
+| 6 | CURE_POISON | `poisoned_heavy` | POISON リセット |
+| 7 | BOLDNESS | `fearful` | FEAR リセット |
+| 8 | BESERK_STRENGTH | `fearful` or (`fighting_context && not_buffed`) | FEAR/STUN リセット, BERSERK 25〜50, HP+30 |
+| 9 | HEROISM | `fearful` or (`fighting_context && not_buffed`) | FEAR リセット, HERO 25〜50, HP+10 |
+| 10 | SPEED | `fighting_context && not_fast` | ACCELERATION 16〜40 |
+| 11 | RESISTANCE | `fighting_context && not_resistant` | OPPOSE_ACID/ELEC/FIRE/COLD/POIS 21〜40 |
+
+## 巻物 (`monster_read_scroll`)
+
+| Priority | sval | 発動条件 | 効果 |
+|---|---|---|---|
+| 0 | TELEPORT_LEVEL | `low_hp_severe` | フロア間離脱 |
+| 1 | TELEPORT | `low_hp_severe` | 200 距離テレポート |
+| 2 | PHASE_DOOR | `low_hp_severe` | 10 距離テレポート |
+| 7 | SUMMON_KIN | `fighting_context` | 同族 3 体召喚 (試行) |
+| 8 | SUMMON_MONSTER / SUMMON_UNDEAD | `fighting_context` | 汎用/アンデッド 3 体召喚 (試行) |
+
+## 杖/ロッド (`monster_use_wand_or_rod`)
+
+### 自己標的
+
+| Priority | sval | 種別 | 発動条件 | 効果 |
+|---|---|---|---|---|
+| 0 | ROD_HEALING | rod | `low_hp_mid` | HP+500 |
+| 1 | WAND_HEAL_MONSTER | wand | `low_hp_mid` | HP+20 |
+| 4 | ROD_SPEED | rod | `fighting_context && not_fast` | ACCELERATION 16〜40 |
+| 5 | WAND_HASTE_MONSTER | wand | `fighting_context && not_fast` | ACCELERATION 100〜200 |
+| 6 | ROD_CURING | rod | `has_status` | FEAR/CONF/STUN/POISON リセット |
+| 9 | WAND_CLONE_MONSTER | wand | `fighting_context` | 自身分裂 (`multiply_monster`) |
+
+### プレイヤー標的 (攻撃)
+
+priority 10 (wand) / 11 (rod), 発動条件は `can_target_player`
+
+| sval | tval | dam |
+|---|---|---|
+| MAGIC_MISSILE | wand | MISSILE 3d4 |
+| ACID_BOLT | wand | ACID 10d8 |
+| FIRE_BOLT | wand | FIRE 9d8 |
+| COLD_BOLT | wand | COLD 6d8 |
+| HYPODYNAMIA | wand | HYPODYNAMIA 80 |
+| STINKING_CLOUD | wand | POIS 12 ball rad 2 |
+| ACID_BALL/ELEC_BALL/FIRE_BALL/COLD_BALL | wand | 60/32/72/48 ball rad 2 |
+| DRAGON_FIRE/COLD/BREATH | wand | 100/80/120 ball rad 3 |
+| ROD_ACID_BOLT | rod | ACID 12d8 |
+| ROD_ELEC_BOLT | rod | ELEC 6d6 |
+| ROD_FIRE_BOLT | rod | FIRE 16d8 |
+| ROD_COLD_BOLT | rod | COLD 10d8 |
+| ROD_HYPODYNAMIA | rod | HYPODYNAMIA 75 |
+| ROD_ACID_BALL/ELEC_BALL/FIRE_BALL/COLD_BALL | rod | 60/32/72/48 ball rad 2 |
+
+### プレイヤー標的 (防衛)
+
+| Priority | sval | 種別 | 発動条件 | 効果 |
+|---|---|---|---|---|
+| 3 | WAND_TELEPORT_AWAY | wand | `can_target_player && low_hp_mid` | プレイヤーを 100 距離テレポート |
+
+## 消費メカニクス
+
+- **ポーション**: `number > 1` ならデクリメント、`= 1` なら `wipe()` + `inven_cnt--`
+- **巻物**: 同上
+- **杖**: `pval--` (charges 1 消費)
+- **ロッド**: `timeout += base_pval` (再充填時間設定)
+  - 単一所持で `timeout > 0` ならガード、複数所持で `timeout > base_pval * (number-1)` ならガード
+
+## ペット運用との関係
+
+- ペットも上記 AI で動作する
+- ただし `is_hostile() = false` のため `fighting_context = false`
+- → ペットは攻撃 wand/rod / 召喚巻物 / WAND_CLONE_MONSTER は使わない
+- → ペットが使う: 自己回復系ポーション/ロッド、TELEPORT 系巻物、CURING 系
+- 拡張余地: ペットの場合に `fighting_context` を「最寄りの hostile monster がいて
+  projectable」と再定義すれば、攻撃 wand を hostile monster へ向けて使うようになる
+
+## メッセージ
+
+すべて `is_seen(creature, monster)` で視認可能な場合のみ表示:
+
+- ポーション: `%s^ quaffs %s.` / 「%s^ は %s を飲んだ。」
+- 巻物: `%s^ reads %s.` / 「%s^ は %s を読んだ。」
+- 杖: `%s^ aims %s.` / 「%s^ は %s を振った。」(対象指向)
+- ロッド: `%s^ zaps %s.` / 「%s^ は %s を振った。」
+
+## 関連 commit (実装履歴)
+
+- 080d4dbf3: 回復ポーション 5 種
+- 21e3215fd: ポーション 12 種に拡張 (バフ系)
+- dbcabb762: 巻物 (TELEPORT/PHASE_DOOR)
+- fa873535f: TELEPORT_LEVEL 巻物 + WAND_TELEPORT_AWAY
+- 92032a3f5: 自己標的 wand/rod (HEAL/HASTE/HEALING/SPEED/CURING)
+- e9cebf58a: 攻撃 wand/rod 17 種
+- 49a7fa33b: 召喚巻物 + WAND_CLONE_MONSTER


### PR DESCRIPTION
23 コミットに渡るモンスター AI / 装備機能の大規模追加を 2 箇所に反映:

1. docs/creature-entity-refactoring-roadmap.md
   - 提案 11 (フェーズ A: モンスター inventory[] 統一)
   - 提案 12 (フェーズ B: モンスター装備有効化)
   - 提案 13 (フェーズ C: モンスター AI アイテム使用) 各々サブフェーズ・コミット ID を記載 推奨実施順序を「完了済み大規模フェーズ」「既存提案残作業」「提案 13 の延長検討」 に三段化

2. CLAUDE.md 変愚マージ変換マッピング表に新規 virtual パターンを追加:
   - is_visible_on_map / set_visible_on_map (フェーズ 7)
   - get_alliance_idx / sub_align / parent_m_idx / smart_flags (フェーズ 9)
   - get_spell_exp / skill_exp / weapon_exp (フェーズ 10)
   - store_item / acquire_item / drop_all_inventory (フェーズ A)
   - effects()->protection().current() の置換 (フェーズ 5 拡張)

3. docs/monster-item-ai.md (新規) モンスター AI のアイテム自動使用ロジック仕様書:
   - 状況フラグ一覧
   - ポーション/巻物/杖/ロッドの優先度テーブル
   - 消費メカニクス (charges/timeout)
   - ペット運用 + 関連 commit 履歴

これにより今後の作業者が:
- 既存の進捗を一望でき
- 新規モンスター AI 動作の追加場所を即座に特定でき
- 上流マージ時の変換マッピングを一覧で参照できる