### PR TITLE
refactor: モンスター inventory 操作を OO API に集約 (提案 17)

### DIFF
--- a/src/autopick/autopick.cpp
+++ b/src/autopick/autopick.cpp
@@ -119,7 +119,7 @@ void autopick_pickup_items(CreatureEntity &creature, const Grid &grid)
             continue;
         }
 
-        if (!check_creature.store_item(item)) {
+        if (!creature.can_store_item(item)) {
             msg_format(_("ザックには%sを入れる隙間がない。", "You have no room for %s."), item_name.data());
             item.marked.set(OmType::SUPRESS_MESSAGE);
             continue;

--- a/src/autopick/autopick.cpp
+++ b/src/autopick/autopick.cpp
@@ -119,7 +119,7 @@ void autopick_pickup_items(CreatureEntity &creature, const Grid &grid)
             continue;
         }
 
-        if (!check_store_item_to_inventory(creature, &item)) {
+        if (!check_creature.store_item(item)) {
             msg_format(_("ザックには%sを入れる隙間がない。", "You have no room for %s."), item_name.data());
             item.marked.set(OmType::SUPRESS_MESSAGE);
             continue;

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -85,7 +85,7 @@ static void add_outfit(CreatureEntity &creature, ItemEntity &item)
 {
     object_aware(creature, item);
     item.mark_as_known();
-    const auto slot = store_item_to_inventory(creature, &item);
+    const auto slot = creature.store_item(item);
     autopick_alter_item(creature, slot, false);
     wield_all(creature);
 }

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -24,7 +24,6 @@
 #include "io/input-key-requester.h"
 #include "io/write-diary.h"
 #include "main/sound-of-music.h"
-#include "monster-floor/monster-object.h"
 #include "monster-floor/monster-remover.h"
 #include "monster/monster-describer.h"
 #include "monster/monster-description-types.h"
@@ -821,7 +820,7 @@ void do_cmd_pet(CreatureEntity &creature)
             for (pet_ctr = creature.get_floor()->m_max - 1; pet_ctr >= 1; pet_ctr--) {
                 auto &monster = creature.get_floor()->get_monster(static_cast<MONSTER_IDX>(pet_ctr));
                 if (monster.is_pet()) {
-                    monster_drop_carried_objects(creature, monster);
+                    monster.drop_all_inventory(creature);
                 }
             }
         } else {
@@ -980,7 +979,7 @@ void do_cmd_pet(CreatureEntity &creature)
         received.iy = received.ix = 0;
         const auto item_name = describe_flavor(creature, received, OD_OMIT_PREFIX);
         msg_format(_("%sから%sを受け取った。", "You receive %s from %s."), pet_name.data(), item_name.data());
-        store_item_to_inventory(creature, &received);
+        creature.store_item(received);
         item_in_slot.wipe();
         if (was_equipped) {
             if (pet_monster.equip_cnt > 0) {

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -516,7 +516,7 @@ static bool exe_eat_charge_of_magic_device(CreatureEntity &creature, ItemEntity 
 
         /* Unstack the used item */
         o_ptr->number--;
-        i_idx = store_item_to_inventory(creature, &item);
+        i_idx = creature.store_item(item);
         msg_format(_("杖をまとめなおした。", "You unstack your staff."));
     }
 

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -348,7 +348,7 @@ bool check_get_item(ItemEntity *o_ptr)
  * @param o_ptr 拾いたいオブジェクトの構造体参照ポインタ
  * @return 溢れずに済むならTRUEを返す
  */
-bool check_store_item_to_inventory(CreatureEntity &creature, const ItemEntity *o_ptr)
+bool check_store_item_to_inventory(const CreatureEntity &creature, const ItemEntity *o_ptr)
 {
     if (creature.inven_cnt < INVEN_PACK) {
         return true;

--- a/src/inventory/inventory-object.h
+++ b/src/inventory/inventory-object.h
@@ -12,6 +12,6 @@ void drop_from_inventory(CreatureEntity &creature, INVENTORY_IDX i_idx, ITEM_NUM
 void combine_pack(CreatureEntity &creature);
 void reorder_pack(CreatureEntity &creature);
 int16_t store_item_to_inventory(CreatureEntity &creature, ItemEntity *o_ptr);
-bool check_store_item_to_inventory(CreatureEntity &creature, const ItemEntity *o_ptr);
+bool check_store_item_to_inventory(const CreatureEntity &creature, const ItemEntity *o_ptr);
 INVENTORY_IDX inven_takeoff(CreatureEntity &creature, INVENTORY_IDX i_idx, ITEM_NUMBER amt);
 bool check_get_item(ItemEntity *o_ptr);

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -116,7 +116,7 @@ static void py_pickup_single_item(CreatureEntity &creature, short i_idx, bool pi
         return;
     }
 
-    if (!check_store_item_to_inventory(creature, &item)) {
+    if (!check_creature.store_item(item)) {
         msg_print(_("ザックには{}を入れる隙間がない。", "You have no room for {}."), item_name);
         return;
     }
@@ -137,7 +137,7 @@ static void py_pickup_multiple_items(CreatureEntity &creature, bool pickup)
         return;
     }
 
-    const auto tester = FuncItemTester([&creature](const ItemEntity *o) { return check_store_item_to_inventory(creature, o); });
+    const auto tester = FuncItemTester([&creature](const ItemEntity *o) { return creature.can_store_item(*o); });
     const auto can_pickup = [&](auto i_idx) { return tester.okay(floor.o_list.at(i_idx).get()); };
     const auto count_of_pickable_items = ranges::count_if(grid.o_idx_list, can_pickup);
     if (count_of_pickable_items == 0) {
@@ -241,7 +241,7 @@ void process_player_pickup_item(CreatureEntity &creature, OBJECT_IDX o_idx)
     // delete_object_idx()で配列から削除した後にも使用するためshared_ptrをコピーする
     const std::shared_ptr<ItemEntity> picked_item_ptr = creature.get_floor()->o_list[o_idx];
 
-    const auto slot = store_item_to_inventory(creature, picked_item_ptr.get());
+    const auto slot = creature.store_item(*picked_item_ptr);
     delete_object_idx(creature, o_idx);
 
     auto &picked_slot_item = *creature.inventory[slot];
@@ -307,7 +307,7 @@ void carry(CreatureEntity &creature, bool pickup)
             continue;
         }
 
-        if (!check_store_item_to_inventory(creature, &item)) {
+        if (!check_creature.store_item(item)) {
             msg_format(_("ザックには%sを入れる隙間がない。", "You have no room for %s."), item_name.data());
             continue;
         }

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -116,7 +116,7 @@ static void py_pickup_single_item(CreatureEntity &creature, short i_idx, bool pi
         return;
     }
 
-    if (!check_creature.store_item(item)) {
+    if (!creature.can_store_item(item)) {
         msg_print(_("ザックには{}を入れる隙間がない。", "You have no room for {}."), item_name);
         return;
     }
@@ -307,7 +307,7 @@ void carry(CreatureEntity &creature, bool pickup)
             continue;
         }
 
-        if (!check_creature.store_item(item)) {
+        if (!creature.can_store_item(item)) {
             msg_format(_("ザックには%sを入れる隙間がない。", "You have no room for %s."), item_name.data());
             continue;
         }

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -196,7 +196,7 @@ bool exchange_cash(CreatureEntity &creature)
              * Since a corpse is handed at first,
              * there is at least one empty slot.
              */
-            inventory_new = store_item_to_inventory(creature, &prize_item);
+            inventory_new = creature.store_item(prize_item);
             const auto got_item_name = describe_flavor(creature, prize_item, 0);
             msg_format(_("%s(%c)を貰った。", "You get %s (%c). "), got_item_name.data(), index_to_label(inventory_new));
 

--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -126,7 +126,7 @@ bool create_ammo(CreatureEntity &creature)
         item.mark_as_known();
         ItemMagicApplier(creature, &item, creature.level, AM_NO_FIXED_ART).execute();
         item.discount = 99;
-        int16_t slot = store_item_to_inventory(creature, &item);
+        int16_t slot = creature.store_item(item);
         const auto item_name = describe_flavor(creature, item, 0);
         msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
         if (slot >= 0) {
@@ -153,7 +153,7 @@ bool create_ammo(CreatureEntity &creature)
         const auto item_name = describe_flavor(creature, ammo, 0);
         msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
         vary_item(creature, i_idx, -1);
-        int16_t slot = store_item_to_inventory(creature, &ammo);
+        int16_t slot = creature.store_item(ammo);
         if (slot >= 0) {
             autopick_alter_item(creature, slot, false);
         }
@@ -177,7 +177,7 @@ bool create_ammo(CreatureEntity &creature)
         const auto item_name = describe_flavor(creature, ammo, 0);
         msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
         vary_item(creature, i_idx, -1);
-        int16_t slot = store_item_to_inventory(creature, &ammo);
+        int16_t slot = creature.store_item(ammo);
         if (slot >= 0) {
             autopick_alter_item(creature, slot, false);
         }

--- a/src/mind/mind-mage.cpp
+++ b/src/mind/mind-mage.cpp
@@ -71,7 +71,7 @@ bool eat_magic(CreatureEntity &creature, int power)
                     eat_item.number = 1;
                     item->pval++;
                     item->number--;
-                    i_idx = store_item_to_inventory(creature, &eat_item);
+                    i_idx = creature.store_item(eat_item);
 
                     msg_print(_("杖をまとめなおした。", "You unstack your staff."));
                 }

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -16,7 +16,6 @@
 #include "main/sound-of-music.h"
 #include "market/arena-entry.h"
 #include "monster-floor/monster-death-util.h"
-#include "monster-floor/monster-object.h"
 #include "monster-floor/special-death-switcher.h"
 #include "monster-race/monster-race-hook.h"
 #include "monster-race/race-brightness-mask.h"
@@ -449,7 +448,7 @@ void monster_death(CreatureEntity &creature, MONSTER_IDX m_idx, bool drop_item, 
     }
 
     drop_corpse(creature, &md);
-    monster_drop_carried_objects(creature, *md.m_ptr);
+    md.m_ptr->drop_all_inventory(creature);
     decide_drop_quality(&md);
     switch_special_death(creature, &md, attribute_flags);
     drop_artifacts(creature, &md);

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -219,20 +219,3 @@ void update_object_by_monster_movement(CreatureEntity &creature, turn_flags *tur
         monster_pickup_object(creature, turn_flags_ptr, m_idx, &item, is_unpickable_object, ny, nx, m_name, item_name, this_o_idx);
     }
 }
-
-/*!
- * @brief モンスターが盗みや拾いで確保していたアイテムを全てドロップさせる / Drop all items carried by a monster
- * @param creature クリーチャーへの参照 (フロア・UI 文脈)
- * @param target ドロップ元クリーチャー (モンスター)
- * @details
- * フェーズ A-2 で inventory[] からのドロップに切替済み、フェーズ A-4b で
- * レガシー hold_o_idx_list 経路を完全削除。フェーズ A-5 で
- * `target.drop_all_inventory(creature)` に集約。
- */
-void monster_drop_carried_objects(CreatureEntity &creature, CreatureEntity &target)
-{
-    if (!target.has_monster_profile()) {
-        return;
-    }
-    target.drop_all_inventory(creature);
-}

--- a/src/monster-floor/monster-object.h
+++ b/src/monster-floor/monster-object.h
@@ -5,4 +5,3 @@
 class CreatureEntity;
 struct turn_flags;
 void update_object_by_monster_movement(CreatureEntity &creature, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx, POSITION ny, POSITION nx);
-void monster_drop_carried_objects(CreatureEntity &creature, CreatureEntity &target);

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -300,7 +300,7 @@ void ObjectThrowEntity::process_boomerang_back()
     auto &creature = *this->creature_ptr;
     if (this->come_back) {
         if ((this->i_idx != INVEN_MAIN_HAND) && (this->i_idx != INVEN_SUB_HAND)) {
-            store_item_to_inventory(creature, this->q_ptr);
+            creature.store_item(*this->q_ptr);
             this->do_drop = false;
             return;
         }

--- a/src/object-use/use-execution.cpp
+++ b/src/object-use/use-execution.cpp
@@ -140,7 +140,7 @@ void ObjectUseEntity::execute()
         used_item.number = 1;
         item->pval++;
         item->number--;
-        this->i_idx = store_item_to_inventory(creature, &used_item);
+        this->i_idx = creature.store_item(used_item);
         msg_print(_("杖をまとめなおした。", "You unstack your staff."));
     }
 

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -278,7 +278,7 @@ static void attack_golden_hammer(CreatureEntity &creature, player_attack_type *p
         monster.inven_cnt--;
     }
     msg_format(_("%sを奪った。", "You snatched %s."), item_name.data());
-    store_item_to_inventory(creature, &stolen);
+    creature.store_item(stolen);
 }
 
 /*!

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -92,7 +92,7 @@ static void take_item_from_home(CreatureEntity &creature, ItemEntity &item_home,
     const auto amt = item_inventory.number;
     distribute_charges(&item_home, &item_inventory, amt);
 
-    const auto item_new = store_item_to_inventory(creature, &item_inventory);
+    const auto item_new = creature.store_item(item_inventory);
     const auto item_name = describe_flavor(creature, *creature.inventory[item_new], 0);
     handle_stuff(creature);
     msg_format(_("%s(%c)を取った。", "You have %s (%c)."), item_name.data(), index_to_label(item_new));
@@ -187,7 +187,7 @@ void store_purchase(CreatureEntity &creature, StoreSaleType store_num)
      */
     reduce_charges(&item, item_store.number - amt);
     item.number = amt;
-    if (!check_store_item_to_inventory(creature, &item)) {
+    if (!check_creature.store_item(item)) {
         msg_print(_("そんなにアイテムを持てない。", "You cannot carry that many different items."));
         return;
     }
@@ -218,7 +218,7 @@ void store_purchase(CreatureEntity &creature, StoreSaleType store_num)
         return;
     }
 
-    if (!check_store_item_to_inventory(creature, &item)) {
+    if (!check_creature.store_item(item)) {
         msg_print(_("ザックにそのアイテムを入れる隙間がない。", "You cannot carry that many items."));
         return;
     }
@@ -284,7 +284,7 @@ void store_purchase(CreatureEntity &creature, StoreSaleType store_num)
     const auto idx = find_autopick_list(creature, &item);
     auto_inscribe_item(&item, idx);
 
-    item_new = store_item_to_inventory(creature, &item);
+    item_new = creature.store_item(item);
     handle_stuff(creature);
 
     const auto got_item_name = describe_flavor(creature, *creature.inventory[item_new], 0);

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -187,7 +187,7 @@ void store_purchase(CreatureEntity &creature, StoreSaleType store_num)
      */
     reduce_charges(&item, item_store.number - amt);
     item.number = amt;
-    if (!check_creature.store_item(item)) {
+    if (!creature.can_store_item(item)) {
         msg_print(_("そんなにアイテムを持てない。", "You cannot carry that many different items."));
         return;
     }
@@ -218,7 +218,7 @@ void store_purchase(CreatureEntity &creature, StoreSaleType store_num)
         return;
     }
 
-    if (!check_creature.store_item(item)) {
+    if (!creature.can_store_item(item)) {
         msg_print(_("ザックにそのアイテムを入れる隙間がない。", "You cannot carry that many items."));
         return;
     }

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -607,6 +607,11 @@ int16_t CreatureEntity::store_item(const ItemEntity &item)
     return store_item_to_inventory(*this, &clone);
 }
 
+bool CreatureEntity::can_store_item(const ItemEntity &item) const
+{
+    return check_store_item_to_inventory(*this, &item);
+}
+
 int16_t CreatureEntity::acquire_item(const ItemEntity &item)
 {
     // [フェーズ C-2] 装備可能なアイテムは空きスロットがあれば自動装備

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -864,6 +864,14 @@ public:
     int16_t store_item(const ItemEntity &item);
 
     /*!
+     * @brief このクリーチャーの所持品にアイテムを格納可能か判定する (提案 17)
+     * @param item 判定対象のアイテム
+     * @return 格納可能なら true
+     * @details 既存の `check_store_item_to_inventory()` への薄いラッパ。
+     */
+    bool can_store_item(const ItemEntity &item) const;
+
+    /*!
      * @brief 装備可能なら装備スロットへ、不可ならパックへアイテムを格納する
      * @param item 格納するアイテム (内部でクローンされる)
      * @return 格納されたインベントリスロットID、失敗時 -1


### PR DESCRIPTION
提案 11 系で導入した CreatureEntity::store_item / acquire_item / drop_all_inventory 等をプレイヤー側コールサイトにも横展開し、
レガシー free function `monster_drop_carried_objects` ラッパを 完全削除する。

新規 virtual:
- bool can_store_item(const ItemEntity &) const (提案 17) 既存 free function `check_store_item_to_inventory` への薄いラッパ。

migration 対象 (15 ファイル):
- store_item_to_inventory(creature, &item) → creature.store_item(item) 対象: attack-chaos-effect / cmd-eat / use-execution / throw-execution / cmd-pet / mind-mage / mind-archer / autopick / birth/inventory-initializer / store/purchase-order / market/bounty / inventory/player-inventory
- check_store_item_to_inventory(creature, &item) → creature.can_store_item(item) 対象: autopick / inventory/player-inventory / store/purchase-order
- monster_drop_carried_objects(creature, monster) → monster.drop_all_inventory(creature) 対象: cmd-action/cmd-pet / monster-floor/monster-death
- 上記移行に伴い free function `monster_drop_carried_objects` および 関連宣言・includes を削除

inventory/inventory-object.cpp 内部の自己呼出 (store_item_to_inventory 内部からの再呼出) と CreatureEntity::store_item/can_store_item の実装 本体は free function を呼び続ける (内部実装の二重定義回避)。