### PR TITLE
REFACtor: 残った mflag/mflag2 一括操作を virtual に集約 (提案 20)

### DIFF
--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -445,7 +445,7 @@ static void effect_monster_captured(CreatureEntity &creature, EffectMonster *em_
     cap_mon_ptr->current_hp = static_cast<short>(em_ptr->m_ptr->hp);
     cap_mon_ptr->max_hp = static_cast<short>(em_ptr->m_ptr->max_maxhp);
     cap_mon_ptr->name = em_ptr->m_ptr->name;
-    cap_mon_ptr->mflag2 = em_ptr->m_ptr->get_monster_profile().mflag2;
+    cap_mon_ptr->mflag2 = em_ptr->m_ptr->get_all_constant_flags();
     if (em_ptr->m_ptr->is_riding() && process_fall_off_horse(creature, -1, false)) {
         msg_print(_("地面に落とされた。", format("You have fallen from %s.", em_ptr->m_name)));
     }

--- a/src/load/old/monster-loader-savefile50.cpp
+++ b/src/load/old/monster-loader-savefile50.cpp
@@ -64,8 +64,8 @@ void MonsterLoader50::rd_monster(CreatureEntity &monster)
     monster.target.y = any_bits(flags, SaveDataMonsterFlagType::TARGET_Y) ? rd_s16b() : 0;
     monster.target.x = any_bits(flags, SaveDataMonsterFlagType::TARGET_X) ? rd_s16b() : 0;
     monster.set_timed_effect(CreatureTimedEffect::INVULNERABILITY, any_bits(flags, SaveDataMonsterFlagType::INVULNER) ? rd_byte() : 0);
-    monster.get_monster_profile().mflag.clear();
-    monster.get_monster_profile().mflag2.clear();
+    monster.clear_temporary_flags();
+    monster.clear_constant_flags();
     if (any_bits(flags, SaveDataMonsterFlagType::SMART)) {
         if (loading_savefile_version_is_older_than(2)) {
             auto tmp32u = rd_u32b();
@@ -74,9 +74,9 @@ void MonsterLoader50::rd_monster(CreatureEntity &monster)
             // 3.0.0Alpha10以前のSM_CLONED(ビット位置22)、SM_PET(23)、SM_FRIEDLY(28)をMFLAG2に移行する
             // ビット位置の定義はなくなるので、ビット位置の値をハードコードする。
             std::bitset<32> rd_bits(tmp32u);
-            monster.get_monster_profile().mflag2[MonsterConstantFlagType::CLONED] = rd_bits[22];
-            monster.get_monster_profile().mflag2[MonsterConstantFlagType::PET] = rd_bits[23];
-            monster.get_monster_profile().mflag2[MonsterConstantFlagType::FRIENDLY] = rd_bits[28];
+            monster.assign_constant_flag(MonsterConstantFlagType::CLONED, rd_bits[22]);
+            monster.assign_constant_flag(MonsterConstantFlagType::PET, rd_bits[23]);
+            monster.assign_constant_flag(MonsterConstantFlagType::FRIENDLY, rd_bits[28]);
             monster.get_monster_profile().smart.reset(i2enum<MonsterSmartLearnType>(22)).reset(i2enum<MonsterSmartLearnType>(23)).reset(i2enum<MonsterSmartLearnType>(28));
         } else {
             rd_FlagGroup(monster.get_monster_profile().smart, rd_byte);

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -264,8 +264,8 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
 
     m_ptr->set_alliance_idx(monrace.alliance_idx);
 
-    m_ptr->get_monster_profile().mflag.clear();
-    m_ptr->get_monster_profile().mflag2.clear();
+    m_ptr->clear_temporary_flags();
+    m_ptr->clear_constant_flags();
     m_ptr->set_floor(player.get_floor());
 
     if (monrace.misc_flags.has(MonsterMiscType::CHAMELEON)) {

--- a/src/specific-object/monster-ball.cpp
+++ b/src/specific-object/monster-ball.cpp
@@ -117,7 +117,7 @@ static bool release_monster(CreatureEntity &creature, ItemEntity &item, const Di
     if (item.captured_monster_current_hp > 0) {
         monster.hp = item.captured_monster_current_hp;
     }
-    monster.get_monster_profile().mflag2 = item.captured_monster_mflag2;
+    monster.set_all_constant_flags(item.captured_monster_mflag2);
 
     monster.maxhp = monster.max_maxhp;
     restore_monster_nickname(monster, item);

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1126,6 +1126,64 @@ public:
     }
 
     /*!
+     * @brief MonsterConstantFlagType を真偽値で設定する (提案 20)
+     * @details savefile 復元等で `mflag2[flag] = bool` 風の代入を行う
+     *          パターン用。true なら set、false なら reset。
+     */
+    virtual void assign_constant_flag(MonsterConstantFlagType flag, bool value)
+    {
+        if (!this->has_monster_profile()) {
+            return;
+        }
+        if (value) {
+            this->get_monster_profile().mflag2.set(flag);
+        } else {
+            this->get_monster_profile().mflag2.reset(flag);
+        }
+    }
+
+    /*!
+     * @brief MonsterConstantFlagType (mflag2) をすべてクリアする (提案 20)
+     */
+    virtual void clear_constant_flags()
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().mflag2.clear();
+        }
+    }
+
+    /*!
+     * @brief mflag2 全体を読み取る (提案 20)
+     * @details モンスターボール捕獲・解放等で mflag2 ビット集合を
+     *          まるごとコピーする用途。プレイヤーは空集合を返す。
+     */
+    virtual const EnumClassFlagGroup<MonsterConstantFlagType> &get_all_constant_flags() const
+    {
+        static const EnumClassFlagGroup<MonsterConstantFlagType> empty{};
+        return this->has_monster_profile() ? this->get_monster_profile().mflag2 : empty;
+    }
+
+    /*!
+     * @brief mflag2 全体を上書きする (提案 20)
+     */
+    virtual void set_all_constant_flags(const EnumClassFlagGroup<MonsterConstantFlagType> &flags)
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().mflag2 = flags;
+        }
+    }
+
+    /*!
+     * @brief MonsterTemporaryFlagType (mflag) をすべてクリアする (提案 20)
+     */
+    virtual void clear_temporary_flags()
+    {
+        if (this->has_monster_profile()) {
+            this->get_monster_profile().mflag.clear();
+        }
+    }
+
+    /*!
      * @brief MonsterTemporaryFlagType (mflag) のチェック共通ヘルパ (提案 16)
      */
     bool has_temporary_flag(MonsterTemporaryFlagType flag) const


### PR DESCRIPTION
提案 18 で個別フラグ set/reset を virtual 化したのに続き、savefile
復元・モンスター捕獲時の bitset 一括操作系も CreatureEntity の
virtual に集約する。

新規 virtual:
- assign_constant_flag(flag, bool) - savefile での `mflag2[X] = bool` 風代入の OO 形
- clear_constant_flags() - mflag2 全クリア
- clear_temporary_flags() - mflag 全クリア
- get_all_constant_flags() - モンスターボール捕獲時の mflag2 抽出
- set_all_constant_flags(group) - モンスターボール解放時の mflag2 適用

migration 対象 (4 ファイル):
- monster-floor/one-monster-placer: 生成初期化時の mflag/mflag2 全クリア
- load/old/monster-loader-savefile50: savefile からの mflag/mflag2 復元、 Alpha10 以前の bitset → mflag2 移行
- specific-object/monster-ball: 捕獲モンスター解放時の mflag2 適用
- effect/effect-monster-charm: モンスター捕獲時の mflag2 抽出

savefile loader の `migrate_bitflag_to_flaggroup(...)` / `rd_FlagGroup(...)` / smart の chained reset 等、低レベル bitset ヘルパへの参照渡しが必要な箇所のみ direct access を維持。