### PR TITLE
refactor: 装備派生キャッシュフィールドを private 化 (提案 39)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,6 +312,15 @@ API 経由に統一された。一部フィールド (r_idx / ap_r_idx / riding)
   三項演算子パターン 24 箇所を意図明示形 (`has_X_spell(realm, idx)`)
   に簡素化。savefile load/save の API も統一。**合計 private 化
   フィールド数: 77 → 83**
+- **提案 39**: 装備派生キャッシュフィールド 11 個 (num_blow[2] / num_fire /
+  to_m_chance / cur_lite / cumber_armor / cumber_glove / heavy_wield[2] /
+  icky_wield[2] / icky_riding_wield[2] / riding_ryoute / monlite) を private
+  化。get/set virtual 23 個を整備し、31 ファイルの read/write site を移行。
+  メソッド名衝突回避のため `is_icky_wield[2]` → `icky_wield[2]`,
+  `is_icky_riding_wield[2]` → `icky_riding_wield[2]` にフィールドをリネーム。
+  `ac` は書込のみ `set_ac()` virtual に統一し、フィールドは public のまま
+  残置 (io-dump で raw 値が JSON 出力されるため意味が異なる)。
+  **合計 private 化フィールド数: 83 → 94**
 - **提案 1/2**: プレイヤー専用フィールドのモンスター運用化基盤完了。
   種族 (`prace`) / 職業 (`pclass`) / 魔法領域 (`realm1` / `realm2` /
   `element_realm`) / パトロン (`patron`) / 変身形態 (`mimic_form`)
@@ -659,6 +668,13 @@ bakabakaband 側と上流側でよくある構造的差異を以下のルール�
 | `creature.max_plv = X` / `creature.msp = X` 書込 | `creature.set_max_plv(X)` / `creature.set_msp(X)` (提案 27) |
 | `creature.exp = X` / `creature.max_exp = X` / `creature.max_max_exp = X` 書込 | `creature.set_exp(X)` / `set_max_exp(X)` / `set_max_max_exp(X)` (提案 27) |
 | `creature.au [+\-/]= X` / `creature.csp [+\-]= X` の compound assignment | `creature.set_au(X)` / `add_au(X)` / `sub_au(X)` / `divide_au(X)`、`set_csp(X)` / `add_csp(X)` / `sub_csp(X)` (提案 27b)。約 110 箇所の `+=` / `-=` を移行済み |
+| `creature.num_blow[hand]` / `creature.num_fire` / `creature.to_m_chance` / `creature.cur_lite` 読取り | `creature.get_num_blow(hand)` / `get_num_fire()` / `get_to_m_chance()` / `get_cur_lite()` (提案 39) |
+| `creature.num_blow[hand] = X` / `num_fire = X` 等の書込 | `creature.set_num_blow(hand, X)` / `set_num_fire(X)` / `set_to_m_chance(X)` / `set_cur_lite(X)` (提案 39) |
+| `creature.cumber_armor` / `cumber_glove` 読取り | `creature.is_cumber_armor()` / `is_cumber_glove()` (提案 39) |
+| `creature.heavy_wield[hand]` / `is_icky_wield[hand]` / `is_icky_riding_wield[hand]` 読取り | `creature.is_heavy_wield(hand)` / `is_icky_wield(hand)` / `is_icky_riding_wield(hand)` (提案 39) |
+| `creature.riding_ryoute` / `creature.monlite` 読取り | `creature.is_riding_ryoute()` / `creature.is_monlite()` (提案 39) |
+| `creature.is_icky_wield[hand]` / `is_icky_riding_wield[hand]` フィールド | **提案 39 でフィールド名を `icky_wield[hand]` / `icky_riding_wield[hand]` にリネーム。** メソッドからの読取りは `is_X(hand)` 経由のみ |
+| `creature.ac = X` / `m_ptr->ac = X` 書込 | `creature.set_ac(X)` (提案 39)。`ac` フィールドの直接読取りは public 残置 (io-dump 用) |
 
 **GCC 固有の注意**:
 上流は MSVC 前提のことが多く、`<cstdint>` 等のインクルード漏れがあれば追加する。

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -1691,6 +1691,90 @@ is_player() ガードを持つ関数」を外部から `if (is_player()) X(...)`
 
 ---
 
+## 提案 39: 装備派生キャッシュフィールドの private 化 ✅ 完了
+
+### 背景
+
+`player-status.cpp` の `update_creature()` が装備状態から再計算する
+キャッシュフィールド群が `CreatureEntity` 直下に public で多数残存
+していた。書込元は基本的に `update_creature()` 1 箇所だが、読込は
+戦闘・表示・AI・ペット処理など多数の場所から発生し、外部による
+意図しない書込のリスクを抱えていた。
+
+### 完了内容
+
+#### API 整備 (23 個の virtual メソッド)
+
+`CreatureEntity` に getter / setter virtual を追加:
+
+| メソッド | 役割 |
+|---|---|
+| `set_ac(value)` | 基本 AC を設定 (get_ac() は既存) |
+| `get_num_blow(hand)` / `set_num_blow(hand, value)` | 近接攻撃回数 |
+| `get_num_fire()` / `set_num_fire(value)` | 遠隔攻撃回数 |
+| `get_to_m_chance()` / `set_to_m_chance(value)` | 詠唱成功率減算値 |
+| `get_cur_lite()` / `set_cur_lite(value)` | 光源半径 |
+| `is_cumber_armor()` / `set_cumber_armor(bool)` | 鎧によるマナ減耗 |
+| `is_cumber_glove()` / `set_cumber_glove(bool)` | 篭手によるマナ減耗 |
+| `is_heavy_wield(hand)` / `set_heavy_wield(hand, bool)` | 重武器装備 |
+| `is_icky_wield(hand)` / `set_icky_wield(hand, bool)` | 不適切武器装備 |
+| `is_icky_riding_wield(hand)` / `set_icky_riding_wield(hand, bool)` | 不適切騎乗武器 |
+| `is_riding_ryoute()` / `set_riding_ryoute(bool)` | 騎乗両手持ち |
+| `is_monlite()` / `set_monlite(bool)` | モンスター光源照射 |
+
+#### フィールドリネーム
+
+メソッド名衝突回避のためフィールドをリネーム:
+
+- `is_icky_wield[2]` → `icky_wield[2]`
+- `is_icky_riding_wield[2]` → `icky_riding_wield[2]`
+
+(`old_icky_wield[2]` / `old_riding_wield[2]` は public のまま残置。
+別提案で扱う)
+
+#### 移行
+
+31 ファイル全 read/write site を新 API 経由に統一:
+
+- `player/player-status.cpp`: 最大の集約箇所 (update_creature, 重武器/不適切
+  装備判定, mana cumber 検出)
+- `specific-object/torch.cpp::update_lite_radius()`: 多数の compound 演算
+  (`+=`, `++`) をローカル変数で集約し、最後に `set_cur_lite()` 1 回で書込
+- `pet/`, `mind/mind-ninja.cpp`, `monster-floor/monster-lite.cpp`,
+  `floor/floor-leaver.cpp`: chained assignment
+  (`creature.riding_ryoute = creature.old_riding_ryoute = false;`) を
+  2 文に分割 (old_ は public 直接書込、新は setter 経由)
+- `monster-floor/one-monster-placer.cpp`: モンスター AC 初期化 (place_monster)
+- その他戦闘・表示・AI 各所の読取り site
+
+#### Private 化
+
+11 フィールドを private 化:
+`to_m_chance`, `num_blow[2]`, `num_fire`, `cur_lite`, `cumber_armor`,
+`cumber_glove`, `heavy_wield[2]`, `icky_wield[2]`, `icky_riding_wield[2]`,
+`riding_ryoute`, `monlite`
+
+`ac` フィールドは書込のみ `set_ac()` 経由に統一し、フィールド自体は public
+のまま残置 (`io-dump/player-status-dump-json.cpp` で raw 値が JSON 出力
+されており、`get_ac()` は computed 値を返すため意味が異なる。完全 private
+化は別提案で扱う)。
+
+### 効果
+
+- **合計 private 化フィールド数: 83 → 94**
+- 装備派生キャッシュの書込元が `update_creature()` 系に集約され、外部からの
+  意図しない書込を型システムで防止
+- `is_icky_wield()` 等の意図明示形 getter で読取意図が明確に
+- 将来 monster 側で装備派生キャッシュを別計算する override 点を確保
+
+### 残作業
+
+- `ac` フィールドの完全 private 化 (io-dump の raw アクセス整理)
+- `old_*` 系フィールド (old_cumber_armor / old_heavy_wield 等) の private 化
+  (現状 player-status.cpp の diff 検出で直接アクセスされる)
+
+---
+
 ## 提案 41: 呪文マスク (spell_learned/worked/forgotten) の集約 ✅ 完了
 
 ### 背景

--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -198,7 +198,7 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
             msg_format(_("%sが恐怖していて制御できない。", "%s^ is too scared to control."), steed_name.data());
             can_move = false;
             disturb(creature, false, true);
-        } else if (creature.riding_ryoute) {
+        } else if (creature.is_riding_ryoute()) {
             can_move = false;
             disturb(creature, false, true);
         } else if (terrain.flags.has(TerrainCharacteristics::CAN_FLY) && (riding_monrace.feature_flags.has(MonsterFeatureType::CAN_FLY))) {

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -278,7 +278,7 @@ static int get_mane_power(CreatureEntity &creature, int *sn, bool baigaesi)
                         chance = chance * (baigaesi ? mane.damage * 2 : mane.damage) / spell.manedam;
                     }
 
-                    chance += creature.to_m_chance;
+                    chance += creature.get_to_m_chance();
 
                     if (creature.is_wielding(FixedArtifactId::GOGO_PENDANT)) {
                         chance -= 10;
@@ -1228,7 +1228,7 @@ bool do_cmd_mane(CreatureEntity &creature, bool baigaesi)
         chance = chance * damage / spell.manedam;
     }
 
-    chance += creature.to_m_chance;
+    chance += creature.get_to_m_chance();
 
     /* Extract the minimum failure rate */
     minfail = adj_mag_fail[creature.get_stat_index(spell.use_stat)];

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -127,13 +127,13 @@ static void decide_mind_ki_chance(CreatureEntity &creature, cm_type *cm_ptr)
         cm_ptr->chance += 20;
     }
 
-    if (creature.is_icky_wield[0]) {
+    if (creature.is_icky_wield(0)) {
         cm_ptr->chance += 20;
     } else if (has_melee_weapon(creature, INVEN_MAIN_HAND)) {
         cm_ptr->chance += 10;
     }
 
-    if (creature.is_icky_wield[1]) {
+    if (creature.is_icky_wield(1)) {
         cm_ptr->chance += 20;
     } else if (has_melee_weapon(creature, INVEN_SUB_HAND)) {
         cm_ptr->chance += 10;
@@ -176,7 +176,7 @@ static void decide_mind_chance(CreatureEntity &creature, cm_type *cm_ptr)
     }
 
     cm_ptr->chance -= 3 * (cm_ptr->plev - cm_ptr->spell.min_lev);
-    cm_ptr->chance += creature.to_m_chance;
+    cm_ptr->chance += creature.get_to_m_chance();
     cm_ptr->chance -= 3 * (adj_mag_stat[creature.get_stat_index(mp_ptr->spell_stat)] - 1);
     if ((cm_ptr->mana_cost > creature.get_csp()) && (cm_ptr->use_mind != MindKindType::BERSERKER) && (cm_ptr->use_mind != MindKindType::NINJUTSU)) {
         cm_ptr->chance += 5 * (cm_ptr->mana_cost - creature.get_csp());
@@ -196,11 +196,11 @@ static void decide_mind_chance(CreatureEntity &creature, cm_type *cm_ptr)
         cm_ptr->chance += 5;
     }
 
-    if (creature.is_icky_wield[0]) {
+    if (creature.is_icky_wield(0)) {
         cm_ptr->chance += 5;
     }
 
-    if (creature.is_icky_wield[1]) {
+    if (creature.is_icky_wield(1)) {
         cm_ptr->chance += 5;
     }
 }

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -223,7 +223,8 @@ bool do_cmd_riding(CreatureEntity &creature, bool force)
 
         creature.ride_monster(0);
         creature.pet_extra_flags &= ~(PF_TWO_HANDS);
-        creature.riding_ryoute = creature.old_riding_ryoute = false;
+        creature.old_riding_ryoute = false;
+        creature.set_riding_ryoute(false);
     } else {
         if (cmd_limit_confused(creature)) {
             return false;

--- a/src/combat/attack-criticality.cpp
+++ b/src/combat/attack-criticality.cpp
@@ -100,7 +100,7 @@ static void ninja_critical(CreatureEntity &creature, player_attack_type *pa_ptr)
     const auto no_instantly_death = monrace.resistance_flags.has(MonsterResistanceType::NO_INSTANTLY_DEATH);
     bool is_weaken = pa_ptr->m_ptr->hp < maxhp / 2;
     bool is_unique = monrace.kind_flags.has(MonsterKindType::UNIQUE) || no_instantly_death;
-    bool is_critical = (is_weaken && one_in_((creature.num_blow[0] + creature.num_blow[1] + 1) * 10)) || ((one_in_(666) || ((pa_ptr->backstab || pa_ptr->surprise_attack) && one_in_(11))) && !is_unique);
+    bool is_critical = (is_weaken && one_in_((creature.get_num_blow(0) + creature.get_num_blow(1) + 1) * 10)) || ((one_in_(666) || ((pa_ptr->backstab || pa_ptr->surprise_attack) && one_in_(11))) && !is_unique);
     if (!is_critical) {
         return;
     }
@@ -150,7 +150,7 @@ void critical_attack(CreatureEntity &creature, player_attack_type *pa_ptr)
     }
 
     const auto has_weapon = has_melee_weapon(creature, enum2i(INVEN_MAIN_HAND) + pa_ptr->hand);
-    const auto is_ninja_hit = has_weapon && !creature.is_icky_wield[pa_ptr->hand] && ((creature.cur_lite <= 0) || one_in_(7));
+    const auto is_ninja_hit = has_weapon && !creature.is_icky_wield(pa_ptr->hand) && ((creature.get_cur_lite() <= 0) || one_in_(7));
     if (is_ninja_hit) {
         ninja_critical(creature, pa_ptr);
     }

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -516,7 +516,7 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
     const auto item_name = describe_flavor(creature, *o_ptr, OD_OMIT_PREFIX);
 
     /* Use the proper number of shots */
-    auto thits = creature.num_fire;
+    auto thits = creature.get_num_fire();
 
     /* Use a base distance */
     auto tdis = 10;

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -226,11 +226,11 @@ static std::string describe_accuracy_and_damage_bonus(const ItemEntity &item, co
 static std::string describe_fire_energy(CreatureEntity &creature, const ItemEntity &ammo, const ItemEntity &bow, const describe_option_type &opt, int avgdam)
 {
     const auto energy_fire = bow.get_bow_energy();
-    if (creature.num_fire == 0) {
+    if (creature.get_num_fire() == 0) {
         return "0";
     }
 
-    const auto avgdam_per_turn = avgdam * creature.num_fire * 100 / energy_fire;
+    const auto avgdam_per_turn = avgdam * creature.get_num_fire() * 100 / energy_fire;
 
     std::stringstream ss;
     ss << avgdam_per_turn

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -51,7 +51,8 @@ static void check_riding_preservation(CreatureEntity &creature)
     if (monster.has_parent()) {
         creature.ride_monster(0);
         creature.pet_extra_flags &= ~(PF_TWO_HANDS);
-        creature.riding_ryoute = creature.old_riding_ryoute = false;
+        creature.old_riding_ryoute = false;
+        creature.set_riding_ryoute(false);
     } else {
         party_monsters[0] = monster;
         delete_monster_idx(creature, creature.get_riding());

--- a/src/inventory/inventory-describer.cpp
+++ b/src/inventory/inventory-describer.cpp
@@ -21,25 +21,25 @@ concptr mention_use(CreatureEntity &creature, int i)
     switch (i) {
 #ifdef JP
     case INVEN_MAIN_HAND:
-        p = creature.heavy_wield[0]
+        p = creature.is_heavy_wield(0)
                 ? "運搬中"
                 : ((creature.has_two_handed_weapons() && can_attack_with_main_hand(creature)) ? " 両手" : (left_hander ? " 左手" : " 右手"));
         break;
 #else
     case INVEN_MAIN_HAND:
-        p = creature.heavy_wield[0] ? "Just lifting" : (can_attack_with_main_hand(creature) ? "Wielding" : "On arm");
+        p = creature.is_heavy_wield(0) ? "Just lifting" : (can_attack_with_main_hand(creature) ? "Wielding" : "On arm");
         break;
 #endif
 
 #ifdef JP
     case INVEN_SUB_HAND:
-        p = creature.heavy_wield[1]
+        p = creature.is_heavy_wield(1)
                 ? "運搬中"
                 : ((creature.has_two_handed_weapons() && can_attack_with_sub_hand(creature)) ? " 両手" : (left_hander ? " 右手" : " 左手"));
         break;
 #else
     case INVEN_SUB_HAND:
-        p = creature.heavy_wield[1] ? "Just lifting" : (can_attack_with_sub_hand(creature) ? "Wielding" : "On arm");
+        p = creature.is_heavy_wield(1) ? "Just lifting" : (can_attack_with_sub_hand(creature) ? "Wielding" : "On arm");
         break;
 #endif
 
@@ -98,27 +98,27 @@ concptr describe_use(CreatureEntity &creature, int i)
     switch (i) {
 #ifdef JP
     case INVEN_MAIN_HAND:
-        p = creature.heavy_wield[0]
+        p = creature.is_heavy_wield(0)
                 ? "運搬中の"
                 : ((creature.has_two_handed_weapons() && can_attack_with_main_hand(creature)) ? "両手に装備している"
                                                                                               : (left_hander ? "左手に装備している" : "右手に装備している"));
         break;
 #else
     case INVEN_MAIN_HAND:
-        p = creature.heavy_wield[0] ? "just lifting" : (can_attack_with_main_hand(creature) ? "attacking monsters with" : "wearing on your arm");
+        p = creature.is_heavy_wield(0) ? "just lifting" : (can_attack_with_main_hand(creature) ? "attacking monsters with" : "wearing on your arm");
         break;
 #endif
 
 #ifdef JP
     case INVEN_SUB_HAND:
-        p = creature.heavy_wield[1]
+        p = creature.is_heavy_wield(1)
                 ? "運搬中の"
                 : ((creature.has_two_handed_weapons() && can_attack_with_sub_hand(creature)) ? "両手に装備している"
                                                                                              : (left_hander ? "右手に装備している" : "左手に装備している"));
         break;
 #else
     case INVEN_SUB_HAND:
-        p = creature.heavy_wield[1] ? "just lifting" : (can_attack_with_sub_hand(creature) ? "attacking monsters with" : "wearing on your arm");
+        p = creature.is_heavy_wield(1) ? "just lifting" : (can_attack_with_sub_hand(creature) ? "attacking monsters with" : "wearing on your arm");
         break;
 #endif
 

--- a/src/io-dump/player-status-dump-json.cpp
+++ b/src/io-dump/player-status-dump-json.cpp
@@ -152,8 +152,8 @@ static void add_combat_to_json(nlohmann::json &j, CreatureEntity &creature)
     j["combat"]["ranged_to_hit"] = creature.get_to_h_b();
 
     // 攻撃回数
-    j["combat"]["num_blow"] = creature.num_blow[0];
-    j["combat"]["num_fire"] = creature.num_fire;
+    j["combat"]["num_blow"] = creature.get_num_blow(0);
+    j["combat"]["num_fire"] = creature.get_num_fire();
 }
 
 /*!

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -67,7 +67,7 @@ static void show_weapon_dmg(int r, int c, int mindice, int maxdice, int blows, i
  */
 static void compare_weapon_aux(CreatureEntity &creature, ItemEntity *o_ptr, int col, int r)
 {
-    int blow = creature.num_blow[0];
+    int blow = creature.get_num_blow(0);
     bool force = false;
     bool dokubari = false;
 
@@ -264,7 +264,7 @@ static void list_weapon(CreatureEntity &creature, const ItemEntity &item, TERM_L
     const auto hit_reliability = creature.get_skill_to_hit_melee() + (creature.get_to_h(0) + item.to_h) * BTH_PLUS_ADJ;
     const auto item_name = describe_flavor(creature, item, OD_NAME_ONLY);
     c_put_str(TERM_YELLOW, item_name, row, col);
-    put_str(format(_("攻撃回数: %d", "Number of Blows: %d"), creature.num_blow[0]), row + 1, col);
+    put_str(format(_("攻撃回数: %d", "Number of Blows: %d"), creature.get_num_blow(0)), row + 1, col);
 
     put_str(_("命中率:  0  50 100 150 200 (敵のAC)", "To Hit:  0  50 100 150 200 (AC)"), row + 2, col);
     put_str(format("        %2d  %2d  %2d  %2d  %2d (%%)",
@@ -282,8 +282,8 @@ static void list_weapon(CreatureEntity &creature, const ItemEntity &item, TERM_L
         row + 6, col + 1);
 
     put_str(format(_("１ターンにつき %d-%d", "One Attack: %d-%d damage"),
-                (int)(creature.num_blow[0] * (eff_dd + item.to_d + creature.get_to_d(0))),
-                (int)(creature.num_blow[0] * (eff_ds * eff_dd + item.to_d + creature.get_to_d(0)))),
+                (int)(creature.get_num_blow(0) * (eff_dd + item.to_d + creature.get_to_d(0))),
+                (int)(creature.get_num_blow(0) * (eff_ds * eff_dd + item.to_d + creature.get_to_d(0)))),
         row + 7, col + 1);
 }
 

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -644,7 +644,7 @@ static PERCENTAGE decide_element_chance(CreatureEntity &creature, mind_type spel
     PERCENTAGE chance = spell.fail;
 
     chance -= 3 * (creature.get_level() - spell.min_lev);
-    chance += creature.to_m_chance;
+    chance += creature.get_to_m_chance();
     chance -= 3 * (adj_mag_stat[creature.get_stat_index(A_WIS)] - 1);
 
     PERCENTAGE minfail = adj_mag_fail[creature.get_stat_index(A_WIS)];
@@ -657,11 +657,11 @@ static PERCENTAGE decide_element_chance(CreatureEntity &creature, mind_type spel
         chance += 5;
     }
 
-    if (creature.is_icky_wield[0]) {
+    if (creature.is_icky_wield(0)) {
         chance += 5;
     }
 
-    if (creature.is_icky_wield[1]) {
+    if (creature.is_icky_wield(1)) {
         chance += 5;
     }
 

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -201,12 +201,12 @@ void process_surprise_attack(CreatureEntity &creature, player_attack_type *pa_pt
 {
 
     const auto &monrace = pa_ptr->m_ptr->get_monrace();
-    if (!has_melee_weapon(creature, enum2i(INVEN_MAIN_HAND) + pa_ptr->hand) || creature.is_icky_wield[pa_ptr->hand]) {
+    if (!has_melee_weapon(creature, enum2i(INVEN_MAIN_HAND) + pa_ptr->hand) || creature.is_icky_wield(pa_ptr->hand)) {
         return;
     }
 
     int tmp = creature.get_level() * 6 + (creature.get_skill_stealth() + 10) * 4;
-    if (creature.monlite && (pa_ptr->mode != HISSATSU_NYUSIN)) {
+    if (creature.is_monlite() && (pa_ptr->mode != HISSATSU_NYUSIN)) {
         tmp /= 3;
     }
     if (has_aggravate(creature)) {
@@ -311,10 +311,12 @@ bool set_superstealth(CreatureEntity &creature, bool set)
         if (!ninja_data->s_stealth) {
             if (creature.get_floor()->grid_array[creature.y][creature.x].info & CAVE_MNLT) {
                 msg_print(_("敵の目から薄い影の中に覆い隠された。", "You are mantled in weak shadow from ordinary eyes."));
-                creature.monlite = creature.old_monlite = true;
+                creature.old_monlite = true;
+                creature.set_monlite(true);
             } else {
                 msg_print(_("敵の目から影の中に覆い隠された！", "You are mantled in shadow from ordinary eyes!"));
-                creature.monlite = creature.old_monlite = false;
+                creature.old_monlite = false;
+                creature.set_monlite(false);
             }
 
             notice = true;

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -294,7 +294,7 @@ void MindPowerGetter::calculate_mind_chance(bool has_weapon_main, bool has_weapo
         this->chance += 5 * (this->mana_cost - this->creature_ptr->get_csp());
     }
 
-    this->chance += this->creature_ptr->to_m_chance;
+    this->chance += this->creature_ptr->get_to_m_chance();
     PERCENTAGE minfail = adj_mag_fail[this->creature_ptr->get_stat_index(mp_ptr->spell_stat)];
     if (this->chance < minfail) {
         this->chance = minfail;
@@ -317,13 +317,13 @@ void MindPowerGetter::calculate_ki_chance(bool has_weapon_main, bool has_weapon_
         this->chance += 20;
     }
 
-    if (this->creature_ptr->is_icky_wield[0]) {
+    if (this->creature_ptr->is_icky_wield(0)) {
         this->chance += 20;
     } else if (has_weapon_main) {
         this->chance += 10;
     }
 
-    if (this->creature_ptr->is_icky_wield[1]) {
+    if (this->creature_ptr->is_icky_wield(1)) {
         chance += 20;
     } else if (has_weapon_sub) {
         this->chance += 10;
@@ -346,11 +346,11 @@ void MindPowerGetter::add_ki_chance()
         this->chance += 5;
     }
 
-    if (this->creature_ptr->is_icky_wield[0]) {
+    if (this->creature_ptr->is_icky_wield(0)) {
         this->chance += 5;
     }
 
-    if (this->creature_ptr->is_icky_wield[1]) {
+    if (this->creature_ptr->is_icky_wield(1)) {
         this->chance += 5;
     }
 }

--- a/src/monster-floor/monster-lite.cpp
+++ b/src/monster-floor/monster-lite.cpp
@@ -297,23 +297,23 @@ void update_mon_lite(CreatureEntity &creature)
     points.insert(points.end(), points_mon_lite.begin(), points_mon_lite.end());
     floor.set_mon_lite(points, end_temp);
     RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::DELAY_VISIBILITY);
-    creature.monlite = (floor.get_grid(p_pos).info & CAVE_MNLT) != 0;
+    creature.set_monlite((floor.get_grid(p_pos).info & CAVE_MNLT) != 0);
     const auto ninja_data = CreatureClass(creature).get_specific_data<ninja_data_type>();
     if (!ninja_data || !ninja_data->s_stealth) {
-        creature.old_monlite = creature.monlite;
+        creature.old_monlite = creature.is_monlite();
         return;
     }
 
-    if (creature.old_monlite == creature.monlite) {
-        creature.old_monlite = creature.monlite;
+    if (creature.old_monlite == creature.is_monlite()) {
+        creature.old_monlite = creature.is_monlite();
         return;
     }
 
-    if (creature.monlite) {
+    if (creature.is_monlite()) {
         msg_print(_("影の覆いが薄れた気がする。", "Your mantle of shadow becomes thin."));
     } else {
         msg_print(_("影の覆いが濃くなった！", "Your mantle of shadow is restored to its original darkness."));
     }
 
-    creature.old_monlite = creature.monlite;
+    creature.old_monlite = creature.is_monlite();
 }

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -419,7 +419,7 @@ bool process_monster_movement(CreatureEntity &creature, turn_flags *turn_flags_p
 
         if (turn_flags_ptr->is_riding_mon) {
             const auto &monster_riding = floor.get_monster(creature.get_riding());
-            if (!creature.riding_ryoute && !monster_riding.is_fearful()) {
+            if (!creature.is_riding_ryoute() && !monster_riding.is_fearful()) {
                 turn_flags_ptr->do_move = false;
             }
         }

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -553,9 +553,9 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     m_ptr->set_individual_speed(floor.inside_arena);
 
     // Initialize AC from monster race
-    m_ptr->ac = new_monrace.ac;
+    m_ptr->set_ac(new_monrace.ac);
     if (m_ptr->is_illegal_modified()) {
-        m_ptr->ac += randint1(10) + 5; // +6～+15のACボーナス
+        m_ptr->set_ac(m_ptr->ac + randint1(10) + 5); // +6～+15のACボーナス
     }
 
     if (m_ptr->is_huge()) {

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -1017,7 +1017,7 @@ bool process_stealth(CreatureEntity &creature, MONSTER_IDX m_idx)
     const auto &monster = creature.get_floor()->get_monster(m_idx);
     const auto &monrace = monster.get_monrace();
     int tmp = creature.get_level() * 6 + (creature.get_skill_stealth() + 10) * 4;
-    if (creature.monlite) {
+    if (creature.is_monlite()) {
         tmp /= 3;
     }
 

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -516,7 +516,7 @@ void ObjectThrowEntity::calc_racial_power_damage()
     this->tdam = critical_shot(creature, this->q_ptr->weight, this->q_ptr->to_h, 0, this->tdam);
     this->tdam += (this->q_ptr->to_d > 0 ? 1 : -1) * this->q_ptr->to_d;
     if (this->boomerang) {
-        this->tdam *= (this->mult + creature.num_blow[this->i_idx - INVEN_MAIN_HAND]);
+        this->tdam *= (this->mult + creature.get_num_blow(this->i_idx - INVEN_MAIN_HAND));
         this->tdam += creature.get_to_d_m();
     } else if (this->obj_flags.has(TR_THROW)) {
         this->tdam *= (3 + this->mult);

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -62,7 +62,7 @@ static bool calc_fall_off_possibility(CreatureEntity &creature, const int dam, c
     auto cur = creature.get_skill_exp(PlayerSkillKindType::RIDING);
 
     int fall_off_level = monrace.level;
-    if (creature.riding_ryoute) {
+    if (creature.is_riding_ryoute()) {
         fall_off_level += 20;
     }
 
@@ -72,7 +72,7 @@ static bool calc_fall_off_possibility(CreatureEntity &creature, const int dam, c
         return true;
     }
 
-    if ((CreatureClass(creature).is_tamer() && !creature.riding_ryoute) || !one_in_(creature.get_level() * (creature.riding_ryoute ? 2 : 3) + 30)) {
+    if ((CreatureClass(creature).is_tamer() && !creature.is_riding_ryoute()) || !one_in_(creature.get_level() * (creature.is_riding_ryoute() ? 2 : 3) + 30)) {
         return false;
     }
 
@@ -146,7 +146,8 @@ bool process_fall_off_horse(CreatureEntity &creature, int dam, bool force)
 
     creature.ride_monster(0);
     creature.pet_extra_flags &= ~(PF_TWO_HANDS);
-    creature.riding_ryoute = creature.old_riding_ryoute = false;
+    creature.old_riding_ryoute = false;
+    creature.set_riding_ryoute(false);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {

--- a/src/pet/pet-util.cpp
+++ b/src/pet/pet-util.cpp
@@ -25,7 +25,7 @@ bool can_player_ride_pet(CreatureEntity &creature, const Grid &grid, bool now_ri
     auto &world = AngbandWorld::get_instance();
     const auto old_character_xtra = world.character_xtra;
     const auto old_riding = creature.get_riding();
-    const auto old_riding_two_hands = creature.riding_ryoute;
+    const auto old_riding_two_hands = creature.is_riding_ryoute();
     const auto old_old_riding_two_hands = creature.old_riding_ryoute;
     const auto old_pf_two_hands = any_bits(creature.pet_extra_flags, PF_TWO_HANDS);
     world.character_xtra = true;
@@ -35,7 +35,8 @@ bool can_player_ride_pet(CreatureEntity &creature, const Grid &grid, bool now_ri
     } else {
         creature.ride_monster(0);
         creature.pet_extra_flags &= ~(PF_TWO_HANDS);
-        creature.riding_ryoute = creature.old_riding_ryoute = false;
+        creature.old_riding_ryoute = false;
+        creature.set_riding_ryoute(false);
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
@@ -50,7 +51,7 @@ bool can_player_ride_pet(CreatureEntity &creature, const Grid &grid, bool now_ri
         creature.pet_extra_flags &= ~(PF_TWO_HANDS);
     }
 
-    creature.riding_ryoute = old_riding_two_hands;
+    creature.set_riding_ryoute(old_riding_two_hands);
     creature.old_riding_ryoute = old_old_riding_two_hands;
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(creature);

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -162,9 +162,9 @@ static void calc_num_blow(CreatureEntity &creature, player_attack_type *pa_ptr)
     if ((pa_ptr->mode == HISSATSU_KYUSHO) || (pa_ptr->mode == HISSATSU_MINEUCHI) || (pa_ptr->mode == HISSATSU_3DAN) || (pa_ptr->mode == HISSATSU_IAI)) {
         pa_ptr->num_blow = 1;
     } else if (pa_ptr->mode == HISSATSU_COLD) {
-        pa_ptr->num_blow = creature.num_blow[pa_ptr->hand] + 2;
+        pa_ptr->num_blow = creature.get_num_blow(pa_ptr->hand) + 2;
     } else {
-        pa_ptr->num_blow = creature.num_blow[pa_ptr->hand];
+        pa_ptr->num_blow = creature.get_num_blow(pa_ptr->hand);
     }
 
     auto *o_ptr = creature.inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand].get();
@@ -445,14 +445,14 @@ static bool check_fear_death(CreatureEntity &creature, player_attack_type *pa_pt
         if (can_attack_with_main_hand(creature) && can_attack_with_sub_hand(creature)) {
             ENERGY energy_use;
             if (pa_ptr->hand) {
-                energy_use = creature.energy_use * 3 / 5 + creature.energy_use * num * 2 / (creature.num_blow[pa_ptr->hand] * 5);
+                energy_use = creature.energy_use * 3 / 5 + creature.energy_use * num * 2 / (creature.get_num_blow(pa_ptr->hand) * 5);
             } else {
-                energy_use = creature.energy_use * num * 3 / (creature.num_blow[pa_ptr->hand] * 5);
+                energy_use = creature.energy_use * num * 3 / (creature.get_num_blow(pa_ptr->hand) * 5);
             }
 
             energy.set_player_turn_energy(energy_use);
         } else {
-            auto energy_use = (ENERGY)(creature.energy_use * num / creature.num_blow[pa_ptr->hand]);
+            auto energy_use = (ENERGY)(creature.energy_use * num / creature.get_num_blow(pa_ptr->hand));
             energy.set_player_turn_energy(energy_use);
         }
     }

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -110,7 +110,7 @@ TrFlags CreatureClass::tr_flags() const
                 flags.set(TR_SPEED);
             }
 
-            if (plev > 24 && !creature.is_icky_wield[0] && !creature.is_icky_wield[1]) {
+            if (plev > 24 && !creature.is_icky_wield(0) && !creature.is_icky_wield(1)) {
                 flags.set(TR_FREE_ACT);
             }
         }

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -194,7 +194,7 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
         if (CreatureClass(creature).equals(PlayerClassType::NINJA)) {
             if (grid_new.info & (CAVE_GLOW)) {
                 set_superstealth(creature, false);
-            } else if (creature.cur_lite <= 0) {
+            } else if (creature.get_cur_lite() <= 0) {
                 set_superstealth(creature, true);
             }
         }

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -316,14 +316,14 @@ static void update_bonuses(CreatureEntity &creature)
     o_ptr = creature.inventory[INVEN_BOW].get();
     if (o_ptr->is_valid()) {
         creature.tval_ammo = o_ptr->get_arrow_kind();
-        creature.num_fire = calc_num_fire(creature, o_ptr);
+        creature.set_num_fire(calc_num_fire(creature, o_ptr));
     }
 
     for (int i = 0; i < 2; i++) {
-        creature.is_icky_wield[i] = is_wielding_icky_weapon(creature, i);
-        creature.is_icky_riding_wield[i] = is_wielding_icky_riding_weapon(creature, i);
-        creature.heavy_wield[i] = is_heavy_wield(creature, i);
-        creature.num_blow[i] = calc_num_blow(creature, i);
+        creature.set_icky_wield(i, is_wielding_icky_weapon(creature, i));
+        creature.set_icky_riding_wield(i, is_wielding_icky_riding_weapon(creature, i));
+        creature.set_heavy_wield(i, is_heavy_wield(creature, i));
+        creature.set_num_blow(i, calc_num_blow(creature, i));
         creature.damage_dice_bonus[i].num = calc_to_weapon_dice_num(creature, INVEN_MAIN_HAND + i);
         creature.damage_dice_bonus[i].sides = 0;
     }
@@ -339,7 +339,7 @@ static void update_bonuses(CreatureEntity &creature)
     creature.set_skill_to_hit_melee(calc_to_hit_melee(creature));
     creature.set_skill_to_hit_bow(calc_to_hit_shoot(creature));
     creature.set_skill_to_hit_throw(calc_to_hit_throw(creature));
-    creature.riding_ryoute = is_riding_two_hands(creature);
+    creature.set_riding_ryoute(is_riding_two_hands(creature));
     creature.set_to_d(0, calc_to_damage(creature, INVEN_MAIN_HAND, true));
     creature.set_to_d(1, calc_to_damage(creature, INVEN_SUB_HAND, true));
     creature.set_dis_to_d(0, calc_to_damage(creature, INVEN_MAIN_HAND, false));
@@ -353,8 +353,8 @@ static void update_bonuses(CreatureEntity &creature)
     creature.set_to_d_m(calc_to_damage_misc(creature));
     creature.set_to_h_m(calc_to_hit_misc(creature));
     creature.set_skill_dig(calc_skill_dig(creature));
-    creature.to_m_chance = calc_to_magic_chance(creature);
-    creature.ac = calc_base_ac(creature);
+    creature.set_to_m_chance(calc_to_magic_chance(creature));
+    creature.set_ac(calc_base_ac(creature));
     creature.set_to_a(calc_to_ac(creature, true));
     creature.set_dis_ac(calc_base_ac(creature));
     creature.set_dis_to_a(calc_to_ac(creature, false));
@@ -736,7 +736,7 @@ static void update_max_mana(CreatureEntity &creature)
     }
 
     if (mp_ptr->has_glove_mp_penalty) {
-        creature.cumber_glove = false;
+        creature.set_cumber_glove(false);
         const auto *o_ptr = creature.inventory[INVEN_ARMS].get();
         const auto flags = o_ptr->get_flags();
         auto should_mp_decrease = o_ptr->is_valid();
@@ -746,12 +746,12 @@ static void update_max_mana(CreatureEntity &creature)
         should_mp_decrease &= flags.has_not(TR_MAGIC_MASTERY) || (o_ptr->pval <= 0);
         should_mp_decrease &= flags.has_not(TR_DEX) || (o_ptr->pval <= 0);
         if (should_mp_decrease) {
-            creature.cumber_glove = true;
+            creature.set_cumber_glove(true);
             msp = (3 * msp) / 4;
         }
     }
 
-    creature.cumber_armor = false;
+    creature.set_cumber_armor(false);
 
     auto cur_wgt = 0;
     const auto &item_main_hand = *creature.inventory[INVEN_MAIN_HAND];
@@ -843,7 +843,7 @@ static void update_max_mana(CreatureEntity &creature)
 
     int max_wgt = mp_ptr->spell_weight;
     if ((cur_wgt - max_wgt) > 0) {
-        creature.cumber_armor = true;
+        creature.set_cumber_armor(true);
         switch (creature.pclass) {
         case PlayerClassType::MAGE:
         case PlayerClassType::HIGH_MAGE:
@@ -880,7 +880,7 @@ static void update_max_mana(CreatureEntity &creature)
             break;
         }
         case PlayerClassType::SAMURAI: {
-            creature.cumber_armor = false;
+            creature.set_cumber_armor(false);
             break;
         }
         default: {
@@ -919,27 +919,27 @@ static void update_max_mana(CreatureEntity &creature)
         return;
     }
 
-    if (creature.old_cumber_glove != creature.cumber_glove) {
-        if (creature.cumber_glove) {
+    if (creature.old_cumber_glove != creature.is_cumber_glove()) {
+        if (creature.is_cumber_glove()) {
             msg_print(_("手が覆われて呪文が唱えにくい感じがする。", "Your covered hands feel unsuitable for spellcasting."));
         } else {
             msg_print(_("この手の状態なら、ぐっと呪文が唱えやすい感じだ。", "Your hands feel more suitable for spellcasting."));
         }
 
-        creature.old_cumber_glove = creature.cumber_glove;
+        creature.old_cumber_glove = creature.is_cumber_glove();
     }
 
-    if (creature.old_cumber_armor == creature.cumber_armor) {
+    if (creature.old_cumber_armor == creature.is_cumber_armor()) {
         return;
     }
 
-    if (creature.cumber_armor) {
+    if (creature.is_cumber_armor()) {
         msg_print(_("装備の重さで動きが鈍くなってしまっている。", "The weight of your equipment encumbers your movement."));
     } else {
         msg_print(_("ぐっと楽に体を動かせるようになった。", "You feel able to move more freely."));
     }
 
-    creature.old_cumber_armor = creature.cumber_armor;
+    creature.old_cumber_armor = creature.is_cumber_armor();
 }
 
 /*!
@@ -1398,7 +1398,7 @@ static ACTION_SKILL_POWER calc_skill_dig(CreatureEntity &creature)
 
     for (int i = 0; i < 2; i++) {
         o_ptr = creature.inventory[INVEN_MAIN_HAND + i].get();
-        if (has_melee_weapon(creature, INVEN_MAIN_HAND + i) && !creature.heavy_wield[i]) {
+        if (has_melee_weapon(creature, INVEN_MAIN_HAND + i) && !creature.is_heavy_wield(i)) {
             pow += (o_ptr->weight / 10);
         }
     }
@@ -1437,7 +1437,7 @@ static int16_t calc_num_blow(CreatureEntity &creature, int i)
     const auto *o_ptr = creature.inventory[INVEN_MAIN_HAND + i].get();
     CreatureClass pc(creature);
     if (has_melee_weapon(creature, INVEN_MAIN_HAND + i)) {
-        if (o_ptr->is_valid() && !creature.heavy_wield[i]) {
+        if (o_ptr->is_valid() && !creature.is_heavy_wield(i)) {
             int str_index, dex_index;
             int num = 0, wgt = 0, mul = 0, div = 0;
 
@@ -1962,22 +1962,22 @@ void put_equipment_warning(CreatureEntity &creature)
     }
 
     for (int i = 0; i < 2; i++) {
-        if (creature.old_heavy_wield[i] != creature.heavy_wield[i]) {
-            if (creature.heavy_wield[i]) {
+        if (creature.old_heavy_wield[i] != creature.is_heavy_wield(i)) {
+            if (creature.is_heavy_wield(i)) {
                 msg_print(_("こんな重い武器を装備しているのは大変だ。", "You have trouble wielding such a heavy weapon."));
             } else if (has_melee_weapon(creature, INVEN_MAIN_HAND + i)) {
                 msg_print(_("これなら装備していても辛くない。", "You have no trouble wielding your weapon."));
-            } else if (creature.heavy_wield[1 - i]) {
+            } else if (creature.is_heavy_wield(1 - i)) {
                 msg_print(_("まだ武器が重い。", "You still have trouble wielding a heavy weapon."));
             } else {
                 msg_print(_("重い武器を装備からはずして体が楽になった。", "You feel relieved to put down your heavy weapon."));
             }
 
-            creature.old_heavy_wield[i] = creature.heavy_wield[i];
+            creature.old_heavy_wield[i] = creature.is_heavy_wield(i);
         }
 
-        if (creature.old_riding_wield[i] != creature.is_icky_riding_wield[i]) {
-            if (creature.is_icky_riding_wield[i]) {
+        if (creature.old_riding_wield[i] != creature.is_icky_riding_wield(i)) {
+            if (creature.is_icky_riding_wield(i)) {
                 msg_print(_("この武器は乗馬中に使うにはむかないようだ。", "This weapon is not suitable for use while riding."));
             } else if (!creature.get_riding()) {
                 msg_print(_("この武器は徒歩で使いやすい。", "This weapon is suitable for use on foot."));
@@ -1985,14 +1985,14 @@ void put_equipment_warning(CreatureEntity &creature)
                 msg_print(_("これなら乗馬中にぴったりだ。", "This weapon is suitable for use while riding."));
             }
 
-            creature.old_riding_wield[i] = creature.is_icky_riding_wield[i];
+            creature.old_riding_wield[i] = creature.is_icky_riding_wield(i);
         }
 
-        if (creature.old_icky_wield[i] == creature.is_icky_wield[i]) {
+        if (creature.old_icky_wield[i] == creature.is_icky_wield(i)) {
             continue;
         }
 
-        if (creature.is_icky_wield[i]) {
+        if (creature.is_icky_wield(i)) {
             msg_print(_("今の装備はどうも自分にふさわしくない気がする。", "You do not feel comfortable with your weapon."));
             if (AngbandWorld::get_instance().is_loading_now) {
                 chg_virtue(creature, Virtue::FAITH, -1);
@@ -2003,11 +2003,11 @@ void put_equipment_warning(CreatureEntity &creature)
             msg_print(_("装備をはずしたら随分と気が楽になった。", "You feel more comfortable after removing your weapon."));
         }
 
-        creature.old_icky_wield[i] = creature.is_icky_wield[i];
+        creature.old_icky_wield[i] = creature.is_icky_wield(i);
     }
 
-    if (creature.get_riding() && (creature.old_riding_ryoute != creature.riding_ryoute)) {
-        if (creature.riding_ryoute) {
+    if (creature.get_riding() && (creature.old_riding_ryoute != creature.is_riding_ryoute())) {
+        if (creature.is_riding_ryoute()) {
 #ifdef JP
             msg_format("%s馬を操れない。", (empty_hands(creature, false) == EMPTY_HAND_NONE) ? "両手がふさがっていて" : "");
 #else
@@ -2021,7 +2021,7 @@ void put_equipment_warning(CreatureEntity &creature)
 #endif
         }
 
-        creature.old_riding_ryoute = creature.riding_ryoute;
+        creature.old_riding_ryoute = creature.is_riding_ryoute();
     }
 
     CreatureClass pc(creature);

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -487,7 +487,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
                     basedam /= 9;
                 }
                 damage += basedam;
-                damage *= creature.num_blow[i];
+                damage *= creature.get_num_blow(i);
                 total_damage += damage / 200;
                 if (i) {
                     total_damage = total_damage * 7 / 10;
@@ -720,7 +720,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
                 }
                 damage += basedam;
                 damage += creature.get_to_d(i) * 100;
-                damage *= creature.num_blow[i];
+                damage *= creature.get_num_blow(i);
                 total_damage += (damage / 100);
             }
 

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -70,7 +70,7 @@ void torch_lost_fuel(ItemEntity *o_ptr)
  */
 void update_lite_radius(CreatureEntity &creature)
 {
-    creature.cur_lite = 0;
+    POSITION cur_lite = 0;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         const auto *o_ptr = creature.inventory[i].get();
         if (!o_ptr->is_valid()) {
@@ -86,38 +86,40 @@ void update_lite_radius(CreatureEntity &creature)
                 }
             }
         }
-        creature.cur_lite += o_ptr->get_lite_radius();
+        cur_lite += o_ptr->get_lite_radius();
     }
 
-    if (creature.cur_lite <= 0 && creature.has_lite_flag()) {
-        creature.cur_lite++;
+    if (cur_lite <= 0 && creature.has_lite_flag()) {
+        cur_lite++;
     }
 
-    if (creature.cur_lite > 14) {
-        creature.cur_lite = 14;
+    if (cur_lite > 14) {
+        cur_lite = 14;
     }
 
     if (creature.get_mimic_form() == MimicKindType::ANGEL) {
-        creature.cur_lite += 3;
+        cur_lite += 3;
     }
 
     if (creature.get_mimic_form() == MimicKindType::DEMIGOD) {
-        creature.cur_lite += 6;
+        cur_lite += 6;
     }
 
     if (creature.get_timed_effect(CreatureTimedEffect::TIM_EMISSION) > 0) {
-        creature.cur_lite += creature.get_level() / 5;
+        cur_lite += creature.get_level() / 5;
     }
 
-    if (creature.get_floor()->get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS) && creature.cur_lite > 1) {
-        creature.cur_lite = 1;
+    if (creature.get_floor()->get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS) && cur_lite > 1) {
+        cur_lite = 1;
     }
 
-    if (creature.cur_lite < 0) {
-        creature.cur_lite = 0;
+    if (cur_lite < 0) {
+        cur_lite = 0;
     }
 
-    if (creature.old_lite == creature.cur_lite) {
+    creature.set_cur_lite(cur_lite);
+
+    if (creature.old_lite == cur_lite) {
         return;
     }
 
@@ -127,8 +129,8 @@ void update_lite_radius(CreatureEntity &creature)
         StatusRecalculatingFlag::MONSTER_STATUSES,
     };
     RedrawingFlagsUpdater::get_instance().set_flags(flags);
-    creature.old_lite = creature.cur_lite;
-    if (creature.cur_lite > 0) {
+    creature.old_lite = cur_lite;
+    if (cur_lite > 0) {
         set_superstealth(creature, false);
     }
 }
@@ -159,7 +161,7 @@ void update_lite_radius(CreatureEntity &creature)
  */
 void update_lite(CreatureEntity &creature)
 {
-    POSITION p = creature.cur_lite;
+    POSITION p = creature.get_cur_lite();
     auto &floor = *creature.get_floor();
     const auto points = floor.reset_lite();
     const auto p_pos = creature.get_position();

--- a/src/spell-realm/spells-crusade.cpp
+++ b/src/spell-realm/spells-crusade.cpp
@@ -135,13 +135,13 @@ void check_emission(CreatureEntity &creature)
 {
     if (creature.get_timed_effect(CreatureTimedEffect::TIM_EMISSION) > 0) {
         if (creature.get_level() > 29) {
-            map_area(creature, creature.cur_lite);
+            map_area(creature, creature.get_cur_lite());
         }
         if (creature.get_level() > 24) {
-            detect_traps(creature, creature.cur_lite, true);
+            detect_traps(creature, creature.get_cur_lite(), true);
         }
         if (creature.get_level() > 19) {
-            detect_monsters_evil(creature, creature.cur_lite);
+            detect_monsters_evil(creature, creature.get_cur_lite());
         }
     }
 }

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -65,7 +65,7 @@ MANA_POINT mod_need_mana(CreatureEntity &creature, MANA_POINT need_mana, SPELL_I
  */
 PERCENTAGE mod_spell_chance_1(CreatureEntity &creature, PERCENTAGE chance)
 {
-    chance += creature.to_m_chance;
+    chance += creature.get_to_m_chance();
 
     if (creature.has_hard_spell()) {
         chance += 20;
@@ -151,11 +151,11 @@ PERCENTAGE spell_chance(CreatureEntity &creature, SPELL_IDX spell_id, RealmType 
     }
 
     if ((pc.equals(PlayerClassType::PRIEST) || pc.equals(PlayerClassType::SORCERER))) {
-        if (creature.is_icky_wield[0]) {
+        if (creature.is_icky_wield(0)) {
             chance += 25;
         }
 
-        if (creature.is_icky_wield[1]) {
+        if (creature.is_icky_wield(1)) {
             chance += 25;
         }
     }

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1833,6 +1833,102 @@ public:
         this->dis_ac = value;
     }
 
+    // [提案 39] 装備派生キャッシュフィールド (player-status.cpp の update_creature() から
+    // 装備状態に応じて再計算される) の getter / setter virtual。書込は主に update_creature()
+    // から、読取は戦闘/表示/AI 等から行われる。
+    virtual void set_ac(ARMOUR_CLASS value)
+    {
+        this->ac = value;
+    }
+    virtual int16_t get_num_blow(int hand) const
+    {
+        return this->num_blow[hand];
+    }
+    virtual void set_num_blow(int hand, int16_t value)
+    {
+        this->num_blow[hand] = value;
+    }
+    virtual int16_t get_num_fire() const
+    {
+        return this->num_fire;
+    }
+    virtual void set_num_fire(int16_t value)
+    {
+        this->num_fire = value;
+    }
+    virtual int16_t get_to_m_chance() const
+    {
+        return this->to_m_chance;
+    }
+    virtual void set_to_m_chance(int16_t value)
+    {
+        this->to_m_chance = value;
+    }
+    virtual POSITION get_cur_lite() const
+    {
+        return this->cur_lite;
+    }
+    virtual void set_cur_lite(POSITION value)
+    {
+        this->cur_lite = value;
+    }
+    virtual bool is_cumber_armor() const
+    {
+        return this->cumber_armor;
+    }
+    virtual void set_cumber_armor(bool value)
+    {
+        this->cumber_armor = value;
+    }
+    virtual bool is_cumber_glove() const
+    {
+        return this->cumber_glove;
+    }
+    virtual void set_cumber_glove(bool value)
+    {
+        this->cumber_glove = value;
+    }
+    virtual bool is_heavy_wield(int hand) const
+    {
+        return this->heavy_wield[hand];
+    }
+    virtual void set_heavy_wield(int hand, bool value)
+    {
+        this->heavy_wield[hand] = value;
+    }
+    virtual bool is_icky_wield(int hand) const
+    {
+        return this->icky_wield[hand];
+    }
+    virtual void set_icky_wield(int hand, bool value)
+    {
+        this->icky_wield[hand] = value;
+    }
+    virtual bool is_icky_riding_wield(int hand) const
+    {
+        return this->icky_riding_wield[hand];
+    }
+    virtual void set_icky_riding_wield(int hand, bool value)
+    {
+        this->icky_riding_wield[hand] = value;
+    }
+    virtual bool is_riding_ryoute() const
+    {
+        return this->riding_ryoute;
+    }
+    virtual void set_riding_ryoute(bool value)
+    {
+        this->riding_ryoute = value;
+    }
+    virtual bool is_monlite() const
+    {
+        return this->monlite;
+    }
+    virtual void set_monlite(bool value)
+    {
+        this->monlite = value;
+    }
+
     /*! @brief 能力値最大値 stat_max[idx] を取得する (提案 31b) */
     virtual short get_stat_max(int idx) const
     {
@@ -3320,18 +3416,25 @@ private:
     int16_t to_d[2]{}; /* Bonus to dam (wield) */
     int16_t to_d_m{}; /* Bonus to dam (misc) */
 
-public:
+    // [提案 39] private 化済。get_to_m_chance() / set_to_m_chance() / get_num_blow(hand)
+    // / set_num_blow(hand, value) / get_num_fire() / set_num_fire() 経由。
+private:
     int16_t to_m_chance{}; /* Minusses to cast chance */
 
     int16_t num_blow[2]{}; /* Number of blows */
     int16_t num_fire{}; /* Number of shots */
 
+public:
     // [提案 32b] private 化済。get_food() / set_food() 経由。
 private:
     int16_t food{}; /*!< ゲーム中の滋養度の型定義 / Current nutrition */
 
-public:
+    // [提案 39] cur_lite は private 化済。get_cur_lite() / set_cur_lite() 経由。
+    // old_lite は差分検出キャッシュ。
+private:
     POSITION cur_lite{}; /* Radius of lite (if any) */
+
+public:
     POSITION old_lite{}; /* Radius of lite (if any) */
 
     // [提案 33] private 化済。has_special_attack(flag) / add_special_attack(flag)
@@ -3520,13 +3623,22 @@ public:
     bool old_monlite{};
     int extra_blows[2]{};
 
+    // [提案 39] 装備派生キャッシュフラグは private 化済。
+    // is_cumber_armor() / set_cumber_armor() / is_cumber_glove() / set_cumber_glove() /
+    // is_heavy_wield(hand) / set_heavy_wield(hand, value) / is_icky_wield(hand) /
+    // set_icky_wield(hand, value) / is_icky_riding_wield(hand) /
+    // set_icky_riding_wield(hand, value) / is_riding_ryoute() / set_riding_ryoute() /
+    // is_monlite() / set_monlite() 経由。
+private:
     bool cumber_armor{}; /* Mana draining armor */
     bool cumber_glove{}; /* Mana draining gloves */
     bool heavy_wield[2]{}; /* Heavy weapon */
-    bool is_icky_wield[2]{}; /* クラスにふさわしくない装備をしている / Icky weapon */
-    bool is_icky_riding_wield[2]{}; /* 乗馬中に乗馬にふさわしくない装備をしている / Riding weapon */
+    bool icky_wield[2]{}; /* クラスにふさわしくない装備をしている / Icky weapon */
+    bool icky_riding_wield[2]{}; /* 乗馬中に乗馬にふさわしくない装備をしている / Riding weapon */
     bool riding_ryoute{}; /* Riding weapon */
     bool monlite{};
+
+public:
     BIT_FLAGS yoiyami{};
     BIT_FLAGS easy_2weapon{};
     BIT_FLAGS down_saving{};

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -61,7 +61,7 @@ static void calc_shot_params(CreatureEntity &creature, ItemEntity *o_ptr, int *s
     }
 
     const auto energy_fire = o_ptr->get_bow_energy();
-    *shots = creature.num_fire * 100;
+    *shots = creature.get_num_fire() * 100;
     *shot_frac = ((*shots) * 100 / energy_fire) % 100;
     *shots = (*shots) / energy_fire;
     if (!o_ptr->is_specific_artifact(FixedArtifactId::CRIMSON)) {
@@ -362,8 +362,8 @@ static void display_first_page(CreatureEntity &creature, int xthb, int *damage, 
         muta_att++;
     }
 
-    int blows1 = can_attack_with_main_hand(creature) ? creature.num_blow[0] : 0;
-    int blows2 = can_attack_with_sub_hand(creature) ? creature.num_blow[1] : 0;
+    int blows1 = can_attack_with_main_hand(creature) ? creature.get_num_blow(0) : 0;
+    int blows2 = can_attack_with_sub_hand(creature) ? creature.get_num_blow(1) : 0;
     int xdis = creature.get_skill_disarm();
     int xdev = creature.get_skill_device();
     int xsav = creature.get_skill_save();


### PR DESCRIPTION
player-status.cpp の update_creature() が装備状態から再計算する キャッシュフィールド 11 個を CreatureEntity で private 化し、virtual getter/setter 経由でアクセスするよう統一。

対象フィールド:
- num_blow[2] / num_fire / to_m_chance / cur_lite
- cumber_armor / cumber_glove (mana 減耗フラグ)
- heavy_wield[2] / icky_wield[2] / icky_riding_wield[2]
- riding_ryoute / monlite

API:
- 23 個の virtual アクセサ (get_/set_/is_) を追加
- ac は書込のみ set_ac() 経由に統一、フィールド自体は public 残置 (io-dump で raw 値が JSON 出力されるため意味が異なる)

フィールドリネーム:
- is_icky_wield[2] → icky_wield[2]
- is_icky_riding_wield[2] → icky_riding_wield[2] (メソッド名 is_X(hand) と衝突回避)

31 ファイルの read/write site を新 API に移行:
- player-status.cpp の update_creature() / 重武器・不適切装備判定
- specific-object/torch.cpp::update_lite_radius() で多数の compound 演算をローカル変数集約に書換え、最後に set_cur_lite() 一回呼出
- chained assignment (creature.X = creature.old_X = val) を 2 文に分割

合計 private 化フィールド数: 83 → 94