### PR TITLE
merge: MonraceList を shared_ptr 保有に変更 (hengband#5378 相当)

### DIFF
--- a/src/alliance/alliance.cpp
+++ b/src/alliance/alliance.cpp
@@ -209,9 +209,9 @@ int64_t Alliance::calcCurrentPower()
     const auto &monraces = MonraceList::get_instance();
     int64_t res = this->base_power;
     for (auto &[r_idx, r_ref] : monraces) {
-        if (r_ref.alliance_idx == this->id) {
-            if (r_ref.mob_num > 0) {
-                res += monraces.get_monrace(r_idx).calc_power() * r_ref.mob_num;
+        if (r_ref->alliance_idx == this->id) {
+            if (r_ref->mob_num > 0) {
+                res += monraces.get_monrace(r_idx).calc_power() * r_ref->mob_num;
             }
         }
     }

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -70,19 +70,19 @@ void player_wipe_without_name(CreatureEntity &creature)
     ArtifactList::get_instance().reset_generated_flags();
     BaseitemList::get_instance().reset_identification_flags();
     for (auto &[_, monrace] : MonraceList::get_instance()) {
-        if (!monrace.is_valid()) {
+        if (!monrace->is_valid()) {
             continue;
         }
 
         // 馬鹿馬鹿独自仕様 ... ユニークは常にモブ数1と生成最大数1
-        if (monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
-            monrace.mob_num = monrace.max_num = MAX_UNIQUE_NUM;
+        if (monrace->kind_flags.has(MonsterKindType::UNIQUE)) {
+            monrace->mob_num = monrace->max_num = MAX_UNIQUE_NUM;
         }
 
-        monrace.reset_current_numbers();
-        monrace.reset_max_number();
-        monrace.r_pkills = 0;
-        monrace.r_akills = 0;
+        monrace->reset_current_numbers();
+        monrace->reset_max_number();
+        monrace->r_pkills = 0;
+        monrace->r_akills = 0;
     }
 
     creature.set_food(PY_FOOD_FULL - 1);

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -447,7 +447,7 @@ void do_cmd_pet(CreatureEntity &creature)
     powers[num++] = PET_DISMISS;
 
     const auto is_hallucinated = creature.is_hallucinated();
-    const auto taget_of_pet = creature.get_floor()->get_monster(creature.pet_t_m_idx).get_appearance_monrace().name.data();
+    const auto taget_of_pet = creature.get_floor()->get_monster(creature.pet_t_m_idx).get_apparent_monrace().name.data();
     const auto target_of_pet_appearance = is_hallucinated ? _("何か奇妙な物", "something strange") : taget_of_pet;
     const auto mes = _("ペットのターゲットを指定 (現在：%s)", "specify a target of pet (now:%s)");
     const auto target_name = creature.pet_t_m_idx > 0 ? target_of_pet_appearance : _("指定なし", "nothing");

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -128,8 +128,8 @@ void do_cmd_visuals(CreatureEntity &creature)
 
             auto_dump_printf(auto_dump_stream, _("\n# モンスターの[色/文字]の設定\n\n", "\n# Monster attr/char definitions\n\n"));
             for (const auto &[monrace_id, monrace] : MonraceList::get_instance()) {
-                auto_dump_printf(auto_dump_stream, "# %s\n", monrace.name.data());
-                const auto &symbol_config = monrace.symbol_config;
+                auto_dump_printf(auto_dump_stream, "# %s\n", monrace->name.data());
+                const auto &symbol_config = monrace->symbol_config;
                 auto_dump_printf(auto_dump_stream, "R:%d:0x%02X/0x%02X\n\n", enum2i(monrace_id), symbol_config.color, static_cast<uint8_t>(symbol_config.character));
             }
 
@@ -214,7 +214,7 @@ void do_cmd_visuals(CreatureEntity &creature)
             short num = 0;
             auto &monraces = MonraceList::get_instance();
             static auto choice_msg = _("モンスターの[色/文字]を変更します", "Change monster attr/chars");
-            static auto monrace_id = monraces.begin()->second.idx;
+            static auto monrace_id = monraces.begin()->second->idx;
             prt(format(_("コマンド: %s", "Command: %s"), choice_msg), 15, 0);
             while (true) {
                 auto &monrace = monraces.get_monrace(monrace_id);

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -345,7 +345,7 @@ void process_player(CreatureEntity &creature)
                     continue;
                 }
 
-                const auto &monrace = monster.get_appearance_monrace();
+                const auto &monrace = monster.get_apparent_monrace();
 
                 // モンスターのシンボル/カラーの更新
                 if (monster.is_visible_on_map() && monrace.visual_flags.has_any_of({ MonsterVisualType::MULTI_COLOR, MonsterVisualType::SHAPECHANGER })) {

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -40,7 +40,7 @@ static void effect_monster_charm_resist(CreatureEntity &creature, EffectMonster 
         if (one_in_(4)) {
             em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
-    } else if (has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
+    } else if (has_aggravate_nasty(creature) && em_ptr->monrace->kind_flags.has(MonsterKindType::NASTY)) {
         em_ptr->note = _("はあなたを玩具だと思い込んでいる！", " thinks you are a toy!");
         if (one_in_(4)) {
             em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
@@ -50,7 +50,7 @@ static void effect_monster_charm_resist(CreatureEntity &creature, EffectMonster 
         set_pet(creature, *em_ptr->m_ptr);
 
         chg_virtue(creature, Virtue::INDIVIDUALISM, -1);
-        if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::ANIMAL)) {
+        if (em_ptr->monrace->kind_flags.has(MonsterKindType::ANIMAL)) {
             chg_virtue(creature, Virtue::NATURE, 1);
         }
     }
@@ -93,7 +93,7 @@ ProcessResult effect_monster_control_undead(CreatureEntity &creature, EffectMons
         em_ptr->dam -= it->second / 20;
     }
 
-    if (common_saving_throw_control(creature, em_ptr->dam, *em_ptr->m_ptr) || !em_ptr->m_ptr->has_undead_flag()) {
+    if (common_saving_throw_control(creature, em_ptr->dam, *em_ptr->m_ptr) || em_ptr->monrace->kind_flags.has_not(MonsterKindType::UNDEAD)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         if (one_in_(4)) {
@@ -104,7 +104,7 @@ ProcessResult effect_monster_control_undead(CreatureEntity &creature, EffectMons
         if (one_in_(4)) {
             em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
-    } else if (has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
+    } else if (has_aggravate_nasty(creature) && em_ptr->monrace->kind_flags.has(MonsterKindType::NASTY)) {
         em_ptr->note = _("はあなたを玩具だと思い込んでいる！", " thinks you are a toy!");
         if (one_in_(4)) {
             em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
@@ -134,7 +134,7 @@ ProcessResult effect_monster_control_demon(CreatureEntity &creature, EffectMonst
         em_ptr->dam -= it->second / 20;
     }
 
-    if (common_saving_throw_control(creature, em_ptr->dam, *em_ptr->m_ptr) || em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::DEMON)) {
+    if (common_saving_throw_control(creature, em_ptr->dam, *em_ptr->m_ptr) || em_ptr->monrace->kind_flags.has_not(MonsterKindType::DEMON)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         if (one_in_(4)) {
@@ -145,7 +145,7 @@ ProcessResult effect_monster_control_demon(CreatureEntity &creature, EffectMonst
         if (one_in_(4)) {
             em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
-    } else if (has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
+    } else if (has_aggravate_nasty(creature) && em_ptr->monrace->kind_flags.has(MonsterKindType::NASTY)) {
         em_ptr->note = _("はあなたを玩具だと思い込んでいる！", " thinks you are a toy!");
         if (one_in_(4)) {
             em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
@@ -175,7 +175,7 @@ ProcessResult effect_monster_control_animal(CreatureEntity &creature, EffectMons
         em_ptr->dam -= it->second / 20;
     }
 
-    if (common_saving_throw_control(creature, em_ptr->dam, *em_ptr->m_ptr) || em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::ANIMAL)) {
+    if (common_saving_throw_control(creature, em_ptr->dam, *em_ptr->m_ptr) || em_ptr->monrace->kind_flags.has_not(MonsterKindType::ANIMAL)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         if (one_in_(4)) {
@@ -186,7 +186,7 @@ ProcessResult effect_monster_control_animal(CreatureEntity &creature, EffectMons
         if (one_in_(4)) {
             em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
-    } else if (has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
+    } else if (has_aggravate_nasty(creature) && em_ptr->monrace->kind_flags.has(MonsterKindType::NASTY)) {
         em_ptr->note = _("はあなたを玩具だと思い込んでいる！", " thinks you are a toy!");
         if (one_in_(4)) {
             em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
@@ -194,7 +194,7 @@ ProcessResult effect_monster_control_animal(CreatureEntity &creature, EffectMons
     } else {
         em_ptr->note = _("はなついた。", " is tamed!");
         set_pet(creature, *em_ptr->m_ptr);
-        if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::ANIMAL)) {
+        if (em_ptr->monrace->kind_flags.has(MonsterKindType::ANIMAL)) {
             chg_virtue(creature, Virtue::NATURE, 1);
         }
     }
@@ -232,7 +232,7 @@ ProcessResult effect_monster_charm_living(CreatureEntity &creature, EffectMonste
         if (one_in_(4)) {
             em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
         }
-    } else if (has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
+    } else if (has_aggravate_nasty(creature) && em_ptr->monrace->kind_flags.has(MonsterKindType::NASTY)) {
         em_ptr->note = _("はあなたを玩具だと思い込んでいる！", " thinks you are a toy!");
         if (one_in_(4)) {
             em_ptr->m_ptr->set_constant_flag(MonsterConstantFlagType::NOPET);
@@ -240,7 +240,7 @@ ProcessResult effect_monster_charm_living(CreatureEntity &creature, EffectMonste
     } else {
         em_ptr->note = _("を支配した。", " is tamed!");
         set_pet(creature, *em_ptr->m_ptr);
-        if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::ANIMAL)) {
+        if (em_ptr->monrace->kind_flags.has(MonsterKindType::ANIMAL)) {
             chg_virtue(creature, Virtue::NATURE, 1);
         }
     }
@@ -260,7 +260,7 @@ static void effect_monster_domination_corrupted_addition(CreatureEntity &creatur
         (void)bss.mod_confusion(em_ptr->dam / 2);
         return;
     default:
-        if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_FEAR)) {
+        if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_FEAR)) {
             em_ptr->note = _("には効果がなかった。", " is unaffected.");
         } else {
             (void)bss.mod_fear(static_cast<TIME_EFFECT>(em_ptr->dam));
@@ -273,7 +273,7 @@ static void effect_monster_domination_corrupted_addition(CreatureEntity &creatur
 // Powerful demons & undead can turn a mindcrafter's attacks back on them.
 static void effect_monster_domination_corrupted(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    bool is_corrupted = em_ptr->r_ptr->kind_flags.has_any_of(has_corrupted_mind) && (em_ptr->r_ptr->level > creature.get_level() / 2) && (one_in_(2));
+    bool is_corrupted = em_ptr->monrace->kind_flags.has_any_of(has_corrupted_mind) && (em_ptr->monrace->level > creature.get_level() / 2) && (one_in_(2));
     if (!is_corrupted) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
@@ -284,7 +284,7 @@ static void effect_monster_domination_corrupted(CreatureEntity &creature, Effect
     msg_format(_("%s^の堕落した精神は攻撃を跳ね返した！",
                    (em_ptr->seen ? "%s^'s corrupted mind backlashes your attack!" : "%s^s corrupted mind backlashes your attack!")),
         em_ptr->m_name);
-    if (randint0(100 + em_ptr->r_ptr->level / 2) < creature.get_skill_save()) {
+    if (randint0(100 + em_ptr->monrace->level / 2) < creature.get_skill_save()) {
         msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
         return;
     }
@@ -316,12 +316,12 @@ ProcessResult effect_monster_domination(CreatureEntity &creature, EffectMonster 
         em_ptr->obvious = true;
     }
 
-    const auto is_unique = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
-    const auto is_questor = em_ptr->r_ptr->misc_flags.has(MonsterMiscType::QUESTOR);
-    const auto is_no_confusion = em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_CONF);
-    if (is_unique || is_questor || is_no_confusion || (em_ptr->r_ptr->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10)) {
-        if ((em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_CONF)) && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->resistance_flags.set(MonsterResistanceType::NO_CONF);
+    const auto is_unique = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
+    const auto is_questor = em_ptr->monrace->misc_flags.has(MonsterMiscType::QUESTOR);
+    const auto is_no_confusion = em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF);
+    if (is_unique || is_questor || is_no_confusion || (em_ptr->monrace->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10)) {
+        if ((em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF)) && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
+            em_ptr->monrace->resistance_flags.set(MonsterResistanceType::NO_CONF);
         }
 
         em_ptr->do_conf = 0;
@@ -344,11 +344,11 @@ ProcessResult effect_monster_domination(CreatureEntity &creature, EffectMonster 
 
 static bool effect_monster_crusade_domination(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if ((em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::GOOD)) || creature.get_floor()->inside_arena) {
+    if ((em_ptr->monrace->kind_flags.has_not(MonsterKindType::GOOD)) || creature.get_floor()->inside_arena) {
         return false;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
+    if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
         em_ptr->dam -= 50;
     }
     if (em_ptr->dam < 1) {
@@ -361,12 +361,12 @@ static bool effect_monster_crusade_domination(CreatureEntity &creature, EffectMo
         return true;
     }
 
-    bool failed = em_ptr->r_ptr->misc_flags.has(MonsterMiscType::QUESTOR);
-    failed |= em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
+    bool failed = em_ptr->monrace->misc_flags.has(MonsterMiscType::QUESTOR);
+    failed |= em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
     failed |= em_ptr->m_ptr->is_nopet();
     failed |= has_aggravate(creature);
-    failed |= has_aggravate_nasty(creature) && em_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY);
-    failed |= (em_ptr->r_ptr->level + 10) > randint1(em_ptr->dam);
+    failed |= has_aggravate_nasty(creature) && em_ptr->monrace->kind_flags.has(MonsterKindType::NASTY);
+    failed |= (em_ptr->monrace->level + 10) > randint1(em_ptr->dam);
 
     if (failed) {
         if (one_in_(4)) {
@@ -380,7 +380,7 @@ static bool effect_monster_crusade_domination(CreatureEntity &creature, EffectMo
     set_pet(creature, *em_ptr->m_ptr);
     (void)set_monster_fast(*creature.get_floor(), em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_acceleration() + 100);
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::GOOD);
+        em_ptr->monrace->r_kind_flags.set(MonsterKindType::GOOD);
     }
 
     return true;
@@ -397,10 +397,10 @@ ProcessResult effect_monster_crusade(CreatureEntity &creature, EffectMonster *em
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::NO_FEAR)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::NO_FEAR)) {
         em_ptr->do_fear = randint1(90) + 10;
     } else if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::NO_FEAR);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::NO_FEAR);
     }
 
     em_ptr->dam = 0;
@@ -470,11 +470,11 @@ ProcessResult effect_monster_capture(CreatureEntity &creature, EffectMonster *em
     quest_monster &= !em_ptr->m_ptr->is_pet();
 
     auto cannot_capture = quest_monster;
-    cannot_capture |= em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
-    cannot_capture |= em_ptr->r_ptr->misc_flags.has(MonsterMiscType::QUESTOR);
-    cannot_capture |= em_ptr->r_ptr->population_flags.has(MonsterPopulationType::NAZGUL);
-    cannot_capture |= em_ptr->r_ptr->population_flags.has(MonsterPopulationType::ONLY_ONE);
-    cannot_capture |= em_ptr->r_ptr->population_flags.has(MonsterPopulationType::BUNBUN_STRIKER);
+    cannot_capture |= em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
+    cannot_capture |= em_ptr->monrace->misc_flags.has(MonsterMiscType::QUESTOR);
+    cannot_capture |= em_ptr->monrace->population_flags.has(MonsterPopulationType::NAZGUL);
+    cannot_capture |= em_ptr->monrace->population_flags.has(MonsterPopulationType::ONLY_ONE);
+    cannot_capture |= em_ptr->monrace->population_flags.has(MonsterPopulationType::BUNBUN_STRIKER);
     cannot_capture |= em_ptr->m_ptr->has_parent();
     if (cannot_capture) {
         msg_format(_("%sには効果がなかった。", "%s is unaffected."), em_ptr->m_name);
@@ -482,7 +482,7 @@ ProcessResult effect_monster_capture(CreatureEntity &creature, EffectMonster *em
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    auto r_max_hp = em_ptr->r_ptr->hit_dice.maxroll();
+    auto r_max_hp = em_ptr->monrace->hit_dice.maxroll();
     auto threshold_hp = calcutate_capturable_hp(creature, *em_ptr->m_ptr, r_max_hp);
     auto capturable_hp = std::max(2, calcutate_capturable_hp(creature, *em_ptr->m_ptr, em_ptr->m_ptr->max_maxhp));
 

--- a/src/effect/effect-monster-curse.cpp
+++ b/src/effect/effect-monster-curse.cpp
@@ -14,7 +14,7 @@ ProcessResult effect_monster_curse_1(EffectMonster *em_ptr)
     if (em_ptr->is_player()) {
         msg_format(_("%sを指差して呪いをかけた。", "You point at %s and curse."), em_ptr->m_name);
     }
-    if (randint0(100 + (em_ptr->caster_lev / 2)) < (em_ptr->r_ptr->level + 35)) {
+    if (randint0(100 + (em_ptr->caster_lev / 2)) < (em_ptr->monrace->level + 35)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->dam = 0;
     }
@@ -31,7 +31,7 @@ ProcessResult effect_monster_curse_2(EffectMonster *em_ptr)
         msg_format(_("%sを指差して恐ろしげに呪いをかけた。", "You point at %s and curse horribly."), em_ptr->m_name);
     }
 
-    if (randint0(100 + (em_ptr->caster_lev / 2)) < (em_ptr->r_ptr->level + 35)) {
+    if (randint0(100 + (em_ptr->caster_lev / 2)) < (em_ptr->monrace->level + 35)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->dam = 0;
     }
@@ -48,7 +48,7 @@ ProcessResult effect_monster_curse_3(EffectMonster *em_ptr)
         msg_format(_("%sを指差し、恐ろしげに呪文を唱えた！", "You point at %s, incanting terribly!"), em_ptr->m_name);
     }
 
-    if (randint0(100 + (em_ptr->caster_lev / 2)) < (em_ptr->r_ptr->level + 35)) {
+    if (randint0(100 + (em_ptr->caster_lev / 2)) < (em_ptr->monrace->level + 35)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->dam = 0;
     }
@@ -67,7 +67,7 @@ ProcessResult effect_monster_curse_4(EffectMonster *em_ptr)
             em_ptr->m_name);
     }
 
-    if ((randint0(100 + (em_ptr->caster_lev / 2)) < (em_ptr->r_ptr->level + 35)) && (!em_ptr->is_monster() || (em_ptr->m_caster_ptr->get_r_idx() != MonraceId::KENSHIROU))) {
+    if ((randint0(100 + (em_ptr->caster_lev / 2)) < (em_ptr->monrace->level + 35)) && (!em_ptr->is_monster() || (em_ptr->m_caster_ptr->get_r_idx() != MonraceId::KENSHIROU))) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->dam = 0;
     }

--- a/src/effect/effect-monster-evil.cpp
+++ b/src/effect/effect-monster-evil.cpp
@@ -8,21 +8,21 @@
 
 static bool effect_monster_away_resist(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_TELEPORT)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_TELEPORT)) {
         return false;
     }
 
-    if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) || em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_ALL)) {
+    if (em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE) || em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_ALL)) {
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
         }
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         return true;
     }
 
-    if (em_ptr->r_ptr->level > randint1(100)) {
+    if (em_ptr->monrace->level > randint1(100)) {
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
         }
         em_ptr->note = _("には耐性がある！", " resists!");
         return true;
@@ -33,7 +33,7 @@ static bool effect_monster_away_resist(CreatureEntity &creature, EffectMonster *
 
 ProcessResult effect_monster_away_undead(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (!em_ptr->m_ptr->has_undead_flag()) {
+    if (em_ptr->monrace->kind_flags.has_not(MonsterKindType::UNDEAD)) {
         em_ptr->skipped = true;
         em_ptr->dam = 0;
         return ProcessResult::PROCESS_CONTINUE;
@@ -45,7 +45,7 @@ ProcessResult effect_monster_away_undead(CreatureEntity &creature, EffectMonster
             em_ptr->obvious = true;
         }
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::UNDEAD);
+            em_ptr->monrace->r_kind_flags.set(MonsterKindType::UNDEAD);
         }
 
         em_ptr->do_dist = em_ptr->dam;
@@ -57,7 +57,7 @@ ProcessResult effect_monster_away_undead(CreatureEntity &creature, EffectMonster
 
 ProcessResult effect_monster_away_evil(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::EVIL)) {
+    if (em_ptr->monrace->kind_flags.has_not(MonsterKindType::EVIL)) {
         em_ptr->skipped = true;
         em_ptr->dam = 0;
         return ProcessResult::PROCESS_CONTINUE;
@@ -69,7 +69,7 @@ ProcessResult effect_monster_away_evil(CreatureEntity &creature, EffectMonster *
             em_ptr->obvious = true;
         }
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::EVIL);
+            em_ptr->monrace->r_kind_flags.set(MonsterKindType::EVIL);
         }
 
         em_ptr->do_dist = em_ptr->dam;
@@ -96,7 +96,7 @@ ProcessResult effect_monster_away_all(CreatureEntity &creature, EffectMonster *e
 
 ProcessResult effect_monster_turn_undead(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (!em_ptr->m_ptr->has_undead_flag()) {
+    if (em_ptr->monrace->kind_flags.has_not(MonsterKindType::UNDEAD)) {
         em_ptr->skipped = true;
         em_ptr->dam = 0;
         return ProcessResult::PROCESS_CONTINUE;
@@ -107,12 +107,11 @@ ProcessResult effect_monster_turn_undead(CreatureEntity &creature, EffectMonster
     }
 
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::UNDEAD);
+        em_ptr->monrace->r_kind_flags.set(MonsterKindType::UNDEAD);
     }
 
     em_ptr->do_fear = Dice::roll(3, (em_ptr->dam / 2)) + 1;
-    if (em_ptr->r_ptr->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10 ||
-        em_ptr->m_ptr->is_frenzied()) {
+    if (em_ptr->monrace->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         em_ptr->do_fear = 0;
@@ -124,7 +123,7 @@ ProcessResult effect_monster_turn_undead(CreatureEntity &creature, EffectMonster
 
 ProcessResult effect_monster_turn_evil(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::EVIL)) {
+    if (em_ptr->monrace->kind_flags.has_not(MonsterKindType::EVIL)) {
         em_ptr->skipped = true;
         em_ptr->dam = 0;
         return ProcessResult::PROCESS_CONTINUE;
@@ -135,12 +134,11 @@ ProcessResult effect_monster_turn_evil(CreatureEntity &creature, EffectMonster *
     }
 
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::EVIL);
+        em_ptr->monrace->r_kind_flags.set(MonsterKindType::EVIL);
     }
 
     em_ptr->do_fear = Dice::roll(3, (em_ptr->dam / 2)) + 1;
-    if (em_ptr->r_ptr->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10 ||
-        em_ptr->m_ptr->is_frenzied()) {
+    if (em_ptr->monrace->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         em_ptr->do_fear = 0;
@@ -157,10 +155,9 @@ ProcessResult effect_monster_turn_all(EffectMonster *em_ptr)
     }
 
     em_ptr->do_fear = Dice::roll(3, (em_ptr->dam / 2)) + 1;
-    if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ||
-        em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_FEAR) ||
-        em_ptr->m_ptr->is_frenzied() ||
-        (em_ptr->r_ptr->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10)) {
+    if (em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE) ||
+        em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_FEAR) ||
+        (em_ptr->monrace->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         em_ptr->do_fear = 0;
@@ -172,7 +169,7 @@ ProcessResult effect_monster_turn_all(EffectMonster *em_ptr)
 
 ProcessResult effect_monster_disp_undead(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (!em_ptr->m_ptr->has_undead_flag()) {
+    if (em_ptr->monrace->kind_flags.has_not(MonsterKindType::UNDEAD)) {
         em_ptr->skipped = true;
         em_ptr->dam = 0;
         return ProcessResult::PROCESS_CONTINUE;
@@ -183,7 +180,7 @@ ProcessResult effect_monster_disp_undead(CreatureEntity &creature, EffectMonster
     }
 
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::UNDEAD);
+        em_ptr->monrace->r_kind_flags.set(MonsterKindType::UNDEAD);
     }
 
     em_ptr->note = _("は身震いした。", " shudders.");
@@ -193,7 +190,7 @@ ProcessResult effect_monster_disp_undead(CreatureEntity &creature, EffectMonster
 
 ProcessResult effect_monster_disp_evil(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::EVIL)) {
+    if (em_ptr->monrace->kind_flags.has_not(MonsterKindType::EVIL)) {
         em_ptr->skipped = true;
         em_ptr->dam = 0;
         return ProcessResult::PROCESS_CONTINUE;
@@ -204,7 +201,7 @@ ProcessResult effect_monster_disp_evil(CreatureEntity &creature, EffectMonster *
     }
 
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::EVIL);
+        em_ptr->monrace->r_kind_flags.set(MonsterKindType::EVIL);
     }
 
     em_ptr->note = _("は身震いした。", " shudders.");
@@ -214,7 +211,7 @@ ProcessResult effect_monster_disp_evil(CreatureEntity &creature, EffectMonster *
 
 ProcessResult effect_monster_disp_good(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::GOOD)) {
+    if (em_ptr->monrace->kind_flags.has_not(MonsterKindType::GOOD)) {
         em_ptr->skipped = true;
         em_ptr->dam = 0;
         return ProcessResult::PROCESS_CONTINUE;
@@ -225,7 +222,7 @@ ProcessResult effect_monster_disp_good(CreatureEntity &creature, EffectMonster *
     }
 
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::GOOD);
+        em_ptr->monrace->r_kind_flags.set(MonsterKindType::GOOD);
     }
 
     em_ptr->note = _("は身震いした。", " shudders.");
@@ -252,7 +249,7 @@ ProcessResult effect_monster_disp_living(EffectMonster *em_ptr)
 
 ProcessResult effect_monster_disp_demon(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::DEMON)) {
+    if (em_ptr->monrace->kind_flags.has_not(MonsterKindType::DEMON)) {
         em_ptr->skipped = true;
         em_ptr->dam = 0;
         return ProcessResult::PROCESS_CONTINUE;
@@ -263,7 +260,7 @@ ProcessResult effect_monster_disp_demon(CreatureEntity &creature, EffectMonster 
     }
 
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::DEMON);
+        em_ptr->monrace->r_kind_flags.set(MonsterKindType::DEMON);
     }
 
     em_ptr->note = _("は身震いした。", " shudders.");

--- a/src/effect/effect-monster-lite-dark.cpp
+++ b/src/effect/effect-monster-lite-dark.cpp
@@ -12,7 +12,7 @@ ProcessResult effect_monster_lite_weak(CreatureEntity &creature, EffectMonster *
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::HURT_LITE)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::HURT_LITE)) {
         em_ptr->dam = 0;
         return ProcessResult::PROCESS_CONTINUE;
     }
@@ -22,7 +22,7 @@ ProcessResult effect_monster_lite_weak(CreatureEntity &creature, EffectMonster *
     }
 
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::HURT_LITE);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::HURT_LITE);
     }
 
     em_ptr->note = _("は光に身をすくめた！", " cringes from the light!");
@@ -36,16 +36,16 @@ ProcessResult effect_monster_lite(CreatureEntity &creature, EffectMonster *em_pt
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_LITE)) {
+    if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_LITE)) {
         em_ptr->note = _("には耐性がある！", " resists!");
         em_ptr->dam *= 2;
         em_ptr->dam /= (randint1(6) + 6);
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_LITE);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_LITE);
         }
-    } else if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::HURT_LITE)) {
+    } else if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::HURT_LITE)) {
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::HURT_LITE);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::HURT_LITE);
         }
 
         em_ptr->note = _("は光に身をすくめた！", " cringes from the light!");
@@ -62,7 +62,7 @@ ProcessResult effect_monster_dark(CreatureEntity &creature, EffectMonster *em_pt
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_DARK)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_DARK)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
@@ -70,7 +70,7 @@ ProcessResult effect_monster_dark(CreatureEntity &creature, EffectMonster *em_pt
     em_ptr->dam *= 2;
     em_ptr->dam /= (randint1(6) + 6);
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_DARK);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_DARK);
     }
 
     return ProcessResult::PROCESS_CONTINUE;

--- a/src/effect/effect-monster-oldies.cpp
+++ b/src/effect/effect-monster-oldies.cpp
@@ -24,9 +24,9 @@ ProcessResult effect_monster_old_poly(EffectMonster *em_ptr)
     }
     em_ptr->do_polymorph = true;
 
-    bool has_resistance = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
-    has_resistance |= em_ptr->r_ptr->misc_flags.has(MonsterMiscType::QUESTOR);
-    has_resistance |= (em_ptr->r_ptr->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
+    has_resistance |= em_ptr->monrace->misc_flags.has(MonsterMiscType::QUESTOR);
+    has_resistance |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
 
     if (has_resistance) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
@@ -46,9 +46,9 @@ ProcessResult effect_monster_old_clone(CreatureEntity &creature, EffectMonster *
 
     auto has_resistance = (creature.get_floor()->inside_arena);
     has_resistance |= em_ptr->m_ptr->is_pet();
-    has_resistance |= em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
-    has_resistance |= em_ptr->r_ptr->misc_flags.has(MonsterMiscType::QUESTOR);
-    has_resistance |= em_ptr->r_ptr->population_flags.has_any_of({ MonsterPopulationType::NAZGUL, MonsterPopulationType::ONLY_ONE, MonsterPopulationType::BUNBUN_STRIKER });
+    has_resistance |= em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
+    has_resistance |= em_ptr->monrace->misc_flags.has(MonsterMiscType::QUESTOR);
+    has_resistance |= em_ptr->monrace->population_flags.has_any_of({ MonsterPopulationType::NAZGUL, MonsterPopulationType::ONLY_ONE, MonsterPopulationType::BUNBUN_STRIKER });
 
     if (has_resistance) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
@@ -101,21 +101,21 @@ static void effect_monster_old_heal_check_player(CreatureEntity &creature, Effec
     }
 
     chg_virtue(creature, Virtue::VITALITY, 1);
-    if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
+    if (em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE)) {
         chg_virtue(creature, Virtue::INDIVIDUALISM, 1);
     }
 
     if (em_ptr->m_ptr->is_friendly()) {
         chg_virtue(creature, Virtue::HONOUR, 1);
-    } else if (em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::EVIL)) {
-        if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::GOOD)) {
+    } else if (em_ptr->monrace->kind_flags.has_not(MonsterKindType::EVIL)) {
+        if (em_ptr->monrace->kind_flags.has(MonsterKindType::GOOD)) {
             chg_virtue(creature, Virtue::COMPASSION, 2);
         } else {
             chg_virtue(creature, Virtue::COMPASSION, 1);
         }
     }
 
-    if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::ANIMAL)) {
+    if (em_ptr->monrace->kind_flags.has(MonsterKindType::ANIMAL)) {
         chg_virtue(creature, Virtue::NATURE, 1);
     }
 }
@@ -192,7 +192,7 @@ ProcessResult effect_monster_old_speed(CreatureEntity &creature, EffectMonster *
     }
 
     if (em_ptr->is_player()) {
-        if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
+        if (em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE)) {
             chg_virtue(creature, Virtue::INDIVIDUALISM, 1);
         }
         if (em_ptr->m_ptr->is_friendly()) {
@@ -210,8 +210,8 @@ ProcessResult effect_monster_old_slow(CreatureEntity &creature, EffectMonster *e
         em_ptr->obvious = true;
     }
 
-    bool has_resistance = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
-    has_resistance |= (em_ptr->r_ptr->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
+    has_resistance |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
 
     /* Powerful monsters can resist */
     if (has_resistance) {
@@ -239,14 +239,14 @@ ProcessResult effect_monster_old_sleep(CreatureEntity &creature, EffectMonster *
         em_ptr->obvious = true;
     }
 
-    bool has_resistance = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
-    has_resistance |= em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_SLEEP);
-    has_resistance |= (em_ptr->r_ptr->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
+    has_resistance |= em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_SLEEP);
+    has_resistance |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
 
     if (has_resistance) {
-        if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_SLEEP)) {
+        if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_SLEEP)) {
             if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-                em_ptr->r_ptr->resistance_flags.set(MonsterResistanceType::NO_SLEEP);
+                em_ptr->monrace->resistance_flags.set(MonsterResistanceType::NO_SLEEP);
             }
         }
 
@@ -273,13 +273,13 @@ ProcessResult effect_monster_old_conf(CreatureEntity &creature, EffectMonster *e
 
     em_ptr->do_conf = Dice::roll(3, (em_ptr->dam / 2)) + 1;
 
-    bool has_resistance = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
-    has_resistance |= em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_CONF);
-    has_resistance |= (em_ptr->r_ptr->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
+    has_resistance |= em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF);
+    has_resistance |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
     if (has_resistance) {
-        if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
+        if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
             if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-                em_ptr->r_ptr->resistance_flags.set(MonsterResistanceType::NO_CONF);
+                em_ptr->monrace->resistance_flags.set(MonsterResistanceType::NO_CONF);
             }
         }
 
@@ -299,10 +299,10 @@ ProcessResult effect_monster_stasis(EffectMonster *em_ptr, bool to_evil)
     }
 
     int stasis_damage = (em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10);
-    bool has_resistance = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
-    has_resistance |= em_ptr->r_ptr->level > randint1(stasis_damage) + 10;
+    bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
+    has_resistance |= em_ptr->monrace->level > randint1(stasis_damage) + 10;
     if (to_evil) {
-        has_resistance |= em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::EVIL);
+        has_resistance |= em_ptr->monrace->kind_flags.has_not(MonsterKindType::EVIL);
     }
 
     if (has_resistance) {
@@ -325,8 +325,8 @@ ProcessResult effect_monster_stun(EffectMonster *em_ptr)
 
     em_ptr->do_stun = Dice::roll((em_ptr->caster_lev / 20) + 3, (em_ptr->dam)) + 1;
 
-    bool has_resistance = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
-    has_resistance |= (em_ptr->r_ptr->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
+    has_resistance |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
     if (has_resistance) {
         em_ptr->do_stun = 0;
         em_ptr->note = _("には効果がなかった。", " is unaffected.");

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -27,14 +27,14 @@
  */
 static bool resisted_psi_because_empty_mind(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (em_ptr->r_ptr->misc_flags.has_not(MonsterMiscType::EMPTY_MIND)) {
+    if (em_ptr->monrace->misc_flags.has_not(MonsterMiscType::EMPTY_MIND)) {
         return false;
     }
 
     em_ptr->dam = 0;
     em_ptr->note = _("には完全な耐性がある！", " is immune.");
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_misc_flags.set(MonsterMiscType::EMPTY_MIND);
+        em_ptr->monrace->r_misc_flags.set(MonsterMiscType::EMPTY_MIND);
     }
 
     return true;
@@ -52,10 +52,10 @@ static bool resisted_psi_because_empty_mind(CreatureEntity &creature, EffectMons
  */
 static bool resisted_psi_because_weird_mind_or_powerful(EffectMonster *em_ptr)
 {
-    bool has_resistance = em_ptr->r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID);
-    has_resistance |= em_ptr->r_ptr->misc_flags.has(MonsterMiscType::WEIRD_MIND);
-    has_resistance |= em_ptr->r_ptr->kind_flags.has(MonsterKindType::ANIMAL);
-    has_resistance |= (em_ptr->r_ptr->level > randint1(3 * em_ptr->dam));
+    bool has_resistance = em_ptr->monrace->behavior_flags.has(MonsterBehaviorType::STUPID);
+    has_resistance |= em_ptr->monrace->misc_flags.has(MonsterMiscType::WEIRD_MIND);
+    has_resistance |= em_ptr->monrace->kind_flags.has(MonsterKindType::ANIMAL);
+    has_resistance |= (em_ptr->monrace->level > randint1(3 * em_ptr->dam));
     if (!has_resistance) {
         return false;
     }
@@ -77,8 +77,8 @@ static bool resisted_psi_because_weird_mind_or_powerful(EffectMonster *em_ptr)
  */
 static bool reflects_psi_with_currupted_mind(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    bool is_corrupted = em_ptr->r_ptr->kind_flags.has_any_of(has_corrupted_mind);
-    is_corrupted &= (em_ptr->r_ptr->level > creature.get_level() / 2);
+    bool is_corrupted = em_ptr->monrace->kind_flags.has_any_of(has_corrupted_mind);
+    is_corrupted &= (em_ptr->monrace->level > creature.get_level() / 2);
     is_corrupted &= one_in_(2);
     if (!is_corrupted) {
         return false;
@@ -114,7 +114,7 @@ static void effect_monster_psi_reflect_extra_effect(CreatureEntity &creature, Ef
         (void)bss.mod_stun(randnum1<short>(em_ptr->dam));
         return;
     case 3:
-        if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_FEAR)) {
+        if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_FEAR)) {
             em_ptr->note = _("には効果がなかった。", " is unaffected.");
         } else {
             (void)bss.mod_fear(3 + randint1(em_ptr->dam));
@@ -150,7 +150,7 @@ static void effect_monster_psi_resist(CreatureEntity &creature, EffectMonster *e
     }
 
     /* プレイヤーの反射判定 */
-    if ((randint0(100 + em_ptr->r_ptr->level / 2) < creature.get_skill_save()) && !check_multishadow(creature)) {
+    if ((randint0(100 + em_ptr->monrace->level / 2) < creature.get_skill_save()) && !check_multishadow(creature)) {
         msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));
         em_ptr->dam = 0;
         return;
@@ -243,7 +243,7 @@ static void effect_monster_psi_drain_resist(CreatureEntity &creature, EffectMons
     }
 
     /* プレイヤーの反射判定 */
-    if ((randint0(100 + em_ptr->r_ptr->level / 2) < creature.get_skill_save()) && !check_multishadow(creature)) {
+    if ((randint0(100 + em_ptr->monrace->level / 2) < creature.get_skill_save()) && !check_multishadow(creature)) {
         msg_print(_("あなたは効力を跳ね返した！", "You resist the effects!"));
         em_ptr->dam = 0;
         return;
@@ -333,7 +333,7 @@ ProcessResult effect_monster_telekinesis(EffectMonster *em_ptr)
     }
 
     em_ptr->do_stun = Dice::roll((em_ptr->caster_lev / 20) + 3, em_ptr->dam) + 1;
-    if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) || (em_ptr->r_ptr->level > 5 + randint1(em_ptr->dam))) {
+    if (em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE) || (em_ptr->monrace->level > 5 + randint1(em_ptr->dam))) {
         em_ptr->do_stun = 0;
         em_ptr->obvious = false;
     }

--- a/src/effect/effect-monster-resist-hurt.cpp
+++ b/src/effect/effect-monster-resist-hurt.cpp
@@ -31,14 +31,14 @@ ProcessResult effect_monster_acid(CreatureEntity &creature, EffectMonster *em_pt
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::IMMUNE_ACID)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::IMMUNE_ACID)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     em_ptr->note = _("にはかなり耐性がある！", " resists a lot.");
     em_ptr->dam /= 9;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::IMMUNE_ACID);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::IMMUNE_ACID);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -50,14 +50,14 @@ ProcessResult effect_monster_elec(CreatureEntity &creature, EffectMonster *em_pt
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::IMMUNE_ELEC)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::IMMUNE_ELEC)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     em_ptr->note = _("にはかなり耐性がある！", " resists a lot.");
     em_ptr->dam /= 9;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::IMMUNE_ELEC);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::IMMUNE_ELEC);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -69,24 +69,24 @@ ProcessResult effect_monster_fire(CreatureEntity &creature, EffectMonster *em_pt
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::IMMUNE_FIRE)) {
+    if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::IMMUNE_FIRE)) {
         em_ptr->note = _("にはかなり耐性がある！", " resists a lot.");
         em_ptr->dam /= 9;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::IMMUNE_FIRE);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::IMMUNE_FIRE);
         }
 
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::HURT_FIRE)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::HURT_FIRE)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     em_ptr->note = _("はひどい痛手をうけた。", " is hit hard.");
     em_ptr->dam *= 2;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::HURT_FIRE);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::HURT_FIRE);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -98,24 +98,24 @@ ProcessResult effect_monster_cold(CreatureEntity &creature, EffectMonster *em_pt
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::IMMUNE_COLD)) {
+    if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::IMMUNE_COLD)) {
         em_ptr->note = _("にはかなり耐性がある！", " resists a lot.");
         em_ptr->dam /= 9;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::IMMUNE_COLD);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::IMMUNE_COLD);
         }
 
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::HURT_COLD)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::HURT_COLD)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     em_ptr->note = _("はひどい痛手をうけた。", " is hit hard.");
     em_ptr->dam *= 2;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::HURT_COLD);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::HURT_COLD);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -127,14 +127,14 @@ ProcessResult effect_monster_pois(CreatureEntity &creature, EffectMonster *em_pt
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::IMMUNE_POISON)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::IMMUNE_POISON)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     em_ptr->note = _("にはかなり耐性がある！", " resists a lot.");
     em_ptr->dam /= 9;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::IMMUNE_POISON);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::IMMUNE_POISON);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -146,12 +146,12 @@ ProcessResult effect_monster_nuke(CreatureEntity &creature, EffectMonster *em_pt
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::IMMUNE_POISON)) {
+    if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::IMMUNE_POISON)) {
         em_ptr->note = _("には耐性がある。", " resists.");
         em_ptr->dam *= 3;
         em_ptr->dam /= randint1(6) + 6;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::IMMUNE_POISON);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::IMMUNE_POISON);
         }
 
         return ProcessResult::PROCESS_CONTINUE;
@@ -170,14 +170,14 @@ ProcessResult effect_monster_hell_fire(CreatureEntity &creature, EffectMonster *
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::GOOD)) {
+    if (em_ptr->monrace->kind_flags.has_not(MonsterKindType::GOOD)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     em_ptr->note = _("はひどい痛手をうけた。", " is hit hard.");
     em_ptr->dam *= 2;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::GOOD);
+        em_ptr->monrace->r_kind_flags.set(MonsterKindType::GOOD);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -189,20 +189,20 @@ ProcessResult effect_monster_holy_fire(CreatureEntity &creature, EffectMonster *
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::GOOD)) {
+    if (em_ptr->monrace->kind_flags.has(MonsterKindType::GOOD)) {
         em_ptr->note = _("には完全な耐性がある！", " is immune.");
         em_ptr->dam = 0;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::GOOD);
+            em_ptr->monrace->r_kind_flags.set(MonsterKindType::GOOD);
         }
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::EVIL)) {
+    if (em_ptr->monrace->kind_flags.has(MonsterKindType::EVIL)) {
         em_ptr->dam *= 2;
         em_ptr->note = _("はひどい痛手をうけた。", " is hit hard.");
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::EVIL);
+            em_ptr->monrace->r_kind_flags.set(MonsterKindType::EVIL);
         }
         return ProcessResult::PROCESS_CONTINUE;
     }
@@ -220,7 +220,7 @@ ProcessResult effect_monster_plasma(CreatureEntity &creature, EffectMonster *em_
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_PLASMA)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_PLASMA)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
@@ -228,7 +228,7 @@ ProcessResult effect_monster_plasma(CreatureEntity &creature, EffectMonster *em_
     em_ptr->dam *= 3;
     em_ptr->dam /= randint1(6) + 6;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_PLASMA);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_PLASMA);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -236,15 +236,15 @@ ProcessResult effect_monster_plasma(CreatureEntity &creature, EffectMonster *em_
 
 static bool effect_monster_nether_resist(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_NETHER)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_NETHER)) {
         return false;
     }
 
-    if (em_ptr->m_ptr->has_undead_flag()) {
+    if (em_ptr->monrace->kind_flags.has(MonsterKindType::UNDEAD)) {
         em_ptr->note = _("には完全な耐性がある！", " is immune.");
         em_ptr->dam = 0;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::UNDEAD);
+            em_ptr->monrace->r_kind_flags.set(MonsterKindType::UNDEAD);
         }
     } else {
         em_ptr->note = _("には耐性がある。", " resists.");
@@ -253,7 +253,7 @@ static bool effect_monster_nether_resist(CreatureEntity &creature, EffectMonster
     }
 
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_NETHER);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_NETHER);
     }
 
     return true;
@@ -265,14 +265,14 @@ ProcessResult effect_monster_nether(CreatureEntity &creature, EffectMonster *em_
         em_ptr->obvious = true;
     }
 
-    if (effect_monster_nether_resist(creature, em_ptr) || (em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::EVIL))) {
+    if (effect_monster_nether_resist(creature, em_ptr) || (em_ptr->monrace->kind_flags.has_not(MonsterKindType::EVIL))) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     em_ptr->note = _("はいくらか耐性を示した。", " resists somewhat.");
     em_ptr->dam /= 2;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::EVIL);
+        em_ptr->monrace->r_kind_flags.set(MonsterKindType::EVIL);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -284,7 +284,7 @@ ProcessResult effect_monster_water(CreatureEntity &creature, EffectMonster *em_p
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_WATER)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_WATER)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
@@ -298,7 +298,7 @@ ProcessResult effect_monster_water(CreatureEntity &creature, EffectMonster *em_p
     }
 
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_WATER);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_WATER);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -310,19 +310,19 @@ ProcessResult effect_monster_chaos(CreatureEntity &creature, EffectMonster *em_p
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_CHAOS)) {
+    if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_CHAOS)) {
         em_ptr->note = _("には耐性がある。", " resists.");
         em_ptr->dam *= 3;
         em_ptr->dam /= randint1(6) + 6;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_CHAOS);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_CHAOS);
         }
-    } else if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::DEMON) && one_in_(3)) {
+    } else if (em_ptr->monrace->kind_flags.has(MonsterKindType::DEMON) && one_in_(3)) {
         em_ptr->note = _("はいくらか耐性を示した。", " resists somewhat.");
         em_ptr->dam *= 3;
         em_ptr->dam /= randint1(6) + 6;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::DEMON);
+            em_ptr->monrace->r_kind_flags.set(MonsterKindType::DEMON);
         }
     } else {
         em_ptr->do_polymorph = true;
@@ -338,7 +338,7 @@ ProcessResult effect_monster_shards(CreatureEntity &creature, EffectMonster *em_
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_SHARDS)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_SHARDS)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
@@ -346,7 +346,7 @@ ProcessResult effect_monster_shards(CreatureEntity &creature, EffectMonster *em_
     em_ptr->dam *= 3;
     em_ptr->dam /= randint1(6) + 6;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_SHARDS);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_SHARDS);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -358,14 +358,14 @@ ProcessResult effect_monster_rocket(CreatureEntity &creature, EffectMonster *em_
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_SHARDS)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_SHARDS)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     em_ptr->note = _("はいくらか耐性を示した。", " resists somewhat.");
     em_ptr->dam /= 2;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_SHARDS);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_SHARDS);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -377,7 +377,7 @@ ProcessResult effect_monster_sound(CreatureEntity &creature, EffectMonster *em_p
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_SOUND)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_SOUND)) {
         em_ptr->do_stun = (10 + randint1(15) + em_ptr->r) / (em_ptr->r + 1);
         return ProcessResult::PROCESS_CONTINUE;
     }
@@ -386,7 +386,7 @@ ProcessResult effect_monster_sound(CreatureEntity &creature, EffectMonster *em_p
     em_ptr->dam *= 2;
     em_ptr->dam /= randint1(6) + 6;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_SOUND);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_SOUND);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -398,7 +398,7 @@ ProcessResult effect_monster_confusion(CreatureEntity &creature, EffectMonster *
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::NO_CONF)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::NO_CONF)) {
         em_ptr->do_conf = (10 + randint1(15) + em_ptr->r) / (em_ptr->r + 1);
         return ProcessResult::PROCESS_CONTINUE;
     }
@@ -407,7 +407,7 @@ ProcessResult effect_monster_confusion(CreatureEntity &creature, EffectMonster *
     em_ptr->dam *= 3;
     em_ptr->dam /= randint1(6) + 6;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->resistance_flags.set(MonsterResistanceType::NO_CONF);
+        em_ptr->monrace->resistance_flags.set(MonsterResistanceType::NO_CONF);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -419,7 +419,7 @@ ProcessResult effect_monster_disenchant(CreatureEntity &creature, EffectMonster 
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_DISENCHANT)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_DISENCHANT)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
@@ -427,7 +427,7 @@ ProcessResult effect_monster_disenchant(CreatureEntity &creature, EffectMonster 
     em_ptr->dam *= 3;
     em_ptr->dam /= randint1(6) + 6;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_DISENCHANT);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_DISENCHANT);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -439,7 +439,7 @@ ProcessResult effect_monster_nexus(CreatureEntity &creature, EffectMonster *em_p
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_NEXUS)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_NEXUS)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
@@ -447,7 +447,7 @@ ProcessResult effect_monster_nexus(CreatureEntity &creature, EffectMonster *em_p
     em_ptr->dam *= 3;
     em_ptr->dam /= randint1(6) + 6;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_NEXUS);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_NEXUS);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -459,7 +459,7 @@ ProcessResult effect_monster_force(CreatureEntity &creature, EffectMonster *em_p
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_FORCE)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_FORCE)) {
         em_ptr->do_stun = (randint1(15) + em_ptr->r) / (em_ptr->r + 1);
         return ProcessResult::PROCESS_CONTINUE;
     }
@@ -468,7 +468,7 @@ ProcessResult effect_monster_force(CreatureEntity &creature, EffectMonster *em_p
     em_ptr->dam *= 3;
     em_ptr->dam /= randint1(6) + 6;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_FORCE);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_FORCE);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -481,19 +481,19 @@ ProcessResult effect_monster_inertial(CreatureEntity &creature, EffectMonster *e
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_INERTIA)) {
+    if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_INERTIA)) {
         em_ptr->note = _("には耐性がある。", " resists.");
         em_ptr->dam *= 3;
         em_ptr->dam /= randint1(6) + 6;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_INERTIA);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_INERTIA);
         }
 
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    bool cancel_effect = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
-    cancel_effect |= (em_ptr->r_ptr->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    bool cancel_effect = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
+    cancel_effect |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
     if (cancel_effect) {
         em_ptr->obvious = false;
         return ProcessResult::PROCESS_CONTINUE;
@@ -512,7 +512,7 @@ ProcessResult effect_monster_time(CreatureEntity &creature, EffectMonster *em_pt
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_TIME)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_TIME)) {
         em_ptr->do_time = (em_ptr->dam + 1) / 2;
         return ProcessResult::PROCESS_CONTINUE;
     }
@@ -521,7 +521,7 @@ ProcessResult effect_monster_time(CreatureEntity &creature, EffectMonster *em_pt
     em_ptr->dam *= 3;
     em_ptr->dam /= randint1(6) + 6;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_TIME);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_TIME);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -529,27 +529,27 @@ ProcessResult effect_monster_time(CreatureEntity &creature, EffectMonster *em_pt
 
 static bool effect_monster_gravity_resist_teleport(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_TELEPORT)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_TELEPORT)) {
         em_ptr->obvious = true;
         return false;
     }
 
-    if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
+    if (em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE)) {
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
         }
 
         em_ptr->note = _("には効果がなかった。", " is unaffected!");
         return true;
     }
 
-    if (em_ptr->r_ptr->level <= randint1(100)) {
+    if (em_ptr->monrace->level <= randint1(100)) {
         em_ptr->obvious = true;
         return false;
     }
 
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
     }
 
     em_ptr->note = _("には耐性がある！", " resists!");
@@ -558,8 +558,8 @@ static bool effect_monster_gravity_resist_teleport(CreatureEntity &creature, Eff
 
 static void effect_monster_gravity_slow(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    bool cancel_effect = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
-    cancel_effect |= (em_ptr->r_ptr->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    bool cancel_effect = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
+    cancel_effect |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
     if (cancel_effect) {
         em_ptr->obvious = false;
         return;
@@ -574,9 +574,9 @@ static void effect_monster_gravity_slow(CreatureEntity &creature, EffectMonster 
 static void effect_monster_gravity_stun(EffectMonster *em_ptr)
 {
     em_ptr->do_stun = Dice::roll((em_ptr->caster_lev / 20) + 3, (em_ptr->dam)) + 1;
-    bool has_resistance = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
-    has_resistance |= (em_ptr->r_ptr->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
-    has_resistance |= em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_GRAVITY);
+    bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
+    has_resistance |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    has_resistance |= em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_GRAVITY);
     if (has_resistance) {
         em_ptr->do_stun = 0;
         return;
@@ -595,13 +595,13 @@ ProcessResult effect_monster_gravity(CreatureEntity &creature, EffectMonster *em
         em_ptr->do_dist = 0;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_GRAVITY)) {
+    if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_GRAVITY)) {
         em_ptr->note = _("には耐性がある！", " resists!");
         em_ptr->dam *= 3;
         em_ptr->dam /= randint1(6) + 6;
         em_ptr->do_dist = 0;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_GRAVITY);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_GRAVITY);
         }
         return ProcessResult::PROCESS_CONTINUE;
     }
@@ -619,12 +619,12 @@ ProcessResult effect_monster_disintegration(CreatureEntity &creature, EffectMons
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::HURT_ROCK)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::HURT_ROCK)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::HURT_ROCK);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::HURT_ROCK);
     }
 
     em_ptr->note = _("の皮膚がただれた！", " loses some skin!");
@@ -639,21 +639,21 @@ ProcessResult effect_monster_icee_bolt(CreatureEntity &creature, EffectMonster *
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_SOUND)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_SOUND)) {
         em_ptr->do_stun = (randint1(15) + 1) / (em_ptr->r + 1);
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::IMMUNE_COLD)) {
+    if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::IMMUNE_COLD)) {
         em_ptr->note = _("にはかなり耐性がある！", " resists a lot.");
         em_ptr->dam /= 9;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::IMMUNE_COLD);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::IMMUNE_COLD);
         }
-    } else if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::HURT_COLD)) {
+    } else if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::HURT_COLD)) {
         em_ptr->note = _("はひどい痛手をうけた。", " is hit hard.");
         em_ptr->dam *= 2;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::HURT_COLD);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::HURT_COLD);
         }
     }
 
@@ -674,34 +674,34 @@ ProcessResult effect_monster_void(CreatureEntity &creature, EffectMonster *em_pt
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::QUANTUM)) {
+    if (em_ptr->monrace->kind_flags.has(MonsterKindType::QUANTUM)) {
         em_ptr->note = _("の存在確率が減少した。", "'s wave function is reduced.");
         em_ptr->note_dies = _("は観測されなくなった。", "'s wave function collapses.");
         em_ptr->dam *= 2;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::QUANTUM);
+            em_ptr->monrace->r_kind_flags.set(MonsterKindType::QUANTUM);
         }
-    } else if (em_ptr->r_ptr->feature_flags.has(MonsterFeatureType::PASS_WALL)) {
+    } else if (em_ptr->monrace->feature_flags.has(MonsterFeatureType::PASS_WALL)) {
         em_ptr->note = _("の存在が薄れていく。", " is fading out.");
         em_ptr->note_dies = _("は消えてしまった。", " has disappeared.");
         em_ptr->dam *= 3;
         em_ptr->dam /= 2;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_feature_flags.set(MonsterFeatureType::PASS_WALL);
+            em_ptr->monrace->r_feature_flags.set(MonsterFeatureType::PASS_WALL);
         }
-    } else if (em_ptr->r_ptr->resistance_flags.has_any_of({ MonsterResistanceType::RESIST_TELEPORT, MonsterResistanceType::RESIST_FORCE, MonsterResistanceType::RESIST_GRAVITY })) {
+    } else if (em_ptr->monrace->resistance_flags.has_any_of({ MonsterResistanceType::RESIST_TELEPORT, MonsterResistanceType::RESIST_FORCE, MonsterResistanceType::RESIST_GRAVITY })) {
         em_ptr->note = _("には耐性がある！", " resists!");
         em_ptr->dam *= 3;
         em_ptr->dam /= randint1(6) + 6;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT)) {
-                em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
+            if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT)) {
+                em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
             }
-            if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_FORCE)) {
-                em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_FORCE);
+            if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_FORCE)) {
+                em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_FORCE);
             }
-            if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_GRAVITY)) {
-                em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_GRAVITY);
+            if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_GRAVITY)) {
+                em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_GRAVITY);
             }
         }
     } else {
@@ -728,23 +728,23 @@ ProcessResult effect_monster_abyss(CreatureEntity &creature, EffectMonster *em_p
 
     auto dark = { MonsterBrightnessType::SELF_DARK_1, MonsterBrightnessType::SELF_DARK_2, MonsterBrightnessType::HAS_DARK_1, MonsterBrightnessType::HAS_DARK_2 };
 
-    if (em_ptr->r_ptr->brightness_flags.has_any_of(dark)) {
+    if (em_ptr->monrace->brightness_flags.has_any_of(dark)) {
         em_ptr->note = _("には耐性がある！", " resists!");
         em_ptr->dam *= 3;
         em_ptr->dam /= (randint1(6) + 6);
-    } else if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_DARK)) {
+    } else if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_DARK)) {
         em_ptr->note = _("には耐性がある！", " resists!");
         em_ptr->dam *= 3;
         em_ptr->dam /= (randint1(4) + 5);
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_DARK);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_DARK);
         }
-    } else if (em_ptr->r_ptr->feature_flags.has_not(MonsterFeatureType::CAN_FLY)) {
-        if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT)) {
+    } else if (em_ptr->monrace->feature_flags.has_not(MonsterFeatureType::CAN_FLY)) {
+        if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT)) {
             em_ptr->dam *= 5;
             em_ptr->dam /= 4;
             if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-                em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
+                em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
             }
         }
 
@@ -756,7 +756,7 @@ ProcessResult effect_monster_abyss(CreatureEntity &creature, EffectMonster *em_p
         }
     }
 
-    if (em_ptr->r_ptr->misc_flags.has(MonsterMiscType::ELDRITCH_HORROR) || em_ptr->r_ptr->misc_flags.has(MonsterMiscType::EMPTY_MIND)) {
+    if (em_ptr->monrace->misc_flags.has(MonsterMiscType::ELDRITCH_HORROR) || em_ptr->monrace->misc_flags.has(MonsterMiscType::EMPTY_MIND)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
@@ -785,31 +785,31 @@ ProcessResult effect_monster_dirt(CreatureEntity &creature, EffectMonster *em_pt
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->misc_flags.has(MonsterMiscType::SCATOLOGIST)) {
+    if (em_ptr->monrace->misc_flags.has(MonsterMiscType::SCATOLOGIST)) {
         em_ptr->note = _("には完全な耐性がある！", " resists completely.");
         em_ptr->dam = 0;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_misc_flags.set(MonsterMiscType::SCATOLOGIST);
+            em_ptr->monrace->r_misc_flags.set(MonsterMiscType::SCATOLOGIST);
         }
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     // 毒完全耐性があるモンスターは大幅に軽減
-    if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::IMMUNE_POISON)) {
+    if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::IMMUNE_POISON)) {
         em_ptr->note = _("にはかなり耐性がある！", " resists a lot.");
         em_ptr->dam /= 9;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::IMMUNE_POISON);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::IMMUNE_POISON);
         }
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     // 清浄なモンスター（天使、エレメンタルなど）は追加ダメージ
     bool is_vulnerable = false;
-    if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::ANGEL)) {
+    if (em_ptr->monrace->kind_flags.has(MonsterKindType::ANGEL)) {
         is_vulnerable = true;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::ANGEL);
+            em_ptr->monrace->r_kind_flags.set(MonsterKindType::ANGEL);
         }
     }
 
@@ -820,7 +820,7 @@ ProcessResult effect_monster_dirt(CreatureEntity &creature, EffectMonster *em_pt
 
     // 一定確率で状態異常付与
     if (randint0(100) < 30) {
-        if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::NO_CONF)) {
+        if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::NO_CONF)) {
             em_ptr->do_conf = (10 + randint1(15));
             if (em_ptr->note.empty()) {
                 em_ptr->note = _("は混乱したようだ。", " looks confused.");
@@ -829,7 +829,7 @@ ProcessResult effect_monster_dirt(CreatureEntity &creature, EffectMonster *em_pt
     }
 
     if (randint0(100) < 20) {
-        if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::NO_STUN)) {
+        if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::NO_STUN)) {
             em_ptr->do_stun = (5 + randint1(10));
             if (em_ptr->note.empty()) {
                 em_ptr->note = _("はよろめいている。", " is stunned.");
@@ -847,34 +847,34 @@ ProcessResult effect_monster_spider_string(CreatureEntity &creature, EffectMonst
     }
 
     // 蜘蛛型モンスターは蜘蛛糸に完全耐性
-    if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::SPIDER)) {
+    if (em_ptr->monrace->kind_flags.has(MonsterKindType::SPIDER)) {
         em_ptr->note = _("には完全な耐性がある！", " resists completely.");
         em_ptr->dam = 0;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::SPIDER);
+            em_ptr->monrace->r_kind_flags.set(MonsterKindType::SPIDER);
         }
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     // 無機物系モンスターは糸が効かない
     bool is_vulnerable = true;
-    if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::ELEMENTAL) ||
-        em_ptr->r_ptr->kind_flags.has(MonsterKindType::NONLIVING)) {
+    if (em_ptr->monrace->kind_flags.has(MonsterKindType::ELEMENTAL) ||
+        em_ptr->monrace->kind_flags.has(MonsterKindType::NONLIVING)) {
         em_ptr->note = _("にはあまり効果がない。", " is not affected much.");
         em_ptr->dam /= 3;
         is_vulnerable = false;
     }
 
     // 動物系・人間系は特に蜘蛛糸に弱い
-    if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::ANIMAL) ||
-        em_ptr->r_ptr->kind_flags.has(MonsterKindType::HUMAN)) {
+    if (em_ptr->monrace->kind_flags.has(MonsterKindType::ANIMAL) ||
+        em_ptr->monrace->kind_flags.has(MonsterKindType::HUMAN)) {
         is_vulnerable = true;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::ANIMAL)) {
-                em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::ANIMAL);
+            if (em_ptr->monrace->kind_flags.has(MonsterKindType::ANIMAL)) {
+                em_ptr->monrace->r_kind_flags.set(MonsterKindType::ANIMAL);
             }
-            if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::HUMAN)) {
-                em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::HUMAN);
+            if (em_ptr->monrace->kind_flags.has(MonsterKindType::HUMAN)) {
+                em_ptr->monrace->r_kind_flags.set(MonsterKindType::HUMAN);
             }
         }
     }
@@ -887,7 +887,7 @@ ProcessResult effect_monster_spider_string(CreatureEntity &creature, EffectMonst
     // 蜘蛛糸効果で行動阻害（スロウ効果）
     /* TODO
     if (randint0(100) < 50) {
-        if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::NO_SLOW)) {
+        if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::NO_SLOW)) {
             em_ptr->do_slow = (10 + randint1(20));
             if (em_ptr->note.empty()) {
                 em_ptr->note = _("の動きが鈍くなった。", " moves slower.");
@@ -898,7 +898,7 @@ ProcessResult effect_monster_spider_string(CreatureEntity &creature, EffectMonst
 
     // 高確率で混乱（糸に絡まってパニック）
     if (randint0(100) < 40) {
-        if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::NO_CONF)) {
+        if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::NO_CONF)) {
             em_ptr->do_conf = (5 + randint1(10));
             if (em_ptr->note.empty()) {
                 em_ptr->note = _("は混乱したようだ。", " looks confused.");
@@ -915,14 +915,14 @@ ProcessResult effect_monster_stungun(CreatureEntity &creature, EffectMonster *em
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::IMMUNE_ELEC)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::IMMUNE_ELEC)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     em_ptr->note = _("にはかなり耐性がある！", " resists a lot.");
     em_ptr->dam /= 9;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::IMMUNE_ELEC);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::IMMUNE_ELEC);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -930,7 +930,7 @@ ProcessResult effect_monster_stungun(CreatureEntity &creature, EffectMonster *em
 
 ProcessResult effect_monster_meteor(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_METEOR)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_METEOR)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
@@ -938,7 +938,7 @@ ProcessResult effect_monster_meteor(CreatureEntity &creature, EffectMonster *em_
     em_ptr->dam *= 3;
     em_ptr->dam /= randint1(6) + 6;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_METEOR);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_METEOR);
     }
 
     return ProcessResult::PROCESS_CONTINUE;

--- a/src/effect/effect-monster-spirit.cpp
+++ b/src/effect/effect-monster-spirit.cpp
@@ -21,7 +21,7 @@ ProcessResult effect_monster_drain_mana(CreatureEntity &creature, EffectMonster 
     if (em_ptr->seen) {
         em_ptr->obvious = true;
     }
-    auto ability_flags = em_ptr->r_ptr->ability_flags;
+    auto ability_flags = em_ptr->monrace->ability_flags;
     bool has_mana = ability_flags.reset(RF_ABILITY_NOMAGIC_MASK).any();
     if (!has_mana) {
         if (em_ptr->see_s_msg) {
@@ -72,28 +72,28 @@ ProcessResult effect_monster_mind_blast(CreatureEntity &creature, EffectMonster 
         msg_format(_("%sをじっと睨んだ。", "You gaze intently at %s."), em_ptr->m_name);
     }
 
-    bool has_immute = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
-    has_immute |= em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_CONF);
-    has_immute |= (em_ptr->r_ptr->level > randint1(std::max(1, em_ptr->caster_lev - 10)) + 10);
+    bool has_immute = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
+    has_immute |= em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF);
+    has_immute |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->caster_lev - 10)) + 10);
 
     if (has_immute) {
-        if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
+        if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
             if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-                em_ptr->r_ptr->resistance_flags.set(MonsterResistanceType::NO_CONF);
+                em_ptr->monrace->resistance_flags.set(MonsterResistanceType::NO_CONF);
             }
         }
 
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->dam = 0;
-    } else if (em_ptr->r_ptr->misc_flags.has(MonsterMiscType::EMPTY_MIND)) {
+    } else if (em_ptr->monrace->misc_flags.has(MonsterMiscType::EMPTY_MIND)) {
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_misc_flags.set(MonsterMiscType::EMPTY_MIND);
+            em_ptr->monrace->r_misc_flags.set(MonsterMiscType::EMPTY_MIND);
         }
         em_ptr->note = _("には完全な耐性がある！", " is immune.");
         em_ptr->dam = 0;
-    } else if (em_ptr->r_ptr->misc_flags.has(MonsterMiscType::WEIRD_MIND)) {
+    } else if (em_ptr->monrace->misc_flags.has(MonsterMiscType::WEIRD_MIND)) {
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_misc_flags.set(MonsterMiscType::WEIRD_MIND);
+            em_ptr->monrace->r_misc_flags.set(MonsterMiscType::WEIRD_MIND);
         }
         em_ptr->note = _("には耐性がある。", " resists.");
         em_ptr->dam /= 3;
@@ -120,29 +120,29 @@ ProcessResult effect_monster_brain_smash(CreatureEntity &creature, EffectMonster
         msg_format(_("%sをじっと睨んだ。", "You gaze intently at %s."), em_ptr->m_name);
     }
 
-    bool has_immute = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
-    has_immute |= em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_CONF);
-    has_immute |= (em_ptr->r_ptr->level > randint1(std::max(1, em_ptr->caster_lev - 10)) + 10);
+    bool has_immute = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
+    has_immute |= em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF);
+    has_immute |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->caster_lev - 10)) + 10);
 
     if (has_immute) {
-        if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
+        if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
             if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-                em_ptr->r_ptr->resistance_flags.set(MonsterResistanceType::NO_CONF);
+                em_ptr->monrace->resistance_flags.set(MonsterResistanceType::NO_CONF);
             }
         }
 
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->dam = 0;
-    } else if (em_ptr->r_ptr->misc_flags.has(MonsterMiscType::EMPTY_MIND)) {
+    } else if (em_ptr->monrace->misc_flags.has(MonsterMiscType::EMPTY_MIND)) {
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_misc_flags.set(MonsterMiscType::EMPTY_MIND);
+            em_ptr->monrace->r_misc_flags.set(MonsterMiscType::EMPTY_MIND);
         }
 
         em_ptr->note = _("には完全な耐性がある！", " is immune.");
         em_ptr->dam = 0;
-    } else if (em_ptr->r_ptr->misc_flags.has(MonsterMiscType::WEIRD_MIND)) {
+    } else if (em_ptr->monrace->misc_flags.has(MonsterMiscType::WEIRD_MIND)) {
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_misc_flags.set(MonsterMiscType::WEIRD_MIND);
+            em_ptr->monrace->r_misc_flags.set(MonsterMiscType::WEIRD_MIND);
         }
 
         em_ptr->note = _("には耐性がある！", " resists!");

--- a/src/effect/effect-monster-switcher.cpp
+++ b/src/effect/effect-monster-switcher.cpp
@@ -47,14 +47,14 @@ ProcessResult effect_monster_hypodynamia(CreatureEntity &creature, EffectMonster
     }
 
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::DEMON)) {
-            em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::DEMON);
+        if (em_ptr->monrace->kind_flags.has(MonsterKindType::DEMON)) {
+            em_ptr->monrace->r_kind_flags.set(MonsterKindType::DEMON);
         }
-        if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNDEAD)) {
-            em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::UNDEAD);
+        if (em_ptr->monrace->kind_flags.has(MonsterKindType::UNDEAD)) {
+            em_ptr->monrace->r_kind_flags.set(MonsterKindType::UNDEAD);
         }
-        if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::NONLIVING)) {
-            em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::NONLIVING);
+        if (em_ptr->monrace->kind_flags.has(MonsterKindType::NONLIVING)) {
+            em_ptr->monrace->r_kind_flags.set(MonsterKindType::NONLIVING);
         }
     }
 
@@ -75,14 +75,14 @@ ProcessResult effect_monster_death_ray(CreatureEntity &creature, EffectMonster *
 
     if (!em_ptr->m_ptr->has_living_flag()) {
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::DEMON)) {
-                em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::DEMON);
+            if (em_ptr->monrace->kind_flags.has(MonsterKindType::DEMON)) {
+                em_ptr->monrace->r_kind_flags.set(MonsterKindType::DEMON);
             }
-            if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNDEAD)) {
-                em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::UNDEAD);
+            if (em_ptr->monrace->kind_flags.has(MonsterKindType::UNDEAD)) {
+                em_ptr->monrace->r_kind_flags.set(MonsterKindType::UNDEAD);
             }
-            if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::NONLIVING)) {
-                em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::NONLIVING);
+            if (em_ptr->monrace->kind_flags.has(MonsterKindType::NONLIVING)) {
+                em_ptr->monrace->r_kind_flags.set(MonsterKindType::NONLIVING);
             }
         }
 
@@ -92,8 +92,8 @@ ProcessResult effect_monster_death_ray(CreatureEntity &creature, EffectMonster *
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    bool has_resistance = (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) && (randint1(888) != 666));
-    has_resistance |= (((em_ptr->r_ptr->level + randint1(20)) > randint1((em_ptr->caster_lev / 2) + randint1(10))) && randint1(100) != 66);
+    bool has_resistance = (em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE) && (randint1(888) != 666));
+    has_resistance |= (((em_ptr->monrace->level + randint1(20)) > randint1((em_ptr->caster_lev / 2) + randint1(10))) && randint1(100) != 66);
 
     if (has_resistance) {
         em_ptr->note = _("には耐性がある！", " resists!");
@@ -106,7 +106,7 @@ ProcessResult effect_monster_death_ray(CreatureEntity &creature, EffectMonster *
 
 ProcessResult effect_monster_kill_wall(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::HURT_ROCK)) {
+    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::HURT_ROCK)) {
         em_ptr->dam = 0;
         return ProcessResult::PROCESS_CONTINUE;
     }
@@ -116,7 +116,7 @@ ProcessResult effect_monster_kill_wall(CreatureEntity &creature, EffectMonster *
     }
 
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::HURT_ROCK);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::HURT_ROCK);
     }
 
     em_ptr->note = _("の皮膚がただれた！", " loses some skin!");
@@ -130,14 +130,14 @@ ProcessResult effect_monster_hand_doom(EffectMonster *em_ptr)
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
+    if (em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->dam = 0;
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    if (em_ptr->is_monster() ? ((em_ptr->caster_lev + randint1(em_ptr->dam)) > (em_ptr->r_ptr->level + 10 + randint1(20)))
-                             : (((em_ptr->caster_lev / 2) + randint1(em_ptr->dam)) > (em_ptr->r_ptr->level + randint1(200)))) {
+    if (em_ptr->is_monster() ? ((em_ptr->caster_lev + randint1(em_ptr->dam)) > (em_ptr->monrace->level + 10 + randint1(20)))
+                             : (((em_ptr->caster_lev / 2) + randint1(em_ptr->dam)) > (em_ptr->monrace->level + randint1(200)))) {
         em_ptr->dam = ((40 + randint1(20)) * em_ptr->m_ptr->hp) / 100;
         if (em_ptr->m_ptr->hp < em_ptr->dam) {
             em_ptr->dam = em_ptr->m_ptr->hp - 1;
@@ -166,12 +166,12 @@ ProcessResult effect_monster_engetsu(CreatureEntity &creature, EffectMonster *em
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->r_ptr->misc_flags.has(MonsterMiscType::EMPTY_MIND)) {
+    if (em_ptr->monrace->misc_flags.has(MonsterMiscType::EMPTY_MIND)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->dam = 0;
         em_ptr->skipped = true;
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_misc_flags.set(MonsterMiscType::EMPTY_MIND);
+            em_ptr->monrace->r_misc_flags.set(MonsterMiscType::EMPTY_MIND);
         }
         return ProcessResult::PROCESS_CONTINUE;
     }
@@ -190,13 +190,13 @@ ProcessResult effect_monster_engetsu(CreatureEntity &creature, EffectMonster *em
         }
 
         int power = 10 + randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10));
-        if (em_ptr->r_ptr->level > power) {
+        if (em_ptr->monrace->level > power) {
             continue;
         }
 
         switch (randint0(4)) {
         case 0:
-            if (em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
+            if (em_ptr->monrace->kind_flags.has_not(MonsterKindType::UNIQUE)) {
                 if (set_monster_slow(*creature.get_floor(), em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
                     em_ptr->note = _("の動きが遅くなった。", " starts moving slower.");
                 }
@@ -204,7 +204,7 @@ ProcessResult effect_monster_engetsu(CreatureEntity &creature, EffectMonster *em
             }
             break;
         case 1:
-            if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
+            if (em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE)) {
                 em_ptr->do_stun = 0;
             } else {
                 em_ptr->do_stun = Dice::roll((creature.get_level() / 10) + 3, (em_ptr->dam)) + 1;
@@ -212,10 +212,10 @@ ProcessResult effect_monster_engetsu(CreatureEntity &creature, EffectMonster *em
             }
             break;
         case 2:
-            if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) || em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
-                if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
+            if (em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE) || em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
+                if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
                     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-                        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::NO_CONF);
+                        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::NO_CONF);
                     }
                 }
                 em_ptr->do_conf = 0;
@@ -227,10 +227,10 @@ ProcessResult effect_monster_engetsu(CreatureEntity &creature, EffectMonster *em
             }
             break;
         default:
-            if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) || em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_SLEEP)) {
-                if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_SLEEP)) {
+            if (em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE) || em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_SLEEP)) {
+                if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_SLEEP)) {
                     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-                        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::NO_SLEEP);
+                        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::NO_SLEEP);
                     }
                 }
                 em_ptr->do_sleep = 0;
@@ -264,7 +264,7 @@ ProcessResult effect_monster_genocide(CreatureEntity &creature, EffectMonster *e
     }
 
     std::string_view spell_name(_("モンスター消滅", "Genocide One"));
-    if (genocide_aux(creature, em_ptr->g_ptr->m_idx, em_ptr->dam, em_ptr->is_player(), (em_ptr->r_ptr->level + 1) / 2, spell_name.data())) {
+    if (genocide_aux(creature, em_ptr->g_ptr->m_idx, em_ptr->dam, em_ptr->is_player(), (em_ptr->monrace->level + 1) / 2, spell_name.data())) {
         if (em_ptr->seen_msg) {
             msg_format(_("%sは消滅した！", "%s^ disappeared!"), em_ptr->m_name);
         }
@@ -282,13 +282,13 @@ ProcessResult effect_monster_social_genocide(CreatureEntity &creature, EffectMon
         em_ptr->obvious = true;
     }
 
-    auto &monrace = *em_ptr->r_ptr;
+    auto &monrace = *em_ptr->monrace;
 
     // 変質者モンスターには8倍弱点
     if (monrace.kind_flags.has(MonsterKindType::PERVERT)) {
         auto dam = em_ptr->dam * 8;
         std::string_view spell_name(_("社会的抹殺", "Social Genocide"));
-        if (genocide_aux(creature, em_ptr->g_ptr->m_idx, dam, em_ptr->is_player(), (em_ptr->r_ptr->level + 1) / 2, spell_name.data())) {
+        if (genocide_aux(creature, em_ptr->g_ptr->m_idx, dam, em_ptr->is_player(), (em_ptr->monrace->level + 1) / 2, spell_name.data())) {
             if (em_ptr->seen_msg) {
                 msg_format(_("%sは変質者として社会から完全に抹殺された！", "%s^ has been completely eliminated from society as a pervert!"), em_ptr->m_name);
             }
@@ -304,7 +304,7 @@ ProcessResult effect_monster_social_genocide(CreatureEntity &creature, EffectMon
     }
 
     std::string_view spell_name(_("社会的抹殺", "Social Genocide"));
-    if (genocide_aux(creature, em_ptr->g_ptr->m_idx, em_ptr->dam, em_ptr->is_player(), (em_ptr->r_ptr->level + 1) / 2, spell_name.data())) {
+    if (genocide_aux(creature, em_ptr->g_ptr->m_idx, em_ptr->dam, em_ptr->is_player(), (em_ptr->monrace->level + 1) / 2, spell_name.data())) {
         if (em_ptr->seen_msg) {
             msg_format(_("%sは社会から抹殺された！", "%s^ has been socially eliminated!"), em_ptr->m_name);
         }
@@ -322,13 +322,13 @@ ProcessResult effect_monster_photo(CreatureEntity &creature, EffectMonster *em_p
         msg_format(_("%sを写真に撮った。", "You take a photograph of %s."), em_ptr->m_name);
     }
 
-    if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::HURT_LITE)) {
+    if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::HURT_LITE)) {
         if (em_ptr->seen) {
             em_ptr->obvious = true;
         }
 
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::HURT_LITE);
+            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::HURT_LITE);
         }
 
         em_ptr->note = _("は光に身をすくめた！", " cringes from the light!");
@@ -347,7 +347,7 @@ ProcessResult effect_monster_wounds(EffectMonster *em_ptr)
         em_ptr->obvious = true;
     }
 
-    if (randint0(100 + em_ptr->dam) < (em_ptr->r_ptr->level + 50)) {
+    if (randint0(100 + em_ptr->dam) < (em_ptr->monrace->level + 50)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->dam = 0;
     }

--- a/src/effect/effect-monster-util.cpp
+++ b/src/effect/effect-monster-util.cpp
@@ -41,9 +41,9 @@ EffectMonster::EffectMonster(CreatureEntity &creature, MONSTER_IDX src_idx, POSI
 {
     auto &floor = *creature.get_floor();
     this->g_ptr = &floor.grid_array[this->y][this->x];
-    this->m_ptr = &floor.get_monster(this->g_ptr->m_idx);
-    this->m_caster_ptr = this->is_monster() ? &floor.get_monster(this->src_idx) : nullptr;
-    this->r_ptr = &this->m_ptr->get_monrace();
+    this->m_ptr = &floor.m_list[this->g_ptr->m_idx];
+    this->m_caster_ptr = this->is_monster() ? &floor.m_list[this->src_idx] : nullptr;
+    this->monrace = this->m_ptr->get_monrace_shared();
     this->seen = this->m_ptr->is_visible_on_map();
     this->seen_msg = is_seen(creature, *this->m_ptr);
     this->slept = this->m_ptr->is_asleep();

--- a/src/effect/effect-monster-util.h
+++ b/src/effect/effect-monster-util.h
@@ -3,6 +3,7 @@
 #include "system/angband.h"
 #include "system/creature-entity.h"
 #include "util/point-2d.h"
+#include <memory>
 #include <string>
 
 enum class AttributeType;
@@ -41,7 +42,7 @@ public:
     Grid *g_ptr;
     CreatureEntity *m_ptr;
     CreatureEntity *m_caster_ptr;
-    MonraceDefinition *r_ptr;
+    std::shared_ptr<MonraceDefinition> monrace;
     bool seen;
     bool seen_msg;
     bool slept;

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -145,7 +145,7 @@ static ProcessResult exe_affect_monster_by_effect(CreatureEntity &creature, Effe
         return result;
     }
 
-    bool do_effect = em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_ALL);
+    bool do_effect = em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_ALL);
     do_effect |= std::any_of(effect_arrtibute.cbegin(), effect_arrtibute.cend(), check);
 
     if (do_effect) {
@@ -156,14 +156,14 @@ static ProcessResult exe_affect_monster_by_effect(CreatureEntity &creature, Effe
     ignore_res_all |= (em_ptr->attribute == AttributeType::MONSTER_MELEE);
     ignore_res_all |= (em_ptr->attribute == AttributeType::MONSTER_SHOOT);
 
-    if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_ALL) && ignore_res_all) {
+    if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_ALL) && ignore_res_all) {
         return switch_effects_monster(creature, em_ptr);
     }
 
     em_ptr->note = _("には完全な耐性がある！", " is immune.");
     em_ptr->dam = 0;
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_ALL);
+        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_ALL);
     }
 
     if (em_ptr->attribute == AttributeType::LITE_WEAK || em_ptr->attribute == AttributeType::KILL_WALL) {
@@ -368,10 +368,10 @@ static void effect_makes_change_virtues(CreatureEntity &creature, EffectMonster 
         return;
     }
 
-    if (em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::EVIL) || one_in_(5)) {
+    if (em_ptr->monrace->kind_flags.has_not(MonsterKindType::EVIL) || one_in_(5)) {
         chg_virtue(creature, Virtue::COMPASSION, -1);
     }
-    if (em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::EVIL) || one_in_(5)) {
+    if (em_ptr->monrace->kind_flags.has_not(MonsterKindType::EVIL) || one_in_(5)) {
         chg_virtue(creature, Virtue::HONOUR, -1);
     }
 }
@@ -383,7 +383,7 @@ static void effect_makes_change_virtues(CreatureEntity &creature, EffectMonster 
  */
 static void affected_monster_prevents_bad_status(EffectMonster *em_ptr)
 {
-    const auto &monrace = *em_ptr->r_ptr;
+    const auto &monrace = *em_ptr->monrace;
     auto can_avoid_polymorph = monrace.kind_flags.has(MonsterKindType::UNIQUE);
     can_avoid_polymorph |= monrace.misc_flags.has(MonsterMiscType::QUESTOR);
     can_avoid_polymorph |= em_ptr->m_ptr->is_riding();
@@ -407,7 +407,7 @@ static void affected_monster_prevents_bad_status(EffectMonster *em_ptr)
  */
 static void effect_damage_piles_stun(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    const auto &monrace = *em_ptr->r_ptr;
+    const auto &monrace = *em_ptr->monrace;
     auto can_avoid_stun = em_ptr->do_stun == 0;
     can_avoid_stun |= monrace.resistance_flags.has(MonsterResistanceType::NO_STUN);
     if (can_avoid_stun) {
@@ -439,7 +439,7 @@ static void effect_damage_piles_stun(CreatureEntity &creature, EffectMonster *em
  */
 static void effect_damage_piles_confusion(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if ((em_ptr->do_conf == 0) || (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_CONF))) {
+    if ((em_ptr->do_conf == 0) || (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF))) {
         return;
     }
 
@@ -470,8 +470,7 @@ static void effect_damage_piles_confusion(CreatureEntity &creature, EffectMonste
  */
 static void effect_damage_piles_fear(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (em_ptr->do_fear == 0 || em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_FEAR) ||
-        em_ptr->m_ptr->is_frenzied()) {
+    if (em_ptr->do_fear == 0 || em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_FEAR)) {
         return;
     }
 
@@ -515,7 +514,7 @@ static void effect_damage_makes_weak(EffectMonster *em_ptr)
  */
 static void effect_damage_makes_polymorph(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (!em_ptr->do_polymorph || (randint1(90) <= em_ptr->r_ptr->level)) {
+    if (!em_ptr->do_polymorph || (randint1(90) <= em_ptr->monrace->level)) {
         return;
     }
 
@@ -528,8 +527,8 @@ static void effect_damage_makes_polymorph(CreatureEntity &creature, EffectMonste
         em_ptr->dam = 0;
     }
 
-    em_ptr->m_ptr = &creature.get_floor()->get_monster(em_ptr->g_ptr->m_idx);
-    em_ptr->r_ptr = &em_ptr->m_ptr->get_monrace();
+    em_ptr->m_ptr = &creature.get_floor()->m_list[em_ptr->g_ptr->m_idx];
+    em_ptr->monrace = em_ptr->m_ptr->get_monrace_shared();
 }
 
 /*!

--- a/src/info-reader/vault-reader.cpp
+++ b/src/info-reader/vault-reader.cpp
@@ -87,7 +87,7 @@ errr parse_vaults_info(std::string_view buf, angband_header *)
                 if (s_tokens.size() == 2 && s_tokens[0] == "MONSTER") {
                     const auto &monraces = MonraceList::get_instance();
                     for (const auto &[r_idx, r_ref] : monraces) {
-                        if (s_tokens[1] == r_ref.tag) {
+                        if (s_tokens[1] == r_ref->tag) {
                             v_ptr->place_monster_list[c] = r_idx;
                             break;
                         }

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -299,23 +299,23 @@ static void dump_aux_monsters(FILE *fff)
     auto norm_total = 0;
     for (const auto &[monrace_id, monrace] : monraces) {
         /* Ignore unused index */
-        if (!monrace.is_valid()) {
+        if (!monrace->is_valid()) {
             continue;
         }
 
-        if (monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
-            if (monrace.is_dead_unique()) {
+        if (monrace->kind_flags.has(MonsterKindType::UNIQUE)) {
+            if (monrace->is_dead_unique()) {
                 norm_total++;
 
                 /* Add a unique monster to the list */
-                monrace_ids.push_back(monrace.idx);
+                monrace_ids.push_back(monrace->idx);
             }
 
             continue;
         }
 
-        if (monrace.r_pkills > 0) {
-            norm_total += monrace.r_pkills;
+        if (monrace->r_pkills > 0) {
+            norm_total += monrace->r_pkills;
         }
     }
 

--- a/src/knowledge/knowledge-alliance.cpp
+++ b/src/knowledge/knowledge-alliance.cpp
@@ -46,20 +46,20 @@ void do_cmd_knowledge_alliance(CreatureEntity &creature, bool detail)
             }
 
             for (auto &[r_idx, r_ref] : MonraceList::get_instance()) {
-                if (r_ref.alliance_idx == a.second->id) {
-                    fprintf(fff, _("%s  %-40s レベル %3d 評価値 %9d", "%s  %-40s LEVEL %3d POW %9d"), r_ref.kind_flags.has(MonsterKindType::UNIQUE) ? "[U]" : "---", r_ref.name.data(), r_ref.level, monraces.get_monrace(r_idx).calc_power());
-                    if (r_ref.kind_flags.has_not(MonsterKindType::UNIQUE)) {
-                        if (r_ref.mob_num > 0) {
-                            fprintf(fff, "x %d\n", r_ref.mob_num);
+                if (r_ref->alliance_idx == a.second->id) {
+                    fprintf(fff, _("%s  %-40s レベル %3d 評価値 %9d", "%s  %-40s LEVEL %3d POW %9d"), r_ref->kind_flags.has(MonsterKindType::UNIQUE) ? "[U]" : "---", r_ref->name.data(), r_ref->level, monraces.get_monrace(r_idx).calc_power());
+                    if (r_ref->kind_flags.has_not(MonsterKindType::UNIQUE)) {
+                        if (r_ref->mob_num > 0) {
+                            fprintf(fff, "x %d\n", r_ref->mob_num);
                         } else {
-                            if (r_ref.max_num > 0) {
+                            if (r_ref->max_num > 0) {
                                 fprintf(fff, _(" 全滅\n", " Wiped\n"));
                             } else {
                                 fprintf(fff, _(" ----\n", " ----\n"));
                             }
                         }
                     } else {
-                        if (r_ref.mob_num > 0) {
+                        if (r_ref->mob_num > 0) {
                             fprintf(fff, _(" 生存\n", " Survived\n"));
                         } else {
                             fprintf(fff, _(" 死亡\n", " Dead\n"));

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -65,71 +65,71 @@ static std::vector<MonraceId> collect_monsters(short grp_cur, monster_lore_mode 
     const auto &monraces = MonraceList::get_instance();
     std::vector<MonraceId> monrace_ids;
     for (const auto &[monrace_id, monrace] : monraces) {
-        if (((mode != MONSTER_LORE_DEBUG) && (mode != MONSTER_LORE_RESEARCH)) && !cheat_know && !monrace.r_sights) {
+        if (((mode != MONSTER_LORE_DEBUG) && (mode != MONSTER_LORE_RESEARCH)) && !cheat_know && !monrace->r_sights) {
             continue;
         }
 
         if (grp_unique) {
-            if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {
+            if (monrace->kind_flags.has_not(MonsterKindType::UNIQUE)) {
                 continue;
             }
         } else if (grp_riding) {
-            if (monrace.misc_flags.has_not(MonsterMiscType::RIDING)) {
+            if (monrace->misc_flags.has_not(MonsterMiscType::RIDING)) {
                 continue;
             }
         } else if (grp_wanted) {
             const auto &world = AngbandWorld::get_instance();
             auto wanted = world.knows_daily_bounty && (world.today_mon == monrace_id);
-            wanted |= monrace.is_bounty(false);
+            wanted |= monrace->is_bounty(false);
             if (!wanted) {
                 continue;
             }
         } else if (grp_amberite) {
-            if (monrace.kind_flags.has_not(MonsterKindType::AMBERITE)) {
+            if (monrace->kind_flags.has_not(MonsterKindType::AMBERITE)) {
                 continue;
             }
         } else if (grp_chaosian) {
-            if (monrace.kind_flags.has_not(MonsterKindType::CHOASIAN)) {
+            if (monrace->kind_flags.has_not(MonsterKindType::CHOASIAN)) {
                 continue;
             }
         } else if (grp_skeleton) {
-            if (monrace.kind_flags.has_not(MonsterKindType::SKELETON)) {
+            if (monrace->kind_flags.has_not(MonsterKindType::SKELETON)) {
                 continue;
             }
         } else if (grp_zombie) {
-            if (monrace.kind_flags.has_not(MonsterKindType::ZOMBIE)) {
+            if (monrace->kind_flags.has_not(MonsterKindType::ZOMBIE)) {
                 continue;
             }
         } else if (grp_cancer) {
-            if (monrace.kind_flags.has_not(MonsterKindType::CANCER)) {
+            if (monrace->kind_flags.has_not(MonsterKindType::CANCER)) {
                 continue;
             }
         } else if (grp_fungas) {
-            if (monrace.kind_flags.has_not(MonsterKindType::FUNGAS)) {
+            if (monrace->kind_flags.has_not(MonsterKindType::FUNGAS)) {
                 continue;
             }
         } else if (grp_turtle) {
-            if (monrace.kind_flags.has_not(MonsterKindType::TURTLE)) {
+            if (monrace->kind_flags.has_not(MonsterKindType::TURTLE)) {
                 continue;
             }
         } else if (grp_mimic) {
-            if (monrace.kind_flags.has_not(MonsterKindType::MIMIC)) {
+            if (monrace->kind_flags.has_not(MonsterKindType::MIMIC)) {
                 continue;
             }
         } else if (grp_ixitxachitl) {
-            if (monrace.kind_flags.has_not(MonsterKindType::IXITXACHITL)) {
+            if (monrace->kind_flags.has_not(MonsterKindType::IXITXACHITL)) {
                 continue;
             }
         } else if (grp_naga) {
-            if (monrace.kind_flags.has_not(MonsterKindType::NAGA)) {
+            if (monrace->kind_flags.has_not(MonsterKindType::NAGA)) {
                 continue;
             }
         } else if (grp_pervert) {
-            if (monrace.kind_flags.has_not(MonsterKindType::PERVERT)) {
+            if (monrace->kind_flags.has_not(MonsterKindType::PERVERT)) {
                 continue;
             }
         } else {
-            if (angband_strchr(group_char.data(), monrace.symbol_definition.character) == nullptr) {
+            if (angband_strchr(group_char.data(), monrace->symbol_definition.character) == nullptr) {
                 continue;
             }
         }

--- a/src/knowledge/knowledge-uniques.cpp
+++ b/src/knowledge/knowledge-uniques.cpp
@@ -36,17 +36,17 @@ void UniqueList::sweep()
 {
     auto &monraces = MonraceList::get_instance();
     for (auto &[monrace_id, monrace] : monraces) {
-        if (!monrace.is_valid() || !monrace.should_display(this->is_alive)) {
+        if (!monrace->is_valid() || !monrace->should_display(this->is_alive)) {
             continue;
         }
 
-        if (!monrace.level) {
+        if (!monrace->level) {
             this->num_uniques_surface++;
             this->monrace_ids.push_back(monrace_id);
             continue;
         }
 
-        const auto lev = (monrace.level - 1) / 10;
+        const auto lev = (monrace->level - 1) / 10;
         if (lev >= 10) {
             this->num_uniques_over100++;
             this->monrace_ids.push_back(monrace_id);

--- a/src/lore/combat-types-setter.cpp
+++ b/src/lore/combat-types-setter.cpp
@@ -7,7 +7,7 @@
 
 void set_monster_blow_method(lore_type *lore_ptr, int m)
 {
-    RaceBlowMethodType method = lore_ptr->r_ptr->blows[m].method;
+    RaceBlowMethodType method = lore_ptr->monrace->blows[m].method;
     lore_ptr->p = nullptr;
     lore_ptr->pc = TERM_WHITE;
     switch (method) {
@@ -137,7 +137,7 @@ void set_monster_blow_method(lore_type *lore_ptr, int m)
 
 void set_monster_blow_effect(lore_type *lore_ptr, int m)
 {
-    RaceBlowEffectType effect = lore_ptr->r_ptr->blows[m].effect;
+    RaceBlowEffectType effect = lore_ptr->monrace->blows[m].effect;
     lore_ptr->q = nullptr;
     lore_ptr->qc = TERM_WHITE;
     switch (effect) {

--- a/src/lore/lore-calculator.cpp
+++ b/src/lore/lore-calculator.cpp
@@ -90,25 +90,22 @@ void set_flags_for_full_knowledge(lore_type *lore_ptr)
         return;
     }
 
-    lore_ptr->drop_gold = lore_ptr->drop_item = ((lore_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_4D2) ? 8 : 0) + (lore_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_3D2) ? 6 : 0) + (lore_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_2D2) ? 4 : 0) + (lore_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_1D2) ? 2 : 0) + (lore_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_90) ? 1 : 0) + (lore_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_60) ? 1 : 0));
+    lore_ptr->drop_gold = lore_ptr->drop_item = ((lore_ptr->monrace->drop_flags.has(MonsterDropType::DROP_4D2) ? 8 : 0) + (lore_ptr->monrace->drop_flags.has(MonsterDropType::DROP_3D2) ? 6 : 0) + (lore_ptr->monrace->drop_flags.has(MonsterDropType::DROP_2D2) ? 4 : 0) + (lore_ptr->monrace->drop_flags.has(MonsterDropType::DROP_1D2) ? 2 : 0) + (lore_ptr->monrace->drop_flags.has(MonsterDropType::DROP_90) ? 1 : 0) + (lore_ptr->monrace->drop_flags.has(MonsterDropType::DROP_60) ? 1 : 0));
 
-    if (lore_ptr->r_ptr->drop_flags.has(MonsterDropType::ONLY_GOLD)) {
+    if (lore_ptr->monrace->drop_flags.has(MonsterDropType::ONLY_GOLD)) {
         lore_ptr->drop_item = 0;
     }
 
-    if (lore_ptr->r_ptr->drop_flags.has(MonsterDropType::ONLY_ITEM)) {
+    if (lore_ptr->monrace->drop_flags.has(MonsterDropType::ONLY_ITEM)) {
         lore_ptr->drop_gold = 0;
     }
 
-    lore_ptr->ability_flags = lore_ptr->r_ptr->ability_flags;
-    lore_ptr->aura_flags = lore_ptr->r_ptr->aura_flags;
-    lore_ptr->behavior_flags = lore_ptr->r_ptr->behavior_flags;
-    lore_ptr->visual_flags = lore_ptr->r_ptr->visual_flags;
-    lore_ptr->kind_flags = lore_ptr->r_ptr->kind_flags;
-    lore_ptr->era_flags = lore_ptr->r_ptr->era_flags;
-    lore_ptr->resistance_flags = lore_ptr->r_ptr->resistance_flags;
-    lore_ptr->feature_flags = lore_ptr->r_ptr->feature_flags;
-    lore_ptr->drop_flags = lore_ptr->r_ptr->drop_flags;
-    lore_ptr->special_flags = lore_ptr->r_ptr->special_flags;
-    lore_ptr->misc_flags = lore_ptr->r_ptr->misc_flags;
+    lore_ptr->ability_flags = lore_ptr->monrace->ability_flags;
+    lore_ptr->aura_flags = lore_ptr->monrace->aura_flags;
+    lore_ptr->behavior_flags = lore_ptr->monrace->behavior_flags;
+    lore_ptr->resistance_flags = lore_ptr->monrace->resistance_flags;
+    lore_ptr->feature_flags = lore_ptr->monrace->feature_flags;
+    lore_ptr->drop_flags = lore_ptr->monrace->drop_flags;
+    lore_ptr->special_flags = lore_ptr->monrace->special_flags;
+    lore_ptr->misc_flags = lore_ptr->monrace->misc_flags;
 }

--- a/src/lore/lore-util.cpp
+++ b/src/lore/lore-util.cpp
@@ -43,27 +43,24 @@ lore_type::lore_type(MonraceId monrace_id, monster_lore_mode mode)
     , method(RaceBlowMethodType::NONE)
 {
     this->nightmare = ironman_nightmare && (mode != MONSTER_LORE_DEBUG);
-    this->r_ptr = &MonraceList::get_instance().get_monrace(monrace_id);
-    this->speed = this->nightmare ? this->r_ptr->speed + 5 : this->r_ptr->speed;
-    this->drop_gold = this->r_ptr->r_drop_gold;
-    this->drop_item = this->r_ptr->r_drop_item;
-    this->ability_flags = (this->r_ptr->ability_flags & this->r_ptr->r_ability_flags);
-    this->aura_flags = (this->r_ptr->aura_flags & this->r_ptr->r_aura_flags);
-    this->behavior_flags = (this->r_ptr->behavior_flags & this->r_ptr->r_behavior_flags);
-    this->visual_flags = this->r_ptr->visual_flags;
-    this->kind_flags = (this->r_ptr->kind_flags & this->r_ptr->r_kind_flags);
-    this->era_flags = (this->r_ptr->era_flags & this->r_ptr->r_era_flags);
-    this->drop_flags = (this->r_ptr->drop_flags & this->r_ptr->r_drop_flags);
-    this->resistance_flags = (this->r_ptr->resistance_flags & this->r_ptr->r_resistance_flags);
-    this->feature_flags = (this->r_ptr->feature_flags & this->r_ptr->r_feature_flags);
-    this->brightness_flags = this->r_ptr->brightness_flags;
-    this->special_flags = (this->r_ptr->special_flags & this->r_ptr->r_special_flags);
-    this->misc_flags = (this->r_ptr->misc_flags & this->r_ptr->r_misc_flags);
+    this->monrace = MonraceList::get_instance().get_monrace_shared(monrace_id);
+    this->speed = this->nightmare ? this->monrace->speed + 5 : this->monrace->speed;
+    this->drop_gold = this->monrace->r_drop_gold;
+    this->drop_item = this->monrace->r_drop_item;
+    this->ability_flags = (this->monrace->ability_flags & this->monrace->r_ability_flags);
+    this->aura_flags = (this->monrace->aura_flags & this->monrace->r_aura_flags);
+    this->behavior_flags = (this->monrace->behavior_flags & this->monrace->r_behavior_flags);
+    this->drop_flags = (this->monrace->drop_flags & this->monrace->r_drop_flags);
+    this->resistance_flags = (this->monrace->resistance_flags & this->monrace->r_resistance_flags);
+    this->feature_flags = (this->monrace->feature_flags & this->monrace->r_feature_flags);
+    this->brightness_flags = this->monrace->brightness_flags;
+    this->special_flags = (this->monrace->special_flags & this->monrace->r_special_flags);
+    this->misc_flags = (this->monrace->misc_flags & this->monrace->r_misc_flags);
 }
 
 bool lore_type::has_reinforce() const
 {
-    return this->r_ptr->has_reinforce();
+    return this->monrace->has_reinforce();
 }
 
 bool lore_type::is_details_known() const
@@ -184,10 +181,10 @@ tl::optional<std::vector<lore_msg>> lore_type::build_kill_unique_description() c
     }
 
     std::vector<lore_msg> texts;
-    const auto is_dead = this->r_ptr->is_dead_unique();
-    if (this->r_ptr->r_deaths > 0) {
+    const auto is_dead = this->monrace->is_dead_unique();
+    if (this->monrace->r_deaths > 0) {
         constexpr auto fmt = _("%s^はあなたの先祖を %d 人葬っている", "%s^ has slain %d of your ancestors");
-        texts.emplace_back(format(fmt, Who::who(this->msex).data(), this->r_ptr->r_deaths));
+        texts.emplace_back(format(fmt, Who::who(this->msex).data(), this->monrace->r_deaths));
         texts.emplace_back(this->build_revenge_description(is_dead));
         texts.emplace_back("\n");
     } else {
@@ -209,11 +206,11 @@ std::string lore_type::build_revenge_description(bool has_defeated) const
     return has_defeated ? "が、すでに仇討ちは果たしている！" : "のに、まだ仇討ちを果たしていない。";
 #else
     if (has_defeated) {
-        return format(", but you have avenged %s!  ", Who::whom(this->msex, this->r_ptr->r_deaths == 1).data());
+        return format(", but you have avenged %s!  ", Who::whom(this->msex, this->monrace->r_deaths == 1).data());
     }
 
     std::stringstream ss;
-    ss << ", who remain" << (this->r_ptr->r_deaths != 1 ? "" : "s") << " unavenged.  ";
+    ss << ", who remain" << (this->monrace->r_deaths != 1 ? "" : "s") << " unavenged.  ";
     return ss.str();
 #endif
 }

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -16,6 +16,7 @@
 #include "system/angband.h"
 #include "term/term-color-types.h"
 #include "util/flag-group.h"
+#include <memory>
 #include <string>
 #include <string_view>
 #include <tl/optional.hpp>
@@ -68,7 +69,7 @@ struct lore_type {
     RaceBlowMethodType method;
 
     bool nightmare;
-    MonraceDefinition *r_ptr;
+    std::shared_ptr<MonraceDefinition> monrace;
     byte speed;
     ITEM_NUMBER drop_gold;
     ITEM_NUMBER drop_item;

--- a/src/lore/magic-types-setter.cpp
+++ b/src/lore/magic-types-setter.cpp
@@ -353,7 +353,7 @@ void set_teleport_types(lore_type *lore_ptr)
 void set_floor_types(CreatureEntity &creature, lore_type *lore_ptr)
 {
     if (lore_ptr->ability_flags.has(MonsterAbilityType::DARKNESS)) {
-        if (!CreatureClass(creature).equals(PlayerClassType::NINJA) || lore_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNDEAD) || lore_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::HURT_LITE) || (lore_ptr->r_ptr->brightness_flags.has_any_of(dark_mask))) {
+        if (!CreatureClass(creature).equals(PlayerClassType::NINJA) || lore_ptr->monrace->kind_flags.has_not(MonsterKindType::UNDEAD) || lore_ptr->monrace->resistance_flags.has(MonsterResistanceType::HURT_LITE) || (lore_ptr->monrace->brightness_flags.has_any_of(dark_mask))) {
             lore_ptr->lore_msgs.emplace_back(_("暗闇", "create darkness"), TERM_L_DARK);
         } else {
             lore_ptr->lore_msgs.emplace_back(_("閃光", "create light"), TERM_YELLOW);

--- a/src/lore/monster-lore.cpp
+++ b/src/lore/monster-lore.cpp
@@ -27,546 +27,330 @@
 static void set_msex_flags(lore_type *lore_ptr)
 {
     lore_ptr->msex = MonsterSex::NONE;
-    if (lore_ptr->r_ptr->is_male()) {
+    if (lore_ptr->monrace->is_male()) {
         lore_ptr->msex = MonsterSex::MALE;
     }
-    if (lore_ptr->r_ptr->is_female()) {
+    if (lore_ptr->monrace->is_female()) {
         lore_ptr->msex = MonsterSex::FEMALE;
     }
 }
 
 static void set_flags1(lore_type *lore_ptr)
 {
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE)) {
         lore_ptr->kind_flags.set(MonsterKindType::UNIQUE);
     }
 
-    if (lore_ptr->r_ptr->misc_flags.has(MonsterMiscType::QUESTOR)) {
+    if (lore_ptr->monrace->misc_flags.has(MonsterMiscType::QUESTOR)) {
         lore_ptr->misc_flags.set(MonsterMiscType::QUESTOR);
     }
 
-    if (lore_ptr->r_ptr->misc_flags.has(MonsterMiscType::HAS_FRIENDS)) {
+    if (lore_ptr->monrace->misc_flags.has(MonsterMiscType::HAS_FRIENDS)) {
         lore_ptr->misc_flags.set(MonsterMiscType::HAS_FRIENDS);
     }
 
-    if (lore_ptr->r_ptr->misc_flags.has(MonsterMiscType::ESCORT)) {
+    if (lore_ptr->monrace->misc_flags.has(MonsterMiscType::ESCORT)) {
         lore_ptr->misc_flags.set(MonsterMiscType::ESCORT);
     }
 
-    if (lore_ptr->r_ptr->misc_flags.has(MonsterMiscType::MORE_ESCORT)) {
+    if (lore_ptr->monrace->misc_flags.has(MonsterMiscType::MORE_ESCORT)) {
         lore_ptr->misc_flags.set(MonsterMiscType::MORE_ESCORT);
     }
 }
 
 static void set_race_flags(lore_type *lore_ptr)
 {
-    if (!lore_ptr->r_ptr->r_tkills && !lore_ptr->know_everything) {
+    if (!lore_ptr->monrace->r_tkills && !lore_ptr->know_everything) {
         return;
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::ORC)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::ORC)) {
         lore_ptr->kind_flags.set(MonsterKindType::ORC);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::TROLL)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::TROLL)) {
         lore_ptr->kind_flags.set(MonsterKindType::TROLL);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::GIANT)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::GIANT)) {
         lore_ptr->kind_flags.set(MonsterKindType::GIANT);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::DRAGON)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::DRAGON)) {
         lore_ptr->kind_flags.set(MonsterKindType::DRAGON);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::DEMON)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::DEMON)) {
         lore_ptr->kind_flags.set(MonsterKindType::DEMON);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::UNDEAD)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::UNDEAD)) {
         lore_ptr->kind_flags.set(MonsterKindType::UNDEAD);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::SKELETON)) {
-        lore_ptr->kind_flags.set(MonsterKindType::SKELETON);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::CANCER)) {
-        lore_ptr->kind_flags.set(MonsterKindType::CANCER);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::FUNGAS)) {
-        lore_ptr->kind_flags.set(MonsterKindType::FUNGAS);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::TURTLE)) {
-        lore_ptr->kind_flags.set(MonsterKindType::TURTLE);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::MIMIC)) {
-        lore_ptr->kind_flags.set(MonsterKindType::MIMIC);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::IXITXACHITL)) {
-        lore_ptr->kind_flags.set(MonsterKindType::IXITXACHITL);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::NAGA)) {
-        lore_ptr->kind_flags.set(MonsterKindType::NAGA);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::PERVERT)) {
-        lore_ptr->kind_flags.set(MonsterKindType::PERVERT);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::EVIL)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::EVIL)) {
         lore_ptr->kind_flags.set(MonsterKindType::EVIL);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::GOOD)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::GOOD)) {
         lore_ptr->kind_flags.set(MonsterKindType::GOOD);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::ANIMAL)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::ANIMAL)) {
         lore_ptr->kind_flags.set(MonsterKindType::ANIMAL);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::AMBERITE)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::AMBERITE)) {
         lore_ptr->kind_flags.set(MonsterKindType::AMBERITE);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::HUMAN)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::HUMAN)) {
         lore_ptr->kind_flags.set(MonsterKindType::HUMAN);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::QUANTUM)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::QUANTUM)) {
         lore_ptr->kind_flags.set(MonsterKindType::QUANTUM);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::MONKEY_SPACE)) {
-        lore_ptr->kind_flags.set(MonsterKindType::MONKEY_SPACE);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::ELF)) {
-        lore_ptr->kind_flags.set(MonsterKindType::ELF);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::DWARF)) {
-        lore_ptr->kind_flags.set(MonsterKindType::DWARF);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::HOBBIT)) {
-        lore_ptr->kind_flags.set(MonsterKindType::HOBBIT);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::ELDRAZI)) {
-        lore_ptr->kind_flags.set(MonsterKindType::ELDRAZI);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::QUYLTHLUG)) {
-        lore_ptr->kind_flags.set(MonsterKindType::QUYLTHLUG);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::SPIDER)) {
-        lore_ptr->kind_flags.set(MonsterKindType::SPIDER);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::ROBOT)) {
-        lore_ptr->kind_flags.set(MonsterKindType::ROBOT);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::WARRIOR)) {
-        lore_ptr->kind_flags.set(MonsterKindType::WARRIOR);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::SOLDIER)) {
-        lore_ptr->kind_flags.set(MonsterKindType::SOLDIER);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::ROGUE)) {
-        lore_ptr->kind_flags.set(MonsterKindType::ROGUE);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::MAGE)) {
-        lore_ptr->kind_flags.set(MonsterKindType::MAGE);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::PRIEST)) {
-        lore_ptr->kind_flags.set(MonsterKindType::PRIEST);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::PALADIN)) {
-        lore_ptr->kind_flags.set(MonsterKindType::PALADIN);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::RANGER)) {
-        lore_ptr->kind_flags.set(MonsterKindType::RANGER);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::GRANDMA)) {
-        lore_ptr->kind_flags.set(MonsterKindType::GRANDMA);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::WEREWOLF)) {
-        lore_ptr->kind_flags.set(MonsterKindType::WEREWOLF);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::SAMURAI)) {
-        lore_ptr->kind_flags.set(MonsterKindType::SAMURAI);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::PAPER)) {
-        lore_ptr->kind_flags.set(MonsterKindType::PAPER);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::WOODEN)) {
-        lore_ptr->kind_flags.set(MonsterKindType::WOODEN);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::IRON)) {
-        lore_ptr->kind_flags.set(MonsterKindType::IRON);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::COPPER)) {
-        lore_ptr->kind_flags.set(MonsterKindType::COPPER);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::STONE)) {
-        lore_ptr->kind_flags.set(MonsterKindType::STONE);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::SILVER)) {
-        lore_ptr->kind_flags.set(MonsterKindType::SILVER);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::GOLD)) {
-        lore_ptr->kind_flags.set(MonsterKindType::GOLD);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::MITHRIL)) {
-        lore_ptr->kind_flags.set(MonsterKindType::MITHRIL);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::ADAMANTITE)) {
-        lore_ptr->kind_flags.set(MonsterKindType::ADAMANTITE);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::FECES)) {
-        lore_ptr->kind_flags.set(MonsterKindType::FECES);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::FLESH)) {
-        lore_ptr->kind_flags.set(MonsterKindType::FLESH);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::DARKSTEEL)) {
-        lore_ptr->kind_flags.set(MonsterKindType::DARKSTEEL);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::WARPSTONE)) {
-        lore_ptr->kind_flags.set(MonsterKindType::WARPSTONE);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::NINJA)) {
-        lore_ptr->kind_flags.set(MonsterKindType::NINJA);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::SUMOU_WRESTLER)) {
-        lore_ptr->kind_flags.set(MonsterKindType::SUMOU_WRESTLER);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::YAKUZA)) {
-        lore_ptr->kind_flags.set(MonsterKindType::YAKUZA);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::KARATEKA)) {
-        lore_ptr->kind_flags.set(MonsterKindType::KARATEKA);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::JOKE)) {
-        lore_ptr->kind_flags.set(MonsterKindType::JOKE);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::NASTY)) {
-        lore_ptr->kind_flags.set(MonsterKindType::NASTY);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::TANK)) {
-        lore_ptr->kind_flags.set(MonsterKindType::TANK);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::HENTAI)) {
-        lore_ptr->kind_flags.set(MonsterKindType::HENTAI);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::ELEMENTAL)) {
-        lore_ptr->kind_flags.set(MonsterKindType::ELEMENTAL);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::GOLEM)) {
-        lore_ptr->kind_flags.set(MonsterKindType::GOLEM);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::PUYO)) {
-        lore_ptr->kind_flags.set(MonsterKindType::PUYO);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::INSECT)) {
-        lore_ptr->kind_flags.set(MonsterKindType::INSECT);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::ANGEL)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::ANGEL)) {
         lore_ptr->kind_flags.set(MonsterKindType::ANGEL);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::SLUG)) {
-        lore_ptr->kind_flags.set(MonsterKindType::SLUG);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::EYE)) {
-        lore_ptr->kind_flags.set(MonsterKindType::EYE);
-    }
-
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::ALIEN)) {
-        lore_ptr->kind_flags.set(MonsterKindType::ALIEN);
-    }
-
-    if (lore_ptr->r_ptr->misc_flags.has(MonsterMiscType::FORCE_DEPTH)) {
+    if (lore_ptr->monrace->misc_flags.has(MonsterMiscType::FORCE_DEPTH)) {
         lore_ptr->misc_flags.set(MonsterMiscType::FORCE_DEPTH);
     }
 
-    if (lore_ptr->r_ptr->misc_flags.has(MonsterMiscType::FORCE_MAXHP)) {
+    if (lore_ptr->monrace->misc_flags.has(MonsterMiscType::FORCE_MAXHP)) {
         lore_ptr->misc_flags.set(MonsterMiscType::FORCE_MAXHP);
     }
 
-    if (lore_ptr->r_ptr->misc_flags.has(MonsterMiscType::STALKER)) {
+    if (lore_ptr->monrace->misc_flags.has(MonsterMiscType::STALKER)) {
         lore_ptr->misc_flags.set(MonsterMiscType::STALKER);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::YAZYU)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::YAZYU)) {
         lore_ptr->kind_flags.set(MonsterKindType::YAZYU);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::DOG)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::DOG)) {
         lore_ptr->kind_flags.set(MonsterKindType::DOG);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::CAT)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::CAT)) {
         lore_ptr->kind_flags.set(MonsterKindType::CAT);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::RABBIT)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::RABBIT)) {
         lore_ptr->kind_flags.set(MonsterKindType::RABBIT);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::PEASANT)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::PEASANT)) {
         lore_ptr->kind_flags.set(MonsterKindType::PEASANT);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::RABBLE)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::RABBLE)) {
         lore_ptr->kind_flags.set(MonsterKindType::RABBLE);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::NOBLE)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::NOBLE)) {
         lore_ptr->kind_flags.set(MonsterKindType::NOBLE);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::BEAST)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::BEAST)) {
         lore_ptr->kind_flags.set(MonsterKindType::BEAST);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::LEECH)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::LEECH)) {
         lore_ptr->kind_flags.set(MonsterKindType::LEECH);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::JELLYFISH)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::JELLYFISH)) {
         lore_ptr->kind_flags.set(MonsterKindType::JELLYFISH);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::CITIZEN)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::CITIZEN)) {
         lore_ptr->kind_flags.set(MonsterKindType::CITIZEN);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::TREEFOLK)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::TREEFOLK)) {
         lore_ptr->kind_flags.set(MonsterKindType::TREEFOLK);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::VIRUS)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::VIRUS)) {
         lore_ptr->kind_flags.set(MonsterKindType::VIRUS);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::SPHINX)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::SPHINX)) {
         lore_ptr->kind_flags.set(MonsterKindType::SPHINX);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::SCORPION)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::SCORPION)) {
         lore_ptr->kind_flags.set(MonsterKindType::SCORPION);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::MINDCRAFTER)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::MINDCRAFTER)) {
         lore_ptr->kind_flags.set(MonsterKindType::MINDCRAFTER);
     }
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::TANUKI)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::TANUKI)) {
         lore_ptr->kind_flags.set(MonsterKindType::TANUKI);
     }
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::CHAMELEON)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::CHAMELEON)) {
         lore_ptr->kind_flags.set(MonsterKindType::CHAMELEON);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::ARCHER)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::ARCHER)) {
         lore_ptr->kind_flags.set(MonsterKindType::ARCHER);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::GUNNER)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::GUNNER)) {
         lore_ptr->kind_flags.set(MonsterKindType::GUNNER);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::SMITH)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::SMITH)) {
         lore_ptr->kind_flags.set(MonsterKindType::SMITH);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::WHEEL)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::WHEEL)) {
         lore_ptr->kind_flags.set(MonsterKindType::WHEEL);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::GREAT_OLD_ONE)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::GREAT_OLD_ONE)) {
         lore_ptr->kind_flags.set(MonsterKindType::GREAT_OLD_ONE);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::APE)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::APE)) {
         lore_ptr->kind_flags.set(MonsterKindType::APE);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::HORSE)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::HORSE)) {
         lore_ptr->kind_flags.set(MonsterKindType::HORSE);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::FROG)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::FROG)) {
         lore_ptr->kind_flags.set(MonsterKindType::FROG);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::BEHOLDER)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::BEHOLDER)) {
         lore_ptr->kind_flags.set(MonsterKindType::BEHOLDER);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::YEEK)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::YEEK)) {
         lore_ptr->kind_flags.set(MonsterKindType::YEEK);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::AQUATIC_MAMMAL)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::AQUATIC_MAMMAL)) {
         lore_ptr->kind_flags.set(MonsterKindType::AQUATIC_MAMMAL);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::FISH)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::FISH)) {
         lore_ptr->kind_flags.set(MonsterKindType::FISH);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::BIRD)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::BIRD)) {
         lore_ptr->kind_flags.set(MonsterKindType::BIRD);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::WALL)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::WALL)) {
         lore_ptr->kind_flags.set(MonsterKindType::WALL);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::PLANT)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::PLANT)) {
         lore_ptr->kind_flags.set(MonsterKindType::PLANT);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::FUNGUS)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::FUNGUS)) {
         lore_ptr->kind_flags.set(MonsterKindType::FUNGUS);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::TURTLE)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::TURTLE)) {
         lore_ptr->kind_flags.set(MonsterKindType::TURTLE);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::SNAKE)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::SNAKE)) {
         lore_ptr->kind_flags.set(MonsterKindType::SNAKE);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::FAIRY)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::FAIRY)) {
         lore_ptr->kind_flags.set(MonsterKindType::FAIRY);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::VAMPIRE)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::VAMPIRE)) {
         lore_ptr->kind_flags.set(MonsterKindType::VAMPIRE);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::BEAR)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::BEAR)) {
         lore_ptr->kind_flags.set(MonsterKindType::BEAR);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::VORTEX)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::VORTEX)) {
         lore_ptr->kind_flags.set(MonsterKindType::VORTEX);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::OOZE)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::OOZE)) {
         lore_ptr->kind_flags.set(MonsterKindType::OOZE);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::DINOSAUR)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::DINOSAUR)) {
         lore_ptr->kind_flags.set(MonsterKindType::DINOSAUR);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::LICH)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::LICH)) {
         lore_ptr->kind_flags.set(MonsterKindType::LICH);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::GHOST)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::GHOST)) {
         lore_ptr->kind_flags.set(MonsterKindType::GHOST);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::BERSERK)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::BERSERK)) {
         lore_ptr->kind_flags.set(MonsterKindType::BERSERK);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::EXPLOSIVE)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::EXPLOSIVE)) {
         lore_ptr->kind_flags.set(MonsterKindType::EXPLOSIVE);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::RAT)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::RAT)) {
         lore_ptr->kind_flags.set(MonsterKindType::RAT);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::MINOTAUR)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::MINOTAUR)) {
         lore_ptr->kind_flags.set(MonsterKindType::MINOTAUR);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::SKAVEN)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::SKAVEN)) {
         lore_ptr->kind_flags.set(MonsterKindType::SKAVEN);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::KOBOLD)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::KOBOLD)) {
         lore_ptr->kind_flags.set(MonsterKindType::KOBOLD);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::OGRE)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::OGRE)) {
         lore_ptr->kind_flags.set(MonsterKindType::OGRE);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::BOVINE)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::BOVINE)) {
         lore_ptr->kind_flags.set(MonsterKindType::BOVINE);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::MERFOLK)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::MERFOLK)) {
         lore_ptr->kind_flags.set(MonsterKindType::MERFOLK);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::SHARK)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::SHARK)) {
         lore_ptr->kind_flags.set(MonsterKindType::SHARK);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::MESUGAKI)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::MESUGAKI)) {
         lore_ptr->kind_flags.set(MonsterKindType::MESUGAKI);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::HYDRA)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::HYDRA)) {
         lore_ptr->kind_flags.set(MonsterKindType::HYDRA);
     }
 
-    if (lore_ptr->r_ptr->kind_flags.has(MonsterKindType::SHIP)) {
+    if (lore_ptr->monrace->kind_flags.has(MonsterKindType::SHIP)) {
         lore_ptr->kind_flags.set(MonsterKindType::SHIP);
     }
 }
@@ -592,7 +376,7 @@ void process_monster_lore(CreatureEntity &creature, MonraceId r_idx, monster_lor
     set_msex_flags(lore_ptr);
     set_flags1(lore_ptr);
     set_race_flags(lore_ptr);
-    const auto &text = lore_ptr->r_ptr->text;
+    const auto &text = lore_ptr->monrace->text;
 
     if (show_lore_summary) {
         display_monster_kind_tags(lore_ptr);

--- a/src/main/scene-table-monster.cpp
+++ b/src/main/scene-table-monster.cpp
@@ -13,10 +13,11 @@
 #include "util/bit-flags-calculator.h"
 #include "world/world.h"
 #include <ctime>
+#include <memory>
 
 struct scene_monster_info {
     MONSTER_IDX m_idx;
-    MonraceDefinition *ap_r_ptr;
+    std::shared_ptr<const MonraceDefinition> apparent_monrace;
     GAME_TURN last_seen; //!< 最後に対象モンスター見たゲームターン
     uint32_t mute_until; //!< この時間に到達するまでモンスターBGMは設定しない
 };
@@ -25,7 +26,7 @@ scene_monster_info scene_target_monster;
 
 void clear_scene_target_monster()
 {
-    scene_target_monster.ap_r_ptr = nullptr;
+    scene_target_monster.apparent_monrace = nullptr;
 }
 
 static int get_game_turn()
@@ -73,12 +74,12 @@ static bool is_high_rate(CreatureEntity &creature, MONSTER_IDX m_idx1, MONSTER_I
     const auto &floor = *creature.get_floor();
     const auto &monster1 = floor.get_monster(m_idx1);
     const auto &monster2 = floor.get_monster(m_idx2);
-    auto ap_r_ptr1 = &monster1.get_appearance_monrace();
-    auto ap_r_ptr2 = &monster2.get_appearance_monrace();
+    const auto &apparent_monrace1 = monster1.get_apparent_monrace();
+    const auto &apparent_monrace2 = monster2.get_apparent_monrace();
 
     /* Unique monsters first */
-    if (ap_r_ptr1->kind_flags.has(MonsterKindType::UNIQUE) != ap_r_ptr2->kind_flags.has(MonsterKindType::UNIQUE)) {
-        return ap_r_ptr1->kind_flags.has(MonsterKindType::UNIQUE);
+    if (apparent_monrace1.kind_flags.has(MonsterKindType::UNIQUE) != apparent_monrace2.kind_flags.has(MonsterKindType::UNIQUE)) {
+        return apparent_monrace1.kind_flags.has(MonsterKindType::UNIQUE);
     }
 
     /* Shadowers first (あやしい影) */
@@ -87,13 +88,13 @@ static bool is_high_rate(CreatureEntity &creature, MONSTER_IDX m_idx1, MONSTER_I
     }
 
     /* Unknown monsters first */
-    if ((ap_r_ptr1->r_tkills == 0) != (ap_r_ptr2->r_tkills == 0)) {
-        return ap_r_ptr1->r_tkills == 0;
+    if ((apparent_monrace1.r_tkills == 0) != (apparent_monrace2.r_tkills == 0)) {
+        return apparent_monrace1.r_tkills == 0;
     }
 
     /* Higher level monsters first (if known) */
-    if (ap_r_ptr1->r_tkills && ap_r_ptr2->r_tkills && ap_r_ptr1->level != ap_r_ptr2->level) {
-        return ap_r_ptr1->level > ap_r_ptr2->level;
+    if (apparent_monrace1.r_tkills && apparent_monrace2.r_tkills && apparent_monrace1.level != apparent_monrace2.level) {
+        return apparent_monrace1.level > apparent_monrace2.level;
     }
 
     /* Sort by index if all conditions are same */
@@ -110,12 +111,12 @@ static bool is_high_rate(CreatureEntity &creature, MONSTER_IDX m_idx1, MONSTER_I
  */
 static void update_target_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
-    if (scene_target_monster.ap_r_ptr && (scene_target_monster.m_idx == m_idx)) {
+    if (scene_target_monster.apparent_monrace && (scene_target_monster.m_idx == m_idx)) {
         // 同一モンスター。最後に見たゲームターンを更新。
         scene_target_monster.last_seen = get_game_turn();
     } else {
         bool do_dwap = false;
-        if (!scene_target_monster.ap_r_ptr) {
+        if (!scene_target_monster.apparent_monrace) {
             // 空席
             do_dwap = true;
         } else if (is_high_rate(creature, m_idx, scene_target_monster.m_idx)) {
@@ -125,9 +126,8 @@ static void update_target_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
 
         if (do_dwap) {
             const auto &monster = creature.get_floor()->get_monster(m_idx);
-            auto *ap_r_ptr = &monster.get_appearance_monrace();
             scene_target_monster.m_idx = m_idx;
-            scene_target_monster.ap_r_ptr = ap_r_ptr;
+            scene_target_monster.apparent_monrace = monster.get_apparent_monrace_shared();
             scene_target_monster.last_seen = get_game_turn();
         }
     }
@@ -154,7 +154,7 @@ static bool scene_unique(CreatureEntity &creature, scene_type *value)
 {
     (void)creature;
 
-    if (scene_target_monster.ap_r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
+    if (scene_target_monster.apparent_monrace->kind_flags.has(MonsterKindType::UNIQUE)) {
         value->type = TERM_XTRA_MUSIC_BASIC;
         value->val = MUSIC_BASIC_UNIQUE;
         return true;
@@ -166,7 +166,7 @@ static bool scene_unique(CreatureEntity &creature, scene_type *value)
 static bool scene_unknown(CreatureEntity &creature, scene_type *value)
 {
     (void)creature;
-    if (scene_target_monster.ap_r_ptr->r_tkills == 0) {
+    if (scene_target_monster.apparent_monrace->r_tkills == 0) {
         value->type = TERM_XTRA_MUSIC_BASIC;
         value->val = MUSIC_BASIC_UNKNOWN_MONSTER;
         return true;
@@ -177,7 +177,7 @@ static bool scene_unknown(CreatureEntity &creature, scene_type *value)
 
 static bool scene_high_level(CreatureEntity &creature, scene_type *value)
 {
-    if (scene_target_monster.ap_r_ptr->r_tkills > 0 && (scene_target_monster.ap_r_ptr->level >= creature.get_level())) {
+    if (scene_target_monster.apparent_monrace->r_tkills > 0 && (scene_target_monster.apparent_monrace->level >= creature.get_level())) {
         value->type = TERM_XTRA_MUSIC_BASIC;
         value->val = MUSIC_BASIC_HIGHER_LEVEL_MONSTER;
         return true;
@@ -223,15 +223,14 @@ void refresh_scene_monster(CreatureEntity &creature, const std::vector<MONSTER_I
         // モンスターBGM制限中
         clear_scene_target_monster();
     } else {
-        if (scene_target_monster.ap_r_ptr) {
+        if (scene_target_monster.apparent_monrace) {
             // BGM対象から外すチェック
             if (get_game_turn() - scene_target_monster.last_seen >= 200) {
                 // 最後に見かけてから一定のゲームターンが経過した場合、BGM対象から外す
                 clear_scene_target_monster();
             } else {
                 const auto &monster = creature.get_floor()->get_monster(scene_target_monster.m_idx);
-                auto *ap_r_ptr = &monster.get_appearance_monrace();
-                if (ap_r_ptr != scene_target_monster.ap_r_ptr) {
+                if (monster.get_apparent_monrace_shared() != scene_target_monster.apparent_monrace) {
                     // 死亡、チェンジモンスター、etc.
                     clear_scene_target_monster();
                 }
@@ -244,7 +243,7 @@ void refresh_scene_monster(CreatureEntity &creature, const std::vector<MONSTER_I
         }
     }
 
-    if (scene_target_monster.ap_r_ptr) {
+    if (scene_target_monster.apparent_monrace) {
         // BGM対象の条件で選曲リストを設定する
         for (auto func : scene_monster_def_list) {
             scene_type &item = list[from_index];

--- a/src/market/building-monster.cpp
+++ b/src/market/building-monster.cpp
@@ -77,17 +77,17 @@ bool research_mon(CreatureEntity &creature)
     std::vector<MonraceId> monrace_ids;
     auto &monraces = MonraceList::get_instance();
     for (const auto &[monrace_id, monrace] : monraces) {
-        if (!monrace.is_valid()) {
+        if (!monrace->is_valid()) {
             continue;
         }
 
         /* Require non-unique monsters if needed */
-        if (norm && monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
+        if (norm && monrace->kind_flags.has(MonsterKindType::UNIQUE)) {
             continue;
         }
 
         /* Require unique monsters if needed */
-        if (uniq && monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {
+        if (uniq && monrace->kind_flags.has_not(MonsterKindType::UNIQUE)) {
             continue;
         }
 
@@ -105,7 +105,7 @@ bool research_mon(CreatureEntity &creature)
                 }
             }
 
-            std::string temp2 = monrace.name.en_string();
+            std::string temp2 = monrace->name.en_string();
             for (auto &ch : temp2) {
                 if (isupper(ch)) {
                     ch = static_cast<char>(tolower(ch));
@@ -113,12 +113,12 @@ bool research_mon(CreatureEntity &creature)
             }
 
 #ifdef JP
-            if (str_find(temp2, monster_name) || str_find(monrace.name.string(), monster_name))
+            if (str_find(temp2, monster_name) || str_find(monrace->name.string(), monster_name))
 #else
             if (str_find(temp2, monster_name))
 #endif
                 monrace_ids.push_back(monrace_id);
-        } else if (all || (monrace.symbol_definition.character == sym)) {
+        } else if (all || (monrace->symbol_definition.character == sym)) {
             monrace_ids.push_back(monrace_id);
         }
     }

--- a/src/melee/melee-spell-flags-checker.cpp
+++ b/src/melee/melee-spell-flags-checker.cpp
@@ -113,10 +113,10 @@ static void check_darkness(CreatureEntity &creature, melee_spell_type *ms_ptr)
     }
 
     const auto vs_ninja = CreatureClass(creature).equals(PlayerClassType::NINJA) && !ms_ptr->t_ptr->is_hostile();
-    auto can_use_lite_area = vs_ninja && !ms_ptr->m_ptr->has_undead_flag();
-    can_use_lite_area &= ms_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::HURT_LITE);
-    can_use_lite_area &= ms_ptr->r_ptr->brightness_flags.has_none_of(dark_mask);
-    if (ms_ptr->r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID)) {
+    auto can_use_lite_area = vs_ninja && ms_ptr->monrace->kind_flags.has_not(MonsterKindType::UNDEAD);
+    can_use_lite_area &= ms_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::HURT_LITE);
+    can_use_lite_area &= ms_ptr->monrace->brightness_flags.has_none_of(dark_mask);
+    if (ms_ptr->monrace->behavior_flags.has(MonsterBehaviorType::STUPID)) {
         return;
     }
 
@@ -132,7 +132,7 @@ static void check_darkness(CreatureEntity &creature, melee_spell_type *ms_ptr)
 
 static void check_stupid(melee_spell_type *ms_ptr)
 {
-    if (!ms_ptr->in_no_magic_dungeon || ms_ptr->r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID)) {
+    if (!ms_ptr->in_no_magic_dungeon || ms_ptr->monrace->behavior_flags.has(MonsterBehaviorType::STUPID)) {
         return;
     }
 
@@ -226,7 +226,7 @@ static void check_melee_spell_breath(CreatureEntity &creature, melee_spell_type 
         return;
     }
 
-    POSITION rad = ms_ptr->r_ptr->misc_flags.has(MonsterMiscType::POWERFUL) ? 3 : 2;
+    POSITION rad = ms_ptr->monrace->misc_flags.has(MonsterMiscType::POWERFUL) ? 3 : 2;
     if (!breath_direct(creature, ms_ptr->m_ptr->get_position(), ms_ptr->t_ptr->get_position(), rad, AttributeType::NONE, true)) {
         ms_ptr->ability_flags.reset(RF_ABILITY_BREATH_MASK);
         return;
@@ -258,7 +258,7 @@ static void check_melee_spell_special(CreatureEntity &creature, melee_spell_type
         return;
     }
 
-    if (ms_ptr->r_ptr->symbol_char_is_any_of("B")) {
+    if (ms_ptr->monrace->symbol_char_is_any_of("B")) {
         if ((creature.pet_extra_flags & (PF_ATTACK_SPELL | PF_TELEPORT)) != (PF_ATTACK_SPELL | PF_TELEPORT)) {
             ms_ptr->ability_flags.reset(MonsterAbilityType::SPECIAL);
         }
@@ -309,7 +309,7 @@ static void check_pet(CreatureEntity &creature, melee_spell_type *ms_ptr)
 
 static void check_non_stupid(CreatureEntity &creature, melee_spell_type *ms_ptr)
 {
-    if (ms_ptr->r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID)) {
+    if (ms_ptr->monrace->behavior_flags.has(MonsterBehaviorType::STUPID)) {
         return;
     }
 
@@ -336,7 +336,7 @@ static void check_non_stupid(CreatureEntity &creature, melee_spell_type *ms_ptr)
 
 static void check_smart(CreatureEntity &creature, melee_spell_type *ms_ptr)
 {
-    if (ms_ptr->r_ptr->behavior_flags.has_not(MonsterBehaviorType::SMART)) {
+    if (ms_ptr->monrace->behavior_flags.has_not(MonsterBehaviorType::SMART)) {
         return;
     }
 
@@ -367,7 +367,7 @@ bool check_melee_spell_set(CreatureEntity &creature, melee_spell_type *ms_ptr)
         return false;
     }
 
-    ms_ptr->ability_flags = ms_ptr->r_ptr->ability_flags;
+    ms_ptr->ability_flags = ms_ptr->monrace->ability_flags;
     decide_melee_spell_target(creature, ms_ptr);
     decide_indirection_melee_spell(creature, ms_ptr);
     if (!check_melee_spell_projection(creature, ms_ptr)) {
@@ -382,7 +382,7 @@ bool check_melee_spell_set(CreatureEntity &creature, melee_spell_type *ms_ptr)
         ms_ptr->ability_flags.reset(MonsterAbilityType::BR_LITE);
     }
 
-    if (ms_ptr->ability_flags.has(MonsterAbilityType::SPECIAL) && (ms_ptr->m_ptr->get_r_idx() != MonraceId::ROLENTO) && !ms_ptr->r_ptr->symbol_char_is_any_of("B")) {
+    if (ms_ptr->ability_flags.has(MonsterAbilityType::SPECIAL) && (ms_ptr->m_ptr->get_r_idx() != MonraceId::ROLENTO) && !ms_ptr->monrace->symbol_char_is_any_of("B")) {
         ms_ptr->ability_flags.reset(MonsterAbilityType::SPECIAL);
     }
 

--- a/src/melee/melee-spell-util.cpp
+++ b/src/melee/melee-spell-util.cpp
@@ -15,7 +15,7 @@ melee_spell_type::melee_spell_type(CreatureEntity &creature, MONSTER_IDX m_idx)
     auto &floor = *creature.get_floor();
     this->m_ptr = &floor.get_monster(m_idx);
     this->t_ptr = nullptr;
-    this->r_ptr = &this->m_ptr->get_monrace();
+    this->monrace = this->m_ptr->get_monrace_shared();
     this->see_m = is_seen(creature, *this->m_ptr);
     this->maneable = floor.has_los_at(this->m_ptr->get_position());
     this->pet = this->m_ptr->is_pet();

--- a/src/melee/melee-spell-util.h
+++ b/src/melee/melee-spell-util.h
@@ -4,6 +4,7 @@
 #include "system/angband.h"
 #include "util/flag-group.h"
 #include "util/point-2d.h"
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -26,7 +27,7 @@ struct melee_spell_type {
 
     CreatureEntity *m_ptr;
     const CreatureEntity *t_ptr;
-    MonraceDefinition *r_ptr;
+    std::shared_ptr<MonraceDefinition> monrace;
     bool see_m;
     bool maneable;
     bool pet;

--- a/src/melee/melee-spell.cpp
+++ b/src/melee/melee-spell.cpp
@@ -85,10 +85,10 @@ static void process_rememberance(melee_spell_type *ms_ptr)
         return;
     }
 
-    ms_ptr->r_ptr->r_ability_flags.set(ms_ptr->thrown_spell);
+    ms_ptr->monrace->r_ability_flags.set(ms_ptr->thrown_spell);
 
-    if (ms_ptr->r_ptr->r_cast_spell < MAX_UCHAR) {
-        ms_ptr->r_ptr->r_cast_spell++;
+    if (ms_ptr->monrace->r_cast_spell < MAX_UCHAR) {
+        ms_ptr->monrace->r_cast_spell++;
     }
 }
 
@@ -128,8 +128,8 @@ bool monst_spell_monst(CreatureEntity &creature, MONSTER_IDX m_idx)
     ms_ptr->dam = res.dam;
     process_special_melee_spell(creature, ms_ptr);
     process_rememberance(ms_ptr);
-    if (creature.is_dead() && (ms_ptr->r_ptr->r_deaths < MAX_SHORT) && !creature.get_floor()->inside_arena) {
-        ms_ptr->r_ptr->r_deaths++;
+    if (creature.is_dead() && (ms_ptr->monrace->r_deaths < MAX_SHORT) && !creature.get_floor()->inside_arena) {
+        ms_ptr->monrace->r_deaths++;
     }
 
     return true;

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -1075,7 +1075,7 @@ ProcessResult effect_monster_elemental_genocide(CreatureEntity &creature, Effect
     }
 
     const auto type = get_element_type(creature.element_realm, 0);
-    const auto is_effective = is_elemental_genocide_effective(*em_ptr->r_ptr, type);
+    const auto is_effective = is_elemental_genocide_effective(*em_ptr->monrace, type);
     if (!is_effective) {
         if (em_ptr->seen_msg) {
             msg_format(_("%sには効果がなかった。", "%s^ is unaffected."), em_ptr->m_name);
@@ -1084,7 +1084,7 @@ ProcessResult effect_monster_elemental_genocide(CreatureEntity &creature, Effect
         return ProcessResult::PROCESS_TRUE;
     }
 
-    if (genocide_aux(creature, em_ptr->g_ptr->m_idx, em_ptr->dam, em_ptr->is_player(), (em_ptr->r_ptr->level + 1) / 2, _("モンスター消滅", "Genocide One"))) {
+    if (genocide_aux(creature, em_ptr->g_ptr->m_idx, em_ptr->dam, em_ptr->is_player(), (em_ptr->monrace->level + 1) / 2, _("モンスター消滅", "Genocide One"))) {
         if (em_ptr->seen_msg) {
             msg_format(_("%sは消滅した！", "%s^ disappeared!"), em_ptr->m_name);
         }

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -30,6 +30,7 @@
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
+#include "system/monrace/monrace-list.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"
@@ -38,21 +39,21 @@
 #include "view/display-messages.h"
 
 struct samurai_slaying_type {
-    samurai_slaying_type(MULTIPLY mult, const TrFlags &flags, const CreatureEntity &monster, combat_options mode, MonraceDefinition &monrace);
+    samurai_slaying_type(MULTIPLY mult, const TrFlags &flags, const CreatureEntity &monster, combat_options mode);
     MULTIPLY mult;
     TrFlags flags;
     const CreatureEntity *m_ptr;
     combat_options mode;
-    MonraceDefinition *r_ptr;
+    std::shared_ptr<MonraceDefinition> monrace;
 };
 
-samurai_slaying_type::samurai_slaying_type(MULTIPLY mult, const TrFlags &flags, const CreatureEntity &monster, combat_options mode, MonraceDefinition &monrace)
+samurai_slaying_type::samurai_slaying_type(MULTIPLY mult, const TrFlags &flags, const CreatureEntity &monster, combat_options mode)
     : mult(mult)
     , flags(flags)
     , m_ptr(&monster)
     , mode(mode)
-    , r_ptr(&monrace)
 {
+    this->monrace = MonraceList::get_instance().get_monrace_shared(monster.get_r_idx());
 }
 
 /*!
@@ -67,9 +68,9 @@ static void hissatsu_burning_strike(CreatureEntity &creature, samurai_slaying_ty
     }
 
     /* Notice immunity */
-    if (samurai_slaying_ptr->r_ptr->resistance_flags.has_any_of(RFR_EFF_IM_FIRE_MASK)) {
+    if (samurai_slaying_ptr->monrace->resistance_flags.has_any_of(RFR_EFF_IM_FIRE_MASK)) {
         if (is_original_ap_and_seen(creature, *samurai_slaying_ptr->m_ptr)) {
-            samurai_slaying_ptr->r_ptr->r_resistance_flags.set(samurai_slaying_ptr->r_ptr->resistance_flags & RFR_EFF_IM_FIRE_MASK);
+            samurai_slaying_ptr->monrace->r_resistance_flags.set(samurai_slaying_ptr->monrace->resistance_flags & RFR_EFF_IM_FIRE_MASK);
         }
 
         return;
@@ -77,13 +78,13 @@ static void hissatsu_burning_strike(CreatureEntity &creature, samurai_slaying_ty
 
     /* Otherwise, take the damage */
     if (samurai_slaying_ptr->flags.has(TR_BRAND_FIRE)) {
-        if (samurai_slaying_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::HURT_FIRE)) {
+        if (samurai_slaying_ptr->monrace->resistance_flags.has(MonsterResistanceType::HURT_FIRE)) {
             if (samurai_slaying_ptr->mult < 70) {
                 samurai_slaying_ptr->mult = 70;
             }
 
             if (is_original_ap_and_seen(creature, *samurai_slaying_ptr->m_ptr)) {
-                samurai_slaying_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::HURT_FIRE);
+                samurai_slaying_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::HURT_FIRE);
             }
 
         } else if (samurai_slaying_ptr->mult < 35) {
@@ -93,13 +94,13 @@ static void hissatsu_burning_strike(CreatureEntity &creature, samurai_slaying_ty
         return;
     }
 
-    if (samurai_slaying_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::HURT_FIRE)) {
+    if (samurai_slaying_ptr->monrace->resistance_flags.has(MonsterResistanceType::HURT_FIRE)) {
         if (samurai_slaying_ptr->mult < 50) {
             samurai_slaying_ptr->mult = 50;
         }
 
         if (is_original_ap_and_seen(creature, *samurai_slaying_ptr->m_ptr)) {
-            samurai_slaying_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::HURT_FIRE);
+            samurai_slaying_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::HURT_FIRE);
         }
     } else if (samurai_slaying_ptr->mult < 25) {
         samurai_slaying_ptr->mult = 25;
@@ -122,9 +123,9 @@ static void hissatsu_serpent_tongue(CreatureEntity &creature, samurai_slaying_ty
     }
 
     /* Notice immunity */
-    if (samurai_slaying_ptr->r_ptr->resistance_flags.has_any_of(RFR_EFF_IM_POISON_MASK)) {
+    if (samurai_slaying_ptr->monrace->resistance_flags.has_any_of(RFR_EFF_IM_POISON_MASK)) {
         if (is_original_ap_and_seen(creature, *samurai_slaying_ptr->m_ptr)) {
-            samurai_slaying_ptr->r_ptr->r_resistance_flags.set(samurai_slaying_ptr->r_ptr->resistance_flags & RFR_EFF_IM_POISON_MASK);
+            samurai_slaying_ptr->monrace->r_resistance_flags.set(samurai_slaying_ptr->monrace->resistance_flags & RFR_EFF_IM_POISON_MASK);
         }
 
         return;
@@ -150,7 +151,7 @@ static void hissatsu_zanma_ken(samurai_slaying_type *samurai_slaying_ptr)
         return;
     }
 
-    if (!samurai_slaying_ptr->m_ptr->has_living_flag() && samurai_slaying_ptr->r_ptr->kind_flags.has(MonsterKindType::EVIL)) {
+    if (!samurai_slaying_ptr->m_ptr->has_living_flag() && samurai_slaying_ptr->monrace->kind_flags.has(MonsterKindType::EVIL)) {
         if (samurai_slaying_ptr->mult < 15) {
             samurai_slaying_ptr->mult = 25;
         } else if (samurai_slaying_ptr->mult < 50) {
@@ -170,9 +171,9 @@ static void hissatsu_rock_smash(CreatureEntity &creature, samurai_slaying_type *
         return;
     }
 
-    if (samurai_slaying_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::HURT_ROCK)) {
+    if (samurai_slaying_ptr->monrace->resistance_flags.has(MonsterResistanceType::HURT_ROCK)) {
         if (is_original_ap_and_seen(creature, *samurai_slaying_ptr->m_ptr)) {
-            samurai_slaying_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::HURT_ROCK);
+            samurai_slaying_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::HURT_ROCK);
         }
 
         if (samurai_slaying_ptr->mult == 10) {
@@ -195,9 +196,9 @@ static void hissatsu_midare_setsugetsuka(CreatureEntity &creature, samurai_slayi
     }
 
     /* Notice immunity */
-    if (samurai_slaying_ptr->r_ptr->resistance_flags.has_any_of(RFR_EFF_IM_COLD_MASK)) {
+    if (samurai_slaying_ptr->monrace->resistance_flags.has_any_of(RFR_EFF_IM_COLD_MASK)) {
         if (is_original_ap_and_seen(creature, *samurai_slaying_ptr->m_ptr)) {
-            samurai_slaying_ptr->r_ptr->r_resistance_flags.set(samurai_slaying_ptr->r_ptr->resistance_flags & RFR_EFF_IM_COLD_MASK);
+            samurai_slaying_ptr->monrace->r_resistance_flags.set(samurai_slaying_ptr->monrace->resistance_flags & RFR_EFF_IM_COLD_MASK);
         }
 
         return;
@@ -205,13 +206,13 @@ static void hissatsu_midare_setsugetsuka(CreatureEntity &creature, samurai_slayi
 
     /* Otherwise, take the damage */
     if (samurai_slaying_ptr->flags.has(TR_BRAND_COLD)) {
-        if (samurai_slaying_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::HURT_COLD)) {
+        if (samurai_slaying_ptr->monrace->resistance_flags.has(MonsterResistanceType::HURT_COLD)) {
             if (samurai_slaying_ptr->mult < 70) {
                 samurai_slaying_ptr->mult = 70;
             }
 
             if (is_original_ap_and_seen(creature, *samurai_slaying_ptr->m_ptr)) {
-                samurai_slaying_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::HURT_COLD);
+                samurai_slaying_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::HURT_COLD);
             }
         } else if (samurai_slaying_ptr->mult < 35) {
             samurai_slaying_ptr->mult = 35;
@@ -220,13 +221,13 @@ static void hissatsu_midare_setsugetsuka(CreatureEntity &creature, samurai_slayi
         return;
     }
 
-    if (samurai_slaying_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::HURT_COLD)) {
+    if (samurai_slaying_ptr->monrace->resistance_flags.has(MonsterResistanceType::HURT_COLD)) {
         if (samurai_slaying_ptr->mult < 50) {
             samurai_slaying_ptr->mult = 50;
         }
 
         if (is_original_ap_and_seen(creature, *samurai_slaying_ptr->m_ptr)) {
-            samurai_slaying_ptr->r_ptr->r_resistance_flags.set(MonsterResistanceType::HURT_COLD);
+            samurai_slaying_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::HURT_COLD);
         }
     } else if (samurai_slaying_ptr->mult < 25) {
         samurai_slaying_ptr->mult = 25;
@@ -245,9 +246,9 @@ static void hissatsu_lightning_eagle(CreatureEntity &creature, samurai_slaying_t
     }
 
     /* Notice immunity */
-    if (samurai_slaying_ptr->r_ptr->resistance_flags.has_any_of(RFR_EFF_IM_ELEC_MASK)) {
+    if (samurai_slaying_ptr->monrace->resistance_flags.has_any_of(RFR_EFF_IM_ELEC_MASK)) {
         if (is_original_ap_and_seen(creature, *samurai_slaying_ptr->m_ptr)) {
-            samurai_slaying_ptr->r_ptr->r_resistance_flags.set(samurai_slaying_ptr->r_ptr->resistance_flags & RFR_EFF_IM_ELEC_MASK);
+            samurai_slaying_ptr->monrace->r_resistance_flags.set(samurai_slaying_ptr->monrace->resistance_flags & RFR_EFF_IM_ELEC_MASK);
         }
 
         return;
@@ -289,9 +290,9 @@ static void hissatsu_keiun_kininken(CreatureEntity &creature, samurai_slaying_ty
         return;
     }
 
-    if (samurai_slaying_ptr->m_ptr->has_undead_flag()) {
+    if (samurai_slaying_ptr->monrace->kind_flags.has(MonsterKindType::UNDEAD)) {
         if (is_original_ap_and_seen(creature, *samurai_slaying_ptr->m_ptr)) {
-            samurai_slaying_ptr->r_ptr->r_kind_flags.set(MonsterKindType::UNDEAD);
+            samurai_slaying_ptr->monrace->r_kind_flags.set(MonsterKindType::UNDEAD);
 
             if (samurai_slaying_ptr->mult == 10) {
                 samurai_slaying_ptr->mult = 70;
@@ -319,23 +320,21 @@ static void hissatsu_keiun_kininken(CreatureEntity &creature, samurai_slaying_ty
  */
 MULTIPLY mult_hissatsu(CreatureEntity &creature, MULTIPLY mult, const TrFlags &flags, const CreatureEntity &target, combat_options mode)
 {
-    auto &monrace = target.get_monrace();
-    samurai_slaying_type tmp_slaying(mult, flags, target, mode, monrace);
-    samurai_slaying_type *samurai_slaying_ptr = &tmp_slaying;
-    hissatsu_burning_strike(creature, samurai_slaying_ptr);
-    hissatsu_serpent_tongue(creature, samurai_slaying_ptr);
-    hissatsu_zanma_ken(samurai_slaying_ptr);
-    hissatsu_rock_smash(creature, samurai_slaying_ptr);
-    hissatsu_midare_setsugetsuka(creature, samurai_slaying_ptr);
-    hissatsu_lightning_eagle(creature, samurai_slaying_ptr);
-    hissatsu_bloody_maelstroem(creature, samurai_slaying_ptr);
-    hissatsu_keiun_kininken(creature, samurai_slaying_ptr);
+    samurai_slaying_type slaying(mult, flags, target, mode);
+    hissatsu_burning_strike(creature, &slaying);
+    hissatsu_serpent_tongue(creature, &slaying);
+    hissatsu_zanma_ken(&slaying);
+    hissatsu_rock_smash(creature, &slaying);
+    hissatsu_midare_setsugetsuka(creature, &slaying);
+    hissatsu_lightning_eagle(creature, &slaying);
+    hissatsu_bloody_maelstroem(creature, &slaying);
+    hissatsu_keiun_kininken(creature, &slaying);
 
-    if (samurai_slaying_ptr->mult > 150) {
-        samurai_slaying_ptr->mult = 150;
+    if (slaying.mult > 150) {
+        slaying.mult = 150;
     }
 
-    return samurai_slaying_ptr->mult;
+    return slaying.mult;
 }
 
 void concentration(CreatureEntity &creature)

--- a/src/monster-floor/monster-death-util.cpp
+++ b/src/monster-floor/monster-death-util.cpp
@@ -12,16 +12,16 @@ MonsterDeath::MonsterDeath(FloorType &floor, short m_idx, bool drop_item)
     : m_idx(m_idx)
     , m_ptr(&floor.get_monster(m_idx))
 {
-    this->r_ptr = &this->m_ptr->get_monrace();
-    this->ap_r_ptr = this->r_ptr;
-    this->do_gold = this->r_ptr->drop_flags.has_none_of({
+    this->monrace = this->m_ptr->get_monrace_shared();
+    this->apparent_monrace = this->monrace;
+    this->do_gold = this->monrace->drop_flags.has_none_of({
         MonsterDropType::ONLY_ITEM,
         MonsterDropType::DROP_GOOD,
         MonsterDropType::DROP_GREAT,
     });
-    this->do_item = this->r_ptr->drop_flags.has_not(MonsterDropType::ONLY_GOLD);
-    this->do_item |= this->r_ptr->drop_flags.has_any_of({ MonsterDropType::DROP_GOOD, MonsterDropType::DROP_GREAT });
-    this->cloned = this->m_ptr->is_cloned();
+    this->do_item = this->monrace->drop_flags.has_not(MonsterDropType::ONLY_GOLD);
+    this->do_item |= this->monrace->drop_flags.has_any_of({ MonsterDropType::DROP_GOOD, MonsterDropType::DROP_GREAT });
+    this->cloned = this->m_ptr->has_constant_flag(MonsterConstantFlagType::CLONED);
     this->is_chameleon = this->m_ptr->is_chameleon();
     this->drop_chosen_item = drop_item && !this->cloned && !this->is_chameleon && !floor.inside_arena && !AngbandSystem::get_instance().is_phase_out() && !this->m_ptr->is_pet();
 }

--- a/src/monster-floor/monster-death-util.h
+++ b/src/monster-floor/monster-death-util.h
@@ -2,6 +2,7 @@
 
 #include "util/point-2d.h"
 #include <cstdint>
+#include <memory>
 
 // @todo PlayerType に依存するオブジェクトメソッドを追加予定.
 class FloorType;
@@ -12,8 +13,8 @@ public:
     MonsterDeath(FloorType &floor, short m_idx, bool drop_item);
     short m_idx;
     CreatureEntity *m_ptr;
-    MonraceDefinition *r_ptr;
-    MonraceDefinition *ap_r_ptr;
+    std::shared_ptr<MonraceDefinition> monrace;
+    std::shared_ptr<MonraceDefinition> apparent_monrace;
     bool do_gold;
     bool do_item;
     bool cloned;

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -65,7 +65,7 @@ static void write_pet_death(CreatureEntity &creature, MonsterDeath *md_ptr)
 
 static void on_dead_explosion(CreatureEntity &creature, MonsterDeath *md_ptr)
 {
-    for (const auto &blow : md_ptr->r_ptr->blows) {
+    for (const auto &blow : md_ptr->monrace->blows) {
         if (blow.method != RaceBlowMethodType::EXPLODE) {
             continue;
         }
@@ -117,19 +117,19 @@ static void on_defeat_arena_monster(CreatureEntity &creature, MonsterDeath *md_p
 static void drop_corpse(CreatureEntity &creature, MonsterDeath *md_ptr)
 {
     const auto &floor = *creature.get_floor();
-    auto is_drop_corpse = one_in_(md_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? 1 : 4);
-    is_drop_corpse &= md_ptr->r_ptr->drop_flags.has_any_of({ MonsterDropType::DROP_CORPSE, MonsterDropType::DROP_SKELETON, MonsterDropType::DROP_JUNK });
+    auto is_drop_corpse = one_in_(md_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE) ? 1 : 4);
+    is_drop_corpse &= md_ptr->monrace->drop_flags.has_any_of({ MonsterDropType::DROP_CORPSE, MonsterDropType::DROP_SKELETON });
     is_drop_corpse &= !(floor.inside_arena || AngbandSystem::get_instance().is_phase_out() || md_ptr->cloned || ((md_ptr->m_ptr->get_r_idx() == AngbandWorld::get_instance().today_mon) && md_ptr->m_ptr->is_pet()));
     if (!is_drop_corpse) {
         return;
     }
 
     bool corpse = false;
-    if (md_ptr->r_ptr->drop_flags.has_not(MonsterDropType::DROP_SKELETON)) {
+    if (md_ptr->monrace->drop_flags.has_not(MonsterDropType::DROP_SKELETON)) {
         corpse = true;
-    } else if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_CORPSE) && md_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
+    } else if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_CORPSE) && md_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE)) {
         corpse = true;
-    } else if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_CORPSE)) {
+    } else if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_CORPSE)) {
         if ((0 - ((md_ptr->m_ptr->maxhp) / 4)) > md_ptr->m_ptr->hp) {
             if (one_in_(5)) {
                 corpse = true;
@@ -147,7 +147,7 @@ static void drop_corpse(CreatureEntity &creature, MonsterDeath *md_ptr)
     (void)drop_near(creature, item, md_ptr->get_position());
 
     try {
-        if (one_in_(md_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? 1 : 4)) {
+        if (one_in_(md_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE) ? 1 : 4)) {
             item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::MONSTER_REMAINS, SV_SOUL }));
             item.pval = enum2i(md_ptr->m_ptr->get_r_idx());
             (void)drop_near(creature, item, md_ptr->get_position());
@@ -159,7 +159,7 @@ static void drop_corpse(CreatureEntity &creature, MonsterDeath *md_ptr)
 #endif
     }
 
-    if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_JUNK)) {
+    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_JUNK)) {
         ItemEntity item_junk({ ItemKindType::MONSTER_REMAINS, SV_JUNK });
         item_junk.pval = enum2i(md_ptr->m_ptr->get_r_idx());
         (void)drop_near(creature, item_junk, md_ptr->get_position());
@@ -175,7 +175,7 @@ static void drop_corpse(CreatureEntity &creature, MonsterDeath *md_ptr)
 static void drop_artifact_from_unique(CreatureEntity &creature, MonsterDeath *md_ptr)
 {
     const auto is_wizard = AngbandWorld::get_instance().wizard;
-    for (const auto &[a_idx, chance] : md_ptr->r_ptr->drop_artifacts) {
+    for (const auto &[a_idx, chance] : md_ptr->monrace->get_drop_artifacts()) {
         if (!is_wizard && !evaluate_percent(chance)) {
             continue;
         }
@@ -231,7 +231,7 @@ static void drop_artifacts(CreatureEntity &creature, MonsterDeath *md_ptr)
     drop_artifact_from_unique(creature, md_ptr);
     const auto &floor = *creature.get_floor();
     const auto &dungeon = floor.get_dungeon_definition();
-    if (md_ptr->r_ptr->misc_flags.has_not(MonsterMiscType::GUARDIAN) || (dungeon.final_guardian != md_ptr->m_ptr->get_r_idx())) {
+    if (md_ptr->monrace->misc_flags.has_not(MonsterMiscType::GUARDIAN) || (dungeon.final_guardian != md_ptr->m_ptr->get_r_idx())) {
         return;
     }
 
@@ -248,15 +248,15 @@ static void drop_artifacts(CreatureEntity &creature, MonsterDeath *md_ptr)
 static void decide_drop_quality(MonsterDeath *md_ptr)
 {
     md_ptr->mo_mode = 0L;
-    if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_GOOD)) {
+    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_GOOD)) {
         md_ptr->mo_mode |= AM_GOOD;
     }
 
-    if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_GREAT)) {
+    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_GREAT)) {
         md_ptr->mo_mode |= (AM_GOOD | AM_GREAT);
     }
 
-    if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_NASTY)) {
+    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_NASTY)) {
         md_ptr->mo_mode |= AM_NASTY;
     }
 }
@@ -264,36 +264,31 @@ static void decide_drop_quality(MonsterDeath *md_ptr)
 static int decide_drop_numbers(CreatureEntity &creature, MonsterDeath *md_ptr, const bool drop_item, const bool inside_arena)
 {
     int drop_numbers = 0;
-    if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_60) && evaluate_percent(60)) {
+    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_60) && evaluate_percent(60)) {
         drop_numbers++;
     }
 
-    if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_90) && evaluate_percent(90)) {
+    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_90) && evaluate_percent(90)) {
         drop_numbers++;
     }
 
-    if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_1D2)) {
+    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_1D2)) {
         drop_numbers += Dice::roll(1, 2);
     }
 
-    if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_2D2)) {
+    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_2D2)) {
         drop_numbers += Dice::roll(2, 2);
     }
 
-    if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_3D2)) {
+    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_3D2)) {
         drop_numbers += Dice::roll(3, 2);
     }
 
-    if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_4D2)) {
+    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_4D2)) {
         drop_numbers += Dice::roll(4, 2);
     }
 
-    if (md_ptr->m_ptr->is_santa()) {
-        drop_numbers += Dice::roll(3, 3);
-    }
-
-    // クローンは、クローン地獄内のユニークモンスター以外はドロップしない
-    if (md_ptr->cloned && !(md_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) && (creature.get_floor()->quest_number == QuestId::CLONE))) {
+    if (md_ptr->cloned && md_ptr->monrace->kind_flags.has_not(MonsterKindType::UNIQUE)) {
         drop_numbers = 0;
     }
 
@@ -301,11 +296,11 @@ static int decide_drop_numbers(CreatureEntity &creature, MonsterDeath *md_ptr, c
         drop_numbers = 0;
     }
 
-    if (!drop_item && !md_ptr->r_ptr->symbol_char_is_any_of("$")) {
+    if (!drop_item && !md_ptr->monrace->symbol_char_is_any_of("$")) {
         drop_numbers = 0;
     }
 
-    if (md_ptr->r_ptr->misc_flags.has(MonsterMiscType::MULTIPLY) && (md_ptr->r_ptr->r_akills > 1024)) {
+    if (md_ptr->monrace->misc_flags.has(MonsterMiscType::MULTIPLY) && (md_ptr->monrace->r_akills > 1024)) {
         drop_numbers = 0;
     }
 
@@ -335,7 +330,7 @@ static void drop_items_golds(CreatureEntity &creature, MonsterDeath *md_ptr, int
 
     floor.object_level = floor.base_level;
     auto visible = md_ptr->m_ptr->is_visible_on_map() && !creature.is_hallucinated();
-    visible |= (md_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE));
+    visible |= (md_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE));
     if (visible && (dump_item || dump_gold)) {
         md_ptr->m_ptr->make_lore_treasure(dump_item, dump_gold);
     }
@@ -402,13 +397,13 @@ void monster_death(CreatureEntity &creature, MONSTER_IDX m_idx, bool drop_item, 
     }
 
     // プレイヤーしかユニークを倒せないのでここで時間を記録
-    if (md.r_ptr->kind_flags.has(MonsterKindType::UNIQUE) && !md.m_ptr->is_cloned()) {
+    if (md.monrace->kind_flags.has(MonsterKindType::UNIQUE) && !md.m_ptr->has_constant_flag(MonsterConstantFlagType::CLONED)) {
         world.play_time.update();
-        md.r_ptr->defeat_time = world.play_time.elapsed_sec();
-        md.r_ptr->defeat_level = creature.get_level();
+        md.monrace->defeat_time = world.play_time.elapsed_sec();
+        md.monrace->defeat_level = creature.get_level();
     }
 
-    if (md.r_ptr->brightness_flags.has_any_of(ld_mask)) {
+    if (md.monrace->brightness_flags.has_any_of(ld_mask)) {
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
     }
 
@@ -416,7 +411,7 @@ void monster_death(CreatureEntity &creature, MONSTER_IDX m_idx, bool drop_item, 
     on_dead_explosion(creature, &md);
     if (md.m_ptr->is_chameleon()) {
         md.m_ptr->reset_chameleon_polymorph();
-        md.r_ptr = &md.m_ptr->get_monrace();
+        md.monrace = md.m_ptr->get_monrace_shared();
     }
 
     // ジョークオプション：モンスターの墓石を立てる
@@ -434,14 +429,14 @@ void monster_death(CreatureEntity &creature, MONSTER_IDX m_idx, bool drop_item, 
         msg_print(_("地面に落とされた。", "You have fallen from the pet you were riding."));
     }
 
-    wc_ptr->plus_collapsion(md.r_ptr->plus_collapse);
+    wc_ptr->plus_collapsion(md.monrace->plus_collapse);
 
     // オディオアライアンスがNONLIVINGでないモンスター死亡時に戦力を増加
-    if (md.r_ptr->kind_flags.has_not(MonsterKindType::NONLIVING)) {
+    if (md.monrace->kind_flags.has_not(MonsterKindType::NONLIVING)) {
         auto it = alliance_list.find(AllianceType::ODIO);
         if (it != alliance_list.end()) {
             // モンスターのレベルに応じて戦力を増加（レベル * 10）
-            const auto power_gain = md.r_ptr->level * 10;
+            const auto power_gain = md.monrace->level * 10;
             it->second->base_power += power_gain;
         }
     }
@@ -452,9 +447,9 @@ void monster_death(CreatureEntity &creature, MONSTER_IDX m_idx, bool drop_item, 
     switch_special_death(creature, &md, attribute_flags);
     drop_artifacts(creature, &md);
     const auto drop_numbers = decide_drop_numbers(creature, &md, drop_item, floor.inside_arena);
-    floor.object_level = (floor.dun_level + md.r_ptr->level) / 2;
+    floor.object_level = (floor.dun_level + md.monrace->level) / 2;
     drop_items_golds(creature, &md, drop_numbers);
-    if ((md.r_ptr->misc_flags.has_not(MonsterMiscType::QUESTOR)) || AngbandSystem::get_instance().is_phase_out() || (md.m_ptr->get_r_idx() != MonraceId::MELKO) || md.cloned) {
+    if ((md.monrace->misc_flags.has_not(MonsterMiscType::QUESTOR)) || AngbandSystem::get_instance().is_phase_out() || (md.m_ptr->get_r_idx() != MonraceId::SERPENT) || md.cloned) {
         return;
     }
 

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -261,7 +261,7 @@ static void decide_drop_quality(MonsterDeath *md_ptr)
     }
 }
 
-static int decide_drop_numbers(CreatureEntity &creature, MonsterDeath *md_ptr, const bool drop_item, const bool inside_arena)
+static int decide_drop_numbers(MonsterDeath *md_ptr, const bool drop_item, const bool inside_arena)
 {
     int drop_numbers = 0;
     if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_60) && evaluate_percent(60)) {
@@ -446,7 +446,7 @@ void monster_death(CreatureEntity &creature, MONSTER_IDX m_idx, bool drop_item, 
     decide_drop_quality(&md);
     switch_special_death(creature, &md, attribute_flags);
     drop_artifacts(creature, &md);
-    const auto drop_numbers = decide_drop_numbers(creature, &md, drop_item, floor.inside_arena);
+    const auto drop_numbers = decide_drop_numbers(&md, drop_item, floor.inside_arena);
     floor.object_level = (floor.dun_level + md.monrace->level) / 2;
     drop_items_golds(creature, &md, drop_numbers);
     if ((md.monrace->misc_flags.has_not(MonsterMiscType::QUESTOR)) || AngbandSystem::get_instance().is_phase_out() || (md.m_ptr->get_r_idx() != MonraceId::SERPENT) || md.cloned) {

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -474,7 +474,7 @@ bool process_monster_movement(CreatureEntity &creature, turn_flags *turn_flags_p
             break;
         }
 
-        const auto &apparent_monrace = monster.get_appearance_monrace();
+        const auto &apparent_monrace = monster.get_apparent_monrace();
         const auto p_pos = creature.get_position(); //!< @details 関数が長すぎてプレイヤーの座標が不変であることを保証できない.
         const auto m_pos = monster.get_position();
         const auto is_projectable = projectable(floor, p_pos, m_pos);
@@ -520,7 +520,7 @@ static bool can_speak(const MonraceDefinition &ap_r_ref, MonsterSpeakType mon_sp
 
 static tl::optional<MonsterMessageType> get_speak_type(const CreatureEntity &monster)
 {
-    const auto &ap_monrace = monster.get_appearance_monrace();
+    const auto &ap_monrace = monster.get_apparent_monrace();
     if (monster.is_fearful() && can_speak(ap_monrace, MonsterSpeakType::SPEAK_FEAR)) {
         return MonsterMessageType::SPEAK_FEAR;
     }
@@ -618,7 +618,7 @@ void process_speak(CreatureEntity &creature, MONSTER_IDX m_idx, POSITION oy, POS
     constexpr auto chance_speak = 8;
     auto vociferous = monrace.r_misc_flags.has(MonsterMiscType::VOCIFEROUS) && (Grid::calc_distance(creature.get_position(), monster.get_position()) <= MAX_PLAYER_SIGHT * 2) && one_in_(chance_speak / 3 + 1);
     const auto p_pos = creature.get_position();
-    const auto can_speak = monster.get_appearance_monrace().speak_flags.any();
+    const auto can_speak = monster.get_apparent_monrace().speak_flags.any();
     if ((!vociferous) && (!can_speak || !aware || !floor.has_los_at({ oy, ox }) || !projectable(floor, pos, p_pos))) {
         return;
     }

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -18,6 +18,7 @@
 #include "monster-floor/monster-death.h"
 #include "monster-floor/monster-summon.h"
 #include "monster-floor/place-monster-types.h"
+#include "monster-race/race-kind-flags.h"
 #include "monster/monster-describer.h"
 #include "monster/monster-description-types.h"
 #include "object-enchant/item-apply-magic.h"
@@ -581,7 +582,26 @@ void switch_special_death(CreatureEntity &creature, MonsterDeath *md_ptr, Attrib
         return;
     }
 
+    on_dead_drop_kind_item(creature, md_ptr);
+    on_dead_drop_tval_item(creature, md_ptr);
+    on_dead_spawn_monsters(creature, md_ptr);
+
+    if (md_ptr->monrace->kind_flags.has(MonsterKindType::NINJA)) {
+        on_dead_ninja(creature, md_ptr);
+        return;
+    }
+
+    if (creature.is_sushi_eater()) {
+        drop_sushi(creature, md_ptr);
+    }
+
     switch (md_ptr->apparent_monrace->idx) {
+    case MonraceId::EARTH_DESTROYER:
+        on_dead_earth_destroyer(creature, md_ptr);
+        return;
+    case MonraceId::BOTTLE_GNOME:
+        on_dead_bottle_gnome(creature, md_ptr);
+        return;
     case MonraceId::BLOODLETTER:
         on_dead_bloodletter(creature, md_ptr);
         return;

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -115,7 +115,7 @@ static void on_dead_spawn_monsters(CreatureEntity &killer, MonsterDeath *md_ptr)
     }
     bool notice = false;
 
-    for (auto race : md_ptr->r_ptr->dead_spawns) {
+    for (auto race : md_ptr->monrace->dead_spawns) {
         int num = std::get<0>(race);
         int deno = std::get<1>(race);
         if (randint1(deno) > num) {
@@ -149,7 +149,7 @@ static void on_dead_spawn_monsters(CreatureEntity &killer, MonsterDeath *md_ptr)
  */
 static void on_dead_drop_kind_item(CreatureEntity &killer, MonsterDeath *md_ptr)
 {
-    for (auto kind : md_ptr->r_ptr->drop_kinds) {
+    for (auto kind : md_ptr->monrace->drop_kinds) {
         ItemEntity item;
         int num = std::get<0>(kind);
         int deno = std::get<1>(kind);
@@ -208,7 +208,7 @@ static void on_dead_drop_kind_item(CreatureEntity &killer, MonsterDeath *md_ptr)
  */
 static void on_dead_drop_tval_item(CreatureEntity &killer, MonsterDeath *md_ptr)
 {
-    for (auto kind : md_ptr->r_ptr->drop_tvals) {
+    for (auto kind : md_ptr->monrace->drop_tvals) {
         ItemEntity item;
         int num = std::get<0>(kind);
         int deno = std::get<1>(kind);
@@ -401,7 +401,7 @@ static void on_dead_can_angel(CreatureEntity &killer, MonsterDeath *md_ptr)
 {
     auto is_drop_can = md_ptr->drop_chosen_item;
     auto is_silver = md_ptr->m_ptr->get_r_idx() == MonraceId::A_SILVER;
-    is_silver &= md_ptr->r_ptr->r_akills % 5 == 0;
+    is_silver &= md_ptr->monrace->r_akills % 5 == 0;
     is_drop_can &= (md_ptr->m_ptr->get_r_idx() == MonraceId::A_GOLD) || is_silver;
     if (!is_drop_can) {
         return;
@@ -503,7 +503,7 @@ static void on_dead_mimics(CreatureEntity &killer, MonsterDeath *md_ptr)
         return;
     }
 
-    switch (md_ptr->r_ptr->symbol_definition.character) {
+    switch (md_ptr->monrace->symbol_definition.character) {
     case '(':
         if (killer.get_floor()->dun_level <= 0) {
             return;
@@ -562,7 +562,7 @@ static void on_dead_swordfish(CreatureEntity &killer, MonsterDeath *md_ptr, Attr
 
 void switch_special_death(CreatureEntity &creature, MonsterDeath *md_ptr, AttributeFlags attribute_flags)
 {
-    auto &monrace = MonraceList::get_instance().get_monrace(md_ptr->ap_r_ptr->idx);
+    auto &monrace = MonraceList::get_instance().get_monrace(md_ptr->apparent_monrace->idx);
     const auto &summon_list = monrace.get_final_summons();
     if (!summon_list.empty()) {
         auto do_message = false;
@@ -581,26 +581,7 @@ void switch_special_death(CreatureEntity &creature, MonsterDeath *md_ptr, Attrib
         return;
     }
 
-    on_dead_drop_kind_item(creature, md_ptr);
-    on_dead_drop_tval_item(creature, md_ptr);
-    on_dead_spawn_monsters(creature, md_ptr);
-
-    if (md_ptr->r_ptr->kind_flags.has(MonsterKindType::NINJA)) {
-        on_dead_ninja(creature, md_ptr);
-        return;
-    }
-
-    if (creature.is_sushi_eater()) {
-        drop_sushi(creature, md_ptr);
-    }
-
-    switch (md_ptr->ap_r_ptr->idx) {
-    case MonraceId::EARTH_DESTROYER:
-        on_dead_earth_destroyer(creature, md_ptr);
-        return;
-    case MonraceId::BOTTLE_GNOME:
-        on_dead_bottle_gnome(creature, md_ptr);
-        return;
+    switch (md_ptr->apparent_monrace->idx) {
     case MonraceId::BLOODLETTER:
         on_dead_bloodletter(creature, md_ptr);
         return;

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -120,7 +120,7 @@ static tl::optional<std::string> get_monster_self_pronoun(const CreatureEntity &
 
 static std::string get_describing_monster_name(const CreatureEntity &monster, const bool is_hallucinated, const BIT_FLAGS mode)
 {
-    const auto &monrace = monster.get_appearance_monrace();
+    const auto &monrace = monster.get_apparent_monrace();
     if (!is_hallucinated || any_bits(mode, MD_IGNORE_HALLU)) {
         return any_bits(mode, MD_TRUE_NAME) ? monster.get_real_monrace().name.string() : monrace.name.string();
     }
@@ -159,7 +159,7 @@ static std::string replace_monster_name_undefined(std::string_view name)
 
 static tl::optional<std::string> get_fake_monster_name(const CreatureEntity &creature, const CreatureEntity &monster, const std::string &name, const BIT_FLAGS mode)
 {
-    const auto &monrace = monster.get_appearance_monrace();
+    const auto &monrace = monster.get_apparent_monrace();
     const auto is_hallucinated = creature.is_hallucinated();
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) || (is_hallucinated && none_bits(mode, MD_IGNORE_HALLU))) {
         return tl::nullopt;
@@ -213,7 +213,7 @@ static std::string add_cameleon_name(const CreatureEntity &monster, const BIT_FL
         return "";
     }
 
-    const auto &monrace = monster.get_appearance_monrace();
+    const auto &monrace = monster.get_apparent_monrace();
     if (monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
         return _("(カメレオンの王)", "(Chameleon Lord)");
     }

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -525,7 +525,7 @@ static void update_invisible_monster(CreatureEntity &creature, um_type *um_ptr, 
     }
 
     const auto &world = AngbandWorld::get_instance();
-    if (world.is_loading_now && world.character_dungeon && !AngbandSystem::get_instance().is_phase_out() && monster.get_appearance_monrace().misc_flags.has(MonsterMiscType::ELDRITCH_HORROR)) {
+    if (world.is_loading_now && world.character_dungeon && !AngbandSystem::get_instance().is_phase_out() && monster.get_apparent_monrace().misc_flags.has(MonsterMiscType::ELDRITCH_HORROR)) {
         monster.set_temporary_flag(MonsterTemporaryFlagType::SANITY_BLAST);
     }
 
@@ -586,8 +586,8 @@ void update_monster(CreatureEntity &creature, MONSTER_IDX m_idx, bool full)
     um_type tmp_um;
     um_type *um_ptr = initialize_um_type(creature, &tmp_um, m_idx, full);
     if (disturb_high) {
-        auto *ap_r_ptr = &um_ptr->m_ptr->get_appearance_monrace();
-        if (ap_r_ptr->r_tkills && ap_r_ptr->level >= creature.get_level()) {
+        const auto &apparent_monrace = um_ptr->m_ptr->get_apparent_monrace();
+        if (apparent_monrace.r_tkills && apparent_monrace.level >= creature.get_level()) {
             um_ptr->do_disturb = true;
         }
     }

--- a/src/mspell/element-resistance-checker.cpp
+++ b/src/mspell/element-resistance-checker.cpp
@@ -77,15 +77,15 @@ static void check_acid_resistance(msr_type *msr_ptr)
     }
 
     if (msr_ptr->smart_flags.has_all_of({ MonsterSmartLearnType::OPP_ACID, MonsterSmartLearnType::RES_ACID })) {
-        if (int_outof(*msr_ptr->r_ptr, 80)) {
+        if (int_outof(*msr_ptr->monrace, 80)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BR_ACID);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 80)) {
+        if (int_outof(*msr_ptr->monrace, 80)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BA_ACID);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 80)) {
+        if (int_outof(*msr_ptr->monrace, 80)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BO_ACID);
         }
 
@@ -93,15 +93,15 @@ static void check_acid_resistance(msr_type *msr_ptr)
     }
 
     if (msr_ptr->smart_flags.has_any_of({ MonsterSmartLearnType::OPP_ACID, MonsterSmartLearnType::RES_ACID })) {
-        if (int_outof(*msr_ptr->r_ptr, 30)) {
+        if (int_outof(*msr_ptr->monrace, 30)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BR_ACID);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 30)) {
+        if (int_outof(*msr_ptr->monrace, 30)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BA_ACID);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 30)) {
+        if (int_outof(*msr_ptr->monrace, 30)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BO_ACID);
         }
     }
@@ -117,15 +117,15 @@ static void check_elec_resistance(msr_type *msr_ptr)
     }
 
     if (msr_ptr->smart_flags.has_all_of({ MonsterSmartLearnType::OPP_ELEC, MonsterSmartLearnType::RES_ELEC })) {
-        if (int_outof(*msr_ptr->r_ptr, 80)) {
+        if (int_outof(*msr_ptr->monrace, 80)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BR_ELEC);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 80)) {
+        if (int_outof(*msr_ptr->monrace, 80)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BA_ELEC);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 80)) {
+        if (int_outof(*msr_ptr->monrace, 80)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BO_ELEC);
         }
 
@@ -133,15 +133,15 @@ static void check_elec_resistance(msr_type *msr_ptr)
     }
 
     if (msr_ptr->smart_flags.has_any_of({ MonsterSmartLearnType::OPP_ELEC, MonsterSmartLearnType::RES_ELEC })) {
-        if (int_outof(*msr_ptr->r_ptr, 30)) {
+        if (int_outof(*msr_ptr->monrace, 30)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BR_ELEC);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 30)) {
+        if (int_outof(*msr_ptr->monrace, 30)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BA_ELEC);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 30)) {
+        if (int_outof(*msr_ptr->monrace, 30)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BO_ELEC);
         }
     }
@@ -157,15 +157,15 @@ static void check_fire_resistance(msr_type *msr_ptr)
     }
 
     if (msr_ptr->smart_flags.has_all_of({ MonsterSmartLearnType::OPP_FIRE, MonsterSmartLearnType::RES_FIRE })) {
-        if (int_outof(*msr_ptr->r_ptr, 80)) {
+        if (int_outof(*msr_ptr->monrace, 80)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BR_FIRE);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 80)) {
+        if (int_outof(*msr_ptr->monrace, 80)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BA_FIRE);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 80)) {
+        if (int_outof(*msr_ptr->monrace, 80)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BO_FIRE);
         }
 
@@ -173,15 +173,15 @@ static void check_fire_resistance(msr_type *msr_ptr)
     }
 
     if (msr_ptr->smart_flags.has_any_of({ MonsterSmartLearnType::OPP_FIRE, MonsterSmartLearnType::RES_FIRE })) {
-        if (int_outof(*msr_ptr->r_ptr, 30)) {
+        if (int_outof(*msr_ptr->monrace, 30)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BR_FIRE);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 30)) {
+        if (int_outof(*msr_ptr->monrace, 30)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BA_FIRE);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 30)) {
+        if (int_outof(*msr_ptr->monrace, 30)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BO_FIRE);
         }
     }
@@ -198,19 +198,19 @@ static void check_cold_resistance(msr_type *msr_ptr)
     }
 
     if (msr_ptr->smart_flags.has_all_of({ MonsterSmartLearnType::OPP_COLD, MonsterSmartLearnType::RES_COLD })) {
-        if (int_outof(*msr_ptr->r_ptr, 80)) {
+        if (int_outof(*msr_ptr->monrace, 80)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BR_COLD);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 80)) {
+        if (int_outof(*msr_ptr->monrace, 80)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BA_COLD);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 80)) {
+        if (int_outof(*msr_ptr->monrace, 80)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BO_COLD);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 80)) {
+        if (int_outof(*msr_ptr->monrace, 80)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BO_ICEE);
         }
 
@@ -218,19 +218,19 @@ static void check_cold_resistance(msr_type *msr_ptr)
     }
 
     if (msr_ptr->smart_flags.has_any_of({ MonsterSmartLearnType::OPP_COLD, MonsterSmartLearnType::RES_COLD })) {
-        if (int_outof(*msr_ptr->r_ptr, 30)) {
+        if (int_outof(*msr_ptr->monrace, 30)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BR_COLD);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 30)) {
+        if (int_outof(*msr_ptr->monrace, 30)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BA_COLD);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 30)) {
+        if (int_outof(*msr_ptr->monrace, 30)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BO_COLD);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 20)) {
+        if (int_outof(*msr_ptr->monrace, 20)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BO_ICEE);
         }
     }
@@ -239,19 +239,19 @@ static void check_cold_resistance(msr_type *msr_ptr)
 static void check_pois_resistance(msr_type *msr_ptr)
 {
     if (msr_ptr->smart_flags.has_all_of({ MonsterSmartLearnType::OPP_POIS, MonsterSmartLearnType::RES_POIS })) {
-        if (int_outof(*msr_ptr->r_ptr, 80)) {
+        if (int_outof(*msr_ptr->monrace, 80)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BR_POIS);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 80)) {
+        if (int_outof(*msr_ptr->monrace, 80)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BA_POIS);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 60)) {
+        if (int_outof(*msr_ptr->monrace, 60)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BA_NUKE);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 60)) {
+        if (int_outof(*msr_ptr->monrace, 60)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BR_NUKE);
         }
 
@@ -259,11 +259,11 @@ static void check_pois_resistance(msr_type *msr_ptr)
     }
 
     if (msr_ptr->smart_flags.has_any_of({ MonsterSmartLearnType::OPP_POIS, MonsterSmartLearnType::RES_POIS })) {
-        if (int_outof(*msr_ptr->r_ptr, 30)) {
+        if (int_outof(*msr_ptr->monrace, 30)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BR_POIS);
         }
 
-        if (int_outof(*msr_ptr->r_ptr, 30)) {
+        if (int_outof(*msr_ptr->monrace, 30)) {
             msr_ptr->ability_flags.reset(MonsterAbilityType::BA_POIS);
         }
     }

--- a/src/mspell/high-resistance-checker.cpp
+++ b/src/mspell/high-resistance-checker.cpp
@@ -80,15 +80,15 @@ static void check_nether_resistance(CreatureEntity &creature, msr_type *msr_ptr)
         return;
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 20)) {
+    if (int_outof(*msr_ptr->monrace, 20)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BR_NETH);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 50)) {
+    if (int_outof(*msr_ptr->monrace, 50)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BA_NETH);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 50)) {
+    if (int_outof(*msr_ptr->monrace, 50)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BO_NETH);
     }
 }
@@ -99,15 +99,15 @@ static void check_lite_resistance(msr_type *msr_ptr)
         return;
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 50)) {
+    if (int_outof(*msr_ptr->monrace, 50)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BR_LITE);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 50)) {
+    if (int_outof(*msr_ptr->monrace, 50)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BA_LITE);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 50)) {
+    if (int_outof(*msr_ptr->monrace, 50)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BO_LITE);
     }
 }
@@ -124,11 +124,11 @@ static void check_dark_resistance(CreatureEntity &creature, msr_type *msr_ptr)
         return;
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 50)) {
+    if (int_outof(*msr_ptr->monrace, 50)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BR_DARK);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 50)) {
+    if (int_outof(*msr_ptr->monrace, 50)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BA_DARK);
     }
 }
@@ -140,7 +140,7 @@ static void check_conf_resistance(msr_type *msr_ptr)
     }
 
     msr_ptr->ability_flags.reset(MonsterAbilityType::CONF);
-    if (int_outof(*msr_ptr->r_ptr, 50)) {
+    if (int_outof(*msr_ptr->monrace, 50)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BR_CONF);
     }
 }
@@ -151,11 +151,11 @@ static void check_chaos_resistance(msr_type *msr_ptr)
         return;
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 20)) {
+    if (int_outof(*msr_ptr->monrace, 20)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BR_CHAO);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 50)) {
+    if (int_outof(*msr_ptr->monrace, 50)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BA_CHAO);
     }
 }
@@ -166,7 +166,7 @@ static void check_nexus_resistance(msr_type *msr_ptr)
         return;
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 50)) {
+    if (int_outof(*msr_ptr->monrace, 50)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BR_NEXU);
     }
 
@@ -179,59 +179,59 @@ static void check_reflection(msr_type *msr_ptr)
         return;
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 150)) {
+    if (int_outof(*msr_ptr->monrace, 150)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BO_COLD);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 150)) {
+    if (int_outof(*msr_ptr->monrace, 150)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BO_FIRE);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 150)) {
+    if (int_outof(*msr_ptr->monrace, 150)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BO_ACID);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 150)) {
+    if (int_outof(*msr_ptr->monrace, 150)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BO_ELEC);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 150)) {
+    if (int_outof(*msr_ptr->monrace, 150)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BO_NETH);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 150)) {
+    if (int_outof(*msr_ptr->monrace, 150)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BO_WATE);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 150)) {
+    if (int_outof(*msr_ptr->monrace, 150)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BO_MANA);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 150)) {
+    if (int_outof(*msr_ptr->monrace, 150)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BO_PLAS);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 150)) {
+    if (int_outof(*msr_ptr->monrace, 150)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BO_ICEE);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 150)) {
+    if (int_outof(*msr_ptr->monrace, 150)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BO_VOID);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 150)) {
+    if (int_outof(*msr_ptr->monrace, 150)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BO_ABYSS);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 150)) {
+    if (int_outof(*msr_ptr->monrace, 150)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BO_METEOR);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 150)) {
+    if (int_outof(*msr_ptr->monrace, 150)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BO_LITE);
     }
 
-    if (int_outof(*msr_ptr->r_ptr, 150)) {
+    if (int_outof(*msr_ptr->monrace, 150)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::MISSILE);
     }
 }
@@ -247,7 +247,7 @@ void check_high_resistances(CreatureEntity &creature, msr_type *msr_ptr)
 
     check_conf_resistance(msr_ptr);
     check_chaos_resistance(msr_ptr);
-    if (msr_ptr->smart_flags.has(MonsterSmartLearnType::RES_DISEN) && int_outof(*msr_ptr->r_ptr, 40)) {
+    if (msr_ptr->smart_flags.has(MonsterSmartLearnType::RES_DISEN) && int_outof(*msr_ptr->monrace, 40)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BR_DISE);
     }
 
@@ -256,11 +256,11 @@ void check_high_resistances(CreatureEntity &creature, msr_type *msr_ptr)
     }
 
     check_nexus_resistance(msr_ptr);
-    if (msr_ptr->smart_flags.has(MonsterSmartLearnType::RES_SOUND) && int_outof(*msr_ptr->r_ptr, 50)) {
+    if (msr_ptr->smart_flags.has(MonsterSmartLearnType::RES_SOUND) && int_outof(*msr_ptr->monrace, 50)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BR_SOUN);
     }
 
-    if (msr_ptr->smart_flags.has(MonsterSmartLearnType::RES_SHARD) && int_outof(*msr_ptr->r_ptr, 40)) {
+    if (msr_ptr->smart_flags.has(MonsterSmartLearnType::RES_SHARD) && int_outof(*msr_ptr->monrace, 40)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BR_SHAR);
     }
 

--- a/src/mspell/improper-mspell-remover.cpp
+++ b/src/mspell/improper-mspell-remover.cpp
@@ -30,7 +30,7 @@ void remove_bad_spells(MONSTER_IDX m_idx, CreatureEntity &creature, EnumClassFla
 {
     msr_type tmp_msr(creature, m_idx, ability_flags);
     auto *msr_ptr = &tmp_msr;
-    if (msr_ptr->r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID)) {
+    if (msr_ptr->monrace->behavior_flags.has(MonsterBehaviorType::STUPID)) {
         return;
     }
 

--- a/src/mspell/mspell-attack-util.cpp
+++ b/src/mspell/mspell-attack-util.cpp
@@ -11,9 +11,9 @@ msa_type::msa_type(CreatureEntity &creature, MONSTER_IDX m_idx)
     , do_spell(DO_SPELL_NONE)
     , thrown_spell(MonsterAbilityType::MAX)
 {
-    this->r_ptr = &this->m_ptr->get_monrace();
-    this->no_inate = !evaluate_percent(this->r_ptr->freq_spell * 2);
-    this->ability_flags = this->r_ptr->ability_flags;
+    this->monrace = this->m_ptr->get_monrace_shared();
+    this->no_inate = !evaluate_percent(this->monrace->freq_spell * 2);
+    this->ability_flags = this->monrace->ability_flags;
 }
 
 Pos2D msa_type::get_position() const

--- a/src/mspell/mspell-attack-util.h
+++ b/src/mspell/mspell-attack-util.h
@@ -4,6 +4,7 @@
 #include "system/angband.h"
 #include "util/flag-group.h"
 #include "util/point-2d.h"
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -37,7 +38,7 @@ struct msa_type {
     mspell_lite_type do_spell;
     MonsterAbilityType thrown_spell;
 
-    MonraceDefinition *r_ptr;
+    std::shared_ptr<MonraceDefinition> monrace;
     bool no_inate;
     EnumClassFlagGroup<MonsterAbilityType> ability_flags;
 

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -57,7 +57,7 @@ static void check_mspell_stupid(CreatureEntity &creature, msa_type *msa_ptr)
     is_in_no_magic_dungeon &= floor.is_underground();
     is_in_no_magic_dungeon &= !floor.is_in_quest() || QuestType::is_fixed(floor.quest_number);
     msa_ptr->in_no_magic_dungeon = is_in_no_magic_dungeon;
-    if (!msa_ptr->in_no_magic_dungeon || (msa_ptr->r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID))) {
+    if (!msa_ptr->in_no_magic_dungeon || (msa_ptr->monrace->behavior_flags.has(MonsterBehaviorType::STUPID))) {
         return;
     }
 
@@ -66,7 +66,7 @@ static void check_mspell_stupid(CreatureEntity &creature, msa_type *msa_ptr)
 
 static void check_mspell_smart(const FloorType &floor, msa_type *msa_ptr)
 {
-    if (msa_ptr->r_ptr->behavior_flags.has_not(MonsterBehaviorType::SMART)) {
+    if (msa_ptr->monrace->behavior_flags.has_not(MonsterBehaviorType::SMART)) {
         return;
     }
 
@@ -94,7 +94,7 @@ static void check_mspell_arena(const FloorType &floor, msa_type *msa_ptr)
 
 static bool check_mspell_non_stupid(CreatureEntity &creature, msa_type *msa_ptr)
 {
-    if (msa_ptr->r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID)) {
+    if (msa_ptr->monrace->behavior_flags.has(MonsterBehaviorType::STUPID)) {
         return true;
     }
 
@@ -184,7 +184,7 @@ static bool check_mspell_continuation(CreatureEntity &creature, msa_type *msa_pt
 static bool check_mspell_unexploded(CreatureEntity &creature, msa_type *msa_ptr)
 {
     PERCENTAGE fail_rate = 25 - (msa_ptr->rlev + 3) / 4;
-    if (msa_ptr->r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID)) {
+    if (msa_ptr->monrace->behavior_flags.has(MonsterBehaviorType::STUPID)) {
         fail_rate = 0;
     }
 
@@ -291,9 +291,9 @@ static void remember_mspell(msa_type *msa_ptr)
         return;
     }
 
-    msa_ptr->r_ptr->r_ability_flags.set(msa_ptr->thrown_spell);
-    if (msa_ptr->r_ptr->r_cast_spell < MAX_UCHAR) {
-        msa_ptr->r_ptr->r_cast_spell++;
+    msa_ptr->monrace->r_ability_flags.set(msa_ptr->thrown_spell);
+    if (msa_ptr->monrace->r_cast_spell < MAX_UCHAR) {
+        msa_ptr->monrace->r_cast_spell++;
     }
 }
 
@@ -327,7 +327,7 @@ bool make_attack_spell(CreatureEntity &creature, MONSTER_IDX m_idx)
     }
 
     msa_ptr->m_ptr->reset_target();
-    msa_ptr->rlev = ((msa_ptr->r_ptr->level >= 1) ? msa_ptr->r_ptr->level : 1);
+    msa_ptr->rlev = ((msa_ptr->monrace->level >= 1) ? msa_ptr->monrace->level : 1);
     set_no_magic_mask(msa_ptr);
     decide_lite_area(creature, msa_ptr);
     check_mspell_stupid(creature, msa_ptr);
@@ -354,8 +354,8 @@ bool make_attack_spell(CreatureEntity &creature, MONSTER_IDX m_idx)
     msa_ptr->dam = monspell_res.dam;
     check_mspell_imitation(creature, msa_ptr);
     remember_mspell(msa_ptr);
-    if (creature.is_dead() && (msa_ptr->r_ptr->r_deaths < MAX_SHORT) && !creature.get_floor()->inside_arena) {
-        msa_ptr->r_ptr->r_deaths++;
+    if (creature.is_dead() && (msa_ptr->monrace->r_deaths < MAX_SHORT) && !creature.get_floor()->inside_arena) {
+        msa_ptr->monrace->r_deaths++;
     }
 
     return true;

--- a/src/mspell/mspell-lite.cpp
+++ b/src/mspell/mspell-lite.cpp
@@ -236,11 +236,11 @@ void decide_lite_area(CreatureEntity &creature, msa_type *msa_ptr)
 
     CreatureClass pc(creature);
     auto can_use_lite_area = pc.equals(PlayerClassType::NINJA);
-    can_use_lite_area &= !msa_ptr->m_ptr->has_undead_flag();
-    can_use_lite_area &= msa_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::HURT_LITE);
-    can_use_lite_area &= (msa_ptr->r_ptr->brightness_flags.has_none_of(dark_mask));
+    can_use_lite_area &= msa_ptr->monrace->kind_flags.has_not(MonsterKindType::UNDEAD);
+    can_use_lite_area &= msa_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::HURT_LITE);
+    can_use_lite_area &= (msa_ptr->monrace->brightness_flags.has_none_of(dark_mask));
 
-    if (msa_ptr->r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID)) {
+    if (msa_ptr->monrace->behavior_flags.has(MonsterBehaviorType::STUPID)) {
         return;
     }
 

--- a/src/mspell/smart-mspell-util.cpp
+++ b/src/mspell/smart-mspell-util.cpp
@@ -8,8 +8,8 @@
 msr_type::msr_type(CreatureEntity &creature, short m_idx, const EnumClassFlagGroup<MonsterAbilityType> &ability_flags)
     : ability_flags(ability_flags)
 {
-    const auto &monster = creature.get_floor()->get_monster(m_idx);
-    this->r_ptr = &monster.get_monrace();
+    const auto &monster = creature.get_floor()->m_list[m_idx];
+    this->monrace = monster.get_monrace_shared();
 }
 
 /*!

--- a/src/mspell/smart-mspell-util.h
+++ b/src/mspell/smart-mspell-util.h
@@ -3,13 +3,14 @@
 #include "monster-race/race-ability-flags.h"
 #include "monster/smart-learn-types.h"
 #include "util/flag-group.h"
+#include <memory>
 
 // Monster Spell Remover.
 class CreatureEntity;
 class MonraceDefinition;
 struct msr_type {
     msr_type(CreatureEntity &creature, short m_idx, const EnumClassFlagGroup<MonsterAbilityType> &ability_flags);
-    MonraceDefinition *r_ptr;
+    std::shared_ptr<const MonraceDefinition> monrace;
     EnumClassFlagGroup<MonsterAbilityType> ability_flags;
     EnumClassFlagGroup<MonsterSmartLearnType> smart_flags{};
 };

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -53,7 +53,7 @@ static void attack_confuse(CreatureEntity &creature, player_attack_type *pa_ptr,
         RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     }
 
-    auto &monrace = *pa_ptr->r_ptr;
+    auto &monrace = *pa_ptr->monrace;
     if (monrace.resistance_flags.has(MonsterResistanceType::NO_CONF)) {
         if (is_original_ap_and_seen(creature, *pa_ptr->m_ptr)) {
             monrace.r_resistance_flags.set(MonsterResistanceType::NO_CONF);
@@ -78,7 +78,7 @@ static void attack_confuse(CreatureEntity &creature, player_attack_type *pa_ptr,
  */
 static void attack_stun(CreatureEntity &creature, player_attack_type *pa_ptr, bool can_resist = true)
 {
-    auto &monrace = *pa_ptr->r_ptr;
+    auto &monrace = *pa_ptr->monrace;
     if (monrace.resistance_flags.has(MonsterResistanceType::NO_STUN)) {
         if (is_original_ap_and_seen(creature, *pa_ptr->m_ptr)) {
             monrace.resistance_flags.set(MonsterResistanceType::NO_STUN);
@@ -102,8 +102,8 @@ static void attack_stun(CreatureEntity &creature, player_attack_type *pa_ptr, bo
  */
 static void attack_scare(CreatureEntity &creature, player_attack_type *pa_ptr, bool can_resist = true)
 {
-    auto &monrace = *pa_ptr->r_ptr;
-    if (monrace.resistance_flags.has(MonsterResistanceType::NO_FEAR) || pa_ptr->m_ptr->is_frenzied()) {
+    auto &monrace = *pa_ptr->monrace;
+    if (monrace.resistance_flags.has(MonsterResistanceType::NO_FEAR)) {
         if (is_original_ap_and_seen(creature, *pa_ptr->m_ptr)) {
             monrace.resistance_flags.set(MonsterResistanceType::NO_FEAR);
         }
@@ -125,7 +125,7 @@ static void attack_scare(CreatureEntity &creature, player_attack_type *pa_ptr, b
  */
 static void attack_dispel(CreatureEntity &creature, player_attack_type *pa_ptr)
 {
-    if (pa_ptr->r_ptr->ability_flags.has_none_of(RF_ABILITY_ATTACK_MASK) && pa_ptr->r_ptr->ability_flags.has_none_of(RF_ABILITY_INDIRECT_MASK)) {
+    if (pa_ptr->monrace->ability_flags.has_none_of(RF_ABILITY_ATTACK_MASK) && pa_ptr->monrace->ability_flags.has_none_of(RF_ABILITY_INDIRECT_MASK)) {
         return;
     }
 
@@ -159,7 +159,7 @@ static void attack_probe(CreatureEntity &creature, player_attack_type *pa_ptr)
 {
     msg_print(_("刃が敵を調査した...", "The blade probed your enemy..."));
     msg_erase();
-    msg_print(probed_monster_info(creature, *pa_ptr->m_ptr, *pa_ptr->r_ptr));
+    msg_print(probed_monster_info(creature, *pa_ptr->m_ptr, *pa_ptr->monrace));
     msg_erase();
     const auto mes = MonraceList::get_instance().probe_lore(pa_ptr->r_idx);
     if (mes) {
@@ -176,7 +176,7 @@ static void attack_probe(CreatureEntity &creature, player_attack_type *pa_ptr)
  */
 static bool judge_tereprt_resistance(CreatureEntity &creature, player_attack_type *pa_ptr)
 {
-    auto &monrace = *pa_ptr->r_ptr;
+    auto &monrace = *pa_ptr->monrace;
     if (monrace.resistance_flags.has_not(MonsterResistanceType::RESIST_TELEPORT)) {
         return false;
     }
@@ -229,7 +229,7 @@ static void attack_teleport_away(CreatureEntity &creature, player_attack_type *p
  */
 static void attack_polymorph(CreatureEntity &creature, player_attack_type *pa_ptr, POSITION y, POSITION x)
 {
-    const auto &monrace = *pa_ptr->r_ptr;
+    const auto &monrace = *pa_ptr->monrace;
     if (monrace.kind_flags.has(MonsterKindType::UNIQUE) || monrace.misc_flags.has(MonsterMiscType::QUESTOR) || monrace.resistance_flags.has_any_of(RFR_EFF_RESIST_CHAOS_MASK)) {
         return;
     }

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -73,9 +73,9 @@ player_attack_type::player_attack_type(FloorType &floor, POSITION y, POSITION x,
     , magical_effect(MagicalBrandEffectType::NONE)
 {
     this->m_idx = this->g_ptr->m_idx;
-    this->m_ptr = &floor.get_monster(this->g_ptr->m_idx);
+    this->m_ptr = &floor.m_list[this->g_ptr->m_idx];
     this->r_idx = this->m_ptr->get_r_idx();
-    this->r_ptr = &this->m_ptr->get_monrace();
+    this->monrace = this->m_ptr->get_monrace_shared();
     this->ma_ptr = &ma_blows[0];
 }
 
@@ -542,8 +542,8 @@ void exe_player_attack_to_monster(CreatureEntity &creature, POSITION y, POSITION
     player_attack_type tmp_attack(*creature.get_floor(), y, x, hand, mode, fear, mdeath);
     auto pa_ptr = &tmp_attack;
 
-    const auto is_human = pa_ptr->r_ptr->symbol_char_is_any_of("p");
-    const auto is_lowlevel = (pa_ptr->r_ptr->level < (creature.get_level() - 15));
+    const auto is_human = pa_ptr->monrace->symbol_char_is_any_of("p");
+    const auto is_lowlevel = (pa_ptr->monrace->level < (creature.get_level() - 15));
 
     attack_classify(creature, pa_ptr);
     get_attack_exp(creature, pa_ptr);
@@ -554,8 +554,8 @@ void exe_player_attack_to_monster(CreatureEntity &creature, POSITION y, POSITION
 
     int chance = calc_attack_quality(creature, pa_ptr);
     auto *o_ptr = creature.inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand].get();
-    const auto is_zantetsu_nullified = o_ptr->is_specific_artifact(FixedArtifactId::ZANTETSU) && pa_ptr->r_ptr->symbol_char_is_any_of("j");
-    const auto is_ej_nullified = o_ptr->is_specific_artifact(FixedArtifactId::EXCALIBUR_J) && pa_ptr->r_ptr->symbol_char_is_any_of("S");
+    const auto is_zantetsu_nullified = o_ptr->is_specific_artifact(FixedArtifactId::ZANTETSU) && pa_ptr->monrace->symbol_char_is_any_of("j");
+    const auto is_ej_nullified = o_ptr->is_specific_artifact(FixedArtifactId::EXCALIBUR_J) && pa_ptr->monrace->symbol_char_is_any_of("S");
     calc_num_blow(creature, pa_ptr);
 
     /* Attack once for each legal blow */

--- a/src/player-attack/player-attack.h
+++ b/src/player-attack/player-attack.h
@@ -6,6 +6,7 @@
 #include "object-enchant/tr-flags.h"
 #include "system/angband.h"
 #include "system/system-variables.h"
+#include <memory>
 
 /*!
  * @brief カオス効果種別
@@ -67,7 +68,7 @@ struct player_attack_type {
     MONSTER_IDX m_idx; //!< モンスターID
     CreatureEntity *m_ptr; //!< モンスター情報(参照ポインタ)
     MonraceId r_idx; //!< モンスター種族ID
-    MonraceDefinition *r_ptr; //!< モンスター種族情報(参照ポインタ)
+    std::shared_ptr<MonraceDefinition> monrace; //!< モンスター種族情報
     const martial_arts *ma_ptr; //!< マーシャルアーツ種別
 };
 

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -64,7 +64,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
     auto power = 100;
     if (!necro && m_idx) {
         auto &monster = creature.get_floor()->get_monster(*m_idx);
-        auto &monrace = monster.get_appearance_monrace();
+        auto &monrace = monster.get_apparent_monrace();
         const auto m_name = monster_desc(creature, monster, 0);
         power = monrace.level / 2;
         if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -158,9 +158,29 @@ MonraceDefinition &CreatureEntity::get_monrace() const
     return MonraceList::get_instance().get_monrace(this->r_idx);
 }
 
-MonraceDefinition &CreatureEntity::get_appearance_monrace() const
+std::shared_ptr<MonraceDefinition> CreatureEntity::get_monrace_shared()
+{
+    return MonraceList::get_instance().get_monrace_shared(this->r_idx);
+}
+
+std::shared_ptr<const MonraceDefinition> CreatureEntity::get_monrace_shared() const
+{
+    return MonraceList::get_instance().get_monrace_shared(this->r_idx);
+}
+
+MonraceDefinition &CreatureEntity::get_apparent_monrace() const
 {
     return MonraceList::get_instance().get_monrace(this->ap_r_idx);
+}
+
+std::shared_ptr<MonraceDefinition> CreatureEntity::get_apparent_monrace_shared()
+{
+    return MonraceList::get_instance().get_monrace_shared(this->ap_r_idx);
+}
+
+std::shared_ptr<const MonraceDefinition> CreatureEntity::get_apparent_monrace_shared() const
+{
+    return MonraceList::get_instance().get_monrace_shared(this->ap_r_idx);
 }
 
 MonraceId CreatureEntity::get_real_monrace_id() const
@@ -221,19 +241,19 @@ const player_class_info *CreatureEntity::get_class_info() const
 
 bool CreatureEntity::has_living_flag(bool is_appearance) const
 {
-    const auto &monrace = is_appearance ? this->get_appearance_monrace() : this->get_monrace();
+    const auto &monrace = is_appearance ? this->get_apparent_monrace() : this->get_monrace();
     return monrace.has_living_flag();
 }
 
 bool CreatureEntity::has_demon_flag(bool is_appearance) const
 {
-    const auto &monrace = is_appearance ? this->get_appearance_monrace() : this->get_monrace();
+    const auto &monrace = is_appearance ? this->get_apparent_monrace() : this->get_monrace();
     return monrace.has_demon_flag();
 }
 
 bool CreatureEntity::has_undead_flag(bool is_appearance) const
 {
-    const auto &monrace = is_appearance ? this->get_appearance_monrace() : this->get_monrace();
+    const auto &monrace = is_appearance ? this->get_apparent_monrace() : this->get_monrace();
     return monrace.has_undead_flag();
 }
 
@@ -753,7 +773,7 @@ bool CreatureEntity::is_mimicry() const
         return true;
     }
 
-    const auto &monrace = this->get_appearance_monrace();
+    const auto &monrace = this->get_apparent_monrace();
     if (!monrace.symbol_char_is_any_of(R"(/|\()[]="$,.!?&`#%<>+~)")) {
         return false;
     }
@@ -1106,7 +1126,7 @@ std::string CreatureEntity::build_looking_description(bool needs_attitude) const
     const auto description = this->build_damage_description();
     const auto attitude = needs_attitude ? this->build_attitude_description() : "";
     const std::string clone(this->has_monster_profile() && this->is_cloned() ? ", clone" : "");
-    const auto &apparent_monrace = this->get_appearance_monrace();
+    const auto &apparent_monrace = this->get_apparent_monrace();
 
     const bool show_alliance = this->has_monster_profile() && !this->is_pet() && this->get_alliance_idx() != AllianceType::NONE;
     const std::string alliance_part = show_alliance ? format("(%s)", alliance_list.at(this->get_alliance_idx())->name.data()) : "";

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -342,10 +342,19 @@ public:
     MonraceDefinition &get_monrace() const;
 
     /*!
+     * @brief クリーチャーの実種族定義を shared_ptr で取得する
+     * @return 実種族定義への shared_ptr
+     */
+    std::shared_ptr<MonraceDefinition> get_monrace_shared();
+    std::shared_ptr<const MonraceDefinition> get_monrace_shared() const;
+
+    /*!
      * @brief クリーチャーの外見種族定義を取得する
      * @return 外見種族定義への参照（通常は get_monrace() と同じ、変身・誤認時は異なる）
      */
-    MonraceDefinition &get_appearance_monrace() const;
+    MonraceDefinition &get_apparent_monrace() const;
+    std::shared_ptr<MonraceDefinition> get_apparent_monrace_shared();
+    std::shared_ptr<const MonraceDefinition> get_apparent_monrace_shared() const;
 
     /*!
      * @brief クリーチャーの真の種族IDを取得する（カメレオン変身考慮）

--- a/src/system/monrace/monrace-allocation.cpp
+++ b/src/system/monrace/monrace-allocation.cpp
@@ -95,9 +95,9 @@ void MonraceAllocationTable::initialize()
     const auto &monraces = MonraceList::get_instance();
     this->entries.reserve(monraces.size());
 
-    for (const auto &[id, monrace] : monraces | ranges::views::filter([](const auto &x) { return x.second.is_valid(); })) {
-        const auto prob = static_cast<short>(100 / monrace.rarity);
-        this->entries.emplace_back(id, monrace.level, prob, prob);
+    for (const auto &[id, monrace] : monraces | ranges::views::filter([](const auto &x) { return x.second->is_valid(); })) {
+        const auto prob = static_cast<short>(100 / monrace->rarity);
+        this->entries.emplace_back(id, monrace->level, prob, prob);
     }
 
     ranges::stable_sort(this->entries, {}, &MonraceAllocationEntry::level);

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -233,6 +233,11 @@ const MonraceDefinition &MonraceDefinition::get_next() const
     return MonraceList::get_instance().get_monrace(this->next_r_idx);
 }
 
+std::shared_ptr<const MonraceDefinition> MonraceDefinition::get_next_shared() const
+{
+    return MonraceList::get_instance().get_monrace_shared(this->next_r_idx);
+}
+
 /*!
  * @brief モンスター種族が賞金首の対象かどうかを調べる。日替わり賞金首は対象外。
  * @param unachieved_only true の場合未達成の賞金首のみを対象とする。false の場合達成未達成に関わらずすべての賞金首を対象とする。

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -225,6 +225,7 @@ public:
     tl::optional<bool> order_pet(const MonraceDefinition &other) const;
     std::string get_pronoun_of_summoned_kin() const;
     const MonraceDefinition &get_next() const;
+    std::shared_ptr<const MonraceDefinition> get_next_shared() const;
     bool is_bounty(bool unachieved_only) const;
     int calc_power() const;
     int calc_figurine_value() const;

--- a/src/system/monrace/monrace-list.cpp
+++ b/src/system/monrace/monrace-list.cpp
@@ -101,7 +101,7 @@ bool MonraceList::is_chapel(MonraceId monrace_id)
 
 MonraceDefinition &MonraceList::emplace(MonraceId monrace_id)
 {
-    return this->monraces.emplace_hint(this->monraces.end(), monrace_id, MonraceDefinition{})->second;
+    return *this->monraces.emplace_hint(this->monraces.end(), monrace_id, std::make_shared<MonraceDefinition>())->second;
 }
 
 /*!
@@ -112,7 +112,7 @@ MonraceDefinition &MonraceList::emplace(MonraceId monrace_id)
  */
 MonraceDefinition &MonraceList::get_monrace(MonraceId monrace_id)
 {
-    return this->monraces.at(monrace_id);
+    return *this->monraces.at(monrace_id);
 }
 
 /*!
@@ -122,6 +122,16 @@ MonraceDefinition &MonraceList::get_monrace(MonraceId monrace_id)
  * @details モンスター実体からモンスター定義を得るためには使用しないこと
  */
 const MonraceDefinition &MonraceList::get_monrace(MonraceId monrace_id) const
+{
+    return *this->monraces.at(monrace_id);
+}
+
+std::shared_ptr<MonraceDefinition> MonraceList::get_monrace_shared(MonraceId monrace_id)
+{
+    return this->monraces.at(monrace_id);
+}
+
+std::shared_ptr<const MonraceDefinition> MonraceList::get_monrace_shared(MonraceId monrace_id) const
 {
     return this->monraces.at(monrace_id);
 }
@@ -149,15 +159,15 @@ std::vector<MonraceId> MonraceList::search(std::function<bool(const MonraceDefin
     std::vector<MonraceId> result_ids;
 
     for (const auto &[id, monrace] : this->monraces) {
-        if (!monrace.is_valid()) {
+        if (!monrace->is_valid()) {
             continue;
         }
 
-        if (is_known_only && (monrace.r_sights == 0)) {
+        if (is_known_only && (monrace->r_sights == 0)) {
             continue;
         }
 
-        if (filter(monrace)) {
+        if (filter(*monrace)) {
             result_ids.push_back(id);
         }
     }
@@ -351,8 +361,8 @@ bool MonraceList::order(MonraceId id1, MonraceId id2, bool is_detailed) const
     const auto &monrace1 = this->monraces.at(id1);
     const auto &monrace2 = this->monraces.at(id2);
     if (is_detailed) {
-        const auto pkills1 = monrace1.r_pkills;
-        const auto pkills2 = monrace2.r_pkills;
+        const auto pkills1 = monrace1->r_pkills;
+        const auto pkills2 = monrace2->r_pkills;
         if (pkills1 < pkills2) {
             return true;
         }
@@ -361,8 +371,8 @@ bool MonraceList::order(MonraceId id1, MonraceId id2, bool is_detailed) const
             return false;
         }
 
-        const auto tkills1 = monrace1.r_tkills;
-        const auto tkills2 = monrace2.r_tkills;
+        const auto tkills1 = monrace1->r_tkills;
+        const auto tkills2 = monrace2->r_tkills;
         if (tkills1 < tkills2) {
             return true;
         }
@@ -372,8 +382,8 @@ bool MonraceList::order(MonraceId id1, MonraceId id2, bool is_detailed) const
         }
     }
 
-    const auto level1 = monrace1.level;
-    const auto level2 = monrace2.level;
+    const auto level1 = monrace1->level;
+    const auto level2 = monrace2->level;
     if (level1 < level2) {
         return true;
     }
@@ -382,8 +392,8 @@ bool MonraceList::order(MonraceId id1, MonraceId id2, bool is_detailed) const
         return false;
     }
 
-    const auto exp1 = monrace1.mexp;
-    const auto exp2 = monrace2.mexp;
+    const auto exp1 = monrace1->mexp;
+    const auto exp2 = monrace2->mexp;
     if (exp1 < exp2) {
         return true;
     }
@@ -432,7 +442,7 @@ MonraceId MonraceList::pick_id_at_random() const
     static ProbabilityTable<MonraceId> table;
     if (table.empty()) {
         for (const auto &[monrace_id, monrace] : this->monraces) {
-            if (monrace.is_valid()) {
+            if (monrace->is_valid()) {
                 table.entry_item(monrace_id, 1);
             }
         }
@@ -443,23 +453,23 @@ MonraceId MonraceList::pick_id_at_random() const
 
 const MonraceDefinition &MonraceList::pick_monrace_at_random() const
 {
-    return this->monraces.at(this->pick_id_at_random());
+    return *this->monraces.at(this->pick_id_at_random());
 }
 
 int MonraceList::calc_defeat_count() const
 {
     auto total = 0;
     for (const auto &[_, monrace] : this->monraces) {
-        if (monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
-            if (monrace.is_dead_unique()) {
+        if (monrace->kind_flags.has(MonsterKindType::UNIQUE)) {
+            if (monrace->is_dead_unique()) {
                 total++;
             }
 
             continue;
         }
 
-        if (monrace.r_pkills > 0) {
-            total += monrace.r_pkills;
+        if (monrace->r_pkills > 0) {
+            total += monrace->r_pkills;
         }
     }
 
@@ -491,14 +501,14 @@ MonraceId MonraceList::select_figurine(int max_level) const
 void MonraceList::reset_current_numbers()
 {
     for (auto &[_, monrace] : this->monraces) {
-        monrace.reset_current_numbers();
+        monrace->reset_current_numbers();
     }
 }
 
 void MonraceList::reset_all_visuals()
 {
     for (auto &[_, monrace] : this->monraces) {
-        monrace.symbol_config = monrace.symbol_definition;
+        monrace->symbol_config = monrace->symbol_definition;
     }
 }
 

--- a/src/system/monrace/monrace-list.h
+++ b/src/system/monrace/monrace-list.h
@@ -9,6 +9,7 @@
 #include "util/abstract-map-wrapper.h"
 #include <functional>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <tl/optional.hpp>
@@ -17,7 +18,7 @@
 enum class MonraceId : short;
 
 class MonraceDefinition;
-class MonraceList : public util::AbstractMapWrapper<MonraceId, MonraceDefinition> {
+class MonraceList : public util::AbstractMapWrapper<MonraceId, std::shared_ptr<MonraceDefinition>> {
 public:
     MonraceList(MonraceList &&) = delete;
     MonraceList(const MonraceList &) = delete;
@@ -34,6 +35,8 @@ public:
     MonraceDefinition &emplace(MonraceId monrace_id);
     MonraceDefinition &get_monrace(MonraceId monrace_id);
     const MonraceDefinition &get_monrace(MonraceId monrace_id) const;
+    std::shared_ptr<MonraceDefinition> get_monrace_shared(MonraceId monrace_id);
+    std::shared_ptr<const MonraceDefinition> get_monrace_shared(MonraceId monrace_id) const;
     const std::vector<MonraceId> &get_valid_monrace_ids() const;
     std::vector<MonraceId> search(std::function<bool(const MonraceDefinition &)> filter, bool is_known_only = false) const;
     std::vector<MonraceId> search_by_name(std::string_view name, bool is_known_only = false) const;
@@ -64,11 +67,11 @@ private:
     MonraceList() = default;
 
     static MonraceList instance;
-    std::map<MonraceId, MonraceDefinition> monraces;
+    std::map<MonraceId, std::shared_ptr<MonraceDefinition>> monraces;
 
     const static std::map<MonraceId, std::set<MonraceId>> unified_uniques;
 
-    std::map<MonraceId, MonraceDefinition> &get_inner_container() override
+    std::map<MonraceId, std::shared_ptr<MonraceDefinition>> &get_inner_container() override
     {
         return this->monraces;
     }

--- a/src/system/services/baseitem-monrace-service.cpp
+++ b/src/system/services/baseitem-monrace-service.cpp
@@ -64,7 +64,7 @@ tl::optional<std::string> BaseitemMonraceService::check_specific_drop_gold_flags
 
     const auto &monraces = MonraceList::get_instance();
     for (const auto &[monrace_id, monrace] : monraces) {
-        const auto monrace_specific_gold_drop_flags = specific_gold_drop_flags & monrace.drop_flags;
+        const auto monrace_specific_gold_drop_flags = specific_gold_drop_flags & monrace->drop_flags;
 
         if (monrace_specific_gold_drop_flags.count() > 1) {
             constexpr auto fmt = _("財宝種別は同時に2つ以上指定できません。 ID: %d",

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -109,7 +109,7 @@ bool show_gold_on_floor = false;
  */
 static std::string evaluate_monster_exp(CreatureEntity &creature, const CreatureEntity &monster)
 {
-    const auto &monrace = monster.get_appearance_monrace();
+    const auto &monrace = monster.get_apparent_monrace();
     if ((creature.get_level() >= PY_MAX_LEVEL) || CreatureRace(&creature).equals(PlayerRaceType::ANDROID)) {
         return "**";
     }

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -193,8 +193,8 @@ void target_sensing_monsters_prepare(CreatureEntity &creature, std::vector<MONST
     auto comp_importance = [&floor = *creature.get_floor()](MONSTER_IDX idx1, MONSTER_IDX idx2) {
         const auto &monster1 = floor.get_monster(idx1);
         const auto &monster2 = floor.get_monster(idx2);
-        const auto &monrace1 = monster1.get_appearance_monrace();
-        const auto &monrace2 = monster2.get_appearance_monrace();
+        const auto &monrace1 = monster1.get_apparent_monrace();
+        const auto &monrace2 = monster2.get_apparent_monrace();
 
         /* Unique monsters first */
         if (monrace1.kind_flags.has(MonsterKindType::UNIQUE) != monrace2.kind_flags.has(MonsterKindType::UNIQUE)) {
@@ -253,8 +253,8 @@ std::vector<MONSTER_IDX> target_pets_prepare(CreatureEntity &creature)
     auto comp_importance = [&floor](MONSTER_IDX idx1, MONSTER_IDX idx2) {
         const auto &monster1 = floor.get_monster(idx1);
         const auto &monster2 = floor.get_monster(idx2);
-        const auto &ap_monrace1 = monster1.get_appearance_monrace();
-        const auto &ap_monrace2 = monster2.get_appearance_monrace();
+        const auto &ap_monrace1 = monster1.get_apparent_monrace();
+        const auto &ap_monrace2 = monster2.get_apparent_monrace();
 
         if (monster1.is_riding() != monster2.is_riding()) {
             return monster1.is_riding();

--- a/src/target/target-sorter.cpp
+++ b/src/target/target-sorter.cpp
@@ -50,8 +50,8 @@ bool TargetSorter::compare_importance(const FloorType &floor, const Pos2D &pos_a
     }
 
     if (can_see_grid1 && can_see_grid2) {
-        const auto &appearent_monrace1 = monster_a.get_appearance_monrace();
-        const auto &appearent_monrace2 = monster_b.get_appearance_monrace();
+        const auto &appearent_monrace1 = monster_a.get_apparent_monrace();
+        const auto &appearent_monrace2 = monster_b.get_apparent_monrace();
         if (appearent_monrace1.kind_flags.has(MonsterKindType::UNIQUE) && appearent_monrace2.kind_flags.has_not(MonsterKindType::UNIQUE)) {
             return true;
         }

--- a/src/view/display-lore-attacks.cpp
+++ b/src/view/display-lore-attacks.cpp
@@ -168,12 +168,12 @@ void display_monster_melee_summary_line(lore_type *lore_ptr)
     hooked_roff(_("[打撃] ", "[Melee] "));
 
     for (int m = 0; m < max_attack_numbers; m++) {
-        const auto &blow = lore_ptr->r_ptr->blows[m];
+        const auto &blow = lore_ptr->monrace->blows[m];
         if (blow.method == RaceBlowMethodType::NONE) {
             continue;
         }
 
-        if (!lore_ptr->know_everything && (lore_ptr->r_ptr->r_blows[m] == 0)) {
+        if (!lore_ptr->know_everything && (lore_ptr->monrace->r_blows[m] == 0)) {
             continue;
         }
 
@@ -192,7 +192,7 @@ void display_monster_melee_summary_line(lore_type *lore_ptr)
         // 手段（pc）
         hook_c_roff(lore_ptr->pc, method_abbrev);
 
-        const bool blow_seen = lore_ptr->know_everything || (lore_ptr->r_ptr->r_blows[m] != 0);
+        const bool blow_seen = lore_ptr->know_everything || (lore_ptr->monrace->r_blows[m] != 0);
         const bool dmg_known = lore_ptr->know_everything || lore_ptr->is_blow_damage_known(m);
 
         // ダイスあり
@@ -316,7 +316,7 @@ static void display_monster_blow_en(lore_type *lore_ptr, int attack_numbers, con
 void display_monster_blow(lore_type *lore_ptr, int m, int attack_numbers)
 {
     auto display_monster_blows_pf = _(display_monster_blow_jp, display_monster_blow_en);
-    display_monster_blows_pf(lore_ptr, attack_numbers, lore_ptr->r_ptr->blows[m].damage_dice, m);
+    display_monster_blows_pf(lore_ptr, attack_numbers, lore_ptr->monrace->blows[m].damage_dice, m);
 }
 
 /*!
@@ -325,22 +325,20 @@ void display_monster_blow(lore_type *lore_ptr, int m, int attack_numbers)
  */
 void display_monster_blows(lore_type *lore_ptr)
 {
-    const int blow_count = static_cast<int>(lore_ptr->r_ptr->blows.size());
-    const int r_blow_count = static_cast<int>(lore_ptr->r_ptr->r_blows.size());
-    for (int m = 0; m < blow_count; m++) {
-        if (lore_ptr->r_ptr->blows[m].method == RaceBlowMethodType::NONE) {
+    const int max_attack_numbers = 4;
+    for (int m = 0; m < max_attack_numbers; m++) {
+        if (lore_ptr->monrace->blows[m].method == RaceBlowMethodType::NONE) {
             continue;
         }
 
-        if ((m < r_blow_count && lore_ptr->r_ptr->r_blows[m]) || lore_ptr->know_everything) {
+        if (lore_ptr->monrace->r_blows[m] || lore_ptr->know_everything) {
             lore_ptr->count++;
         }
     }
 
     int attack_numbers = 0;
-    for (int m = 0; m < blow_count; m++) {
-        const bool has_r_blow = m < r_blow_count && lore_ptr->r_ptr->r_blows[m] > 0;
-        if (lore_ptr->r_ptr->blows[m].method == RaceBlowMethodType::NONE || (!has_r_blow && !lore_ptr->know_everything)) {
+    for (int m = 0; m < max_attack_numbers; m++) {
+        if (lore_ptr->monrace->blows[m].method == RaceBlowMethodType::NONE || (((lore_ptr->monrace->r_blows[m] == 0) && !lore_ptr->know_everything))) {
             continue;
         }
 

--- a/src/view/display-lore-magics.cpp
+++ b/src/view/display-lore-magics.cpp
@@ -93,8 +93,8 @@ void display_mosnter_magic_possibility(lore_type *lore_ptr)
         return;
     }
 
-    int m = lore_ptr->r_ptr->r_cast_spell;
-    int n = lore_ptr->r_ptr->freq_spell;
+    int m = lore_ptr->monrace->r_cast_spell;
+    int n = lore_ptr->monrace->freq_spell;
     if (m > 100 || lore_ptr->know_everything) {
         hooked_roff(format(_("(確率:1/%d)", "; 1 time in %d"), 100 / n));
     } else if (m) {
@@ -141,15 +141,15 @@ static FlagState get_ability_state(lore_type *lore_ptr, MonsterAbilityType flag)
 {
     const bool fully_known = lore_ptr->know_everything || lore_ptr->is_details_known();
     if (fully_known) {
-        return lore_ptr->r_ptr->ability_flags.has(flag) ? FlagState::HAVE : FlagState::ABSENT;
+        return lore_ptr->monrace->ability_flags.has(flag) ? FlagState::HAVE : FlagState::ABSENT;
     }
-    return lore_ptr->r_ptr->r_ability_flags.has(flag) ? FlagState::HAVE : FlagState::UNKNOWN;
+    return lore_ptr->monrace->r_ability_flags.has(flag) ? FlagState::HAVE : FlagState::UNKNOWN;
 }
 
 static std::string mind_tag(const lore_type *lore_ptr)
 {
     const bool fully_known = lore_ptr->know_everything || lore_ptr->is_details_known();
-    const auto &flags = fully_known ? lore_ptr->r_ptr->behavior_flags : lore_ptr->r_ptr->r_behavior_flags;
+    const auto &flags = fully_known ? lore_ptr->monrace->behavior_flags : lore_ptr->monrace->r_behavior_flags;
 
     const bool has_smart = flags.has(MonsterBehaviorType::SMART);
     const bool has_stupid = flags.has(MonsterBehaviorType::STUPID);
@@ -169,8 +169,8 @@ static std::string mind_tag(const lore_type *lore_ptr)
 
 static std::string rate_tag(const lore_type *lore_ptr)
 {
-    const int m = lore_ptr->r_ptr->r_cast_spell;
-    int n = lore_ptr->r_ptr->freq_spell;
+    const int m = lore_ptr->monrace->r_cast_spell;
+    int n = lore_ptr->monrace->freq_spell;
     if (n <= 0) {
         const bool fully_known = lore_ptr->know_everything || lore_ptr->is_details_known();
         return fully_known ? "---" : "???";
@@ -368,7 +368,7 @@ static const std::vector<AbilityCellDef> &support_magic_defs()
 void display_monster_magic_rate(lore_type *lore_ptr)
 {
     const bool fully_known = lore_ptr->know_everything || lore_ptr->is_details_known();
-    if (!fully_known && lore_ptr->r_ptr->r_ability_flags.none()) {
+    if (!fully_known && lore_ptr->monrace->r_ability_flags.none()) {
         return;
     }
 
@@ -380,7 +380,7 @@ void display_monster_magic_rate(lore_type *lore_ptr)
 void display_monster_magic_tables(CreatureEntity &creature, lore_type *lore_ptr)
 {
     const bool fully_known = lore_ptr->know_everything || lore_ptr->is_details_known();
-    if (!fully_known && lore_ptr->r_ptr->r_ability_flags.none()) {
+    if (!fully_known && lore_ptr->monrace->r_ability_flags.none()) {
         return;
     }
 

--- a/src/view/display-lore-status.cpp
+++ b/src/view/display-lore-status.cpp
@@ -16,12 +16,12 @@ void display_monster_hp_ac(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("%s^は AC%d の防御力と", "%s^ has an armor rating of %d"), Who::who(lore_ptr->msex).data(), lore_ptr->r_ptr->ac));
-    if (lore_ptr->misc_flags.has(MonsterMiscType::FORCE_MAXHP) || (lore_ptr->r_ptr->hit_dice.sides == 1)) {
-        auto hp = lore_ptr->r_ptr->hit_dice.maxroll() * (lore_ptr->nightmare ? 2 : 1);
+    hooked_roff(format(_("%s^は AC%d の防御力と", "%s^ has an armor rating of %d"), Who::who(lore_ptr->msex).data(), lore_ptr->monrace->ac));
+    if (lore_ptr->misc_flags.has(MonsterMiscType::FORCE_MAXHP) || (lore_ptr->monrace->hit_dice.sides == 1)) {
+        auto hp = lore_ptr->monrace->hit_dice.maxroll() * (lore_ptr->nightmare ? 2 : 1);
         hooked_roff(format(_(" %d の体力がある。", " and a life rating of %d.  "), std::min(MONSTER_MAXHP, hp)));
     } else {
-        auto hit_dice = lore_ptr->r_ptr->hit_dice;
+        auto hit_dice = lore_ptr->monrace->hit_dice;
         if (lore_ptr->nightmare) {
             hit_dice.num *= 2;
         }
@@ -39,18 +39,18 @@ void display_monster_hp_ac_summary(lore_type *lore_ptr)
     }
 
     std::string hp_text;
-    if (lore_ptr->misc_flags.has(MonsterMiscType::FORCE_MAXHP) || (lore_ptr->r_ptr->hit_dice.sides == 1)) {
-        auto hp = lore_ptr->r_ptr->hit_dice.maxroll() * (lore_ptr->nightmare ? 2 : 1);
+    if (lore_ptr->misc_flags.has(MonsterMiscType::FORCE_MAXHP) || (lore_ptr->monrace->hit_dice.sides == 1)) {
+        auto hp = lore_ptr->monrace->hit_dice.maxroll() * (lore_ptr->nightmare ? 2 : 1);
         hp_text = format("%d", std::min(MONSTER_MAXHP, hp));
     } else {
-        auto hit_dice = lore_ptr->r_ptr->hit_dice;
+        auto hit_dice = lore_ptr->monrace->hit_dice;
         if (lore_ptr->nightmare) {
             hit_dice.num *= 2;
         }
         hp_text = hit_dice.to_string().data();
     }
 
-    const auto ac = lore_ptr->r_ptr->ac;
+    const auto ac = lore_ptr->monrace->ac;
 
     hooked_roff(format(_("最大HP:%s AC:%d ", "MaxHP:%s AC:%d "), hp_text.data(), ac));
 }
@@ -73,11 +73,11 @@ void display_monster_concrete_abilities(lore_type *lore_ptr)
         lore_ptr->lore_msgs.emplace_back(_("ドアを打ち破る", "bash down doors"), TERM_WHITE);
     }
 
-    if (lore_ptr->r_ptr->feature_flags.has(MonsterFeatureType::CAN_FLY)) {
+    if (lore_ptr->monrace->feature_flags.has(MonsterFeatureType::CAN_FLY)) {
         lore_ptr->lore_msgs.emplace_back(_("空を飛ぶ", "fly"), TERM_WHITE);
     }
 
-    if (lore_ptr->r_ptr->feature_flags.has(MonsterFeatureType::CAN_SWIM)) {
+    if (lore_ptr->monrace->feature_flags.has(MonsterFeatureType::CAN_SWIM)) {
         lore_ptr->lore_msgs.emplace_back(_("水を渡る", "swim"), TERM_WHITE);
     }
 
@@ -141,7 +141,7 @@ void display_monster_abilities(lore_type *lore_ptr)
 
 void display_monster_constitutions(lore_type *lore_ptr)
 {
-    if (lore_ptr->r_ptr->feature_flags.has(MonsterFeatureType::AQUATIC)) {
+    if (lore_ptr->monrace->feature_flags.has(MonsterFeatureType::AQUATIC)) {
         hooked_roff(format(_("%s^は水中に棲んでいる。", "%s^ lives in water.  "), Who::who(lore_ptr->msex).data()));
     }
 
@@ -345,7 +345,7 @@ void display_monster_concrete_resistances(lore_type *lore_ptr)
         lore_ptr->lore_msgs.emplace_back(_("あらゆる攻撃", "all"), TERM_YELLOW);
     }
 
-    if (lore_ptr->resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT) && lore_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
+    if (lore_ptr->resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT) && lore_ptr->monrace->kind_flags.has_not(MonsterKindType::UNIQUE)) {
         lore_ptr->lore_msgs.emplace_back(_("テレポート", "teleportation"), TERM_ORANGE);
     }
 }
@@ -380,30 +380,30 @@ void display_monster_resistances(lore_type *lore_ptr)
 
 void display_monster_evolution_summary(lore_type *lore_ptr)
 {
-    if (!lore_ptr->r_ptr->r_can_evolve && !lore_ptr->know_everything) {
+    if (!lore_ptr->monrace->r_can_evolve && !lore_ptr->know_everything) {
         return;
     }
 
-    const auto &monrace_next = lore_ptr->r_ptr->get_next();
+    const auto &monrace_next = lore_ptr->monrace->get_next();
     if (monrace_next.is_valid()) {
         hooked_roff(format(_("進化:%s ", "evolve:%s "), monrace_next.name.data()));
-    } else if (lore_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
+    } else if (lore_ptr->monrace->kind_flags.has_not(MonsterKindType::UNIQUE)) {
         hooked_roff(_("進化:なし ", "evolve:none "));
     }
 }
 
 void display_monster_evolution(lore_type *lore_ptr)
 {
-    if (!lore_ptr->r_ptr->r_can_evolve && !lore_ptr->know_everything) {
+    if (!lore_ptr->monrace->r_can_evolve && !lore_ptr->know_everything) {
         return;
     }
 
-    const auto &monrace_next = lore_ptr->r_ptr->get_next();
+    const auto &monrace_next = lore_ptr->monrace->get_next();
     if (monrace_next.is_valid()) {
         hooked_roff(format(_("%s^は経験を積むと、", "%s^ will evolve into "), Who::who(lore_ptr->msex).data()));
         hook_c_roff(TERM_YELLOW, format("%s", monrace_next.name.data()));
         hooked_roff(_(format("に進化する。"), format(" when %s gets enough experience.  ", Who::who(lore_ptr->msex).data())));
-    } else if (lore_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
+    } else if (lore_ptr->monrace->kind_flags.has_not(MonsterKindType::UNIQUE)) {
         hooked_roff(format(_("%sは進化しない。", "%s won't evolve.  "), Who::who(lore_ptr->msex).data()));
     }
 }
@@ -426,11 +426,11 @@ void display_monster_concrete_immunities(lore_type *lore_ptr)
         lore_ptr->lore_msgs.emplace_back(_("眠らされない", "slept"), TERM_BLUE);
     }
 
-    if (lore_ptr->resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT) && lore_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
+    if (lore_ptr->resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT) && lore_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE)) {
         lore_ptr->lore_msgs.emplace_back(_("テレポートされない", "teleported"), TERM_ORANGE);
     }
 
-    if (lore_ptr->resistance_flags.has(MonsterResistanceType::NO_INSTANTLY_DEATH) || lore_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
+    if (lore_ptr->resistance_flags.has(MonsterResistanceType::NO_INSTANTLY_DEATH) || lore_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE)) {
         lore_ptr->lore_msgs.emplace_back(_("即死しない", "instantly killed"), TERM_L_DARK);
     }
 }
@@ -465,46 +465,46 @@ void display_monster_immunities(lore_type *lore_ptr)
 
 void display_monster_alert_summary(lore_type *lore_ptr)
 {
-    auto alert = ((int)lore_ptr->r_ptr->r_wake * (int)lore_ptr->r_ptr->r_wake) > lore_ptr->r_ptr->sleep;
-    alert |= lore_ptr->r_ptr->r_ignore == MAX_UCHAR;
-    alert |= (lore_ptr->r_ptr->sleep == 0) && (lore_ptr->r_ptr->r_tkills >= 10);
+    auto alert = ((int)lore_ptr->monrace->r_wake * (int)lore_ptr->monrace->r_wake) > lore_ptr->monrace->sleep;
+    alert |= lore_ptr->monrace->r_ignore == MAX_UCHAR;
+    alert |= (lore_ptr->monrace->sleep == 0) && (lore_ptr->monrace->r_tkills >= 10);
     alert |= lore_ptr->know_everything;
     if (!alert) {
         return;
     }
-    hooked_roff(format(_("警戒度:%d/255 感知範囲:%dft ", "alertness:%d notice:%dft"), 255 - lore_ptr->r_ptr->sleep, 10 * lore_ptr->r_ptr->aaf));
+    hooked_roff(format(_("警戒度:%d/255 感知範囲:%dft ", "alertness:%d notice:%dft"), 255 - lore_ptr->monrace->sleep, 10 * lore_ptr->monrace->aaf));
 }
 
 void display_monster_alert(lore_type *lore_ptr)
 {
-    auto alert = ((int)lore_ptr->r_ptr->r_wake * (int)lore_ptr->r_ptr->r_wake) > lore_ptr->r_ptr->sleep;
-    alert |= lore_ptr->r_ptr->r_ignore == MAX_UCHAR;
-    alert |= (lore_ptr->r_ptr->sleep == 0) && (lore_ptr->r_ptr->r_tkills >= 10);
+    auto alert = ((int)lore_ptr->monrace->r_wake * (int)lore_ptr->monrace->r_wake) > lore_ptr->monrace->sleep;
+    alert |= lore_ptr->monrace->r_ignore == MAX_UCHAR;
+    alert |= (lore_ptr->monrace->sleep == 0) && (lore_ptr->monrace->r_tkills >= 10);
     alert |= lore_ptr->know_everything;
     if (!alert) {
         return;
     }
 
     std::string action;
-    if (lore_ptr->r_ptr->sleep > 200) {
+    if (lore_ptr->monrace->sleep > 200) {
         action = _("を無視しがちであるが", "prefers to ignore");
-    } else if (lore_ptr->r_ptr->sleep > 95) {
+    } else if (lore_ptr->monrace->sleep > 95) {
         action = _("に対してほとんど注意を払わないが", "pays very little attention to");
-    } else if (lore_ptr->r_ptr->sleep > 75) {
+    } else if (lore_ptr->monrace->sleep > 75) {
         action = _("に対してあまり注意を払わないが", "pays little attention to");
-    } else if (lore_ptr->r_ptr->sleep > 45) {
+    } else if (lore_ptr->monrace->sleep > 45) {
         action = _("を見過ごしがちであるが", "tends to overlook");
-    } else if (lore_ptr->r_ptr->sleep > 25) {
+    } else if (lore_ptr->monrace->sleep > 25) {
         action = _("をほんの少しは見ており", "takes quite a while to see");
-    } else if (lore_ptr->r_ptr->sleep > 10) {
+    } else if (lore_ptr->monrace->sleep > 10) {
         action = _("をしばらくは見ており", "takes a while to see");
-    } else if (lore_ptr->r_ptr->sleep > 5) {
+    } else if (lore_ptr->monrace->sleep > 5) {
         action = _("を幾分注意深く見ており", "is fairly observant of");
-    } else if (lore_ptr->r_ptr->sleep > 3) {
+    } else if (lore_ptr->monrace->sleep > 3) {
         action = _("を注意深く見ており", "is observant of");
-    } else if (lore_ptr->r_ptr->sleep > 1) {
+    } else if (lore_ptr->monrace->sleep > 1) {
         action = _("をかなり注意深く見ており", "is very observant of");
-    } else if (lore_ptr->r_ptr->sleep > 0) {
+    } else if (lore_ptr->monrace->sleep > 0) {
         action = _("を警戒しており", "is vigilant for");
     } else {
         action = _("をかなり警戒しており", "is ever vigilant for");
@@ -512,8 +512,8 @@ void display_monster_alert(lore_type *lore_ptr)
 
     constexpr auto fmt = _("%s^は侵入者%s、 %d フィート先から侵入者に気付くことがある。", "%s^ %s intruders, which %s may notice from %d feet.  ");
     const auto who = Who::who(lore_ptr->msex);
-    hooked_roff(_(format(fmt, who.data(), action.data(), 10 * lore_ptr->r_ptr->aaf),
-        format(fmt, who.data(), action.data(), who.data(), 10 * lore_ptr->r_ptr->aaf)));
+    hooked_roff(_(format(fmt, who.data(), action.data(), 10 * lore_ptr->monrace->aaf),
+        format(fmt, who.data(), action.data(), who.data(), 10 * lore_ptr->monrace->aaf)));
 }
 
 static void push_tag(std::vector<std::string> &tags, const char *msg)
@@ -688,19 +688,19 @@ struct GroupState {
 static GroupState get_group_state(const lore_type *lore_ptr, const ResistGroupDef &d)
 {
     const bool fully_known = lore_ptr->know_everything || lore_ptr->is_details_known();
-    const auto &flags = fully_known ? lore_ptr->r_ptr->resistance_flags : lore_ptr->r_ptr->r_resistance_flags;
+    const auto &flags = fully_known ? lore_ptr->monrace->resistance_flags : lore_ptr->monrace->r_resistance_flags;
 
     if (d.immune) {
-        const auto no_teleport = d.immune.value() == MonsterResistanceType::RESIST_TELEPORT && lore_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
+        const auto no_teleport = d.immune.value() == MonsterResistanceType::RESIST_TELEPORT && lore_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
         const auto other_flag = d.immune.value() != MonsterResistanceType::RESIST_TELEPORT;
-        const auto no_inst_death = d.immune.value() == MonsterResistanceType::NO_INSTANTLY_DEATH && lore_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
+        const auto no_inst_death = d.immune.value() == MonsterResistanceType::NO_INSTANTLY_DEATH && lore_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
         if ((no_teleport || other_flag) && (flags.has(d.immune.value()) || no_inst_death)) {
             return { GroupStateKind::IMMUNE, _(d.jp_immune, d.en_immune), d.color_immune };
         }
     }
 
     if (d.resist) {
-        const auto res_teleport = d.resist.value() == MonsterResistanceType::RESIST_TELEPORT && lore_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE);
+        const auto res_teleport = d.resist.value() == MonsterResistanceType::RESIST_TELEPORT && lore_ptr->monrace->kind_flags.has_not(MonsterKindType::UNIQUE);
         const auto other_flag = d.resist.value() != MonsterResistanceType::RESIST_TELEPORT;
         if ((res_teleport || other_flag) && flags.has(d.resist.value())) {
             return { GroupStateKind::RESIST, _(d.jp_resist, d.en_resist), d.color_resist };
@@ -879,10 +879,10 @@ static const std::vector<ResistGroupDef> &resist_group_defs()
 
 void display_monster_resistance_table(lore_type *lore_ptr)
 {
-    const auto see_reflecting = lore_ptr->r_ptr->r_misc_flags.has(MonsterMiscType::REFLECTING);
+    const auto see_reflecting = lore_ptr->monrace->r_misc_flags.has(MonsterMiscType::REFLECTING);
     const bool fully_known = lore_ptr->know_everything || lore_ptr->is_details_known();
 
-    if (!fully_known && lore_ptr->r_ptr->r_resistance_flags.none() && !see_reflecting) {
+    if (!fully_known && lore_ptr->monrace->r_resistance_flags.none() && !see_reflecting) {
         return;
     }
 
@@ -892,7 +892,7 @@ void display_monster_resistance_table(lore_type *lore_ptr)
     hooked_roff(_("[耐性] ", "[Resists] "));
 
     if (fully_known) {
-        if (lore_ptr->r_ptr->misc_flags.has(MonsterMiscType::REFLECTING)) {
+        if (lore_ptr->monrace->misc_flags.has(MonsterMiscType::REFLECTING)) {
             hook_c_roff(TERM_L_WHITE, _("反射 ", "REFLECTING "));
         } else {
             hook_c_roff(RES_ABSENT_COLOR, "------ ");

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -128,18 +128,18 @@ void output_monster_spoiler(MonraceId r_idx, hook_c_roff_pf roff_func)
 static void display_killed(lore_type *lore_ptr)
 {
 #ifdef JP
-    hooked_roff(format("このモンスターはあなたの先祖を %d 人葬っている", lore_ptr->r_ptr->r_deaths));
+    hooked_roff(format("このモンスターはあなたの先祖を %d 人葬っている", lore_ptr->monrace->r_deaths));
 #else
-    const auto present_perfect_tense = lore_ptr->r_ptr->r_deaths == 1 ? "has" : "have";
-    hooked_roff(format("%d of your ancestors %s been killed by this creature, ", lore_ptr->r_ptr->r_deaths, present_perfect_tense));
+    const auto present_perfect_tense = lore_ptr->monrace->r_deaths == 1 ? "has" : "have";
+    hooked_roff(format("%d of your ancestors %s been killed by this creature, ", lore_ptr->monrace->r_deaths, present_perfect_tense));
 #endif
-    if (lore_ptr->r_ptr->r_pkills) {
+    if (lore_ptr->monrace->r_pkills) {
         hooked_roff(format(_("が、あなたはこのモンスターを少なくとも %d 体は倒している。", "and you have exterminated at least %d of the creatures.  "),
-            lore_ptr->r_ptr->r_pkills));
-    } else if (lore_ptr->r_ptr->r_tkills) {
+            lore_ptr->monrace->r_pkills));
+    } else if (lore_ptr->monrace->r_tkills) {
         hooked_roff(format(
             _("が、あなたの先祖はこのモンスターを少なくとも %d 体は倒している。", "and your ancestors have exterminated at least %d of the creatures.  "),
-            lore_ptr->r_ptr->r_tkills));
+            lore_ptr->monrace->r_tkills));
     } else {
         hooked_roff(format(_("が、まだ%sを倒したことはない。", "and %s is not ever known to have been defeated.  "), Who::who(lore_ptr->msex).data()));
     }
@@ -147,12 +147,12 @@ static void display_killed(lore_type *lore_ptr)
 
 static void display_no_killed(lore_type *lore_ptr)
 {
-    if (lore_ptr->r_ptr->r_pkills) {
+    if (lore_ptr->monrace->r_pkills) {
         hooked_roff(format(
-            _("あなたはこのモンスターを少なくとも %d 体は殺している。", "You have killed at least %d of these creatures.  "), lore_ptr->r_ptr->r_pkills));
-    } else if (lore_ptr->r_ptr->r_tkills) {
+            _("あなたはこのモンスターを少なくとも %d 体は殺している。", "You have killed at least %d of these creatures.  "), lore_ptr->monrace->r_pkills));
+    } else if (lore_ptr->monrace->r_tkills) {
         hooked_roff(format(_("あなたの先祖はこのモンスターを少なくとも %d 体は殺している。", "Your ancestors have killed at least %d of these creatures.  "),
-            lore_ptr->r_ptr->r_tkills));
+            lore_ptr->monrace->r_tkills));
     } else {
         hooked_roff(_("このモンスターを倒したことはない。", "No battles to the death are recalled.  "));
     }
@@ -166,15 +166,15 @@ static void display_no_killed(lore_type *lore_ptr)
  */
 static void display_number_of_nazguls(lore_type *lore_ptr)
 {
-    if (lore_ptr->mode != MONSTER_LORE_DEBUG && lore_ptr->r_ptr->r_tkills == 0) {
+    if (lore_ptr->mode != MONSTER_LORE_DEBUG && lore_ptr->monrace->r_tkills == 0) {
         return;
     }
-    if (!lore_ptr->r_ptr->population_flags.has(MonsterPopulationType::NAZGUL)) {
+    if (!lore_ptr->monrace->population_flags.has(MonsterPopulationType::NAZGUL)) {
         return;
     }
 
-    const auto remain = lore_ptr->r_ptr->mob_num;
-    const auto killed = lore_ptr->r_ptr->r_akills;
+    const auto remain = lore_ptr->monrace->max_num;
+    const auto killed = lore_ptr->monrace->r_akills;
     if (remain == 0) {
         const auto whom = Who::whom(lore_ptr->msex, (killed > 1));
 #ifdef JP
@@ -207,7 +207,7 @@ void display_kill_numbers(lore_type *lore_ptr)
         return;
     }
 
-    if (lore_ptr->r_ptr->r_deaths == 0) {
+    if (lore_ptr->monrace->r_deaths == 0) {
         display_no_killed(lore_ptr);
     } else {
         display_killed(lore_ptr);
@@ -220,15 +220,15 @@ void display_kill_numbers(lore_type *lore_ptr)
 
 void display_where_to_appear_summary(lore_type *lore_ptr)
 {
-    if (lore_ptr->r_ptr->level == 0) {
+    if (lore_ptr->monrace->level == 0) {
         hooked_roff(_("出現:町 ", "live:town "));
         lore_ptr->old = true;
-    } else if (lore_ptr->r_ptr->r_tkills || lore_ptr->know_everything) {
+    } else if (lore_ptr->monrace->r_tkills || lore_ptr->know_everything) {
         if (depth_in_feet) {
             hooked_roff(format(
-                _("出現:%d フィート ", "depth:%d ft "), lore_ptr->r_ptr->level * 50));
+                _("出現:%d フィート ", "depth:%d ft "), lore_ptr->monrace->level * 50));
         } else {
-            hooked_roff(format(_("出現:%d階 ", "depth:%d F "), lore_ptr->r_ptr->level));
+            hooked_roff(format(_("出現:%d階 ", "depth:%d F "), lore_ptr->monrace->level));
         }
     }
 }
@@ -241,15 +241,15 @@ void display_where_to_appear_summary(lore_type *lore_ptr)
 bool display_where_to_appear(lore_type *lore_ptr)
 {
     lore_ptr->old = false;
-    if (lore_ptr->r_ptr->level == 0) {
+    if (lore_ptr->monrace->level == 0) {
         hooked_roff(format(_("%s^は町に住み", "%s^ lives in the town"), Who::who(lore_ptr->msex).data()));
         lore_ptr->old = true;
-    } else if (lore_ptr->r_ptr->r_tkills || lore_ptr->know_everything) {
+    } else if (lore_ptr->monrace->r_tkills || lore_ptr->know_everything) {
         if (depth_in_feet) {
             hooked_roff(format(
-                _("%s^は通常地下 %d フィートで出現し", "%s^ is normally found at depths of %d feet"), Who::who(lore_ptr->msex).data(), lore_ptr->r_ptr->level * 50));
+                _("%s^は通常地下 %d フィートで出現し", "%s^ is normally found at depths of %d feet"), Who::who(lore_ptr->msex).data(), lore_ptr->monrace->level * 50));
         } else {
-            hooked_roff(format(_("%s^は通常地下 %d 階で出現し", "%s^ is normally found on dungeon level %d"), Who::who(lore_ptr->msex).data(), lore_ptr->r_ptr->level));
+            hooked_roff(format(_("%s^は通常地下 %d 階で出現し", "%s^ is normally found on dungeon level %d"), Who::who(lore_ptr->msex).data(), lore_ptr->monrace->level));
         }
 
         lore_ptr->old = true;
@@ -303,17 +303,17 @@ void display_monster_never_move(lore_type *lore_ptr)
 
 void display_monster_exp_summary(lore_type *lore_ptr)
 {
-    if ((lore_ptr->r_ptr->r_tkills == 0) && !lore_ptr->know_everything) {
+    if ((lore_ptr->monrace->r_tkills == 0) && !lore_ptr->know_everything) {
         hooked_roff(_("経験:??? ", "Exp:??? "));
         return;
     }
-    hooked_roff(format(_("経験:%d ", "Exp:%d "), lore_ptr->r_ptr->mexp));
+    hooked_roff(format(_("経験:%d ", "Exp:%d "), lore_ptr->monrace->mexp));
 }
 
 void display_monster_kills_summary(lore_type *lore_ptr)
 {
     if (lore_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
-        if (lore_ptr->r_ptr->r_pkills == 0) {
+        if (lore_ptr->monrace->r_pkills == 0) {
             hook_c_roff(TERM_L_GREEN, _("生存 ", "alive "));
             return;
         }
@@ -322,12 +322,12 @@ void display_monster_kills_summary(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("殺:%d ", "kill:%d "), lore_ptr->r_ptr->r_pkills));
+    hooked_roff(format(_("殺:%d ", "kill:%d "), lore_ptr->monrace->r_pkills));
 
-    if (!lore_ptr->r_ptr->population_flags.has(MonsterPopulationType::NAZGUL)) {
+    if (!lore_ptr->monrace->population_flags.has(MonsterPopulationType::NAZGUL)) {
         return;
     }
-    hooked_roff(format(_("残:%d ", "remain:%d "), lore_ptr->r_ptr->max_num));
+    hooked_roff(format(_("残:%d ", "remain:%d "), lore_ptr->monrace->max_num));
 }
 
 void display_monster_kind_tags(lore_type *lore_ptr)
@@ -393,7 +393,7 @@ void display_monster_kind_tags(lore_type *lore_ptr)
     }
 
     // [モンスター体構造] 体構造タグ (HUMANOID は記載省略)
-    switch (lore_ptr->r_ptr->body_structure) {
+    switch (lore_ptr->monrace->body_structure) {
     case BodyStructureType::HUMANOID:
         break; // デフォルト、記載省略
     case BodyStructureType::BIPEDAL:
@@ -1172,16 +1172,16 @@ void display_monster_exp(CreatureEntity &creature, lore_type *lore_ptr)
     hooked_roff("を倒すことは");
 #endif
 
-    if (lore_ptr->r_ptr->plus_collapse) {
+    if (lore_ptr->monrace->plus_collapse) {
 #ifdef JP
-        hooked_roff(format("時空崩壊度に %s%d.%06d%% の変動を与え、", lore_ptr->r_ptr->plus_collapse > 0 ? "+" : "-", std::abs(lore_ptr->r_ptr->plus_collapse / 1000000), std::abs(lore_ptr->r_ptr->plus_collapse % 1000000)));
+        hooked_roff(format("時空崩壊度に %s%d.%06d%% の変動を与え、", lore_ptr->monrace->plus_collapse > 0 ? "+" : "-", std::abs(lore_ptr->monrace->plus_collapse / 1000000), std::abs(lore_ptr->monrace->plus_collapse % 1000000)));
 #else
-        hooked_roff(format(" gives %s%d.%06d%% collapse degree to world and ", lore_ptr->r_ptr->plus_collapse > 0 ? "+" : "-", std::abs(lore_ptr->r_ptr->plus_collapse / 1000000), std::abs(lore_ptr->r_ptr->plus_collapse % 1000000)));
+        hooked_roff(format(" gives %s%d.%06d%% collapse degree to world and ", lore_ptr->monrace->plus_collapse > 0 ? "+" : "-", std::abs(lore_ptr->monrace->plus_collapse / 1000000), std::abs(lore_ptr->monrace->plus_collapse % 1000000)));
 
 #endif
     }
 
-    int64_t base_exp = lore_ptr->r_ptr->mexp * lore_ptr->r_ptr->level * 3 / 2;
+    int64_t base_exp = lore_ptr->monrace->mexp * lore_ptr->monrace->level * 3 / 2;
     int64_t player_factor = (int64_t)creature.get_max_plv() + 2;
 
     int64_t exp_integer = base_exp / player_factor;
@@ -1272,7 +1272,7 @@ void display_monster_aura(lore_type *lore_ptr)
 
 void display_lore_this(CreatureEntity &creature, lore_type *lore_ptr)
 {
-    if ((lore_ptr->r_ptr->r_tkills == 0) && !lore_ptr->know_everything) {
+    if ((lore_ptr->monrace->r_tkills == 0) && !lore_ptr->know_everything) {
         return;
     }
 
@@ -1286,13 +1286,13 @@ void display_lore_this(CreatureEntity &creature, lore_type *lore_ptr)
     }
 #endif
 
-    if (lore_ptr->r_ptr->alliance_idx != AllianceType::NONE) {
+    if (lore_ptr->monrace->alliance_idx != AllianceType::NONE) {
 #ifdef JP
-        hooked_roff(alliance_list.at(lore_ptr->r_ptr->alliance_idx)->name.c_str());
+        hooked_roff(alliance_list.at(lore_ptr->monrace->alliance_idx)->name.c_str());
         hooked_roff("に所属している");
 #else
         hooked_roff("belonging to ");
-        hooked_roff(alliance_list.at(lore_ptr->r_ptr->alliance_idx)->name.c_str());
+        hooked_roff(alliance_list.at(lore_ptr->monrace->alliance_idx)->name.c_str());
 #endif
     }
 
@@ -1312,7 +1312,7 @@ static void display_monster_escort_contents(lore_type *lore_ptr)
         hooked_roff(_("少なくとも", " at the least"));
     }
 
-    const auto &reinforces = lore_ptr->r_ptr->get_reinforces();
+    const auto &reinforces = lore_ptr->monrace->get_reinforces();
 #ifdef JP
 #else
     hooked_roff(" contain");
@@ -1382,7 +1382,7 @@ void display_monster_launching(CreatureEntity &creature, lore_type *lore_ptr)
 
     std::string msg;
     if (lore_ptr->is_details_known() || lore_ptr->know_everything) {
-        msg = format(_("威力 %s の射撃をする", "fire an arrow (Power:%s)"), lore_ptr->r_ptr->shoot_damage_dice.to_string().data());
+        msg = format(_("威力 %s の射撃をする", "fire an arrow (Power:%s)"), lore_ptr->monrace->shoot_damage_dice.to_string().data());
     } else {
         msg = _("射撃をする", "fire an arrow");
     }
@@ -1427,15 +1427,15 @@ void display_monster_sometimes(lore_type *lore_ptr)
 
 void display_monster_dead_spawns(lore_type *lore_ptr)
 {
-    if (lore_ptr->r_ptr->dead_spawns.empty()) {
+    if (lore_ptr->monrace->dead_spawns.empty()) {
         return;
     }
 
-    if (!lore_ptr->know_everything && lore_ptr->r_ptr->r_tkills == 0) {
+    if (!lore_ptr->know_everything && lore_ptr->monrace->r_tkills == 0) {
         return;
     }
 
-    for (const auto &[numerator, denominator, spawn_monrace_id, dice_side, dice_num] : lore_ptr->r_ptr->dead_spawns) {
+    for (const auto &[numerator, denominator, spawn_monrace_id, dice_side, dice_num] : lore_ptr->monrace->dead_spawns) {
         const auto &spawn_monrace = MonraceList::get_instance().get_monrace(spawn_monrace_id);
 
 #ifdef JP
@@ -1460,11 +1460,11 @@ void display_monster_dead_spawns(lore_type *lore_ptr)
  */
 void display_drop_kind_items(lore_type *lore_ptr)
 {
-    if (lore_ptr->r_ptr->drop_kinds.empty()) {
+    if (lore_ptr->monrace->drop_kinds.empty()) {
         return;
     }
 
-    if (!lore_ptr->know_everything && lore_ptr->r_ptr->r_tkills == 0) {
+    if (!lore_ptr->know_everything && lore_ptr->monrace->r_tkills == 0) {
         return;
     }
 
@@ -1475,7 +1475,7 @@ void display_drop_kind_items(lore_type *lore_ptr)
 #endif
 
     bool first = true;
-    for (const auto &[numerator, denominator, item_id, grade, dice_num, dice_side] : lore_ptr->r_ptr->drop_kinds) {
+    for (const auto &[numerator, denominator, item_id, grade, dice_num, dice_side] : lore_ptr->monrace->drop_kinds) {
         if (!first) {
 #ifdef JP
             hooked_roff("、");
@@ -1517,9 +1517,9 @@ void display_drop_kind_items(lore_type *lore_ptr)
 void display_monster_guardian(lore_type *lore_ptr)
 {
     bool is_kingpin = lore_ptr->misc_flags.has(MonsterMiscType::QUESTOR);
-    is_kingpin &= lore_ptr->r_ptr->r_sights > 0;
-    is_kingpin &= !lore_ptr->r_ptr->is_dead_unique();
-    is_kingpin &= (lore_ptr->monrace_id == MonraceId::MELKO);
+    is_kingpin &= lore_ptr->monrace->r_sights > 0;
+    is_kingpin &= lore_ptr->monrace->max_num > 0;
+    is_kingpin &= (lore_ptr->monrace_id == MonraceId::OBERON) || (lore_ptr->monrace_id == MonraceId::SERPENT);
     if (is_kingpin) {
         hook_c_roff(TERM_VIOLET, _("あなたはこのモンスターを殺したいという強い欲望を感じている...", "You feel an intense desire to kill this monster...  "));
     } else if (lore_ptr->misc_flags.has(MonsterMiscType::GUARDIAN)) {

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -260,7 +260,7 @@ DisplaySymbolPair map_info(CreatureEntity &creature, const Pos2D &pos)
         return symbol_pair;
     }
 
-    const auto &monrace_ap = monster.get_appearance_monrace();
+    const auto &monrace_ap = monster.get_apparent_monrace();
     feat_priority = 30;
     if (is_hallucinated) {
         if (!monrace_ap.visual_flags.has_all_of({ MonsterVisualType::CLEAR, MonsterVisualType::CLEAR_COLOR })) {

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -131,7 +131,7 @@ static void print_monster_line(TERM_LEN x, TERM_LEN y, const CreatureEntity &mon
 {
     term_erase(0, y);
     term_gotoxy(x, y);
-    const auto &monrace = monster.get_appearance_monrace();
+    const auto &monrace = monster.get_apparent_monrace();
     if (!monrace.is_valid()) {
         return;
     }
@@ -220,7 +220,7 @@ void print_monster_list(const FloorType &floor, const std::vector<MONSTER_IDX> &
 
 static void print_pet_list_oneline(CreatureEntity &creature, const CreatureEntity &monster, TERM_LEN x, TERM_LEN y, TERM_LEN width)
 {
-    const auto &monrace = monster.get_appearance_monrace();
+    const auto &monrace = monster.get_apparent_monrace();
     const auto name = monster_desc(creature, monster, MD_ASSUME_VISIBLE | MD_INDEF_VISIBLE | MD_NO_OWNER);
     const auto &[bar_color, bar_len] = monster.get_hp_bar_data();
     const auto is_visible = monster.is_visible_on_map() && !creature.is_hallucinated();
@@ -568,7 +568,7 @@ static void display_floor_item_list(CreatureEntity &creature, const Pos2D &pos)
             line = format(_("(X:%03d Y:%03d) 何か奇妙な物の足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under something strange"), pos.x, pos.y);
         } else {
             const auto &monster = floor_ptr->get_monster(g_ptr->m_idx);
-            const auto &monrace = monster.get_appearance_monrace();
+            const auto &monrace = monster.get_apparent_monrace();
             line = format(_("(X:%03d Y:%03d) %sの足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under %s"), pos.x, pos.y, monrace.name.data());
         }
     } else {

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -63,9 +63,9 @@ static auto get_mon_evol_roots()
     std::set<MonraceId> evol_children;
     const auto &monraces = MonraceList::get_instance();
     for (const auto &[monrace_id, monrace] : monraces) {
-        if (monrace.get_next().is_valid()) {
+        if (monrace->get_next().is_valid()) {
             evol_parents.emplace(monrace_id);
-            evol_children.emplace(monrace.next_r_idx);
+            evol_children.emplace(monrace->next_r_idx);
         }
     }
 
@@ -106,15 +106,20 @@ static SpoilerOutputResultType spoil_mon_evol()
     spoil_out("------------------------------------------\n\n");
     const auto &monraces = MonraceList::get_instance();
     for (auto monrace_id : get_mon_evol_roots()) {
-        const auto *monrace_ptr = &monraces.get_monrace(monrace_id);
+        auto monrace = monraces.get_monrace_shared(monrace_id);
         constexpr auto fmt_before = _("[%d]: %s (レベル%d, '%c')\n", "[%d]: %s (Level %d, '%c')\n");
-        fprintf(spoiler_file, fmt_before, enum2i(monrace_id), monrace_ptr->name.data(), monrace_ptr->level, monrace_ptr->symbol_definition.character);
-        for (auto n = 1; monrace_ptr->get_next().is_valid(); n++) {
-            fprintf(spoiler_file, "%*s-(%d)-> ", n * 2, "", monrace_ptr->next_exp);
-            monrace_ptr = &monrace_ptr->get_next();
-            fprintf(spoiler_file, "[%d]: ", enum2i(monrace_ptr->idx));
+        fprintf(spoiler_file, fmt_before, enum2i(monrace_id), monrace->name.data(), monrace->level, monrace->symbol_definition.character);
+        for (auto n = 1;; n++) {
+            const auto monrace_next = monrace->get_next_shared();
+            if (!monrace_next->is_valid()) {
+                break;
+            }
+
+            fprintf(spoiler_file, "%*s-(%d)-> ", n * 2, "", monrace->next_exp);
+            monrace = monrace_next;
+            fprintf(spoiler_file, "[%d]: ", enum2i(monrace->idx));
             constexpr auto fmt_after = _("%s (レベル%d, '%c')\n", "%s (Level %d, '%c')\n");
-            fprintf(spoiler_file, fmt_after, monrace_ptr->name.data(), monrace_ptr->level, monrace_ptr->symbol_definition.character);
+            fprintf(spoiler_file, fmt_after, monrace->name.data(), monrace->level, monrace->symbol_definition.character);
         }
 
         fputc('\n', spoiler_file);


### PR DESCRIPTION
変愚蛮怒 PR #5378 の 4 連コミットを bakabakaband 構造に適応してマージ。

上流コミット 4 個を統合:
- bb7072d4b MonraceList の MonraceDefinition を shared_ptr で保有する形式に変えた
- 5f618d18e get_monrace() に関する生ポインタを shared_ptr に全て差し替えた
- 09995824e MonsterEntity::get_appearance_monrace() を get_apparent_monrace() に改名した
- bd98bb1b1 get_apparent_monrace() に関する生ポインタを shared_ptr に全て差し替えた

主要 API 変更:
- MonraceList の内部ストレージを std::map<MonraceId, MonraceDefinition> から std::map<MonraceId, std::shared_ptr<MonraceDefinition>> に変更
- 大量の MonraceDefinition * 引数を std::shared_ptr<MonraceDefinition> に置換
- get_appearance_monrace() を get_apparent_monrace() に改名
- get_monrace_shared() / get_apparent_monrace_shared() の virtual を追加 (CreatureEntity に移植済み、本来上流は MonsterEntity)
- 構造体 (scene_monster_info / smart_mspell_util の m_ptr 引数等) の raw pointer 保有を shared_ptr に統一

bakabakaband 側差分吸収:
- PlayerType *player_ptr → CreatureEntity &creature (引数置換)
- floor.m_list[idx] → floor.get_monster(idx) (bakabakaband アクセサ)
- player_ptr->current_floor_ptr → creature.get_floor()
- player_ptr->lev → creature.get_level()
- player_ptr->skill_sav → creature.get_skill_save() 等
- m_ptr->r_idx → m_ptr->get_r_idx() (提案 28 で private 化済)
- m_ptr->ml → m_ptr->is_visible_on_map()
- m_ptr->mflag2.has(...) → m_ptr->has_constant_flag(...)
- creature.effects()->hallucination().is_hallucinated() → creature.is_hallucinated()
- PlayerClass → CreatureClass (bakabakaband 改名済)
- monster.get_monrace_id() → monster.get_r_idx() (samurai constructor)

保持した bakabakaband 独自ブロック (raw merge で失われたもの):
- effect-monster-charm.cpp: has_aggravate_nasty / is_nopet() 関連
- mind-samurai.cpp: 独自 include + struct samurai_slaying_type
- monster-death.cpp: アライアンス処理 / plus_collapsion / defeat_level
- display-lore.cpp: plus_collapse 時空崩壊度ブロック
- effect-monster-resist-hurt.cpp: effect_monster_dirt 本体 + effect_monster_spider_string + effect_monster_stungun + effect_monster_meteor の bakabakaband 独自実装 165 行
- birth/game-play-initializer.cpp: ユニーク種族 mob_num/max_num 初期化
- alliance/knowledge-alliance/vault-reader: monraces ループの shared_ptr 化

monster-entity.{cpp,h} は bakabakaband で既に削除済みのため
modify/delete conflict を git rm で解決。

cherry-pick: bb7072d4b + 5f618d18e + 09995824e + bd98bb1b1