### PR TITLE
merge: ダンジョン定義 stream を可変ベクタ化 (hengband#5384 相当)

### DIFF
--- a/lib/edit/DungeonDefinitions.jsonc
+++ b/lib/edit/DungeonDefinitions.jsonc
@@ -62,8 +62,11 @@
         ],
         "outer": "FLOOR",
         "inner": "FLOOR",
-        "stream1": "FLOOR",
-        "stream2": "FLOOR",
+        "streams": [
+          { "type": "FLOOR", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "FLOOR", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "normal_monster_rate": 0,
     },
@@ -150,8 +153,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "MAGMA_VEIN",
-        "stream2": "QUARTZ_VEIN",
+        "streams": [
+          { "type": "QUARTZ_VEIN", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "MAGMA_VEIN", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": [
         "CAVERN",
@@ -244,8 +250,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "MAGMA_VEIN",
-        "stream2": "QUARTZ_VEIN",
+        "streams": [
+          { "type": "QUARTZ_VEIN", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "MAGMA_VEIN", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["NO_VAULT", "BEGINNER"],
       "room_rates": [
@@ -318,8 +327,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "MAGMA_VEIN",
-        "stream2": "QUARTZ_VEIN",
+        "streams": [
+          { "type": "QUARTZ_VEIN", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "MAGMA_VEIN", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["CAVE", "WATER_RIVER", "CAVERN", "LAKE_TREE", "DESTROY", "LARGEST"],
       "monster_flags": ["ORC", "ANIMAL"],
@@ -387,8 +399,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "MAGMA_VEIN",
-        "stream2": "QUARTZ_VEIN",
+        "streams": [
+          { "type": "QUARTZ_VEIN", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "MAGMA_VEIN", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["MAZE", "SMALLEST", "FORGET", "VANISH_STAIRS"],
       "normal_monster_rate": 100,
@@ -455,8 +470,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "MAGMA_VEIN",
-        "stream2": "DARK_PIT",
+        "streams": [
+          { "type": "DARK_PIT", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "MAGMA_VEIN", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": [
         "LARGEST",
@@ -537,8 +555,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "SHALLOW_WATER",
-        "stream2": "DEEP_WATER",
+        "streams": [
+          { "type": "DEEP_WATER", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "SHALLOW_WATER", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": [
         "WATER_RIVER",
@@ -615,8 +636,11 @@
         ],
         "outer": "BRAKE",
         "inner": "TREE",
-        "stream1": "GRANITE",
-        "stream2": "BRAKE",
+        "streams": [
+          { "type": "BRAKE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "GRANITE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["NO_DOORS", "WATER_RIVER", "NO_TUNNEL"],
       "monster_flags": ["ANIMAL", "ELF", "WILD_WOOD", "GOOD"],
@@ -693,8 +717,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "DARK_PIT",
-        "stream2": "QUARTZ_VEIN",
+        "streams": [
+          { "type": "QUARTZ_VEIN", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "DARK_PIT", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["CAVE", "CAVERN", "LAKE_LAVA", "LAVA_RIVER", "DESTROY"],
       "monster_flags": ["IM_FIRE", "CAN_FLY", "WILD_VOLCANO"],
@@ -762,8 +789,11 @@
         ],
         "outer": "GRANITE",
         "inner": "DEEP_LAVA",
-        "stream1": "NONE",
-        "stream2": "NONE",
+        "streams": [
+          { "type": "NONE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "NONE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["CAVERN", "LAKE_LAVA", "LAVA_RIVER", "WINNER", "LARGEST"],
       "monster_flags": ["IM_FIRE", "EVIL"],
@@ -830,8 +860,11 @@
         ],
         "outer": "PERMANENT",
         "inner": "GRANITE",
-        "stream1": "NONE",
-        "stream2": "NONE",
+        "streams": [
+          { "type": "NONE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "NONE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["WATER_RIVER", "WINNER", "LARGEST", "GLASS_ROOM"],
       "monster_flags": ["GOOD"],
@@ -898,8 +931,11 @@
         ],
         "outer": "GRANITE",
         "inner": "DEEP_WATER",
-        "stream1": "NONE",
-        "stream2": "NONE",
+        "streams": [
+          { "type": "NONE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "NONE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["LAKE_WATER", "WATER_RIVER", "DESTROY"],
       "monster_flags": ["CAN_SWIM", "CAN_FLY", "AQUATIC", "WILD_OCEAN"],
@@ -987,8 +1023,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "NONE",
-        "stream2": "NONE",
+        "streams": [
+          { "type": "NONE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "NONE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["ARENA", "NO_CAVE", "CURTAIN", "GLASS_ROOM", "ALWAY_ARENA"],
       "monster_flags": ["DEMON"],
@@ -1071,8 +1110,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "SHALLOW_WATER",
-        "stream2": "DEEP_WATER",
+        "streams": [
+          { "type": "DEEP_WATER", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "SHALLOW_WATER", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": [
         "ARENA",
@@ -1148,8 +1190,11 @@
         ],
         "outer": "MOUNTAIN_WALL",
         "inner": "GRANITE",
-        "stream1": "NONE",
-        "stream2": "NONE",
+        "streams": [
+          { "type": "NONE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "NONE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["WATER_RIVER", "CAVE", "CAVERN", "NO_DOORS", "LARGEST"],
       "monster_flags": ["TROLL", "GIANT", "CAN_FLY", "ANIMAL", "WILD_MOUNTAIN"],
@@ -1218,8 +1263,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "MAGMA_VEIN",
-        "stream2": "QUARTZ_VEIN",
+        "streams": [
+          { "type": "QUARTZ_VEIN", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "MAGMA_VEIN", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": [
         "WATER_RIVER",
@@ -1307,8 +1355,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "MAGMA_VEIN",
-        "stream2": "QUARTZ_VEIN",
+        "streams": [
+          { "type": "QUARTZ_VEIN", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "MAGMA_VEIN", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": [
         "CAVERN",
@@ -1395,8 +1446,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "MAGMA_VEIN",
-        "stream2": "QUARTZ_VEIN",
+        "streams": [
+          { "type": "QUARTZ_VEIN", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "MAGMA_VEIN", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": [
         "CAVERN",
@@ -1474,8 +1528,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "MAGMA_VEIN",
-        "stream2": "QUARTZ_VEIN",
+        "streams": [
+          { "type": "QUARTZ_VEIN", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "MAGMA_VEIN", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": [
         "CAVERN",
@@ -1576,8 +1633,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "MAGMA_VEIN",
-        "stream2": "QUARTZ_VEIN",
+        "streams": [
+          { "type": "QUARTZ_VEIN", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "MAGMA_VEIN", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": [
         "CAVERN",
@@ -1660,8 +1720,11 @@
         ],
         "outer": "GLASS_WALL",
         "inner": "GLASS_WALL",
-        "stream1": "NONE",
-        "stream2": "NONE",
+        "streams": [
+          { "type": "NONE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "NONE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["ARENA", "NO_CAVE", "CURTAIN", "GLASS_DOOR", "GLASS_ROOM"],
       "monster_flags": [
@@ -1758,8 +1821,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "NONE",
-        "stream2": "NONE",
+        "streams": [
+          { "type": "NONE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "NONE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["ALWAY_ARENA", "NO_CAVE", "CURTAIN", "GLASS_ROOM"],
       "monster_flags": ["MALE", "NASTY", "HOMO_SEXUAL"],
@@ -1863,8 +1929,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "NONE",
-        "stream2": "NONE",
+        "streams": [
+          { "type": "NONE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "NONE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["ARENA", "NO_CAVE", "CURTAIN", "GLASS_ROOM"],
       "monster_flags": ["FEMALE", "NASTY", "HOMO_SEXUAL"],
@@ -1955,8 +2024,11 @@
         ],
         "outer": "VOID_ZONE",
         "inner": "VOID_ZONE",
-        "stream1": "VOID_ZONE",
-        "stream2": "VOID_ZONE",
+        "streams": [
+          { "type": "VOID_ZONE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "VOID_ZONE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["CAVERN", "DESTROY", "DIFFICULT_RECALL", "NO_ROOM", "VESTIGE"],
       "normal_monster_rate": 100,
@@ -2041,8 +2113,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "NONE",
-        "stream2": "NONE",
+        "streams": [
+          { "type": "NONE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "NONE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["ARENA", "NO_CAVE", "CURTAIN", "GLASS_ROOM"],
       "monster_flags": ["DEMON"],
@@ -2140,8 +2215,11 @@
         ],
         "outer": "VEGITABLE_FIELD",
         "inner": "VEGITABLE_FIELD",
-        "stream1": "VEGITABLE_FIELD",
-        "stream2": "VEGITABLE_FIELD",
+        "streams": [
+          { "type": "VEGITABLE_FIELD", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "VEGITABLE_FIELD", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": [
         "CAVERN",
@@ -2244,8 +2322,11 @@
         ],
         "outer": "ORGANIC_WALL",
         "inner": "ORGANIC_WALL",
-        "stream1": "ORGANIC_WALL",
-        "stream2": "ORGANIC_WALL",
+        "streams": [
+          { "type": "ORGANIC_WALL", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "ORGANIC_WALL", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": [
         "CAVERN",
@@ -2357,8 +2438,11 @@
         ],
         "outer": "DIRT",
         "inner": "DIRT",
-        "stream1": "NONE",
-        "stream2": "NONE",
+        "streams": [
+          { "type": "NONE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "NONE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["NO_ROOM", "NO_DOORS", "WATER_RIVER", "ALWAY_MAX_SIZE", "ALWAYS_LIGHT"],
       "monster_flags": ["ANIMAL"],
@@ -2444,8 +2528,11 @@
         ],
         "outer": "SNOW_FIELD",
         "inner": "SNOW_FIELD",
-        "stream1": "NONE",
-        "stream2": "NONE",
+        "streams": [
+          { "type": "NONE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "NONE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["NO_ROOM", "NO_DOORS", "WATER_RIVER", "ALWAY_MAX_SIZE", "ALWAYS_LIGHT"],
       "monster_flags": ["ANIMAL"],
@@ -2531,8 +2618,11 @@
         ],
         "outer": "CONCRETE",
         "inner": "CONCRETE",
-        "stream1": "NONE",
-        "stream2": "NONE",
+        "streams": [
+          { "type": "NONE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "NONE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["ARENA", "NO_CAVE", "CURTAIN", "GLASS_ROOM", "ALWAYS_LIGHT"],
       "monster_flags": ["HUMAN"],
@@ -2620,8 +2710,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "NONE",
-        "stream2": "NONE",
+        "streams": [
+          { "type": "NONE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "NONE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["MAZE", "SMALLEST"],
       "monster_flags": [],
@@ -2689,8 +2782,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "MAGMA_VEIN",
-        "stream2": "QUARTZ_VEIN",
+        "streams": [
+          { "type": "QUARTZ_VEIN", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "MAGMA_VEIN", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": [
         "WATER_RIVER",
@@ -2767,8 +2863,11 @@
         ],
         "outer": "GRANITE",
         "inner": "GRANITE",
-        "stream1": "MAGMA_VEIN",
-        "stream2": "QUARTZ_VEIN",
+        "streams": [
+          { "type": "QUARTZ_VEIN", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "MAGMA_VEIN", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["CAVE", "CAVERN", "SMALLEST"],
       "monster_flags": ["PUYO"],
@@ -2836,8 +2935,11 @@
         ],
         "outer": "GRANITE",
         "inner": "DEEP_POISONOUS_PUDDLE",
-        "stream1": "NONE",
-        "stream2": "NONE",
+        "streams": [
+          { "type": "NONE", "count": 4, "chance": 15, "priority": 0 },
+
+          { "type": "NONE", "count": 6, "chance": 30, "priority": 1 },
+        ],
       },
       "flags": ["CAVERN", "LAKE_POISONOUS", "POISONOUS_RIVER", "ALWAYS_RIVER"],
       "monster_flags": ["IM_POIS", "EVIL"],

--- a/schema/DungeonDefinitions.schema.json
+++ b/schema/DungeonDefinitions.schema.json
@@ -115,8 +115,21 @@
                             },
                             "outer": { "type": "string" },
                             "inner": { "type": "string" },
-                            "stream1": { "type": "string" },
-                            "stream2": { "type": "string" }
+                            "streams": {
+                                "type": "array",
+                                "description": "壁内の鉱脈 stream の配列。priority 順にソートされる。",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": { "type": "string", "description": "stream の地形種別タグ" },
+                                        "count": { "type": "integer", "minimum": 1, "maximum": 255, "description": "stream の生成回数" },
+                                        "chance": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "stream 1 個ごとの分岐確率" },
+                                        "priority": { "type": "integer", "minimum": 0, "maximum": 255, "description": "TerrainConversionType::STREAM の stream_index と対応する優先順位 (小さい順)" }
+                                    },
+                                    "required": ["type", "count", "chance", "priority"],
+                                    "additionalProperties": false
+                                }
+                            }
                         }
                     },
                     "flags": {

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -364,19 +364,12 @@ static void make_aqua_streams(CreatureEntity &creature, DungeonData *dd_ptr, con
         return;
     }
 
-    if (dungeon.stream2 > 0) {
-        constexpr auto num_quartz = 4;
-        constexpr auto chance_quartz = 15;
-        for (auto i = 0; i < num_quartz; i++) {
-            build_streamer(creature, dungeon.stream2, chance_quartz);
+    for (const auto &stream : dungeon.streams) {
+        if (stream.terrain_id <= 0) {
+            continue;
         }
-    }
-
-    if (dungeon.stream1 > 0) {
-        constexpr auto num_magma = 6;
-        constexpr auto chance_magma = 30;
-        for (auto i = 0; i < num_magma; i++) {
-            build_streamer(creature, dungeon.stream1, chance_magma);
+        for (auto i = 0; i < stream.count; i++) {
+            build_streamer(creature, stream.terrain_id, stream.chance);
         }
     }
 }

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -307,8 +307,11 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
             const auto tags = std::span(tokens).subspan(terrain_probability_num * 2 + 1, 4);
             dungeon->outer_wall = terrains.get_terrain_id(tags[0]);
             dungeon->inner_wall = terrains.get_terrain_id(tags[1]);
-            dungeon->stream1 = terrains.get_terrain_id(tags[2]);
-            dungeon->stream2 = terrains.get_terrain_id(tags[3]);
+            // 旧 v1 A: 行は stream1 (magma×6@30) / stream2 (quartz×4@15) のハードコード値を
+            // streams ベクタ化する。順序は旧 cave-generator と同じ stream2 → stream1。
+            dungeon->streams.clear();
+            dungeon->streams.push_back({ terrains.get_terrain_id(tags[3]), 4, 15, 0 });
+            dungeon->streams.push_back({ terrains.get_terrain_id(tags[2]), 6, 30, 1 });
             return PARSE_ERROR_NONE;
         } catch (const std::exception &) {
             return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
@@ -735,10 +738,52 @@ static errr set_dungeon_wall(DungeonDefinition &dungeon, const nlohmann::json &w
     try {
         dungeon.outer_wall = terrains.get_terrain_id(wall_obj.value("outer", std::string("GRANITE")));
         dungeon.inner_wall = terrains.get_terrain_id(wall_obj.value("inner", std::string("GRANITE")));
-        dungeon.stream1 = terrains.get_terrain_id(wall_obj.value("stream1", std::string("MAGMA_VEIN")));
-        dungeon.stream2 = terrains.get_terrain_id(wall_obj.value("stream2", std::string("QUARTZ_VEIN")));
     } catch (const std::exception &) {
         return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
+    }
+
+    dungeon.streams.clear();
+    if (wall_obj.contains("streams") && wall_obj["streams"].is_array()) {
+        // 新形式: streams: [{ type, count, chance, priority }, ...]
+        for (const auto &s_obj : wall_obj["streams"]) {
+            if (!s_obj.is_object() || !s_obj.contains("type")) {
+                return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+            }
+            DungeonStreamDefinition stream;
+            try {
+                stream.terrain_id = terrains.get_terrain_id(s_obj["type"].get<std::string>());
+            } catch (const std::exception &) {
+                return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
+            }
+            stream.count = s_obj.value("count", 0);
+            stream.chance = s_obj.value("chance", 0);
+            stream.priority = s_obj.value("priority", 0);
+            if (stream.count <= 0 || stream.chance <= 0) {
+                return PARSE_ERROR_INVALID_FLAG;
+            }
+            dungeon.streams.push_back(stream);
+        }
+        dungeon.sort_streams_by_priority();
+    } else {
+        // 後方互換: stream1/stream2 単一指定。旧 cave-generator のハードコード値
+        // (stream1: magma×6@30, stream2: quartz×4@15) で構造体化する。
+        // priority は stream2 を先に処理する旧挙動と一致させるため 0/1 を割当。
+        if (wall_obj.contains("stream2")) {
+            try {
+                const auto id = terrains.get_terrain_id(wall_obj["stream2"].get<std::string>());
+                dungeon.streams.push_back({ id, 4, 15, 0 });
+            } catch (const std::exception &) {
+                return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
+            }
+        }
+        if (wall_obj.contains("stream1")) {
+            try {
+                const auto id = terrains.get_terrain_id(wall_obj["stream1"].get<std::string>());
+                dungeon.streams.push_back({ id, 6, 30, 1 });
+            } catch (const std::exception &) {
+                return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
+            }
+        }
     }
     return PARSE_ERROR_NONE;
 }

--- a/src/system/dungeon/dungeon-definition.cpp
+++ b/src/system/dungeon/dungeon-definition.cpp
@@ -12,6 +12,7 @@
 #include "system/terrain/terrain-list.h"
 #include "term/z-form.h"
 #include "term/z-rand.h"
+#include <algorithm>
 
 bool DungeonDefinition::has_river_flag() const
 {
@@ -70,10 +71,26 @@ short DungeonDefinition::convert_terrain_id(short terrain_id) const
     case TerrainConversionType::SOLID:
         return this->outer_wall;
     case TerrainConversionType::STREAM:
-        return (terrain.stream_index == 0) ? this->stream1 : this->stream2;
+        return this->select_stream_terrain_id(terrain_id, terrain.stream_index);
     default:
         return terrain_id;
     }
+}
+
+void DungeonDefinition::sort_streams_by_priority()
+{
+    std::stable_sort(this->streams.begin(), this->streams.end(), [](const auto &lhs, const auto &rhs) {
+        return lhs.priority < rhs.priority;
+    });
+}
+
+short DungeonDefinition::select_stream_terrain_id(short terrain_id, int stream_index) const
+{
+    if ((stream_index < 0) || (static_cast<size_t>(stream_index) >= this->streams.size())) {
+        return terrain_id;
+    }
+    const auto stream_terrain_id = this->streams[stream_index].terrain_id;
+    return stream_terrain_id > 0 ? stream_terrain_id : terrain_id;
 }
 
 /*!

--- a/src/system/dungeon/dungeon-definition.h
+++ b/src/system/dungeon/dungeon-definition.h
@@ -87,6 +87,13 @@ enum class MonsterSex;
 enum class TerrainCharacteristics;
 enum class TerrainTag;
 class MonraceDefinition;
+struct DungeonStreamDefinition {
+    FEAT_IDX terrain_id{};
+    int count{};
+    int chance{};
+    int priority{};
+};
+
 class DungeonDefinition {
 public:
     std::string name; /* Name */
@@ -97,8 +104,7 @@ public:
     ProbabilityTable<short> prob_table_wall{}; /* Cave wall probability */
     short outer_wall{}; /* 外壁の地形ID */
     short inner_wall{}; /* 内壁の地形ID */
-    FEAT_IDX stream1{}; /* stream tile */
-    FEAT_IDX stream2{}; /* stream tile */
+    std::vector<DungeonStreamDefinition> streams{}; /* Stream definitions (terrain / count / chance / priority) */
 
     DEPTH mindepth{}; /* Minimal depth */
     DEPTH maxdepth{}; /* Maximal depth */
@@ -152,6 +158,8 @@ public:
     const MonraceDefinition &get_guardian() const;
     short convert_terrain_id(short terrain_id, TerrainCharacteristics action) const;
     short convert_terrain_id(short terrain_id) const;
+    void sort_streams_by_priority();
+    short select_stream_terrain_id(short terrain_id, int stream_index) const;
     bool is_open(short terrain_id) const;
     bool is_conquered() const;
     std::string build_entrance_message() const;


### PR DESCRIPTION
変愚蛮怒 PR #5384 (commit effab4a05) の内容を bakabakaband 構造に 適応してマージ。

- 旧 `stream1` / `stream2` の 2 種固定 + ハードコード生成パラメータ (count=6/4, chance=30/15) を廃止
- 新規 `DungeonStreamDefinition` 構造体を導入: { terrain_id, count, chance, priority }
- `DungeonDefinition::streams` を `std::vector<DungeonStreamDefinition>` に
- `sort_streams_by_priority()` / `select_stream_terrain_id()` メソッド追加
- `TerrainConversionType::STREAM` を 1 つに統合し、`terrain.stream_index` で vector index を指定

- `dungeon-definition.h`:
  - `FEAT_IDX stream1{}` / `stream2{}` を削除し `std::vector<DungeonStreamDefinition> streams{}` に置換
  - `DungeonStreamDefinition` 構造体追加
  - `sort_streams_by_priority()` / `select_stream_terrain_id()` を宣言
- `dungeon-definition.cpp`:
  - `convert_terrain_id()` の `STREAM` ケースを `select_stream_terrain_id(terrain_id, terrain.stream_index)` に変更
  - 上記 2 メソッドの実装を追加
- `cave-generator.cpp`:
  - `make_aqua_streams()` のハードコード生成ループを `for (auto &stream : dungeon.streams)` の汎用化
- `dungeon-reader.cpp`:
  - `set_dungeon_wall()` に `streams` 配列パスを追加
  - 後方互換: 旧 `stream1` / `stream2` 単独キーを受けた場合は ハードコード値 (magma×6@30, quartz×4@15) で 2 要素 streams に 変換 (priority 0:stream2, 1:stream1 で旧 cave-generator の処理順を 維持)
  - 旧 v1 token-parser (A: 行) も同様に変換
- `lib/edit/DungeonDefinitions.jsonc` 移行:
  - 34 dungeons の stream1/stream2 ペアを streams 配列に変換
  - 各 entry に旧仕様のデフォルト count/chance/priority を付与
- `schema/DungeonDefinitions.schema.json` 同期更新:
  - stream1/stream2 削除、streams 配列 + 要素オブジェクト制約追加

cherry-pick: effab4a05 (適応)