### PR TITLE
merge: ダンジョン定義の最下層定義を更新 (hengband#5379 相当)

### DIFF
--- a/lib/edit/DungeonDefinitions.jsonc
+++ b/lib/edit/DungeonDefinitions.jsonc
@@ -232,8 +232,7 @@
           "rate": 100,
         },
       ],
-      "final_guardian": 237,
-      "final_object": 426,
+      "final_floor": { "guardian": 237, "object": 426 },
       "normal_monster_rate": 0,
     },
     {
@@ -303,8 +302,7 @@
       "flags": ["CAVE", "WATER_RIVER", "CAVERN", "LAKE_TREE", "DESTROY", "LARGEST"],
       "monster_flags": ["ORC", "ANIMAL"],
       "monster_symbols": ["k", "o", "O"],
-      "final_guardian": 373,
-      "final_object": 148,
+      "final_floor": { "guardian": 373, "object": 148 },
       "normal_monster_rate": 50,
     },
     {
@@ -372,8 +370,7 @@
       },
       "flags": ["MAZE", "SMALLEST", "FORGET", "VANISH_STAIRS"],
       "normal_monster_rate": 100,
-      "final_guardian": 1034,
-      "final_object": 354,
+      "final_floor": { "guardian": 1034, "object": 354 },
     },
     {
       "id": 5,
@@ -533,8 +530,7 @@
       ],
       "monster_flags": ["UNDEAD", "NONLIVING"],
       "normal_monster_rate": 6,
-      "final_guardian": 804,
-      "final_artifact": 89,
+      "final_floor": { "guardian": 804, "artifact": 89 },
     },
     {
       "id": 7,
@@ -603,8 +599,7 @@
       "flags": ["NO_DOORS", "WATER_RIVER", "NO_TUNNEL"],
       "monster_flags": ["ANIMAL", "ELF", "WILD_WOOD", "GOOD"],
       "normal_monster_rate": 23,
-      "final_guardian": 1946,
-      "final_object": 409,
+      "final_floor": { "guardian": 1946, "object": 409 },
     },
     {
       "id": 8,
@@ -673,8 +668,7 @@
       "flags": ["CAVE", "CAVERN", "LAKE_LAVA", "LAVA_RIVER", "DESTROY"],
       "monster_flags": ["IM_FIRE", "CAN_FLY", "WILD_VOLCANO"],
       "normal_monster_rate": 0,
-      "final_guardian": 972,
-      "final_object": 629,
+      "final_floor": { "guardian": 972, "object": 629 },
     },
     {
       "id": 9,
@@ -879,8 +873,7 @@
       "flags": ["LAKE_WATER", "WATER_RIVER", "DESTROY"],
       "monster_flags": ["CAN_SWIM", "CAN_FLY", "AQUATIC", "WILD_OCEAN"],
       "normal_monster_rate": 0,
-      "final_guardian": 854,
-      "final_artifact": 107,
+      "final_floor": { "guardian": 854, "artifact": 107 },
       "alliance": "NUMENOR",
     },
     {
@@ -964,7 +957,7 @@
         },
       ],
       "normal_monster_rate": 25,
-      "final_guardian": 882,
+      "final_floor": { "guardian": 882 },
       "trap_rate": 10000,
     },
     {
@@ -1042,8 +1035,7 @@
       ],
       "monster_flags": ["DEMON", "ELDRITCH_HORROR"],
       "normal_monster_rate": 25,
-      "final_guardian": 857,
-      "final_artifact": 129,
+      "final_floor": { "guardian": 857, "artifact": 129 },
     },
     {
       "id": 14,
@@ -1112,8 +1104,7 @@
       "flags": ["WATER_RIVER", "CAVE", "CAVERN", "NO_DOORS", "LARGEST"],
       "monster_flags": ["TROLL", "GIANT", "CAN_FLY", "ANIMAL", "WILD_MOUNTAIN"],
       "monster_symbols": ["O", "Y", "H"],
-      "final_guardian": 468,
-      "final_object": 239,
+      "final_floor": { "guardian": 468, "object": 239 },
       "normal_monster_rate": 25,
     },
     {
@@ -1430,8 +1421,7 @@
       ],
       "monster_flags": ["CHAMELEON"],
       "normal_monster_rate": 0,
-      "final_guardian": 1041,
-      "final_object": 617,
+      "final_floor": { "guardian": 1041, "object": 617 },
     },
     {
       "id": 19,
@@ -1515,7 +1505,7 @@
         "DARKNESS",
       ],
       "normal_monster_rate": 100,
-      "final_guardian": 803,
+      "final_floor": { "guardian": 803 },
     },
     {
       "id": 20,
@@ -1680,7 +1670,7 @@
         },
       ],
       "normal_monster_rate": 2,
-      "final_guardian": 1309,
+      "final_floor": { "guardian": 1309 },
     },
     {
       "id": 22,
@@ -1750,7 +1740,7 @@
       "monster_flags": ["FEMALE", "NASTY", "HOMO_SEXUAL"],
       "monster_symbols": ["p", "h", "H", "g"],
       "normal_monster_rate": 2,
-      "final_guardian": 1308,
+      "final_floor": { "guardian": 1308 },
     },
     {
       "id": 23,
@@ -2092,7 +2082,7 @@
         },
       ],
       "normal_monster_rate": 2,
-      "final_guardian": 1704,
+      "final_floor": { "guardian": 1704 },
     },
     {
       "id": 27,
@@ -2297,7 +2287,7 @@
       "flags": ["ARENA", "NO_CAVE", "CURTAIN", "GLASS_ROOM", "ALWAYS_LIGHT"],
       "monster_flags": ["HUMAN"],
       "normal_monster_rate": 25,
-      "final_guardian": 1607,
+      "final_floor": { "guardian": 1607 },
       "alliance": "GOLAN",
     },
     {
@@ -2367,7 +2357,7 @@
       "flags": ["MAZE", "SMALLEST"],
       "monster_flags": [],
       "monster_symbols": ["p", "h", "H", "g"],
-      "final_guardian": 935,
+      "final_floor": { "guardian": 935 },
     },
     {
       "id": 31,
@@ -2444,7 +2434,7 @@
         "ACID_RIVER",
       ],
       "normal_monster_rate": 25,
-      "final_guardian": 1480,
+      "final_floor": { "guardian": 1480 },
       "monster_rate": 12,
     },
     {

--- a/schema/DungeonDefinitions.schema.json
+++ b/schema/DungeonDefinitions.schema.json
@@ -1,12 +1,230 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
-  "additionalProperties": false,
-  "description": "ダンジョン定義 (bakabakaband 構造化形式 version 2)",
-  "properties": {
-    "version": {
-      "type": "number",
-      "description": "Version 情報 (現在 2、version 1 wrapped-line 形式も読み込み互換)"
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": false,
+    "description": "ダンジョン定義 (bakabakaband 構造化形式 version 2)",
+    "properties": {
+        "version": {
+            "type": "number",
+            "description": "Version 情報 (現在 2、version 1 wrapped-line 形式も読み込み互換)"
+        },
+        "dungeons": {
+            "type": "array",
+            "description": "ダンジョン定義配列",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["id"],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "ダンジョン ID"
+                    },
+                    "name": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "ja": { "type": "string" },
+                            "en": { "type": "string" }
+                        }
+                    },
+                    "tag": {
+                        "type": "string",
+                        "description": "タグ識別子 (ANGBAND/MORIA 等)"
+                    },
+                    "description": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "ja": { "type": "string" },
+                            "en": { "type": "string" }
+                        }
+                    },
+                    "position": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["y", "x"],
+                        "properties": {
+                            "y": { "type": "integer", "minimum": 0 },
+                            "x": { "type": "integer", "minimum": 0 }
+                        }
+                    },
+                    "generation": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "min_depth": { "type": "integer" },
+                            "max_depth": { "type": "integer" },
+                            "min_player_level": { "type": "integer" },
+                            "flags_mode": { "type": "string", "enum": ["NONE", "AND", "NAND", "OR", "NOR"] },
+                            "min_count": { "type": "integer", "description": "1 階層に最低限生成されるモンスター数" },
+                            "extra_spawn_probability": { "type": "integer", "minimum": 1, "maximum": 1000000, "description": "モンスター追加生成率 (X / 1,000,000)。大きいほど追加生成されやすい" },
+                            "obj_good": { "type": "integer" },
+                            "obj_great": { "type": "integer" },
+                            "pit": { "type": "string", "pattern": "^0x[0-9a-fA-F]+$" },
+                            "nest": { "type": "string", "pattern": "^0x[0-9a-fA-F]+$" }
+                        }
+                    },
+                    "floor": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "tiles": {
+                                "type": "array",
+                                "minItems": 3,
+                                "maxItems": 3,
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "required": ["terrain", "rate"],
+                                    "properties": {
+                                        "terrain": { "type": "string" },
+                                        "rate": { "type": "integer", "minimum": 0, "maximum": 100 }
+                                    }
+                                }
+                            },
+                            "tunnel_rate": { "type": "integer", "minimum": 0, "maximum": 100 }
+                        }
+                    },
+                    "wall": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "tiles": {
+                                "type": "array",
+                                "minItems": 3,
+                                "maxItems": 3,
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "required": ["terrain", "rate"],
+                                    "properties": {
+                                        "terrain": { "type": "string" },
+                                        "rate": { "type": "integer", "minimum": 0, "maximum": 100 }
+                                    }
+                                }
+                            },
+                            "outer": { "type": "string" },
+                            "inner": { "type": "string" },
+                            "stream1": { "type": "string" },
+                            "stream2": { "type": "string" }
+                        }
+                    },
+                    "flags": {
+                        "type": "array",
+                        "description": "通常のダンジョンフラグ (CAVERN/WATER_RIVER/DESTROY 等)",
+                        "items": { "type": "string" }
+                    },
+                    "monster_rate": {
+                        "type": "integer",
+                        "description": "F:MONSTER_RATE_X 相当 (モンスター生成率%)"
+                    },
+                    "trap_rate": {
+                        "type": "integer",
+                        "description": "F:TRAP_RATE_X 相当"
+                    },
+                    "normal_monster_rate": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 100,
+                        "description": "通常モンスター生成率 (%) — ダンジョン制限モンスター以外の通常モンスターが出る確率"
+                    },
+                    "alliance": {
+                        "type": "string",
+                        "description": "F:ALLIANCE_X 相当 (支配アライアンス名)"
+                    },
+                    "final_floor": {
+                        "type": "object",
+                        "description": "最下層の固有設定 (ガーディアン / 報酬オブジェクト / 報酬アーティファクト)",
+                        "properties": {
+                            "guardian": { "type": "integer", "description": "最終ガーディアン MonraceId" },
+                            "object": { "type": "integer", "minimum": 1, "maximum": 9999, "description": "最終報酬オブジェクト BaseitemId" },
+                            "artifact": { "type": "integer", "description": "最終報酬アーティファクト FixedArtifactId" }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fixed_rooms": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["depth", "id", "percentage"],
+                            "properties": {
+                                "depth": { "type": "integer" },
+                                "id": { "type": "integer" },
+                                "percentage": { "type": "integer", "minimum": 0, "maximum": 100 }
+                            }
+                        }
+                    },
+                    "monster_flags": {
+                        "type": "array",
+                        "description": "M: モンスター制限フラグ",
+                        "items": { "type": "string" }
+                    },
+                    "monster_symbols": {
+                        "type": "array",
+                        "description": "出現許可モンスターシンボル (一文字配列)",
+                        "items": { "type": "string", "minLength": 1, "maxLength": 1 }
+                    },
+                    "monster_spells": {
+                        "type": "array",
+                        "description": "S: モンスター呪文制限",
+                        "items": { "type": "string" }
+                    },
+                    "specific_items": {
+                        "type": "array",
+                        "description": "K: 特定階層アイテム生成",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["floor", "probability", "dice_num", "dice_sides", "item_id"],
+                            "properties": {
+                                "floor": { "type": "integer" },
+                                "probability": { "type": "integer" },
+                                "dice_num": { "type": "integer" },
+                                "dice_sides": { "type": "integer" },
+                                "item_id": { "type": "integer" }
+                            }
+                        }
+                    },
+                    "specific_vaults": {
+                        "type": "array",
+                        "description": "Z: 特定階層 vault",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["floor", "vault_id"],
+                            "properties": {
+                                "floor": { "type": "integer" },
+                                "vault_id": { "type": "integer" }
+                            }
+                        }
+                    },
+                    "room_rates": {
+                        "type": "array",
+                        "description": "R: 部屋生成率",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["type", "rate"],
+                            "properties": {
+                                "type": { "type": "integer" },
+                                "rate": { "type": "integer" }
+                            }
+                        }
+                    },
+                    "lines": {
+                        "type": "array",
+                        "description": "[後方互換] version 1 wrapped-line 形式トークン行",
+                        "items": {
+                            "type": "string",
+                            "pattern": "^[A-Z]:"
+                        }
+                    }
+                }
+            }
+        }
     },
     "dungeons": {
       "type": "array",

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -1,4 +1,5 @@
 #include "info-reader/dungeon-reader.h"
+#include "artifact/fixed-art-types.h"
 #include "info-reader/dungeon-info-tokens-table.h"
 #include "info-reader/info-reader-util.h"
 #include "info-reader/parse-error-types.h"
@@ -6,16 +7,22 @@
 #include "io/tokenizer.h"
 #include "locale/japanese.h"
 #include "main/angband-headers.h"
+#include "system/artifact-type-definition.h"
+#include "system/baseitem/baseitem-definition.h"
+#include "system/baseitem/baseitem-list.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/dungeon/dungeon-list.h"
 #include "system/enums/dungeon/dungeon-id.h"
+#include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
+#include "system/monrace/monrace-list.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "util/dice.h"
 #include "util/enum-converter.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
+#include <exception>
 #include <span>
 
 /*!
@@ -677,6 +684,55 @@ static errr set_dungeon_wall(DungeonDefinition &dungeon, const nlohmann::json &w
 }
 
 /*!
+ * @brief final_floor オブジェクトをパースし、ダンジョン最下層の固有設定を直接フィル
+ * @details `guardian` (MonraceId 整数) / `object` (BaseitemId 整数) / `artifact`
+ *          (FixedArtifactId 整数) を受け取り、それぞれの整合性も検証する。
+ */
+static errr set_dungeon_final_floor(DungeonDefinition &dungeon, const nlohmann::json &final_floor_obj)
+{
+    if (final_floor_obj.is_null()) {
+        return PARSE_ERROR_NONE;
+    }
+    if (!final_floor_obj.is_object()) {
+        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    }
+
+    if (final_floor_obj.contains("guardian")) {
+        const auto value = final_floor_obj["guardian"].get<int>();
+        const auto monrace_id = i2enum<MonraceId>(value);
+        const auto &monraces = MonraceList::get_instance();
+        if (!MonraceList::is_valid(monrace_id) || !monraces.contains(monrace_id)) {
+            msg_format(_("不正な final_floor.guardian ID '%d'。", "Invalid final_floor.guardian ID '%d'."), value);
+            return PARSE_ERROR_INVALID_FLAG;
+        }
+        dungeon.final_guardian = monrace_id;
+    }
+    if (final_floor_obj.contains("object")) {
+        const auto value = final_floor_obj["object"].get<int>();
+        const auto value_short = static_cast<short>(value);
+        try {
+            static_cast<void>(BaseitemList::get_instance().get_baseitem(value_short));
+        } catch (const std::exception &) {
+            msg_format(_("不正な final_floor.object ID '%d'。", "Invalid final_floor.object ID '%d'."), value);
+            return PARSE_ERROR_INVALID_FLAG;
+        }
+        dungeon.final_object = value_short;
+    }
+    if (final_floor_obj.contains("artifact")) {
+        const auto value = final_floor_obj["artifact"].get<int>();
+        const auto artifact_id = i2enum<FixedArtifactId>(value);
+        const auto &artifacts = ArtifactList::get_instance();
+        if ((artifact_id != FixedArtifactId::NONE) && !artifacts.contains(artifact_id)) {
+            msg_format(_("不正な final_floor.artifact ID '%d'。", "Invalid final_floor.artifact ID '%d'."), value);
+            return PARSE_ERROR_INVALID_FLAG;
+        }
+        dungeon.final_artifact = artifact_id;
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
+/*!
  * @brief JSON flags 配列、および MONSTER_RATE / TRAP_RATE 等のスカラ
  *        + FIXED_ROOM / ALLIANCE 等のサブ構造を DungeonDefinition に直接フィル
  */
@@ -701,15 +757,6 @@ static errr set_dungeon_feature_flags(DungeonDefinition &dungeon, const nlohmann
     }
     if (dungeon_data.contains("normal_monster_rate")) {
         dungeon.normal_monster_rate = static_cast<PROB>(dungeon_data["normal_monster_rate"].get<int>());
-    }
-    if (dungeon_data.contains("final_guardian")) {
-        dungeon.final_guardian = i2enum<MonraceId>(dungeon_data["final_guardian"].get<int>());
-    }
-    if (dungeon_data.contains("final_object")) {
-        dungeon.final_object = static_cast<short>(dungeon_data["final_object"].get<int>());
-    }
-    if (dungeon_data.contains("final_artifact")) {
-        dungeon.final_artifact = i2enum<FixedArtifactId>(dungeon_data["final_artifact"].get<int>());
     }
     if (dungeon_data.contains("alliance")) {
         const auto alliance_tag = dungeon_data["alliance"].get<std::string>();
@@ -940,9 +987,16 @@ errr parse_dungeons_info_json(nlohmann::json &dungeon_data, angband_header *head
         }
     }
 
-    // flags + 各種スカラ (monster_rate / trap_rate / monster_div / final_* / alliance / fixed_rooms)
+    // flags + 各種スカラ (monster_rate / trap_rate / alliance / fixed_rooms)
     if (auto err = set_dungeon_feature_flags(dungeon, dungeon_data); err != PARSE_ERROR_NONE) {
         return err;
+    }
+
+    // final_floor (最下層: ガーディアン / 報酬オブジェクト / 報酬アーティファクト)
+    if (dungeon_data.contains("final_floor")) {
+        if (auto err = set_dungeon_final_floor(dungeon, dungeon_data["final_floor"]); err != PARSE_ERROR_NONE) {
+            return err;
+        }
     }
 
     // monster_flags


### PR DESCRIPTION
変愚蛮怒 PR #5379 (commit 96fcf51ea) の内容を bakabakaband 構造に 適応してマージ。

- 旧 `FINAL_GUARDIAN_X` / `FINAL_OBJECT_Y` / `FINAL_ARTIFACT_Z` の フラグ文字列形式を排除し、`final_floor` ネストオブジェクトに集約: `final_floor: { guardian: 237, object: 426, artifact: 89 }`
- reader 側に `set_dungeon_final_floor()` ヘルパを追加し、各 ID の 整合性を検証 (MonraceList::contains / BaseitemList::get_baseitem / ArtifactList::contains)
- 不正 ID の場合 PARSE_ERROR_INVALID_FLAG を返す

- bakabakaband は既に top-level `final_guardian` / `final_object` / `final_artifact` の独立キー方式を採用 (旧 FINAL_*_N フラグ形式は 使用していない)。本 PR ではその独立キー方式から、上流の `final_floor` ネスト形式へ移行
- `lib/edit/DungeonDefinitions.jsonc` 移行:
  - 18 ダンジョンの final_* キー (18 guardian + 7 object + 3 artifact) を `final_floor` オブジェクト 18 件にまとめ直し
- `schema/DungeonDefinitions.schema.json` も同期更新:
  - `final_guardian` / `final_object` / `final_artifact` 削除
  - `final_floor` オブジェクト追加 (guardian / object / artifact の minimum/maximum 制約付き)
- reader 側で個別 ID の整合性検証を行う `set_dungeon_final_floor()` を 追加 (BaseitemList::get_baseitem は例外を上げる API なので try/catch でラップ)
- `set_dungeon_feature_flags()` から top-level final_* キー読込を削除 (final_floor 専用ハンドラに集約)

cherry-pick: 96fcf51ea (適応)