### PR TITLE
refactor: 提案 33 完了 - ESP / 装備集計 BIT_FLAGS の private 化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,9 +288,15 @@ API 経由に統一された。一部フィールド (r_idx / ap_r_idx / riding)
   to_h[] / to_d[]) を個別 fix で完全 private 化。**合計 37 フィールド
   が完全 private 化**に到達し、CreatureEntity のフィールドカプセル化
   は事実上最終形
+- **提案 33**: ESP 系 15 個 + 装備集計系 19 個 + special_attack の合計
+  35 個の BIT_FLAGS フィールドを private 化。`set_X(BIT_FLAGS)` setter,
+  `get_X_flags()` getter (差分検出キャッシュ用), `add_special_attack(flag)`
+  / `remove_special_attack(flag)` 等の compound assignment 用 virtual を
+  整備し、約 70 箇所の write/read site を migration。**合計 private 化
+  フィールド数: 37 → 72** (約 2 倍に到達)
 
 今後の残作業としては、現在 `CreatureEntity` 直下に残存するプレイヤー
-固有フィールド群（種族・職業・熟練度・ESP 等）を、モンスターにも
+固有フィールド群（種族・職業・熟練度等）を、モンスターにも
 共通で持たせて運用できる形に整備していく方針。プレイヤー専用構造体
 （`PlayerProfile` のようなもの）に切り出してモンスターから隔離する
 方向は取らない。
@@ -709,7 +715,10 @@ EOF
    `creature.special_attack & FLAG` 等の読取りは
    `creature.get_skill_save()` / `creature.get_infravision()` /
    `creature.has_telepathy()` / `creature.has_special_attack(FLAG)` に変換済み。
-   書き込み (代入・ビットマスク更新) は直接フィールドのまま。
+   **提案 33 完了で telepathy / esp_* / 装備集計 BIT_FLAGS / special_attack
+   の書き込みも `set_X(BIT_FLAGS)` / `add_special_attack(flag)` /
+   `remove_special_attack(flag)` virtual 経由に統一済み。**
+   フィールド直接アクセスは private 化されており不可。
 
 9. **PlayerType::get_timed_effect() オーバーライドの廃止**: 上流では PlayerType が
    この virtual を override して TimedEffects オブジェクト経由でアクセスしているが、
@@ -748,8 +757,17 @@ EOF
   creature.get_infravision()
 - creature.telepathy/esp_X/see_inv/can_swim/levitation 等の読取り →
   creature.has_telepathy()/has_esp_X()/can_see_invisible()/has_can_swim()/
-  has_levitation() 等
+  has_levitation() 等。**書込みは creature.set_telepathy(BIT_FLAGS) /
+  set_esp_X(BIT_FLAGS) / set_can_swim(bool) / set_levitation(BIT_FLAGS)
+  virtual 経由 (提案 33 完了)。** 差分検出キャッシュ用 read は
+  `creature.get_telepathy_flags()` / `get_esp_X_flags()` / `get_see_inv_flags()`
+  / `get_mighty_throw_flags()` / `get_impact_flags()` /
+  `get_earthquake_flags()` 経由
 - creature.special_attack & FLAG → creature.has_special_attack(FLAG)
+  / 書込みは `add_special_attack(flag)` / `remove_special_attack(flag)`
+  / `set_special_attack_flags(BIT_FLAGS)` / `get_special_attack_flags()`
+  経由 (提案 33 完了)。`creature.special_attack |= ATTACK_X` は
+  `creature.add_special_attack(ATTACK_X)` に変換
 - creature.effects()->X().current()/set/reset → creature.get/set_timed_effect(...)
   (提案 5 完了で effects() API 自体が削除済み)
 - creature.effects()->stun().get_rank() / get_magic_chance_penalty 等 →

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -1411,12 +1411,82 @@ lvalue 参照を直接渡せないため、ラッパとして導入)
 | r_idx / ap_r_idx / riding (提案 29) | 3 個 |
 | 提案 32 安全フィールド | 7 個 |
 | 提案 32b 残りフィールド | 15 個 |
-| **合計** | **37 個** |
+| 提案 33 BIT_FLAGS 群 (ESP / 装備集計 / 特殊攻撃防御) | 35 個 |
+| **合計** | **72 個** |
 | inven_cnt / equip_cnt (提案 25) | フィールド廃止 |
 
 CreatureEntity のフィールドカプセル化が**事実上最終形**に到達。
 これらフィールドへのアクセスは全て virtual API 経由でのみ可能となり、
 将来 friend 宣言を撤廃すれば完全閉鎖系となる。
+
+---
+
+## 提案 33: ESP / 装備集計 BIT_FLAGS の private 化 ✅ 完了
+
+### 背景
+
+提案 32 / 32b で plain field (能力値・経験値・所持金等) の private 化に
+成功した後、CreatureEntity 直下に残る public BIT_FLAGS フィールド
+(ESP 系 15 個 + 装備集計系 19 個 + special_attack/defense 2 個 = 36 個) を
+カプセル化する。
+
+read 側は既に提案 4 系列で `has_telepathy()` / `has_esp_X()` 等の
+virtual に統一済みだったため、書込みパターンの集約と差分検出キャッシュ
+読取りの整備のみで private 化可能。
+
+### 完了内容
+
+- ✅ ESP 15 個 (telepathy / esp_animal / esp_nasty / esp_homo /
+  esp_undead / esp_demon / esp_orc / esp_troll / esp_giant /
+  esp_dragon / esp_human / esp_evil / esp_good / esp_nonliving /
+  esp_unique) の `set_X(BIT_FLAGS)` virtual を追加
+- ✅ 装備集計系 19 個 (can_swim / levitation / free_act / see_inv /
+  regenerate / hold_exp / slow_digest / lite / warning / impact /
+  earthquake / dec_mana / easy_spell / hard_spell / mighty_throw /
+  see_nocto / anti_magic / anti_tele / bless_blade / xtra_might) の
+  `set_X(BIT_FLAGS)` virtual を追加
+- ✅ `has_bless_blade()` virtual を新規追加 (既存 `has_X()` 群に
+  欠けていたため補完)
+- ✅ `get_X_flags()` 系 read virtual を 15 ESP + see_inv +
+  mighty_throw + impact + earthquake に追加 (差分検出キャッシュ・
+  bitmask 読取り用)
+- ✅ special_attack / special_defense に
+  `set_X_flags(BIT_FLAGS)` / `get_X_flags()` /
+  `add_X(flag)` / `remove_X(flag)` の 4 virtual セットを追加
+- ✅ player-status.cpp の update_creature() 内 35 箇所の
+  `creature.X = has_X(creature)` 形式書込みを `creature.set_X(...)`
+  形式に migration
+- ✅ player-status.cpp の差分検出キャッシュ 15 箇所の
+  `creature.X != old_X` を `creature.get_X_flags() != old_X` に migration
+- ✅ special_attack/defense の compound assignment 約 18 箇所
+  (`|= flag` / `&= ~flag`) を `add_X(flag)` / `remove_X(flag)` に migration
+  (spell-realm/spells-craft / mspell/mspell-dispel / realm/realm-chaos /
+   player-attack/attack-chaos-effect / scroll-read-executor / quaff-effects
+   / status/bad-status-setter)
+- ✅ savefile load/save 経路 (player-attack-loader / player-writer)
+  と reset 経路 (status/buff-setter) を `set_X_flags(value)` 経由に
+- ✅ player-attack/player-attack の `does_weapon_has_flag(BIT_FLAGS &)`
+  を `does_weapon_has_flag(BIT_FLAGS)` に変更 (rvalue 受け入れのため)
+- ✅ body-improvement-info.cpp / flavor-describer.cpp の bool 用途
+  read を `has_X()` に置換
+- ✅ **ESP 15 + 装備集計 19 + special_attack 1 = 35 個を private 化**
+
+### 効果
+
+- CreatureEntity 直下の plain public BIT_FLAGS field がほぼ消滅
+- **合計 private 化フィールド数: 37 → 72** (約 2 倍)
+- 装備変更時の状態再計算経路が明示的な setter API 経由に統一され、
+  将来 setter 内で監査ログ・レンダフラグ自動連動などを追加可能
+- special_attack/defense の compound assignment 約 18 箇所が
+  意味的に明確な OO 形式 (`add_special_attack(ATTACK_X)`) に統一
+
+### 残作業
+
+なし。残る public BIT_FLAGS は `cursed` / `cursed_special`
+(EnumClassFlagGroup 型、外部走査多数のため別提案で扱う)、
+`cur_lite` / `old_lite` (POSITION 型キャッシュ、提案 24 系列で
+扱う候補)、`hack_mutation` / `is_fired` / `level_up_message` /
+`invoking_midnight_curse` (短命 bool フラグ、private 化価値低) のみ。
 
 ---
 

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -260,7 +260,7 @@ static std::string describe_ammo_detail(CreatureEntity &creature, const ItemEnti
         avgdam += (ammo.to_d * 10);
     }
 
-    if (creature.xtra_might) {
+    if (creature.has_xtra_might()) {
         tmul++;
     }
 
@@ -292,7 +292,7 @@ static std::string describe_ammo_detail(CreatureEntity &creature, const ItemEnti
 
 static std::string describe_spike_detail(const CreatureEntity &creature)
 {
-    auto avgdam = creature.mighty_throw ? (1 + 3) : 1;
+    auto avgdam = creature.has_mighty_throw() ? (1 + 3) : 1;
     avgdam += ((creature.get_level() + 30) * (creature.get_level() + 30) - 900) / 55;
     const auto energy_fire = 100 - creature.get_level();
     const auto avgdam_per_turn = 100 * avgdam / energy_fire;

--- a/src/load/player-attack-loader.cpp
+++ b/src/load/player-attack-loader.cpp
@@ -11,7 +11,7 @@
 void rd_special_attack(CreatureEntity &creature)
 {
     creature.set_timed_effect(CreatureTimedEffect::ELE_ATTACK, rd_s16b());
-    creature.special_attack = rd_u32b();
+    creature.set_special_attack_flags(rd_u32b());
 }
 
 void rd_special_action(CreatureEntity &creature)
@@ -29,7 +29,7 @@ void rd_special_action(CreatureEntity &creature)
 void rd_special_defense(CreatureEntity &creature)
 {
     creature.set_timed_effect(CreatureTimedEffect::ELE_IMMUNE, rd_s16b());
-    creature.special_defense = rd_u32b();
+    creature.set_special_defense_flags(rd_u32b());
 }
 
 void rd_action(CreatureEntity &creature)

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -497,7 +497,7 @@ void MonsterAttackPlayer::describe_attack_evasion()
 
     disturb(creature, true, true);
 #ifdef JP
-    auto is_suiken = any_bits(creature.special_attack, ATTACK_SUIKEN);
+    auto is_suiken = creature.has_special_attack(ATTACK_SUIKEN);
     if (this->abbreviate) {
         msg_format("%sかわした。", is_suiken ? "奇妙な動きで" : "");
     } else {

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -82,7 +82,7 @@ static void dispel_player(CreatureEntity &creature)
     (void)set_tim_imm_dark(creature, 0, true);
 
     if (creature.has_special_attack(ATTACK_CONFUSE)) {
-        creature.special_attack &= ~(ATTACK_CONFUSE);
+        creature.remove_special_attack(ATTACK_CONFUSE);
         msg_print(_("手の輝きがなくなった。", "Your hands stop glowing."));
     }
 

--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -305,7 +305,7 @@ bool QuaffEffects::booze()
     if (!is_monk) {
         chg_virtue(this->creature, Virtue::HARMONY, -1);
     } else if (!has_resist_conf(this->creature)) {
-        set_bits(this->creature.special_attack, ATTACK_SUIKEN);
+        this->creature.add_special_attack(ATTACK_SUIKEN);
     }
 
     BadStatusSetter bss(this->creature);

--- a/src/object-use/read/scroll-read-executor.cpp
+++ b/src/object-use/read/scroll-read-executor.cpp
@@ -308,12 +308,12 @@ bool ScrollReadExecutor::read()
 
         break;
     case SV_SCROLL_MONSTER_CONFUSION:
-        if (any_bits(this->creature.special_attack, ATTACK_CONFUSE)) {
+        if (this->creature.has_special_attack(ATTACK_CONFUSE)) {
             break;
         }
 
         msg_print(_("手が輝き始めた。", "Your hands begin to glow."));
-        this->creature.special_attack |= ATTACK_CONFUSE;
+        this->creature.add_special_attack(ATTACK_CONFUSE);
         RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
         this->ident = true;
         break;

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -48,7 +48,7 @@
 static void attack_confuse(CreatureEntity &creature, player_attack_type *pa_ptr, bool can_resist = true)
 {
     if (creature.has_special_attack(ATTACK_CONFUSE)) {
-        creature.special_attack &= ~(ATTACK_CONFUSE);
+        creature.remove_special_attack(ATTACK_CONFUSE);
         msg_print(_("手の輝きがなくなった。", "Your hands stop glowing."));
         RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     }
@@ -290,7 +290,7 @@ static void attack_golden_hammer(CreatureEntity &creature, player_attack_type *p
  */
 void change_monster_stat(CreatureEntity &creature, player_attack_type *pa_ptr, const POSITION y, const POSITION x, int *num)
 {
-    auto should_confuse = any_bits(creature.special_attack, ATTACK_CONFUSE);
+    auto should_confuse = creature.has_special_attack(ATTACK_CONFUSE);
     should_confuse |= pa_ptr->chaos_effect == CE_CONFUSION;
     should_confuse |= pa_ptr->mode == HISSATSU_CONF;
     should_confuse |= SpellHex(creature).is_spelling_specific(HEX_CONFUSION);

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -277,10 +277,10 @@ static bool does_equip_cause_earthquake(CreatureEntity &creature, player_attack_
     auto do_quake = false;
 
     auto hand = (pa_ptr->hand == 0) ? FLAG_CAUSE_INVEN_MAIN_HAND : FLAG_CAUSE_INVEN_SUB_HAND;
-    if (any_bits(creature.earthquake, hand)) {
+    if (any_bits(creature.get_earthquake_flags(), hand)) {
         do_quake = true;
     } else {
-        auto flags = creature.earthquake;
+        auto flags = creature.get_earthquake_flags();
         reset_bits(flags, FLAG_CAUSE_INVEN_MAIN_HAND | FLAG_CAUSE_INVEN_SUB_HAND);
         do_quake = flags != 0;
     }
@@ -298,7 +298,7 @@ static bool does_equip_cause_earthquake(CreatureEntity &creature, player_attack_
  * @param pa_ptr 直接攻撃構造体への参照ポインタ
  * @return 持つならtrue、持たないならfalse
  */
-static bool does_weapon_has_flag(BIT_FLAGS &attacker_flags, player_attack_type *pa_ptr)
+static bool does_weapon_has_flag(BIT_FLAGS attacker_flags, player_attack_type *pa_ptr)
 {
     if (!attacker_flags) {
         return false;
@@ -334,7 +334,7 @@ static void process_weapon_attack(CreatureEntity &creature, player_attack_type *
         *do_quake = true;
     }
 
-    auto do_impact = does_weapon_has_flag(creature.impact, pa_ptr);
+    auto do_impact = does_weapon_has_flag(creature.get_impact_flags(), pa_ptr);
     if ((o_ptr->bi_key != BaseitemKey(ItemKindType::SWORD, SV_POISON_NEEDLE)) && !(pa_ptr->mode == HISSATSU_KYUSHO)) {
         pa_ptr->attack_damage = critical_norm(creature, o_ptr->weight, o_ptr->to_h, pa_ptr->attack_damage, creature.get_to_h(pa_ptr->hand), pa_ptr->mode, do_impact);
     }

--- a/src/player-info/body-improvement-info.cpp
+++ b/src/player-info/body-improvement-info.cpp
@@ -131,23 +131,23 @@ void set_body_improvement_info_3(CreatureEntity &creature, self_info_type *self_
         self_ptr->info_list.emplace_back(_("あなたはテレポートできない。", "You cannot teleport."));
     }
 
-    if (creature.lite) {
+    if (creature.has_lite_flag()) {
         self_ptr->info_list.emplace_back(_("あなたの身体は光っている。", "You are carrying a permanent light."));
     }
 
-    if (creature.warning) {
+    if (creature.has_warning_flag()) {
         self_ptr->info_list.emplace_back(_("あなたは行動の前に危険を察知することができる。", "You will be warned before dangerous actions."));
     }
 
-    if (creature.dec_mana) {
+    if (creature.has_dec_mana()) {
         self_ptr->info_list.emplace_back(_("あなたは少ない消費魔力で魔法を唱えることができる。", "You can cast spells with fewer mana points."));
     }
 
-    if (creature.easy_spell) {
+    if (creature.has_easy_spell()) {
         self_ptr->info_list.emplace_back(_("あなたは低い失敗率で魔法を唱えることができる。", "Your magic fails less often."));
     }
 
-    if (creature.mighty_throw) {
+    if (creature.has_mighty_throw()) {
         self_ptr->info_list.emplace_back(_("あなたは強く物を投げる。", "You can throw objects powerfully."));
     }
 }

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -135,7 +135,7 @@ BIT_FLAGS player_flags_brand_pois(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_BRAND_POIS);
 
-    if (creature.special_attack & ATTACK_POIS) {
+    if (creature.has_special_attack(ATTACK_POIS)) {
         set_bits(result, FLAG_CAUSE_MAGIC_TIME_EFFECT);
     }
 
@@ -146,7 +146,7 @@ BIT_FLAGS player_flags_brand_acid(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_BRAND_ACID);
 
-    if (creature.special_attack & ATTACK_ACID) {
+    if (creature.has_special_attack(ATTACK_ACID)) {
         set_bits(result, FLAG_CAUSE_MAGIC_TIME_EFFECT);
     }
 
@@ -157,7 +157,7 @@ BIT_FLAGS player_flags_brand_elec(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_BRAND_ELEC);
 
-    if (creature.special_attack & ATTACK_ELEC) {
+    if (creature.has_special_attack(ATTACK_ELEC)) {
         set_bits(result, FLAG_CAUSE_MAGIC_TIME_EFFECT);
     }
 
@@ -168,7 +168,7 @@ BIT_FLAGS player_flags_brand_fire(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_BRAND_FIRE);
 
-    if (creature.special_attack & ATTACK_FIRE) {
+    if (creature.has_special_attack(ATTACK_FIRE)) {
         set_bits(result, FLAG_CAUSE_MAGIC_TIME_EFFECT);
     }
 
@@ -179,7 +179,7 @@ BIT_FLAGS player_flags_brand_cold(CreatureEntity &creature)
 {
     BIT_FLAGS result = common_cause_flags(creature, TR_BRAND_COLD);
 
-    if (creature.special_attack & ATTACK_COLD) {
+    if (creature.has_special_attack(ATTACK_COLD)) {
         set_bits(result, FLAG_CAUSE_MAGIC_TIME_EFFECT);
     }
 
@@ -1576,7 +1576,7 @@ BIT_FLAGS has_immune_acid(CreatureEntity &creature)
     BIT_FLAGS result = common_cause_flags(creature, TR_IM_ACID);
 
     if (creature.get_timed_effect(CreatureTimedEffect::ELE_IMMUNE)) {
-        if (creature.special_defense & DEFENSE_ACID) {
+        if (creature.has_special_defense(DEFENSE_ACID)) {
             result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
         }
     }
@@ -1589,7 +1589,7 @@ BIT_FLAGS has_immune_elec(CreatureEntity &creature)
     BIT_FLAGS result = common_cause_flags(creature, TR_IM_ELEC);
 
     if (creature.get_timed_effect(CreatureTimedEffect::ELE_IMMUNE)) {
-        if (creature.special_defense & DEFENSE_ELEC) {
+        if (creature.has_special_defense(DEFENSE_ELEC)) {
             result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
         }
     }
@@ -1602,7 +1602,7 @@ BIT_FLAGS has_immune_fire(CreatureEntity &creature)
     BIT_FLAGS result = common_cause_flags(creature, TR_IM_FIRE);
 
     if (creature.get_timed_effect(CreatureTimedEffect::ELE_IMMUNE)) {
-        if (creature.special_defense & DEFENSE_FIRE) {
+        if (creature.has_special_defense(DEFENSE_FIRE)) {
             result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
         }
     }
@@ -1615,7 +1615,7 @@ BIT_FLAGS has_immune_cold(CreatureEntity &creature)
     BIT_FLAGS result = common_cause_flags(creature, TR_IM_COLD);
 
     if (creature.get_timed_effect(CreatureTimedEffect::ELE_IMMUNE)) {
-        if (creature.special_defense & DEFENSE_COLD) {
+        if (creature.has_special_defense(DEFENSE_COLD)) {
             result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
         }
     }

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -243,67 +243,67 @@ static void update_bonuses(CreatureEntity &creature)
     ItemEntity *o_ptr;
 
     /* Save the old vision stuff */
-    BIT_FLAGS old_telepathy = creature.telepathy;
-    BIT_FLAGS old_esp_animal = creature.esp_animal;
-    BIT_FLAGS old_esp_undead = creature.esp_undead;
-    BIT_FLAGS old_esp_demon = creature.esp_demon;
-    BIT_FLAGS old_esp_orc = creature.esp_orc;
-    BIT_FLAGS old_esp_troll = creature.esp_troll;
-    BIT_FLAGS old_esp_giant = creature.esp_giant;
-    BIT_FLAGS old_esp_dragon = creature.esp_dragon;
-    BIT_FLAGS old_esp_human = creature.esp_human;
-    BIT_FLAGS old_esp_evil = creature.esp_evil;
-    BIT_FLAGS old_esp_good = creature.esp_good;
-    BIT_FLAGS old_esp_nonliving = creature.esp_nonliving;
-    BIT_FLAGS old_esp_unique = creature.esp_unique;
-    BIT_FLAGS old_see_inv = creature.see_inv;
-    BIT_FLAGS old_mighty_throw = creature.mighty_throw;
+    BIT_FLAGS old_telepathy = creature.get_telepathy_flags();
+    BIT_FLAGS old_esp_animal = creature.get_esp_animal_flags();
+    BIT_FLAGS old_esp_undead = creature.get_esp_undead_flags();
+    BIT_FLAGS old_esp_demon = creature.get_esp_demon_flags();
+    BIT_FLAGS old_esp_orc = creature.get_esp_orc_flags();
+    BIT_FLAGS old_esp_troll = creature.get_esp_troll_flags();
+    BIT_FLAGS old_esp_giant = creature.get_esp_giant_flags();
+    BIT_FLAGS old_esp_dragon = creature.get_esp_dragon_flags();
+    BIT_FLAGS old_esp_human = creature.get_esp_human_flags();
+    BIT_FLAGS old_esp_evil = creature.get_esp_evil_flags();
+    BIT_FLAGS old_esp_good = creature.get_esp_good_flags();
+    BIT_FLAGS old_esp_nonliving = creature.get_esp_nonliving_flags();
+    BIT_FLAGS old_esp_unique = creature.get_esp_unique_flags();
+    BIT_FLAGS old_see_inv = creature.get_see_inv_flags();
+    BIT_FLAGS old_mighty_throw = creature.get_mighty_throw_flags();
     int16_t old_speed = static_cast<int16_t>(creature.get_speed());
 
     ARMOUR_CLASS old_dis_ac = creature.dis_ac;
     ARMOUR_CLASS old_dis_to_a = creature.dis_to_a;
 
-    creature.xtra_might = has_xtra_might(creature);
-    creature.esp_evil = has_esp_evil(creature);
-    creature.esp_animal = has_esp_animal(creature);
-    creature.esp_nasty = has_esp_nasty(creature);
-    creature.esp_homo = has_esp_homo(creature);
-    creature.esp_undead = has_esp_undead(creature);
-    creature.esp_demon = has_esp_demon(creature);
-    creature.esp_orc = has_esp_orc(creature);
-    creature.esp_troll = has_esp_troll(creature);
-    creature.esp_giant = has_esp_giant(creature);
-    creature.esp_dragon = has_esp_dragon(creature);
-    creature.esp_human = has_esp_human(creature);
-    creature.esp_good = has_esp_good(creature);
-    creature.esp_nonliving = has_esp_nonliving(creature);
-    creature.esp_unique = has_esp_unique(creature);
-    creature.telepathy = has_esp_telepathy(creature);
-    creature.bless_blade = has_bless_blade(creature);
+    creature.set_xtra_might(has_xtra_might(creature));
+    creature.set_esp_evil(has_esp_evil(creature));
+    creature.set_esp_animal(has_esp_animal(creature));
+    creature.set_esp_nasty(has_esp_nasty(creature));
+    creature.set_esp_homo(has_esp_homo(creature));
+    creature.set_esp_undead(has_esp_undead(creature));
+    creature.set_esp_demon(has_esp_demon(creature));
+    creature.set_esp_orc(has_esp_orc(creature));
+    creature.set_esp_troll(has_esp_troll(creature));
+    creature.set_esp_giant(has_esp_giant(creature));
+    creature.set_esp_dragon(has_esp_dragon(creature));
+    creature.set_esp_human(has_esp_human(creature));
+    creature.set_esp_good(has_esp_good(creature));
+    creature.set_esp_nonliving(has_esp_nonliving(creature));
+    creature.set_esp_unique(has_esp_unique(creature));
+    creature.set_telepathy(has_esp_telepathy(creature));
+    creature.set_bless_blade(has_bless_blade(creature));
     creature.easy_2weapon = creature.has_easy2_weapon();
     creature.down_saving = creature.has_down_saving();
     creature.yoiyami = creature.has_no_ac();
-    creature.mighty_throw = has_mighty_throw(creature);
-    creature.dec_mana = has_dec_mana(creature);
-    creature.see_nocto = has_see_nocto(creature);
-    creature.warning = has_warning(creature);
-    creature.anti_magic = has_anti_magic(creature);
-    creature.anti_tele = has_anti_tele(creature);
-    creature.easy_spell = has_easy_spell(creature);
-    creature.hard_spell = has_hard_spell(creature);
-    creature.hold_exp = has_hold_exp(creature);
-    creature.see_inv = has_see_inv(creature);
-    creature.free_act = has_free_act(creature);
-    creature.levitation = has_levitation(creature);
-    creature.can_swim = has_can_swim(creature);
-    creature.slow_digest = has_slow_digest(creature);
-    creature.regenerate = has_regenerate(creature);
+    creature.set_mighty_throw(has_mighty_throw(creature));
+    creature.set_dec_mana(has_dec_mana(creature));
+    creature.set_see_nocto(has_see_nocto(creature));
+    creature.set_warning_flags(has_warning(creature));
+    creature.set_anti_magic(has_anti_magic(creature));
+    creature.set_anti_tele(has_anti_tele(creature));
+    creature.set_easy_spell(has_easy_spell(creature));
+    creature.set_hard_spell(has_hard_spell(creature));
+    creature.set_hold_exp(has_hold_exp(creature));
+    creature.set_see_inv(has_see_inv(creature));
+    creature.set_free_act(has_free_act(creature));
+    creature.set_levitation(has_levitation(creature));
+    creature.set_can_swim(has_can_swim(creature));
+    creature.set_slow_digest(has_slow_digest(creature));
+    creature.set_regenerate(has_regenerate(creature));
     update_curses(creature);
-    creature.impact = has_impact(creature);
-    creature.earthquake = has_earthquake(creature);
+    creature.set_impact_flags(has_impact(creature));
+    creature.set_earthquake_flags(has_earthquake(creature));
     update_extra_blows(creature);
 
-    creature.lite = has_lite(creature);
+    creature.set_lite_flags(has_lite(creature));
 
     if (!CreatureClass(creature).monk_stance_is(MonkStanceType::NONE)) {
         if (none_bits(empty_hands_status, EMPTY_HAND_MAIN)) {
@@ -359,31 +359,31 @@ static void update_bonuses(CreatureEntity &creature)
     creature.dis_to_a = calc_to_ac(creature, false);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (old_mighty_throw != creature.mighty_throw) {
+    if (old_mighty_throw != creature.get_mighty_throw_flags()) {
         rfu.set_flag(SubWindowRedrawingFlag::INVENTORY);
     }
 
-    if (creature.telepathy != old_telepathy) {
+    if (creature.get_telepathy_flags() != old_telepathy) {
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     }
 
-    auto is_esp_updated = creature.esp_animal != old_esp_animal;
-    is_esp_updated |= creature.esp_undead != old_esp_undead;
-    is_esp_updated |= creature.esp_demon != old_esp_demon;
-    is_esp_updated |= creature.esp_orc != old_esp_orc;
-    is_esp_updated |= creature.esp_troll != old_esp_troll;
-    is_esp_updated |= creature.esp_giant != old_esp_giant;
-    is_esp_updated |= creature.esp_dragon != old_esp_dragon;
-    is_esp_updated |= creature.esp_human != old_esp_human;
-    is_esp_updated |= creature.esp_evil != old_esp_evil;
-    is_esp_updated |= creature.esp_good != old_esp_good;
-    is_esp_updated |= creature.esp_nonliving != old_esp_nonliving;
-    is_esp_updated |= creature.esp_unique != old_esp_unique;
+    auto is_esp_updated = creature.get_esp_animal_flags() != old_esp_animal;
+    is_esp_updated |= creature.get_esp_undead_flags() != old_esp_undead;
+    is_esp_updated |= creature.get_esp_demon_flags() != old_esp_demon;
+    is_esp_updated |= creature.get_esp_orc_flags() != old_esp_orc;
+    is_esp_updated |= creature.get_esp_troll_flags() != old_esp_troll;
+    is_esp_updated |= creature.get_esp_giant_flags() != old_esp_giant;
+    is_esp_updated |= creature.get_esp_dragon_flags() != old_esp_dragon;
+    is_esp_updated |= creature.get_esp_human_flags() != old_esp_human;
+    is_esp_updated |= creature.get_esp_evil_flags() != old_esp_evil;
+    is_esp_updated |= creature.get_esp_good_flags() != old_esp_good;
+    is_esp_updated |= creature.get_esp_nonliving_flags() != old_esp_nonliving;
+    is_esp_updated |= creature.get_esp_unique_flags() != old_esp_unique;
     if (is_esp_updated) {
         rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     }
 
-    if (creature.see_inv != old_see_inv) {
+    if (creature.get_see_inv_flags() != old_see_inv) {
         rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     }
 
@@ -1135,7 +1135,7 @@ static ACTION_SKILL_POWER calc_saving_throw(CreatureEntity &creature)
         pow += 30;
     }
 
-    if (creature.bless_blade) {
+    if (creature.has_bless_blade()) {
         pow += 6 + (creature.get_level() - 1) / 10;
     }
 
@@ -1153,7 +1153,7 @@ static ACTION_SKILL_POWER calc_saving_throw(CreatureEntity &creature)
         pow -= 30;
     }
 
-    if (creature.anti_magic && (pow < (90 + creature.get_level()))) {
+    if (creature.has_anti_magic() && (pow < (90 + creature.get_level()))) {
         pow = 90 + creature.get_level();
     }
 

--- a/src/realm/realm-chaos.cpp
+++ b/src/realm/realm-chaos.cpp
@@ -88,7 +88,7 @@ tl::optional<std::string> do_chaos_spell(CreatureEntity &creature, SPELL_IDX spe
         if (cast) {
             if (!(creature.has_special_attack(ATTACK_CONFUSE))) {
                 msg_print(_("あなたの手は光り始めた。", "Your hands start glowing."));
-                creature.special_attack |= ATTACK_CONFUSE;
+                creature.add_special_attack(ATTACK_CONFUSE);
                 RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
             }
         }

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -291,9 +291,9 @@ void wr_player(CreatureEntity &creature)
     }
 
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::ELE_ATTACK));
-    wr_u32b(creature.special_attack);
+    wr_u32b(creature.get_special_attack_flags());
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::ELE_IMMUNE));
-    wr_u32b(creature.special_defense);
+    wr_u32b(creature.get_special_defense_flags());
     wr_byte(creature.knowledge);
     wr_bool(creature.autopick_autoregister);
     wr_byte(0);

--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -39,37 +39,37 @@ bool set_ele_attack(CreatureEntity &creature, uint32_t attack_type, TIME_EFFECT 
                                       : v;
 
     if ((creature.has_special_attack(ATTACK_ACID)) && (attack_type != ATTACK_ACID)) {
-        creature.special_attack &= ~(ATTACK_ACID);
+        creature.remove_special_attack(ATTACK_ACID);
         msg_print(_("酸で攻撃できなくなった。", "Your temporary acidic brand fades away."));
         sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_attack(ATTACK_ELEC)) && (attack_type != ATTACK_ELEC)) {
-        creature.special_attack &= ~(ATTACK_ELEC);
+        creature.remove_special_attack(ATTACK_ELEC);
         msg_print(_("電撃で攻撃できなくなった。", "Your temporary electrical brand fades away."));
         sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_attack(ATTACK_FIRE)) && (attack_type != ATTACK_FIRE)) {
-        creature.special_attack &= ~(ATTACK_FIRE);
+        creature.remove_special_attack(ATTACK_FIRE);
         msg_print(_("火炎で攻撃できなくなった。", "Your temporary fiery brand fades away."));
         sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_attack(ATTACK_COLD)) && (attack_type != ATTACK_COLD)) {
-        creature.special_attack &= ~(ATTACK_COLD);
+        creature.remove_special_attack(ATTACK_COLD);
         msg_print(_("冷気で攻撃できなくなった。", "Your temporary frost brand fades away."));
         sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_attack(ATTACK_POIS)) && (attack_type != ATTACK_POIS)) {
-        creature.special_attack &= ~(ATTACK_POIS);
+        creature.remove_special_attack(ATTACK_POIS);
         msg_print(_("毒で攻撃できなくなった。", "Your temporary poison brand fades away."));
         sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((v) && (attack_type)) {
-        creature.special_attack |= (attack_type);
+        creature.add_special_attack(attack_type);
         creature.set_timed_effect(CreatureTimedEffect::ELE_ATTACK, v);
         std::string element;
         switch (attack_type) {
@@ -122,37 +122,37 @@ bool set_ele_immune(CreatureEntity &creature, uint32_t immune_type, TIME_EFFECT 
                                       : v;
 
     if ((creature.has_special_defense(DEFENSE_ACID)) && (immune_type != DEFENSE_ACID)) {
-        creature.special_defense &= ~(DEFENSE_ACID);
+        creature.remove_special_defense(DEFENSE_ACID);
         msg_print(_("酸の攻撃で傷つけられるようになった。", "You are no longer immune to acid."));
         sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_defense(DEFENSE_ELEC)) && (immune_type != DEFENSE_ELEC)) {
-        creature.special_defense &= ~(DEFENSE_ELEC);
+        creature.remove_special_defense(DEFENSE_ELEC);
         msg_print(_("電撃の攻撃で傷つけられるようになった。", "You are no longer immune to electricity."));
         sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_defense(DEFENSE_FIRE)) && (immune_type != DEFENSE_FIRE)) {
-        creature.special_defense &= ~(DEFENSE_FIRE);
+        creature.remove_special_defense(DEFENSE_FIRE);
         msg_print(_("火炎の攻撃で傷つけられるようになった。", "You are no longer immune to fire."));
         sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_defense(DEFENSE_COLD)) && (immune_type != DEFENSE_COLD)) {
-        creature.special_defense &= ~(DEFENSE_COLD);
+        creature.remove_special_defense(DEFENSE_COLD);
         msg_print(_("冷気の攻撃で傷つけられるようになった。", "You are no longer immune to cold."));
         sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((creature.has_special_defense(DEFENSE_POIS)) && (immune_type != DEFENSE_POIS)) {
-        creature.special_defense &= ~(DEFENSE_POIS);
+        creature.remove_special_defense(DEFENSE_POIS);
         msg_print(_("毒の攻撃で傷つけられるようになった。", "You are no longer immune to poison."));
         sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((v) && (immune_type)) {
-        creature.special_defense |= (immune_type);
+        creature.add_special_defense(immune_type);
         creature.set_timed_effect(CreatureTimedEffect::ELE_IMMUNE, v);
         std::string element;
         switch (immune_type) {

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -159,7 +159,7 @@ bool BadStatusSetter::set_confusion(const TIME_EFFECT tmp_v)
     } else {
         if (is_confused) {
             msg_print(_("やっと混乱がおさまった。", "You feel less confused now."));
-            this->creature.special_attack &= ~(ATTACK_SUIKEN);
+            this->creature.remove_special_attack(ATTACK_SUIKEN);
             notice = true;
         }
     }

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -91,8 +91,8 @@ void reset_tim_flags(CreatureEntity &creature)
     // 非 CreatureTimedEffect のリセット
     creature.sutemi = false;
     creature.counter = false;
-    creature.special_attack = 0L;
-    creature.special_defense = 0L;
+    creature.set_special_attack_flags(0L);
+    creature.set_special_defense_flags(0L);
 
     while (creature.get_energy_need() < 0) {
         creature.set_energy_need(creature.get_energy_need() + ENERGY_NEED());

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -2309,6 +2309,268 @@ public:
         return this->xtra_might != 0;
     }
     /*!
+     * @brief 装備由来の祝福武器有無
+     */
+    virtual bool has_bless_blade() const
+    {
+        return this->bless_blade != 0;
+    }
+
+    // [提案 33] BIT_FLAGS フィールドの setter virtual 群。
+    // すべて player-status.cpp の update_creature() から
+    // 装備状態を再計算した結果を書き込むのみ。
+    virtual void set_telepathy(BIT_FLAGS value)
+    {
+        this->telepathy = value;
+    }
+    virtual void set_esp_animal(BIT_FLAGS value)
+    {
+        this->esp_animal = value;
+    }
+    virtual void set_esp_nasty(BIT_FLAGS value)
+    {
+        this->esp_nasty = value;
+    }
+    virtual void set_esp_homo(BIT_FLAGS value)
+    {
+        this->esp_homo = value;
+    }
+    virtual void set_esp_undead(BIT_FLAGS value)
+    {
+        this->esp_undead = value;
+    }
+    virtual void set_esp_demon(BIT_FLAGS value)
+    {
+        this->esp_demon = value;
+    }
+    virtual void set_esp_orc(BIT_FLAGS value)
+    {
+        this->esp_orc = value;
+    }
+    virtual void set_esp_troll(BIT_FLAGS value)
+    {
+        this->esp_troll = value;
+    }
+    virtual void set_esp_giant(BIT_FLAGS value)
+    {
+        this->esp_giant = value;
+    }
+    virtual void set_esp_dragon(BIT_FLAGS value)
+    {
+        this->esp_dragon = value;
+    }
+    virtual void set_esp_human(BIT_FLAGS value)
+    {
+        this->esp_human = value;
+    }
+    virtual void set_esp_evil(BIT_FLAGS value)
+    {
+        this->esp_evil = value;
+    }
+    virtual void set_esp_good(BIT_FLAGS value)
+    {
+        this->esp_good = value;
+    }
+    virtual void set_esp_nonliving(BIT_FLAGS value)
+    {
+        this->esp_nonliving = value;
+    }
+    virtual void set_esp_unique(BIT_FLAGS value)
+    {
+        this->esp_unique = value;
+    }
+
+    virtual void set_can_swim(bool value)
+    {
+        this->can_swim = value;
+    }
+    virtual void set_levitation(BIT_FLAGS value)
+    {
+        this->levitation = value;
+    }
+    virtual void set_free_act(BIT_FLAGS value)
+    {
+        this->free_act = value;
+    }
+    virtual void set_see_inv(BIT_FLAGS value)
+    {
+        this->see_inv = value;
+    }
+    virtual void set_regenerate(BIT_FLAGS value)
+    {
+        this->regenerate = value;
+    }
+    virtual void set_hold_exp(BIT_FLAGS value)
+    {
+        this->hold_exp = value;
+    }
+    virtual void set_slow_digest(BIT_FLAGS value)
+    {
+        this->slow_digest = value;
+    }
+    virtual void set_lite_flags(BIT_FLAGS value)
+    {
+        this->lite = value;
+    }
+    virtual void set_warning_flags(BIT_FLAGS value)
+    {
+        this->warning = value;
+    }
+    virtual void set_impact_flags(BIT_FLAGS value)
+    {
+        this->impact = value;
+    }
+    virtual void set_earthquake_flags(BIT_FLAGS value)
+    {
+        this->earthquake = value;
+    }
+    virtual void set_dec_mana(BIT_FLAGS value)
+    {
+        this->dec_mana = value;
+    }
+    virtual void set_easy_spell(BIT_FLAGS value)
+    {
+        this->easy_spell = value;
+    }
+    virtual void set_hard_spell(BIT_FLAGS value)
+    {
+        this->hard_spell = value;
+    }
+    virtual void set_mighty_throw(BIT_FLAGS value)
+    {
+        this->mighty_throw = value;
+    }
+    virtual void set_see_nocto(BIT_FLAGS value)
+    {
+        this->see_nocto = value;
+    }
+    virtual void set_anti_magic(BIT_FLAGS value)
+    {
+        this->anti_magic = value;
+    }
+    virtual void set_anti_tele(BIT_FLAGS value)
+    {
+        this->anti_tele = value;
+    }
+    virtual void set_bless_blade(BIT_FLAGS value)
+    {
+        this->bless_blade = value;
+    }
+    virtual void set_xtra_might(BIT_FLAGS value)
+    {
+        this->xtra_might = value;
+    }
+
+    // impact / earthquake は装備別ハンドフラグを保持しているため
+    // BIT_FLAGS 値そのものを返す getter を提供 (any_bits 等に渡す用)。
+    virtual BIT_FLAGS get_impact_flags() const
+    {
+        return this->impact;
+    }
+    virtual BIT_FLAGS get_earthquake_flags() const
+    {
+        return this->earthquake;
+    }
+
+    // 旧値スナップショット用 BIT_FLAGS getter (差分検出キャッシュ向け)。
+    virtual BIT_FLAGS get_telepathy_flags() const
+    {
+        return this->telepathy;
+    }
+    virtual BIT_FLAGS get_esp_animal_flags() const
+    {
+        return this->esp_animal;
+    }
+    virtual BIT_FLAGS get_esp_undead_flags() const
+    {
+        return this->esp_undead;
+    }
+    virtual BIT_FLAGS get_esp_demon_flags() const
+    {
+        return this->esp_demon;
+    }
+    virtual BIT_FLAGS get_esp_orc_flags() const
+    {
+        return this->esp_orc;
+    }
+    virtual BIT_FLAGS get_esp_troll_flags() const
+    {
+        return this->esp_troll;
+    }
+    virtual BIT_FLAGS get_esp_giant_flags() const
+    {
+        return this->esp_giant;
+    }
+    virtual BIT_FLAGS get_esp_dragon_flags() const
+    {
+        return this->esp_dragon;
+    }
+    virtual BIT_FLAGS get_esp_human_flags() const
+    {
+        return this->esp_human;
+    }
+    virtual BIT_FLAGS get_esp_evil_flags() const
+    {
+        return this->esp_evil;
+    }
+    virtual BIT_FLAGS get_esp_good_flags() const
+    {
+        return this->esp_good;
+    }
+    virtual BIT_FLAGS get_esp_nonliving_flags() const
+    {
+        return this->esp_nonliving;
+    }
+    virtual BIT_FLAGS get_esp_unique_flags() const
+    {
+        return this->esp_unique;
+    }
+    virtual BIT_FLAGS get_see_inv_flags() const
+    {
+        return this->see_inv;
+    }
+    virtual BIT_FLAGS get_mighty_throw_flags() const
+    {
+        return this->mighty_throw;
+    }
+
+    // 特殊攻撃 / 特殊防御フラグ。compound assignment が複数箇所にあるため
+    // add / remove / set / get の 4 種を提供。has_special_attack(flag) は既存。
+    virtual void set_special_attack_flags(BIT_FLAGS value)
+    {
+        this->special_attack = value;
+    }
+    virtual BIT_FLAGS get_special_attack_flags() const
+    {
+        return this->special_attack;
+    }
+    virtual void add_special_attack(BIT_FLAGS flag)
+    {
+        this->special_attack |= flag;
+    }
+    virtual void remove_special_attack(BIT_FLAGS flag)
+    {
+        this->special_attack &= ~flag;
+    }
+
+    virtual void set_special_defense_flags(BIT_FLAGS value)
+    {
+        this->special_defense = value;
+    }
+    virtual BIT_FLAGS get_special_defense_flags() const
+    {
+        return this->special_defense;
+    }
+    virtual void add_special_defense(BIT_FLAGS flag)
+    {
+        this->special_defense |= flag;
+    }
+    virtual void remove_special_defense(BIT_FLAGS flag)
+    {
+        this->special_defense &= ~flag;
+    }
+
+    /*!
      * @brief 突然変異フラグ集合への参照
      * @details プレイヤーは装備・レベル・クラス起因の変異、モンスターは
      *          将来的に種族由来の変異を返す想定。
@@ -2675,7 +2937,10 @@ public:
     // 名前関連
     std::string name{}; /*!< クリーチャーの名前（プレイヤー名またはペット名） / Creature's name (player name or pet nickname) */
 
-    // テレパシー・感知能力関連 / Telepathy and ESP abilities
+    // [提案 33] テレパシー・感知能力フラグ / Telepathy and ESP abilities
+    // すべて player-status.cpp の update_creature() で装備状態から再計算。
+    // 外部アクセスは has_X() / set_X() / get_X_flags() (旧値スナップショット用) 経由。
+private:
     BIT_FLAGS telepathy{}; /* Telepathy */
     BIT_FLAGS esp_animal{};
     BIT_FLAGS esp_nasty{};
@@ -2692,30 +2957,41 @@ public:
     BIT_FLAGS esp_nonliving{};
     BIT_FLAGS esp_unique{};
 
-    // 地形移動能力 / Terrain movement abilities
+public:
+    // [提案 33] 地形移動能力 / Terrain movement abilities
+private:
     bool can_swim{}; /* No damage in water */
 
-    /* クリーチャーの防御状態の定義 / Bit flags for the "special_defense" variable. -LM- */
+public:
+    // [提案 33] 特殊防御フラグ / Bit flags for the "special_defense" variable. -LM-
+    // has_special_defense(flag) / add_special_defense(flag) 等経由。
+private:
     BIT_FLAGS special_defense{};
 
+public:
     // 装備・能力関連フラグ / Equipment and ability flags
     bool hack_mutation{};
     bool is_fired{};
     bool level_up_message{};
 
+    // [提案 33] 装備由来 BIT_FLAGS 群。
+    // 全て has_X() / set_X() 経由でアクセス。
+    // EnumClassFlagGroup の cursed / cursed_special は public 維持。
+private:
     BIT_FLAGS anti_magic{}; /* Anti-magic */
     BIT_FLAGS anti_tele{}; /* Prevent teleportation */
 
+public:
     EnumClassFlagGroup<CurseTraitType> cursed{}; /* Player is cursed */
     EnumClassFlagGroup<CurseSpecialTraitType> cursed_special{}; /* Player is special type cursed */
 
+private:
     BIT_FLAGS levitation{}; /* No damage falling */
     BIT_FLAGS lite{}; /* Permanent light */
     BIT_FLAGS free_act{}; /* Never paralyzed */
     BIT_FLAGS see_inv{}; /* Can see invisible */
     BIT_FLAGS regenerate{}; /* Regenerate hit pts */
     BIT_FLAGS hold_exp{}; /* Resist exp draining */
-
     BIT_FLAGS slow_digest{}; /* Slower digestion */
     BIT_FLAGS bless_blade{}; //!< 祝福された装備をしている / Blessed by inventory items
     BIT_FLAGS xtra_might{}; /* Extra might bow */
@@ -2727,6 +3003,8 @@ public:
     BIT_FLAGS warning{};
     BIT_FLAGS mighty_throw{};
     BIT_FLAGS see_nocto{}; /* Noctovision */
+
+public:
     bool invoking_midnight_curse{};
 
     // インシデント記録（ツリー構造）
@@ -2774,8 +3052,13 @@ public:
     POSITION cur_lite{}; /* Radius of lite (if any) */
     POSITION old_lite{}; /* Radius of lite (if any) */
 
+    // [提案 33] private 化済。has_special_attack(flag) / add_special_attack(flag)
+    // / remove_special_attack(flag) / set_special_attack_flags(BIT_FLAGS) /
+    // get_special_attack_flags() 経由。
+private:
     BIT_FLAGS special_attack{};
 
+public:
     SUB_EXP spell_exp[64]{}; /* Proficiency of spells */
     std::map<ItemKindType, std::array<SUB_EXP, 64>> weapon_exp{}; /* Proficiency of weapons */
     std::map<ItemKindType, std::array<SUB_EXP, 64>> weapon_exp_max{}; /* Maximum proficiency of weapons */


### PR DESCRIPTION
ESP 系 15 個 + 装備集計系 19 個 + special_attack 1 個の合計 35 個の public BIT_FLAGS フィールドを private 化。

主な変更:
- set_X(BIT_FLAGS) virtual を 35 ESP/装備集計 + has_bless_blade() 追加
- get_X_flags() 差分検出キャッシュ用 virtual を 17 ESP/see_inv/etc 追加
- special_attack/defense に add/remove/set/get の 4 virtual セットを追加
- player-status.cpp の 50+ 箇所の write/snapshot read を migration
- compound assignment 18 箇所 (|= flag / &= ~flag) を add/remove に統一
- savefile load/save と reset_tim_flags の経路を setter 経由化
- does_weapon_has_flag(BIT_FLAGS &) を rvalue 受け入れ可能に変更

効果:
- 合計 private 化フィールド数: 37 → 72 (約 2 倍)
- CreatureEntity 直下の plain public BIT_FLAGS field がほぼ消滅
- 装備状態再計算が明示的な setter API 経由に統一
- special_attack/defense の compound assignment が OO 形式に