### PR TITLE
fix: ダンジョン定義 JSON v2 で日本語名/説明の UTF-8→SJIS 変換漏れを修正

### DIFF
--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -4,6 +4,7 @@
 #include "info-reader/parse-error-types.h"
 #include "info-reader/race-info-tokens-table.h"
 #include "io/tokenizer.h"
+#include "locale/japanese.h"
 #include "main/angband-headers.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/dungeon/dungeon-list.h"
@@ -529,6 +530,15 @@ errr parse_dungeons_info_json(nlohmann::json &dungeon_data, angband_header *head
     if (dungeon_data.contains("name") && dungeon_data["name"].contains("ja")) {
         name_ja = dungeon_data["name"]["ja"].get<std::string>();
     }
+#ifdef JP
+    if (!name_ja.empty()) {
+        auto name_ja_sys = utf8_to_sys(name_ja);
+        if (!name_ja_sys) {
+            return PARSE_ERROR_INVALID_FLAG;
+        }
+        name_ja = std::move(*name_ja_sys);
+    }
+#endif
     if (auto err = emit_token("N:" + std::to_string(id) + ":" + name_ja, head); err != PARSE_ERROR_NONE) {
         return err;
     }
@@ -557,8 +567,15 @@ errr parse_dungeons_info_json(nlohmann::json &dungeon_data, angband_header *head
     if (dungeon_data.contains("description")) {
         const auto &desc = dungeon_data["description"];
         if (desc.contains("ja")) {
-            const auto ja = desc["ja"].get<std::string>();
+            auto ja = desc["ja"].get<std::string>();
             if (!ja.empty()) {
+#ifdef JP
+                auto ja_sys = utf8_to_sys(ja);
+                if (!ja_sys) {
+                    return PARSE_ERROR_INVALID_FLAG;
+                }
+                ja = std::move(*ja_sys);
+#endif
                 if (auto err = emit_token("D:" + ja, head); err != PARSE_ERROR_NONE) {
                     return err;
                 }


### PR DESCRIPTION
commit a7e2da0ba で DungeonDefinitions.jsonc を構造化 v2 形式に 移行した際、name.ja / description.ja を UTF-8 のまま
DungeonDefinition::name へ詰めていた。race-reader.cpp や
message-reader.cpp、json-reader-util.cpp は同じ JP 文字列を utf8_to_sys(...) で SJIS に変換してから格納しているが、
dungeon-reader.cpp の v2 パスにこの変換が抜けていた。

JP ビルドはダンジョン名を内部的に SJIS として扱うため、UTF-8
バイト列を SJIS とみなして印字する term_queue_chars (z-term.cpp) で:

  1. UTF-8 末尾バイト (例: "荒野" の 0x8E) が SJIS リードバイト 範囲 (0x81-0x9F / 0xE0-0xFC) に当たり iskanji() が真になる
  2. 1 バイト目を読んだ後 s++ で末尾を通過し、続く *s で end iterator 参照を行う

MSVC デバッグランタイムでは __msvc_string_view.hpp:1221 の
"cannot dereference end string_view iterator" でアサート失敗。 ウィザード J コマンドでダンジョン選択メニュー (CandidateSelector)
が日本語ダンジョン名を 22 件一気に印字するため特に踏みやすい。

修正: dungeon-reader.cpp の v2 パスで JP ビルド時に
utf8_to_sys() 経由で SJIS に変換する。name.ja / description.ja の 2 箇所のみ対象 (tag や terrain 名は ASCII 識別子のため不要)。