### PR TITLE
refactor: ペット関連フィールドを private 化 (提案 40)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,6 +330,15 @@ API 経由に統一された。一部フィールド (r_idx / ap_r_idx / riding)
   `patron` 12) の read/write を migration。`get_X_flags()` 系の
   const ref getter は savefile save 用に残置。**合計 private 化
   フィールド数: 94 → 99**
+- **提案 40**: ペット関連フィールド 4 個 (`pet_extra_flags` /
+  `pet_follow_distance` / `pet_t_m_idx` / `riding_t_m_idx`) を private
+  化。11 個の virtual API (`has_pet_extra_flag` / `add_pet_extra_flag` /
+  `remove_pet_extra_flag` / `get_pet_extra_flags` /
+  `set_pet_extra_flags`、scalar 系の get/set) を整備し、19 ファイル
+  約 102 サイトを migration。`(flags & MASK) != MASK` の全ビットセット
+  セマンティクスは個別 `has_X()` 2 連検査に分解。さらにデッド
+  フィールド `health_who` (宣言以外で未使用) を削除。
+  **合計 private 化フィールド数: 99 → 103**
 - **提案 1/2**: プレイヤー専用フィールドのモンスター運用化基盤完了。
   種族 (`prace`) / 職業 (`pclass`) / 魔法領域 (`realm1` / `realm2` /
   `element_realm`) / パトロン (`patron`) / 変身形態 (`mimic_form`)
@@ -693,6 +702,15 @@ bakabakaband 側と上流側でよくある構造的差異を以下のルール�
 | `creature.cursed.reset(X)` / `creature.cursed.clear()` 書込 | `creature.remove_curse(X)` / `creature.clear_curses()` (提案 44)。cursed_special 系も同様 |
 | `creature.cursed = flags` 一括代入 | `creature.set_curses(flags)` (提案 44。savefile load 用) |
 | `creature.patron` 読取 / `creature.patron = X` 書込 | `creature.get_patron()` / `creature.set_patron(X)` (提案 44。Birther 等の他構造体の `patron` フィールドは別物で migration 対象外) |
+| `creature.pet_extra_flags & PF_X` / `any_bits(creature.pet_extra_flags, PF_X)` 読取 | `creature.has_pet_extra_flag(PF_X)` (提案 40) |
+| `creature.pet_extra_flags \|= PF_X` 書込 | `creature.add_pet_extra_flag(PF_X)` (提案 40) |
+| `creature.pet_extra_flags &= ~PF_X` 書込 | `creature.remove_pet_extra_flag(PF_X)` (提案 40) |
+| `creature.pet_extra_flags = value` 一括代入 | `creature.set_pet_extra_flags(value)` (提案 40。savefile load 用) |
+| `creature.pet_extra_flags` 全体読取 | `creature.get_pet_extra_flags()` (提案 40。savefile save 用) |
+| `(creature.pet_extra_flags & MASK) != MASK` (全ビットセット判定) | `!creature.has_pet_extra_flag(A) \|\| !creature.has_pet_extra_flag(B)` 等の個別判定に分解 (提案 40) |
+| `creature.pet_follow_distance` / `creature.pet_t_m_idx` / `creature.riding_t_m_idx` 読取 | `creature.get_pet_follow_distance()` / `get_pet_t_m_idx()` / `get_riding_t_m_idx()` (提案 40) |
+| 同上書込 | `creature.set_pet_follow_distance(X)` / `set_pet_t_m_idx(X)` / `set_riding_t_m_idx(X)` (提案 40) |
+| `creature.health_who` | **提案 40 でフィールド削除** (デッドフィールドだった) |
 
 **GCC 固有の注意**:
 上流は MSVC 前提のことが多く、`<cstdint>` 等のインクルード漏れがあれば追加する。

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -59,7 +59,7 @@ Phase 1-8 完了後に残存している統合作業項目を整理したもの�
 | [34](#提案-34-表示用既知値-dis_to_hdaac-の-private-化--完了) | 表示用既知値 (dis_*) private 化 | ✅ 完了 | **+5 = 77 個** |
 | [35](#提案-35-is_player-分岐の縮減--完了-調査ベース縮小スコープ) | is_player() 分岐縮減 | ✅ 完了 (縮小) | 1 サイトのみ |
 | [39](#提案-39-装備派生キャッシュフィールドの-private-化--完了) | 装備派生キャッシュフィールド private 化 | ✅ 完了 | **+11 = 94 個** (num_blow/cumber/icky 等) |
-| [40](#提案-40-ペット関連フィールドの-private-化) | ペット関連フィールド private 化 | 🚧 | pet_extra_flags / pet_follow_distance 等 |
+| [40](#提案-40-ペット関連フィールドの-private-化--完了) | ペット関連フィールド private 化 | ✅ 完了 | **+4 = 103 個** (pet_extra_flags / pet_follow_distance 等、health_who 削除) |
 | [41](#提案-41-呪文マスク-spell_learnedworkedforgotten-の集約--完了) | 呪文マスク集約 (spell_learned/worked/forgotten) | ✅ 完了 | **+6 = 83 個**、realm_idx ベース API |
 | [42](#提案-42-旧差分検出キャッシュ-old_-の-private-化) | 旧差分検出キャッシュ (`old_*`) private 化 | 🚧 | old_cumber_* / old_heavy_* 等 |
 | [43](#提案-43-行動状態フラグの-private-化) | 行動状態フラグ private 化 | 🚧 | resting / running / action 等 |
@@ -69,7 +69,7 @@ Phase 1-8 完了後に残存している統合作業項目を整理したもの�
 
 **累計 private 化フィールド数 (主要マイルストーン):**
 - 提案 29 (3 個) → 32 (10 個) → 32b (37 個) → 33 (72 個) → 34 (77 個) →
-  41 (83 個) → 39 (94 個) → **44 (99 個)**
+  41 (83 個) → 39 (94 個) → 44 (99 個) → **40 (103 個)**
 
 未完了の提案 6 / 40 / 42 / 43 / 45 / 46 を全完了で **130+ 個** に到達見込み。
 
@@ -1841,11 +1841,61 @@ is_player() ガードを持つ関数」を外部から `if (is_player()) X(...)`
 
 ---
 
-## 提案 40: ペット関連フィールドの private 化
+## 提案 40: ペット関連フィールドの private 化 ✅ 完了
 
-**対象**: `pet_extra_flags` / `pet_follow_distance` / `pet_t_m_idx` / `riding_t_m_idx` / `health_who` (5 フィールド)
-**規模**: access 約 30 サイト (`pet_extra_flags` だけで 12 ファイル)
-**価値**: ペット AI 拡張で将来モンスターも持つ余地
+### 背景
+
+`pet_extra_flags` (BIT_FLAGS16 ビットマスク、`PF_OPEN_DOORS` 等 7 フラグ) /
+`pet_follow_distance` / `pet_t_m_idx` / `riding_t_m_idx` (4 フィールド) が
+CreatureEntity 直下に public で残存していた。
+
+加えて調査の結果、`health_who` (IDX) は宣言以外で一切使用されていない
+**デッドフィールド**であることが判明した。
+
+### 完了内容
+
+#### API 整備
+
+`CreatureEntity` に 11 個の virtual を追加:
+
+| メソッド | 役割 |
+|---|---|
+| `has_pet_extra_flag(BIT_FLAGS16)` | `& flag`、`any_bits()` 相当 |
+| `add_pet_extra_flag(BIT_FLAGS16)` | `\|= flag` |
+| `remove_pet_extra_flag(BIT_FLAGS16)` | `&= ~flag` |
+| `get_pet_extra_flags()` | 全体読取り (savefile save 用) |
+| `set_pet_extra_flags(BIT_FLAGS16)` | 全体代入 (savefile load 用) |
+| `get_pet_follow_distance()` / `set_pet_follow_distance()` | scalar getter/setter |
+| `get_pet_t_m_idx()` / `set_pet_t_m_idx()` | 同 |
+| `get_riding_t_m_idx()` / `set_riding_t_m_idx()` | 同 |
+
+#### 移行
+
+19 ファイル、約 102 サイトを移行:
+
+- `cmd-action/cmd-pet.cpp`: 最大の集約箇所 (38+ サイト、ペット行動設定 UI)
+- `monster-floor/monster-direction.cpp`: 13 サイト (`pet_follow_distance`
+  の reference-mutate-restore パターンをローカル変数 + 明示的 setter
+  呼出に書換え)
+- `melee/melee-spell-flags-checker.cpp`: 9 サイト (うち
+  `(flags & MASK) != MASK` の「全 bit セット」セマンティクスは
+  `!has_X(A) \|\| !has_X(B)` の 2 個別チェックに分割)
+- savefile load/save、ペット制御コマンド、io-dump、フロア切替、
+  モンスター削除/圧縮 等
+
+#### Private 化と削除
+
+- 4 フィールド (`pet_extra_flags` / `pet_follow_distance` / `pet_t_m_idx` /
+  `riding_t_m_idx`) を完全 private 化
+- `health_who` を完全削除 (デッドフィールド)
+
+### 効果
+
+- **合計 private 化フィールド数: 99 → 103**
+- ペット制御フラグの操作意図 (有効化/無効化/問合せ) が明示化
+- 将来モンスター AI 側でもペット相当の「制御フラグ・追従距離・標的」
+  を持たせる設計余地を確保
+- 不要フィールド (`health_who`) の整理によりオブジェクトサイズ若干削減
 
 ---
 

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -115,8 +115,8 @@ void player_wipe_without_name(CreatureEntity &creature)
     world.noscore = 0;
     world.wizard = false;
     system.set_awaiting_report_score(false);
-    creature.pet_follow_distance = PET_FOLLOW_DIST;
-    creature.pet_extra_flags = (PF_TELEPORT | PF_ATTACK_SPELL | PF_SUMMON_SPELL);
+    creature.set_pet_follow_distance(PET_FOLLOW_DIST);
+    creature.set_pet_extra_flags(PF_TELEPORT | PF_ATTACK_SPELL | PF_SUMMON_SPELL);
     DungeonRecords::get_instance().reset_all();
     creature.visit = 1;
     world.set_wild_mode(false);

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -450,7 +450,7 @@ bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_opti
 
     creature.plus_incident_tree("ATTACK_ACT_COUNT", 1);
 
-    creature.riding_t_m_idx = grid.m_idx;
+    creature.set_riding_t_m_idx(grid.m_idx);
     bool fear = false;
     bool mdeath = false;
     if (can_attack_with_main_hand(creature)) {

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -222,7 +222,7 @@ bool do_cmd_riding(CreatureEntity &creature, bool force)
         }
 
         creature.ride_monster(0);
-        creature.pet_extra_flags &= ~(PF_TWO_HANDS);
+        creature.remove_pet_extra_flag(PF_TWO_HANDS);
         creature.old_riding_ryoute = false;
         creature.set_riding_ryoute(false);
     } else {
@@ -448,80 +448,80 @@ void do_cmd_pet(CreatureEntity &creature)
     powers[num++] = PET_DISMISS;
 
     const auto is_hallucinated = creature.is_hallucinated();
-    const auto taget_of_pet = creature.get_floor()->get_monster(creature.pet_t_m_idx).get_apparent_monrace().name.data();
+    const auto taget_of_pet = creature.get_floor()->get_monster(creature.get_pet_t_m_idx()).get_apparent_monrace().name.data();
     const auto target_of_pet_appearance = is_hallucinated ? _("何か奇妙な物", "something strange") : taget_of_pet;
     const auto mes = _("ペットのターゲットを指定 (現在：%s)", "specify a target of pet (now:%s)");
-    const auto target_name = creature.pet_t_m_idx > 0 ? target_of_pet_appearance : _("指定なし", "nothing");
+    const auto target_name = creature.get_pet_t_m_idx() > 0 ? target_of_pet_appearance : _("指定なし", "nothing");
     const auto target_ask = format(mes, target_name);
     power_desc[num] = target_ask;
     powers[num++] = PET_TARGET;
     power_desc[num] = _("近くにいろ", "stay close");
 
-    if (creature.pet_follow_distance == PET_CLOSE_DIST) {
+    if (creature.get_pet_follow_distance() == PET_CLOSE_DIST) {
         command_idx = num;
     }
     powers[num++] = PET_STAY_CLOSE;
     power_desc[num] = _("ついて来い", "follow me");
 
-    if (creature.pet_follow_distance == PET_FOLLOW_DIST) {
+    if (creature.get_pet_follow_distance() == PET_FOLLOW_DIST) {
         command_idx = num;
     }
     powers[num++] = PET_FOLLOW_ME;
     power_desc[num] = _("敵を見つけて倒せ", "seek and destroy");
 
-    if (creature.pet_follow_distance == PET_DESTROY_DIST) {
+    if (creature.get_pet_follow_distance() == PET_DESTROY_DIST) {
         command_idx = num;
     }
     powers[num++] = PET_SEEK_AND_DESTROY;
     power_desc[num] = _("少し離れていろ", "give me space");
 
-    if (creature.pet_follow_distance == PET_SPACE_DIST) {
+    if (creature.get_pet_follow_distance() == PET_SPACE_DIST) {
         command_idx = num;
     }
     powers[num++] = PET_ALLOW_SPACE;
     power_desc[num] = _("離れていろ", "stay away");
 
-    if (creature.pet_follow_distance == PET_AWAY_DIST) {
+    if (creature.get_pet_follow_distance() == PET_AWAY_DIST) {
         command_idx = num;
     }
     powers[num++] = PET_STAY_AWAY;
 
-    if (creature.pet_extra_flags & PF_OPEN_DOORS) {
+    if (creature.has_pet_extra_flag(PF_OPEN_DOORS)) {
         power_desc[num] = _("ドアを開ける (現在:ON)", "pets open doors (now On)");
     } else {
         power_desc[num] = _("ドアを開ける (現在:OFF)", "pets open doors (now Off)");
     }
     powers[num++] = PET_OPEN_DOORS;
 
-    if (creature.pet_extra_flags & PF_PICKUP_ITEMS) {
+    if (creature.has_pet_extra_flag(PF_PICKUP_ITEMS)) {
         power_desc[num] = _("アイテムを拾う (現在:ON)", "pets pick up items (now On)");
     } else {
         power_desc[num] = _("アイテムを拾う (現在:OFF)", "pets pick up items (now Off)");
     }
     powers[num++] = PET_TAKE_ITEMS;
 
-    if (creature.pet_extra_flags & PF_TELEPORT) {
+    if (creature.has_pet_extra_flag(PF_TELEPORT)) {
         power_desc[num] = _("テレポート系魔法を使う (現在:ON)", "allow teleport (now On)");
     } else {
         power_desc[num] = _("テレポート系魔法を使う (現在:OFF)", "allow teleport (now Off)");
     }
     powers[num++] = PET_TELEPORT;
 
-    if (creature.pet_extra_flags & PF_ATTACK_SPELL) {
+    if (creature.has_pet_extra_flag(PF_ATTACK_SPELL)) {
         power_desc[num] = _("攻撃魔法を使う (現在:ON)", "allow cast attack spell (now On)");
     } else {
         power_desc[num] = _("攻撃魔法を使う (現在:OFF)", "allow cast attack spell (now Off)");
     }
     powers[num++] = PET_ATTACK_SPELL;
 
-    if (creature.pet_extra_flags & PF_SUMMON_SPELL) {
+    if (creature.has_pet_extra_flag(PF_SUMMON_SPELL)) {
         power_desc[num] = _("召喚魔法を使う (現在:ON)", "allow cast summon spell (now On)");
     } else {
         power_desc[num] = _("召喚魔法を使う (現在:OFF)", "allow cast summon spell (now Off)");
     }
     powers[num++] = PET_SUMMON_SPELL;
 
-    if (creature.pet_extra_flags & PF_BALL_SPELL) {
+    if (creature.has_pet_extra_flag(PF_BALL_SPELL)) {
         power_desc[num] = _("プレイヤーを巻き込む範囲魔法を使う (現在:ON)", "allow involve creature in area spell (now On)");
     } else {
         power_desc[num] = _("プレイヤーを巻き込む範囲魔法を使う (現在:OFF)", "allow involve creature in area spell (now Off)");
@@ -547,7 +547,7 @@ void do_cmd_pet(CreatureEntity &creature)
 
     if (creature.get_riding()) {
         if (empty_main || empty_sub) {
-            if (creature.pet_extra_flags & PF_TWO_HANDS) {
+            if (creature.has_pet_extra_flag(PF_TWO_HANDS)) {
                 power_desc[num] = _("武器を片手で持つ", "use one hand to control the pet you are riding");
             } else {
                 power_desc[num] = _("武器を両手で持つ", "use both hands for a weapon");
@@ -560,7 +560,7 @@ void do_cmd_pet(CreatureEntity &creature)
             case PlayerClassType::FORCETRAINER:
             case PlayerClassType::BERSERKER: {
                 if (empty_hands(creature, false) == (EMPTY_HAND_MAIN | EMPTY_HAND_SUB)) {
-                    if (creature.pet_extra_flags & PF_TWO_HANDS) {
+                    if (creature.has_pet_extra_flag(PF_TWO_HANDS)) {
                         power_desc[num] = _("片手で格闘する", "use one hand to control the pet you are riding");
                     } else {
                         power_desc[num] = _("両手で格闘する", "use both hands for melee");
@@ -573,7 +573,7 @@ void do_cmd_pet(CreatureEntity &creature)
                 auto has_any_melee_weapon = has_melee_weapon(creature, INVEN_MAIN_HAND);
                 has_any_melee_weapon |= has_melee_weapon(creature, INVEN_SUB_HAND);
                 if ((empty_hands(creature, false) != EMPTY_HAND_NONE) && !has_any_melee_weapon) {
-                    if (creature.pet_extra_flags & PF_TWO_HANDS) {
+                    if (creature.has_pet_extra_flag(PF_TWO_HANDS)) {
                         power_desc[num] = _("格闘を行わない", "use one hand to control the pet you are riding");
                     } else {
                         power_desc[num] = _("格闘を行う", "use one hand for melee");
@@ -763,14 +763,14 @@ void do_cmd_pet(CreatureEntity &creature)
         project_length = -1;
         const auto pos = target_set(creature, TARGET_KILL).get_position();
         if (!pos) {
-            creature.pet_t_m_idx = 0;
+            creature.set_pet_t_m_idx(0);
         } else {
             const auto &grid = creature.get_floor()->get_grid(*pos);
             if (grid.has_monster() && (creature.get_floor()->get_monster(grid.m_idx).is_visible_on_map())) {
-                creature.pet_t_m_idx = creature.get_floor()->get_grid(*pos).m_idx;
-                creature.pet_follow_distance = PET_DESTROY_DIST;
+                creature.set_pet_t_m_idx(creature.get_floor()->get_grid(*pos).m_idx);
+                creature.set_pet_follow_distance(PET_DESTROY_DIST);
             } else {
-                creature.pet_t_m_idx = 0;
+                creature.set_pet_t_m_idx(0);
             }
         }
         project_length = 0;
@@ -779,44 +779,44 @@ void do_cmd_pet(CreatureEntity &creature)
     }
     /* Call pets */
     case PET_STAY_CLOSE: {
-        creature.pet_follow_distance = PET_CLOSE_DIST;
-        creature.pet_t_m_idx = 0;
+        creature.set_pet_follow_distance(PET_CLOSE_DIST);
+        creature.set_pet_t_m_idx(0);
         break;
     }
     /* "Follow Me" */
     case PET_FOLLOW_ME: {
-        creature.pet_follow_distance = PET_FOLLOW_DIST;
-        creature.pet_t_m_idx = 0;
+        creature.set_pet_follow_distance(PET_FOLLOW_DIST);
+        creature.set_pet_t_m_idx(0);
         break;
     }
     /* "Seek and destoy" */
     case PET_SEEK_AND_DESTROY: {
-        creature.pet_follow_distance = PET_DESTROY_DIST;
+        creature.set_pet_follow_distance(PET_DESTROY_DIST);
         break;
     }
     /* "Give me space" */
     case PET_ALLOW_SPACE: {
-        creature.pet_follow_distance = PET_SPACE_DIST;
+        creature.set_pet_follow_distance(PET_SPACE_DIST);
         break;
     }
     /* "Stay away" */
     case PET_STAY_AWAY: {
-        creature.pet_follow_distance = PET_AWAY_DIST;
+        creature.set_pet_follow_distance(PET_AWAY_DIST);
         break;
     }
     /* flag - allow pets to open doors */
     case PET_OPEN_DOORS: {
-        if (creature.pet_extra_flags & PF_OPEN_DOORS) {
-            creature.pet_extra_flags &= ~(PF_OPEN_DOORS);
+        if (creature.has_pet_extra_flag(PF_OPEN_DOORS)) {
+            creature.remove_pet_extra_flag(PF_OPEN_DOORS);
         } else {
-            creature.pet_extra_flags |= (PF_OPEN_DOORS);
+            creature.add_pet_extra_flag(PF_OPEN_DOORS);
         }
         break;
     }
     /* flag - allow pets to pickup items */
     case PET_TAKE_ITEMS: {
-        if (creature.pet_extra_flags & PF_PICKUP_ITEMS) {
-            creature.pet_extra_flags &= ~(PF_PICKUP_ITEMS);
+        if (creature.has_pet_extra_flag(PF_PICKUP_ITEMS)) {
+            creature.remove_pet_extra_flag(PF_PICKUP_ITEMS);
             for (pet_ctr = creature.get_floor()->m_max - 1; pet_ctr >= 1; pet_ctr--) {
                 auto &monster = creature.get_floor()->get_monster(static_cast<MONSTER_IDX>(pet_ctr));
                 if (monster.is_pet()) {
@@ -824,44 +824,44 @@ void do_cmd_pet(CreatureEntity &creature)
                 }
             }
         } else {
-            creature.pet_extra_flags |= (PF_PICKUP_ITEMS);
+            creature.add_pet_extra_flag(PF_PICKUP_ITEMS);
         }
 
         break;
     }
     /* flag - allow pets to teleport */
     case PET_TELEPORT: {
-        if (creature.pet_extra_flags & PF_TELEPORT) {
-            creature.pet_extra_flags &= ~(PF_TELEPORT);
+        if (creature.has_pet_extra_flag(PF_TELEPORT)) {
+            creature.remove_pet_extra_flag(PF_TELEPORT);
         } else {
-            creature.pet_extra_flags |= (PF_TELEPORT);
+            creature.add_pet_extra_flag(PF_TELEPORT);
         }
         break;
     }
     /* flag - allow pets to cast attack spell */
     case PET_ATTACK_SPELL: {
-        if (creature.pet_extra_flags & PF_ATTACK_SPELL) {
-            creature.pet_extra_flags &= ~(PF_ATTACK_SPELL);
+        if (creature.has_pet_extra_flag(PF_ATTACK_SPELL)) {
+            creature.remove_pet_extra_flag(PF_ATTACK_SPELL);
         } else {
-            creature.pet_extra_flags |= (PF_ATTACK_SPELL);
+            creature.add_pet_extra_flag(PF_ATTACK_SPELL);
         }
         break;
     }
     /* flag - allow pets to cast attack spell */
     case PET_SUMMON_SPELL: {
-        if (creature.pet_extra_flags & PF_SUMMON_SPELL) {
-            creature.pet_extra_flags &= ~(PF_SUMMON_SPELL);
+        if (creature.has_pet_extra_flag(PF_SUMMON_SPELL)) {
+            creature.remove_pet_extra_flag(PF_SUMMON_SPELL);
         } else {
-            creature.pet_extra_flags |= (PF_SUMMON_SPELL);
+            creature.add_pet_extra_flag(PF_SUMMON_SPELL);
         }
         break;
     }
     /* flag - allow pets to cast attack spell */
     case PET_BALL_SPELL: {
-        if (creature.pet_extra_flags & PF_BALL_SPELL) {
-            creature.pet_extra_flags &= ~(PF_BALL_SPELL);
+        if (creature.has_pet_extra_flag(PF_BALL_SPELL)) {
+            creature.remove_pet_extra_flag(PF_BALL_SPELL);
         } else {
-            creature.pet_extra_flags |= (PF_BALL_SPELL);
+            creature.add_pet_extra_flag(PF_BALL_SPELL);
         }
         break;
     }
@@ -877,10 +877,10 @@ void do_cmd_pet(CreatureEntity &creature)
     }
 
     case PET_TWO_HANDS: {
-        if (creature.pet_extra_flags & PF_TWO_HANDS) {
-            creature.pet_extra_flags &= ~(PF_TWO_HANDS);
+        if (creature.has_pet_extra_flag(PF_TWO_HANDS)) {
+            creature.remove_pet_extra_flag(PF_TWO_HANDS);
         } else {
-            creature.pet_extra_flags |= (PF_TWO_HANDS);
+            creature.add_pet_extra_flag(PF_TWO_HANDS);
         }
 
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -113,8 +113,8 @@ void process_dungeon(CreatureEntity &creature, bool load_game)
     command_dir = Direction::none();
 
     Target::clear_last_target();
-    creature.pet_t_m_idx = 0;
-    creature.riding_t_m_idx = 0;
+    creature.set_pet_t_m_idx(0);
+    creature.set_riding_t_m_idx(0);
     creature.set_ambush_flag(false);
     health_track(creature, 0);
 

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -50,7 +50,7 @@ static void check_riding_preservation(CreatureEntity &creature)
     const auto &monster = creature.get_floor()->m_list[creature.get_riding()];
     if (monster.has_parent()) {
         creature.ride_monster(0);
-        creature.pet_extra_flags &= ~(PF_TWO_HANDS);
+        creature.remove_pet_extra_flag(PF_TWO_HANDS);
         creature.old_riding_ryoute = false;
         creature.set_riding_ryoute(false);
     } else {

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -92,22 +92,22 @@ static void dump_aux_pet(CreatureEntity &creature, FILE *fff)
     fmt::println(fff, _("\n\n  [ペットへの命令]", "\n\n  [Command for Pets]"));
 
     fmt::print(fff, _("\n ドアを開ける:                       {}", "\n Pets open doors:                    {}"),
-        (creature.pet_extra_flags & PF_OPEN_DOORS) ? "ON" : "OFF");
+        creature.has_pet_extra_flag(PF_OPEN_DOORS) ? "ON" : "OFF");
 
     fmt::print(fff, _("\n アイテムを拾う:                     {}", "\n Pets pick up items:                 {}"),
-        (creature.pet_extra_flags & PF_PICKUP_ITEMS) ? "ON" : "OFF");
+        creature.has_pet_extra_flag(PF_PICKUP_ITEMS) ? "ON" : "OFF");
 
     fmt::print(fff, _("\n テレポート系魔法を使う:             {}", "\n Allow teleport:                     {}"),
-        (creature.pet_extra_flags & PF_TELEPORT) ? "ON" : "OFF");
+        creature.has_pet_extra_flag(PF_TELEPORT) ? "ON" : "OFF");
 
     fmt::print(fff, _("\n 攻撃魔法を使う:                     {}", "\n Allow cast attack spell:            {}"),
-        (creature.pet_extra_flags & PF_ATTACK_SPELL) ? "ON" : "OFF");
+        creature.has_pet_extra_flag(PF_ATTACK_SPELL) ? "ON" : "OFF");
 
     fmt::print(fff, _("\n 召喚魔法を使う:                     {}", "\n Allow cast summon spell:            {}"),
-        (creature.pet_extra_flags & PF_SUMMON_SPELL) ? "ON" : "OFF");
+        creature.has_pet_extra_flag(PF_SUMMON_SPELL) ? "ON" : "OFF");
 
     fmt::print(fff, _("\n プレイヤーを巻き込む範囲魔法を使う: {}", "\n Allow involve creature in area spell: {}"),
-        (creature.pet_extra_flags & PF_BALL_SPELL) ? "ON" : "OFF");
+        creature.has_pet_extra_flag(PF_BALL_SPELL) ? "ON" : "OFF");
 
     fmt::print(fff, "\n");
 }

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -234,8 +234,8 @@ static errr exe_reading_savefile(CreatureEntity &creature)
     }
 
     load_store(creature);
-    creature.pet_follow_distance = rd_s16b();
-    creature.pet_extra_flags = rd_u16b();
+    creature.set_pet_follow_distance(rd_s16b());
+    creature.set_pet_extra_flags(rd_u16b());
 
     auto restore_dungeon_result = restore_dungeon(creature);
     if (restore_dungeon_result != 0) {

--- a/src/melee/melee-spell-flags-checker.cpp
+++ b/src/melee/melee-spell-flags-checker.cpp
@@ -26,11 +26,11 @@
 
 static void decide_melee_spell_target(CreatureEntity &creature, melee_spell_type *ms_ptr)
 {
-    if ((creature.pet_t_m_idx == 0) || !ms_ptr->pet) {
+    if ((creature.get_pet_t_m_idx() == 0) || !ms_ptr->pet) {
         return;
     }
 
-    ms_ptr->target_idx = creature.pet_t_m_idx;
+    ms_ptr->target_idx = creature.get_pet_t_m_idx();
     const auto &floor = *creature.get_floor();
     ms_ptr->t_ptr = &floor.get_monster(ms_ptr->target_idx);
     if ((ms_ptr->m_idx == ms_ptr->target_idx) || !projectable(floor, ms_ptr->m_ptr->get_position(), ms_ptr->t_ptr->get_position())) {
@@ -54,7 +54,7 @@ static void decide_indirection_melee_spell(CreatureEntity &creature, melee_spell
 
     ms_ptr->t_ptr = &floor.get_monster(ms_ptr->target_idx);
     const auto &monster_to = *ms_ptr->t_ptr;
-    if ((ms_ptr->m_idx == ms_ptr->target_idx) || ((ms_ptr->target_idx != creature.pet_t_m_idx) && !monster_from.is_hostile_to_melee(monster_to))) {
+    if ((ms_ptr->m_idx == ms_ptr->target_idx) || ((ms_ptr->target_idx != creature.get_pet_t_m_idx()) && !monster_from.is_hostile_to_melee(monster_to))) {
         ms_ptr->target_idx = 0;
         return;
     }
@@ -251,7 +251,7 @@ static void check_melee_spell_special(CreatureEntity &creature, melee_spell_type
     }
 
     if (ms_ptr->m_ptr->get_r_idx() == MonraceId::ROLENTO) {
-        if ((creature.pet_extra_flags & (PF_ATTACK_SPELL | PF_SUMMON_SPELL)) != (PF_ATTACK_SPELL | PF_SUMMON_SPELL)) {
+        if (!creature.has_pet_extra_flag(PF_ATTACK_SPELL) || !creature.has_pet_extra_flag(PF_SUMMON_SPELL)) {
             ms_ptr->ability_flags.reset(MonsterAbilityType::SPECIAL);
         }
 
@@ -259,7 +259,7 @@ static void check_melee_spell_special(CreatureEntity &creature, melee_spell_type
     }
 
     if (ms_ptr->monrace->symbol_char_is_any_of("B")) {
-        if ((creature.pet_extra_flags & (PF_ATTACK_SPELL | PF_TELEPORT)) != (PF_ATTACK_SPELL | PF_TELEPORT)) {
+        if (!creature.has_pet_extra_flag(PF_ATTACK_SPELL) || !creature.has_pet_extra_flag(PF_TELEPORT)) {
             ms_ptr->ability_flags.reset(MonsterAbilityType::SPECIAL);
         }
 
@@ -285,19 +285,19 @@ static void check_pet(CreatureEntity &creature, melee_spell_type *ms_ptr)
     }
 
     ms_ptr->ability_flags.reset({ MonsterAbilityType::SHRIEK, MonsterAbilityType::DARKNESS, MonsterAbilityType::TRAPS });
-    if (!(creature.pet_extra_flags & PF_TELEPORT)) {
+    if (!creature.has_pet_extra_flag(PF_TELEPORT)) {
         ms_ptr->ability_flags.reset({ MonsterAbilityType::BLINK, MonsterAbilityType::TPORT, MonsterAbilityType::TELE_TO, MonsterAbilityType::TELE_AWAY, MonsterAbilityType::TELE_LEVEL });
     }
 
-    if (!(creature.pet_extra_flags & PF_ATTACK_SPELL)) {
+    if (!creature.has_pet_extra_flag(PF_ATTACK_SPELL)) {
         ms_ptr->ability_flags.reset(RF_ABILITY_ATTACK_MASK);
     }
 
-    if (!(creature.pet_extra_flags & PF_SUMMON_SPELL)) {
+    if (!creature.has_pet_extra_flag(PF_SUMMON_SPELL)) {
         ms_ptr->ability_flags.reset(RF_ABILITY_SUMMON_MASK);
     }
 
-    if (!(creature.pet_extra_flags & PF_BALL_SPELL) && !ms_ptr->m_ptr->is_riding()) {
+    if (!creature.has_pet_extra_flag(PF_BALL_SPELL) && !ms_ptr->m_ptr->is_riding()) {
         check_melee_spell_distance(creature, ms_ptr);
         check_melee_spell_rocket(creature, ms_ptr);
         check_melee_spell_beam(creature, ms_ptr);

--- a/src/monster-floor/monster-direction.cpp
+++ b/src/monster-floor/monster-direction.cpp
@@ -36,11 +36,12 @@ static bool decide_pet_approch_direction(CreatureEntity &creature, const Creatur
     const auto p_pos = creature.get_position();
     const auto cdis_from = Grid::calc_distance(p_pos, monster_from.get_position());
     const auto cdis_to = Grid::calc_distance(p_pos, monster_to.get_position());
-    if (creature.pet_follow_distance < 0) {
-        if (cdis_to <= (0 - creature.pet_follow_distance)) {
+    const auto pet_follow_distance = creature.get_pet_follow_distance();
+    if (pet_follow_distance < 0) {
+        if (cdis_to <= (0 - pet_follow_distance)) {
             return true;
         }
-    } else if ((cdis_from < cdis_to) && (cdis_to > creature.pet_follow_distance)) {
+    } else if ((cdis_from < cdis_to) && (cdis_to > pet_follow_distance)) {
         return true;
     }
 
@@ -116,12 +117,12 @@ static tl::optional<MonsterMovementDirectionList> get_enemy_dir(CreatureEntity &
     const auto &monster = floor.get_monster(m_idx);
 
     POSITION x = 0, y = 0;
-    if (creature.riding_t_m_idx && creature.is_located_at({ monster.y, monster.x })) {
-        y = floor.get_monster(creature.riding_t_m_idx).y;
-        x = floor.get_monster(creature.riding_t_m_idx).x;
-    } else if (monster.is_pet() && creature.pet_t_m_idx) {
-        y = floor.get_monster(creature.pet_t_m_idx).y;
-        x = floor.get_monster(creature.pet_t_m_idx).x;
+    if (creature.get_riding_t_m_idx() && creature.is_located_at({ monster.y, monster.x })) {
+        y = floor.get_monster(creature.get_riding_t_m_idx()).y;
+        x = floor.get_monster(creature.get_riding_t_m_idx()).x;
+    } else if (monster.is_pet() && creature.get_pet_t_m_idx()) {
+        y = floor.get_monster(creature.get_pet_t_m_idx()).y;
+        x = floor.get_monster(creature.get_pet_t_m_idx()).x;
     } else {
         int start;
         int plus = 1;
@@ -201,7 +202,7 @@ static tl::optional<MonsterMovementDirectionList> decide_pet_movement_direction(
     }
 
     const auto cdis = Grid::calc_distance(creature.get_position(), monster.get_position());
-    auto &pet_follow_distance = creature.pet_follow_distance;
+    const auto pet_follow_distance = creature.get_pet_follow_distance();
     const auto avoid = ((pet_follow_distance < 0) && (cdis <= (0 - pet_follow_distance)));
     const auto lonely = (!avoid && (cdis > pet_follow_distance));
     const auto distant = (cdis > PET_SEEK_DIST);
@@ -211,12 +212,12 @@ static tl::optional<MonsterMovementDirectionList> decide_pet_movement_direction(
 
     const auto distance_orig = pet_follow_distance;
     if (pet_follow_distance > PET_SEEK_DIST) {
-        pet_follow_distance = PET_SEEK_DIST;
+        creature.set_pet_follow_distance(PET_SEEK_DIST);
     }
 
     MonsterSweepGrid msd(&creature, m_idx);
     const auto mmdl = msd.get_movable_grid();
-    pet_follow_distance = distance_orig;
+    creature.set_pet_follow_distance(distance_orig);
     return mmdl;
 }
 

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -117,7 +117,7 @@ static bool bash_normal_door(CreatureEntity &creature, turn_flags *turn_flags_pt
     using Tc = TerrainCharacteristics;
     auto can_bash = monrace.behavior_flags.has_not(MonsterBehaviorType::OPEN_DOOR);
     can_bash |= terrain.flags.has_not(Tc::OPEN);
-    can_bash |= monster.is_pet() && ((creature.pet_extra_flags & PF_OPEN_DOORS) == 0);
+    can_bash |= monster.is_pet() && !creature.has_pet_extra_flag(PF_OPEN_DOORS);
     if (can_bash) {
         return true;
     }
@@ -152,7 +152,7 @@ static void bash_glass_door(CreatureEntity &creature, turn_flags *turn_flags_ptr
     auto can_bash = may_bash;
     can_bash &= monrace.behavior_flags.has(MonsterBehaviorType::BASH_DOOR);
     can_bash &= terrain.flags.has(TerrainCharacteristics::BASH);
-    can_bash &= !monster.is_pet() || any_bits(creature.pet_extra_flags, PF_OPEN_DOORS);
+    can_bash &= !monster.is_pet() || creature.has_pet_extra_flag(PF_OPEN_DOORS);
     if (!can_bash) {
         return;
     }
@@ -489,7 +489,7 @@ bool process_monster_movement(CreatureEntity &creature, turn_flags *turn_flags_p
 
         auto is_takable_or_killable = !grid.o_idx_list.empty();
         is_takable_or_killable &= monrace.behavior_flags.has_any_of({ MonsterBehaviorType::TAKE_ITEM, MonsterBehaviorType::KILL_ITEM });
-        auto is_pickup_items = (creature.pet_extra_flags & PF_PICKUP_ITEMS) != 0;
+        auto is_pickup_items = creature.has_pet_extra_flag(PF_PICKUP_ITEMS);
         is_pickup_items &= monrace.behavior_flags.has(MonsterBehaviorType::TAKE_ITEM);
         is_takable_or_killable &= !monster.is_pet() || is_pickup_items;
         if (!is_takable_or_killable) {

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -61,11 +61,11 @@ void delete_monster_idx(CreatureEntity &creature, short m_idx)
         health_track(creature, 0);
     }
 
-    if (creature.pet_t_m_idx == m_idx) {
-        creature.pet_t_m_idx = 0;
+    if (creature.get_pet_t_m_idx() == m_idx) {
+        creature.set_pet_t_m_idx(0);
     }
-    if (creature.riding_t_m_idx == m_idx) {
-        creature.riding_t_m_idx = 0;
+    if (creature.get_riding_t_m_idx() == m_idx) {
+        creature.set_riding_t_m_idx(0);
     }
     if (monster.is_riding()) { // creature.get_riding() == m_idx のままの方がいい？
         creature.ride_monster(0);
@@ -117,8 +117,8 @@ void wipe_monsters_list(CreatureEntity &creature)
     floor.reset_mproc_max();
     floor.num_repro = 0;
     Target::clear_last_target();
-    creature.pet_t_m_idx = 0;
-    creature.riding_t_m_idx = 0;
+    creature.set_pet_t_m_idx(0);
+    creature.set_riding_t_m_idx(0);
     health_track(creature, 0);
 }
 

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -41,7 +41,7 @@ bool mon_will_run(CreatureEntity &creature, MONSTER_IDX m_idx)
 
     const auto cdis = Grid::calc_distance(creature.get_position(), monster.get_position());
     if (monster.is_pet()) {
-        return (creature.pet_follow_distance < 0) && (cdis <= (0 - creature.pet_follow_distance));
+        return (creature.get_pet_follow_distance() < 0) && (cdis <= (0 - creature.get_pet_follow_distance()));
     }
 
     if (cdis > MAX_PLAYER_SIGHT + 5) {

--- a/src/monster/monster-compaction.cpp
+++ b/src/monster/monster-compaction.cpp
@@ -46,11 +46,11 @@ static void compact_monsters_aux(CreatureEntity &creature, MONSTER_IDX i1, MONST
         Target::set_last_target(Target::create_monster_target(creature, i2));
     }
 
-    if (creature.pet_t_m_idx == i1) {
-        creature.pet_t_m_idx = i2;
+    if (creature.get_pet_t_m_idx() == i1) {
+        creature.set_pet_t_m_idx(i2);
     }
-    if (creature.riding_t_m_idx == i1) {
-        creature.riding_t_m_idx = i2;
+    if (creature.get_riding_t_m_idx() == i1) {
+        creature.set_riding_t_m_idx(i2);
     }
 
     if (monster.is_riding()) { // creature.get_riding() == i1 のままの方がいい？

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -145,7 +145,7 @@ bool process_fall_off_horse(CreatureEntity &creature, int dam, bool force)
     }
 
     creature.ride_monster(0);
-    creature.pet_extra_flags &= ~(PF_TWO_HANDS);
+    creature.remove_pet_extra_flag(PF_TWO_HANDS);
     creature.old_riding_ryoute = false;
     creature.set_riding_ryoute(false);
 

--- a/src/pet/pet-util.cpp
+++ b/src/pet/pet-util.cpp
@@ -27,14 +27,14 @@ bool can_player_ride_pet(CreatureEntity &creature, const Grid &grid, bool now_ri
     const auto old_riding = creature.get_riding();
     const auto old_riding_two_hands = creature.is_riding_ryoute();
     const auto old_old_riding_two_hands = creature.old_riding_ryoute;
-    const auto old_pf_two_hands = any_bits(creature.pet_extra_flags, PF_TWO_HANDS);
+    const auto old_pf_two_hands = creature.has_pet_extra_flag(PF_TWO_HANDS);
     world.character_xtra = true;
 
     if (now_riding) {
         creature.ride_monster(grid.m_idx);
     } else {
         creature.ride_monster(0);
-        creature.pet_extra_flags &= ~(PF_TWO_HANDS);
+        creature.remove_pet_extra_flag(PF_TWO_HANDS);
         creature.old_riding_ryoute = false;
         creature.set_riding_ryoute(false);
     }
@@ -46,9 +46,9 @@ bool can_player_ride_pet(CreatureEntity &creature, const Grid &grid, bool now_ri
     bool p_can_enter = player_can_enter(creature, grid.feat, CEM_P_CAN_ENTER_PATTERN);
     creature.ride_monster(old_riding);
     if (old_pf_two_hands) {
-        creature.pet_extra_flags |= (PF_TWO_HANDS);
+        creature.add_pet_extra_flag(PF_TWO_HANDS);
     } else {
-        creature.pet_extra_flags &= ~(PF_TWO_HANDS);
+        creature.remove_pet_extra_flag(PF_TWO_HANDS);
     }
 
     creature.set_riding_ryoute(old_riding_two_hands);

--- a/src/player-info/equipment-info.cpp
+++ b/src/player-info/equipment-info.cpp
@@ -37,7 +37,7 @@ BIT_FLAGS16 empty_hands(CreatureEntity &creature, bool riding_control)
         status |= EMPTY_HAND_SUB;
     }
 
-    if (riding_control && (status != EMPTY_HAND_NONE) && creature.get_riding() && none_bits(creature.pet_extra_flags, PF_TWO_HANDS)) {
+    if (riding_control && (status != EMPTY_HAND_NONE) && creature.get_riding() && !creature.has_pet_extra_flag(PF_TWO_HANDS)) {
         if (any_bits(status, EMPTY_HAND_SUB)) {
             reset_bits(status, EMPTY_HAND_SUB);
         } else if (any_bits(status, EMPTY_HAND_MAIN)) {
@@ -50,7 +50,7 @@ BIT_FLAGS16 empty_hands(CreatureEntity &creature, bool riding_control)
 
 bool can_two_hands_wielding(CreatureEntity &creature)
 {
-    return !creature.get_riding() || any_bits(creature.pet_extra_flags, PF_TWO_HANDS);
+    return !creature.get_riding() || creature.has_pet_extra_flag(PF_TWO_HANDS);
 }
 
 /*!

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1905,7 +1905,7 @@ static bool is_riding_two_hands(CreatureEntity &creature)
         return true;
     }
 
-    if (any_bits(creature.pet_extra_flags, PF_TWO_HANDS)) {
+    if (creature.has_pet_extra_flag(PF_TWO_HANDS)) {
         switch (creature.pclass) {
         case PlayerClassType::MONK:
         case PlayerClassType::FORCETRAINER:

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -226,8 +226,8 @@ static bool wr_savefile_new(CreatureEntity &creature)
         }
     }
 
-    wr_s16b(creature.pet_follow_distance);
-    wr_s16b(creature.pet_extra_flags);
+    wr_s16b(creature.get_pet_follow_distance());
+    wr_s16b(creature.get_pet_extra_flags());
     if (AngbandSystem::get_instance().is_awaiting_report_status() || !creature.is_dead()) {
         wr_string(screen_dump);
     } else {

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1411,6 +1411,54 @@ public:
         this->riding = m_idx;
     }
 
+    // [提案 40] ペット関連フィールドの virtual API。
+    // pet_extra_flags は BIT_FLAGS16 のビットマスク (`PF_OPEN_DOORS` 等) で、
+    // 単一フラグ操作は add/remove/has、一括代入は set/get_X_flags 経由。
+    virtual bool has_pet_extra_flag(BIT_FLAGS16 flag) const
+    {
+        return (this->pet_extra_flags & flag) != 0;
+    }
+    virtual void add_pet_extra_flag(BIT_FLAGS16 flag)
+    {
+        this->pet_extra_flags |= flag;
+    }
+    virtual void remove_pet_extra_flag(BIT_FLAGS16 flag)
+    {
+        this->pet_extra_flags &= static_cast<BIT_FLAGS16>(~flag);
+    }
+    virtual BIT_FLAGS16 get_pet_extra_flags() const
+    {
+        return this->pet_extra_flags;
+    }
+    virtual void set_pet_extra_flags(BIT_FLAGS16 value)
+    {
+        this->pet_extra_flags = value;
+    }
+    virtual int16_t get_pet_follow_distance() const
+    {
+        return this->pet_follow_distance;
+    }
+    virtual void set_pet_follow_distance(int16_t value)
+    {
+        this->pet_follow_distance = value;
+    }
+    virtual MONSTER_IDX get_pet_t_m_idx() const
+    {
+        return this->pet_t_m_idx;
+    }
+    virtual void set_pet_t_m_idx(MONSTER_IDX value)
+    {
+        this->pet_t_m_idx = value;
+    }
+    virtual MONSTER_IDX get_riding_t_m_idx() const
+    {
+        return this->riding_t_m_idx;
+    }
+    virtual void set_riding_t_m_idx(MONSTER_IDX value)
+    {
+        this->riding_t_m_idx = value;
+    }
+
     /*!
      * @brief パック内の所持品数を inventory[] から計算する (提案 25)
      * @details inventory[0..INVEN_PACK) の有効アイテム数を返す。
@@ -3531,7 +3579,6 @@ private:
 
 public:
     POSITION old_lite{}; /* Radius of lite (if any) */
-
     // [提案 33] private 化済。has_special_attack(flag) / add_special_attack(flag)
     // / remove_special_attack(flag) / set_special_attack_flags(BIT_FLAGS) /
     // get_special_attack_flags() 経由。
@@ -3679,9 +3726,15 @@ public:
     BIT_FLAGS old_race2{}; /* Record of race changes */
     int16_t old_realm{}; /* Record of realm changes */
 
+    // [提案 40] ペット関連フィールドは private 化済。
+    // get_pet_follow_distance() / set_pet_follow_distance() /
+    // has_pet_extra_flag() / add_pet_extra_flag() / remove_pet_extra_flag() /
+    // get_pet_extra_flags() / set_pet_extra_flags() 経由。
+private:
     int16_t pet_follow_distance{}; /* Length of the imaginary "leash" for pets */
     BIT_FLAGS16 pet_extra_flags{}; /* Various flags for controling pets */
 
+public:
     bool dtrap{}; /* Whether you are on trap-safe grids */
     FLOOR_IDX floor_id{}; /* Current floor location */
 
@@ -3698,8 +3751,6 @@ public:
     bool monk_notify_aux{};
 
     bool teleport_town{};
-
-    IDX health_who{}; /* Health bar trackee */
 
     short tracking_bi_id{}; /* Object kind trackee */
 
@@ -3743,9 +3794,14 @@ public:
 
     DIRECTION fishing_dir{};
 
+    // [提案 40] ペット/騎乗ターゲット m_idx は private 化済。
+    // get_pet_t_m_idx() / set_pet_t_m_idx() / get_riding_t_m_idx() /
+    // set_riding_t_m_idx() 経由。
+private:
     MONSTER_IDX pet_t_m_idx{};
     MONSTER_IDX riding_t_m_idx{};
 
+public:
     /*** Extracted fields ***/
 
     bool suppress_multi_reward{}; /*!< 複数レベルアップ時のパトロンからの報酬多重受け取りを防止 */


### PR DESCRIPTION
CreatureEntity 直下に public で残存していたペット関連 4 フィールドを
private 化し、操作意図を明示する virtual API に統一。さらにデッド
フィールド `health_who` を削除。

対象フィールド:
- pet_extra_flags (BIT_FLAGS16、PF_OPEN_DOORS 等 7 種のペット制御フラグ)
- pet_follow_distance (ペット追従距離)
- pet_t_m_idx (ペットの標的モンスター idx)
- riding_t_m_idx (騎乗中の標的モンスター idx)

削除フィールド:
- health_who (宣言以外で一切未使用のデッドフィールド)

API (11 個の virtual):
- has_pet_extra_flag / add_pet_extra_flag / remove_pet_extra_flag
- get_pet_extra_flags / set_pet_extra_flags (savefile load/save 用)
- get/set_pet_follow_distance
- get/set_pet_t_m_idx
- get/set_riding_t_m_idx

19 ファイル約 102 サイトを migration:
- cmd-action/cmd-pet.cpp (38 サイト、ペット行動設定 UI)
- monster-floor/monster-direction.cpp (13 サイト、reference-mutate-restore パターンをローカル変数 + 明示的 setter に書換え)
- melee/melee-spell-flags-checker.cpp (9 サイト、(flags & MASK) != MASK の 全ビットセット判定を個別 !has_X(A) || !has_X(B) に分解)
- savefile load/save、フロア切替、モンスター削除/圧縮 等

合計 private 化フィールド数: 99 → 103