### PR TITLE
merge: QuestType::reward_fa_id をカプセル化 (hengband#5388 相当)

### DIFF
--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -65,13 +65,72 @@ bool QuestType::is_fixed(QuestId quest_id)
 
 bool QuestType::has_reward() const
 {
-    return this->reward_fa_id != FixedArtifactId::NONE;
+    return this->reward_fa_id.has_value();
 }
 
-ArtifactType &QuestType::get_reward() const
+tl::optional<FixedArtifactId> QuestType::get_reward() const
+{
+    return this->reward_fa_id;
+}
+
+ArtifactType &QuestType::get_reward_artifact() const
 {
     auto &artifacts = ArtifactList::get_instance();
-    return artifacts.get_artifact(this->reward_fa_id);
+    return artifacts.get_artifact(this->reward_fa_id.value_or(FixedArtifactId::NONE));
+}
+
+short QuestType::get_reward_bi_id() const
+{
+    if (!this->has_reward()) {
+        return 0;
+    }
+
+    const auto &artifact = ArtifactList::get_instance().get_artifact(*this->reward_fa_id);
+    return BaseitemList::get_instance().lookup_baseitem_id(artifact.bi_key);
+}
+
+bool QuestType::is_reward_instant_artifact() const
+{
+    if (!this->has_reward()) {
+        return false;
+    }
+
+    return ArtifactList::get_instance().get_artifact(*this->reward_fa_id).gen_flags.has(ItemGenerationTraitType::INSTA_ART);
+}
+
+bool QuestType::is_reward_target(const BaseitemKey &key) const
+{
+    if (!this->has_reward()) {
+        return false;
+    }
+
+    return ArtifactList::get_instance().get_artifact(*this->reward_fa_id).bi_key == key;
+}
+
+void QuestType::set_reward(FixedArtifactId fa_id)
+{
+    if (fa_id == FixedArtifactId::NONE) {
+        this->reset_reward();
+        return;
+    }
+
+    // 馬鹿馬鹿固有: 上流の ArtifactRecords は未導入のため、
+    // 既存通り ArtifactType::gen_flags の QUESTITEM ビットでクエスト報酬状態を管理する。
+    auto &artifacts = ArtifactList::get_instance();
+    if (this->reward_fa_id && (*this->reward_fa_id != fa_id)) {
+        artifacts.get_artifact(*this->reward_fa_id).gen_flags.reset(ItemGenerationTraitType::QUESTITEM);
+    }
+
+    this->reward_fa_id = fa_id;
+    artifacts.get_artifact(fa_id).gen_flags.set(ItemGenerationTraitType::QUESTITEM);
+}
+
+void QuestType::reset_reward()
+{
+    if (this->reward_fa_id) {
+        ArtifactList::get_instance().get_artifact(*this->reward_fa_id).gen_flags.reset(ItemGenerationTraitType::QUESTITEM);
+        this->reward_fa_id.reset();
+    }
 }
 
 /*!
@@ -234,7 +293,7 @@ void check_find_art_quest_completion(CreatureEntity &creature, ItemEntity *o_ptr
     for (const auto &[quest_id, quest] : quests) {
         auto found_artifact = (quest.type == QuestKindType::FIND_ARTIFACT);
         found_artifact &= (quest.status == QuestStatusType::TAKEN);
-        found_artifact &= (o_ptr->is_specific_artifact(quest.reward_fa_id));
+        found_artifact &= quest.get_reward().map_or([o_ptr](FixedArtifactId fa_id) { return o_ptr->is_specific_artifact(fa_id); }, false);
         if (found_artifact) {
             complete_quest(creature, quest_id);
         }
@@ -304,7 +363,7 @@ void leave_quest_check(CreatureEntity &creature)
         quests.get_quest(QuestId::TOWER1).complev = creature.get_level();
         break;
     case QuestKindType::FIND_ARTIFACT:
-        quest.get_reward().gen_flags.reset(ItemGenerationTraitType::QUESTITEM);
+        quest.get_reward_artifact().gen_flags.reset(ItemGenerationTraitType::QUESTITEM);
         break;
     case QuestKindType::RANDOM:
         quest.get_bounty().misc_flags.reset(MonsterMiscType::QUESTOR);

--- a/src/dungeon/quest.h
+++ b/src/dungeon/quest.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <stdint.h>
 #include <string>
+#include <tl/optional.hpp>
 #include <vector>
 
 // clang-format off
@@ -104,6 +105,7 @@ enum class DungeonId;
 enum class FixedArtifactId : short;
 enum class MonraceId : int16_t;
 class ArtifactType;
+class BaseitemKey;
 class MonraceDefinition;
 class QuestType {
 public:
@@ -119,7 +121,6 @@ public:
     MONSTER_NUMBER cur_num = 0; /*!< 撃破したモンスターの数 / Number killed */
     MONSTER_NUMBER max_num = 0; /*!< 求められるモンスターの撃破数 / Number required */
 
-    FixedArtifactId reward_fa_id{}; /*!< クエスト対象のアイテムID / object index */
     MONSTER_NUMBER num_mon = 0; /*!< QuestKindTypeがKILL_NUMBER時の目標撃破数 number of monsters on level */
 
     BIT_FLAGS flags = 0; /*!< クエストに関するフラグビット / quest flags */
@@ -130,9 +131,18 @@ public:
 
     static bool is_fixed(QuestId quest_idx);
     bool has_reward() const;
-    ArtifactType &get_reward() const;
+    tl::optional<FixedArtifactId> get_reward() const;
+    ArtifactType &get_reward_artifact() const;
+    short get_reward_bi_id() const;
+    bool is_reward_instant_artifact() const;
+    bool is_reward_target(const BaseitemKey &key) const;
+    void set_reward(FixedArtifactId fa_id);
+    void reset_reward();
     MonraceDefinition &get_bounty();
     const MonraceDefinition &get_bounty() const;
+
+private:
+    tl::optional<FixedArtifactId> reward_fa_id{}; /*!< クエスト対象のアイテムID / object index */
 };
 
 class QuestList final : public util::AbstractMapWrapper<QuestId, QuestType> {

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -206,7 +206,6 @@ static bool parse_qtw_QQ(QuestType *q_ptr, const std::vector<std::string> &token
     q_ptr->level = std::stoi(tokens[6]);
     q_ptr->r_idx = i2enum<MonraceId>(std::stoi(tokens[7]));
     const auto fa_id = i2enum<FixedArtifactId>(std::stoi(tokens[8]));
-    q_ptr->reward_fa_id = fa_id;
     q_ptr->dungeon = i2enum<DungeonId>(std::stoi(tokens[9]));
 
     if (num > 10) {
@@ -222,8 +221,7 @@ static bool parse_qtw_QQ(QuestType *q_ptr, const std::vector<std::string> &token
         return true;
     }
 
-    auto &artifact = q_ptr->get_reward();
-    artifact.gen_flags.set(ItemGenerationTraitType::QUESTITEM);
+    q_ptr->set_reward(fa_id);
     return true;
 }
 
@@ -260,8 +258,7 @@ static bool parse_qtw_QR(QuestType *q_ptr, const std::vector<std::string> &token
     }
 
     if (reward_idx != FixedArtifactId::NONE) {
-        q_ptr->reward_fa_id = reward_idx;
-        artifacts.get_artifact(reward_idx).gen_flags.set(ItemGenerationTraitType::QUESTITEM);
+        q_ptr->set_reward(reward_idx);
     } else {
         q_ptr->type = QuestKindType::KILL_ALL;
     }

--- a/src/info-reader/general-parser.cpp
+++ b/src/info-reader/general-parser.cpp
@@ -196,8 +196,8 @@ parse_error_type parse_line_feature(const FloorType &floor, std::string_view buf
             }
         } else if (token.starts_with('!')) {
             if (floor.is_in_quest()) {
-                const auto &quests = QuestList::get_instance();
-                one_letter.artifact = quests.get_quest(floor.quest_number).reward_fa_id;
+                const auto &quest = QuestList::get_instance().get_quest(floor.quest_number);
+                one_letter.artifact = quest.get_reward().value_or(FixedArtifactId::NONE);
             }
         } else {
             one_letter.artifact = i2enum<FixedArtifactId>(std::stoi(token));
@@ -228,7 +228,7 @@ parse_error_type parse_line_feature(const FloorType &floor, std::string_view buf
                 const auto &quests = QuestList::get_instance();
                 const auto &quest = quests.get_quest(floor.quest_number);
                 if (quest.has_reward()) {
-                    const auto &artifact = quest.get_reward();
+                    const auto &artifact = quest.get_reward_artifact();
                     if (artifact.gen_flags.has_not(ItemGenerationTraitType::INSTA_ART)) {
                         one_letter.object = BaseitemList::get_instance().lookup_baseitem_id(artifact.bi_key);
                     }

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -102,9 +102,8 @@ static void do_cmd_knowledge_quests_current(CreatureEntity &creature, FILE *fff)
                 case QuestKindType::FIND_ARTIFACT: {
                     std::string item_name("");
                     if (quest.has_reward()) {
-                        const auto &artifact = quest.get_reward();
-                        ItemEntity item(artifact.bi_key);
-                        item.fa_id = quest.reward_fa_id;
+                        ItemEntity item(quest.get_reward_bi_id());
+                        item.fa_id = quest.get_reward().value_or(FixedArtifactId::NONE);
                         item.ident = IDENT_STORE;
                         item_name = describe_flavor(creature, item, OD_NAME_ONLY);
                     }

--- a/src/load/quest-loader.cpp
+++ b/src/load/quest-loader.cpp
@@ -52,9 +52,11 @@ static void load_quest_details(CreatureEntity &creature, QuestType *q_ptr, const
         auto &quests = QuestList::get_instance();
         determine_random_questor(creature, quests.get_quest(loading_quest_id));
     }
-    q_ptr->reward_fa_id = i2enum<FixedArtifactId>(rd_s16b());
-    if (q_ptr->has_reward()) {
-        q_ptr->get_reward().gen_flags.set(ItemGenerationTraitType::QUESTITEM);
+
+    q_ptr->reset_reward();
+    const auto reward_fa_id = i2enum<FixedArtifactId>(rd_s16b());
+    if (reward_fa_id != FixedArtifactId::NONE) {
+        q_ptr->set_reward(reward_fa_id);
     }
 
     q_ptr->flags = rd_byte();

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -13,6 +13,7 @@
 
 #include "save/save.h"
 #include "alliance/alliance.h"
+#include "artifact/fixed-art-types.h"
 #include "core/object-compressor.h"
 #include "dungeon/quest.h"
 #include "inventory/inventory-slot-types.h"
@@ -145,7 +146,7 @@ static bool wr_savefile_new(CreatureEntity &creature)
         wr_s16b((int16_t)quest.max_num);
         wr_s16b(enum2i(quest.type));
         wr_s16b(enum2i(quest.r_idx));
-        wr_s16b(enum2i(quest.reward_fa_id));
+        wr_s16b(enum2i(quest.get_reward().value_or(FixedArtifactId::NONE)));
         wr_byte((byte)quest.flags);
         wr_byte((byte)quest.dungeon);
     }

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -833,7 +833,7 @@ bool ItemEntity::is_target_of(QuestId quest_id) const
         return false;
     }
 
-    const auto &artifact = quest.get_reward();
+    const auto &artifact = quest.get_reward_artifact();
     if (artifact.gen_flags.has(ItemGenerationTraitType::INSTA_ART)) {
         return false;
     }


### PR DESCRIPTION
変愚蛮怒 PR #5388 の内容を bakabakaband 構造に適応してマージ。

- `QuestType::reward_fa_id` を public から private へ移し、型を `FixedArtifactId` から `tl::optional<FixedArtifactId>` に変更
- 操作を全てメンバ関数経由に統一:
  - `bool has_reward()` (optional の has_value 経由)
  - `tl::optional<FixedArtifactId> get_reward()` 新規 (報酬の固定アーティファクト ID 取得)
  - `short get_reward_bi_id()` 新規 (報酬のベースアイテム ID)
  - `bool is_reward_instant_artifact()` 新規
  - `bool is_reward_target(const BaseitemKey &)` 新規
  - `void set_reward(FixedArtifactId)` (新引数版、非 const)
  - `void reset_reward()` (非 const)

- bakabakaband 既存の `ArtifactType &get_reward() const` (ArtifactType 参照を返すヘルパ) を `get_reward_artifact()` に改名して保持 → 上流の `get_reward()` (optional ID 返却) と名前衝突を回避
- 既存 7 サイトの `quest.get_reward().X` (ArtifactType メンバ access) を `quest.get_reward_artifact().X` に migration (quest.cpp / floor/fixed-map-generator.cpp / info-reader/general-parser.cpp / knowledge/knowledge-quests.cpp / load/quest-loader.cpp / system/item-entity.cpp)
- upstream の `ArtifactRecords::set_quest_reward(fa_id, bool)` 呼出は bakabakaband に該当クラスが存在しないため、既存仕様通り `ArtifactList::get_instance().get_artifact(fa_id).gen_flags.{set,reset}(QUESTITEM)` で代替。同等のクエスト報酬マーキング機能を維持
- `is_reward_instant_artifact()` は bakabakaband に `ArtifactType::is_instant_artifact()` メソッドが無いため、 `gen_flags.has(ItemGenerationTraitType::INSTA_ART)` で代替実装
- `BaseitemKey` の前方宣言を quest.h に追加
- 重複していた `gen_flags.set(QUESTITEM)` を `set_reward()` 内で 集約管理するように整理 (fixed-map-generator.cpp / quest-loader.cpp)
- save.cpp のヘッダ include は bakabakaband 独自の `alliance/alliance.h` と upstream 追加の `artifact/fixed-art-types.h` を併存

cherry-pick: 38470d094