### PR TITLE
refactor: 提案 41 完了 - 呪文マスクの集約と private 化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,12 @@ API 経由に統一された。一部フィールド (r_idx / ap_r_idx / riding)
   `if (creature.is_player() && ...) disturb(...)` を `disturb` 内部
   ガードに委ねる形に簡素化。さらなる削減は signature 変更
   (`bool foo(PlayerType &)`) が必要で別提案として扱う方針。
+- **提案 41**: 呪文マスク 6 個 (spell_learned1/2 / spell_worked1/2 /
+  spell_forgotten1/2) を private 化。realm_idx (0/1) と spell_id (0..31)
+  ベースの virtual API 12 個を整備し、`is_realm1 ? *_1 : *_2` の
+  三項演算子パターン 24 箇所を意図明示形 (`has_X_spell(realm, idx)`)
+  に簡素化。savefile load/save の API も統一。**合計 private 化
+  フィールド数: 77 → 83**
 
 今後の残作業としては、現在 `CreatureEntity` 直下に残存するプレイヤー
 固有フィールド群（種族・職業・熟練度等）を、モンスターにも

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -1444,7 +1444,8 @@ lvalue 参照を直接渡せないため、ラッパとして導入)
 | 提案 32b 残りフィールド | 15 個 |
 | 提案 33 BIT_FLAGS 群 (ESP / 装備集計 / 特殊攻撃防御) | 35 個 |
 | 提案 34 表示用既知値 (dis_to_h/d/a/ac) | 5 個 |
-| **合計** | **77 個** |
+| 提案 41 呪文マスク (spell_learned/worked/forgotten 1/2) | 6 個 |
+| **合計** | **83 個** |
 | inven_cnt / equip_cnt (提案 25) | フィールド廃止 |
 
 CreatureEntity のフィールドカプセル化が**事実上最終形**に到達。
@@ -1631,7 +1632,66 @@ is_player() ガードを持つ関数」を外部から `if (is_player()) X(...)`
 
 ---
 
-## 推奨実施順序
+## 提案 41: 呪文マスク (spell_learned/worked/forgotten) の集約 ✅ 完了
+
+### 背景
+
+`BIT_FLAGS spell_learned1` / `spell_learned2` / `spell_worked1` / `spell_worked2`
+/ `spell_forgotten1` / `spell_forgotten2` の 6 フィールドは、64 個の呪文
+(2 領域 × 32 呪文) の習得/使用/忘却状態をビットマスクで保持する古い仕様。
+
+各呼び出し箇所では `is_realm1 ? *_1 : *_2` の三項演算子で領域選択し、
+`(1UL << spell_id)` でビット操作する冗長なパターンが反復していた。
+
+### 完了内容
+
+#### API 整備 (12 個の virtual メソッド)
+
+`CreatureEntity` に realm_idx (0/1) ベースの virtual API を追加:
+
+| メソッド | 役割 |
+|---|---|
+| `get_spell_learned_flags(realm_idx)` | 領域全体の BIT_FLAGS 取得 (savefile 用) |
+| `get_spell_worked_flags(realm_idx)` | 同上 (worked) |
+| `get_spell_forgotten_flags(realm_idx)` | 同上 (forgotten) |
+| `set_spell_learned_flags(realm_idx, value)` | 領域全体の BIT_FLAGS 設定 |
+| `set_spell_worked_flags(realm_idx, value)` | 同上 (worked) |
+| `set_spell_forgotten_flags(realm_idx, value)` | 同上 (forgotten) |
+| `has_learned_spell(realm_idx, spell_id)` | 個別呪文の習得判定 (0..31) |
+| `has_worked_spell(realm_idx, spell_id)` | 個別呪文の使用判定 |
+| `has_forgotten_spell(realm_idx, spell_id)` | 個別呪文の忘却判定 |
+| `set_learned_spell(realm_idx, spell_id, value)` | 個別呪文の習得状態設定 |
+| `set_worked_spell(realm_idx, spell_id, value)` | 個別呪文の使用状態設定 |
+| `set_forgotten_spell(realm_idx, spell_id, value)` | 個別呪文の忘却状態設定 |
+
+#### 移行
+
+- `player/player-spell-status.cpp`: 9 site (PlayerSpellStatus::Realm の
+  initialize/is_X/set_X 各メソッドが三項演算子で *_1/*_2 を選択していた)。
+  全て virtual API 経由に書き換え、コード行数も大幅減
+- `window/display-sub-window-spells.cpp`: 3 site (表示色判定の
+  ネスト三項演算子) を `has_X_spell(j, i % 32)` に簡素化
+- `load/load.cpp`: 6 site (savefile load を `set_spell_X_flags()` 経由)
+- `save/save.cpp`: 6 site (savefile save を `get_spell_X_flags()` 経由)
+
+#### Private 化
+
+6 フィールド (spell_learned1/2, spell_worked1/2, spell_forgotten1/2)
+を完全 private 化。
+
+### 効果
+
+- **合計 private 化フィールド数: 77 → 83**
+- 三項演算子による領域選択ロジックが realm_idx パラメータの伝播に簡素化
+- 個別呪文アクセスが `has_X_spell(realm, idx)` の意図明示形に
+- savefile load/save の API 統一
+- 将来モンスター呪文習得概念を導入する際の override 点を確保
+
+### 残作業
+
+`std::vector<int> spell_order_learned` も呪文関連のフィールドだが、
+これは vector 型でマスクとは別の構造 (習得順序リスト) を持つ。
+`std::erase_if` での mutation も含むため、抽象化価値が低く今回は対象外。
 
 ### 完了済み (大規模フェーズ)
 

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -150,12 +150,12 @@ static errr load_hp(CreatureEntity &creature)
 
 static void load_spells(CreatureEntity &creature)
 {
-    creature.spell_learned1 = rd_u32b();
-    creature.spell_learned2 = rd_u32b();
-    creature.spell_worked1 = rd_u32b();
-    creature.spell_worked2 = rd_u32b();
-    creature.spell_forgotten1 = rd_u32b();
-    creature.spell_forgotten2 = rd_u32b();
+    creature.set_spell_learned_flags(0, rd_u32b());
+    creature.set_spell_learned_flags(1, rd_u32b());
+    creature.set_spell_worked_flags(0, rd_u32b());
+    creature.set_spell_worked_flags(1, rd_u32b());
+    creature.set_spell_forgotten_flags(0, rd_u32b());
+    creature.set_spell_forgotten_flags(1, rd_u32b());
     creature.learned_spells = rd_s16b();
     creature.add_spells = rd_s16b();
 }

--- a/src/player/player-spell-status.cpp
+++ b/src/player/player-spell-status.cpp
@@ -3,19 +3,6 @@
 #include "system/creature-entity.h"
 #include "util/bit-flags-calculator.h"
 
-namespace {
-
-void set_flag_bit(BIT_FLAGS &flags, int bit_pos, bool value)
-{
-    if (value) {
-        set_bits(flags, 1U << bit_pos);
-    } else {
-        reset_bits(flags, 1U << bit_pos);
-    }
-}
-
-}
-
 PlayerSpellStatus::PlayerSpellStatus(CreatureEntity &creature)
 {
     this->creature_ptr = &creature;
@@ -39,13 +26,12 @@ PlayerSpellStatus::Realm::Realm(CreatureEntity &creature, bool is_realm1)
 
 void PlayerSpellStatus::Realm::initialize()
 {
-    auto &learned = this->is_realm1 ? this->creature_ptr->spell_learned1 : this->creature_ptr->spell_learned2;
-    auto &worked = this->is_realm1 ? this->creature_ptr->spell_worked1 : this->creature_ptr->spell_worked2;
-    auto &forgotten = this->is_realm1 ? this->creature_ptr->spell_forgotten1 : this->creature_ptr->spell_forgotten2;
-
+    const auto realm_idx = this->is_realm1 ? 0 : 1;
     const auto is_sorcerer = CreatureClass(*this->creature_ptr).equals(PlayerClassType::SORCERER);
-    learned = worked = is_sorcerer ? 0xffffffffU : 0;
-    forgotten = 0;
+    const BIT_FLAGS initial = is_sorcerer ? 0xffffffffU : 0;
+    this->creature_ptr->set_spell_learned_flags(realm_idx, initial);
+    this->creature_ptr->set_spell_worked_flags(realm_idx, initial);
+    this->creature_ptr->set_spell_forgotten_flags(realm_idx, 0);
 
     auto is_erase_spell_id = this->is_realm1 ? [](int spell_id) { return spell_id >= 32; } : [](int spell_id) { return spell_id < 32; };
     std::erase_if(this->creature_ptr->spell_order_learned, is_erase_spell_id);
@@ -53,42 +39,42 @@ void PlayerSpellStatus::Realm::initialize()
 
 bool PlayerSpellStatus::Realm::is_nothing_learned() const
 {
-    const auto learned = this->is_realm1 ? this->creature_ptr->spell_learned1 : this->creature_ptr->spell_learned2;
-    return learned == 0;
+    const auto realm_idx = this->is_realm1 ? 0 : 1;
+    return this->creature_ptr->get_spell_learned_flags(realm_idx) == 0;
 }
 
 bool PlayerSpellStatus::Realm::is_learned(int spell_id) const
 {
-    const auto learned = this->is_realm1 ? this->creature_ptr->spell_learned1 : this->creature_ptr->spell_learned2;
-    return any_bits(learned, 1U << spell_id);
+    const auto realm_idx = this->is_realm1 ? 0 : 1;
+    return this->creature_ptr->has_learned_spell(realm_idx, spell_id);
 }
 
 bool PlayerSpellStatus::Realm::is_worked(int spell_id) const
 {
-    const auto worked = this->is_realm1 ? this->creature_ptr->spell_worked1 : this->creature_ptr->spell_worked2;
-    return any_bits(worked, 1U << spell_id);
+    const auto realm_idx = this->is_realm1 ? 0 : 1;
+    return this->creature_ptr->has_worked_spell(realm_idx, spell_id);
 }
 
 bool PlayerSpellStatus::Realm::is_forgotten(int spell_id) const
 {
-    const auto forgotten = this->is_realm1 ? this->creature_ptr->spell_forgotten1 : this->creature_ptr->spell_forgotten2;
-    return any_bits(forgotten, 1U << spell_id);
+    const auto realm_idx = this->is_realm1 ? 0 : 1;
+    return this->creature_ptr->has_forgotten_spell(realm_idx, spell_id);
 }
 
 void PlayerSpellStatus::Realm::set_learned(int spell_id, bool value)
 {
-    auto &learned = this->is_realm1 ? this->creature_ptr->spell_learned1 : this->creature_ptr->spell_learned2;
-    set_flag_bit(learned, spell_id, value);
+    const auto realm_idx = this->is_realm1 ? 0 : 1;
+    this->creature_ptr->set_learned_spell(realm_idx, spell_id, value);
 }
 
 void PlayerSpellStatus::Realm::set_worked(int spell_id, bool value)
 {
-    auto &worked = this->is_realm1 ? this->creature_ptr->spell_worked1 : this->creature_ptr->spell_worked2;
-    set_flag_bit(worked, spell_id, value);
+    const auto realm_idx = this->is_realm1 ? 0 : 1;
+    this->creature_ptr->set_worked_spell(realm_idx, spell_id, value);
 }
 
 void PlayerSpellStatus::Realm::set_forgotten(int spell_id, bool value)
 {
-    auto &forgotten = this->is_realm1 ? this->creature_ptr->spell_forgotten1 : this->creature_ptr->spell_forgotten2;
-    set_flag_bit(forgotten, spell_id, value);
+    const auto realm_idx = this->is_realm1 ? 0 : 1;
+    this->creature_ptr->set_forgotten_spell(realm_idx, spell_id, value);
 }

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -190,12 +190,12 @@ static bool wr_savefile_new(CreatureEntity &creature)
         wr_s16b((int16_t)creature.player_hp[i]);
     }
 
-    wr_u32b(creature.spell_learned1);
-    wr_u32b(creature.spell_learned2);
-    wr_u32b(creature.spell_worked1);
-    wr_u32b(creature.spell_worked2);
-    wr_u32b(creature.spell_forgotten1);
-    wr_u32b(creature.spell_forgotten2);
+    wr_u32b(creature.get_spell_learned_flags(0));
+    wr_u32b(creature.get_spell_learned_flags(1));
+    wr_u32b(creature.get_spell_worked_flags(0));
+    wr_u32b(creature.get_spell_worked_flags(1));
+    wr_u32b(creature.get_spell_forgotten_flags(0));
+    wr_u32b(creature.get_spell_forgotten_flags(1));
     wr_s16b(creature.learned_spells);
     wr_s16b(creature.add_spells);
     for (auto i = 0; i < 64; i++) {

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -3201,12 +3201,80 @@ public:
      * prevents the player from getting more than one at a time.
      */
 
+    // [提案 41] 呪文マスクを private 化。
+    // realm_idx は 0 (第 1 領域) / 1 (第 2 領域)、spell_id は 0..31。
+    // savefile load/save 時は get_spell_*_flags() / set_spell_*_flags() を使用。
+    // 通常アクセスは has_*_spell() / set_*_spell() を使用。
+private:
     BIT_FLAGS spell_learned1{}; /* bit mask of spells learned */
     BIT_FLAGS spell_learned2{}; /* bit mask of spells learned */
     BIT_FLAGS spell_worked1{}; /* bit mask of spells tried and worked */
     BIT_FLAGS spell_worked2{}; /* bit mask of spells tried and worked */
     BIT_FLAGS spell_forgotten1{}; /* bit mask of spells learned but forgotten */
     BIT_FLAGS spell_forgotten2{}; /* bit mask of spells learned but forgotten */
+
+public:
+    // [提案 41] 呪文マスクの virtual API。
+    // realm_idx: 0 (realm1) または 1 (realm2)。
+    // spell_id: 0..31 (realm 内呪文番号)。
+    virtual BIT_FLAGS get_spell_learned_flags(int realm_idx) const
+    {
+        return (realm_idx == 0) ? this->spell_learned1 : this->spell_learned2;
+    }
+    virtual BIT_FLAGS get_spell_worked_flags(int realm_idx) const
+    {
+        return (realm_idx == 0) ? this->spell_worked1 : this->spell_worked2;
+    }
+    virtual BIT_FLAGS get_spell_forgotten_flags(int realm_idx) const
+    {
+        return (realm_idx == 0) ? this->spell_forgotten1 : this->spell_forgotten2;
+    }
+    virtual void set_spell_learned_flags(int realm_idx, BIT_FLAGS value)
+    {
+        (realm_idx == 0 ? this->spell_learned1 : this->spell_learned2) = value;
+    }
+    virtual void set_spell_worked_flags(int realm_idx, BIT_FLAGS value)
+    {
+        (realm_idx == 0 ? this->spell_worked1 : this->spell_worked2) = value;
+    }
+    virtual void set_spell_forgotten_flags(int realm_idx, BIT_FLAGS value)
+    {
+        (realm_idx == 0 ? this->spell_forgotten1 : this->spell_forgotten2) = value;
+    }
+
+    virtual bool has_learned_spell(int realm_idx, int spell_id) const
+    {
+        return (this->get_spell_learned_flags(realm_idx) & (1UL << spell_id)) != 0;
+    }
+    virtual bool has_worked_spell(int realm_idx, int spell_id) const
+    {
+        return (this->get_spell_worked_flags(realm_idx) & (1UL << spell_id)) != 0;
+    }
+    virtual bool has_forgotten_spell(int realm_idx, int spell_id) const
+    {
+        return (this->get_spell_forgotten_flags(realm_idx) & (1UL << spell_id)) != 0;
+    }
+    virtual void set_learned_spell(int realm_idx, int spell_id, bool value)
+    {
+        const auto bit = 1UL << spell_id;
+        auto flags = this->get_spell_learned_flags(realm_idx);
+        flags = value ? (flags | bit) : (flags & ~bit);
+        this->set_spell_learned_flags(realm_idx, flags);
+    }
+    virtual void set_worked_spell(int realm_idx, int spell_id, bool value)
+    {
+        const auto bit = 1UL << spell_id;
+        auto flags = this->get_spell_worked_flags(realm_idx);
+        flags = value ? (flags | bit) : (flags & ~bit);
+        this->set_spell_worked_flags(realm_idx, flags);
+    }
+    virtual void set_forgotten_spell(int realm_idx, int spell_id, bool value)
+    {
+        const auto bit = 1UL << spell_id;
+        auto flags = this->get_spell_forgotten_flags(realm_idx);
+        flags = value ? (flags | bit) : (flags & ~bit);
+        this->set_spell_forgotten_flags(realm_idx, flags);
+    }
     std::vector<int> spell_order_learned{}; /* order spells learned */
 
     int player_hp[PY_MAX_LEVEL]{};

--- a/src/window/display-sub-window-spells.cpp
+++ b/src/window/display-sub-window-spells.cpp
@@ -152,11 +152,11 @@ static void display_spell_list(CreatureEntity &creature)
             if (s_ptr->slevel >= 99) {
                 strcpy(name, _("(判読不能)", "(illegible)"));
                 a = TERM_L_DARK;
-            } else if ((j < 1) ? ((creature.spell_forgotten1 & (1UL << i))) : ((creature.spell_forgotten2 & (1UL << (i % 32))))) {
+            } else if (creature.has_forgotten_spell(j, i % 32)) {
                 a = TERM_ORANGE;
-            } else if (!((j < 1) ? (creature.spell_learned1 & (1UL << i)) : (creature.spell_learned2 & (1UL << (i % 32))))) {
+            } else if (!creature.has_learned_spell(j, i % 32)) {
                 a = TERM_RED;
-            } else if (!((j < 1) ? (creature.spell_worked1 & (1UL << i)) : (creature.spell_worked2 & (1UL << (i % 32))))) {
+            } else if (!creature.has_worked_spell(j, i % 32)) {
                 a = TERM_YELLOW;
             }
 


### PR DESCRIPTION
spell_learned1/2 / spell_worked1/2 / spell_forgotten1/2 (6 BIT_FLAGS) を realm_idx ベースの virtual API に集約し private 化。

追加 virtual (12 個):
- get/set_spell_learned/worked/forgotten_flags(realm_idx) - 領域全体
- has/set_learned/worked/forgotten_spell(realm_idx, spell_id) - 個別

移行:
- player/player-spell-status.cpp (9 site): 三項演算子による領域選択を簡素化
- window/display-sub-window-spells.cpp (3 site): ネスト三項を has_X_spell に
- load/load.cpp (6 site) / save/save.cpp (6 site): savefile API 統一

効果:
- 合計 private 化フィールド数: 77 → 83
- 三項演算子 (is_realm1 ? *_1 : *_2) のパターン 24 箇所を意図明示形に
- 将来モンスター呪文習得概念導入時の override 点を確保