### PR TITLE
[Refactor] tokenize() からTOKENIZE_CHECKQUOTE マクロ定数とmode 引数を削除した (hengband#5356)

### DIFF
--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -291,7 +291,7 @@ static int parse_qtw_Q(qtwg_type *qtwg_ptr, char **zz)
     }
 #endif
 
-    int num = tokenize(qtwg_ptr->buf + _(2, 3), 33, zz, 0);
+    int num = tokenize(qtwg_ptr->buf + _(2, 3), 33, zz);
     if (num < 3) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
@@ -336,7 +336,7 @@ static bool parse_qtw_P(CreatureEntity &creature, qtwg_type *qtwg_ptr, char **zz
         return true;
     }
 
-    if (tokenize(qtwg_ptr->buf + 2, 2, zz, 0) != 2) {
+    if (tokenize(qtwg_ptr->buf + 2, 2, zz) != 2) {
         return true;
     }
 

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -701,7 +701,7 @@ tl::expected<Pos2D, parse_error_type> parse_line_wilderness(char *line, int xmin
 #endif
     {
         char *zz[33];
-        const auto num = tokenize(line + 4, 6, zz, 0);
+        const auto num = tokenize(line + 4, 6, zz);
         if (num <= 1) {
             return tl::unexpected(PARSE_ERROR_TOO_FEW_ARGUMENTS);
         }
@@ -755,7 +755,7 @@ tl::expected<Pos2D, parse_error_type> parse_line_wilderness(char *line, int xmin
         }
 
         char *zz[33];
-        if (tokenize(line + 4, 2, zz, 0) != 2) {
+        if (tokenize(line + 4, 2, zz) != 2) {
             return tl::unexpected(PARSE_ERROR_TOO_FEW_ARGUMENTS);
         }
 

--- a/src/info-reader/general-parser.cpp
+++ b/src/info-reader/general-parser.cpp
@@ -99,7 +99,7 @@ std::tuple<errr, int> init_info_txt(FILE *fp, char *buf, angband_header *head, P
 parse_error_type parse_line_alliance(FloorType *floor_ptr, char *buf)
 {
     char *zz[1];
-    int num = tokenize(buf + 2, 6, zz, 0);
+    int num = tokenize(buf + 2, 6, zz);
     if (num != 1) {
         return PARSE_ERROR_GENERIC;
     }
@@ -118,7 +118,7 @@ parse_error_type parse_line_vault(FloorType *floor_ptr, char *buf)
 {
     char *zz[6];
     town_vault tv;
-    int num = tokenize(buf + 2, 6, zz, 0);
+    int num = tokenize(buf + 2, 6, zz);
     if (num != 6) {
         return PARSE_ERROR_GENERIC;
     }
@@ -147,7 +147,7 @@ parse_error_type parse_line_feature(const FloorType &floor, char *buf)
     }
 
     char *zz[9];
-    int num = tokenize(buf + 2, 9, zz, 0);
+    int num = tokenize(buf + 2, 9, zz);
     if (num <= 1) {
         return PARSE_ERROR_GENERIC;
     }
@@ -306,7 +306,7 @@ parse_error_type parse_line_building(char *buf)
 
     switch (s[0]) {
     case 'N': {
-        if (tokenize(s + 2, 3, zz, 0) == 3) {
+        if (tokenize(s + 2, 3, zz) == 3) {
             strcpy(buildings[index].name, zz[0]);
             strcpy(buildings[index].owner_name, zz[1]);
             strcpy(buildings[index].owner_race, zz[2]);
@@ -316,7 +316,7 @@ parse_error_type parse_line_building(char *buf)
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
     case 'A': {
-        if (tokenize(s + 2, 8, zz, 0) >= 7) {
+        if (tokenize(s + 2, 8, zz) >= 7) {
             int action_index = atoi(zz[0]);
             strcpy(buildings[index].act_names[action_index], zz[1]);
             buildings[index].member_costs[action_index] = (PRICE)atoi(zz[2]);
@@ -331,7 +331,7 @@ parse_error_type parse_line_building(char *buf)
     }
     case 'C': {
         auto pct_max = PLAYER_CLASS_TYPE_MAX;
-        auto n = tokenize(s + 2, pct_max, zz, 0);
+        auto n = tokenize(s + 2, pct_max, zz);
         for (auto i = 0; i < pct_max; i++) {
             buildings[index].member_class[i] = (i < n) ? atoi(zz[i]) : 1;
         }
@@ -339,7 +339,7 @@ parse_error_type parse_line_building(char *buf)
         break;
     }
     case 'R': {
-        auto n = tokenize(s + 2, MAX_RACES, zz, 0);
+        auto n = tokenize(s + 2, MAX_RACES, zz);
         for (int i = 0; i < MAX_RACES; i++) {
             buildings[index].member_race[i] = (i < n) ? atoi(zz[i]) : 1;
         }
@@ -348,7 +348,7 @@ parse_error_type parse_line_building(char *buf)
     }
     case 'M': {
         int n;
-        n = tokenize(s + 2, MAX_MAGIC, zz, 0);
+        n = tokenize(s + 2, MAX_MAGIC, zz);
         for (int i = 0; i < MAX_MAGIC; i++) {
             buildings[index].member_realm[i + 1] = ((i < n) ? static_cast<int16_t>(atoi(zz[i])) : 1);
         }

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -48,7 +48,7 @@ static void add_history_from_pref_line(std::string_view t)
 static bool interpret_r_token(char *buf)
 {
     char *zz[16];
-    if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) {
+    if (tokenize(buf + 2, 3, zz) != 3) {
         return false;
     }
 
@@ -81,7 +81,7 @@ static bool interpret_r_token(char *buf)
 static bool interpret_k_token(char *buf)
 {
     char *zz[16];
-    if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) {
+    if (tokenize(buf + 2, 3, zz) != 3) {
         return false;
     }
 
@@ -177,7 +177,7 @@ static void decide_feature_type(int i, int num, char **zz)
 static bool interpret_f_token(char *buf)
 {
     char *zz[16];
-    int num = tokenize(buf + 2, F_LIT_MAX * 2 + 1, zz, TOKENIZE_CHECKQUOTE);
+    int num = tokenize(buf + 2, F_LIT_MAX * 2 + 1, zz);
 
     if ((num != 3) && (num != 4) && (num != F_LIT_MAX * 2 + 1)) {
         return false;
@@ -204,7 +204,7 @@ static bool interpret_f_token(char *buf)
 static bool interpret_s_token(char *buf)
 {
     char *zz[16];
-    if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) {
+    if (tokenize(buf + 2, 3, zz) != 3) {
         return false;
     }
 
@@ -223,7 +223,7 @@ static bool interpret_s_token(char *buf)
 static bool interpret_u_token(char *buf)
 {
     char *zz[16];
-    if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) {
+    if (tokenize(buf + 2, 3, zz) != 3) {
         return false;
     }
 
@@ -253,7 +253,7 @@ static bool interpret_u_token(char *buf)
 static bool interpret_e_token(char *buf)
 {
     char *zz[16];
-    if (tokenize(buf + 2, 2, zz, TOKENIZE_CHECKQUOTE) != 2) {
+    if (tokenize(buf + 2, 2, zz) != 2) {
         return false;
     }
 
@@ -285,7 +285,7 @@ static int interpret_p_token(char *buf)
 static bool interpret_c_token(char *buf)
 {
     char *zz[16];
-    if (tokenize(buf + 2, 2, zz, TOKENIZE_CHECKQUOTE) != 2) {
+    if (tokenize(buf + 2, 2, zz) != 2) {
         return false;
     }
 
@@ -313,7 +313,7 @@ static bool interpret_c_token(char *buf)
 static bool interpret_v_token(char *buf)
 {
     char *zz[16];
-    if (tokenize(buf + 2, 5, zz, TOKENIZE_CHECKQUOTE) != 5) {
+    if (tokenize(buf + 2, 5, zz) != 5) {
         return false;
     }
 
@@ -480,7 +480,7 @@ static bool interpret_macro_keycodes(int tok, char **zz)
 static bool interpret_t_token(char *buf)
 {
     char *zz[16];
-    int tok = tokenize(buf + 2, 2 + MAX_MACRO_MOD, zz, 0);
+    int tok = tokenize(buf + 2, 2 + MAX_MACRO_MOD, zz);
     if (tok >= 4) {
         return decide_template_modifier(tok, zz);
     }

--- a/src/io/tokenizer.cpp
+++ b/src/io/tokenizer.cpp
@@ -18,7 +18,7 @@
  * Hack -- We will always extract at least one token
  * </pre>
  */
-int16_t tokenize(char *buf, int16_t num, char **tokens, BIT_FLAGS mode)
+int16_t tokenize(char *buf, int16_t num, char **tokens)
 {
     int16_t i = 0;
     char *s = buf;
@@ -27,21 +27,6 @@ int16_t tokenize(char *buf, int16_t num, char **tokens, BIT_FLAGS mode)
         for (t = s; *t; t++) {
             if ((*t == ':') || (*t == '/')) {
                 break;
-            }
-
-            if ((mode & TOKENIZE_CHECKQUOTE) && (*t == '\'')) {
-                t++;
-                if (*t == '\\') {
-                    t++;
-                }
-                if (!*t) {
-                    break;
-                }
-
-                t++;
-                if (*t != '\'') {
-                    *t = '\'';
-                }
             }
 
             if (*t == '\\') {

--- a/src/io/tokenizer.h
+++ b/src/io/tokenizer.h
@@ -2,6 +2,4 @@
 
 #include "system/angband.h"
 
-#define TOKENIZE_CHECKQUOTE 0x01 /* Special handling of single quotes */
-
-int16_t tokenize(char *buf, int16_t num, char **tokens, BIT_FLAGS mode);
+int16_t tokenize(char *buf, int16_t num, char **tokens);

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -3,6 +3,7 @@
 #include "flavor/object-flavor-types.h"
 #include "io/files-util.h"
 #include "io/tokenizer.h"
+#include "locale/language-switcher.h"
 #include "object-enchant/special-object-flags.h"
 #include "system/angband-exceptions.h"
 #include "system/artifact-type-definition.h"
@@ -56,7 +57,7 @@ tl::optional<std::vector<std::string>> get_rumor_tokens(std::string rumor)
 {
     constexpr auto num_tokens = 3;
     char *tmp_tokens[num_tokens];
-    if (tokenize(rumor.data() + 2, num_tokens, tmp_tokens, TOKENIZE_CHECKQUOTE) != num_tokens) {
+    if (tokenize(rumor.data() + 2, num_tokens, tmp_tokens) != num_tokens) {
         msg_print(_("この情報は間違っている。", "This information is wrong."));
         return tl::nullopt;
     }


### PR DESCRIPTION
変愚蛮怒 PR #5356 (1/2) を bakabakaband に適応。

bakabakaband の info-reader/general-parser.cpp は上流に無い独自エントリ (town_vault パーサ) で tokenize() を 4 引数で呼んでいたため、上流の
auto-merge で漏れていた呼出を 3 引数形式に手動修正。

上流コミット: 642fe1c8d (hengband/develop)

ビルド・スモークテスト確認:
- フルビルド (exit 0, 警告なし)