### PR TITLE
feat: ペット AI で攻撃 wand/rod / 戦闘バフポーション発動 (フェーズ C-1 拡張)

### DIFF
--- a/docs/monster-item-ai.md
+++ b/docs/monster-item-ai.md
@@ -111,12 +111,32 @@ priority 10 (wand) / 11 (rod), 発動条件は `can_target_player`
 
 ## ペット運用との関係
 
-- ペットも上記 AI で動作する
-- ただし `is_hostile() = false` のため `fighting_context = false`
-- → ペットは攻撃 wand/rod / 召喚巻物 / WAND_CLONE_MONSTER は使わない
-- → ペットが使う: 自己回復系ポーション/ロッド、TELEPORT 系巻物、CURING 系
-- 拡張余地: ペットの場合に `fighting_context` を「最寄りの hostile monster がいて
-  projectable」と再定義すれば、攻撃 wand を hostile monster へ向けて使うようになる
+`fighting_context` の判定は `ai_is_in_fighting_context()` ヘルパに集約され、
+以下の 2 つの状況で true を返す:
+
+- 敵対モンスター: 視認可能 (`is_visible_on_map()`) かつ `is_hostile()`
+- ペット: 視認可能で、視認可能な hostile monster が同フロアに存在
+
+これにより、ペットも以下が発動するようになっている:
+
+- ポーション: SPEED, HEROISM, BERSERK, RESISTANCE 等の戦闘バフ
+- 杖/ロッド: HEAL_MONSTER, HASTE_MONSTER, CLONE_MONSTER (自身分裂で増援)
+- 攻撃 wand/rod: 最寄りの hostile monster (projectable) を標的として発射
+
+ただし以下は `monster_read_scroll` 内の独自 `fighting_context` (hostile only) で
+ガードされており、ペットは使わない:
+
+- SCROLL_SUMMON_MONSTER / UNDEAD / KIN (敵を増やす行動)
+
+`monster_use_wand_or_rod` 内で攻撃 wand の標的決定は:
+
+- 敵対モンスター: target = プレイヤー位置
+- ペット: target = `is_pet() && best_dist` で選定された最寄り hostile monster の位置
+
+ペットの WAND_CLONE_MONSTER は分身が `multiply_monster(..., PM_NO_PET)` で
+生成されるため、ペット自身が分裂したものは敵性ではないが pet flag は
+継承されない (NO_PET 強制) 仕様。これは「ペットが一時的に増援を呼ぶ」
+意図に合っている (バランス上 ペットが無限増殖しないように)。
 
 ## メッセージ
 

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -117,6 +117,35 @@ constexpr auto STALKER_CHANCE_DENOMINATOR = 32; //!< モンスターが背後に
 constexpr auto STALKER_DISTANCE_THRESHOLD = 20; //!< モンスターが背後に忍び寄る距離の閾値
 
 /*!
+ * @brief モンスター AI が「戦闘中」と見做せる状況かを判定 (フェーズ C-1 拡張)
+ * @param creature 視点クリーチャー (プレイヤー)
+ * @param monster 判定対象モンスター
+ * @return 敵対モンスターはプレイヤー視認時、ペットは hostile monster 視認時に true
+ * @details モンスターのバフ系/攻撃系アイテム使用判定で共有される判定。
+ *          ペットでも hostile monster が近くにいれば fighting_context = true として
+ *          バフ・攻撃用アイテムを発動できるようにする。
+ */
+static bool ai_is_in_fighting_context(const CreatureEntity &creature, const CreatureEntity &monster)
+{
+    if (!monster.is_visible_on_map()) {
+        return false;
+    }
+    if (monster.is_hostile()) {
+        return true;
+    }
+    if (monster.is_pet()) {
+        const auto &floor = *creature.get_floor();
+        for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
+            const auto &target_mon = floor.get_monster(i);
+            if (target_mon.is_valid() && target_mon.is_hostile() && target_mon.is_visible_on_map()) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/*!
  * @brief モンスターがポーションを飲んで状況に応じた効果を得る (フェーズ C-1 拡張)
  * @param creature 視点クリーチャー (メッセージ表示用)
  * @param monster ポーションを飲むモンスター
@@ -145,7 +174,7 @@ static bool monster_quaff_potion(CreatureEntity &creature, CreatureEntity &monst
     const bool not_fast = monster.get_timed_effect(CreatureTimedEffect::ACCELERATION) == 0;
     const bool not_resistant = monster.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE) == 0 && monster.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD) == 0;
     const bool not_buffed = monster.get_timed_effect(CreatureTimedEffect::HERO) == 0 && monster.get_timed_effect(CreatureTimedEffect::BERSERK) == 0;
-    const bool fighting_context = monster.is_hostile() && monster.is_visible_on_map();
+    const bool fighting_context = ai_is_in_fighting_context(creature, monster);
 
     INVENTORY_IDX potion_slot = -1;
     int priority = -1; // 0=最優先 ... 大=後回し
@@ -467,9 +496,42 @@ static bool monster_use_wand_or_rod(CreatureEntity &creature, CreatureEntity &mo
 {
     const bool low_hp_mid = monster.hp < monster.maxhp / 2;
     const bool not_fast = monster.get_timed_effect(CreatureTimedEffect::ACCELERATION) == 0;
-    const bool fighting_context = monster.is_hostile() && monster.is_visible_on_map();
     const bool has_status = monster.is_fearful() || monster.is_confused() || monster.is_stunned() || monster.get_timed_effect(CreatureTimedEffect::POISON) > 0;
-    const bool can_target_player = fighting_context && projectable(*creature.get_floor(), monster.get_position(), creature.get_position());
+
+    // [ペット AI 拡張] モンスターの場合: target = プレイヤー
+    //                  ペットの場合: target = 最寄りの hostile monster (projectable)
+    auto &floor = *creature.get_floor();
+    POSITION attack_target_y = creature.y;
+    POSITION attack_target_x = creature.x;
+    bool can_attack_target = false;
+    bool fighting_context = false;
+    fighting_context = ai_is_in_fighting_context(creature, monster);
+    if (monster.is_pet()) {
+        // ペットは hostile monster を直射目標として選定
+        int best_dist = INT_MAX;
+        const auto m_pos = monster.get_position();
+        for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
+            const auto &target_mon = floor.get_monster(i);
+            if (!target_mon.is_valid() || !target_mon.is_hostile() || !target_mon.is_visible_on_map()) {
+                continue;
+            }
+            const auto t_pos = target_mon.get_position();
+            if (!projectable(floor, m_pos, t_pos)) {
+                continue;
+            }
+            const auto dist = Grid::calc_distance(m_pos, t_pos);
+            if (dist < best_dist) {
+                best_dist = dist;
+                attack_target_y = t_pos.y;
+                attack_target_x = t_pos.x;
+                can_attack_target = true;
+            }
+        }
+    } else {
+        can_attack_target = fighting_context && projectable(floor, monster.get_position(), creature.get_position());
+    }
+    // 旧来名 can_target_player を残してコード互換性を保つ (実際には pet の場合 hostile monster)
+    const bool can_target_player = can_attack_target;
 
     INVENTORY_IDX device_slot = -1;
     int priority = -1;
@@ -604,9 +666,9 @@ static bool monster_use_wand_or_rod(CreatureEntity &creature, CreatureEntity &mo
         monster.set_timed_effect(effect, static_cast<short>(std::min<int>(MAX_SHORT, current + duration)));
     };
 
-    // 攻撃系の標的座標 (プレイヤー)
-    const auto target_y = creature.y;
-    const auto target_x = creature.x;
+    // 攻撃系の標的座標 (敵対モンスターはプレイヤー、ペットは hostile monster)
+    const auto target_y = attack_target_y;
+    const auto target_x = attack_target_x;
     constexpr BIT_FLAGS flg_bolt = PROJECT_STOP | PROJECT_KILL | PROJECT_REFLECTABLE;
     constexpr BIT_FLAGS flg_ball = PROJECT_STOP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM;
     auto fire_bolt_at_player = [&](AttributeType typ, int dam) {


### PR DESCRIPTION
これまで `fighting_context = monster.is_hostile()` の判定により、ペット (`is_hostile() = false`) は攻撃用 wand/rod や戦闘バフポーションを発動しない 仕様だった。ペットも視認可能な hostile monster がいれば「戦闘中」と
見做すように `ai_is_in_fighting_context()` ヘルパを導入。

変更点 (src/monster/monster-processor.cpp):
- 新規ヘルパ `ai_is_in_fighting_context(creature, monster)`:
  - 視認不可なら false
  - is_hostile() なら true
  - is_pet() なら、フロア内に視認可能な hostile monster があれば true
- monster_quaff_potion / monster_use_wand_or_rod の `fighting_context` を新ヘルパ呼出に変更
- monster_use_wand_or_rod の標的座標 (attack_target_x/y) を:
  - 敵対モンスター: プレイヤー位置 (creature.y/x)
  - ペット: 最寄りの projectable hostile monster の位置
- monster_read_scroll の `fighting_context` は引き続き hostile-only (ペットが SUMMON 系で敵を増やすのは設計上望ましくない)

ゲームプレイ影響:
- 治癒のロッド + 加速のロッド + ファイアボールの杖を給与したペットが hostile monster に対して自動的に攻撃発動
- ペットも HEROISM / BERSERK / SPEED / RESISTANCE ポーションを戦闘前に 自動使用してバフをかける
- WAND_CLONE_MONSTER をペットに与えれば自身の分身を呼ぶ (multiply_monster は PM_NO_PET なので分身は中立。一時的な増援)
- SCROLL_SUMMON 系はペットでは発動しない (敵を増やすのを防止)

ドキュメント更新:
- docs/monster-item-ai.md にペット運用節の更新

ビルド・スモークテスト確認:
- フルビルド (exit 0, 警告なし)
- ./src/hengband --output-spoilers (exit 0)