### PR TITLE
refactor: MonsterProfile を class 化してメンバを private 化 (提案 21)

### DIFF
--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -364,8 +364,8 @@ void process_player(CreatureEntity &creature)
 
                 // 感知中のモンスターのフラグを落とす処理
                 // 感知したターンはMFLAG2_SHOWを落とし、次のターンに感知中フラグのMFLAG2_MARKを落とす
-                if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::MARK)) {
-                    if (monster.get_monster_profile().mflag2.has(MonsterConstantFlagType::SHOW)) {
+                if (monster.has_constant_flag(MonsterConstantFlagType::MARK)) {
+                    if (monster.has_constant_flag(MonsterConstantFlagType::SHOW)) {
                         monster.reset_constant_flag(MonsterConstantFlagType::SHOW);
                     } else {
                         monster.reset_constant_flag(MonsterConstantFlagType::MARK);

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -593,7 +593,7 @@ void update_monster(CreatureEntity &creature, MONSTER_IDX m_idx, bool full)
         }
     }
 
-    if (um_ptr->m_ptr->get_monster_profile().mflag2.has(MonsterConstantFlagType::MARK)) {
+    if (um_ptr->m_ptr->has_constant_flag(MonsterConstantFlagType::MARK)) {
         um_ptr->flag = true;
     }
 

--- a/src/system/monster-profile.h
+++ b/src/system/monster-profile.h
@@ -7,6 +7,9 @@
 #include "util/flag-group.h"
 #include <vector>
 
+class CreatureEntity;
+class MonsterLoader50;
+class MonsterWriter;
 enum class PlayerRaceType;
 enum class PlayerClassType : short;
 
@@ -17,8 +20,17 @@ enum class PlayerClassType : short;
 
 /*!
  * @brief モンスターインスタンス固有データ
+ * @details 提案 21 でメンバを private 化。アクセスは CreatureEntity の
+ *          virtual API (`is_pet()`, `get_alliance_idx()`, `set_constant_flag()`,
+ *          etc.) を介して行うこと。低レベルな bitset I/O が必要な savefile
+ *          loader / writer のみ friend 経由で直接フィールドを操作する。
  */
-struct MonsterProfile {
+class MonsterProfile {
+    friend class CreatureEntity;
+    friend class MonsterLoader50;
+    friend class MonsterWriter;
+
+private:
     BIT_FLAGS8 sub_align{}; /*!< 中立属性のモンスターが召喚主のアライメントに従い一時的に立っている善悪陣営 / Sub-alignment for a neutral monster */
     AllianceType alliance_idx{}; /*!< 現在の所属アライアンス */
     std::vector<PlayerRaceType> equivalent_player_races{}; /*!< モンスターのフラグに基づいて対応するプレイヤー種族IDリスト */

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -184,7 +184,7 @@ void target_sensing_monsters_prepare(CreatureEntity &creature, std::vector<MONST
         }
 
         // 感知魔法/スキルやESPで感知していない擬態モンスターはモンスター一覧に表示しない
-        if (monster.is_mimicry() && monster.get_monster_profile().mflag2.has_none_of({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW }) && monster.get_monster_profile().mflag.has_not(MonsterTemporaryFlagType::ESP)) {
+        if (monster.is_mimicry() && !monster.has_constant_flag(MonsterConstantFlagType::MARK) && !monster.has_constant_flag(MonsterConstantFlagType::SHOW) && !monster.has_temporary_flag(MonsterTemporaryFlagType::ESP)) {
             continue;
         }
 


### PR DESCRIPTION
提案 9b〜20 で MonsterProfile への外部書き込みパスを CreatureEntity の virtual API に集約し終えたため、`struct MonsterProfile` を `class MonsterProfile` に変更し、全データメンバを private 化する。

friend として直接アクセスを許可するクラス:
- CreatureEntity (virtual アクセサの実装に必要)
- MonsterLoader50 (savefile 復元時の bitset 一括読込・移行)
- MonsterWriter (savefile 書出時の bitset / フラグ抽出)

migration 残対象 (3 箇所):
- core/player-processor: MARK/SHOW チェックを has_constant_flag() に
- monster/monster-update: MARK チェックを has_constant_flag() に
- target/target-preparation: 擬態モンスター表示判定を has_constant_flag / has_temporary_flag の組合せに

これにより MonsterProfile は完全にカプセル化された。今後 MonsterProfile にフィールドを追加する場合は CreatureEntity 側にも対応する virtual
アクセサを実装することが必須になる。