### PR TITLE
refactor: skill_* / see_infra に setter virtual を追加し private 化 (提案 37)

### DIFF
--- a/src/io-dump/player-status-dump-json.cpp
+++ b/src/io-dump/player-status-dump-json.cpp
@@ -163,15 +163,15 @@ static void add_combat_to_json(nlohmann::json &j, CreatureEntity &creature)
  */
 static void add_skills_to_json(nlohmann::json &j, CreatureEntity &creature)
 {
-    j["skills"]["fighting"] = creature.skill_thn;
-    j["skills"]["shooting"] = creature.skill_thb;
-    j["skills"]["saving_throw"] = creature.skill_sav;
-    j["skills"]["stealth"] = creature.skill_stl;
-    j["skills"]["perception"] = creature.skill_fos;
-    j["skills"]["searching"] = creature.skill_srh;
-    j["skills"]["disarming"] = creature.skill_dis;
-    j["skills"]["magic_device"] = creature.skill_dev;
-    j["skills"]["infravision"] = creature.see_infra;
+    j["skills"]["fighting"] = creature.get_skill_to_hit_melee();
+    j["skills"]["shooting"] = creature.get_skill_to_hit_bow();
+    j["skills"]["saving_throw"] = creature.get_skill_save();
+    j["skills"]["stealth"] = creature.get_skill_stealth();
+    j["skills"]["perception"] = creature.get_skill_perception();
+    j["skills"]["searching"] = creature.get_skill_search();
+    j["skills"]["disarming"] = creature.get_skill_disarm();
+    j["skills"]["magic_device"] = creature.get_skill_device();
+    j["skills"]["infravision"] = creature.get_infravision();
     j["skills"]["speed"] = creature.speed - 110;
 }
 

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -475,7 +475,7 @@ static void rd_player_status(CreatureEntity &creature)
     creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, rd_s16b());
     creature.recall_dungeon = i2enum<DungeonId>(rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::ALTER_REALITY, rd_s16b());
-    creature.see_infra = rd_s16b();
+    creature.set_infravision(rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::TIM_INFRA, rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::OPPOSE_FIRE, rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::OPPOSE_COLD, rd_s16b());

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -191,7 +191,7 @@ void ObjectThrowEntity::set_racial_chance()
 {
     auto &creature = *this->creature_ptr;
     auto compensation = this->obj_flags.has(TR_THROW) ? this->q_ptr->to_h : 0;
-    this->chance = creature.skill_tht + (creature.get_to_h_b() + compensation) * BTH_PLUS_ADJ;
+    this->chance = creature.get_skill_to_hit_throw() + (creature.get_to_h_b() + compensation) * BTH_PLUS_ADJ;
     if (this->shuriken != 0) {
         this->chance *= 2;
     }

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -328,16 +328,16 @@ static void update_bonuses(CreatureEntity &creature)
     }
 
     creature.set_speed(PlayerSpeed(creature).get_value());
-    creature.see_infra = PlayerInfravision(creature).get_value();
-    creature.skill_stl = PlayerStealth(creature).get_value();
-    creature.skill_dis = calc_disarming(creature);
-    creature.skill_dev = calc_device_ability(creature);
-    creature.skill_sav = calc_saving_throw(creature);
-    creature.skill_srh = calc_search(creature);
-    creature.skill_fos = calc_search_freq(creature);
-    creature.skill_thn = calc_to_hit_melee(creature);
-    creature.skill_thb = calc_to_hit_shoot(creature);
-    creature.skill_tht = calc_to_hit_throw(creature);
+    creature.set_infravision(PlayerInfravision(creature).get_value());
+    creature.set_skill_stealth(PlayerStealth(creature).get_value());
+    creature.set_skill_disarm(calc_disarming(creature));
+    creature.set_skill_device(calc_device_ability(creature));
+    creature.set_skill_save(calc_saving_throw(creature));
+    creature.set_skill_search(calc_search(creature));
+    creature.set_skill_perception(calc_search_freq(creature));
+    creature.set_skill_to_hit_melee(calc_to_hit_melee(creature));
+    creature.set_skill_to_hit_bow(calc_to_hit_shoot(creature));
+    creature.set_skill_to_hit_throw(calc_to_hit_throw(creature));
     creature.riding_ryoute = is_riding_two_hands(creature);
     creature.set_to_d(0, calc_to_damage(creature, INVEN_MAIN_HAND, true));
     creature.set_to_d(1, calc_to_damage(creature, INVEN_SUB_HAND, true));
@@ -351,7 +351,7 @@ static void update_bonuses(CreatureEntity &creature)
     creature.set_dis_to_h_b(calc_to_hit_bow(creature, false));
     creature.set_to_d_m(calc_to_damage_misc(creature));
     creature.set_to_h_m(calc_to_hit_misc(creature));
-    creature.skill_dig = calc_skill_dig(creature);
+    creature.set_skill_dig(calc_skill_dig(creature));
     creature.to_m_chance = calc_to_magic_chance(creature);
     creature.ac = calc_base_ac(creature);
     creature.set_to_a(calc_to_ac(creature, true));

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -208,7 +208,7 @@ void wr_player(CreatureEntity &creature)
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::WORD_RECALL));
     wr_s16b(static_cast<int16_t>(creature.recall_dungeon));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::ALTER_REALITY));
-    wr_s16b(creature.see_infra);
+    wr_s16b(creature.get_infravision());
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::TIM_INFRA));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::OPPOSE_FIRE));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::OPPOSE_COLD));

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -237,7 +237,7 @@ void Chest::fire_trap(const Pos2D &pos, short item_idx)
     if ((trap.has(ChestTrapType::RUNES_OF_EVIL)) && o_ptr->is_valid()) {
         msg_print(_("恐ろしい声が響いた:  「暗闇が汝をつつまん！」", "Hideous voices bid:  'Let the darkness have thee!'"));
         for (auto count = 4 + randint0(3); count > 0; count--) {
-            if (randint1(100 + o_ptr->pval * 2) <= this->creature_ptr->skill_sav) {
+            if (randint1(100 + o_ptr->pval * 2) <= this->creature_ptr->get_skill_save()) {
                 continue;
             }
 

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -2837,12 +2837,20 @@ public:
     {
         return this->see_infra;
     }
+    virtual void set_infravision(ACTION_SKILL_POWER value)
+    {
+        this->see_infra = value;
+    }
     /*!
      * @brief 解除能力スキル
      */
     virtual ACTION_SKILL_POWER get_skill_disarm() const
     {
         return this->skill_dis;
+    }
+    virtual void set_skill_disarm(ACTION_SKILL_POWER value)
+    {
+        this->skill_dis = value;
     }
     /*!
      * @brief 魔道具使用スキル
@@ -2851,12 +2859,20 @@ public:
     {
         return this->skill_dev;
     }
+    virtual void set_skill_device(ACTION_SKILL_POWER value)
+    {
+        this->skill_dev = value;
+    }
     /*!
      * @brief 魔法防御スキル
      */
     virtual ACTION_SKILL_POWER get_skill_save() const
     {
         return this->skill_sav;
+    }
+    virtual void set_skill_save(ACTION_SKILL_POWER value)
+    {
+        this->skill_sav = value;
     }
     /*!
      * @brief 隠密スキル
@@ -2865,12 +2881,20 @@ public:
     {
         return this->skill_stl;
     }
+    virtual void set_skill_stealth(ACTION_SKILL_POWER value)
+    {
+        this->skill_stl = value;
+    }
     /*!
      * @brief 知覚スキル
      */
     virtual ACTION_SKILL_POWER get_skill_search() const
     {
         return this->skill_srh;
+    }
+    virtual void set_skill_search(ACTION_SKILL_POWER value)
+    {
+        this->skill_srh = value;
     }
     /*!
      * @brief 探索スキル
@@ -2879,12 +2903,20 @@ public:
     {
         return this->skill_fos;
     }
+    virtual void set_skill_perception(ACTION_SKILL_POWER value)
+    {
+        this->skill_fos = value;
+    }
     /*!
      * @brief 打撃命中スキル
      */
     virtual ACTION_SKILL_POWER get_skill_to_hit_melee() const
     {
         return this->skill_thn;
+    }
+    virtual void set_skill_to_hit_melee(ACTION_SKILL_POWER value)
+    {
+        this->skill_thn = value;
     }
     /*!
      * @brief 射撃命中スキル
@@ -2893,12 +2925,31 @@ public:
     {
         return this->skill_thb;
     }
+    virtual void set_skill_to_hit_bow(ACTION_SKILL_POWER value)
+    {
+        this->skill_thb = value;
+    }
+    /*!
+     * @brief 投射命中スキル
+     */
+    virtual ACTION_SKILL_POWER get_skill_to_hit_throw() const
+    {
+        return this->skill_tht;
+    }
+    virtual void set_skill_to_hit_throw(ACTION_SKILL_POWER value)
+    {
+        this->skill_tht = value;
+    }
     /*!
      * @brief 掘削スキル
      */
     virtual ACTION_SKILL_POWER get_skill_dig() const
     {
         return this->skill_dig;
+    }
+    virtual void set_skill_dig(ACTION_SKILL_POWER value)
+    {
+        this->skill_dig = value;
     }
 
     /*!
@@ -2988,7 +3039,10 @@ public:
     const player_personality *personality{}; /*!< 現在の性格情報 / Current personality info (accessed like reference) */
     const player_class_info *pclass_ref{}; /*!< 現在の職業情報 / Current class info (accessed like reference) */
 
-    // 行動技能値 / Action skills
+    // [提案 37] 行動技能値 / Action skills
+    //          private 化済。アクセスは get_X() / set_X() virtual 経由。
+    //          値は player-status.cpp の update_creature() で装備・能力値等から再計算。
+private:
     ACTION_SKILL_POWER see_infra{}; /*!< 赤外線視能力の強さ / Infravision range */
     ACTION_SKILL_POWER skill_dis{}; /*!< 行動技能値:解除能力 / Skill: Disarming */
     ACTION_SKILL_POWER skill_dev{}; /*!< 行動技能値:魔道具使用 / Skill: Magic Devices */
@@ -3001,6 +3055,7 @@ public:
     ACTION_SKILL_POWER skill_tht{}; /*!< 行動技能値:投射命中能力 / Skill: To hit (throwing) */
     ACTION_SKILL_POWER skill_dig{}; /*!< 行動技能値:掘削 / Skill: Digging */
 
+public:
     POSITION run_py{}; /*!< 走行中の目標Y座標 / Target Y position while running */
     POSITION run_px{}; /*!< 走行中の目標X座標 / Target X position while running */
 


### PR DESCRIPTION
CreatureEntity の行動技能値 11 フィールド (see_infra / skill_dis / skill_dev / skill_sav / skill_stl / skill_srh / skill_fos / skill_thn / skill_thb / skill_tht / skill_dig) について、setter virtual を整備し private 化を完了する。

- ヘッダに setter virtual を 11 個追加 (set_infravision / set_skill_disarm / set_skill_device / set_skill_save / set_skill_stealth / set_skill_search / set_skill_perception / set_skill_to_hit_melee / set_skill_to_hit_bow / set_skill_to_hit_throw / set_skill_dig)
- skill_tht 用の get_skill_to_hit_throw() getter を新規追加 (既存 getter 群と整合)
- player-status.cpp の update_creature() 内 12 箇所の直接代入を setter 経由に migration
- io-dump/player-status-dump-json.cpp の 9 箇所の直接読取りを getter 経由に migration
- chest.cpp / throw-execution.cpp の各 1 箇所を getter 経由に
- save/load の 2 箇所 (savefile I/O) も getter/setter 経由に統一
- フィールド 11 個を private: ブロックに移動

- CreatureEntity 直下フィールドの完全 private 化フィールド数: 83 → 94 (+11)
- 提案 33 (ESP/装備集計) や提案 32/32b (plain field) と同様、 外部からの直接書込みパスを完全に塞いだ
- モンスター個別運用 (将来種族別 skill 設計) の余地を保持

フルクリーンビルド成功 (exit 0)、hengband バイナリ生成確認。