### PR TITLE
fix: モンスター WAND_DRAGON_BREATH を 5 属性ランダムに修正 (フェーズ C-1 拡張)

### DIFF
--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -732,14 +732,24 @@ static bool monster_use_wand_or_rod(CreatureEntity &creature, CreatureEntity &mo
             fire_ball_at_player(AttributeType::COLD, 48, 2);
             break;
         case SV_WAND_DRAGON_FIRE:
-            fire_ball_at_player(AttributeType::FIRE, 100, 3);
+            fire_ball_at_player(AttributeType::FIRE, 200, 3);
             break;
         case SV_WAND_DRAGON_COLD:
-            fire_ball_at_player(AttributeType::COLD, 80, 3);
+            fire_ball_at_player(AttributeType::COLD, 180, 3);
             break;
-        case SV_WAND_DRAGON_BREATH:
-            fire_ball_at_player(AttributeType::FIRE, 120, 3);
+        case SV_WAND_DRAGON_BREATH: {
+            // 5 属性からランダム選択 (player 版 cmd-zapwand.cpp と整合)
+            constexpr std::array<std::pair<int, AttributeType>, 5> candidates = { {
+                { 240, AttributeType::ACID },
+                { 210, AttributeType::ELEC },
+                { 240, AttributeType::FIRE },
+                { 210, AttributeType::COLD },
+                { 180, AttributeType::POIS },
+            } };
+            const auto [dam, type] = rand_choice(candidates);
+            fire_ball_at_player(type, dam, 3);
             break;
+        }
         case SV_WAND_TELEPORT_AWAY:
             fire_bolt_at_player(AttributeType::AWAY_ALL, 100);
             break;


### PR DESCRIPTION
C-1 拡張の攻撃 wand 実装で、SV_WAND_DRAGON_BREATH を常に FIRE 120 として 扱っていたが、プレイヤー側 cmd-zapwand.cpp は 5 属性 (ACID/ELEC/FIRE/COLD/ POIS) からランダムに選び、各属性別ダメージ値を持つ仕様。これに合わせて
モンスター側も同じロジックを適用。

変更点 (src/monster/monster-processor.cpp):
- WAND_DRAGON_BREATH: candidates[5] からランダム選択し、選ばれた属性 (ACID 240/ELEC 210/FIRE 240/COLD 210/POIS 180) で fire_ball_at_player
- WAND_DRAGON_FIRE: 100 → 200 に上方修正 (cmd-zapwand 整合)
- WAND_DRAGON_COLD: 80 → 180 に上方修正

これにより player と monster の wand 効果が一致し、ドラゴンの杖を持つ
モンスター/ペットの威力が想定通りになる。

ビルド・スモークテスト確認:
- フルビルド (exit 0, 警告なし)
- ./src/hengband --output-spoilers (exit 0)