### PR TITLE
merge: ダンジョン定義の pit / nest 表記を変更 (hengband#5383 相当)

### DIFF
--- a/lib/edit/DungeonDefinitions.jsonc
+++ b/lib/edit/DungeonDefinitions.jsonc
@@ -25,8 +25,8 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x0000",
-        "nest": "0x0000",
+        "pit": [],
+        "nest": [],
       },
       "floor": {
         "tiles": [
@@ -91,8 +91,30 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0xffff",
-        "nest": "0xffff",
+        "pit": [
+          "ORC",
+          "TROLL",
+          "GIANT",
+          "HORROR",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "CHAPEL",
+          "DRAGON",
+          "DEMON",
+          "DARK_ELF",
+        ],
+        "nest": [
+          "CLONE",
+          "JELLY",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "MIMIC",
+          "HORROR",
+          "KENNEL",
+          "ANIMAL",
+          "CHAPEL",
+          "UNDEAD",
+        ],
       },
       "floor": {
         "tiles": [
@@ -185,8 +207,8 @@
         "extra_spawn_probability": 4166,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x0000",
-        "nest": "0x0000",
+        "pit": [],
+        "nest": [],
       },
       "floor": {
         "tiles": [
@@ -259,8 +281,8 @@
         "extra_spawn_probability": 5000,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x0031",
-        "nest": "0x006d",
+        "pit": ["ORC", "SYMBOL_GOOD", "SYMBOL_EVIL"],
+        "nest": ["CLONE", "SYMBOL_GOOD", "SYMBOL_EVIL", "HORROR", "KENNEL"],
       },
       "floor": {
         "tiles": [
@@ -328,8 +350,8 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x0000",
-        "nest": "0x0000",
+        "pit": [],
+        "nest": [],
       },
       "floor": {
         "tiles": [
@@ -396,8 +418,8 @@
         "extra_spawn_probability": 7142,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x00a6",
-        "nest": "0x00c1",
+        "pit": ["TROLL", "GIANT", "SYMBOL_EVIL", "DRAGON"],
+        "nest": ["CLONE", "KENNEL", "ANIMAL"],
       },
       "floor": {
         "tiles": [
@@ -478,8 +500,8 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x0128",
-        "nest": "0x027b",
+        "pit": ["HORROR", "SYMBOL_EVIL", "DEMON"],
+        "nest": ["CLONE", "JELLY", "SYMBOL_EVIL", "MIMIC", "HORROR", "KENNEL", "UNDEAD"],
       },
       "floor": {
         "tiles": [
@@ -556,8 +578,8 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x0001",
-        "nest": "0x0052",
+        "pit": ["ORC"],
+        "nest": ["JELLY", "MIMIC", "KENNEL"],
       },
       "floor": {
         "tiles": [
@@ -625,8 +647,17 @@
         "extra_spawn_probability": 6250,
         "obj_good": 80,
         "obj_great": 30,
-        "pit": "0x01bf",
-        "nest": "0x02fd",
+        "pit": ["ORC", "TROLL", "GIANT", "HORROR", "SYMBOL_GOOD", "SYMBOL_EVIL", "DRAGON", "DEMON"],
+        "nest": [
+          "CLONE",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "MIMIC",
+          "HORROR",
+          "KENNEL",
+          "ANIMAL",
+          "UNDEAD",
+        ],
       },
       "floor": {
         "tiles": [
@@ -694,8 +725,8 @@
         "extra_spawn_probability": 6250,
         "obj_good": 90,
         "obj_great": 77,
-        "pit": "0x0188",
-        "nest": "0x0280",
+        "pit": ["HORROR", "DRAGON", "DEMON"],
+        "nest": ["ANIMAL", "UNDEAD"],
       },
       "floor": {
         "tiles": [
@@ -762,8 +793,8 @@
         "extra_spawn_probability": 6250,
         "obj_good": 85,
         "obj_great": 35,
-        "pit": "0x0040",
-        "nest": "0x0104",
+        "pit": ["CHAPEL"],
+        "nest": ["SYMBOL_GOOD", "CHAPEL"],
       },
       "floor": {
         "tiles": [
@@ -830,8 +861,8 @@
         "extra_spawn_probability": 6250,
         "obj_good": 80,
         "obj_great": 30,
-        "pit": "0x0000",
-        "nest": "0x0000",
+        "pit": [],
+        "nest": [],
       },
       "floor": {
         "tiles": [
@@ -900,8 +931,27 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x037f",
-        "nest": "0x033f",
+        "pit": [
+          "ORC",
+          "TROLL",
+          "GIANT",
+          "HORROR",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "CHAPEL",
+          "DEMON",
+          "DARK_ELF",
+        ],
+        "nest": [
+          "CLONE",
+          "JELLY",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "MIMIC",
+          "HORROR",
+          "CHAPEL",
+          "UNDEAD",
+        ],
       },
       "floor": {
         "tiles": [
@@ -984,8 +1034,8 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x01a8",
-        "nest": "0x023f",
+        "pit": ["HORROR", "SYMBOL_EVIL", "DRAGON", "DEMON"],
+        "nest": ["CLONE", "JELLY", "SYMBOL_GOOD", "SYMBOL_EVIL", "MIMIC", "HORROR", "UNDEAD"],
       },
       "floor": {
         "tiles": [
@@ -1061,8 +1111,8 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x00b7",
-        "nest": "0x00df",
+        "pit": ["ORC", "TROLL", "GIANT", "SYMBOL_GOOD", "SYMBOL_EVIL", "DRAGON"],
+        "nest": ["CLONE", "JELLY", "SYMBOL_GOOD", "SYMBOL_EVIL", "MIMIC", "KENNEL", "ANIMAL"],
       },
       "floor": {
         "tiles": [
@@ -1131,8 +1181,8 @@
         "extra_spawn_probability": 12500,
         "obj_good": 80,
         "obj_great": 25,
-        "pit": "0x0000",
-        "nest": "0x0010",
+        "pit": [],
+        "nest": ["MIMIC"],
       },
       "floor": {
         "tiles": [
@@ -1210,8 +1260,18 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x01ff",
-        "nest": "0x01ed",
+        "pit": [
+          "ORC",
+          "TROLL",
+          "GIANT",
+          "HORROR",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "CHAPEL",
+          "DRAGON",
+          "DEMON",
+        ],
+        "nest": ["CLONE", "SYMBOL_GOOD", "SYMBOL_EVIL", "HORROR", "KENNEL", "ANIMAL", "CHAPEL"],
       },
       "floor": {
         "tiles": [
@@ -1288,8 +1348,18 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x01ff",
-        "nest": "0x01ed",
+        "pit": [
+          "ORC",
+          "TROLL",
+          "GIANT",
+          "HORROR",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "CHAPEL",
+          "DRAGON",
+          "DEMON",
+        ],
+        "nest": ["CLONE", "SYMBOL_GOOD", "SYMBOL_EVIL", "HORROR", "KENNEL", "ANIMAL", "CHAPEL"],
       },
       "floor": {
         "tiles": [
@@ -1367,8 +1437,8 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x0000",
-        "nest": "0x0000",
+        "pit": [],
+        "nest": [],
       },
       "floor": {
         "tiles": [
@@ -1447,8 +1517,30 @@
         "extra_spawn_probability": 6250,
         "obj_good": 80,
         "obj_great": 30,
-        "pit": "0xffff",
-        "nest": "0xffff",
+        "pit": [
+          "ORC",
+          "TROLL",
+          "GIANT",
+          "HORROR",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "CHAPEL",
+          "DRAGON",
+          "DEMON",
+          "DARK_ELF",
+        ],
+        "nest": [
+          "CLONE",
+          "JELLY",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "MIMIC",
+          "HORROR",
+          "KENNEL",
+          "ANIMAL",
+          "CHAPEL",
+          "UNDEAD",
+        ],
       },
       "floor": {
         "tiles": [
@@ -1531,8 +1623,8 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x01f8",
-        "nest": "0x033d",
+        "pit": ["HORROR", "SYMBOL_GOOD", "SYMBOL_EVIL", "CHAPEL", "DRAGON", "DEMON"],
+        "nest": ["CLONE", "SYMBOL_GOOD", "SYMBOL_EVIL", "MIMIC", "HORROR", "CHAPEL", "UNDEAD"],
       },
       "floor": {
         "tiles": [
@@ -1610,8 +1702,27 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x037f",
-        "nest": "0x033f",
+        "pit": [
+          "ORC",
+          "TROLL",
+          "GIANT",
+          "HORROR",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "CHAPEL",
+          "DEMON",
+          "DARK_ELF",
+        ],
+        "nest": [
+          "CLONE",
+          "JELLY",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "MIMIC",
+          "HORROR",
+          "CHAPEL",
+          "UNDEAD",
+        ],
       },
       "floor": {
         "tiles": [
@@ -1696,8 +1807,27 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x037f",
-        "nest": "0x033f",
+        "pit": [
+          "ORC",
+          "TROLL",
+          "GIANT",
+          "HORROR",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "CHAPEL",
+          "DEMON",
+          "DARK_ELF",
+        ],
+        "nest": [
+          "CLONE",
+          "JELLY",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "MIMIC",
+          "HORROR",
+          "CHAPEL",
+          "UNDEAD",
+        ],
       },
       "floor": {
         "tiles": [
@@ -1766,8 +1896,30 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0xffff",
-        "nest": "0xffff",
+        "pit": [
+          "ORC",
+          "TROLL",
+          "GIANT",
+          "HORROR",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "CHAPEL",
+          "DRAGON",
+          "DEMON",
+          "DARK_ELF",
+        ],
+        "nest": [
+          "CLONE",
+          "JELLY",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "MIMIC",
+          "HORROR",
+          "KENNEL",
+          "ANIMAL",
+          "CHAPEL",
+          "UNDEAD",
+        ],
       },
       "floor": {
         "tiles": [
@@ -1833,8 +1985,27 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x037f",
-        "nest": "0x033f",
+        "pit": [
+          "ORC",
+          "TROLL",
+          "GIANT",
+          "HORROR",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "CHAPEL",
+          "DEMON",
+          "DARK_ELF",
+        ],
+        "nest": [
+          "CLONE",
+          "JELLY",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "MIMIC",
+          "HORROR",
+          "CHAPEL",
+          "UNDEAD",
+        ],
       },
       "floor": {
         "tiles": [
@@ -1932,8 +2103,8 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x0000",
-        "nest": "0x0000",
+        "pit": [],
+        "nest": [],
       },
       "floor": {
         "tiles": [
@@ -2014,8 +2185,30 @@
         "extra_spawn_probability": 6250,
         "obj_good": 80,
         "obj_great": 30,
-        "pit": "0xffff",
-        "nest": "0xffff",
+        "pit": [
+          "ORC",
+          "TROLL",
+          "GIANT",
+          "HORROR",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "CHAPEL",
+          "DRAGON",
+          "DEMON",
+          "DARK_ELF",
+        ],
+        "nest": [
+          "CLONE",
+          "JELLY",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "MIMIC",
+          "HORROR",
+          "KENNEL",
+          "ANIMAL",
+          "CHAPEL",
+          "UNDEAD",
+        ],
       },
       "floor": {
         "tiles": [
@@ -2108,8 +2301,27 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x037f",
-        "nest": "0x033f",
+        "pit": [
+          "ORC",
+          "TROLL",
+          "GIANT",
+          "HORROR",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "CHAPEL",
+          "DEMON",
+          "DARK_ELF",
+        ],
+        "nest": [
+          "CLONE",
+          "JELLY",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "MIMIC",
+          "HORROR",
+          "CHAPEL",
+          "UNDEAD",
+        ],
       },
       "floor": {
         "tiles": [
@@ -2176,8 +2388,27 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x037f",
-        "nest": "0x033f",
+        "pit": [
+          "ORC",
+          "TROLL",
+          "GIANT",
+          "HORROR",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "CHAPEL",
+          "DEMON",
+          "DARK_ELF",
+        ],
+        "nest": [
+          "CLONE",
+          "JELLY",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "MIMIC",
+          "HORROR",
+          "CHAPEL",
+          "UNDEAD",
+        ],
       },
       "floor": {
         "tiles": [
@@ -2244,8 +2475,27 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x037f",
-        "nest": "0x033f",
+        "pit": [
+          "ORC",
+          "TROLL",
+          "GIANT",
+          "HORROR",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "CHAPEL",
+          "DEMON",
+          "DARK_ELF",
+        ],
+        "nest": [
+          "CLONE",
+          "JELLY",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "MIMIC",
+          "HORROR",
+          "CHAPEL",
+          "UNDEAD",
+        ],
       },
       "floor": {
         "tiles": [
@@ -2314,8 +2564,27 @@
         "extra_spawn_probability": 6250,
         "obj_good": 75,
         "obj_great": 20,
-        "pit": "0x037f",
-        "nest": "0x033f",
+        "pit": [
+          "ORC",
+          "TROLL",
+          "GIANT",
+          "HORROR",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "CHAPEL",
+          "DEMON",
+          "DARK_ELF",
+        ],
+        "nest": [
+          "CLONE",
+          "JELLY",
+          "SYMBOL_GOOD",
+          "SYMBOL_EVIL",
+          "MIMIC",
+          "HORROR",
+          "CHAPEL",
+          "UNDEAD",
+        ],
       },
       "floor": {
         "tiles": [
@@ -2383,8 +2652,8 @@
         "extra_spawn_probability": 12500,
         "obj_good": 80,
         "obj_great": 25,
-        "pit": "0x0000",
-        "nest": "0x0010",
+        "pit": [],
+        "nest": ["MIMIC"],
       },
       "floor": {
         "tiles": [
@@ -2461,8 +2730,8 @@
         "extra_spawn_probability": 12500,
         "obj_good": 80,
         "obj_great": 25,
-        "pit": "0x0000",
-        "nest": "0x0000",
+        "pit": [],
+        "nest": [],
       },
       "floor": {
         "tiles": [
@@ -2530,8 +2799,8 @@
         "extra_spawn_probability": 6250,
         "obj_good": 90,
         "obj_great": 77,
-        "pit": "0x0188",
-        "nest": "0x0280",
+        "pit": ["HORROR", "DRAGON", "DEMON"],
+        "nest": ["ANIMAL", "UNDEAD"],
       },
       "floor": {
         "tiles": [

--- a/schema/DungeonDefinitions.schema.json
+++ b/schema/DungeonDefinitions.schema.json
@@ -62,8 +62,16 @@
                             "extra_spawn_probability": { "type": "integer", "minimum": 1, "maximum": 1000000, "description": "モンスター追加生成率 (X / 1,000,000)。大きいほど追加生成されやすい" },
                             "obj_good": { "type": "integer" },
                             "obj_great": { "type": "integer" },
-                            "pit": { "type": "string", "pattern": "^0x[0-9a-fA-F]+$" },
-                            "nest": { "type": "string", "pattern": "^0x[0-9a-fA-F]+$" }
+                            "pit": {
+                                "type": "array",
+                                "description": "pit 種別フラグ名の配列 (ORC / TROLL / GIANT / HORROR / SYMBOL_GOOD / SYMBOL_EVIL / CHAPEL / DRAGON / DEMON / DARK_ELF)",
+                                "items": { "type": "string", "enum": ["ORC", "TROLL", "GIANT", "HORROR", "SYMBOL_GOOD", "SYMBOL_EVIL", "CHAPEL", "DRAGON", "DEMON", "DARK_ELF"] }
+                            },
+                            "nest": {
+                                "type": "array",
+                                "description": "nest 種別フラグ名の配列 (CLONE / JELLY / SYMBOL_GOOD / SYMBOL_EVIL / MIMIC / HORROR / KENNEL / ANIMAL / CHAPEL / UNDEAD)",
+                                "items": { "type": "string", "enum": ["CLONE", "JELLY", "SYMBOL_GOOD", "SYMBOL_EVIL", "MIMIC", "HORROR", "KENNEL", "ANIMAL", "CHAPEL", "UNDEAD"] }
+                            }
                         }
                     },
                     "floor": {

--- a/src/info-reader/dungeon-info-tokens-table.cpp
+++ b/src/info-reader/dungeon-info-tokens-table.cpp
@@ -1,5 +1,6 @@
 #include "info-reader/dungeon-info-tokens-table.h"
 #include "dungeon/dungeon-flag-types.h"
+#include "room/pit-nest-util.h"
 #include "system/dungeon/dungeon-definition.h"
 
 /*!
@@ -60,4 +61,38 @@ const std::unordered_map<std::string_view, DungeonMode> dungeon_modes = {
     { "NAND", DungeonMode::NAND },
     { "OR", DungeonMode::OR },
     { "NOR", DungeonMode::NOR },
+};
+
+/*!
+ * pit種別トークンの定義 /
+ * Dungeon pit kinds
+ */
+const std::unordered_map<std::string_view, PitKind> dungeon_pit_kinds = {
+    { "ORC", PitKind::ORC },
+    { "TROLL", PitKind::TROLL },
+    { "GIANT", PitKind::GIANT },
+    { "HORROR", PitKind::HORROR },
+    { "SYMBOL_GOOD", PitKind::SYMBOL_GOOD },
+    { "SYMBOL_EVIL", PitKind::SYMBOL_EVIL },
+    { "CHAPEL", PitKind::CHAPEL },
+    { "DRAGON", PitKind::DRAGON },
+    { "DEMON", PitKind::DEMON },
+    { "DARK_ELF", PitKind::DARK_ELF },
+};
+
+/*!
+ * nest種別トークンの定義 /
+ * Dungeon nest kinds
+ */
+const std::unordered_map<std::string_view, NestKind> dungeon_nest_kinds = {
+    { "CLONE", NestKind::CLONE },
+    { "JELLY", NestKind::JELLY },
+    { "SYMBOL_GOOD", NestKind::SYMBOL_GOOD },
+    { "SYMBOL_EVIL", NestKind::SYMBOL_EVIL },
+    { "MIMIC", NestKind::MIMIC },
+    { "HORROR", NestKind::HORROR },
+    { "KENNEL", NestKind::KENNEL },
+    { "ANIMAL", NestKind::ANIMAL },
+    { "CHAPEL", NestKind::CHAPEL },
+    { "UNDEAD", NestKind::UNDEAD },
 };

--- a/src/info-reader/dungeon-info-tokens-table.h
+++ b/src/info-reader/dungeon-info-tokens-table.h
@@ -7,6 +7,10 @@
 
 enum class DungeonFeatureType;
 enum class DungeonMode;
+enum class NestKind;
+enum class PitKind;
 
 extern const std::unordered_map<std::string_view, DungeonFeatureType> dungeon_flags;
 extern const std::unordered_map<std::string_view, DungeonMode> dungeon_modes;
+extern const std::unordered_map<std::string_view, PitKind> dungeon_pit_kinds;
+extern const std::unordered_map<std::string_view, NestKind> dungeon_nest_kinds;

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -240,8 +240,24 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
         info_set_value(dungeon->additional_monster_spawn_chance, tokens[6]);
         info_set_value(dungeon->obj_good, tokens[7]);
         info_set_value(dungeon->obj_great, tokens[8]);
-        info_set_value(dungeon->pit, tokens[9], 16);
-        info_set_value(dungeon->nest, tokens[10], 16);
+        // 旧 v1 (lines 配列) は 16 進数ビットマスクのまま。EnumClassFlagGroup に
+        // 各 bit を展開する後方互換変換。
+        try {
+            const auto pit_raw = std::stoul(tokens[9], nullptr, 16);
+            for (size_t i = 0; i < dungeon_pit_kinds.size(); ++i) {
+                if (pit_raw & (1UL << i)) {
+                    dungeon->pit.set(i2enum<PitKind>(static_cast<int>(i)));
+                }
+            }
+            const auto nest_raw = std::stoul(tokens[10], nullptr, 16);
+            for (size_t i = 0; i < dungeon_nest_kinds.size(); ++i) {
+                if (nest_raw & (1UL << i)) {
+                    dungeon->nest.set(i2enum<NestKind>(static_cast<int>(i)));
+                }
+            }
+        } catch (const std::exception &) {
+            return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+        }
         return PARSE_ERROR_NONE;
     }
 
@@ -604,10 +620,54 @@ static errr set_dungeon_generation(DungeonDefinition &dungeon, const nlohmann::j
 
         dungeon.obj_good = gen_obj.value("obj_good", 0);
         dungeon.obj_great = gen_obj.value("obj_great", 0);
-        const auto pit = gen_obj.value("pit", std::string("0x0000"));
-        const auto nest = gen_obj.value("nest", std::string("0x0000"));
-        dungeon.pit = static_cast<BIT_FLAGS16>(std::stoul(pit, nullptr, 16));
-        dungeon.nest = static_cast<BIT_FLAGS16>(std::stoul(nest, nullptr, 16));
+
+        // pit: 配列 (PitKind name 文字列の列挙) または旧 16 進数文字列 (後方互換)
+        if (gen_obj.contains("pit")) {
+            const auto &pit_node = gen_obj["pit"];
+            if (pit_node.is_array()) {
+                for (const auto &p : pit_node) {
+                    const auto name = p.get<std::string>();
+                    if (name.empty()) {
+                        continue;
+                    }
+                    if (!EnumClassFlagGroup<PitKind>::grab_one_flag(dungeon.pit, dungeon_pit_kinds, name)) {
+                        msg_format(_("未知のダンジョン pit 種別 '%s'。", "Unknown dungeon pit kind '%s'."), name.data());
+                        return PARSE_ERROR_INVALID_FLAG;
+                    }
+                }
+            } else if (pit_node.is_string()) {
+                // 旧 0xXXXX 形式 (後方互換: ビットマスクから対応 enum をセット)
+                const auto raw = std::stoul(pit_node.get<std::string>(), nullptr, 16);
+                for (size_t i = 0; i < dungeon_pit_kinds.size(); ++i) {
+                    if (raw & (1UL << i)) {
+                        dungeon.pit.set(i2enum<PitKind>(static_cast<int>(i)));
+                    }
+                }
+            }
+        }
+        // nest: 同様
+        if (gen_obj.contains("nest")) {
+            const auto &nest_node = gen_obj["nest"];
+            if (nest_node.is_array()) {
+                for (const auto &n : nest_node) {
+                    const auto name = n.get<std::string>();
+                    if (name.empty()) {
+                        continue;
+                    }
+                    if (!EnumClassFlagGroup<NestKind>::grab_one_flag(dungeon.nest, dungeon_nest_kinds, name)) {
+                        msg_format(_("未知のダンジョン nest 種別 '%s'。", "Unknown dungeon nest kind '%s'."), name.data());
+                        return PARSE_ERROR_INVALID_FLAG;
+                    }
+                }
+            } else if (nest_node.is_string()) {
+                const auto raw = std::stoul(nest_node.get<std::string>(), nullptr, 16);
+                for (size_t i = 0; i < dungeon_nest_kinds.size(); ++i) {
+                    if (raw & (1UL << i)) {
+                        dungeon.nest.set(i2enum<NestKind>(static_cast<int>(i)));
+                    }
+                }
+            }
+        }
     } catch (const std::exception &) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }

--- a/src/room/pit-nest-util.cpp
+++ b/src/room/pit-nest-util.cpp
@@ -55,7 +55,7 @@ tl::optional<NestKind> pick_nest_type(const FloorType &floor, const std::map<Nes
             continue;
         }
 
-        if (none_bits(floor.get_dungeon_definition().nest, (1UL << enum2i(nest_kind)))) {
+        if (floor.get_dungeon_definition().nest.has_not(nest_kind)) {
             continue;
         }
 
@@ -83,7 +83,7 @@ tl::optional<PitKind> pick_pit_type(const FloorType &floor, const std::map<PitKi
             continue;
         }
 
-        if (none_bits(floor.get_dungeon_definition().pit, (1UL << enum2i(pit_kind)))) {
+        if (floor.get_dungeon_definition().pit.has_not(pit_kind)) {
             continue;
         }
 

--- a/src/system/dungeon/dungeon-definition.h
+++ b/src/system/dungeon/dungeon-definition.h
@@ -20,6 +20,7 @@
 #include "monster-race/race-special-flags.h"
 #include "monster-race/race-visual-flags.h"
 #include "monster-race/race-wilderness-flags.h"
+#include "room/pit-nest-util.h"
 #include "room/room-info-table.h"
 #include "room/vault-builder.h"
 #include "system/angband.h"
@@ -102,8 +103,8 @@ public:
     DEPTH mindepth{}; /* Minimal depth */
     DEPTH maxdepth{}; /* Maximal depth */
     PLAYER_LEVEL min_plev{}; /* Minimal plev needed to enter -- it's an anti-cheating mesure */
-    BIT_FLAGS16 pit{};
-    BIT_FLAGS16 nest{};
+    EnumClassFlagGroup<PitKind> pit{};
+    EnumClassFlagGroup<NestKind> nest{};
     DungeonMode mode{}; /* Mode of combinaison of the monster flags */
 
     int min_monster_count_on_floor{}; /* Minimal number of monsters per floor */


### PR DESCRIPTION
変愚蛮怒 PR #5383 (3 commit) の内容を bakabakaband 構造に
適応してマージ。

- 旧 `pit: "0x037f"` の 16 進ビットマスクから `pit: ["ORC", "TROLL", "GIANT", ...]` の名前列挙配列に
- `DungeonDefinition::pit` の型を `BIT_FLAGS16` から `EnumClassFlagGroup<PitKind>` へ変更

- 旧 `nest: "0x033f"` から `nest: ["CLONE", "JELLY", ...]` の名前列挙配列に
- `DungeonDefinition::nest` を `EnumClassFlagGroup<NestKind>` 化

- bakabakaband では generation オブジェクト直下に pit/nest を 保持しているため、helper 化までは行わず set_dungeon_generation 内のループ処理として埋め込み実装

et-ExecutionPolicy -Scope Process -ExecutionPolicy RemoteSigned) ; (& c:\Users\nabra\Documents\bakabakaband\.venv\Scripts\Activate.ps1)

  `dungeon_nest_kinds` ルックアップテーブルを追加
- `dungeon-reader.cpp` の `set_dungeon_generation()` 内で:
  - pit/nest が配列ならフラグ名列挙として処理
  - 文字列 (旧 0xXXXX) なら後方互換のためビットマスクから enum を 展開する fallback path を残置
- レガシー v1 token-parser (W: 行、`info_set_value`) でも 16 進ビットマスクから EnumClassFlagGroup へ展開 (互換維持)
- `room/pit-nest-util.cpp` の bit テスト `none_bits(pit, 1UL << X)` を `pit.has_not(kind)` に書き換え
- `lib/edit/DungeonDefinitions.jsonc` 移行:
  - 全 33 entries の pit (10 unique values) を配列形式に変換
  - 全 33 entries の nest (15 unique values) を配列形式に変換
  - 0x0000 → 空配列、0xffff → 全 10 種 (PitKind / NestKind の全エントリ)
- `schema/DungeonDefinitions.schema.json` 同期更新:
  - pit/nest を string pattern → array + enum 制約に変更

cherry-pick: 5a67c60bd + 6072c53cc + 96d1ad30a (適応)