### PR TITLE
refactor: モンスター種族 ID と riding に setter virtual を追加 (提案 22)

### DIFF
--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -88,7 +88,7 @@ static std::pair<short, Pos2D> decide_pet_index(CreatureEntity &creature, const 
     Pos2D pos(0, 0);
     if (current_monster == 0) {
         const auto m_idx = floor.pop_empty_index_monster();
-        creature.riding = m_idx;
+        creature.set_riding(m_idx);
         if (m_idx) {
             pos = p_pos;
         }

--- a/src/floor/party-monsters.cpp
+++ b/src/floor/party-monsters.cpp
@@ -19,7 +19,7 @@ const CreatureEntity &PartyMonsters::operator[](int i) const
 void PartyMonsters::invalidate_all()
 {
     for (auto &monster : monsters_) {
-        monster.r_idx = MonraceList::empty_id();
+        monster.set_r_idx(MonraceList::empty_id());
     }
 }
 

--- a/src/load/old/monster-loader-savefile50.cpp
+++ b/src/load/old/monster-loader-savefile50.cpp
@@ -21,7 +21,7 @@
 void MonsterLoader50::rd_monster(CreatureEntity &monster)
 {
     auto flags = rd_u32b();
-    monster.r_idx = i2enum<MonraceId>(rd_s16b());
+    monster.set_r_idx(i2enum<MonraceId>(rd_s16b()));
 
     if (loading_savefile_version_is_older_than(16)) {
         MonraceDefinition *r_ptr = &MonraceList::get_instance().get_monrace(monster.r_idx);
@@ -45,7 +45,7 @@ void MonsterLoader50::rd_monster(CreatureEntity &monster)
 
     monster.dealt_damage = rd_s32b();
 
-    monster.ap_r_idx = any_bits(flags, SaveDataMonsterFlagType::AP_R_IDX) ? i2enum<MonraceId>(rd_s16b()) : monster.r_idx;
+    monster.set_ap_r_idx(any_bits(flags, SaveDataMonsterFlagType::AP_R_IDX) ? i2enum<MonraceId>(rd_s16b()) : monster.r_idx);
     monster.set_sub_align(any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN) ? rd_byte() : 0);
     monster.set_timed_effect(CreatureTimedEffect::SLEEP_OR_PARALYSIS, any_bits(flags, SaveDataMonsterFlagType::SLEEP) ? rd_s16b() : 0);
     monster.speed = rd_byte();

--- a/src/monster/monster-compaction.cpp
+++ b/src/monster/monster-compaction.cpp
@@ -54,7 +54,7 @@ static void compact_monsters_aux(CreatureEntity &creature, MONSTER_IDX i1, MONST
     }
 
     if (monster.is_riding()) { // creature.riding == i1 のままの方がいい？
-        creature.riding = i2;
+        creature.set_riding(i2);
     }
 
     if (HealthBarTracker::get_instance().is_tracking(i1)) {

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -182,7 +182,7 @@ void MonsterDamageProcessor::death_special_flag_monster()
     auto monrace_id = monster.r_idx;
     auto &monrace = monster.get_monrace();
     if (monrace.misc_flags.has(MonsterMiscType::TANUKI)) {
-        monster.ap_r_idx = monrace_id;
+        monster.set_ap_r_idx(monrace_id);
         if (monrace.r_sights < MAX_SHORT) {
             monrace.r_sights++;
         }
@@ -604,9 +604,9 @@ bool MonsterDamageProcessor::check_and_process_hp_transform()
 
     // 種族カウンターの更新
     monster.get_real_monrace().decrement_current_numbers();
-    monster.r_idx = new_r_idx;
+    monster.set_r_idx(new_r_idx);
     new_monrace.increment_current_numbers();
-    monster.ap_r_idx = new_r_idx;
+    monster.set_ap_r_idx(new_r_idx);
 
     // 新しいHPの計算
     monster.max_maxhp = new_monrace.misc_flags.has(MonsterMiscType::FORCE_MAXHP)

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -194,8 +194,7 @@ void choose_chameleon_polymorph(CreatureEntity &creature, short m_idx, short ter
         return;
     }
 
-    monster.r_idx = *new_monrace_id;
-    monster.ap_r_idx = *new_monrace_id;
+    monster.polymorph_to(*new_monrace_id);
 }
 
 /*!

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -384,11 +384,11 @@ void monster_gain_exp(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId mon
     monster.get_real_monrace().decrement_current_numbers();
 
     const auto m_name = monster_desc(creature, monster, 0);
-    monster.r_idx = old_monrace.next_r_idx;
+    monster.set_r_idx(old_monrace.next_r_idx);
 
     /* Count the monsters on the level */
     monster.get_real_monrace().increment_current_numbers();
-    monster.ap_r_idx = monster.r_idx;
+    monster.set_ap_r_idx(monster.r_idx);
 
     const auto &new_monrace = monster.get_monrace(); //!< @details 進化後の種族.
     monster.max_maxhp = new_monrace.misc_flags.has(MonsterMiscType::FORCE_MAXHP) ? new_monrace.hit_dice.maxroll() : new_monrace.hit_dice.roll();

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -376,7 +376,7 @@ std::string probed_monster_info(CreatureEntity &creature, CreatureEntity &target
             target.reset_constant_flag(MonsterConstantFlagType::KAGE);
         }
 
-        target.ap_r_idx = target.r_idx;
+        target.set_ap_r_idx(target.r_idx);
         lite_spot(creature, target.get_position());
     }
 

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1247,6 +1247,45 @@ public:
         return this->has_temporary_flag(MonsterTemporaryFlagType::SANITY_BLAST);
     }
 
+    /*!
+     * @brief モンスター実種族 ID を設定する (提案 22)
+     * @details ap_r_idx は変更しない。両方更新したい場合は polymorph_to() を使う。
+     */
+    virtual void set_r_idx(MonraceId new_r_idx)
+    {
+        this->r_idx = new_r_idx;
+    }
+
+    /*!
+     * @brief モンスター外見種族 ID を設定する (提案 22)
+     */
+    virtual void set_ap_r_idx(MonraceId new_ap_r_idx)
+    {
+        this->ap_r_idx = new_ap_r_idx;
+    }
+
+    /*!
+     * @brief 実種族と外見種族をまとめて設定する (提案 22)
+     * @details polymorph / 進化 / 変身などで両者を同期させたいときに使用。
+     */
+    virtual void polymorph_to(MonraceId new_r_idx)
+    {
+        this->r_idx = new_r_idx;
+        this->ap_r_idx = new_r_idx;
+    }
+
+    /*!
+     * @brief 騎乗中のモンスター m_idx を直接設定する (提案 22)
+     * @details ride_monster() と異なり mflag2/RIDING の更新を行わない低レベル
+     *          setter。compaction で m_idx 圧縮時に既に立っている RIDING を
+     *          別 idx へ付け替える等の用途。通常の騎乗開始/終了処理は
+     *          ride_monster() を使用すること。
+     */
+    virtual void set_riding(MONSTER_IDX m_idx)
+    {
+        this->riding = m_idx;
+    }
+
     /*! @brief 影 (KAGE) かどうか */
     virtual bool is_kage() const
     {

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -114,8 +114,7 @@ void wiz_select_chameleon_polymorph(CreatureEntity &monster)
     msg_erase();
 
     if (const auto polymorph_monrace_id = wiz_select_summon_monrace_id()) {
-        monster.r_idx = *polymorph_monrace_id;
-        monster.ap_r_idx = *polymorph_monrace_id;
+        monster.polymorph_to(*polymorph_monrace_id);
     }
 }
 


### PR DESCRIPTION
これまで CreatureEntity の public フィールドへ直書きしていた
identity 系フィールド (r_idx / ap_r_idx / riding) に virtual setter を 追加し、polymorph・evolution・savefile 復元等の書き込み箇所を OO 経由 に統一する。

新規 virtual:
- set_r_idx(MonraceId)
- set_ap_r_idx(MonraceId)
- polymorph_to(MonraceId) - r_idx と ap_r_idx をまとめて設定
- set_riding(MONSTER_IDX) - mflag2 RIDING を更新しない低レベル setter (compaction や floor 切替時の付替え用。通常の騎乗は ride_monster())

migration 対象 (8 ファイル):
- floor/party-monsters: 死亡モンスター初期化
- floor/floor-changer: フロア生成時の騎乗 m_idx 設定
- monster/monster-compaction: m_idx 圧縮時の riding 付替え
- monster/monster-damage: TANUKI 擬態と HP 変身時
- monster/monster-list: polymorph 後の identity 同期
- monster/monster-status: 進化処理 (next_r_idx)
- spell-kind/spells-sight: probing 後の偽装解除
- wizard/wizard-spells: wizard polymorph
- load/old/monster-loader-savefile50: savefile 復元

読取り (==比較等) は引き続きフィールド直接アクセスのまま。CreatureEntity
基底クラスにフィールドを残しているのは多数の参照箇所があり、setter
の整備のみでも書き込み経路の一元化という目的は達成できるため。