### PR TITLE
refactor: 提案 1/2 完了 - プレイヤー専用フィールドのクリーチャー共通化基盤

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,6 +312,15 @@ API 経由に統一された。一部フィールド (r_idx / ap_r_idx / riding)
   三項演算子パターン 24 箇所を意図明示形 (`has_X_spell(realm, idx)`)
   に簡素化。savefile load/save の API も統一。**合計 private 化
   フィールド数: 77 → 83**
+- **提案 1/2**: プレイヤー専用フィールドのモンスター運用化基盤完了。
+  種族 (`prace`) / 職業 (`pclass`) / 魔法領域 (`realm1` / `realm2` /
+  `element_realm`) / パトロン (`patron`) / 変身形態 (`mimic_form`)
+  の get/set virtual を追加。表示系の主要 access site 約 24 箇所を
+  `creature.get_X()` 形式に migration。残約 177 直接 access は player
+  専用 path で型契約済として残置 (機械的 sed の構造的価値が低いため)。
+  モンスター個別運用 (種族や職業の付与) を実装する将来提案でこの
+  基盤を利用可能。提案 2 (能力問合せ系 virtual の共通化) も提案 10/36
+  / 30 / 31b / 32b / 33 等で実質完了。
 
 今後の残作業としては、現在 `CreatureEntity` 直下に残存するプレイヤー
 固有フィールド群（種族・職業・熟練度等）を、モンスターにも

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -28,7 +28,7 @@ Phase 1-8 完了後に残存している統合作業項目を整理したもの�
 
 ---
 
-## 提案 1: プレイヤー専用フィールドのクリーチャー共通化 🚧 一部完了
+## 提案 1: プレイヤー専用フィールドのクリーチャー共通化 ✅ 基盤完了
 
 ### 背景
 
@@ -43,11 +43,11 @@ ESP 系 BIT_FLAGS 等）が残存している。モンスターでも将来運�
 | カテゴリ | フィールド | モンスター運用の想定 |
 |---|---|---|
 | 種族/職業/性格 | `prace`, `pclass`, `ppersonality`, `psex` | 特殊個体（ユニーク / 召喚された英雄系）の種族職業付与 |
-| 熟練度 | `spell_exp[]`, `weapon_exp[][]`, `skill_exp[]` | 経験を積むモンスター・成長するボス |
+| 熟練度 | `spell_exp[]`, `weapon_exp[][]`, `skill_exp[]` | 経験を積むモンスター・成長するボス (提案 10/36 で virtual 化済) |
 | 魔法領域 | `realm1`, `realm2`, `element_realm` | 魔法使い系モンスターのスペル選択根拠 |
 | 突然変異 | `muta`, `trait`, `patron` | 変異個体・カオスパトロン配下 |
 | キャラクタ履歴 | `old_race1/2`, `old_realm`, `history[4][60]`, `player_hp[PY_MAX_LEVEL]` | モンスターのレベル成長履歴 |
-| ESP/特殊能力 BIT_FLAGS | `telepathy`, `esp_*`, `cursed`, `special_defense`, `special_attack`, `dec_mana`, `easy_spell` 等 | モンスターの ESP / 呪い装備 / 特殊攻撃防御 |
+| ESP/特殊能力 BIT_FLAGS | `telepathy`, `esp_*`, `cursed`, `special_defense`, `special_attack`, `dec_mana`, `easy_spell` 等 | モンスターの ESP / 呪い装備 / 特殊攻撃防御 (提案 33 で virtual 化済) |
 | 休息/旅行 | `resting`, `running`, `action` | モンスターの待機・徘徊行動状態 |
 | その他 | `class_specific_data`, `old_*` 差分検出キャッシュ | 状態キャッシュはそのままクリーチャー共通で利用 |
 
@@ -70,7 +70,7 @@ ESP 系 BIT_FLAGS 等）が残存している。モンスターでも将来運�
 - モンスターに種族・職業・熟練度等の概念を導入する下地が整う
 - コード分岐（`if (creature.is_player()) ...`）の削減
 
-### 進捗
+### 完了内容
 
 - ✅ モンスター生成時に `prace` / `pclass` / `realm1` / `realm2` /
   `element_realm` を NONE に明示初期化（`init_monster_profile()`）
@@ -79,12 +79,42 @@ ESP 系 BIT_FLAGS 等）が残存している。モンスターでも将来運�
 - ✅ `player_sex` enum に `SEX_NONE = 4` を追加 (sex_info に「未設定」エントリ
   も追加)。`init_monster_profile()` で `psex = SEX_NONE` に初期化し、
   `get_sex_info()` は範囲外の値を SEX_NONE にフォールバック
-- ✅ virtual アクセサ `get_psex()` / `get_ppersonality()` を `CreatureEntity`
-  に追加 (将来モンスター固有のオーバーライド余地を確保)
+- ✅ virtual アクセサ `get_psex()` / `get_ppersonality()` / `get_prace()` /
+  `get_pclass()` / `get_realm1()` / `get_realm2()` / `get_element_realm()` /
+  `get_patron()` / `get_mimic_form()` を `CreatureEntity` に整備
+- ✅ 対応する setter virtual (`set_psex` / `set_ppersonality` / `set_prace` /
+  `set_pclass` / `set_realm1` / `set_realm2` / `set_element_realm` /
+  `set_patron` / `set_mimic_form`) も整備
+- ✅ ESP/装備集計 BIT_FLAGS 群は提案 33 で virtual 化済 (合計 35 フィールド)
+- ✅ 熟練度 (spell_exp / weapon_exp / skill_exp) は提案 10/36 で
+  virtual 化済 (read 31 + write 13 ＋ adder 3 virtuals)
+- ✅ 表示系の主要 access site (display-player / window /
+  io-dump 系) 約 24 箇所を `creature.get_X()` 形式に migration
+
+### 設計判断: 残約 177 直接 access site は player 経路で残置
+
+`birth/` `wizard/` `cmd-action/cmd-spell` `info-reader` `save/` `load/`
+等のプレイヤー専用 code path に残る `creature.prace` / `creature.pclass`
+等の直接 access (約 177 箇所) は意図的に残置する。これらは:
+
+- 呼出側が必ずプレイヤー (引数で型契約済) であり virtual 化価値が低い
+- 機械的 sed migration は可能だが提案 35 同様、構造的改善に乏しい
+- フィールドは将来 private 化候補だが、`class_specific_data` /
+  `incident` / `name` 等とともに別提案として扱う
+
+提案 1 は **「virtual アクセサ整備 + 主要 display path の migration」**
+を基盤完了として確定する。モンスター個別運用 (種族や職業の付与) を
+実装する将来の提案ではこの基盤を利用できる。
+
+### 残作業
+
+- プレイヤー専用 path の直接 access 177 箇所の機械的 migration
+  (低価値・別提案推奨)
+- モンスター override の実装 (具体的な enemy 機能拡張時に行う)
 
 ---
 
-## 提案 2: プレイヤー専用仮想メソッドのクリーチャー共通化 ✅ 主要部分完了
+## 提案 2: プレイヤー専用仮想メソッドのクリーチャー共通化 ✅ 完了
 
 ### 背景
 
@@ -148,10 +178,15 @@ Phase 2 で基本的な状態チェックは virtual 化済みだが、能力問
   `get_skill_perception()` / `get_skill_to_hit_melee()` /
   `get_skill_to_hit_bow()` / `get_skill_dig()` / `get_infravision()`）
   の virtual 化と読取り 80 箇所の移行
-- 🚧 残り: 配列系フィールド（`spell_exp[]` / `weapon_exp[][]` /
-  `skill_exp[]` / `stat_cur[]` / `stat_max[]` 等）は virtual 化が
-  構文的に困難で保留。書込み系セッターの整備は setter 間接コスト
-  vs 効果のバランスで現状維持の判断
+- ✅ 配列系フィールド (`spell_exp[]` / `weapon_exp[][]` / `skill_exp[]`)
+  は提案 10/36 で read/write virtual 整備済
+- ✅ `stat_cur[]` / `stat_max[]` / `to_h[]` / `to_d[]` 等は提案
+  30/31b/32b で virtual 化と private 化完了
+- ✅ 種族 / 職業 / 性格 / 性別 / 魔法領域 / パトロン / 変身形態の
+  getter/setter virtual 整備は提案 1 で完了
+
+提案 2 は実質完了。残るプレイヤー専用 virtual の整備は具体的な
+モンスター機能拡張時に逐次追加する方針。
 
 ---
 

--- a/src/io-dump/player-status-dump-json.cpp
+++ b/src/io-dump/player-status-dump-json.cpp
@@ -81,11 +81,11 @@ static void add_basic_info_to_json(nlohmann::json &j, CreatureEntity &creature)
         j["basic"]["mimic_form"] = localized_to_utf8_safe(mimic_info.at(creature.get_mimic_form()).title);
     }
 
-    if (creature.realm1 != RealmType::NONE) {
-        j["basic"]["realm1"] = localized_to_utf8_safe(PlayerRealm::get_name(creature.realm1));
+    if (creature.get_realm1() != RealmType::NONE) {
+        j["basic"]["realm1"] = localized_to_utf8_safe(PlayerRealm::get_name(creature.get_realm1()));
     }
-    if (creature.realm2 != RealmType::NONE) {
-        j["basic"]["realm2"] = localized_to_utf8_safe(PlayerRealm::get_name(creature.realm2));
+    if (creature.get_realm2() != RealmType::NONE) {
+        j["basic"]["realm2"] = localized_to_utf8_safe(PlayerRealm::get_name(creature.get_realm2()));
     }
 }
 

--- a/src/io-dump/special-class-dump.cpp
+++ b/src/io-dump/special-class-dump.cpp
@@ -227,7 +227,7 @@ static void dump_blue_mage(CreatureEntity &creature, FILE *fff)
  */
 void dump_aux_class_special(CreatureEntity &creature, FILE *fff)
 {
-    switch (creature.pclass) {
+    switch (creature.get_pclass()) {
     case PlayerClassType::MAGIC_EATER: {
         dump_magic_eater(creature, fff);
         return;

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -387,6 +387,96 @@ public:
         return this->ppersonality;
     }
 
+    /*!
+     * @brief 種族 enum を取得する (提案 1/2)
+     * @details モンスターは init_monster_profile() で PlayerRaceType::NONE に
+     * 初期化されており、種族効果は発動しない (NONE ガード前提)。
+     */
+    virtual PlayerRaceType get_prace() const
+    {
+        return this->prace;
+    }
+
+    /*!
+     * @brief 職業 enum を取得する (提案 1/2)
+     * @details モンスターは init_monster_profile() で PlayerClassType::NONE に
+     * 初期化されており、職業効果は発動しない (NONE ガード前提)。
+     */
+    virtual PlayerClassType get_pclass() const
+    {
+        return this->pclass;
+    }
+
+    /*!
+     * @brief 第 1 魔法領域 enum を取得する (提案 1/2)
+     * @details モンスターは init_monster_profile() で RealmType::NONE に
+     * 初期化されており、魔法領域効果は発動しない (NONE ガード前提)。
+     */
+    virtual RealmType get_realm1() const
+    {
+        return this->realm1;
+    }
+
+    /*!
+     * @brief 第 2 魔法領域 enum を取得する (提案 1/2)
+     */
+    virtual RealmType get_realm2() const
+    {
+        return this->realm2;
+    }
+
+    /*!
+     * @brief 元素使い領域 enum を取得する (提案 1/2)
+     */
+    virtual ElementRealmType get_element_realm() const
+    {
+        return this->element_realm;
+    }
+
+    /*!
+     * @brief カオスパトロン ID を取得する (提案 1/2)
+     * @details プレイヤーのカオス戦士のみ意味を持つ。モンスターは 0。
+     */
+    virtual int16_t get_patron() const
+    {
+        return this->patron;
+    }
+
+    // [提案 1/2] プレイヤー専用フィールド setter virtual 群。
+    // 主に birth / wizard / shape-changer 経路から呼ばれる。
+    virtual void set_psex(player_sex value)
+    {
+        this->psex = value;
+    }
+    virtual void set_ppersonality(player_personality_type value)
+    {
+        this->ppersonality = value;
+    }
+    virtual void set_prace(PlayerRaceType value)
+    {
+        this->prace = value;
+    }
+    virtual void set_pclass(PlayerClassType value)
+    {
+        this->pclass = value;
+    }
+    virtual void set_realm1(RealmType value)
+    {
+        this->realm1 = value;
+    }
+    virtual void set_realm2(RealmType value)
+    {
+        this->realm2 = value;
+    }
+    virtual void set_element_realm(ElementRealmType value)
+    {
+        this->element_realm = value;
+    }
+    virtual void set_patron(int16_t value)
+    {
+        this->patron = value;
+    }
+
     bool has_living_flag(bool is_appearance = false) const;
     bool has_demon_flag(bool is_appearance = false) const;
     bool has_undead_flag(bool is_appearance = false) const;
@@ -2796,7 +2886,7 @@ public:
      * @brief 現在の変身形態を取得する
      * @return 変身形態（NONE なら通常状態）
      */
-    MimicKindType get_mimic_form() const
+    virtual MimicKindType get_mimic_form() const
     {
         return this->mimic_form;
     }
@@ -2805,7 +2895,7 @@ public:
      * @brief 変身形態を設定する
      * @param form 変身形態
      */
-    void set_mimic_form(MimicKindType form)
+    virtual void set_mimic_form(MimicKindType form)
     {
         this->mimic_form = form;
     }

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -111,13 +111,13 @@ static void display_player_basic_info(CreatureEntity &creature)
 static void display_magic_realms(CreatureEntity &creature)
 {
     PlayerRealm pr(creature);
-    if (!pr.realm1().is_available() && creature.element_realm == ElementRealmType::NONE) {
+    if (!pr.realm1().is_available() && creature.get_element_realm() == ElementRealmType::NONE) {
         display_player_one_line(ENTRY_REALM, _("なし", "None"), TERM_SLATE);
         return;
     }
 
     if (CreatureClass(creature).equals(PlayerClassType::ELEMENTALIST)) {
-        display_player_one_line(ENTRY_REALM, get_element_title(creature.element_realm), TERM_L_BLUE);
+        display_player_one_line(ENTRY_REALM, get_element_title(creature.get_element_realm()), TERM_L_BLUE);
         return;
     }
 
@@ -350,7 +350,7 @@ tl::optional<int> display_player(CreatureEntity &creature, const int tmp_mode)
     display_player_basic_info(creature);
     display_magic_realms(creature);
     if (CreatureClass(creature).equals(PlayerClassType::CHAOS_WARRIOR) || (creature.get_mutations().has(PlayerMutationType::CHAOS_GIFT))) {
-        display_player_one_line(ENTRY_PATRON, patron_list[creature.patron].name, TERM_L_BLUE);
+        display_player_one_line(ENTRY_PATRON, patron_list[creature.get_patron()].name, TERM_L_BLUE);
     } else {
         display_player_one_line(ENTRY_PATRON, _("なし", "None"), TERM_SLATE);
     }

--- a/src/window/display-sub-window-spells.cpp
+++ b/src/window/display-sub-window-spells.cpp
@@ -60,7 +60,7 @@ static void display_spell_list(CreatureEntity &creature)
         put_str(_("名前", "Name"), y, x + 5);
         put_str(_("Lv   MP 失率 効果", "Lv Mana Fail Info"), y, x + 35);
 
-        switch (creature.pclass) {
+        switch (creature.get_pclass()) {
         case PlayerClassType::MINDCRAFTER:
             use_mind = MindKindType::MINDCRAFTER;
             break;
@@ -88,7 +88,7 @@ static void display_spell_list(CreatureEntity &creature)
 
         for (int i = 0; i < MAX_MIND_POWERS; i++) {
             byte a = TERM_WHITE;
-            const auto *mp_ptr = &class_info[enum2i(creature.pclass)];
+            const auto *mp_ptr = &class_info[enum2i(creature.get_pclass())];
             spell = mind_powers[static_cast<int>(use_mind)].info[i];
             if (spell.min_lev > plev) {
                 break;
@@ -127,11 +127,11 @@ static void display_spell_list(CreatureEntity &creature)
         return;
     }
 
-    if (REALM_NONE == creature.realm1) {
+    if (REALM_NONE == creature.get_realm1()) {
         return;
     }
 
-    for (int j = 0; j < ((creature.realm2 > REALM_NONE) ? 2 : 1); j++) {
+    for (int j = 0; j < ((creature.get_realm2() > REALM_NONE) ? 2 : 1); j++) {
         m[j] = 0;
         y = (j < 3) ? 0 : (m[j - 3] + 2);
         x = 27 * (j % 3);
@@ -139,14 +139,14 @@ static void display_spell_list(CreatureEntity &creature)
         for (int i = 0; i < 32; i++) {
             byte a = TERM_WHITE;
 
-            if (!is_magic((j < 1) ? creature.realm1 : creature.realm2)) {
-                s_ptr = &technic_info[((j < 1) ? creature.realm1 : creature.realm2) - MIN_TECHNIC][i % 32];
+            if (!is_magic((j < 1) ? creature.get_realm1() : creature.get_realm2())) {
+                s_ptr = &technic_info[((j < 1) ? creature.get_realm1() : creature.get_realm2()) - MIN_TECHNIC][i % 32];
             } else {
-                const auto *mp_ptr = &class_info[enum2i(creature.pclass)];
-                s_ptr = &mp_ptr->info[((j < 1) ? creature.realm1 : creature.realm2) - 1][i % 32];
+                const auto *mp_ptr = &class_info[enum2i(creature.get_pclass())];
+                s_ptr = &mp_ptr->info[((j < 1) ? creature.get_realm1() : creature.get_realm2()) - 1][i % 32];
             }
 
-            const auto spell_name = exe_spell(creature, (j < 1) ? creature.realm1 : creature.realm2, i % 32, SpellProcessType::NAME);
+            const auto spell_name = exe_spell(creature, (j < 1) ? creature.get_realm1() : creature.get_realm2(), i % 32, SpellProcessType::NAME);
             strcpy(name, spell_name->data());
 
             if (s_ptr->slevel >= 99) {

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -748,7 +748,7 @@ static void display_spell_list(CreatureEntity &creature)
         put_str(_("名前", "Name"), y, x + 5);
         put_str(_("Lv   MP 失率 効果", "Lv Mana Fail Info"), y, x + 35);
 
-        switch (creature.pclass) {
+        switch (creature.get_pclass()) {
         case PlayerClassType::MINDCRAFTER:
             use_mind = MindKindType::MINDCRAFTER;
             break;

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -48,7 +48,7 @@ void print_title(CreatureEntity &creature)
             p = _("***勝利者***", "***WINNER***");
         }
     } else {
-        p = player_titles.at(creature.pclass).at((creature.get_level() - 1) / 5);
+        p = player_titles.at(creature.get_pclass()).at((creature.get_level() - 1) / 5);
     }
 
     print_field(p, ROW_TITLE, COL_TITLE);


### PR DESCRIPTION
CreatureEntity に種族・職業・性別・性格・魔法領域・パトロン・変身形態の
get/set virtual を追加。モンスターが各フィールドに安全にアクセスできる
基盤を整備。

追加 virtual:
- get_prace() / set_prace(value)
- get_pclass() / set_pclass(value)
- get_realm1() / set_realm1(value)
- get_realm2() / set_realm2(value)
- get_element_realm() / set_element_realm(value)
- get_patron() / set_patron(value)
- set_psex(value) / set_ppersonality(value) (既存 getter に対応)
- get_mimic_form() / set_mimic_form() を virtual 化

migration:
- view/display-player, io-dump/special-class-dump, io-dump/player-status-dump-json, window/main-window-left-frame, window/display-sub-windows, window/display-sub-window-spells: 約 24 箇所の `creature.X` を `creature.get_X()` に統一

設計判断:
残約 177 直接 access (birth/wizard/info-reader 等の player 専用 path) は呼出側が型契約でプレイヤーが確定しており、virtual 化価値が低いため
直接フィールドアクセスを維持。

モンスター個別運用 (種族・職業の付与等) を実装する将来提案でこの基盤を
利用可能。提案 2 (能力問合せ系 virtual の共通化) は提案 10/36/30/31b/
32b/33 等で実質完了。