### PR TITLE
refactor: 提案 10/36 完了 - 熟練度書込みの OO 化

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -318,46 +318,77 @@ TimedEffects 優先の特殊分岐を持っていた。一方モンスターは 
 
 ---
 
-## 提案 10: 配列フィールド virtual インデックスアクセサ ✅ 一部完了
+## 提案 10/36: 熟練度配列の virtual アクセサ ✅ 完了
 
 ### 背景
 
 `spell_exp[64]` (固定配列) / `weapon_exp` / `weapon_exp_max` /
 `skill_exp` (`std::map`) はプレイヤーの熟練度システム用フィールドだが
 `CreatureEntity` 直下に存在するため、モンスターからもアクセス可能な
-構造になっている。直アクセスのみで virtual がなく、将来モンスターに
-熟練度概念を導入する際の拡張点が無かった。
+構造になっている。
 
 ### 作業内容
 
-`CreatureEntity` に 3 つの read-only virtual インデックサを追加:
+#### read 側 (提案 10 前半、既完了)
 
-| 仮想関数 | 役割 | デフォルト動作 |
-|---|---|---|
-| `get_spell_exp(int idx)` | 呪文熟練度 | `spell_exp[idx]` を返す |
-| `get_skill_exp(PlayerSkillKindType)` | スキル熟練度 | map に存在すれば値、無ければ 0 |
-| `get_weapon_exp(ItemKindType, int sval)` | 武器熟練度 | map に存在すれば値、無ければ 0 |
+3 つの read-only virtual インデックサ:
+
+| 仮想関数 | 役割 |
+|---|---|
+| `get_spell_exp(int idx)` | 呪文熟練度を返す |
+| `get_skill_exp(PlayerSkillKindType)` | スキル熟練度を返す (map に無ければ 0) |
+| `get_weapon_exp(ItemKindType, int sval)` | 武器熟練度を返す (map に無ければ 0) |
+
+#### write 側 (提案 36、新規完了)
+
+7 つの write virtual を追加:
+
+| 仮想関数 | 役割 |
+|---|---|
+| `set_spell_exp(int idx, SUB_EXP value)` | 呪文熟練度を設定 |
+| `add_spell_exp(int idx, SUB_EXP delta)` | 呪文熟練度に加算 |
+| `set_skill_exp(PlayerSkillKindType, SUB_EXP)` | スキル熟練度を設定 |
+| `add_skill_exp(PlayerSkillKindType, SUB_EXP delta)` | スキル熟練度に加算 |
+| `set_weapon_exp(ItemKindType, int sval, SUB_EXP)` | 武器熟練度を設定 |
+| `add_weapon_exp(ItemKindType, int sval, SUB_EXP delta)` | 武器熟練度に加算 |
+| `set_weapon_exp_max(ItemKindType, int sval, SUB_EXP)` | 武器熟練度上限を設定 |
+
+加えて `get_weapon_exp_max(tval, sval)` virtual も新規追加。
 
 ### 移行結果
 
-- 読取り 31 箇所 (spell_exp 4, skill_exp 22, weapon_exp 5) を新 virtual 経由に置換
-- 書込み・参照取得 (`auto &exp = ...`)・複合代入 16 箇所は従来通り
-  直接配列アクセス形式で残置 (mutation/reference 取得には virtual が
-  対応できないため)
+- 読取り 31 箇所 (spell_exp 4, skill_exp 22, weapon_exp 5) を get_X_exp() 経由に置換 (提案 10)
+- 書込み 13 箇所を新 virtual 経由に置換 (提案 36)
+  - wizard-special-process.cpp: 7 site
+  - load/player-info-loader.cpp: 3 site
+  - cmd-action/cmd-spell / monster-attack-player /
+    quaff-effects / birth-stat: 各 1-2 site
+- `weapon_exp_max[tval][sval]` 読取り 4 箇所を `get_weapon_exp_max()` に置換
+  (object-hook/hook-weapon, knowledge-experiences)
+
+### 残存パターン (private 化できない理由)
+
+以下のパターンは API 抽象化が困難なため direct access 残置:
+
+- `auto &exp = creature.weapon_exp[tval][sval]` のリファレンス取得
+  (player-skill.cpp の `gain_attack_skill_exp` が `SUB_EXP &` を受ける)
+- `for (auto &[type, exp] : creature.skill_exp)` の構造化束縛
+- `for (auto &exp : creature.weapon_exp[tval])` の配列走査
+- `std::span(creature.spell_exp)` の span 構築
+- `creature.weapon_exp = class_skills_info[pclass].w_start` の map 全体代入
+- `for (auto sval = 0U; sval < creature.weapon_exp[tval].size(); ++sval)` の
+  size() 経由イテレーション
+
+これらの抽象化には functor 受け取り API (e.g.
+`apply_to_weapon_exp(tval, [&](SUB_EXP &exp){ ... })`) や
+配列スパン返却 virtual (e.g. `get_weapon_exp_span(tval)`) が
+必要だが、コール側の書き換えコストが大きく抽象化価値が低いため見送り。
 
 ### 効果
 
-- 読取りパスがプレイヤー・モンスター共通の API を通る
-- 将来モンスターに `get_X_exp()` を override させて種族別/個体別の
-  熟練度ロジックを導入可能
-
-### 残作業
-
-- 書込み setter virtual 整備は呼び出しパターン (集計加算/上限クランプ/
-  `auto &` 経由 in-place 変更) が多様で抽象コストが大きく、優先度低
-  として保留
-- 配列全体走査 (`for (auto &exp : creature.weapon_exp[tval])`) は
-  span 経由の virtual 化も検討余地あり
+- 単純な write/read パターンはプレイヤー・モンスター共通の API を通る
+- 将来モンスター熟練度導入時の override 点を確保
+- 「set_X_exp で書込みすると整合性チェックが走る」等の拡張余地
 
 ---
 

--- a/src/birth/birth-stat.cpp
+++ b/src/birth/birth-stat.cpp
@@ -160,11 +160,11 @@ void get_extra(CreatureEntity &creature, bool roll_hitdie)
     auto is_sorcerer = pc.equals(PlayerClassType::SORCERER);
     for (int i = 0; i < 64; i++) {
         if (is_sorcerer) {
-            creature.spell_exp[i] = PlayerSkill::spell_exp_at(PlayerSkillRank::MASTER);
+            creature.set_spell_exp(i, PlayerSkill::spell_exp_at(PlayerSkillRank::MASTER));
         } else if (pc.equals(PlayerClassType::RED_MAGE)) {
-            creature.spell_exp[i] = PlayerSkill::spell_exp_at(PlayerSkillRank::SKILLED);
+            creature.set_spell_exp(i, PlayerSkill::spell_exp_at(PlayerSkillRank::SKILLED));
         } else {
-            creature.spell_exp[i] = PlayerSkill::spell_exp_at(PlayerSkillRank::UNSKILLED);
+            creature.set_spell_exp(i, PlayerSkill::spell_exp_at(PlayerSkillRank::UNSKILLED));
         }
     }
 
@@ -178,7 +178,7 @@ void get_extra(CreatureEntity &creature, bool roll_hitdie)
     }
 
     for (auto i : PLAYER_SKILL_KIND_TYPE_RANGE) {
-        creature.skill_exp[i] = class_skills_info[pclass].s_start[i];
+        creature.set_skill_exp(i, class_skills_info[pclass].s_start[i]);
     }
 
     // 武術スタイルの初期設定

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -679,7 +679,7 @@ static void change_realm2(CreatureEntity &creature, PlayerRealm &pr, RealmType n
     PlayerSpellStatus(creature).realm2().initialize();
 
     for (auto i = 32; i < 64; i++) {
-        creature.spell_exp[i] = PlayerSkill::spell_exp_at(PlayerSkillRank::UNSKILLED);
+        creature.set_spell_exp(i, PlayerSkill::spell_exp_at(PlayerSkillRank::UNSKILLED));
     }
 
     constexpr auto fmt_realm = _("魔法の領域を%sから%sに変更した。", "changed magic realm from %s to %s.");

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -46,7 +46,7 @@ void do_cmd_knowledge_weapon_exp(CreatureEntity &creature)
                 }
 
                 SUB_EXP weapon_exp = creature.get_weapon_exp(tval, num);
-                SUB_EXP weapon_max = creature.weapon_exp_max[tval][num];
+                SUB_EXP weapon_max = creature.get_weapon_exp_max(tval, num);
                 fprintf(fff, "%-25s ", baseitem.stripped_name().data());
                 if (show_actual_value) {
                     fprintf(fff, "%4d/%4d ", weapon_exp, weapon_max);

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -126,18 +126,18 @@ void rd_experience(CreatureEntity &creature)
 
     creature.set_level(rd_s16b());
     for (int i = 0; i < 64; i++) {
-        creature.spell_exp[i] = rd_s16b();
+        creature.set_spell_exp(i, rd_s16b());
     }
 
     const int max_weapon_exp_size = 64;
     for (auto tval : TV_WEAPON_RANGE) {
         for (int j = 0; j < max_weapon_exp_size; j++) {
-            creature.weapon_exp[tval][j] = rd_s16b();
+            creature.set_weapon_exp(tval, j, rd_s16b());
         }
     }
 
     for (auto i : PLAYER_SKILL_KIND_TYPE_RANGE) {
-        creature.skill_exp[i] = rd_s16b();
+        creature.set_skill_exp(i, rd_s16b());
     }
 
     // resreved skills

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -533,7 +533,7 @@ void MonsterAttackPlayer::gain_armor_exp()
         increment += 1 + addition;
     }
 
-    creature.skill_exp[PlayerSkillKindType::SHIELD] = std::min<short>(max, cur + increment);
+    creature.set_skill_exp(PlayerSkillKindType::SHIELD, std::min<short>(max, cur + increment));
     RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
 }
 

--- a/src/object-hook/hook-weapon.cpp
+++ b/src/object-hook/hook-weapon.cpp
@@ -31,7 +31,7 @@ bool object_is_favorite(CreatureEntity &creature, const ItemEntity *o_ptr)
     case PlayerClassType::MONK:
     case PlayerClassType::FORCETRAINER:
         /* Icky to wield? */
-        return creature.weapon_exp_max[tval][sval] != PlayerSkill::weapon_exp_at(PlayerSkillRank::UNSKILLED);
+        return creature.get_weapon_exp_max(tval, sval) != PlayerSkill::weapon_exp_at(PlayerSkillRank::UNSKILLED);
     case PlayerClassType::BEASTMASTER:
     case PlayerClassType::CAVALRY: {
         /* Is it known to be suitable to using while riding? */
@@ -39,10 +39,10 @@ bool object_is_favorite(CreatureEntity &creature, const ItemEntity *o_ptr)
         return flags.has(TR_RIDING);
     }
     case PlayerClassType::SORCERER:
-        return creature.weapon_exp_max[tval][sval] >= PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER);
+        return creature.get_weapon_exp_max(tval, sval) >= PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER);
     case PlayerClassType::NINJA:
         /* Icky to wield? */
-        return creature.weapon_exp_max[tval][sval] > PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER);
+        return creature.get_weapon_exp_max(tval, sval) > PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER);
     default:
         return true;
     }

--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -621,7 +621,7 @@ bool QuaffEffects::mesudachi()
     for (int i = 0; i < 10; i++) {
         skill_gain += randint1(10);
     }
-    this->creature.skill_exp[PlayerSkillKindType::ASSHOLE] += static_cast<SUB_EXP>(skill_gain);
+    this->creature.add_skill_exp(PlayerSkillKindType::ASSHOLE, static_cast<SUB_EXP>(skill_gain));
     msg_format(_("尻の穴技能が%d向上した！", "Your asshole skill increased by %d!"), skill_gain);
 
     // 1/36の確率で性別が女になる（両性の場合は無効）

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1970,6 +1970,51 @@ public:
     }
 
     /*!
+     * @brief 指定武器種別・サブ種別の武器熟練度の上限値を取得する (提案 10/36)
+     */
+    virtual SUB_EXP get_weapon_exp_max(ItemKindType tval, int sval) const
+    {
+        const auto it = this->weapon_exp_max.find(tval);
+        return (it != this->weapon_exp_max.end()) ? it->second[sval] : 0;
+    }
+
+    // [提案 10/36] 熟練度書込みの setter virtual 群。
+    // 参照取得 (auto &) パターンは player-skill.cpp / wizard-special-process.cpp
+    // 等の一部で残存するため、フィールドの private 化はせず、API として
+    // 提供のみ行う。
+    virtual void set_spell_exp(int spell_idx, SUB_EXP value)
+    {
+        this->spell_exp[spell_idx] = value;
+    }
+    virtual void add_spell_exp(int spell_idx, SUB_EXP delta)
+    {
+        this->spell_exp[spell_idx] += delta;
+    }
+
+    virtual void set_skill_exp(PlayerSkillKindType skill, SUB_EXP value)
+    {
+        this->skill_exp[skill] = value;
+    }
+    virtual void add_skill_exp(PlayerSkillKindType skill, SUB_EXP delta)
+    {
+        this->skill_exp[skill] += delta;
+    }
+
+    virtual void set_weapon_exp(ItemKindType tval, int sval, SUB_EXP value)
+    {
+        this->weapon_exp[tval][sval] = value;
+    }
+    virtual void add_weapon_exp(ItemKindType tval, int sval, SUB_EXP delta)
+    {
+        this->weapon_exp[tval][sval] += delta;
+    }
+
+    virtual void set_weapon_exp_max(ItemKindType tval, int sval, SUB_EXP value)
+    {
+        this->weapon_exp_max[tval][sval] = value;
+    }
+
+    /*!
      * @brief クリーチャーがフレンドリー状態かどうかを判定
      * @return フレンドリーならtrue、デフォルトはfalse（プレイヤーはフレンドリー判定対象外）
      */

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -353,26 +353,26 @@ void wiz_change_status(CreatureEntity &creature)
 
     for (auto tval : TV_WEAPON_RANGE) {
         for (int i = 0; i < 64; i++) {
-            creature.weapon_exp[tval][i] = *proficiency;
+            creature.set_weapon_exp(tval, i, *proficiency);
         }
     }
 
     PlayerSkill(creature).limit_weapon_skills_by_max_value();
     for (auto j : PLAYER_SKILL_KIND_TYPE_RANGE) {
-        creature.skill_exp[j] = *proficiency;
+        creature.set_skill_exp(j, *proficiency);
         auto short_pclass = enum2i(creature.pclass);
         if (creature.get_skill_exp(j) > class_skills_info[short_pclass].s_max[j]) {
-            creature.skill_exp[j] = class_skills_info[short_pclass].s_max[j];
+            creature.set_skill_exp(j, class_skills_info[short_pclass].s_max[j]);
         }
     }
 
     int k;
     for (k = 0; k < 32; k++) {
-        creature.spell_exp[k] = std::min(PlayerSkill::spell_exp_at(PlayerSkillRank::MASTER), *proficiency);
+        creature.set_spell_exp(k, std::min(PlayerSkill::spell_exp_at(PlayerSkillRank::MASTER), *proficiency));
     }
 
     for (; k < 64; k++) {
-        creature.spell_exp[k] = std::min(PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT), *proficiency);
+        creature.set_spell_exp(k, std::min(PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT), *proficiency));
     }
 
     const auto gold = input_numerics("Gold: ", 0, MAX_INT, creature.get_au());


### PR DESCRIPTION
spell_exp / weapon_exp / weapon_exp_max / skill_exp の書込みパターンを setter virtual 経由に統一。提案 10 (read 側) の続編として write 側を補完。

追加 virtual:
- set_spell_exp(idx, value) / add_spell_exp(idx, delta)
- set_skill_exp(skill, value) / add_skill_exp(skill, delta)
- set_weapon_exp(tval, sval, value) / add_weapon_exp(tval, sval, delta)
- set_weapon_exp_max(tval, sval, value)
- get_weapon_exp_max(tval, sval) (read 側補完)

移行:
- wizard-special-process.cpp: 7 直接代入 site
- load/player-info-loader.cpp: 3 site
- cmd-action/cmd-spell / monster-attack-player / quaff-effects / birth-stat: 各 1-2 site
- object-hook/hook-weapon, knowledge-experiences: weapon_exp_max 読取り 4 site

残存パターン (private 化見送り):
- auto &exp = ... のリファレンス取得
- for (auto &[type, exp] : skill_exp) の構造化束縛
- std::span(spell_exp) の span 構築
- creature.weapon_exp = ... の map 全体代入

将来モンスター熟練度導入時の override 点を確保。