### PR TITLE
refactor: 突然変異/呪い系フラグを private 化 (提案 44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,6 +321,15 @@ API 経由に統一された。一部フィールド (r_idx / ap_r_idx / riding)
   `ac` は書込のみ `set_ac()` virtual に統一し、フィールドは public のまま
   残置 (io-dump で raw 値が JSON 出力されるため意味が異なる)。
   **合計 private 化フィールド数: 83 → 94**
+- **提案 44**: 突然変異/呪い系フラグ 5 個 (`muta` / `trait` /
+  `cursed` / `cursed_special` / `patron`) を private 化。23 個の virtual
+  API (`has_mutation` / `add_mutation` / `remove_mutation` /
+  `clear_mutations` / `set_mutations`、同様に trait / curse /
+  curse_special) を整備し、29 ファイルで約 97 サイト
+  (`muta` 52 + `trait` 2 + `cursed` 27 + `cursed_special` 4 +
+  `patron` 12) の read/write を migration。`get_X_flags()` 系の
+  const ref getter は savefile save 用に残置。**合計 private 化
+  フィールド数: 94 → 99**
 - **提案 1/2**: プレイヤー専用フィールドのモンスター運用化基盤完了。
   種族 (`prace`) / 職業 (`pclass`) / 魔法領域 (`realm1` / `realm2` /
   `element_realm`) / パトロン (`patron`) / 変身形態 (`mimic_form`)
@@ -675,6 +684,15 @@ bakabakaband 側と上流側でよくある構造的差異を以下のルール�
 | `creature.riding_ryoute` / `creature.monlite` 読取り | `creature.is_riding_ryoute()` / `creature.is_monlite()` (提案 39) |
 | `creature.is_icky_wield[hand]` / `is_icky_riding_wield[hand]` フィールド | **提案 39 でフィールド名を `icky_wield[hand]` / `icky_riding_wield[hand]` にリネーム。** メソッドからの読取りは `is_X(hand)` 経由のみ |
 | `creature.ac = X` / `m_ptr->ac = X` 書込 | `creature.set_ac(X)` (提案 39)。`ac` フィールドの直接読取りは public 残置 (io-dump 用) |
+| `creature.muta.has(X)` / `creature.trait.has(X)` 読取 | `creature.has_mutation(X)` / `creature.has_trait(X)` (提案 44) |
+| `creature.muta.set(X)` / `creature.muta.reset(X)` / `creature.muta.clear()` 書込 | `creature.add_mutation(X)` / `creature.remove_mutation(X)` / `creature.clear_mutations()` (提案 44)。trait 系も同様 (`add_trait` / `remove_trait` / `clear_traits`) |
+| `creature.muta = flags` / `creature.trait = flags` 一括代入 | `creature.set_mutations(flags)` / `creature.set_traits(flags)` (提案 44。savefile load 用) |
+| `creature.cursed.has(X)` / `creature.cursed_special.has(X)` 読取 | `creature.has_curse(X)` / `creature.has_curse_special(X)` (提案 44) |
+| `creature.cursed.set(CurseTraitType::X)` 単一フラグ | `creature.add_curse(CurseTraitType::X)` (提案 44) |
+| `creature.cursed.set(obj_curse_flags)` 一括 OR-in | `creature.add_curses(obj_curse_flags)` (提案 44。bulk OR-in 専用) |
+| `creature.cursed.reset(X)` / `creature.cursed.clear()` 書込 | `creature.remove_curse(X)` / `creature.clear_curses()` (提案 44)。cursed_special 系も同様 |
+| `creature.cursed = flags` 一括代入 | `creature.set_curses(flags)` (提案 44。savefile load 用) |
+| `creature.patron` 読取 / `creature.patron = X` 書込 | `creature.get_patron()` / `creature.set_patron(X)` (提案 44。Birther 等の他構造体の `patron` フィールドは別物で migration 対象外) |
 
 **GCC 固有の注意**:
 上流は MSVC 前提のことが多く、`<cstdint>` 等のインクルード漏れがあれば追加する。

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -1775,6 +1775,122 @@ is_player() ガードを持つ関数」を外部から `if (is_player()) X(...)`
 
 ---
 
+## 提案 40: ペット関連フィールドの private 化
+
+**対象**: `pet_extra_flags` / `pet_follow_distance` / `pet_t_m_idx` / `riding_t_m_idx` / `health_who` (5 フィールド)
+**規模**: access 約 30 サイト (`pet_extra_flags` だけで 12 ファイル)
+**価値**: ペット AI 拡張で将来モンスターも持つ余地
+
+---
+
+## 提案 42: 旧差分検出キャッシュ (`old_*`) の private 化
+
+**対象**: `old_race1/2` / `old_realm` / `old_food_aux` / `old_lite` / `old_monlite` /
+`old_heavy_*` / `old_icky_*` / `old_riding_*` / `old_spells` / `old_cumber_*` (10+ フィールド)
+**規模**: 主に `update_creature()` 内部のみで使用 — call site 集中
+**価値**: 「前回値スナップショット」の意味的グループ化
+
+---
+
+## 提案 43: 行動状態フラグの private 化
+
+**対象**: `resting` / `running` / `action` / `fishing_dir` / `sutemi` / `yoiyami` /
+`timewalk` / `teleport_town` / `is_fired` / `leaving` / `playing` / `now_damaged` /
+`monk_notify_aux` / `last_message` / `level_up_message` (15+ フィールド)
+**規模**: access 多数 (`running` で 8 ファイル、`resting` で 4 等)
+**価値**: モンスター AI と共通化余地大 (徘徊・休息など)
+
+---
+
+## 提案 44: 突然変異/呪い系フラグの private 化 ✅ 完了
+
+### 背景
+
+`muta` / `trait` (EnumClassFlagGroup<PlayerMutationType>) / `cursed`
+(EnumClassFlagGroup<CurseTraitType>) / `cursed_special`
+(EnumClassFlagGroup<CurseSpecialTraitType>) / `patron` (int16_t) の
+5 フィールドが CreatureEntity 直下に public で残存していた。
+
+`get_mutations()` / `get_traits()` / `get_cursed_flags()` /
+`get_cursed_special_flags()` の const ref getter は既存だが、書込
+パターン (`creature.muta.set(X)` / `creature.muta.reset(X)` /
+`creature.cursed.set(...)` / `creature.cursed.clear()` 等) は外部から
+直接フィールドにアクセスする形が残っていた。`patron` は
+`get_patron()` / `set_patron()` 既存だが直接 `creature.patron = X` の
+書込みも残存。
+
+### 完了内容
+
+#### API 整備
+
+`CreatureEntity` に flag 操作 virtual を追加:
+
+| メソッド | 役割 |
+|---|---|
+| `has_mutation(PlayerMutationType)` | 単一変異判定 |
+| `add_mutation(PlayerMutationType)` | 単一変異設定 |
+| `remove_mutation(PlayerMutationType)` | 単一変異クリア |
+| `clear_mutations()` | 全変異クリア |
+| `set_mutations(const EnumClassFlagGroup<>&)` | 一括代入 (savefile load) |
+| `has_trait` / `add_trait` / `remove_trait` / `clear_traits` / `set_traits` | trait 用同等 |
+| `has_curse(CurseTraitType)` | 単一呪い判定 |
+| `add_curse(CurseTraitType)` | 単一呪い設定 |
+| `add_curses(const EnumClassFlagGroup<>&)` | 装備呪いフラグ集計 (`obj_curse_flags` 等) の `set(flags)` 相当 |
+| `remove_curse(CurseTraitType)` | 単一呪いクリア |
+| `clear_curses()` | 全呪いクリア |
+| `set_curses(const EnumClassFlagGroup<>&)` | 一括代入 (savefile load) |
+| `has_curse_special` / `add_curse_special` / `remove_curse_special` / `clear_curses_special` / `set_curses_special` | cursed_special 用同等 |
+| `get_patron()` / `set_patron()` | 既存 (継続利用) |
+
+`get_mutations()` / `get_traits()` / `get_cursed_flags()` /
+`get_cursed_special_flags()` の const ref getter は引き続き残置
+(savefile save の `get_X_flags()` 経由読取り用)。
+
+#### 移行
+
+- `mutation/mutation-investor-remover.cpp`: 20+ サイトの
+  `creature.muta.reset(X)` / `creature.muta.set(X)` を
+  `remove_mutation(X)` / `add_mutation(X)` に migration
+- `mutation/mutation-processor.cpp` / `wizard/wizard-mutation.cpp` /
+  `object-use/quaff/quaff-effects.cpp`: 同様
+- `player/player-status-flags.cpp`: cursed/cursed_special 書込み (26 + 4 = 30 サイト)
+- `birth/` 系・`load/player-info-loader.cpp` / `birth-loader.cpp` /
+  `quick-start.cpp` / `birth-select-patron.cpp` / `birth-wizard.cpp`:
+  patron の `=` 代入を `set_patron()` 経由に migration
+- read 側 (`.muta.has(X)` 等) は `has_mutation(X)` に migration
+
+#### Private 化
+
+5 フィールド (`muta`, `trait`, `cursed`, `cursed_special`, `patron`) を
+完全 private 化。
+
+### 効果
+
+- **合計 private 化フィールド数: 94 → 99**
+- 変異・特性・呪いフラグの書込パターンが意図明示形 (`add_mutation()` /
+  `remove_curse()` 等) に統一
+- 将来モンスターに種族由来変異 (e.g. ドラゴンの吐息特性) を導入する際の
+  override 点を確保
+- `get_mutations()` const ref getter は savefile save 経路で読取り用に
+  残置 (`get_X_flags()` 系と同じ役割)
+
+---
+
+## 提案 45: pet_t_m_idx / riding_t_m_idx 系を `target` Pos2D に統合
+
+`riding` の getter/setter 化と同様、ターゲットモンスター idx を
+CreatureEntity 共通化。**規模**: 10-15 サイト
+
+---
+
+## 提案 46: ESP / 装備集計の差分検出を `update_creature()` 内 raw access に閉じる
+
+提案 33 で telepathy/esp_* は private 化済だが、`get_X_flags()` が
+差分検出キャッシュ用に依然外部公開。これを `update_creature()`
+内部完結に閉じる試み。
+
+---
+
 ## 提案 41: 呪文マスク (spell_learned/worked/forgotten) の集約 ✅ 完了
 
 ### 背景

--- a/src/birth/birth-select-patron.cpp
+++ b/src/birth/birth-select-patron.cpp
@@ -91,7 +91,7 @@ static int interpret_patron_select_key_move(char key, int initial_patron)
 
 static bool select_patron(CreatureEntity &creature, int *k, concptr sym)
 {
-    int cs = creature.patron;
+    int cs = creature.get_patron();
     int os = MAX_PATRON;
     std::string cur = birth_patron_label(os, sym);
     while (true) {
@@ -167,7 +167,7 @@ bool get_player_patron(CreatureEntity &creature)
         return false;
     }
 
-    creature.patron = static_cast<int16_t>(k);
+    creature.set_patron(static_cast<int16_t>(k));
     display_player_name(creature);
     return true;
 }

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -239,11 +239,11 @@ static bool let_player_select_patron(CreatureEntity &creature)
 {
     // 混沌の戦士以外はパトロンを選択しない
     if (creature.pclass != PlayerClassType::CHAOS_WARRIOR) {
-        creature.patron = randnum0<short>(MAX_PATRON);
+        creature.set_patron(randnum0<short>(MAX_PATRON));
         return true;
     }
 
-    creature.patron = 0; // 初期値
+    creature.set_patron(0); // 初期値
     while (true) {
         if (!get_player_patron(creature)) {
             return false;

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -89,7 +89,7 @@ static void write_birth_diary(CreatureEntity &creature)
     exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_personality);
     if (CreatureClass(creature).equals(PlayerClassType::CHAOS_WARRIOR)) {
         const auto fmt_patron = _("%s守護神%sと契約を交わした。", "%smade a contract with patron %s.");
-        const auto mes_patron = format(fmt_patron, indent, patron_list[creature.patron].name.data());
+        const auto mes_patron = format(fmt_patron, indent, patron_list[creature.get_patron()].name.data());
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_patron);
     }
 }

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -114,7 +114,7 @@ void save_prev_data(CreatureEntity &creature, birther *birther_ptr)
         birther_ptr->player_hp[i] = creature.player_hp[i];
     }
 
-    birther_ptr->patron = creature.patron;
+    birther_ptr->patron = creature.get_patron();
     birther_ptr->virtues = creature.virtues;
 
     for (int i = 0; i < 4; i++) {
@@ -169,7 +169,7 @@ void load_prev_data(CreatureEntity &creature, bool swap)
 
     creature.maxhp = creature.player_hp[0];
     creature.hp = creature.player_hp[0];
-    creature.patron = previous_char.patron;
+    creature.set_patron(previous_char.patron);
     creature.virtues = previous_char.virtues;
 
     CreatureClass(creature).init_specific_data();

--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -224,7 +224,7 @@ static bool bldg_process_command(CreatureEntity &creature, const building_type &
         screen_load();
         return false;
     case BACT_LOSE_MUTATION: {
-        auto muta = creature.muta;
+        auto muta = creature.get_mutations();
         if (creature.ppersonality == PERSONALITY_LUCKY) {
             // ラッキーマンの白オーラは突然変異治療の対象外
             muta.reset(PlayerMutationType::GOOD_LUCK);

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -463,7 +463,7 @@ static void dump_aux_virtues(CreatureEntity &creature, FILE *fff)
  */
 static void dump_aux_mutations(CreatureEntity &creature, FILE *fff)
 {
-    if (creature.muta.any()) {
+    if (creature.get_mutations().any()) {
         fmt::println(fff, _("\n\n  [突然変異]\n", "\n\n  [Mutations]\n"));
         dump_mutations(creature, fff);
     }

--- a/src/io/mutations-dump.cpp
+++ b/src/io/mutations-dump.cpp
@@ -19,7 +19,7 @@ void dump_mutations(CreatureEntity &creature, FILE *out_file)
         return;
     }
 
-    if (creature.muta.any() || has_good_luck(creature) || has_pervert_attraction(creature)) {
+    if (creature.get_mutations().any() || has_good_luck(creature) || has_pervert_attraction(creature)) {
         if (creature.get_mutations().has(PlayerMutationType::SPIT_ACID)) {
             fprintf(out_file, _(" あなたは酸を吹きかけることができる。(ダメージ レベルX1)\n", " You can spit acid (dam lvl).\n"));
         }

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -393,18 +393,22 @@ static void set_timed_effects(CreatureEntity &creature)
 
 static void set_mutations(CreatureEntity &creature)
 {
+    EnumClassFlagGroup<PlayerMutationType> muta_flags{};
+    EnumClassFlagGroup<PlayerMutationType> trait_flags{};
     if (loading_savefile_version_is_older_than(2)) {
         for (int i = 0; i < 3; i++) {
             auto tmp32u = rd_u32b();
-            migrate_bitflag_to_flaggroup(creature.muta, tmp32u, i * 32);
+            migrate_bitflag_to_flaggroup(muta_flags, tmp32u, i * 32);
         }
     } else {
-        rd_FlagGroup(creature.muta, rd_byte);
+        rd_FlagGroup(muta_flags, rd_byte);
 
         if (!loading_savefile_version_is_older_than(7)) {
-            rd_FlagGroup(creature.trait, rd_byte);
+            rd_FlagGroup(trait_flags, rd_byte);
         }
     }
+    creature.set_mutations(muta_flags);
+    creature.set_traits(trait_flags);
 }
 
 static void set_virtues(CreatureEntity &creature)
@@ -432,7 +436,7 @@ static void set_virtues(CreatureEntity &creature)
 static void rd_timed_effects(CreatureEntity &creature)
 {
     set_timed_effects(creature);
-    creature.patron = rd_s16b();
+    creature.set_patron(rd_s16b());
     set_mutations(creature);
     set_virtues(creature);
 }

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -348,7 +348,7 @@ static void on_defeat_last_boss(CreatureEntity &creature)
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TITLE);
     play_music(TERM_XTRA_MUSIC_BASIC, MUSIC_BASIC_FINAL_QUEST_CLEAR);
     exe_write_diary(*creature.get_floor(), DiaryKind::DESCRIPTION, 0, _("見事に馬鹿馬鹿蛮怒の勝利者となった！", "finally became *WINNER* of Bakabakaband!"));
-    patron_list[creature.patron].admire(creature);
+    patron_list[creature.get_patron()].admire(creature);
     msg_print(_("*** おめでとう ***", "*** CONGRATULATIONS ***"));
     msg_print(_("あなたはゲームをコンプリートしました。", "You have won the game!"));
     msg_print(_("準備が整ったら引退(自殺コマンド)しても結構です。", "You may retire (commit suicide) when you are ready."));

--- a/src/mutation/mutation-investor-remover.cpp
+++ b/src/mutation/mutation-investor-remover.cpp
@@ -76,7 +76,7 @@ static void neutralize_base_status(CreatureEntity &creature, glm_type *gm_ptr)
     if (gm_ptr->muta_which == PlayerMutationType::PUNY) {
         if (creature.get_mutations().has(PlayerMutationType::HYPER_STR)) {
             msg_print(_("あなたはもう超人的に強くはない！", "You no longer feel super-strong!"));
-            creature.muta.reset(PlayerMutationType::HYPER_STR);
+            creature.remove_mutation(PlayerMutationType::HYPER_STR);
         }
 
         return;
@@ -85,7 +85,7 @@ static void neutralize_base_status(CreatureEntity &creature, glm_type *gm_ptr)
     if (gm_ptr->muta_which == PlayerMutationType::HYPER_STR) {
         if (creature.get_mutations().has(PlayerMutationType::PUNY)) {
             msg_print(_("あなたはもう虚弱ではない！", "You no longer feel puny!"));
-            creature.muta.reset(PlayerMutationType::PUNY);
+            creature.remove_mutation(PlayerMutationType::PUNY);
         }
 
         return;
@@ -94,7 +94,7 @@ static void neutralize_base_status(CreatureEntity &creature, glm_type *gm_ptr)
     if (gm_ptr->muta_which == PlayerMutationType::MORONIC) {
         if (creature.get_mutations().has(PlayerMutationType::HYPER_INT)) {
             msg_print(_("あなたの脳はもう生体コンピュータではない。", "Your brain is no longer a living computer."));
-            creature.muta.reset(PlayerMutationType::HYPER_INT);
+            creature.remove_mutation(PlayerMutationType::HYPER_INT);
         }
 
         return;
@@ -103,7 +103,7 @@ static void neutralize_base_status(CreatureEntity &creature, glm_type *gm_ptr)
     if (gm_ptr->muta_which == PlayerMutationType::HYPER_INT) {
         if (creature.get_mutations().has(PlayerMutationType::MORONIC)) {
             msg_print(_("あなたはもう精神薄弱ではない。", "You are no longer moronic."));
-            creature.muta.reset(PlayerMutationType::MORONIC);
+            creature.remove_mutation(PlayerMutationType::MORONIC);
         }
 
         return;
@@ -112,17 +112,17 @@ static void neutralize_base_status(CreatureEntity &creature, glm_type *gm_ptr)
     if (gm_ptr->muta_which == PlayerMutationType::IRON_SKIN) {
         if (creature.get_mutations().has(PlayerMutationType::SCALES)) {
             msg_print(_("鱗がなくなった。", "You lose your scales."));
-            creature.muta.reset(PlayerMutationType::SCALES);
+            creature.remove_mutation(PlayerMutationType::SCALES);
         }
 
         if (creature.get_mutations().has(PlayerMutationType::FLESH_ROT)) {
             msg_print(_("肉体が腐乱しなくなった。", "Your flesh rots no longer."));
-            creature.muta.reset(PlayerMutationType::FLESH_ROT);
+            creature.remove_mutation(PlayerMutationType::FLESH_ROT);
         }
 
         if (creature.get_mutations().has(PlayerMutationType::WART_SKIN)) {
             msg_print(_("肌のイボイボがなくなった。", "You lose your warts."));
-            creature.muta.reset(PlayerMutationType::WART_SKIN);
+            creature.remove_mutation(PlayerMutationType::WART_SKIN);
         }
 
         return;
@@ -131,7 +131,7 @@ static void neutralize_base_status(CreatureEntity &creature, glm_type *gm_ptr)
     if (gm_ptr->muta_which == PlayerMutationType::WART_SKIN || gm_ptr->muta_which == PlayerMutationType::SCALES || gm_ptr->muta_which == PlayerMutationType::FLESH_ROT) {
         if (creature.get_mutations().has(PlayerMutationType::IRON_SKIN)) {
             msg_print(_("あなたの肌はもう鉄ではない。", "Your skin is no longer made of steel."));
-            creature.muta.reset(PlayerMutationType::IRON_SKIN);
+            creature.remove_mutation(PlayerMutationType::IRON_SKIN);
         }
 
         return;
@@ -140,7 +140,7 @@ static void neutralize_base_status(CreatureEntity &creature, glm_type *gm_ptr)
     if (gm_ptr->muta_which == PlayerMutationType::FEARLESS) {
         if (creature.get_mutations().has(PlayerMutationType::COWARDICE)) {
             msg_print(_("臆病でなくなった。", "You are no longer cowardly."));
-            creature.muta.reset(PlayerMutationType::COWARDICE);
+            creature.remove_mutation(PlayerMutationType::COWARDICE);
         }
 
         return;
@@ -149,7 +149,7 @@ static void neutralize_base_status(CreatureEntity &creature, glm_type *gm_ptr)
     if (gm_ptr->muta_which == PlayerMutationType::FLESH_ROT) {
         if (creature.get_mutations().has(PlayerMutationType::REGEN)) {
             msg_print(_("急速に回復しなくなった。", "You stop regenerating."));
-            creature.muta.reset(PlayerMutationType::REGEN);
+            creature.remove_mutation(PlayerMutationType::REGEN);
         }
 
         return;
@@ -158,7 +158,7 @@ static void neutralize_base_status(CreatureEntity &creature, glm_type *gm_ptr)
     if (gm_ptr->muta_which == PlayerMutationType::REGEN) {
         if (creature.get_mutations().has(PlayerMutationType::FLESH_ROT)) {
             msg_print(_("肉体が腐乱しなくなった。", "Your flesh stops rotting."));
-            creature.muta.reset(PlayerMutationType::FLESH_ROT);
+            creature.remove_mutation(PlayerMutationType::FLESH_ROT);
         }
 
         return;
@@ -167,7 +167,7 @@ static void neutralize_base_status(CreatureEntity &creature, glm_type *gm_ptr)
     if (gm_ptr->muta_which == PlayerMutationType::LIMBER) {
         if (creature.get_mutations().has(PlayerMutationType::ARTHRITIS)) {
             msg_print(_("関節が痛くなくなった。", "Your joints stop hurting."));
-            creature.muta.reset(PlayerMutationType::ARTHRITIS);
+            creature.remove_mutation(PlayerMutationType::ARTHRITIS);
         }
 
         return;
@@ -176,7 +176,7 @@ static void neutralize_base_status(CreatureEntity &creature, glm_type *gm_ptr)
     if (gm_ptr->muta_which == PlayerMutationType::ARTHRITIS) {
         if (creature.get_mutations().has(PlayerMutationType::LIMBER)) {
             msg_print(_("あなたはしなやかでなくなった。", "You no longer feel limber."));
-            creature.muta.reset(PlayerMutationType::LIMBER);
+            creature.remove_mutation(PlayerMutationType::LIMBER);
         }
 
         return;
@@ -188,35 +188,35 @@ static void neutralize_other_status(CreatureEntity &creature, glm_type *gm_ptr)
     if (gm_ptr->muta_which == PlayerMutationType::COWARDICE) {
         if (creature.get_mutations().has(PlayerMutationType::FEARLESS)) {
             msg_print(_("恐れ知らずでなくなった。", "You no longer feel fearless."));
-            creature.muta.reset(PlayerMutationType::FEARLESS);
+            creature.remove_mutation(PlayerMutationType::FEARLESS);
         }
     }
 
     if (gm_ptr->muta_which == PlayerMutationType::BEAK) {
         if (creature.get_mutations().has(PlayerMutationType::TRUNK)) {
             msg_print(_("あなたの鼻はもう象の鼻のようではなくなった。", "Your nose is no longer elephantine."));
-            creature.muta.reset(PlayerMutationType::TRUNK);
+            creature.remove_mutation(PlayerMutationType::TRUNK);
         }
     }
 
     if (gm_ptr->muta_which == PlayerMutationType::TRUNK) {
         if (creature.get_mutations().has(PlayerMutationType::BEAK)) {
             msg_print(_("硬いクチバシがなくなった。", "You no longer have a hard beak."));
-            creature.muta.reset(PlayerMutationType::BEAK);
+            creature.remove_mutation(PlayerMutationType::BEAK);
         }
     }
 
     if (gm_ptr->muta_which == PlayerMutationType::HOMO_SEXUAL) {
         if (creature.get_mutations().has(PlayerMutationType::BI_SEXUAL)) {
             msg_print(_("あなたは同性しか興味を持たなくなった。", "You are only interested in the same sex."));
-            creature.muta.reset(PlayerMutationType::BI_SEXUAL);
+            creature.remove_mutation(PlayerMutationType::BI_SEXUAL);
         }
     }
 
     if (gm_ptr->muta_which == PlayerMutationType::BI_SEXUAL) {
         if (creature.get_mutations().has(PlayerMutationType::HOMO_SEXUAL)) {
             msg_print(_("あなたは同性のみならず、異性にも興味を持ち始めた。", "You have begun to be interested not only in the same sex but also in the opposite sex."));
-            creature.muta.reset(PlayerMutationType::HOMO_SEXUAL);
+            creature.remove_mutation(PlayerMutationType::HOMO_SEXUAL);
         }
     }
 }
@@ -241,7 +241,7 @@ bool gain_mutation(CreatureEntity &creature, MUTATION_IDX choose_mut)
     msg_print(_("突然変異した！", "You mutate!"));
     msg_print(gm_ptr->muta_desc);
     if (gm_ptr->muta_which != PlayerMutationType::MAX) {
-        creature.muta.set(gm_ptr->muta_which);
+        creature.add_mutation(gm_ptr->muta_which);
     }
 
     neutralize_base_status(creature, gm_ptr);
@@ -299,7 +299,7 @@ bool lose_mutation(CreatureEntity &creature, MUTATION_IDX choose_mut)
 
     msg_print(glm_ptr->muta_desc);
     if (glm_ptr->muta_which != PlayerMutationType::MAX) {
-        creature.muta.reset(glm_ptr->muta_which);
+        creature.remove_mutation(glm_ptr->muta_which);
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
@@ -310,10 +310,10 @@ bool lose_mutation(CreatureEntity &creature, MUTATION_IDX choose_mut)
 
 void lose_all_mutations(CreatureEntity &creature)
 {
-    if (creature.muta.any()) {
+    if (creature.get_mutations().any()) {
         chg_virtue(creature, Virtue::CHANCE, -5);
         msg_print(_("全ての突然変異が治った。", "You are cured of all mutations."));
-        creature.muta.clear();
+        creature.clear_mutations();
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
         handle_stuff(creature);
         creature.mutant_regenerate_mod = calc_mutant_regenerate_mod(creature);

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -100,7 +100,7 @@ void process_world_aux_sudden_attack(CreatureEntity &creature)
  */
 void process_world_aux_mutation(CreatureEntity &creature)
 {
-    if (creature.muta.none() || AngbandSystem::get_instance().is_phase_out() || AngbandWorld::get_instance().is_wild_mode()) {
+    if (creature.get_mutations().none() || AngbandSystem::get_instance().is_phase_out() || AngbandWorld::get_instance().is_wild_mode()) {
         return;
     }
 

--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -590,7 +590,7 @@ bool QuaffEffects::tsuyoshi()
  */
 bool QuaffEffects::polymorph()
 {
-    if (this->creature.muta.any() && one_in_(23)) {
+    if (this->creature.get_mutations().any() && one_in_(23)) {
         lose_all_mutations(this->creature);
         return false;
     }

--- a/src/player-ability/player-charisma.cpp
+++ b/src/player-ability/player-charisma.cpp
@@ -59,7 +59,7 @@ int16_t PlayerCharisma::mutation_bonus()
 {
     int16_t result = 0;
 
-    if (this->creature.muta.any()) {
+    if (this->creature.get_mutations().any()) {
         if (this->creature.get_mutations().has(PlayerMutationType::FLESH_ROT)) {
             result -= 1;
         }

--- a/src/player-ability/player-constitution.cpp
+++ b/src/player-ability/player-constitution.cpp
@@ -109,7 +109,7 @@ int16_t PlayerConstitution::mutation_bonus()
 {
     int16_t result = 0;
 
-    if (this->creature.muta.any()) {
+    if (this->creature.get_mutations().any()) {
         if (this->creature.get_mutations().has(PlayerMutationType::RESILIENT)) {
             result += 4;
         }

--- a/src/player-ability/player-intelligence.cpp
+++ b/src/player-ability/player-intelligence.cpp
@@ -65,7 +65,7 @@ int16_t PlayerIntelligence::stance_bonus()
 int16_t PlayerIntelligence::mutation_bonus()
 {
     int16_t result = 0;
-    if (this->creature.muta.any()) {
+    if (this->creature.get_mutations().any()) {
         if (this->creature.get_mutations().has(PlayerMutationType::HYPER_INT)) {
             result += 4;
         }

--- a/src/player-ability/player-strength.cpp
+++ b/src/player-ability/player-strength.cpp
@@ -111,7 +111,7 @@ int16_t PlayerStrength::mutation_bonus()
 {
     int16_t result = 0;
 
-    if (this->creature.muta.any()) {
+    if (this->creature.get_mutations().any()) {
         if (this->creature.get_mutations().has(PlayerMutationType::HYPER_STR)) {
             result += 4;
         }

--- a/src/player-ability/player-wisdom.cpp
+++ b/src/player-ability/player-wisdom.cpp
@@ -64,7 +64,7 @@ int16_t PlayerWisdom::mutation_bonus()
 {
     int16_t result = 0;
 
-    if (this->creature.muta.any()) {
+    if (this->creature.get_mutations().any()) {
         if (this->creature.get_mutations().has(PlayerMutationType::HYPER_INT)) {
             result += 4;
         }

--- a/src/player-info/mutation-info.cpp
+++ b/src/player-info/mutation-info.cpp
@@ -8,7 +8,7 @@
 /*!< @todo FEAELESS フラグも記述して問題ないと思われる */
 void set_mutation_info(CreatureEntity &creature, self_info_type *self_ptr)
 {
-    if (creature.muta.none()) {
+    if (creature.get_mutations().none()) {
         return;
     }
 

--- a/src/player-status/player-speed.cpp
+++ b/src/player-status/player-speed.cpp
@@ -242,7 +242,7 @@ int16_t PlayerSpeed::stance_bonus()
 int16_t PlayerSpeed::mutation_bonus()
 {
     int16_t bonus = 0;
-    const auto &muta = this->creature.muta;
+    const auto &muta = this->creature.get_mutations();
     if (muta.has(PlayerMutationType::XTRA_FAT)) {
         bonus -= 2;
     }

--- a/src/player-status/player-stealth.cpp
+++ b/src/player-status/player-stealth.cpp
@@ -93,7 +93,7 @@ int16_t PlayerStealth::class_bonus()
 int16_t PlayerStealth::mutation_bonus()
 {
     int16_t bonus = 0;
-    const auto &muta = this->creature.muta;
+    const auto &muta = this->creature.get_mutations();
     if (muta.has(PlayerMutationType::XTRA_NOIS)) {
         bonus -= 3;
     }

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -191,10 +191,10 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
 
             if (creature.get_mutations().has(PlayerMutationType::HYPER_INT)) {
                 msg_print(_("あなたの脳は生体コンピュータではなくなった。", "Your brain is no longer a living computer."));
-                creature.muta.reset(PlayerMutationType::HYPER_INT);
+                creature.remove_mutation(PlayerMutationType::HYPER_INT);
             }
 
-            creature.muta.set(PlayerMutationType::MORONIC);
+            creature.add_mutation(PlayerMutationType::MORONIC);
         }
 
         break;
@@ -204,10 +204,10 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
             msg_print(_("あなたはパラノイアになった！", "You become paranoid!"));
             if (creature.get_mutations().has(PlayerMutationType::FEARLESS)) {
                 msg_print(_("あなたはもう恐れ知らずではなくなった。", "You are no longer fearless."));
-                creature.muta.reset(PlayerMutationType::FEARLESS);
+                creature.remove_mutation(PlayerMutationType::FEARLESS);
             }
 
-            creature.muta.set(PlayerMutationType::COWARDICE);
+            creature.add_mutation(PlayerMutationType::COWARDICE);
         }
 
         break;
@@ -215,7 +215,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
     case 3: {
         if (creature.get_mutations().has_not(PlayerMutationType::HALLU) && !creature.has_resist_chaos()) {
             msg_print(_("幻覚をひき起こす精神錯乱に陥った！", "You are afflicted by a hallucinatory insanity!"));
-            creature.muta.set(PlayerMutationType::HALLU);
+            creature.add_mutation(PlayerMutationType::HALLU);
         }
 
         break;
@@ -223,7 +223,7 @@ void sanity_blast(CreatureEntity &creature, tl::optional<short> m_idx, bool necr
     case 4: {
         if (creature.get_mutations().has_not(PlayerMutationType::BERS_RAGE) && !creature.has_resist_conf()) {
             msg_print(_("激烈な感情の発作におそわれるようになった！", "You become subject to fits of berserk rage!"));
-            creature.muta.set(PlayerMutationType::BERS_RAGE);
+            creature.add_mutation(PlayerMutationType::BERS_RAGE);
         }
 
         break;

--- a/src/player/permanent-resistances.cpp
+++ b/src/player/permanent-resistances.cpp
@@ -22,7 +22,7 @@
  */
 static void add_mutation_flags(CreatureEntity &creature, TrFlags &flags)
 {
-    if (creature.muta.none()) {
+    if (creature.get_mutations().none()) {
         return;
     }
 

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -1099,14 +1099,14 @@ BIT_FLAGS has_regenerate(CreatureEntity &creature)
 void update_curses(CreatureEntity &creature)
 {
     ItemEntity *o_ptr;
-    creature.cursed.clear();
-    creature.cursed_special.clear();
+    creature.clear_curses();
+    creature.clear_curses_special();
 
     if (creature.ppersonality == PERSONALITY_SEXY) {
-        creature.cursed.set(CurseTraitType::AGGRAVATE);
+        creature.add_curse(CurseTraitType::AGGRAVATE);
     }
     if (creature.ppersonality == PERSONALITY_MESUGAKI) {
-        creature.cursed.set(CurseTraitType::AGGRAVATE);
+        creature.add_curse(CurseTraitType::AGGRAVATE);
     }
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
@@ -1116,91 +1116,91 @@ void update_curses(CreatureEntity &creature)
         }
         const auto flags = o_ptr->get_flags();
         if (flags.has(TR_AGGRAVATE)) {
-            creature.cursed.set(CurseTraitType::AGGRAVATE);
+            creature.add_curse(CurseTraitType::AGGRAVATE);
         }
         if (flags.has(TR_NASTY_AGGRAVATE)) {
-            creature.cursed.set(CurseTraitType::NASTY_AGGRAVATE);
+            creature.add_curse(CurseTraitType::NASTY_AGGRAVATE);
         }
         if (flags.has(TR_DRAIN_EXP)) {
-            creature.cursed.set(CurseTraitType::DRAIN_EXP);
+            creature.add_curse(CurseTraitType::DRAIN_EXP);
         }
         if (flags.has(TR_TY_CURSE)) {
-            creature.cursed.set(CurseTraitType::TY_CURSE);
+            creature.add_curse(CurseTraitType::TY_CURSE);
         }
         if (flags.has(TR_ADD_L_CURSE)) {
-            creature.cursed.set(CurseTraitType::ADD_L_CURSE);
+            creature.add_curse(CurseTraitType::ADD_L_CURSE);
         }
         if (flags.has(TR_ADD_H_CURSE)) {
-            creature.cursed.set(CurseTraitType::ADD_H_CURSE);
+            creature.add_curse(CurseTraitType::ADD_H_CURSE);
         }
         if (flags.has(TR_DRAIN_HP)) {
-            creature.cursed.set(CurseTraitType::DRAIN_HP);
+            creature.add_curse(CurseTraitType::DRAIN_HP);
         }
         if (flags.has(TR_DRAIN_MANA)) {
-            creature.cursed.set(CurseTraitType::DRAIN_MANA);
+            creature.add_curse(CurseTraitType::DRAIN_MANA);
         }
         if (flags.has(TR_CALL_ANIMAL)) {
-            creature.cursed.set(CurseTraitType::CALL_ANIMAL);
+            creature.add_curse(CurseTraitType::CALL_ANIMAL);
         }
         if (flags.has(TR_CALL_DEMON)) {
-            creature.cursed.set(CurseTraitType::CALL_DEMON);
+            creature.add_curse(CurseTraitType::CALL_DEMON);
         }
         if (flags.has(TR_CALL_DRAGON)) {
-            creature.cursed.set(CurseTraitType::CALL_DRAGON);
+            creature.add_curse(CurseTraitType::CALL_DRAGON);
         }
         if (flags.has(TR_CALL_UNDEAD)) {
-            creature.cursed.set(CurseTraitType::CALL_UNDEAD);
+            creature.add_curse(CurseTraitType::CALL_UNDEAD);
         }
         if (flags.has(TR_COWARDICE)) {
-            creature.cursed.set(CurseTraitType::COWARDICE);
+            creature.add_curse(CurseTraitType::COWARDICE);
         }
         if (flags.has(TR_LOW_MELEE)) {
-            creature.cursed.set(CurseTraitType::LOW_MELEE);
+            creature.add_curse(CurseTraitType::LOW_MELEE);
         }
         if (flags.has(TR_LOW_AC)) {
-            creature.cursed.set(CurseTraitType::LOW_AC);
+            creature.add_curse(CurseTraitType::LOW_AC);
         }
         if (flags.has(TR_HARD_SPELL)) {
-            creature.cursed.set(CurseTraitType::HARD_SPELL);
+            creature.add_curse(CurseTraitType::HARD_SPELL);
         }
         if (flags.has(TR_FAST_DIGEST)) {
-            creature.cursed.set(CurseTraitType::FAST_DIGEST);
+            creature.add_curse(CurseTraitType::FAST_DIGEST);
         }
         if (flags.has(TR_SLOW_REGEN)) {
-            creature.cursed.set(CurseTraitType::SLOW_REGEN);
+            creature.add_curse(CurseTraitType::SLOW_REGEN);
         }
         if (flags.has(TR_BERS_RAGE)) {
-            creature.cursed.set(CurseTraitType::BERS_RAGE);
+            creature.add_curse(CurseTraitType::BERS_RAGE);
         }
         if (flags.has(TR_PERSISTENT_CURSE)) {
-            creature.cursed.set(CurseTraitType::PERSISTENT_CURSE);
+            creature.add_curse(CurseTraitType::PERSISTENT_CURSE);
         }
         if (flags.has(TR_VUL_CURSE)) {
-            creature.cursed.set(CurseTraitType::VUL_CURSE);
+            creature.add_curse(CurseTraitType::VUL_CURSE);
         }
 
         auto obj_curse_flags = o_ptr->curse_flags;
         obj_curse_flags.reset({ CurseTraitType::CURSED, CurseTraitType::HEAVY_CURSE, CurseTraitType::PERMA_CURSE });
-        creature.cursed.set(obj_curse_flags);
+        creature.add_curses(obj_curse_flags);
         if (o_ptr->is_specific_artifact(FixedArtifactId::CHAINSWORD)) {
-            creature.cursed_special.set(CurseSpecialTraitType::CHAINSWORD);
+            creature.add_curse_special(CurseSpecialTraitType::CHAINSWORD);
         }
 
         if (flags.has(TR_TELEPORT)) {
             if (o_ptr->is_cursed()) {
-                creature.cursed.set(CurseTraitType::TELEPORT);
+                creature.add_curse(CurseTraitType::TELEPORT);
             } else {
                 /* {.} will stop random teleportation. */
                 if (o_ptr->is_inscribed() && angband_strchr(o_ptr->inscription->data(), '.')) {
                 } else {
-                    creature.cursed_special.set(CurseSpecialTraitType::TELEPORT_SELF);
+                    creature.add_curse_special(CurseSpecialTraitType::TELEPORT_SELF);
                 }
             }
         }
     }
 
     if (creature.get_cursed_flags().has(CurseTraitType::TELEPORT)) {
-        creature.cursed_special.reset(CurseSpecialTraitType::TELEPORT_SELF);
+        creature.remove_curse_special(CurseSpecialTraitType::TELEPORT_SELF);
     }
 }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2916,7 +2916,7 @@ void check_experience(CreatureEntity &creature)
          * 呼ばれるので順番を最後にする。
          */
         if (level_reward) {
-            patron_list[creature.patron].gain_level_reward(creature, 0);
+            patron_list[creature.get_patron()].gain_level_reward(creature, 0);
             level_reward = false;
         }
 

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -245,9 +245,9 @@ void wr_player(CreatureEntity &creature)
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::TIM_EXORCISM));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::TIM_IMM_DARK));
 
-    wr_s16b(creature.patron);
-    wr_FlagGroup(creature.muta, wr_byte);
-    wr_FlagGroup(creature.trait, wr_byte);
+    wr_s16b(creature.get_patron());
+    wr_FlagGroup(creature.get_mutations(), wr_byte);
+    wr_FlagGroup(creature.get_traits(), wr_byte);
 
     // Save virtues in legacy format (8 entries)
     // First, collect virtues into arrays

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -2919,6 +2919,95 @@ public:
     {
         return this->cursed_special;
     }
+
+    // [提案 44] 突然変異/特性/呪いフラグの write-side virtual API。
+    // 直接 `creature.muta.set(X)` / `creature.cursed.clear()` 等のフィールド
+    // アクセスを置き換える。一括代入 (`set_X()`) は savefile load 用。
+    virtual bool has_mutation(PlayerMutationType m) const
+    {
+        return this->muta.has(m);
+    }
+    virtual void add_mutation(PlayerMutationType m)
+    {
+        this->muta.set(m);
+    }
+    virtual void remove_mutation(PlayerMutationType m)
+    {
+        this->muta.reset(m);
+    }
+    virtual void clear_mutations()
+    {
+        this->muta.clear();
+    }
+    virtual void set_mutations(const EnumClassFlagGroup<PlayerMutationType> &flags)
+    {
+        this->muta = flags;
+    }
+    virtual bool has_trait(PlayerMutationType t) const
+    {
+        return this->trait.has(t);
+    }
+    virtual void add_trait(PlayerMutationType t)
+    {
+        this->trait.set(t);
+    }
+    virtual void remove_trait(PlayerMutationType t)
+    {
+        this->trait.reset(t);
+    }
+    virtual void clear_traits()
+    {
+        this->trait.clear();
+    }
+    virtual void set_traits(const EnumClassFlagGroup<PlayerMutationType> &flags)
+    {
+        this->trait = flags;
+    }
+    virtual bool has_curse(CurseTraitType c) const
+    {
+        return this->cursed.has(c);
+    }
+    virtual void add_curse(CurseTraitType c)
+    {
+        this->cursed.set(c);
+    }
+    virtual void add_curses(const EnumClassFlagGroup<CurseTraitType> &flags)
+    {
+        this->cursed.set(flags);
+    }
+    virtual void remove_curse(CurseTraitType c)
+    {
+        this->cursed.reset(c);
+    }
+    virtual void clear_curses()
+    {
+        this->cursed.clear();
+    }
+    virtual void set_curses(const EnumClassFlagGroup<CurseTraitType> &flags)
+    {
+        this->cursed = flags;
+    }
+    virtual bool has_curse_special(CurseSpecialTraitType c) const
+    {
+        return this->cursed_special.has(c);
+    }
+    virtual void add_curse_special(CurseSpecialTraitType c)
+    {
+        this->cursed_special.set(c);
+    }
+    virtual void remove_curse_special(CurseSpecialTraitType c)
+    {
+        this->cursed_special.reset(c);
+    }
+    virtual void clear_curses_special()
+    {
+        this->cursed_special.clear();
+    }
+    virtual void set_curses_special(const EnumClassFlagGroup<CurseSpecialTraitType> &flags)
+    {
+        this->cursed_special = flags;
+    }
+
     /*!
      * @brief 種族情報ポインタ
      * @details プレイヤー時は race_info[] の該当エントリへのポインタ、
@@ -3270,12 +3359,17 @@ public:
     ClassSpecificData class_specific_data;
 
     // 変異関連
+    // [提案 44] private 化済。has_mutation/add_mutation/remove_mutation/clear_mutations/set_mutations 経由。
+    // trait についても has_trait/add_trait/remove_trait/clear_traits/set_traits 経由。
+private:
     EnumClassFlagGroup<PlayerMutationType> muta{}; /*!< 突然変異 / mutations */
     EnumClassFlagGroup<PlayerMutationType> trait{}; /*!< 後天特性 / permanent trait */
 
     // パトロン関連（主にカオス戦士用、モンスターでは未使用）
+    // [提案 44] private 化済。get_patron()/set_patron() 経由。
     int16_t patron{}; /*!< カオスパトロンのID / Chaos patron ID */
 
+public:
     // エネルギー関連
     ACTION_ENERGY energy_need{}; /*!< 次の行動までに必要なエネルギー / Energy needed for next move */
 
@@ -3350,16 +3444,17 @@ public:
 
     // [提案 33] 装備由来 BIT_FLAGS 群。
     // 全て has_X() / set_X() 経由でアクセス。
-    // EnumClassFlagGroup の cursed / cursed_special は public 維持。
+    // [提案 44] cursed / cursed_special も private 化済。
+    // has_curse / add_curse / add_curses / remove_curse / clear_curses / set_curses 経由。
+    // cursed_special 側は has_curse_special / add_curse_special / remove_curse_special /
+    // clear_curses_special / set_curses_special 経由。
 private:
     BIT_FLAGS anti_magic{}; /* Anti-magic */
     BIT_FLAGS anti_tele{}; /* Prevent teleportation */
 
-public:
     EnumClassFlagGroup<CurseTraitType> cursed{}; /* Player is cursed */
     EnumClassFlagGroup<CurseSpecialTraitType> cursed_special{}; /* Player is special type cursed */
 
-private:
     BIT_FLAGS levitation{}; /* No damage falling */
     BIT_FLAGS lite{}; /* Permanent light */
     BIT_FLAGS free_act{}; /* Never paralyzed */

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -341,7 +341,7 @@ static std::string decide_current_floor(CreatureEntity &creature)
  */
 tl::optional<int> display_player(CreatureEntity &creature, const int tmp_mode)
 {
-    auto has_any_mutation = (creature.muta.any() || has_good_luck(creature) || has_pervert_attraction(creature)) && display_mutations;
+    auto has_any_mutation = (creature.get_mutations().any() || has_good_luck(creature) || has_pervert_attraction(creature)) && display_mutations;
     // モンスター閲覧時もページ送りを許可。プレイヤー前提の値はサブ関数側で
     // 0/空フォールバックされる（ENTRY_RACE/CLASS が「なし」になるなど）。
     // ページ構成: 0=基本ステータス, 1=キャラクタ生い立ち, 2=能力詳細1,

--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -216,7 +216,7 @@ bool exe_cmd_debug(CreatureEntity &creature, char cmd)
         wiz_generate_room(creature, command_arg);
         return true;
     case 'r':
-        patron_list[creature.patron].gain_level_reward(creature, command_arg);
+        patron_list[creature.get_patron()].gain_level_reward(creature, command_arg);
         return true;
     case 'n':
         wiz_summon_specific_monster(creature, i2enum<MonraceId>(command_arg));

--- a/src/wizard/wizard-mutation.cpp
+++ b/src/wizard/wizard-mutation.cpp
@@ -166,8 +166,8 @@ static void display_mutations_for_selection(CreatureEntity &creature)
 
     for (const auto &[muta_type, name] : mutation_data) {
         const int id = static_cast<int>(muta_type);
-        const bool has_mutation = creature.muta.has(muta_type);
-        all_mutations.emplace_back(id, name, has_mutation);
+        const bool present = creature.has_mutation(muta_type);
+        all_mutations.emplace_back(id, name, present);
     }
 
     // Display all mutations in ultra-compact 4-column format


### PR DESCRIPTION
CreatureEntity 直下に public で残存していた 5 フィールド
(muta / trait / cursed / cursed_special / patron) を private 化し、 書込パターンを意図明示形の virtual API に統一。

対象フィールド:
- muta (突然変異 EnumClassFlagGroup<PlayerMutationType>)
- trait (後天特性 EnumClassFlagGroup<PlayerMutationType>)
- cursed (装備呪い EnumClassFlagGroup<CurseTraitType>)
- cursed_special (特殊呪い EnumClassFlagGroup<CurseSpecialTraitType>)
- patron (カオスパトロン int16_t、set_patron は既存)

API (23 個の virtual):
- has_mutation/add_mutation/remove_mutation/clear_mutations/set_mutations
- has_trait/add_trait/remove_trait/clear_traits/set_traits
- has_curse/add_curse/add_curses (bulk OR-in)/remove_curse/clear_curses/set_curses
- has_curse_special/add_curse_special/remove_curse_special/clear_curses_special/set_curses_special

get_X_flags() 系の const ref getter は引き続き残置 (savefile save 経路で 読取り用に利用)。

29 ファイル約 97 サイトの read/write を migration:
- mutation-investor-remover.cpp (22 サイト) など mutation 系
- player-status-flags.cpp の update_curses() (31 サイト)
- birth/load/save 経路の patron 代入 (12 サイト)

cursed.set() の引数型による意味の違いに注意:
- cursed.set(CurseTraitType::X) (単一フラグ)        → add_curse(X)
- cursed.set(obj_curse_flags) (EnumClassFlagGroup<>) → add_curses(flags)

Birther 構造体の previous_char.patron は CreatureEntity::patron とは別物の ため migration 対象外として保持。

合計 private 化フィールド数: 94 → 99