### PR TITLE
refactor: mflag (MonsterTemporaryFlagType) を virtual 化 (提案 16)

### DIFF
--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -353,12 +353,12 @@ void process_player(CreatureEntity &creature)
                 }
 
                 // 出現して即魔法を使わないようにするフラグを落とす処理
-                if (monster.get_monster_profile().mflag.has(MonsterTemporaryFlagType::PREVENT_MAGIC)) {
-                    monster.get_monster_profile().mflag.reset(MonsterTemporaryFlagType::PREVENT_MAGIC);
+                if (monster.has_temporary_flag(MonsterTemporaryFlagType::PREVENT_MAGIC)) {
+                    monster.reset_temporary_flag(MonsterTemporaryFlagType::PREVENT_MAGIC);
                 }
 
-                if (monster.get_monster_profile().mflag.has(MonsterTemporaryFlagType::SANITY_BLAST)) {
-                    monster.get_monster_profile().mflag.reset(MonsterTemporaryFlagType::SANITY_BLAST);
+                if (monster.has_temporary_flag(MonsterTemporaryFlagType::SANITY_BLAST)) {
+                    monster.reset_temporary_flag(MonsterTemporaryFlagType::SANITY_BLAST);
                     sanity_blast(creature, m_idx);
                 }
 

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -73,7 +73,7 @@ static ProcessResult is_affective(EffectMonster *em_ptr)
     if (em_ptr->m_ptr->hp < 0) {
         return ProcessResult::PROCESS_FALSE;
     }
-    if (em_ptr->m_ptr->get_monster_profile().mflag.has_not(MonsterTemporaryFlagType::PRESENT_AT_TURN_START)) {
+    if (!em_ptr->m_ptr->was_present_at_turn_start()) {
         return ProcessResult::PROCESS_FALSE;
     }
     if (em_ptr->is_monster() || !em_ptr->m_ptr->is_riding()) {

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -129,7 +129,7 @@ static MonraceDefinition &set_pet_params(CreatureEntity &creature, const int cur
     monster.reset_target();
     auto &r_ref = monster.get_real_monrace();
     if (!ironman_nightmare) {
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::PREVENT_MAGIC);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::PREVENT_MAGIC);
     }
 
     return r_ref;

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -478,7 +478,7 @@ bool process_monster_movement(CreatureEntity &creature, turn_flags *turn_flags_p
         const auto p_pos = creature.get_position(); //!< @details 関数が長すぎてプレイヤーの座標が不変であることを保証できない.
         const auto m_pos = monster.get_position();
         const auto is_projectable = projectable(floor, p_pos, m_pos);
-        const auto can_see = disturb_near && monster.get_monster_profile().mflag.has(MonsterTemporaryFlagType::VIEW) && is_projectable;
+        const auto can_see = disturb_near && monster.has_temporary_flag(MonsterTemporaryFlagType::VIEW) && is_projectable;
         const auto is_high_level = disturb_high && (apparent_monrace.r_tkills > 0) && (apparent_monrace.level >= creature.level);
         const auto is_unknown_level = disturb_unknown && (apparent_monrace.r_tkills == 0);
         if (monster.is_visible_on_map() && (disturb_move || can_see || is_high_level || is_unknown_level)) {

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -583,7 +583,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     }
 
     if (!ironman_nightmare) {
-        m_ptr->get_monster_profile().mflag.set(MonsterTemporaryFlagType::PREVENT_MAGIC);
+        m_ptr->set_temporary_flag(MonsterTemporaryFlagType::PREVENT_MAGIC);
     }
 
     auto is_awake_lightning_monster = new_monrace.brightness_flags.has_any_of(self_ld_mask);

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -236,7 +236,7 @@ static bool update_weird_telepathy(CreatureEntity &creature, um_type *um_ptr, MO
     }
 
     um_ptr->flag = true;
-    monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+    monster.set_temporary_flag(MonsterTemporaryFlagType::ESP);
     if (monster.is_original_ap() && !creature.is_hallucinated()) {
         monrace.r_misc_flags.set(MonsterMiscType::WEIRD_MIND);
         update_smart_stupid_flags(monrace);
@@ -252,7 +252,7 @@ static void update_telepathy_sight(CreatureEntity &creature, um_type *um_ptr, MO
     const auto is_hallucinated = creature.is_hallucinated();
     if (CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU)) {
         um_ptr->flag = true;
-        um_ptr->m_ptr->get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        um_ptr->m_ptr->set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (um_ptr->m_ptr->is_original_ap() && !is_hallucinated) {
             update_smart_stupid_flags(monrace);
         }
@@ -277,7 +277,7 @@ static void update_telepathy_sight(CreatureEntity &creature, um_type *um_ptr, MO
     }
 
     um_ptr->flag = true;
-    monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+    monster.set_temporary_flag(MonsterTemporaryFlagType::ESP);
     if (monster.is_original_ap() && !is_hallucinated) {
         update_smart_stupid_flags(monrace);
     }
@@ -290,7 +290,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
     const auto is_hallucinated = creature.is_hallucinated();
     if ((creature.has_esp_animal()) && monrace.kind_flags.has(MonsterKindType::ANIMAL)) {
         um_ptr->flag = true;
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::ANIMAL);
         }
@@ -298,7 +298,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((creature.has_esp_animal()) && monrace.kind_flags.has(MonsterKindType::WEREWOLF)) {
         um_ptr->flag = true;
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::WEREWOLF);
         }
@@ -306,7 +306,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((creature.has_esp_nasty()) && monrace.kind_flags.has(MonsterKindType::NASTY)) {
         um_ptr->flag = true;
-        um_ptr->m_ptr->get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        um_ptr->m_ptr->set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (is_original_ap_and_seen(creature, *um_ptr->m_ptr) && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::NASTY);
         }
@@ -314,7 +314,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((creature.has_esp_homo()) && monrace.kind_flags.has(MonsterKindType::HOMO_SEXUAL)) {
         um_ptr->flag = true;
-        um_ptr->m_ptr->get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        um_ptr->m_ptr->set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (is_original_ap_and_seen(creature, *um_ptr->m_ptr) && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::HOMO_SEXUAL);
         }
@@ -322,7 +322,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((creature.has_esp_undead()) && monster.has_undead_flag()) {
         um_ptr->flag = true;
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::UNDEAD);
         }
@@ -330,7 +330,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((creature.has_esp_demon()) && monrace.kind_flags.has(MonsterKindType::DEMON)) {
         um_ptr->flag = true;
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::DEMON);
         }
@@ -338,7 +338,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((creature.has_esp_orc()) && monrace.kind_flags.has(MonsterKindType::ORC)) {
         um_ptr->flag = true;
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::ORC);
         }
@@ -346,7 +346,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((creature.has_esp_troll()) && monrace.kind_flags.has(MonsterKindType::TROLL)) {
         um_ptr->flag = true;
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::TROLL);
         }
@@ -354,7 +354,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((creature.has_esp_giant()) && monrace.kind_flags.has(MonsterKindType::GIANT)) {
         um_ptr->flag = true;
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::GIANT);
         }
@@ -362,7 +362,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((creature.has_esp_dragon()) && monrace.kind_flags.has(MonsterKindType::DRAGON)) {
         um_ptr->flag = true;
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::DRAGON);
         }
@@ -370,7 +370,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((creature.has_esp_human()) && monrace.kind_flags.has(MonsterKindType::HUMAN)) {
         um_ptr->flag = true;
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::HUMAN);
         }
@@ -378,7 +378,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((creature.has_esp_evil()) && monrace.kind_flags.has(MonsterKindType::EVIL)) {
         um_ptr->flag = true;
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::EVIL);
         }
@@ -386,7 +386,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((creature.has_esp_good()) && monrace.kind_flags.has(MonsterKindType::GOOD)) {
         um_ptr->flag = true;
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::GOOD);
         }
@@ -394,7 +394,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((creature.has_esp_nonliving()) && monrace.kind_flags.has(MonsterKindType::NONLIVING) && monrace.kind_flags.has_none_of({ MonsterKindType::DEMON, MonsterKindType::UNDEAD })) {
         um_ptr->flag = true;
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::NONLIVING);
         }
@@ -402,7 +402,7 @@ static void update_specific_race_telepathy(CreatureEntity &creature, um_type *um
 
     if ((creature.has_esp_unique()) && monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
         um_ptr->flag = true;
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::ESP);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::ESP);
         if (monster.is_original_ap() && !is_hallucinated) {
             monrace.r_kind_flags.set(MonsterKindType::UNIQUE);
         }
@@ -456,7 +456,7 @@ static void decide_sight_invisible_monster(CreatureEntity &creature, um_type *um
     auto &monster = *um_ptr->m_ptr;
     auto &monrace = monster.get_monrace();
 
-    monster.get_monster_profile().mflag.reset(MonsterTemporaryFlagType::ESP);
+    monster.reset_temporary_flag(MonsterTemporaryFlagType::ESP);
 
     if (distance > (um_ptr->in_darkness ? MAX_PLAYER_SIGHT / 2 : MAX_PLAYER_SIGHT)) {
         return;
@@ -527,7 +527,7 @@ static void update_invisible_monster(CreatureEntity &creature, um_type *um_ptr, 
 
     const auto &world = AngbandWorld::get_instance();
     if (world.is_loading_now && world.character_dungeon && !AngbandSystem::get_instance().is_phase_out() && monster.get_appearance_monrace().misc_flags.has(MonsterMiscType::ELDRITCH_HORROR)) {
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::SANITY_BLAST);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::SANITY_BLAST);
     }
 
     const auto &floor = *creature.get_floor();
@@ -567,8 +567,8 @@ static bool update_clear_monster(CreatureEntity &creature, um_type *um_ptr)
         return false;
     }
 
-    if (um_ptr->m_ptr->get_monster_profile().mflag.has_not(MonsterTemporaryFlagType::VIEW)) {
-        um_ptr->m_ptr->get_monster_profile().mflag.set(MonsterTemporaryFlagType::VIEW);
+    if (!um_ptr->m_ptr->has_temporary_flag(MonsterTemporaryFlagType::VIEW)) {
+        um_ptr->m_ptr->set_temporary_flag(MonsterTemporaryFlagType::VIEW);
         if (um_ptr->do_disturb && (disturb_pets || um_ptr->m_ptr->is_hostile())) {
             disturb(creature, true, true);
         }
@@ -604,11 +604,11 @@ void update_monster(CreatureEntity &creature, MONSTER_IDX m_idx, bool full)
         update_visible_monster(creature, um_ptr, m_idx);
     }
 
-    if (update_clear_monster(creature, um_ptr) || um_ptr->m_ptr->get_monster_profile().mflag.has_not(MonsterTemporaryFlagType::VIEW)) {
+    if (update_clear_monster(creature, um_ptr) || !um_ptr->m_ptr->has_temporary_flag(MonsterTemporaryFlagType::VIEW)) {
         return;
     }
 
-    um_ptr->m_ptr->get_monster_profile().mflag.reset(MonsterTemporaryFlagType::VIEW);
+    um_ptr->m_ptr->reset_temporary_flag(MonsterTemporaryFlagType::VIEW);
     if (um_ptr->do_disturb && (disturb_pets || um_ptr->m_ptr->is_hostile())) {
         disturb(creature, true, true);
     }

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -732,7 +732,7 @@ void mark_monsters_present(CreatureEntity &creature)
         if (!monster.is_valid()) {
             continue;
         }
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::PRESENT_AT_TURN_START);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::PRESENT_AT_TURN_START);
     }
 }
 

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -314,7 +314,7 @@ bool make_attack_spell(CreatureEntity &creature, MONSTER_IDX m_idx)
     }
 
     const auto &m_ref = *msa_ptr->m_ptr;
-    auto should_prevent = m_ref.get_monster_profile().mflag.has(MonsterTemporaryFlagType::PREVENT_MAGIC);
+    auto should_prevent = m_ref.has_prevent_magic();
     should_prevent |= !m_ref.is_hostile();
     should_prevent |= (Grid::calc_distance(creature.get_position(), m_ref.get_position()) > AngbandSystem::get_instance().get_max_range()) && !m_ref.get_target_position().y;
     if (should_prevent) {

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -57,18 +57,18 @@ bool project_all_los(CreatureEntity &creature, AttributeType typ, int dam)
             continue;
         }
 
-        monster.get_monster_profile().mflag.set(MonsterTemporaryFlagType::LOS);
+        monster.set_temporary_flag(MonsterTemporaryFlagType::LOS);
     }
 
     BIT_FLAGS flg = PROJECT_JUMP | PROJECT_KILL | PROJECT_HIDE;
     auto obvious = false;
     for (short i = 1; i < floor.m_max; i++) {
         auto &monster = floor.get_monster(i);
-        if (monster.get_monster_profile().mflag.has_not(MonsterTemporaryFlagType::LOS)) {
+        if (!monster.has_temporary_flag(MonsterTemporaryFlagType::LOS)) {
             continue;
         }
 
-        monster.get_monster_profile().mflag.reset(MonsterTemporaryFlagType::LOS);
+        monster.reset_temporary_flag(MonsterTemporaryFlagType::LOS);
         const auto m_pos = monster.get_position();
         if (project(creature, 0, 0, m_pos.y, m_pos.x, dam, typ, flg).notice) {
             obvious = true;

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -992,6 +992,70 @@ public:
         return this->has_monster_profile() && this->get_monster_profile().mflag2.has(flag);
     }
 
+    /*!
+     * @brief MonsterTemporaryFlagType (mflag) のチェック共通ヘルパ (提案 16)
+     */
+    bool has_temporary_flag(MonsterTemporaryFlagType flag) const
+    {
+        return this->has_monster_profile() && this->get_monster_profile().mflag.has(flag);
+    }
+
+    /*!
+     * @brief MonsterTemporaryFlagType を立てる (提案 16)
+     */
+    virtual void set_temporary_flag(MonsterTemporaryFlagType flag)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().mflag.set(flag);
+        }
+    }
+
+    /*!
+     * @brief MonsterTemporaryFlagType をクリアする (提案 16)
+     */
+    virtual void reset_temporary_flag(MonsterTemporaryFlagType flag)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().mflag.reset(flag);
+        }
+    }
+
+    /*! @brief プレイヤーの視界内 (VIEW) にいるか (提案 16) */
+    virtual bool is_in_view() const
+    {
+        return this->has_temporary_flag(MonsterTemporaryFlagType::VIEW);
+    }
+
+    /*! @brief project_all_los の対象 (LOS) としてマークされているか */
+    virtual bool is_marked_for_los() const
+    {
+        return this->has_temporary_flag(MonsterTemporaryFlagType::LOS);
+    }
+
+    /*! @brief ESP で感知されているか */
+    virtual bool is_sensed_by_esp() const
+    {
+        return this->has_temporary_flag(MonsterTemporaryFlagType::ESP);
+    }
+
+    /*! @brief ターン開始時にフロアにいたか (PRESENT_AT_TURN_START) */
+    virtual bool was_present_at_turn_start() const
+    {
+        return this->has_temporary_flag(MonsterTemporaryFlagType::PRESENT_AT_TURN_START);
+    }
+
+    /*! @brief 反魔法状態 (PREVENT_MAGIC) か */
+    virtual bool has_prevent_magic() const
+    {
+        return this->has_temporary_flag(MonsterTemporaryFlagType::PREVENT_MAGIC);
+    }
+
+    /*! @brief 正気喪失効果 (SANITY_BLAST) を持つか */
+    virtual bool has_sanity_blast() const
+    {
+        return this->has_temporary_flag(MonsterTemporaryFlagType::SANITY_BLAST);
+    }
+
     /*! @brief 影 (KAGE) かどうか */
     virtual bool is_kage() const
     {


### PR DESCRIPTION
提案 15/15b の mflag2 集約と同パターンで、mflag (一時フラグ)
の参照・更新を CreatureEntity の virtual に集約する。

新規 virtual:
- has_temporary_flag(flag) (read-only ヘルパ)
- set_temporary_flag(flag) / reset_temporary_flag(flag) (書込)
- 個別アクセサ: is_in_view / is_marked_for_los / is_sensed_by_esp / was_present_at_turn_start / has_prevent_magic / has_sanity_blast

migration 対象 (10 ファイル):
- monster/monster-update: ESP/VIEW テレパシー判定 (約 20 箇所)
- monster/monster-util: PRESENT_AT_TURN_START 設定
- monster-floor/monster-move: VIEW 参照
- monster-floor/one-monster-placer: PREVENT_MAGIC 設定
- floor/floor-changer: PREVENT_MAGIC 設定
- spell-kind/spells-sight: LOS マーク (3 箇所)
- mspell/mspell-attack: PREVENT_MAGIC 判定
- effect/effect-monster: PRESENT_AT_TURN_START チェック
- core/player-processor: PREVENT_MAGIC / SANITY_BLAST のリセット

`mflag.clear()` (一括クリア) は savefile 復元と新規生成時の
初期化用途のみのため、直接アクセスを維持。