### PR TITLE
refactor: 変身/自壊カウンタを virtual に集約 (提案 19)

### DIFF
--- a/src/load/old/monster-loader-savefile50.cpp
+++ b/src/load/old/monster-loader-savefile50.cpp
@@ -158,18 +158,18 @@ void MonsterLoader50::rd_monster(CreatureEntity &monster)
 
     // バージョン43以降: 変身情報の読み込み
     if (loading_savefile_version_is_older_than(43)) {
-        monster.get_monster_profile().transform_r_idx = MonraceId::PLAYER;
-        monster.get_monster_profile().transform_hp_threshold = 0;
-        monster.get_monster_profile().has_transformed = false;
+        monster.set_transform_r_idx(MonraceId::PLAYER);
+        monster.set_transform_hp_threshold(0);
+        monster.set_has_transformed(false);
     } else {
         if (any_bits(flags, SaveDataMonsterFlagType::TRANSFORM)) {
-            monster.get_monster_profile().transform_r_idx = i2enum<MonraceId>(rd_s16b());
-            monster.get_monster_profile().transform_hp_threshold = rd_byte();
-            monster.get_monster_profile().has_transformed = rd_byte() != 0;
+            monster.set_transform_r_idx(i2enum<MonraceId>(rd_s16b()));
+            monster.set_transform_hp_threshold(rd_byte());
+            monster.set_has_transformed(rd_byte() != 0);
         } else {
-            monster.get_monster_profile().transform_r_idx = MonraceId::PLAYER;
-            monster.get_monster_profile().transform_hp_threshold = 0;
-            monster.get_monster_profile().has_transformed = false;
+            monster.set_transform_r_idx(MonraceId::PLAYER);
+            monster.set_transform_hp_threshold(0);
+            monster.set_has_transformed(false);
         }
     }
 

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -436,9 +436,9 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     }
 
     // 変身情報のコピー
-    m_ptr->get_monster_profile().transform_r_idx = new_monrace.transform_r_idx;
-    m_ptr->get_monster_profile().transform_hp_threshold = new_monrace.transform_hp_threshold;
-    m_ptr->get_monster_profile().has_transformed = false;
+    m_ptr->set_transform_r_idx(new_monrace.transform_r_idx);
+    m_ptr->set_transform_hp_threshold(new_monrace.transform_hp_threshold);
+    m_ptr->set_has_transformed(false);
 
     if (any_bits(mode, PM_CLONE)) {
         m_ptr->set_constant_flag(MonsterConstantFlagType::CLONED);
@@ -545,7 +545,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
 
     m_ptr->dealt_damage = 0;
     if (monrace.suicide_dice_num && monrace.suicide_dice_side) {
-        m_ptr->get_monster_profile().death_count = Dice::roll(monrace.suicide_dice_num, monrace.suicide_dice_side);
+        m_ptr->set_death_count(Dice::roll(monrace.suicide_dice_num, monrace.suicide_dice_side));
     }
 
     m_ptr->set_individual_speed(floor.inside_arena);

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -578,22 +578,22 @@ bool MonsterDamageProcessor::check_and_process_hp_transform()
     auto &monster = creature.get_floor()->get_monster(this->m_idx);
 
     // 変身条件のチェック
-    if (monster.get_monster_profile().has_transformed) {
+    if (monster.has_transformed()) {
         return false; // 既に変身済み
     }
 
-    if (!MonraceList::is_valid(monster.get_monster_profile().transform_r_idx) || monster.get_monster_profile().transform_hp_threshold == 0) {
+    if (!MonraceList::is_valid(monster.get_transform_r_idx()) || monster.get_transform_hp_threshold() == 0) {
         return false; // 変身設定がない
     }
 
     // HP閾値チェック（最大HPの%で判定）
     const auto hp_percent = (100 * monster.hp) / monster.maxhp;
-    if (hp_percent > monster.get_monster_profile().transform_hp_threshold) {
+    if (hp_percent > monster.get_transform_hp_threshold()) {
         return false; // まだ変身しない
     }
 
     // 変身先の種族情報を取得
-    const auto new_r_idx = monster.get_monster_profile().transform_r_idx;
+    const auto new_r_idx = monster.get_transform_r_idx();
     auto &new_monrace = MonraceList::get_instance().get_monrace(new_r_idx);
 
     // 変身前の情報を保存
@@ -623,11 +623,11 @@ bool MonsterDamageProcessor::check_and_process_hp_transform()
     monster.hp = old_hp * monster.maxhp / old_maxhp;
 
     // 変身フラグを設定
-    monster.get_monster_profile().has_transformed = true;
+    monster.set_has_transformed(true);
 
     // 変身先の変身情報をコピー
-    monster.get_monster_profile().transform_r_idx = new_monrace.transform_r_idx;
-    monster.get_monster_profile().transform_hp_threshold = new_monrace.transform_hp_threshold;
+    monster.set_transform_r_idx(new_monrace.transform_r_idx);
+    monster.set_transform_hp_threshold(new_monrace.transform_hp_threshold);
 
     // アライメントを維持
     monster.set_sub_align(old_sub_align);

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -1621,9 +1621,8 @@ void sweep_monster_process(CreatureEntity &creature)
         monster.energy_need += ENERGY_NEED();
         auto m_name = monster_desc(creature, monster, 0);
 
-        if (monster.get_monster_profile().death_count > 0) {
-            monster.get_monster_profile().death_count--;
-            if (monster.get_monster_profile().death_count == 0) {
+        if (monster.get_death_count() > 0) {
+            if (monster.decrement_death_count() == 0) {
                 bool fear;
                 monster.max_maxhp = monster.maxhp = monster.hp = -1;
                 MonsterDamageProcessor mdp(creature, m_idx, 0, &fear, AttributeType::ATTACK);

--- a/src/save/monster-writer.cpp
+++ b/src/save/monster-writer.cpp
@@ -132,7 +132,7 @@ uint32_t MonsterWriter::write_monster_flags() const
         set_bits(flags, SaveDataMonsterFlagType::CLASS);
     }
 
-    if (MonraceList::is_valid(this->monster.get_monster_profile().transform_r_idx) || this->monster.get_monster_profile().has_transformed) {
+    if (MonraceList::is_valid(this->monster.get_transform_r_idx()) || this->monster.has_transformed()) {
         set_bits(flags, SaveDataMonsterFlagType::TRANSFORM);
     }
 
@@ -231,9 +231,9 @@ void MonsterWriter::write_monster_info(uint32_t flags) const
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::TRANSFORM)) {
-        wr_s16b(static_cast<int16_t>(enum2i(this->monster.get_monster_profile().transform_r_idx)));
-        wr_byte(static_cast<byte>(this->monster.get_monster_profile().transform_hp_threshold));
-        wr_byte(this->monster.get_monster_profile().has_transformed ? 1 : 0);
+        wr_s16b(static_cast<int16_t>(enum2i(this->monster.get_transform_r_idx())));
+        wr_byte(static_cast<byte>(this->monster.get_transform_hp_threshold()));
+        wr_byte(this->monster.has_transformed() ? 1 : 0);
     }
 
     // インベントリの保存（PlayerTypeと同じ形式）

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -993,6 +993,90 @@ public:
     }
 
     /*!
+     * @brief 変身先モンスター種族 ID を取得する (提案 19)
+     */
+    virtual MonraceId get_transform_r_idx() const
+    {
+        return this->has_monster_profile() ? this->get_monster_profile().transform_r_idx : MonraceId::PLAYER;
+    }
+
+    /*!
+     * @brief 変身先モンスター種族 ID を設定する (提案 19)
+     */
+    virtual void set_transform_r_idx(MonraceId r_idx)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().transform_r_idx = r_idx;
+        }
+    }
+
+    /*!
+     * @brief 変身する HP 閾値 (最大 HP の %) を取得する (提案 19)
+     */
+    virtual PERCENTAGE get_transform_hp_threshold() const
+    {
+        return this->has_monster_profile() ? this->get_monster_profile().transform_hp_threshold : 0;
+    }
+
+    /*!
+     * @brief 変身する HP 閾値を設定する (提案 19)
+     */
+    virtual void set_transform_hp_threshold(PERCENTAGE threshold)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().transform_hp_threshold = threshold;
+        }
+    }
+
+    /*!
+     * @brief 変身済みかどうか (提案 19)
+     */
+    virtual bool has_transformed() const
+    {
+        return this->has_monster_profile() && this->get_monster_profile().has_transformed;
+    }
+
+    /*!
+     * @brief 変身済みフラグを設定する (提案 19)
+     */
+    virtual void set_has_transformed(bool transformed)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().has_transformed = transformed;
+        }
+    }
+
+    /*!
+     * @brief 自壊までの残りターン数を取得する (提案 19)
+     */
+    virtual int get_death_count() const
+    {
+        return this->has_monster_profile() ? this->get_monster_profile().death_count : 0;
+    }
+
+    /*!
+     * @brief 自壊までの残りターン数を設定する (提案 19)
+     */
+    virtual void set_death_count(int count)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().death_count = count;
+        }
+    }
+
+    /*!
+     * @brief 自壊までの残りターン数を 1 減らす (提案 19)
+     * @return 減算後の値
+     */
+    virtual int decrement_death_count()
+    {
+        if (this->has_monster_profile()) {
+            return --this->get_monster_profile().death_count;
+        }
+        return 0;
+    }
+
+    /*!
      * @brief MonsterConstantFlagType (mflag2) のチェック共通ヘルパ
      * @details 提案 15: mflag2.has(...) パターンを virtual で集約
      */

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1003,10 +1003,10 @@ public:
     /*!
      * @brief 変身先モンスター種族 ID を設定する (提案 19)
      */
-    virtual void set_transform_r_idx(MonraceId r_idx)
+    virtual void set_transform_r_idx(MonraceId new_r_idx)
     {
         if (this->has_monster_profile()) {
-            this->get_monster_profile().transform_r_idx = r_idx;
+            this->get_monster_profile().transform_r_idx = new_r_idx;
         }
     }
 
@@ -1057,10 +1057,10 @@ public:
     /*!
      * @brief 自壊までの残りターン数を設定する (提案 19)
      */
-    virtual void set_death_count(int count)
+    virtual void set_death_count(int new_count)
     {
         if (this->has_monster_profile()) {
-            this->get_monster_profile().death_count = count;
+            this->get_monster_profile().death_count = new_count;
         }
     }
 


### PR DESCRIPTION
提案 9b/15b/18 の流れで残されていた MonsterProfile の個別フィールド
(transform_*/has_transformed/death_count) への直書きパターンを CreatureEntity の virtual に集約する。

新規 virtual (10 個):
- get_transform_r_idx / set_transform_r_idx
- get_transform_hp_threshold / set_transform_hp_threshold
- has_transformed / set_has_transformed
- get_death_count / set_death_count / decrement_death_count

migration 対象 (5 ファイル):
- monster-floor/one-monster-placer: 変身情報初期化 + death_count 初期化
- monster/monster-damage: check_and_process_hp_transform 内の判定・更新
- monster/monster-processor: 毎ターン死亡カウンタ減算 (decrement_death_count 利用)
- load/old/monster-loader-savefile50: savefile からの復元
- save/monster-writer: savefile への書き出し

これにより MonsterProfile への直接 `=` 代入は基本的に消え、virtual API 経由でのみ書き込みされる状態に近づいた。残るのは savefile 復元時の
mflag/mflag2 一括 clear や bitset 演算など、特殊な低レベル操作のみ。