### PR TITLE
refactor: 提案 34 完了 - 表示用既知値 (dis_to_h/d/a/ac) の private 化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,11 @@ API 経由に統一された。一部フィールド (r_idx / ap_r_idx / riding)
   / `remove_special_attack(flag)` 等の compound assignment 用 virtual を
   整備し、約 70 箇所の write/read site を migration。**合計 private 化
   フィールド数: 37 → 72** (約 2 倍に到達)
+- **提案 34**: 表示用既知値 5 個 (dis_to_h[2] / dis_to_h_b / dis_to_d[2]
+  / dis_to_a / dis_ac) を private 化。`get_dis_X()` / `set_dis_X()`
+  virtual を整備し、19 箇所の access site を migration。提案 30
+  (to_h/d/a 本体) と対称な仕上げタスク。**合計 private 化フィールド数:
+  72 → 77**
 
 今後の残作業としては、現在 `CreatureEntity` 直下に残存するプレイヤー
 固有フィールド群（種族・職業・熟練度等）を、モンスターにも

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -1412,7 +1412,8 @@ lvalue 参照を直接渡せないため、ラッパとして導入)
 | 提案 32 安全フィールド | 7 個 |
 | 提案 32b 残りフィールド | 15 個 |
 | 提案 33 BIT_FLAGS 群 (ESP / 装備集計 / 特殊攻撃防御) | 35 個 |
-| **合計** | **72 個** |
+| 提案 34 表示用既知値 (dis_to_h/d/a/ac) | 5 個 |
+| **合計** | **77 個** |
 | inven_cnt / equip_cnt (提案 25) | フィールド廃止 |
 
 CreatureEntity のフィールドカプセル化が**事実上最終形**に到達。
@@ -1487,6 +1488,52 @@ virtual に統一済みだったため、書込みパターンの集約と差分
 `cur_lite` / `old_lite` (POSITION 型キャッシュ、提案 24 系列で
 扱う候補)、`hack_mutation` / `is_fired` / `level_up_message` /
 `invoking_midnight_curse` (短命 bool フラグ、private 化価値低) のみ。
+
+---
+
+## 提案 34: 表示用既知値 (dis_to_h/d/a/ac) の private 化 ✅ 完了
+
+### 背景
+
+提案 30 で戦闘ボーナス本体 (to_h / to_d / to_a) を private 化したのに
+対称な仕上げタスク。表示用の既知値キャッシュ 5 フィールド:
+
+- `HIT_PROB dis_to_h[2]`: 表記上の近接武器命中修正値
+- `HIT_PROB dis_to_h_b`: 表記上の射撃武器命中修正値
+- `int dis_to_d[2]`: 表記上の近接武器ダメージ修正値
+- `ARMOUR_CLASS dis_to_a`: 表記上の装備 AC 修正値
+- `ARMOUR_CLASS dis_ac`: 表記上の装備 AC 基礎値
+
+これらは player-status.cpp の update_creature() が装備状態から再計算し、
+画面表示系 (display-player-middle / main-window-left-frame /
+status-first-page / io-dump / cmd-building) が読み取るキャッシュ。
+
+### 完了内容
+
+- ✅ 5 フィールドの getter / setter virtual (合計 10 virtual) を追加
+  - `get_dis_to_h(hand)` / `set_dis_to_h(hand, val)`
+  - `get_dis_to_h_b()` / `set_dis_to_h_b(val)`
+  - `get_dis_to_d(hand)` / `set_dis_to_d(hand, val)`
+  - `get_dis_to_a()` / `set_dis_to_a(val)`
+  - `get_dis_ac()` / `set_dis_ac(val)`
+- ✅ 全 19 アクセスサイト migration
+  - player-status.cpp 内 write 7 箇所
+  - player-status.cpp 内 diff-check read 3 箇所
+  - display-player-middle.cpp / main-window-left-frame.cpp /
+    status-first-page.cpp / io-dump / cmd-building.cpp 内 read 9 箇所
+- ✅ 5 フィールドを private 化
+
+### 効果
+
+- **合計 private 化フィールド数: 72 → 77**
+- 提案 30 (to_h/d/a 本体) と提案 34 (表示用キャッシュ) で
+  戦闘ボーナス系のカプセル化が完結
+- 将来「装備変更時に dis_* と to_* を同時更新するインバリアント」を
+  setter 内で強制可能に
+
+### 残作業
+
+なし。
 
 ---
 

--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -288,7 +288,7 @@ static bool bldg_process_command(CreatureEntity &creature, const building_type &
         creature.sub_au(building_cost);
         return true;
     case BACT_EVAL_AC:
-        if (eval_ac(creature.dis_ac + creature.dis_to_a)) {
+        if (eval_ac(creature.get_dis_ac() + creature.get_dis_to_a())) {
             creature.sub_au(building_cost);
         }
 

--- a/src/io-dump/player-status-dump-json.cpp
+++ b/src/io-dump/player-status-dump-json.cpp
@@ -124,7 +124,7 @@ static void add_status_to_json(nlohmann::json &j, CreatureEntity &creature)
     j["status"]["mana"] = creature.get_csp();
     j["status"]["max_mana"] = creature.get_msp();
     j["status"]["armor_class"] = creature.ac;
-    j["status"]["display_armor_class"] = creature.dis_ac;
+    j["status"]["display_armor_class"] = creature.get_dis_ac();
 
     // 所持金とアイテム
     j["status"]["gold"] = creature.get_au();

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -260,8 +260,8 @@ static void update_bonuses(CreatureEntity &creature)
     BIT_FLAGS old_mighty_throw = creature.get_mighty_throw_flags();
     int16_t old_speed = static_cast<int16_t>(creature.get_speed());
 
-    ARMOUR_CLASS old_dis_ac = creature.dis_ac;
-    ARMOUR_CLASS old_dis_to_a = creature.dis_to_a;
+    ARMOUR_CLASS old_dis_ac = creature.get_dis_ac();
+    ARMOUR_CLASS old_dis_to_a = creature.get_dis_to_a();
 
     creature.set_xtra_might(has_xtra_might(creature));
     creature.set_esp_evil(has_esp_evil(creature));
@@ -341,22 +341,22 @@ static void update_bonuses(CreatureEntity &creature)
     creature.riding_ryoute = is_riding_two_hands(creature);
     creature.set_to_d(0, calc_to_damage(creature, INVEN_MAIN_HAND, true));
     creature.set_to_d(1, calc_to_damage(creature, INVEN_SUB_HAND, true));
-    creature.dis_to_d[0] = calc_to_damage(creature, INVEN_MAIN_HAND, false);
-    creature.dis_to_d[1] = calc_to_damage(creature, INVEN_SUB_HAND, false);
+    creature.set_dis_to_d(0, calc_to_damage(creature, INVEN_MAIN_HAND, false));
+    creature.set_dis_to_d(1, calc_to_damage(creature, INVEN_SUB_HAND, false));
     creature.set_to_h(0, calc_to_hit(creature, INVEN_MAIN_HAND, true));
     creature.set_to_h(1, calc_to_hit(creature, INVEN_SUB_HAND, true));
-    creature.dis_to_h[0] = calc_to_hit(creature, INVEN_MAIN_HAND, false);
-    creature.dis_to_h[1] = calc_to_hit(creature, INVEN_SUB_HAND, false);
+    creature.set_dis_to_h(0, calc_to_hit(creature, INVEN_MAIN_HAND, false));
+    creature.set_dis_to_h(1, calc_to_hit(creature, INVEN_SUB_HAND, false));
     creature.set_to_h_b(calc_to_hit_bow(creature, true));
-    creature.dis_to_h_b = calc_to_hit_bow(creature, false);
+    creature.set_dis_to_h_b(calc_to_hit_bow(creature, false));
     creature.set_to_d_m(calc_to_damage_misc(creature));
     creature.set_to_h_m(calc_to_hit_misc(creature));
     creature.skill_dig = calc_skill_dig(creature);
     creature.to_m_chance = calc_to_magic_chance(creature);
     creature.ac = calc_base_ac(creature);
     creature.set_to_a(calc_to_ac(creature, true));
-    creature.dis_ac = calc_base_ac(creature);
-    creature.dis_to_a = calc_to_ac(creature, false);
+    creature.set_dis_ac(calc_base_ac(creature));
+    creature.set_dis_to_a(calc_to_ac(creature, false));
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     if (old_mighty_throw != creature.get_mighty_throw_flags()) {
@@ -391,7 +391,7 @@ static void update_bonuses(CreatureEntity &creature)
         rfu.set_flag(MainWindowRedrawingFlag::SPEED);
     }
 
-    if ((creature.dis_ac != old_dis_ac) || (creature.dis_to_a != old_dis_to_a)) {
+    if ((creature.get_dis_ac() != old_dis_ac) || (creature.get_dis_to_a() != old_dis_to_a)) {
         rfu.set_flag(MainWindowRedrawingFlag::AC);
         rfu.set_flag(SubWindowRedrawingFlag::PLAYER);
     }

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1655,6 +1655,51 @@ public:
         return this->to_d[hand];
     }
 
+    // [提案 34] 表示用既知値 dis_to_h / dis_to_d / dis_to_h_b / dis_to_a / dis_ac
+    // の getter / setter virtual。書込は player-status.cpp の update_creature()
+    // から、読取は表示系 (display-player-middle / main-window-left-frame /
+    // status-first-page / io-dump 等) から行われる。
+    virtual HIT_PROB get_dis_to_h(int hand) const
+    {
+        return this->dis_to_h[hand];
+    }
+    virtual void set_dis_to_h(int hand, HIT_PROB value)
+    {
+        this->dis_to_h[hand] = value;
+    }
+    virtual HIT_PROB get_dis_to_h_b() const
+    {
+        return this->dis_to_h_b;
+    }
+    virtual void set_dis_to_h_b(HIT_PROB value)
+    {
+        this->dis_to_h_b = value;
+    }
+    virtual int get_dis_to_d(int hand) const
+    {
+        return this->dis_to_d[hand];
+    }
+    virtual void set_dis_to_d(int hand, int value)
+    {
+        this->dis_to_d[hand] = value;
+    }
+    virtual ARMOUR_CLASS get_dis_to_a() const
+    {
+        return this->dis_to_a;
+    }
+    virtual void set_dis_to_a(ARMOUR_CLASS value)
+    {
+        this->dis_to_a = value;
+    }
+    virtual ARMOUR_CLASS get_dis_ac() const
+    {
+        return this->dis_ac;
+    }
+    virtual void set_dis_ac(ARMOUR_CLASS value)
+    {
+        this->dis_ac = value;
+    }
+
     /*! @brief 能力値最大値 stat_max[idx] を取得する (提案 31b) */
     virtual short get_stat_max(int idx) const
     {
@@ -3024,12 +3069,16 @@ public:
      */
     void plus_incident_tree(const std::string &incident_id, int num);
 
+    // [提案 34] 表示用既知値 dis_to_h / dis_to_d / dis_to_h_b / dis_to_a / dis_ac
+    // を private 化。アクセスは get_dis_X() / set_dis_X() 経由。
+private:
     HIT_PROB dis_to_h[2]{}; /*!< 判明している現在の表記上の近接武器命中修正値 /  Known bonus to hit (wield) */
     HIT_PROB dis_to_h_b{}; /*!< 判明している現在の表記上の射撃武器命中修正値 / Known bonus to hit (bow) */
     int dis_to_d[2]{}; /*!< 判明している現在の表記上の近接武器ダメージ修正値 / Known bonus to dam (wield) */
     ARMOUR_CLASS dis_to_a{}; /*!< 判明している現在の表記上の装備AC修正値 / Known bonus to ac */
     ARMOUR_CLASS dis_ac{}; /*!< 判明している現在の表記上の装備AC基礎値 / Known base ac */
 
+public:
     // [提案 32b] to_h[] / to_d[] / to_h_b / to_h_m / to_d_m を private 化済。get_to_h(hand) / set_to_h(hand, val) 等経由。
 private:
     int16_t to_h[2]{}; /* Bonus to hit (wield) */

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -39,8 +39,8 @@
  */
 static void display_player_melee_bonus(CreatureEntity &creature, int hand, int hand_entry)
 {
-    HIT_PROB show_tohit = creature.dis_to_h[hand];
-    int show_todam = creature.dis_to_d[hand];
+    HIT_PROB show_tohit = creature.get_dis_to_h(hand);
+    int show_todam = creature.get_dis_to_d(hand);
     auto *o_ptr = creature.inventory[INVEN_MAIN_HAND + hand].get();
 
     if (o_ptr->is_known()) {
@@ -97,7 +97,7 @@ static void display_sub_hand(CreatureEntity &creature)
 static void display_bow_hit_damage(CreatureEntity &creature)
 {
     const auto &item = *creature.inventory[INVEN_BOW];
-    auto show_tohit = creature.dis_to_h_b;
+    auto show_tohit = creature.get_dis_to_h_b();
     auto show_todam = 0;
     if (item.is_known()) {
         show_tohit += item.to_h;
@@ -338,7 +338,7 @@ void display_player_middle(CreatureEntity &creature)
         display_bow_hit_damage(creature);
         display_shoot_magnification(creature);
     }
-    display_player_one_line(ENTRY_BASE_AC, format("[%d,%+d]", creature.dis_ac, creature.dis_to_a), TERM_L_BLUE);
+    display_player_one_line(ENTRY_BASE_AC, format("[%d,%+d]", creature.get_dis_ac(), creature.get_dis_to_a()), TERM_L_BLUE);
 
     int base_speed = creature.get_speed() - 110;
     if (creature.action == ACTION_SEARCH) {

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -236,7 +236,7 @@ static void calc_two_hands(CreatureEntity &creature, int *damage, int *to_h)
 
     for (int i = 0; i < 2; i++) {
         int basedam;
-        damage[i] = creature.dis_to_d[i] * 100;
+        damage[i] = creature.get_dis_to_d(i) * 100;
         CreatureClass pc(creature);
         if (pc.is_martial_arts_pro() && (empty_hands(creature, true) & EMPTY_HAND_MAIN)) {
             if (!calc_weapon_damage_limit(creature, i, damage, &basedam, o_ptr)) {

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -114,11 +114,11 @@ void print_ac(CreatureEntity &creature)
 #ifdef JP
     /* AC の表示方式を変更している */
     put_str(" ＡＣ(     )", ROW_AC, COL_AC);
-    sprintf(tmp, "%5d", creature.dis_ac + creature.dis_to_a);
+    sprintf(tmp, "%5d", creature.get_dis_ac() + creature.get_dis_to_a());
     c_put_str(TERM_L_GREEN, tmp, ROW_AC, COL_AC + 6);
 #else
     put_str("Cur AC ", ROW_AC, COL_AC);
-    sprintf(tmp, "%5d", creature.dis_ac + creature.dis_to_a);
+    sprintf(tmp, "%5d", creature.get_dis_ac() + creature.get_dis_to_a());
     c_put_str(TERM_L_GREEN, tmp, ROW_AC, COL_AC + 7);
 #endif
 }


### PR DESCRIPTION
戦闘ボーナス本体 (提案 30 の to_h/d/a) と対称な仕上げタスク。
表示用既知値キャッシュ 5 フィールドを private 化。

対象フィールド:
- HIT_PROB dis_to_h[2] / dis_to_h_b: 表記上の命中修正値 (近接/射撃)
- int dis_to_d[2]: 表記上の近接武器ダメージ修正値
- ARMOUR_CLASS dis_to_a / dis_ac: 表記上の AC 修正値/基礎値

主な変更:
- 10 個の getter/setter virtual を追加 (get/set_dis_to_h/h_b/d/a/ac)
- 全 19 アクセスサイトを migration
  - player-status.cpp: 7 write + 3 diff-check read
  - display-player-middle / main-window-left-frame / status-first-page / io-dump / cmd-building: 9 read
- 5 フィールドを private 化

効果:
- 合計 private 化フィールド数: 72 → 77
- 戦闘ボーナス系のカプセル化が完結 (提案 30 と提案 34)