### PR TITLE
refactor: 差分検出キャッシュ old_* を private 化 (提案 42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,6 +339,14 @@ API 経由に統一された。一部フィールド (r_idx / ap_r_idx / riding)
   セマンティクスは個別 `has_X()` 2 連検査に分解。さらにデッド
   フィールド `health_who` (宣言以外で未使用) を削除。
   **合計 private 化フィールド数: 99 → 103**
+- **提案 42**: 旧差分検出キャッシュ `old_*` 系 12 個 (`old_lite` /
+  `old_race1/2` / `old_realm` / `old_spells` / `old_cumber_armor/glove` /
+  `old_heavy_wield[2]` / `old_heavy_shoot` / `old_icky_wield[2]` /
+  `old_riding_wield[2]` / `old_riding_ryoute` / `old_monlite`) を private
+  化。25 個の virtual API (`get_old_X()` / `set_old_X()`、bool 系は意図
+  明示のため `was_X()` / `set_was_X()` 命名) を整備し、11 ファイル
+  約 46 サイトを migration。さらにデッドフィールド `old_food_aux`
+  (宣言以外で未使用) を削除。**合計 private 化フィールド数: 103 → 115**
 - **提案 1/2**: プレイヤー専用フィールドのモンスター運用化基盤完了。
   種族 (`prace`) / 職業 (`pclass`) / 魔法領域 (`realm1` / `realm2` /
   `element_realm`) / パトロン (`patron`) / 変身形態 (`mimic_form`)
@@ -711,6 +719,13 @@ bakabakaband 側と上流側でよくある構造的差異を以下のルール�
 | `creature.pet_follow_distance` / `creature.pet_t_m_idx` / `creature.riding_t_m_idx` 読取 | `creature.get_pet_follow_distance()` / `get_pet_t_m_idx()` / `get_riding_t_m_idx()` (提案 40) |
 | 同上書込 | `creature.set_pet_follow_distance(X)` / `set_pet_t_m_idx(X)` / `set_riding_t_m_idx(X)` (提案 40) |
 | `creature.health_who` | **提案 40 でフィールド削除** (デッドフィールドだった) |
+| `creature.old_lite` / `old_race1/2` / `old_realm` / `old_spells` 読取 | `creature.get_old_lite()` / `get_old_race_flags1/2()` / `get_old_realm()` / `get_old_spells()` (提案 42) |
+| 同上書込 | `creature.set_old_lite(X)` / `set_old_race_flags1/2(X)` / `set_old_realm(X)` / `set_old_spells(X)` (提案 42) |
+| `creature.old_cumber_armor` / `old_cumber_glove` / `old_heavy_shoot` / `old_riding_ryoute` / `old_monlite` 読取 | `creature.was_cumber_armor()` / `was_cumber_glove()` / `was_heavy_shoot()` / `was_riding_ryoute()` / `was_monlite()` (提案 42) |
+| `creature.old_heavy_wield[hand]` / `old_icky_wield[hand]` / `old_riding_wield[hand]` 読取 | `creature.was_heavy_wield(hand)` / `was_icky_wield(hand)` / `was_icky_riding_wield(hand)` (提案 42) |
+| 同上書込 | `creature.set_was_heavy_wield(hand, X)` / `set_was_icky_wield(hand, X)` / `set_was_icky_riding_wield(hand, X)` (提案 42)、scalar bool は `set_was_X(value)` |
+| `creature.old_realm \|= 1U << X` / `old_race1 \|= ...` 単一ビット追加 | `creature.set_old_realm(creature.get_old_realm() \| (1U << X))` (提案 42。意味的な単純化のため raw 操作を保持) |
+| `creature.old_food_aux` | **提案 42 でフィールド削除** (デッドフィールドだった) |
 
 **GCC 固有の注意**:
 上流は MSVC 前提のことが多く、`<cstdint>` 等のインクルード漏れがあれば追加する。

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -61,7 +61,7 @@ Phase 1-8 完了後に残存している統合作業項目を整理したもの�
 | [39](#提案-39-装備派生キャッシュフィールドの-private-化--完了) | 装備派生キャッシュフィールド private 化 | ✅ 完了 | **+11 = 94 個** (num_blow/cumber/icky 等) |
 | [40](#提案-40-ペット関連フィールドの-private-化--完了) | ペット関連フィールド private 化 | ✅ 完了 | **+4 = 103 個** (pet_extra_flags / pet_follow_distance 等、health_who 削除) |
 | [41](#提案-41-呪文マスク-spell_learnedworkedforgotten-の集約--完了) | 呪文マスク集約 (spell_learned/worked/forgotten) | ✅ 完了 | **+6 = 83 個**、realm_idx ベース API |
-| [42](#提案-42-旧差分検出キャッシュ-old_-の-private-化) | 旧差分検出キャッシュ (`old_*`) private 化 | 🚧 | old_cumber_* / old_heavy_* 等 |
+| [42](#提案-42-旧差分検出キャッシュ-old_-の-private-化--完了) | 旧差分検出キャッシュ (`old_*`) private 化 | ✅ 完了 | **+12 = 115 個** (old_race1/2 / old_realm / old_cumber_* / old_heavy_* 等、old_food_aux 削除) |
 | [43](#提案-43-行動状態フラグの-private-化) | 行動状態フラグ private 化 | 🚧 | resting / running / action 等 |
 | [44](#提案-44-突然変異呪い系フラグの-private-化--完了) | 突然変異/呪い系フラグ private 化 | ✅ 完了 | **+5 = 99 個** (muta / cursed / patron 等) |
 | [45](#提案-45-pet_t_m_idx--riding_t_m_idx-系を-target-pos2d-に統合) | pet_t_m_idx / riding_t_m_idx 統合 | 🚧 | Pos2D ベース |
@@ -69,7 +69,7 @@ Phase 1-8 完了後に残存している統合作業項目を整理したもの�
 
 **累計 private 化フィールド数 (主要マイルストーン):**
 - 提案 29 (3 個) → 32 (10 個) → 32b (37 個) → 33 (72 個) → 34 (77 個) →
-  41 (83 個) → 39 (94 個) → 44 (99 個) → **40 (103 個)**
+  41 (83 個) → 39 (94 個) → 44 (99 個) → 40 (103 個) → **42 (115 個)**
 
 未完了の提案 6 / 40 / 42 / 43 / 45 / 46 を全完了で **130+ 個** に到達見込み。
 
@@ -1899,12 +1899,75 @@ CreatureEntity 直下に public で残存していた。
 
 ---
 
-## 提案 42: 旧差分検出キャッシュ (`old_*`) の private 化
+## 提案 42: 旧差分検出キャッシュ (`old_*`) の private 化 ✅ 完了
 
-**対象**: `old_race1/2` / `old_realm` / `old_food_aux` / `old_lite` / `old_monlite` /
-`old_heavy_*` / `old_icky_*` / `old_riding_*` / `old_spells` / `old_cumber_*` (10+ フィールド)
-**規模**: 主に `update_creature()` 内部のみで使用 — call site 集中
-**価値**: 「前回値スナップショット」の意味的グループ化
+### 背景
+
+CreatureEntity 直下に「前回値スナップショット」を保持する `old_*`
+フィールド 13 個 (内 1 個は実質デッド) が public で残存していた。
+これらは主に `update_creature()` / `put_equipment_warning()` /
+`monster-lite.cpp` 等で状態変化検出 (cumber/heavy_wield/icky_wield/
+riding 等のメッセージ出力タイミング判定) に使われ、savefile 経由でも
+一部 (old_race1/2 / old_realm) が永続化される。
+
+### 完了内容
+
+#### API 整備
+
+`CreatureEntity` に 25 個の virtual を追加:
+
+| メソッド | 役割 |
+|---|---|
+| `get_old_lite() / set_old_lite()` | 光源半径前回値 |
+| `get_old_race_flags1/2() / set_old_race_flags1/2()` | 種族変身履歴ビットマスク |
+| `get_old_realm() / set_old_realm()` | 魔法領域変更履歴 |
+| `get_old_spells() / set_old_spells()` | 学習可能呪文数前回値 |
+| `was_cumber_armor() / set_was_cumber_armor()` | 装備過重 (鎧) 前回値 |
+| `was_cumber_glove() / set_was_cumber_glove()` | 装備過重 (篭手) 前回値 |
+| `was_heavy_wield(hand) / set_was_heavy_wield(hand, value)` | 重武器装備前回値 |
+| `was_heavy_shoot() / set_was_heavy_shoot()` | 重弓装備前回値 |
+| `was_icky_wield(hand) / set_was_icky_wield(hand, value)` | 不適切武器装備前回値 |
+| `was_icky_riding_wield(hand) / set_was_icky_riding_wield(hand, value)` | 不適切騎乗武器前回値 |
+| `was_riding_ryoute() / set_was_riding_ryoute()` | 騎乗両手持ち前回値 |
+| `was_monlite() / set_was_monlite()` | モンスター光源照射前回値 |
+
+bool 系は意図明示のため `was_X()` 命名 (現在値は `is_X()`、前回値は
+`was_X()` で対称形)。
+
+#### 移行
+
+11 ファイル約 46 サイトを移行:
+
+- `player/player-status.cpp`: 最大の集約箇所 (cumber/heavy_wield/
+  icky_wield/icky_riding_wield/riding_ryoute/heavy_shoot/spells の
+  diff 検出)
+- `specific-object/torch.cpp`: old_lite
+- `monster-floor/monster-lite.cpp` / `mind/mind-ninja.cpp`: old_monlite
+- `pet/pet-util.cpp` / `pet/pet-fall-off.cpp` / `cmd-action/cmd-pet.cpp` /
+  `floor/floor-leaver.cpp`: old_riding_ryoute (騎乗解除時のリセット)
+- `load/player-info-loader.cpp` / `save/player-writer.cpp`: savefile
+  load/save (old_race1/2 / old_realm)
+- `io-dump/character-dump.cpp`: 種族・領域履歴ダンプ
+- `cmd-action/cmd-spell.cpp` / `status/shape-changer.cpp`:
+  履歴ビット追加 (`|= 1UL << X` 形式を `set(get() | ...)` に書換え)
+- `birth/birth-stat.cpp`: 履歴リセット (種族再生成時)
+
+#### Private 化と削除
+
+- 12 フィールド (`old_lite` / `old_race1` / `old_race2` / `old_realm` /
+  `old_spells` / `old_cumber_armor` / `old_cumber_glove` / `old_heavy_wield[2]` /
+  `old_heavy_shoot` / `old_icky_wield[2]` / `old_riding_wield[2]` /
+  `old_riding_ryoute` / `old_monlite`) を完全 private 化
+- `old_food_aux` を完全削除 (デッドフィールド、宣言以外で未使用)
+
+### 効果
+
+- **合計 private 化フィールド数: 103 → 115**
+- 差分検出キャッシュの読書きが意図明示形 (`was_X()` / `set_was_X()`) に
+  統一され、現在値と前回値の混同を防止
+- 将来モンスターでも独自の状態変化検出 (例: ペットモンスターの装備
+  変更通知) を行う場合の override 点を確保
+- デッドフィールド削除によりオブジェクトサイズ若干削減
 
 ---
 

--- a/src/birth/birth-stat.cpp
+++ b/src/birth/birth-stat.cpp
@@ -152,9 +152,9 @@ void get_extra(CreatureEntity &creature, bool roll_hitdie)
 
     /* Reset record of race/realm changes */
     InnerGameData::get_instance().set_start_race(creature.prace);
-    creature.old_race1 = 0L;
-    creature.old_race2 = 0L;
-    creature.old_realm = 0;
+    creature.set_old_race_flags1(0L);
+    creature.set_old_race_flags2(0L);
+    creature.set_old_realm(0);
 
     CreatureClass pc(creature);
     auto is_sorcerer = pc.equals(PlayerClassType::SORCERER);

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -223,7 +223,7 @@ bool do_cmd_riding(CreatureEntity &creature, bool force)
 
         creature.ride_monster(0);
         creature.remove_pet_extra_flag(PF_TWO_HANDS);
-        creature.old_riding_ryoute = false;
+        creature.set_was_riding_ryoute(false);
         creature.set_riding_ryoute(false);
     } else {
         if (cmd_limit_confused(creature)) {

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -685,7 +685,7 @@ static void change_realm2(CreatureEntity &creature, PlayerRealm &pr, RealmType n
     constexpr auto fmt_realm = _("魔法の領域を%sから%sに変更した。", "changed magic realm from %s to %s.");
     const auto mes = format(fmt_realm, pr.realm2().get_name().data(), PlayerRealm::get_name(next_realm).data());
     exe_write_diary(*creature.get_floor(), DiaryKind::DESCRIPTION, 0, mes);
-    creature.old_realm |= 1U << (enum2i(pr.realm2().to_enum()) - 1);
+    creature.set_old_realm(creature.get_old_realm() | (1U << (enum2i(pr.realm2().to_enum()) - 1)));
     pr.set(pr.realm1().to_enum(), next_realm);
 
     static constexpr auto flags = {

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -51,7 +51,7 @@ static void check_riding_preservation(CreatureEntity &creature)
     if (monster.has_parent()) {
         creature.ride_monster(0);
         creature.remove_pet_extra_flag(PF_TWO_HANDS);
-        creature.old_riding_ryoute = false;
+        creature.set_was_riding_ryoute(false);
         creature.set_riding_ryoute(false);
     } else {
         party_monsters[0] = monster;

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -370,7 +370,7 @@ static void dump_aux_monsters(FILE *fff)
  */
 static void dump_aux_race_history(CreatureEntity &creature, FILE *fff)
 {
-    if (!creature.old_race1 && !creature.old_race2) {
+    if (!creature.get_old_race_flags1() && !creature.get_old_race_flags2()) {
         return;
     }
 
@@ -381,11 +381,11 @@ static void dump_aux_race_history(CreatureEntity &creature, FILE *fff)
             continue;
         }
         if (i < 32) {
-            if (!(creature.old_race1 & 1UL << i)) {
+            if (!(creature.get_old_race_flags1() & 1UL << i)) {
                 continue;
             }
         } else {
-            if (!(creature.old_race2 & 1UL << (i - 32))) {
+            if (!(creature.get_old_race_flags2() & 1UL << (i - 32))) {
                 continue;
             }
         }
@@ -403,13 +403,13 @@ static void dump_aux_race_history(CreatureEntity &creature, FILE *fff)
  */
 static void dump_aux_realm_history(CreatureEntity &creature, FILE *fff)
 {
-    if (creature.old_realm == 0) {
+    if (creature.get_old_realm() == 0) {
         return;
     }
 
     fmt::print(fff, "\n");
     for (auto realm : MAGIC_REALM_RANGE) {
-        if (!(creature.old_realm & (1UL << (enum2i(realm) - 1)))) {
+        if (!(creature.get_old_realm() & (1UL << (enum2i(realm) - 1)))) {
             continue;
         }
         fmt::print(fff, _("\n あなたはかつて{}魔法を使えた。", "\n You were able to use {} magic before."), PlayerRealm::get_name(realm));

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -165,9 +165,9 @@ void rd_skills(CreatureEntity &creature)
 static void set_race(CreatureEntity &creature)
 {
     InnerGameData::get_instance().set_start_race(i2enum<PlayerRaceType>(rd_byte()));
-    creature.old_race1 = rd_u32b();
-    creature.old_race2 = rd_u32b();
-    creature.old_realm = rd_s16b();
+    creature.set_old_race_flags1(rd_u32b());
+    creature.set_old_race_flags2(rd_u32b());
+    creature.set_old_realm(rd_s16b());
 }
 
 void rd_bounty_uniques()

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -311,11 +311,11 @@ bool set_superstealth(CreatureEntity &creature, bool set)
         if (!ninja_data->s_stealth) {
             if (creature.get_floor()->grid_array[creature.y][creature.x].info & CAVE_MNLT) {
                 msg_print(_("敵の目から薄い影の中に覆い隠された。", "You are mantled in weak shadow from ordinary eyes."));
-                creature.old_monlite = true;
+                creature.set_was_monlite(true);
                 creature.set_monlite(true);
             } else {
                 msg_print(_("敵の目から影の中に覆い隠された！", "You are mantled in shadow from ordinary eyes!"));
-                creature.old_monlite = false;
+                creature.set_was_monlite(false);
                 creature.set_monlite(false);
             }
 

--- a/src/monster-floor/monster-lite.cpp
+++ b/src/monster-floor/monster-lite.cpp
@@ -300,12 +300,12 @@ void update_mon_lite(CreatureEntity &creature)
     creature.set_monlite((floor.get_grid(p_pos).info & CAVE_MNLT) != 0);
     const auto ninja_data = CreatureClass(creature).get_specific_data<ninja_data_type>();
     if (!ninja_data || !ninja_data->s_stealth) {
-        creature.old_monlite = creature.is_monlite();
+        creature.set_was_monlite(creature.is_monlite());
         return;
     }
 
-    if (creature.old_monlite == creature.is_monlite()) {
-        creature.old_monlite = creature.is_monlite();
+    if (creature.was_monlite() == creature.is_monlite()) {
+        creature.set_was_monlite(creature.is_monlite());
         return;
     }
 
@@ -315,5 +315,5 @@ void update_mon_lite(CreatureEntity &creature)
         msg_print(_("影の覆いが濃くなった！", "Your mantle of shadow is restored to its original darkness."));
     }
 
-    creature.old_monlite = creature.is_monlite();
+    creature.set_was_monlite(creature.is_monlite());
 }

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -146,7 +146,7 @@ bool process_fall_off_horse(CreatureEntity &creature, int dam, bool force)
 
     creature.ride_monster(0);
     creature.remove_pet_extra_flag(PF_TWO_HANDS);
-    creature.old_riding_ryoute = false;
+    creature.set_was_riding_ryoute(false);
     creature.set_riding_ryoute(false);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();

--- a/src/pet/pet-util.cpp
+++ b/src/pet/pet-util.cpp
@@ -26,7 +26,7 @@ bool can_player_ride_pet(CreatureEntity &creature, const Grid &grid, bool now_ri
     const auto old_character_xtra = world.character_xtra;
     const auto old_riding = creature.get_riding();
     const auto old_riding_two_hands = creature.is_riding_ryoute();
-    const auto old_old_riding_two_hands = creature.old_riding_ryoute;
+    const auto old_old_riding_two_hands = creature.was_riding_ryoute();
     const auto old_pf_two_hands = creature.has_pet_extra_flag(PF_TWO_HANDS);
     world.character_xtra = true;
 
@@ -35,7 +35,7 @@ bool can_player_ride_pet(CreatureEntity &creature, const Grid &grid, bool now_ri
     } else {
         creature.ride_monster(0);
         creature.remove_pet_extra_flag(PF_TWO_HANDS);
-        creature.old_riding_ryoute = false;
+        creature.set_was_riding_ryoute(false);
         creature.set_riding_ryoute(false);
     }
 
@@ -52,7 +52,7 @@ bool can_player_ride_pet(CreatureEntity &creature, const Grid &grid, bool now_ri
     }
 
     creature.set_riding_ryoute(old_riding_two_hands);
-    creature.old_riding_ryoute = old_old_riding_two_hands;
+    creature.set_was_riding_ryoute(old_old_riding_two_hands);
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(creature);
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -657,7 +657,7 @@ static void update_num_of_spells(CreatureEntity &creature)
         creature.new_spells = 0;
     }
 
-    if (creature.old_spells == creature.new_spells) {
+    if (creature.get_old_spells() == creature.new_spells) {
         return;
     }
 
@@ -673,7 +673,7 @@ static void update_num_of_spells(CreatureEntity &creature)
 #endif
     }
 
-    creature.old_spells = creature.new_spells;
+    creature.set_old_spells(creature.new_spells);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::STUDY);
     rfu.set_flag(SubWindowRedrawingFlag::ITEM_KNOWLEDGE);
@@ -919,17 +919,17 @@ static void update_max_mana(CreatureEntity &creature)
         return;
     }
 
-    if (creature.old_cumber_glove != creature.is_cumber_glove()) {
+    if (creature.was_cumber_glove() != creature.is_cumber_glove()) {
         if (creature.is_cumber_glove()) {
             msg_print(_("手が覆われて呪文が唱えにくい感じがする。", "Your covered hands feel unsuitable for spellcasting."));
         } else {
             msg_print(_("この手の状態なら、ぐっと呪文が唱えやすい感じだ。", "Your hands feel more suitable for spellcasting."));
         }
 
-        creature.old_cumber_glove = creature.is_cumber_glove();
+        creature.set_was_cumber_glove(creature.is_cumber_glove());
     }
 
-    if (creature.old_cumber_armor == creature.is_cumber_armor()) {
+    if (creature.was_cumber_armor() == creature.is_cumber_armor()) {
         return;
     }
 
@@ -939,7 +939,7 @@ static void update_max_mana(CreatureEntity &creature)
         msg_print(_("ぐっと楽に体を動かせるようになった。", "You feel able to move more freely."));
     }
 
-    creature.old_cumber_armor = creature.is_cumber_armor();
+    creature.set_was_cumber_armor(creature.is_cumber_armor());
 }
 
 /*!
@@ -1950,7 +1950,7 @@ static int16_t calc_riding_bow_penalty(CreatureEntity &creature)
 void put_equipment_warning(CreatureEntity &creature)
 {
     bool heavy_shoot = is_heavy_shoot(creature, creature.inventory[INVEN_BOW].get());
-    if (creature.old_heavy_shoot != heavy_shoot) {
+    if (creature.was_heavy_shoot() != heavy_shoot) {
         if (heavy_shoot) {
             msg_print(_("こんな重い弓を装備しているのは大変だ。", "You have trouble wielding such a heavy bow."));
         } else if (creature.inventory[INVEN_BOW]->is_valid()) {
@@ -1958,11 +1958,11 @@ void put_equipment_warning(CreatureEntity &creature)
         } else {
             msg_print(_("重い弓を装備からはずして体が楽になった。", "You feel relieved to put down your heavy bow."));
         }
-        creature.old_heavy_shoot = heavy_shoot;
+        creature.set_was_heavy_shoot(heavy_shoot);
     }
 
     for (int i = 0; i < 2; i++) {
-        if (creature.old_heavy_wield[i] != creature.is_heavy_wield(i)) {
+        if (creature.was_heavy_wield(i) != creature.is_heavy_wield(i)) {
             if (creature.is_heavy_wield(i)) {
                 msg_print(_("こんな重い武器を装備しているのは大変だ。", "You have trouble wielding such a heavy weapon."));
             } else if (has_melee_weapon(creature, INVEN_MAIN_HAND + i)) {
@@ -1973,10 +1973,10 @@ void put_equipment_warning(CreatureEntity &creature)
                 msg_print(_("重い武器を装備からはずして体が楽になった。", "You feel relieved to put down your heavy weapon."));
             }
 
-            creature.old_heavy_wield[i] = creature.is_heavy_wield(i);
+            creature.set_was_heavy_wield(i, creature.is_heavy_wield(i));
         }
 
-        if (creature.old_riding_wield[i] != creature.is_icky_riding_wield(i)) {
+        if (creature.was_icky_riding_wield(i) != creature.is_icky_riding_wield(i)) {
             if (creature.is_icky_riding_wield(i)) {
                 msg_print(_("この武器は乗馬中に使うにはむかないようだ。", "This weapon is not suitable for use while riding."));
             } else if (!creature.get_riding()) {
@@ -1985,10 +1985,10 @@ void put_equipment_warning(CreatureEntity &creature)
                 msg_print(_("これなら乗馬中にぴったりだ。", "This weapon is suitable for use while riding."));
             }
 
-            creature.old_riding_wield[i] = creature.is_icky_riding_wield(i);
+            creature.set_was_icky_riding_wield(i, creature.is_icky_riding_wield(i));
         }
 
-        if (creature.old_icky_wield[i] == creature.is_icky_wield(i)) {
+        if (creature.was_icky_wield(i) == creature.is_icky_wield(i)) {
             continue;
         }
 
@@ -2003,10 +2003,10 @@ void put_equipment_warning(CreatureEntity &creature)
             msg_print(_("装備をはずしたら随分と気が楽になった。", "You feel more comfortable after removing your weapon."));
         }
 
-        creature.old_icky_wield[i] = creature.is_icky_wield(i);
+        creature.set_was_icky_wield(i, creature.is_icky_wield(i));
     }
 
-    if (creature.get_riding() && (creature.old_riding_ryoute != creature.is_riding_ryoute())) {
+    if (creature.get_riding() && (creature.was_riding_ryoute() != creature.is_riding_ryoute())) {
         if (creature.is_riding_ryoute()) {
 #ifdef JP
             msg_format("%s馬を操れない。", (empty_hands(creature, false) == EMPTY_HAND_NONE) ? "両手がふさがっていて" : "");
@@ -2021,7 +2021,7 @@ void put_equipment_warning(CreatureEntity &creature)
 #endif
         }
 
-        creature.old_riding_ryoute = creature.is_riding_ryoute();
+        creature.set_was_riding_ryoute(creature.is_riding_ryoute());
     }
 
     CreatureClass pc(creature);

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -128,9 +128,9 @@ void wr_player(CreatureEntity &creature)
     std::visit(PlayerClassSpecificDataWriter(), creature.class_specific_data);
 
     wr_byte(static_cast<uint8_t>(InnerGameData::get_instance().get_start_race()));
-    wr_s32b(creature.old_race1);
-    wr_s32b(creature.old_race2);
-    wr_s16b(creature.old_realm);
+    wr_s32b(creature.get_old_race_flags1());
+    wr_s32b(creature.get_old_race_flags2());
+    wr_s16b(creature.get_old_realm());
 
     const auto &world = AngbandWorld::get_instance();
     for (const auto &[monrace_id, is_achieved] : world.bounties) {

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -119,7 +119,7 @@ void update_lite_radius(CreatureEntity &creature)
 
     creature.set_cur_lite(cur_lite);
 
-    if (creature.old_lite == cur_lite) {
+    if (creature.get_old_lite() == cur_lite) {
         return;
     }
 
@@ -129,7 +129,7 @@ void update_lite_radius(CreatureEntity &creature)
         StatusRecalculatingFlag::MONSTER_STATUSES,
     };
     RedrawingFlagsUpdater::get_instance().set_flags(flags);
-    creature.old_lite = cur_lite;
+    creature.set_old_lite(cur_lite);
     if (cur_lite > 0) {
         set_superstealth(creature, false);
     }

--- a/src/status/shape-changer.cpp
+++ b/src/status/shape-changer.cpp
@@ -63,9 +63,9 @@ void change_race(CreatureEntity &creature, PlayerRaceType new_race, concptr effe
 
     chg_virtue(creature, Virtue::CHANCE, 2);
     if (enum2i(creature.prace) < 32) {
-        creature.old_race1 |= 1UL << enum2i(creature.prace);
+        creature.set_old_race_flags1(creature.get_old_race_flags1() | (1UL << enum2i(creature.prace)));
     } else {
-        creature.old_race2 |= 1UL << (enum2i(creature.prace) - 32);
+        creature.set_old_race_flags2(creature.get_old_race_flags2() | (1UL << (enum2i(creature.prace) - 32)));
     }
 
     creature.prace = new_race;

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1459,6 +1459,114 @@ public:
         this->riding_t_m_idx = value;
     }
 
+    // [提案 42] 差分検出キャッシュ (old_*) の virtual API。
+    // update_creature() 系で 1 ターン前の値スナップショットを保持し、
+    // 状態変化検出 / メッセージ出力に使用される。
+    virtual POSITION get_old_lite() const
+    {
+        return this->old_lite;
+    }
+    virtual void set_old_lite(POSITION value)
+    {
+        this->old_lite = value;
+    }
+    virtual BIT_FLAGS get_old_race_flags1() const
+    {
+        return this->old_race1;
+    }
+    virtual void set_old_race_flags1(BIT_FLAGS value)
+    {
+        this->old_race1 = value;
+    }
+    virtual BIT_FLAGS get_old_race_flags2() const
+    {
+        return this->old_race2;
+    }
+    virtual void set_old_race_flags2(BIT_FLAGS value)
+    {
+        this->old_race2 = value;
+    }
+    virtual int16_t get_old_realm() const
+    {
+        return this->old_realm;
+    }
+    virtual void set_old_realm(int16_t value)
+    {
+        this->old_realm = value;
+    }
+    virtual int16_t get_old_spells() const
+    {
+        return this->old_spells;
+    }
+    virtual void set_old_spells(int16_t value)
+    {
+        this->old_spells = value;
+    }
+    virtual bool was_cumber_armor() const
+    {
+        return this->old_cumber_armor;
+    }
+    virtual void set_was_cumber_armor(bool value)
+    {
+        this->old_cumber_armor = value;
+    }
+    virtual bool was_cumber_glove() const
+    {
+        return this->old_cumber_glove;
+    }
+    virtual void set_was_cumber_glove(bool value)
+    {
+        this->old_cumber_glove = value;
+    }
+    virtual bool was_heavy_wield(int hand) const
+    {
+        return this->old_heavy_wield[hand];
+    }
+    virtual void set_was_heavy_wield(int hand, bool value)
+    {
+        this->old_heavy_wield[hand] = value;
+    }
+    virtual bool was_heavy_shoot() const
+    {
+        return this->old_heavy_shoot;
+    }
+    virtual void set_was_heavy_shoot(bool value)
+    {
+        this->old_heavy_shoot = value;
+    }
+    virtual bool was_icky_wield(int hand) const
+    {
+        return this->old_icky_wield[hand];
+    }
+    virtual void set_was_icky_wield(int hand, bool value)
+    {
+        this->old_icky_wield[hand] = value;
+    }
+    virtual bool was_icky_riding_wield(int hand) const
+    {
+        return this->old_riding_wield[hand];
+    }
+    virtual void set_was_icky_riding_wield(int hand, bool value)
+    {
+        this->old_riding_wield[hand] = value;
+    }
+    virtual bool was_riding_ryoute() const
+    {
+        return this->old_riding_ryoute;
+    }
+    virtual void set_was_riding_ryoute(bool value)
+    {
+        this->old_riding_ryoute = value;
+    }
+    virtual bool was_monlite() const
+    {
+        return this->old_monlite;
+    }
+    virtual void set_was_monlite(bool value)
+    {
+        this->old_monlite = value;
+    }
+
     /*!
      * @brief パック内の所持品数を inventory[] から計算する (提案 25)
      * @details inventory[0..INVEN_PACK) の有効アイテム数を返す。
@@ -3573,12 +3681,12 @@ private:
     int16_t food{}; /*!< ゲーム中の滋養度の型定義 / Current nutrition */
 
     // [提案 39] cur_lite は private 化済。get_cur_lite() / set_cur_lite() 経由。
-    // old_lite は差分検出キャッシュ。
+    // [提案 42] old_lite は private 化済。get_old_lite() / set_old_lite() 経由。
 private:
     POSITION cur_lite{}; /* Radius of lite (if any) */
+    POSITION old_lite{}; /* Radius of lite (if any) */
 
 public:
-    POSITION old_lite{}; /* Radius of lite (if any) */
     // [提案 33] private 化済。has_special_attack(flag) / add_special_attack(flag)
     // / remove_special_attack(flag) / set_special_attack_flags(BIT_FLAGS) /
     // get_special_attack_flags() 経由。
@@ -3722,10 +3830,14 @@ public:
     BIT_FLAGS8 knowledge{}; /* Knowledge about yourself */
     BIT_FLAGS visit{}; /* Visited towns */
 
+    // [提案 42] old_race1/2 / old_realm は private 化済。
+    // get_old_race_flags1/2() / set_old_race_flags1/2() / get_old_realm() / set_old_realm() 経由。
+private:
     BIT_FLAGS old_race1{}; /* Record of race changes */
     BIT_FLAGS old_race2{}; /* Record of race changes */
     int16_t old_realm{}; /* Record of realm changes */
 
+public:
     // [提案 40] ペット関連フィールドは private 化済。
     // get_pet_follow_distance() / set_pet_follow_distance() /
     // has_pet_extra_flag() / add_pet_extra_flag() / remove_pet_extra_flag() /
@@ -3755,9 +3867,13 @@ public:
     short tracking_bi_id{}; /* Object kind trackee */
 
     int16_t new_spells{}; /* Number of spells available */
-    int16_t old_spells{};
 
-    int16_t old_food_aux{}; /* Old value of food */
+    // [提案 42] 差分検出キャッシュ (old_*) は private 化済。
+    // get_old_spells() / set_old_spells() / was_cumber_armor() /
+    // set_was_cumber_armor() / was_heavy_wield(hand) / 等のアクセサ経由。
+    // old_food_aux は宣言以外で未使用のデッドフィールドだったため削除。
+private:
+    int16_t old_spells{};
 
     bool old_cumber_armor{};
     bool old_cumber_glove{};
@@ -3767,6 +3883,8 @@ public:
     bool old_riding_wield[2]{};
     bool old_riding_ryoute{};
     bool old_monlite{};
+
+public:
     int extra_blows[2]{};
 
     // [提案 39] 装備派生キャッシュフラグは private 化済。


### PR DESCRIPTION
CreatureEntity 直下に「前回値スナップショット」を保持する old_*
フィールドを private 化し、bool 系は意図明示形 was_X() / set_was_X() で公開して現在値 is_X() と対称化。

対象フィールド (12 個):
- old_lite (光源半径前回値)
- old_race1 / old_race2 (種族変身履歴ビットマスク)
- old_realm (魔法領域変更履歴)
- old_spells (学習可能呪文数前回値)
- old_cumber_armor / old_cumber_glove (装備過重前回値)
- old_heavy_wield[2] / old_heavy_shoot (重武器装備前回値)
- old_icky_wield[2] / old_riding_wield[2] (不適切武器装備前回値)
- old_riding_ryoute (騎乗両手持ち前回値)
- old_monlite (モンスター光源照射前回値)

削除フィールド:
- old_food_aux (宣言以外で一切未使用のデッドフィールド)

API (25 個の virtual):
- get_old_X() / set_old_X() (数値系)
- was_X() / set_was_X() (bool 系、現在値 is_X() と対称命名)

11 ファイル約 46 サイトを migration:
- player/player-status.cpp の put_equipment_warning() / 学習可能呪文 diff 検出 (cumber/heavy/icky/riding/spells の前回値比較)
- monster-floor/monster-lite.cpp / mind-ninja.cpp の old_monlite
- pet/pet-util.cpp / pet-fall-off.cpp / floor-leaver.cpp / cmd-action/cmd-pet.cpp の old_riding_ryoute (騎乗解除リセット)
- savefile load/save (old_race1/2 / old_realm)
- io-dump/character-dump.cpp の種族・領域履歴ダンプ
- cmd-spell.cpp / shape-changer.cpp / birth-stat.cpp (履歴ビット追加・ リセット、|= を set(get() | bit) に書換え)

合計 private 化フィールド数: 103 → 115