### PR TITLE
refactor: MonsterProfile setter を virtual に集約 (提案 9b)

### DIFF
--- a/src/load/old/monster-loader-savefile50.cpp
+++ b/src/load/old/monster-loader-savefile50.cpp
@@ -25,9 +25,9 @@ void MonsterLoader50::rd_monster(CreatureEntity &monster)
 
     if (loading_savefile_version_is_older_than(16)) {
         MonraceDefinition *r_ptr = &MonraceList::get_instance().get_monrace(monster.r_idx);
-        monster.get_monster_profile().alliance_idx = r_ptr->alliance_idx;
+        monster.set_alliance_idx(r_ptr->alliance_idx);
     } else {
-        monster.get_monster_profile().alliance_idx = i2enum<AllianceType>(rd_s32b());
+        monster.set_alliance_idx(i2enum<AllianceType>(rd_s32b()));
     }
 
     monster.y = rd_byte();
@@ -46,7 +46,7 @@ void MonsterLoader50::rd_monster(CreatureEntity &monster)
     monster.dealt_damage = rd_s32b();
 
     monster.ap_r_idx = any_bits(flags, SaveDataMonsterFlagType::AP_R_IDX) ? i2enum<MonraceId>(rd_s16b()) : monster.r_idx;
-    monster.get_monster_profile().sub_align = any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN) ? rd_byte() : 0;
+    monster.set_sub_align(any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN) ? rd_byte() : 0);
     monster.set_timed_effect(CreatureTimedEffect::SLEEP_OR_PARALYSIS, any_bits(flags, SaveDataMonsterFlagType::SLEEP) ? rd_s16b() : 0);
     monster.speed = rd_byte();
     monster.energy_need = rd_s16b();
@@ -82,7 +82,7 @@ void MonsterLoader50::rd_monster(CreatureEntity &monster)
             rd_FlagGroup(monster.get_monster_profile().smart, rd_byte);
         }
     } else {
-        monster.get_monster_profile().smart.clear();
+        monster.clear_smart_flags();
     }
 
     monster.exp = any_bits(flags, SaveDataMonsterFlagType::EXP) ? rd_u32b() : 0;
@@ -102,7 +102,7 @@ void MonsterLoader50::rd_monster(CreatureEntity &monster)
         monster.name.clear();
     }
 
-    monster.get_monster_profile().parent_m_idx = any_bits(flags, SaveDataMonsterFlagType::PARENT) ? rd_s16b() : 0;
+    monster.set_parent_m_idx(any_bits(flags, SaveDataMonsterFlagType::PARENT) ? rd_s16b() : 0);
 
     // バージョン40以降: 所持金、身長、体重の読み込み
     if (loading_savefile_version_is_older_than(40)) {

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -80,7 +80,7 @@ void delete_monster_idx(CreatureEntity &creature, short m_idx)
     for (MONSTER_IDX child_m_idx = 1; child_m_idx < floor.m_max; child_m_idx++) {
         auto &child_monster = floor.get_monster(child_m_idx);
         if (child_monster.is_valid() && child_monster.get_parent_m_idx() == m_idx) {
-            child_monster.get_monster_profile().parent_m_idx = child_m_idx;
+            child_monster.set_parent_m_idx(child_m_idx);
         }
     }
 

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -262,7 +262,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     // モンスターの能力値をランダムに初期化
     get_stats(*m_ptr);
 
-    m_ptr->get_monster_profile().alliance_idx = monrace.alliance_idx;
+    m_ptr->set_alliance_idx(monrace.alliance_idx);
 
     m_ptr->get_monster_profile().mflag.clear();
     m_ptr->get_monster_profile().mflag2.clear();
@@ -376,16 +376,16 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     }
 
     if (!m_ptr->is_chameleon() && is_summoned && new_monrace.kind_flags.has_none_of(alignment_mask)) {
-        m_ptr->get_monster_profile().sub_align = summoner.get_sub_align();
+        m_ptr->set_sub_align(summoner.get_sub_align());
     } else if (m_ptr->is_chameleon() && new_monrace.kind_flags.has(MonsterKindType::UNIQUE) && !is_summoned) {
-        m_ptr->get_monster_profile().sub_align = SUB_ALIGN_NEUTRAL;
+        m_ptr->set_sub_align(SUB_ALIGN_NEUTRAL);
     } else {
-        m_ptr->get_monster_profile().sub_align = SUB_ALIGN_NEUTRAL;
+        m_ptr->set_sub_align(SUB_ALIGN_NEUTRAL);
         if (new_monrace.kind_flags.has(MonsterKindType::EVIL)) {
-            set_bits(m_ptr->get_monster_profile().sub_align, SUB_ALIGN_EVIL);
+            m_ptr->add_sub_align(SUB_ALIGN_EVIL);
         }
         if (new_monrace.kind_flags.has(MonsterKindType::GOOD)) {
-            set_bits(m_ptr->get_monster_profile().sub_align, SUB_ALIGN_GOOD);
+            m_ptr->add_sub_align(SUB_ALIGN_GOOD);
         }
     }
 
@@ -427,12 +427,12 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     m_ptr->exp = 0;
 
     if (is_summoned) {
-        m_ptr->get_monster_profile().parent_m_idx = *summoner_m_idx;
+        m_ptr->set_parent_m_idx(*summoner_m_idx);
         if (summoner.get_monrace().kind_flags.has(MonsterKindType::QUYLTHLUG)) {
             m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::QUYLTHLUG_BORN);
         }
     } else {
-        m_ptr->get_monster_profile().parent_m_idx = 0;
+        m_ptr->set_parent_m_idx(0);
     }
 
     // 変身情報のコピー

--- a/src/monster/monster-compaction.cpp
+++ b/src/monster/monster-compaction.cpp
@@ -66,7 +66,7 @@ static void compact_monsters_aux(CreatureEntity &creature, MONSTER_IDX i1, MONST
             CreatureEntity *m2_ptr = &floor.get_monster(static_cast<MONSTER_IDX>(i));
 
             if (m2_ptr->get_parent_m_idx() == i1) {
-                m2_ptr->get_monster_profile().parent_m_idx = i2;
+                m2_ptr->set_parent_m_idx(i2);
             }
         }
     }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -630,7 +630,7 @@ bool MonsterDamageProcessor::check_and_process_hp_transform()
     monster.get_monster_profile().transform_hp_threshold = new_monrace.transform_hp_threshold;
 
     // アライメントを維持
-    monster.get_monster_profile().sub_align = old_sub_align;
+    monster.set_sub_align(old_sub_align);
 
     // メッセージ表示
     if (monster.is_visible_on_map()) {

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -34,9 +34,9 @@ void set_pet(CreatureEntity &creature, CreatureEntity &target)
 {
     QuestCompletionChecker(creature, target).complete();
     target.get_monster_profile().mflag2.set(MonsterConstantFlagType::PET);
-    target.get_monster_profile().alliance_idx = AllianceType::NONE;
+    target.set_alliance_idx(AllianceType::NONE);
     if (target.get_monrace().kind_flags.has_none_of(alignment_mask)) {
-        target.get_monster_profile().sub_align = SUB_ALIGN_NEUTRAL;
+        target.set_sub_align(SUB_ALIGN_NEUTRAL);
     }
 }
 

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -408,15 +408,15 @@ void monster_gain_exp(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId mon
 
     /* Sub-alignment of a monster */
     if (!monster.is_pet() && new_monrace.kind_flags.has_none_of(alignment_mask)) {
-        monster.get_monster_profile().sub_align = old_sub_align;
+        monster.set_sub_align(old_sub_align);
     } else {
-        monster.get_monster_profile().sub_align = SUB_ALIGN_NEUTRAL;
+        monster.set_sub_align(SUB_ALIGN_NEUTRAL);
         if (new_monrace.kind_flags.has(MonsterKindType::EVIL)) {
-            monster.get_monster_profile().sub_align |= SUB_ALIGN_EVIL;
+            monster.add_sub_align(SUB_ALIGN_EVIL);
         }
 
         if (new_monrace.kind_flags.has(MonsterKindType::GOOD)) {
-            monster.get_monster_profile().sub_align |= SUB_ALIGN_GOOD;
+            monster.add_sub_align(SUB_ALIGN_GOOD);
         }
     }
 
@@ -441,7 +441,7 @@ void monster_gain_exp(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId mon
         }
 
         /* Now you feel very close to this pet. */
-        monster.get_monster_profile().parent_m_idx = 0;
+        monster.set_parent_m_idx(0);
     }
 
     update_monster(creature, m_idx, false);

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -647,151 +647,151 @@ void update_smart_learn(CreatureEntity &creature, MONSTER_IDX m_idx, int what)
     switch (what) {
     case DRS_ACID:
         if (creature.has_resist_acid()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_ACID);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_ACID);
         }
 
         if (is_oppose_acid(creature)) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::OPP_ACID);
+            monster.add_smart_flag(MonsterSmartLearnType::OPP_ACID);
         }
 
         if (creature.has_immune_acid()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_ACID);
+            monster.add_smart_flag(MonsterSmartLearnType::IMM_ACID);
         }
 
         break;
     case DRS_ELEC:
         if (creature.has_resist_elec()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_ELEC);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_ELEC);
         }
 
         if (is_oppose_elec(creature)) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::OPP_ELEC);
+            monster.add_smart_flag(MonsterSmartLearnType::OPP_ELEC);
         }
 
         if (creature.has_immune_elec()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_ELEC);
+            monster.add_smart_flag(MonsterSmartLearnType::IMM_ELEC);
         }
 
         break;
     case DRS_FIRE:
         if (creature.has_resist_fire()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_FIRE);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_FIRE);
         }
 
         if (is_oppose_fire(creature)) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::OPP_FIRE);
+            monster.add_smart_flag(MonsterSmartLearnType::OPP_FIRE);
         }
 
         if (creature.has_immune_fire()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_FIRE);
+            monster.add_smart_flag(MonsterSmartLearnType::IMM_FIRE);
         }
 
         break;
     case DRS_COLD:
         if (creature.has_resist_cold()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_COLD);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_COLD);
         }
 
         if (is_oppose_cold(creature)) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::OPP_COLD);
+            monster.add_smart_flag(MonsterSmartLearnType::OPP_COLD);
         }
 
         if (creature.has_immune_cold()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_COLD);
+            monster.add_smart_flag(MonsterSmartLearnType::IMM_COLD);
         }
 
         break;
     case DRS_POIS:
         if (creature.has_resist_pois()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_POIS);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_POIS);
         }
 
         if (is_oppose_pois(creature)) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::OPP_POIS);
+            monster.add_smart_flag(MonsterSmartLearnType::OPP_POIS);
         }
 
         break;
     case DRS_NETH:
         if (creature.has_resist_neth()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_NETH);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_NETH);
         }
 
         break;
     case DRS_LITE:
         if (creature.has_resist_lite()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_LITE);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_LITE);
         }
 
         break;
     case DRS_DARK:
         if (creature.has_resist_dark() || creature.has_immune_dark()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_DARK);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_DARK);
         }
 
         break;
     case DRS_FEAR:
         if (creature.has_resist_fear()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_FEAR);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_FEAR);
         }
 
         break;
     case DRS_CONF:
         if (creature.has_resist_conf()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_CONF);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_CONF);
         }
 
         break;
     case DRS_CHAOS:
         if (creature.has_resist_chaos()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_CHAOS);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_CHAOS);
         }
 
         break;
     case DRS_DISEN:
         if (creature.has_resist_disen()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_DISEN);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_DISEN);
         }
 
         break;
     case DRS_BLIND:
         if (creature.has_resist_blind()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_BLIND);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_BLIND);
         }
 
         break;
     case DRS_NEXUS:
         if (creature.has_resist_shard()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_NEXUS);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_NEXUS);
         }
 
         break;
     case DRS_SOUND:
         if (creature.has_resist_sound()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_SOUND);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_SOUND);
         }
 
         break;
     case DRS_SHARD:
         if (creature.has_resist_shard()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::RES_SHARD);
+            monster.add_smart_flag(MonsterSmartLearnType::RES_SHARD);
         }
 
         break;
     case DRS_FREE:
         if (creature.has_free_act()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_FREE);
+            monster.add_smart_flag(MonsterSmartLearnType::IMM_FREE);
         }
 
         break;
     case DRS_MANA:
         if (!creature.msp) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_MANA);
+            monster.add_smart_flag(MonsterSmartLearnType::IMM_MANA);
         }
 
         break;
     case DRS_REFLECT:
         if (creature.has_reflect()) {
-            monster.get_monster_profile().smart.set(MonsterSmartLearnType::IMM_REFLECT);
+            monster.add_smart_flag(MonsterSmartLearnType::IMM_REFLECT);
         }
 
         break;

--- a/src/mspell/improper-mspell-remover.cpp
+++ b/src/mspell/improper-mspell-remover.cpp
@@ -42,7 +42,7 @@ void remove_bad_spells(MONSTER_IDX m_idx, CreatureEntity &creature, EnumClassFla
     if (smart_learn) {
         /* 時々学習情報を忘れる */
         if (one_in_(100)) {
-            monster.get_monster_profile().smart.clear();
+            monster.clear_smart_flags();
         }
 
         msr_ptr->smart_flags = monster.get_smart_flags();

--- a/src/spell-kind/spells-polymorph.cpp
+++ b/src/spell-kind/spells-polymorph.cpp
@@ -122,7 +122,7 @@ bool polymorph_monster(CreatureEntity &creature, POSITION y, POSITION x)
     if (m_idx) {
         auto &monster_polymorphed = floor.get_monster(*m_idx);
         monster_polymorphed.name = back_m.name;
-        monster_polymorphed.get_monster_profile().parent_m_idx = back_m.get_parent_m_idx();
+        monster_polymorphed.set_parent_m_idx(back_m.get_parent_m_idx());
         // 所持アイテムは inventory[] を引き継ぐ
         if (preserve_hold_objects) {
             for (size_t i = 0; i < back_m.inventory.size(); i++) {

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -923,6 +923,67 @@ public:
     }
 
     /*!
+     * @brief アライアンス所属を設定する (提案 9b)
+     * @details モンスター以外（プレイヤー）に対する呼出は無視される
+     */
+    virtual void set_alliance_idx(AllianceType alliance)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().alliance_idx = alliance;
+        }
+    }
+
+    /*!
+     * @brief サブアライメントを設定する (提案 9b)
+     */
+    virtual void set_sub_align(BIT_FLAGS8 sub_align)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().sub_align = sub_align;
+        }
+    }
+
+    /*!
+     * @brief サブアライメントに特定ビットを追加する (提案 9b)
+     */
+    virtual void add_sub_align(BIT_FLAGS8 mask)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().sub_align |= mask;
+        }
+    }
+
+    /*!
+     * @brief 親モンスター m_idx を設定する (提案 9b)
+     */
+    virtual void set_parent_m_idx(MONSTER_IDX m_idx)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().parent_m_idx = m_idx;
+        }
+    }
+
+    /*!
+     * @brief smart_learn フラグに 1 ビット追加する (提案 9b)
+     */
+    virtual void add_smart_flag(MonsterSmartLearnType flag)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().smart.set(flag);
+        }
+    }
+
+    /*!
+     * @brief smart_learn フラグを全クリアする (提案 9b)
+     */
+    virtual void clear_smart_flags()
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().smart.clear();
+        }
+    }
+
+    /*!
      * @brief MonsterConstantFlagType (mflag2) のチェック共通ヘルパ
      * @details 提案 15: mflag2.has(...) パターンを virtual で集約
      */


### PR DESCRIPTION
提案 9 (read-side virtual) の対称形として、MonsterProfile への 書き込みを CreatureEntity の virtual setter にまとめる。

新規 virtual:
- set_alliance_idx(AllianceType)
- set_sub_align(BIT_FLAGS8) / add_sub_align(BIT_FLAGS8)
- set_parent_m_idx(MONSTER_IDX)
- add_smart_flag(MonsterSmartLearnType) / clear_smart_flags()

migration 対象:
- monster-floor/one-monster-placer: 初期化時 alliance/sub_align/parent
- monster-floor/monster-remover: 親消滅時の親 idx 付替え
- monster/monster-compaction: m_idx 圧縮時の親 idx 更新
- monster/monster-damage: 変身時の sub_align 維持
- monster/monster-status / monster-status-setter: 進化・PET 化処理
- monster/monster-update: smart_learn 学習 (約 25 箇所)
- mspell/improper-mspell-remover: smart 忘却
- spell-kind/spells-polymorph: 変身モンスターの親引継ぎ
- load/old/monster-loader-savefile50: savefile からの復元

書き込みも is_player() ガード相当のチェックが基底側に集約され、
誤ってプレイヤーへ書き込んでも no-op で安全になった。
mflag2 自体や transform_r_idx など別途設計が必要なフィールドは
従来どおり直接アクセスを維持。