### PR TITLE
refactor: mflag2 書込パターンを virtual に集約 (提案 18)

### DIFF
--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -285,7 +285,7 @@ bool exe_mutation_power(CreatureEntity &creature, PlayerMutationType power)
 
         msg_print(_("祈りは効果がなかった！", "Your invocation is ineffectual!"));
         if (one_in_(13)) {
-            monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::NOGENO);
+            monster.set_constant_flag(MonsterConstantFlagType::NOGENO);
         }
 
         return true;

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -474,7 +474,7 @@ bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_opti
         // 1/20の確率で恐怖せず狂乱状態になる
         if (one_in_(20)) {
             auto &current_monster = floor.get_monster(grid.m_idx);
-            current_monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::FRENZY);
+            current_monster.set_constant_flag(MonsterConstantFlagType::FRENZY);
             (void)set_monster_monfear(*creature.get_floor(), grid.m_idx, 0);
             sound(SoundKind::FLEE);
             msg_format(_("%s^は恐怖を怒りに変えて狂乱状態になった！", "%s^ turns fear into rage and goes berserk!"), m_name.data());
@@ -569,7 +569,7 @@ bool do_cmd_headbutt(CreatureEntity &creature)
         // 1/20の確率で恐怖せず狂乱状態になる
         if (one_in_(20)) {
             auto &current_monster = floor.get_monster(grid.m_idx);
-            current_monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::FRENZY);
+            current_monster.set_constant_flag(MonsterConstantFlagType::FRENZY);
             (void)set_monster_monfear(*creature.get_floor(), grid.m_idx, 0);
             sound(SoundKind::FLEE);
             msg_format(_("%s^は恐怖を怒りに変えて狂乱状態になった！", "%s^ turns fear into rage and goes berserk!"), m_name.data());
@@ -641,7 +641,7 @@ void do_cmd_body_slam(CreatureEntity &creature)
         // 1/20の確率で恐怖せず狂乱状態になる
         if (one_in_(20)) {
             auto &current_monster = floor.get_monster(m_idx);
-            current_monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::FRENZY);
+            current_monster.set_constant_flag(MonsterConstantFlagType::FRENZY);
             (void)set_monster_monfear(*creature.get_floor(), m_idx, 0);
             sound(SoundKind::FLEE);
             msg_format(_("%s^は恐怖を怒りに変えて狂乱状態になった！", "%s^ turns fear into rage and goes berserk!"), m_name.data());
@@ -782,7 +782,7 @@ void do_cmd_enema(CreatureEntity &creature)
         // 1/20の確率で恐怖せず狂乱状態になる
         if (one_in_(20)) {
             auto &current_monster = floor.get_monster(m_idx);
-            current_monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::FRENZY);
+            current_monster.set_constant_flag(MonsterConstantFlagType::FRENZY);
             (void)set_monster_monfear(*creature.get_floor(), m_idx, 0);
             sound(SoundKind::FLEE);
             msg_format(_("%s^は恐怖を怒りに変えて狂乱状態になった！", "%s^ turns fear into rage and goes berserk!"), m_name.data());

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -128,7 +128,7 @@ void process_player(CreatureEntity &creature)
                 continue;
             }
 
-            monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+            monster.set_constant_flags({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
             update_monster(creature, m_idx, false);
         }
 
@@ -366,9 +366,9 @@ void process_player(CreatureEntity &creature)
                 // 感知したターンはMFLAG2_SHOWを落とし、次のターンに感知中フラグのMFLAG2_MARKを落とす
                 if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::MARK)) {
                     if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::SHOW)) {
-                        monster.get_monster_profile().mflag2.reset(MonsterConstantFlagType::SHOW);
+                        monster.reset_constant_flag(MonsterConstantFlagType::SHOW);
                     } else {
-                        monster.get_monster_profile().mflag2.reset(MonsterConstantFlagType::MARK);
+                        monster.reset_constant_flag(MonsterConstantFlagType::MARK);
                         monster.set_visible_on_map(false);
                         update_monster(creature, m_idx, false);
                         HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -33,17 +33,17 @@ static void effect_monster_charm_resist(CreatureEntity &creature, EffectMonster 
         em_ptr->obvious = false;
 
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate(creature)) {
         em_ptr->note = _("はあなたに敵意を抱いている！", " hates you too much!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
         em_ptr->note = _("はあなたを玩具だと思い込んでいる！", " thinks you are a toy!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
     } else {
         em_ptr->note = _("は突然友好的になったようだ！", " suddenly seems friendly!");
@@ -97,17 +97,17 @@ ProcessResult effect_monster_control_undead(CreatureEntity &creature, EffectMons
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate(creature)) {
         em_ptr->note = _("はあなたに敵意を抱いている！", " hates you too much!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
         em_ptr->note = _("はあなたを玩具だと思い込んでいる！", " thinks you are a toy!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
     } else {
         em_ptr->note = _("は既にあなたの奴隷だ！", " is in your thrall!");
@@ -138,17 +138,17 @@ ProcessResult effect_monster_control_demon(CreatureEntity &creature, EffectMonst
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate(creature)) {
         em_ptr->note = _("はあなたに敵意を抱いている！", " hates you too much!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
         em_ptr->note = _("はあなたを玩具だと思い込んでいる！", " thinks you are a toy!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
     } else {
         em_ptr->note = _("は既にあなたの奴隷だ！", " is in your thrall!");
@@ -179,17 +179,17 @@ ProcessResult effect_monster_control_animal(CreatureEntity &creature, EffectMons
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate(creature)) {
         em_ptr->note = _("はあなたに敵意を抱いている！", " hates you too much!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
         em_ptr->note = _("はあなたを玩具だと思い込んでいる！", " thinks you are a toy!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
     } else {
         em_ptr->note = _("はなついた。", " is tamed!");
@@ -225,17 +225,17 @@ ProcessResult effect_monster_charm_living(CreatureEntity &creature, EffectMonste
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate(creature)) {
         em_ptr->note = _("はあなたに敵意を抱いている！", " hates you too much!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
     } else if (has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
         em_ptr->note = _("はあなたを玩具だと思い込んでいる！", " thinks you are a toy!");
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
     } else {
         em_ptr->note = _("を支配した。", " is tamed!");
@@ -370,7 +370,7 @@ static bool effect_monster_crusade_domination(CreatureEntity &creature, EffectMo
 
     if (failed) {
         if (one_in_(4)) {
-            em_ptr->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+            em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
 
         return false;

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -130,7 +130,7 @@ static void parse_qtw_D(CreatureEntity &creature, qtwg_type *qtwg_ptr, char *s)
 
             const auto m_idx = place_specific_monster(creature, *qtwg_ptr->y, *qtwg_ptr->x, monrace_id, (PM_ALLOW_SLEEP | PM_NO_KAGE));
             if (clone && m_idx) {
-                floor.get_monster(*m_idx).get_monster_profile().mflag2.set(MonsterConstantFlagType::CLONED);
+                floor.get_monster(*m_idx).set_constant_flag(MonsterConstantFlagType::CLONED);
                 monrace.cur_num = old_cur_num;
                 monrace.mob_num = old_mob_num;
                 monrace.max_num = old_max_num;

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -283,7 +283,7 @@ static void generate_gambling_arena(CreatureEntity &creature)
             continue;
         }
 
-        monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+        monster.set_constant_flags({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
         update_monster(creature, i, false);
     }
 }

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -355,7 +355,7 @@ bool check_store_item_to_inventory(const CreatureEntity &creature, const ItemEnt
     }
 
     for (int j = 0; j < INVEN_PACK; j++) {
-        auto *j_ptr = creature.inventory[j].get();
+        const auto *j_ptr = creature.inventory[j].get();
         if (!j_ptr->is_valid()) {
             continue;
         }

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -636,7 +636,7 @@ void MonsterAttackPlayer::process_sadist_reaction()
         (void)set_monster_monfear(*creature.get_floor(), this->m_idx, 0);
 
         // 一時的な攻撃力上昇（怒り状態付与）
-        this->m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::ANGER);
+        this->m_ptr->set_constant_flag(MonsterConstantFlagType::ANGER);
 
         if (this->m_ptr->is_visible_on_map()) {
             msg_format(_("%s^は他者の苦痛に興奮している！", "%s^ gets excited by others' pain!"), this->m_name);

--- a/src/monster-floor/monster-generator.cpp
+++ b/src/monster-floor/monster-generator.cpp
@@ -142,7 +142,7 @@ tl::optional<MONSTER_IDX> multiply_monster(CreatureEntity &creature, MONSTER_IDX
     }
 
     if (clone || monster.is_cloned()) {
-        floor.get_monster(*multiplied_m_idx).get_monster_profile().mflag2.set({ MonsterConstantFlagType::CLONED, MonsterConstantFlagType::NOPET });
+        floor.get_monster(*multiplied_m_idx).set_constant_flags({ MonsterConstantFlagType::CLONED, MonsterConstantFlagType::NOPET });
     }
 
     return multiplied_m_idx;

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -271,16 +271,16 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     if (monrace.misc_flags.has(MonsterMiscType::CHAMELEON)) {
         m_ptr->r_idx = r_idx;
         choose_chameleon_polymorph(player, g_ptr->m_idx, g_ptr->get_terrain_id(), summoner_m_idx);
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::CHAMELEON);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::CHAMELEON);
     } else if (any_bits(mode, PM_CHAMELEON_FINAL_SUMMON)) {
         m_ptr->r_idx = r_idx;
         m_ptr->ap_r_idx = r_idx;
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::CHAMELEON);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::CHAMELEON);
     } else {
         m_ptr->r_idx = r_idx;
         if (any_bits(mode, PM_KAGE) && none_bits(mode, PM_FORCE_PET)) {
             m_ptr->ap_r_idx = MonraceId::KAGE;
-            m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::KAGE);
+            m_ptr->set_constant_flag(MonsterConstantFlagType::KAGE);
         } else {
             m_ptr->ap_r_idx = initial_r_appearance(const_cast<CreatureEntity &>(player), r_idx, mode);
         }
@@ -315,7 +315,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     if (same_appearance_as_parent) {
         m_ptr->ap_r_idx = summoner.ap_r_idx;
         if (summoner.is_kage()) {
-            m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::KAGE);
+            m_ptr->set_constant_flag(MonsterConstantFlagType::KAGE);
         }
     }
 
@@ -323,56 +323,56 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     struct tm *t = localtime(&now);
     if (t->tm_mon == 11 && t->tm_mday >= 24 && t->tm_mday <= 25 && one_in_(6)) {
         if (none_bits(mode, PM_MULTIPLY | PM_KAGE) && m_ptr->r_idx != MonraceId::SANTA) {
-            m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::SANTA);
+            m_ptr->set_constant_flag(MonsterConstantFlagType::SANTA);
         }
     }
 
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) && one_in_(100)) {
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::HUGE);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::HUGE);
     } else if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) && !m_ptr->is_huge() && one_in_(15)) {
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::LARGE);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::LARGE);
     }
 
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) && !m_ptr->is_large() && !m_ptr->is_huge() && one_in_(18)) {
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::SMALL);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::SMALL);
     }
 
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
         monrace.kind_flags.has_not(MonsterKindType::NONLIVING) && one_in_(20)) {
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::FAT);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::FAT);
     } else if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
                monrace.kind_flags.has_not(MonsterKindType::NONLIVING) && !m_ptr->is_fat() && one_in_(25)) {
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::GAUNT);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::GAUNT);
     }
 
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
         monrace.kind_flags.has(MonsterKindType::HUMAN) && one_in_(80)) {
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NAKED);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::NAKED);
     }
 
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
         monrace.kind_flags.has_not(MonsterKindType::NONLIVING) &&
         monrace.kind_flags.has_not(MonsterKindType::UNDEAD) && one_in_(50)) {
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::ZOMBIFIED);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::ZOMBIFIED);
     }
 
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
         monrace.misc_flags.has(MonsterMiscType::NO_WAIFUZATION) && one_in_(20)) {
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::WAIFUIZED);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::WAIFUIZED);
     }
 
     // 違法改造フラグの付与
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
         (monrace.kind_flags.has(MonsterKindType::GOLEM) || monrace.kind_flags.has(MonsterKindType::ROBOT)) &&
         one_in_(40)) {
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::ILLEGAL_MODIFIED);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::ILLEGAL_MODIFIED);
     }
 
     // 軽量化フラグの付与
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) &&
         monrace.kind_flags.has(MonsterKindType::GOLEM) &&
         one_in_(15)) {
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::LIGHTWEIGHT);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::LIGHTWEIGHT);
     }
 
     if (!m_ptr->is_chameleon() && is_summoned && new_monrace.kind_flags.has_none_of(alignment_mask)) {
@@ -429,7 +429,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     if (is_summoned) {
         m_ptr->set_parent_m_idx(*summoner_m_idx);
         if (summoner.get_monrace().kind_flags.has(MonsterKindType::QUYLTHLUG)) {
-            m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::QUYLTHLUG_BORN);
+            m_ptr->set_constant_flag(MonsterConstantFlagType::QUYLTHLUG_BORN);
         }
     } else {
         m_ptr->set_parent_m_idx(0);
@@ -441,11 +441,11 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     m_ptr->get_monster_profile().has_transformed = false;
 
     if (any_bits(mode, PM_CLONE)) {
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::CLONED);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::CLONED);
     }
 
     if (any_bits(mode, PM_NO_PET)) {
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
     }
 
     // モンスターのフラグに基づいて対応するプレイヤー種族IDと職業IDを初期化

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -982,7 +982,7 @@ void process_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
      *  Try to flow by smell.
      */
     if (creature.no_flowed && count > 2 && monster.get_target_position().y) {
-        monster.get_monster_profile().mflag2.reset(MonsterConstantFlagType::NOFLOW);
+        monster.reset_constant_flag(MonsterConstantFlagType::NOFLOW);
     }
 
     if (!turn_flags_ptr->do_turn && !turn_flags_ptr->do_move && !monster.is_fearful() && !turn_flags_ptr->is_riding_mon && turn_flags_ptr->aware) {
@@ -1506,7 +1506,7 @@ bool process_monster_fear(CreatureEntity &creature, turn_flags *turn_flags_ptr, 
         ItemEntity item;
         item.generate(baseitems.lookup_baseitem_id({ ItemKindType::JUNK, SV_JUNK_FECES }));
         (void)drop_near(creature, item, m_ptr->get_position());
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::DEFECATED);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::DEFECATED);
     }
 
     if (monrace.resistance_flags.has_not(MonsterResistanceType::NO_VOMIT) && !m_ptr->is_vomited() && m_ptr->is_fearful() && one_in_(20)) {
@@ -1514,7 +1514,7 @@ bool process_monster_fear(CreatureEntity &creature, turn_flags *turn_flags_ptr, 
         ItemEntity item;
         item.generate(baseitems.lookup_baseitem_id({ ItemKindType::JUNK, SV_JUNK_VOMITTING }));
         (void)drop_near(creature, item, m_ptr->get_position());
-        m_ptr->get_monster_profile().mflag2.set(MonsterConstantFlagType::VOMITED);
+        m_ptr->set_constant_flag(MonsterConstantFlagType::VOMITED);
     }
 
     const auto &monster = creature.get_floor()->get_monster(m_idx);
@@ -1679,7 +1679,7 @@ void sweep_monster_process(CreatureEntity &creature)
         process_monster(creature, m_idx);
         monster.reset_target();
         if (creature.no_flowed && one_in_(3)) {
-            monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::NOFLOW);
+            monster.set_constant_flag(MonsterConstantFlagType::NOFLOW);
         }
 
         if (!creature.playing || creature.is_dead() || creature.leaving) {
@@ -1699,7 +1699,7 @@ bool decide_process_continue(CreatureEntity &creature, CreatureEntity &monster)
     const auto &monrace = monster.get_monrace();
 
     if (!creature.no_flowed) {
-        monster.get_monster_profile().mflag2.reset(MonsterConstantFlagType::NOFLOW);
+        monster.reset_constant_flag(MonsterConstantFlagType::NOFLOW);
     }
 
     const auto cdis = Grid::calc_distance(creature.get_position(), monster.get_position());

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -33,7 +33,7 @@
 void set_pet(CreatureEntity &creature, CreatureEntity &target)
 {
     QuestCompletionChecker(creature, target).complete();
-    target.get_monster_profile().mflag2.set(MonsterConstantFlagType::PET);
+    target.set_constant_flag(MonsterConstantFlagType::PET);
     target.set_alliance_idx(AllianceType::NONE);
     if (target.get_monrace().kind_flags.has_none_of(alignment_mask)) {
         target.set_sub_align(SUB_ALIGN_NEUTRAL);

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -347,7 +347,7 @@ bool detect_monsters_normal(CreatureEntity &creature, POSITION range)
     });
     for (auto i : matched) {
         auto &monster = floor.m_list[i];
-        monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+        monster.set_constant_flags({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
         update_monster(creature, i, false);
         flag = true;
     }
@@ -391,7 +391,7 @@ bool detect_monsters_invis(CreatureEntity &creature, POSITION range)
         if (tracker.is_tracking(monster.r_idx)) {
             rfu.set_flag(SubWindowRedrawingFlag::MONSTER_LORE);
         }
-        monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+        monster.set_constant_flags({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
         update_monster(creature, i, false);
         flag = true;
     }
@@ -439,7 +439,7 @@ bool detect_monsters_evil(CreatureEntity &creature, POSITION range)
                 rfu.set_flag(SubWindowRedrawingFlag::MONSTER_LORE);
             }
         }
-        monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+        monster.set_constant_flags({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
         update_monster(creature, i, false);
         flag = true;
     }
@@ -480,7 +480,7 @@ bool detect_monsters_nonliving(CreatureEntity &creature, POSITION range)
         if (tracker.is_tracking(monster.r_idx)) {
             rfu.set_flag(SubWindowRedrawingFlag::MONSTER_LORE);
         }
-        monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+        monster.set_constant_flags({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
         update_monster(creature, i, false);
         flag = true;
     }
@@ -521,7 +521,7 @@ bool detect_monsters_mind(CreatureEntity &creature, POSITION range)
         if (tracker.is_tracking(monster.r_idx)) {
             rfu.set_flag(SubWindowRedrawingFlag::MONSTER_LORE);
         }
-        monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+        monster.set_constant_flags({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
         update_monster(creature, i, false);
         flag = true;
     }
@@ -563,7 +563,7 @@ bool detect_monsters_string(CreatureEntity &creature, POSITION range, concptr Ma
         if (tracker.is_tracking(monster.r_idx)) {
             rfu.set_flag(SubWindowRedrawingFlag::MONSTER_LORE);
         }
-        monster.get_monster_profile().mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
+        monster.set_constant_flags({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
         update_monster(creature, i, false);
         flag = true;
     }

--- a/src/spell-kind/spells-genocide.cpp
+++ b/src/spell-kind/spells-genocide.cpp
@@ -95,7 +95,7 @@ bool genocide_aux(CreatureEntity &creature, MONSTER_IDX m_idx, int power, bool p
         }
 
         if (one_in_(13)) {
-            monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::NOGENO);
+            monster.set_constant_flag(MonsterConstantFlagType::NOGENO);
         }
     }
 

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -231,12 +231,12 @@ void aggravate_monsters(CreatureEntity &creature, MONSTER_IDX src_idx)
             }
 
             if (!monster.is_pet()) {
-                monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::NOPET);
+                monster.set_constant_flag(MonsterConstantFlagType::NOPET);
             }
         }
 
         if (floor.has_los_at({ monster.y, monster.x }) && !monster.is_pet()) {
-            monster.get_monster_profile().mflag2.set(MonsterConstantFlagType::ANGER);
+            monster.set_constant_flag(MonsterConstantFlagType::ANGER);
             (void)set_monster_fast(floor, i, monster.get_remaining_acceleration() + 100);
             speed = true;
         }
@@ -373,7 +373,7 @@ std::string probed_monster_info(CreatureEntity &creature, CreatureEntity &target
 {
     if (!target.is_original_ap()) {
         if (target.is_kage()) {
-            target.get_monster_profile().mflag2.reset(MonsterConstantFlagType::KAGE);
+            target.reset_constant_flag(MonsterConstantFlagType::KAGE);
         }
 
         target.ap_r_idx = target.r_idx;

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -116,13 +116,13 @@ bool CreatureEntity::try_resist_eldritch_horror() const
 void CreatureEntity::ride_monster(MONSTER_IDX m_idx)
 {
     if (is_monster(this->riding)) {
-        this->get_floor()->get_monster(this->riding).get_monster_profile().mflag2.reset(MonsterConstantFlagType::RIDING);
+        this->get_floor()->get_monster(this->riding).reset_constant_flag(MonsterConstantFlagType::RIDING);
     }
 
     this->riding = m_idx;
 
     if (is_monster(m_idx)) {
-        this->get_floor()->get_monster(m_idx).get_monster_profile().mflag2.set(MonsterConstantFlagType::RIDING);
+        this->get_floor()->get_monster(m_idx).set_constant_flag(MonsterConstantFlagType::RIDING);
     }
 }
 
@@ -726,12 +726,12 @@ void CreatureEntity::set_hostile()
         return;
     }
 
-    this->get_monster_profile().mflag2.reset({ MonsterConstantFlagType::PET, MonsterConstantFlagType::FRIENDLY });
+    this->reset_constant_flags({ MonsterConstantFlagType::PET, MonsterConstantFlagType::FRIENDLY });
 
     if (this->get_alliance_idx() != AllianceType::NONE) {
         for (auto &monster : this->get_floor()->m_list) {
             if (monster.get_alliance_idx() == this->get_alliance_idx()) {
-                monster.get_monster_profile().mflag2.reset({ MonsterConstantFlagType::PET, MonsterConstantFlagType::FRIENDLY });
+                monster.reset_constant_flags({ MonsterConstantFlagType::PET, MonsterConstantFlagType::FRIENDLY });
             }
         }
     }

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -21,6 +21,7 @@
 #include "util/point-2d.h"
 #include <array>
 #include <functional>
+#include <initializer_list>
 #include <map>
 #include <memory>
 #include <string>
@@ -998,6 +999,46 @@ public:
     bool has_constant_flag(MonsterConstantFlagType flag) const
     {
         return this->has_monster_profile() && this->get_monster_profile().mflag2.has(flag);
+    }
+
+    /*!
+     * @brief MonsterConstantFlagType を立てる (提案 18)
+     */
+    virtual void set_constant_flag(MonsterConstantFlagType flag)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().mflag2.set(flag);
+        }
+    }
+
+    /*!
+     * @brief MonsterConstantFlagType を複数まとめて立てる (提案 18)
+     */
+    virtual void set_constant_flags(std::initializer_list<MonsterConstantFlagType> flags)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().mflag2.set(flags);
+        }
+    }
+
+    /*!
+     * @brief MonsterConstantFlagType をクリアする (提案 18)
+     */
+    virtual void reset_constant_flag(MonsterConstantFlagType flag)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().mflag2.reset(flag);
+        }
+    }
+
+    /*!
+     * @brief MonsterConstantFlagType を複数まとめてクリアする (提案 18)
+     */
+    virtual void reset_constant_flags(std::initializer_list<MonsterConstantFlagType> flags)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().mflag2.reset(flags);
+        }
     }
 
     /*!


### PR DESCRIPTION
提案 15/15b/16 の系統で残されていた `monster_profile().mflag2.set/reset(...)` 直書きパターンを CreatureEntity の virtual に集約する。

新規 virtual:
- set_constant_flag(MonsterConstantFlagType) / reset_constant_flag(...)
- set_constant_flags({...}) / reset_constant_flags({...}) (初期化リスト版)

migration 対象 (14 ファイル, 約 60 箇所):
- monster-floor/one-monster-placer: 個体修飾子フラグ初期化
- cmd-action/cmd-attack: FRENZY セット (4 箇所)
- spell-kind/spells-detection: MARK/SHOW 一括セット (6 箇所)
- spell-kind/spells-sight: NOPET/ANGER/KAGE 等
- monster/monster-processor: NOFLOW/DEFECATED/VOMITED
- floor/fixed-map-generator / monster-generator: CLONED / NOPET セット
- floor/floor-generator: MARK/SHOW
- system/creature-entity (内部 ride_monster / 友軍解消等)
- ほか effect-monster-charm / monster-status-setter / mutation-execution / spells-genocide / monster-attack-player / core/player-processor

不随の修正:
- check_store_item_to_inventory(CreatureEntity &, ...) を const CreatureEntity & 受けに変更し、CreatureEntity::can_store_item() const メンバから呼べるように修正 (提案 17 の補強)
- 17 の sed migration で誤って `check_creature.store_item(item)` に 化けていた 4 箇所 (autopick/player-inventory/purchase-order 各所) を 正しい `creature.can_store_item(item)` に修正

savefile loader の一括 `mflag2.clear()` や bitset 演算は従来通り 直接アクセスを維持。