### PR TITLE
refactor: 行動状態フラグを private 化 (提案 43)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,6 +347,15 @@ API 経由に統一された。一部フィールド (r_idx / ap_r_idx / riding)
   明示のため `was_X()` / `set_was_X()` 命名) を整備し、11 ファイル
   約 46 サイトを migration。さらにデッドフィールド `old_food_aux`
   (宣言以外で未使用) を削除。**合計 private 化フィールド数: 103 → 115**
+- **提案 43**: 行動状態フラグ 14 個 (`action` / `running` / `resting` /
+  `fired` (旧 `is_fired`) / `level_up_message` / `timewalk` / `now_damaged` /
+  `playing` / `leaving` / `monk_notify_aux` / `teleport_town` / `yoiyami` /
+  `sutemi` / `fishing_dir`) を private 化。28 個の virtual API (scalar 系は
+  `get_X()` / `set_X()`、bool 系は意図明示のため `is_X()` / `has_X()` /
+  `set_X()` 命名) を整備し、73 ファイル約 180 サイトを migration。
+  メソッド名衝突回避のため `is_fired` フィールドを `fired` にリネーム。
+  `.action` / `.running` / `.leaving` の他構造体での同名フィールドは慎重に
+  除外。**合計 private 化フィールド数: 115 → 129**
 - **提案 1/2**: プレイヤー専用フィールドのモンスター運用化基盤完了。
   種族 (`prace`) / 職業 (`pclass`) / 魔法領域 (`realm1` / `realm2` /
   `element_realm`) / パトロン (`patron`) / 変身形態 (`mimic_form`)
@@ -726,6 +735,13 @@ bakabakaband 側と上流側でよくある構造的差異を以下のルール�
 | 同上書込 | `creature.set_was_heavy_wield(hand, X)` / `set_was_icky_wield(hand, X)` / `set_was_icky_riding_wield(hand, X)` (提案 42)、scalar bool は `set_was_X(value)` |
 | `creature.old_realm \|= 1U << X` / `old_race1 \|= ...` 単一ビット追加 | `creature.set_old_realm(creature.get_old_realm() \| (1U << X))` (提案 42。意味的な単純化のため raw 操作を保持) |
 | `creature.old_food_aux` | **提案 42 でフィールド削除** (デッドフィールドだった) |
+| `creature.action` 読取 / `creature.action = X` 書込 | `creature.get_action()` / `creature.set_action(X)` (提案 43)。`.action` を持つ他構造体 (TerrainCharacteristics / autopick / cmd / DungeonDefinition 等) は別物で migration 対象外 |
+| `creature.running` / `creature.resting` 読取 / 書込 | `creature.get_running()` / `set_running(X)` / `get_resting()` / `set_resting(X)` (提案 43)。`++` / `--` は `set_X(get_X() ± 1)` 形式に展開 |
+| `creature.is_fired` 読取 / 書込 | `creature.is_fired()` / `creature.set_is_fired(X)` (提案 43。**フィールド名を `is_fired` → `fired` にリネーム**) |
+| `creature.timewalk` / `creature.now_damaged` / `creature.playing` / `creature.leaving` / `creature.teleport_town` / `creature.sutemi` 読取 | `creature.is_timewalking()` / `is_now_damaged()` / `is_playing()` / `is_leaving()` / `is_teleport_town()` / `is_sutemi()` (提案 43) |
+| 同上書込 | `creature.set_timewalking(X)` / `set_now_damaged(X)` / `set_playing(X)` / `set_leaving(X)` / `set_teleport_town(X)` / `set_sutemi(X)` (提案 43) |
+| `creature.level_up_message` 読取 / 書込 | `creature.has_level_up_message()` / `set_level_up_message(X)` (提案 43) |
+| `creature.monk_notify_aux` / `creature.fishing_dir` / `creature.yoiyami` 読取 / 書込 | `creature.get_monk_notify_aux()` / `get_fishing_dir()` / `get_yoiyami()` / `set_X(value)` (提案 43)。yoiyami の `\|=` は `set_yoiyami(get_yoiyami() \| X)` |
 
 **GCC 固有の注意**:
 上流は MSVC 前提のことが多く、`<cstdint>` 等のインクルード漏れがあれば追加する。

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -62,14 +62,15 @@ Phase 1-8 完了後に残存している統合作業項目を整理したもの�
 | [40](#提案-40-ペット関連フィールドの-private-化--完了) | ペット関連フィールド private 化 | ✅ 完了 | **+4 = 103 個** (pet_extra_flags / pet_follow_distance 等、health_who 削除) |
 | [41](#提案-41-呪文マスク-spell_learnedworkedforgotten-の集約--完了) | 呪文マスク集約 (spell_learned/worked/forgotten) | ✅ 完了 | **+6 = 83 個**、realm_idx ベース API |
 | [42](#提案-42-旧差分検出キャッシュ-old_-の-private-化--完了) | 旧差分検出キャッシュ (`old_*`) private 化 | ✅ 完了 | **+12 = 115 個** (old_race1/2 / old_realm / old_cumber_* / old_heavy_* 等、old_food_aux 削除) |
-| [43](#提案-43-行動状態フラグの-private-化) | 行動状態フラグ private 化 | 🚧 | resting / running / action 等 |
+| [43](#提案-43-行動状態フラグの-private-化--完了) | 行動状態フラグ private 化 | ✅ 完了 | **+14 = 129 個** (action / running / resting / leaving / playing 等) |
 | [44](#提案-44-突然変異呪い系フラグの-private-化--完了) | 突然変異/呪い系フラグ private 化 | ✅ 完了 | **+5 = 99 個** (muta / cursed / patron 等) |
 | [45](#提案-45-pet_t_m_idx--riding_t_m_idx-系を-target-pos2d-に統合) | pet_t_m_idx / riding_t_m_idx 統合 | 🚧 | Pos2D ベース |
 | [46](#提案-46-esp--装備集計の差分検出を-update_creature-内-raw-access-に閉じる) | ESP / 装備集計の差分検出を内部に閉じる | 🚧 | get_X_flags() 公開撤廃検討 |
 
 **累計 private 化フィールド数 (主要マイルストーン):**
 - 提案 29 (3 個) → 32 (10 個) → 32b (37 個) → 33 (72 個) → 34 (77 個) →
-  41 (83 個) → 39 (94 個) → 44 (99 個) → 40 (103 個) → **42 (115 個)**
+  41 (83 個) → 39 (94 個) → 44 (99 個) → 40 (103 個) → 42 (115 個) →
+  **43 (129 個)**
 
 未完了の提案 6 / 40 / 42 / 43 / 45 / 46 を全完了で **130+ 個** に到達見込み。
 
@@ -1971,13 +1972,74 @@ bool 系は意図明示のため `was_X()` 命名 (現在値は `is_X()`、前�
 
 ---
 
-## 提案 43: 行動状態フラグの private 化
+## 提案 43: 行動状態フラグの private 化 ✅ 完了
 
-**対象**: `resting` / `running` / `action` / `fishing_dir` / `sutemi` / `yoiyami` /
-`timewalk` / `teleport_town` / `is_fired` / `leaving` / `playing` / `now_damaged` /
-`monk_notify_aux` / `last_message` / `level_up_message` (15+ フィールド)
-**規模**: access 多数 (`running` で 8 ファイル、`resting` で 4 等)
-**価値**: モンスター AI と共通化余地大 (徘徊・休息など)
+### 背景
+
+CreatureEntity 直下に「現在の行動状態」を示すスカラー / bool フラグが
+public で 14 個残存していた。プレイヤーの行動制御に使われるが、
+モンスター AI 共通化の余地がある (`resting` / `running` 相当の徘徊・
+休息ロジックなど)。
+
+### 完了内容
+
+#### API 整備
+
+`CreatureEntity` に 28 個の virtual を追加:
+
+| メソッド | 役割 |
+|---|---|
+| `get_action() / set_action()` | 常時行動 ID (ACTION_LEARN 等) |
+| `get_running() / set_running()` | 走行カウンタ |
+| `get_resting() / set_resting()` | 休息カウンタ (GAME_TURN) |
+| `is_fired() / set_is_fired()` | 発射済みフラグ (bool 値) |
+| `has_level_up_message() / set_level_up_message()` | レベルアップメッセージ表示要求 |
+| `is_timewalking() / set_timewalking()` | 時間停止中 |
+| `is_now_damaged() / set_now_damaged()` | 直近ダメージ受領 |
+| `is_playing() / set_playing()` | プレイ中フラグ |
+| `is_leaving() / set_leaving()` | フロア離脱中 |
+| `get_monk_notify_aux() / set_monk_notify_aux()` | 修行僧の重装備通知済フラグ |
+| `is_teleport_town() / set_teleport_town()` | 街へのテレポート要求 |
+| `get_yoiyami() / set_yoiyami()` | 宵闇 (BIT_FLAGS) |
+| `is_sutemi() / set_sutemi()` | 捨て身フラグ |
+| `get_fishing_dir() / set_fishing_dir()` | 釣り方向 |
+
+#### フィールドリネーム
+
+メソッド名衝突回避のためフィールドをリネーム:
+- `bool is_fired` → `bool fired` (メソッド `is_fired()` と衝突回避)
+
+#### 移行
+
+73 ファイル、約 180 サイトを migration:
+
+- `.action` 名前空間衝突への注意深い扱い:
+  `terrain.state[i].action` (TerrainCharacteristics) /
+  `autopick_list[idx].action` (autopick entries) /
+  `cmd.action(creature)` (text command 関数ポインタ) /
+  `dungeon.action` (DungeonDefinition 引数名) は全て CreatureEntity
+  ではないので migration 対象外として残置
+- `running` / `leaving` についても同様に CreatureEntity field のみ migration
+- `++` / `--` compound assignment は `set_X(get_X() + 1)` 形式に展開
+- `this->X` (CreatureEntity 派生メソッド内、`hp-mp-regenerator.cpp` /
+  `player-damage.cpp`) も `this->get_X()` / `this->set_X()` に migration
+
+#### Private 化
+
+14 フィールド (`action` / `running` / `resting` / `fired` /
+`level_up_message` / `timewalk` / `now_damaged` / `playing` / `leaving` /
+`monk_notify_aux` / `teleport_town` / `yoiyami` / `sutemi` / `fishing_dir`)
+を完全 private 化。
+
+### 効果
+
+- **合計 private 化フィールド数: 115 → 129**
+- 行動状態の更新が意図明示形 (`set_action(ACTION_LEARN)` /
+  `is_leaving()` 等) に統一され、外部からの意図しない書込みを型システムで防止
+- 将来モンスター AI で `resting` / `running` 相当の徘徊・休息ロジックを
+  共通化する設計余地を確保
+- `is_fired` のフィールド名衝突を回避することで、is_X() 系メソッドの
+  自然な命名規則を全フィールドに適用可能に
 
 ---
 

--- a/src/action/action-limited.cpp
+++ b/src/action/action-limited.cpp
@@ -100,7 +100,7 @@ bool cmd_limit_blind(CreatureEntity &creature)
 
 bool cmd_limit_time_walk(CreatureEntity &creature)
 {
-    if (creature.timewalk) {
+    if (creature.is_timewalking()) {
         if (flush_failure) {
             flush();
         }

--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -130,7 +130,7 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
                 creature.set_ambush_flag(false);
             }
 
-            creature.leaving = true;
+            creature.set_leaving(true);
             PlayerEnergy(creature).set_player_turn_energy(100);
             return;
         }
@@ -236,7 +236,7 @@ void exe_movement(CreatureEntity &creature, const Direction &dir, bool do_pickup
     } else if (terrain.flags.has_not(TerrainCharacteristics::MOVE) && terrain.flags.has(TerrainCharacteristics::CAN_FLY) && !creature.has_levitation()) {
         msg_format(_("空を飛ばないと%sの上には行けない。", "You need to fly to go through the %s."), grid.get_terrain(TerrainKind::MIMIC).name.data());
         energy.reset_player_turn();
-        creature.running = 0;
+        creature.set_running(0);
         can_move = false;
     } else if (terrain.flags.has(TerrainCharacteristics::TREE) && !p_can_kill_walls) {
         const auto riding_wild_wood = creature.get_riding() && riding_monrace.wilderness_flags.has(MonsterWildernessType::WILD_WOOD);

--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -379,7 +379,8 @@ void run_step(CreatureEntity &creature, const Direction &dir)
         }
     }
 
-    if (--creature.running <= 0) {
+    creature.set_running(creature.get_running() - 1);
+    if (creature.get_running() <= 0) {
         return;
     }
 

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -108,7 +108,7 @@ void player_wipe_without_name(CreatureEntity &creature)
     cheat_immortal = false;
 
     world.total_winner = false;
-    creature.timewalk = false;
+    creature.set_timewalking(false);
     auto &system = AngbandSystem::get_instance();
     system.set_panic_save(false);
 

--- a/src/blue-magic/blue-magic-checker.cpp
+++ b/src/blue-magic/blue-magic-checker.cpp
@@ -30,7 +30,7 @@
  */
 void learn_spell(CreatureEntity &creature, MonsterAbilityType monspell)
 {
-    if (creature.action != ACTION_LEARN) {
+    if (creature.get_action() != ACTION_LEARN) {
         return;
     }
 

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -126,7 +126,7 @@ void do_cmd_go_up(CreatureEntity &creature)
             creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, 0);
         }
 
-        creature.leaving = true;
+        creature.set_leaving(true);
         creature.oldpx = 0;
         creature.oldpy = 0;
         PlayerEnergy(creature).set_player_turn_energy(100);
@@ -208,7 +208,7 @@ void do_cmd_go_up(CreatureEntity &creature)
 
     sound(SoundKind::STAIRWAY);
 
-    creature.leaving = true;
+    creature.set_leaving(true);
 }
 
 /*!
@@ -272,7 +272,7 @@ void do_cmd_go_down(CreatureEntity &creature)
             creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, 0);
         }
 
-        creature.leaving = true;
+        creature.set_leaving(true);
         creature.oldpx = 0;
         creature.oldpy = 0;
         PlayerEnergy(creature).set_player_turn_energy(100);
@@ -366,7 +366,7 @@ void do_cmd_go_down(CreatureEntity &creature)
         sound(SoundKind::STAIRWAY);
     }
 
-    creature.leaving = true;
+    creature.set_leaving(true);
     if (is_fall_trap) {
         fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::DOWN, FloorChangeMode::RANDOM_PLACE, FloorChangeMode::RANDOM_CONNECT });
         return;
@@ -405,7 +405,7 @@ void do_cmd_walk(CreatureEntity &creature, bool pickup)
             energy.mul_player_turn_energy((MAX_HGT + MAX_WID) / 2);
         }
 
-        if (creature.action == ACTION_HAYAGAKE) {
+        if (creature.get_action() == ACTION_HAYAGAKE) {
             auto energy_use = (ENERGY)(creature.energy_use * (45 - (creature.get_level() / 2)) / 100);
             energy.set_player_turn_energy(energy_use);
         }
@@ -453,7 +453,7 @@ void do_cmd_run(CreatureEntity &creature)
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
     if (const auto dir = get_rep_dir(creature)) {
-        creature.running = (command_arg ? command_arg : 1000);
+        creature.set_running(command_arg ? command_arg : 1000);
         run_step(creature, dir);
     }
 }
@@ -550,8 +550,8 @@ void do_cmd_rest(CreatureEntity &creature)
     }
 
     creature.plus_incident_tree("REST", 1);
-    creature.resting = command_arg;
-    creature.action = ACTION_REST;
+    creature.set_resting(command_arg);
+    creature.set_action(ACTION_REST);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
     rfu.set_flag(MainWindowRedrawingFlag::ACTION);
@@ -620,7 +620,7 @@ void do_cmd_go_portal(CreatureEntity &creature)
     }
 
     // 階層移動処理
-    creature.leaving = true;
+    creature.set_leaving(true);
     floor.set_dungeon_index(target_dungeon);
 
     const auto &target_dungeon_info = dungeons.get_dungeon(target_dungeon);

--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -56,7 +56,7 @@ void do_cmd_search(CreatureEntity &creature)
     PlayerEnergy(creature).set_player_turn_energy(100);
     search(creature);
 
-    if (creature.action == ACTION_SEARCH) {
+    if (creature.get_action() == ACTION_SEARCH) {
         search(creature);
     }
 }
@@ -187,9 +187,9 @@ void do_cmd_suicide(CreatureEntity &creature)
     }
 
     creature.last_message = "";
-    creature.playing = false;
+    creature.set_playing(false);
     creature.is_dead_ = true;
-    creature.leaving = true;
+    creature.set_leaving(true);
     if (world.total_winner) {
         accept_winner_message(creature);
         world.add_retired_class(creature.pclass);

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -275,7 +275,7 @@ bool do_cmd_riding(CreatureEntity &creature, bool force)
             msg_format(_("%sを起こした。", "You have woken %s up."), m_name.data());
         }
 
-        if (creature.action == ACTION_MONK_STANCE) {
+        if (creature.get_action() == ACTION_MONK_STANCE) {
             set_action(creature, ACTION_NONE);
         }
 

--- a/src/cmd-action/cmd-shoot.cpp
+++ b/src/cmd-action/cmd-shoot.cpp
@@ -31,7 +31,7 @@ void do_cmd_fire(CreatureEntity &creature, SPELL_IDX snipe_type)
         return;
     }
 
-    creature.is_fired = false;
+    creature.set_is_fired(false);
     auto *bow_ptr = creature.inventory[INVEN_BOW].get();
     const auto tval = bow_ptr->bi_key.tval();
     if (tval == ItemKindType::NONE) {
@@ -63,7 +63,7 @@ void do_cmd_fire(CreatureEntity &creature, SPELL_IDX snipe_type)
     }
 
     exe_fire(creature, ammo_idx, bow_ptr, snipe_type);
-    if (!creature.is_fired || !CreatureClass(creature).equals(PlayerClassType::SNIPER)) {
+    if (!creature.is_fired() || !CreatureClass(creature).equals(PlayerClassType::SNIPER)) {
         return;
     }
 

--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -393,7 +393,7 @@ void do_cmd_building(CreatureEntity &creature)
         } else {
             fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::NO_RETURN });
             floor.inside_arena = false;
-            creature.leaving = true;
+            creature.set_leaving(true);
             command_new = SPECIAL_KEY_BUILDING;
             energy.reset_player_turn();
         }
@@ -406,7 +406,7 @@ void do_cmd_building(CreatureEntity &creature)
     auto &system = AngbandSystem::get_instance();
     if (system.is_phase_out()) {
         fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::NO_RETURN });
-        creature.leaving = true;
+        creature.set_leaving(true);
         system.set_phase_out(false);
         command_new = SPECIAL_KEY_BUILDING;
         energy.reset_player_turn();
@@ -457,7 +457,7 @@ void do_cmd_building(CreatureEntity &creature)
     msg_erase();
 
     if (reinit_wilderness) {
-        creature.leaving = true;
+        creature.set_leaving(true);
     }
 
     world.character_icky_depth--;

--- a/src/cmd-io/cmd-save.cpp
+++ b/src/cmd-io/cmd-save.cpp
@@ -50,7 +50,7 @@ void do_cmd_save_game(CreatureEntity &creature, int is_autosave)
  */
 void do_cmd_save_and_exit(CreatureEntity &creature)
 {
-    creature.playing = false;
-    creature.leaving = true;
+    creature.set_playing(false);
+    creature.set_leaving(true);
     exe_write_diary(*creature.get_floor(), DiaryKind::GAMESTART, 0, _("----ゲーム中断----", "--- Saved and Exited Game ---"));
 }

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -607,7 +607,7 @@ void exe_fire(CreatureEntity &creature, INVENTORY_IDX i_idx, ItemEntity *j_ptr, 
 
     /* Take a (partial) turn */
     PlayerEnergy(creature).div_player_turn_energy(thits);
-    creature.is_fired = true;
+    creature.set_is_fired(true);
 
     creature.plus_incident_tree("SHOOT", 1);
 

--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -245,7 +245,7 @@ bool input_check_strict(CreatureEntity &creature, std::string_view prompt, EnumC
     msg_erase();
 
     prt(buf, 0, 0);
-    if (mode.has_not(UserCheck::NO_HISTORY) && creature.playing) {
+    if (mode.has_not(UserCheck::NO_HISTORY) && creature.is_playing()) {
         message_add(buf);
         rfu.set_flag(SubWindowRedrawingFlag::MESSAGE);
         window_stuff(creature);

--- a/src/core/disturbance.cpp
+++ b/src/core/disturbance.cpp
@@ -29,12 +29,12 @@ void disturb(CreatureEntity &creature, bool stop_search, bool stop_travel)
         rfu.set_flag(MainWindowRedrawingFlag::ACTION);
     }
 
-    if ((creature.action == ACTION_REST) || (creature.action == ACTION_FISH) || (stop_search && (creature.action == ACTION_SEARCH))) {
+    if ((creature.get_action() == ACTION_REST) || (creature.get_action() == ACTION_FISH) || (stop_search && (creature.get_action() == ACTION_SEARCH))) {
         set_action(creature, ACTION_NONE);
     }
 
-    if (creature.running) {
-        creature.running = 0;
+    if (creature.get_running()) {
+        creature.set_running(0);
         if (center_player && !center_running) {
             verify_panel(creature);
         }

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -236,10 +236,10 @@ static void reset_world_info(CreatureEntity &creature)
 {
     auto &world = AngbandWorld::get_instance();
     world.creating_savefile = false;
-    creature.teleport_town = false;
-    creature.sutemi = false;
+    creature.set_teleport_town(false);
+    creature.set_sutemi(false);
     world.timewalk_m_idx = 0;
-    creature.now_damaged = false;
+    creature.set_now_damaged(false);
     now_message = 0;
     record_item_name.clear();
 }
@@ -335,7 +335,7 @@ static void init_riding_pet(CreatureEntity &creature, bool new_game)
 
 static void decide_arena_death(CreatureEntity &creature)
 {
-    if (!creature.playing || !creature.is_dead()) {
+    if (!creature.is_playing() || !creature.is_dead()) {
         return;
     }
 
@@ -370,9 +370,9 @@ static void decide_arena_death(CreatureEntity &creature)
     } else {
         entries.set_defeated_entry();
     }
-    creature.playing = false;
+    creature.set_playing(false);
     creature.is_dead_ = true;
-    creature.leaving = true;
+    creature.set_leaving(true);
 
     world.set_arena(true);
     reset_tim_flags(creature);
@@ -396,7 +396,7 @@ static void process_game_turn(CreatureEntity &creature)
         floor.forget_lite();
         floor.forget_view();
         floor.forget_mon_lite();
-        if (!creature.playing && !creature.is_dead()) {
+        if (!creature.is_playing() && !creature.is_dead()) {
             break;
         }
 
@@ -461,7 +461,7 @@ void play_game(CreatureEntity &creature, bool new_game, bool browsing_movie, std
     }
 
     generate_world(creature, new_game);
-    creature.playing = true;
+    creature.set_playing(true);
     reset_visuals(creature);
     load_all_pref_files(creature);
     if (new_game) {

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -78,7 +78,7 @@ static void process_fishing(CreatureEntity &creature)
         const auto r_idx = get_mon_num(creature, 0, level, PM_NONE);
         msg_erase();
         if (MonraceList::is_valid(r_idx) && one_in_(2)) {
-            const auto pos = creature.get_neighbor(creature.fishing_dir);
+            const auto pos = creature.get_neighbor(creature.get_fishing_dir());
             if (auto m_idx = place_specific_monster(creature, pos.y, pos.x, r_idx, PM_NO_KAGE)) {
                 const auto m_name = monster_desc(creature, floor.m_list[*m_idx], 0);
                 msg_print(_(format("%sが釣れた！", m_name.data()), "You have a good catch!"));
@@ -96,7 +96,7 @@ static void process_fishing(CreatureEntity &creature)
 
 bool continuous_action_running(CreatureEntity &creature)
 {
-    return creature.running || Travel::get_instance().is_ongoing() || command_rep || (creature.action == ACTION_REST) || (creature.action == ACTION_FISH);
+    return creature.get_running() || Travel::get_instance().is_ongoing() || command_rep || (creature.get_action() == ACTION_REST) || (creature.get_action() == ACTION_FISH);
 }
 
 /*!
@@ -154,19 +154,19 @@ void process_player(CreatureEntity &creature)
         stop_term_fresh();
     }
 
-    if (creature.resting < 0) {
-        if (creature.resting == COMMAND_ARG_REST_FULL_HEALING) {
+    if (creature.get_resting() < 0) {
+        if (creature.get_resting() == COMMAND_ARG_REST_FULL_HEALING) {
             if ((creature.hp == creature.maxhp) && (creature.get_csp() >= creature.get_msp())) {
                 set_action(creature, ACTION_NONE);
             }
-        } else if (creature.resting == COMMAND_ARG_REST_UNTIL_DONE) {
+        } else if (creature.get_resting() == COMMAND_ARG_REST_UNTIL_DONE) {
             if (creature.is_fully_healthy()) {
                 set_action(creature, ACTION_NONE);
             }
         }
     }
 
-    if (creature.action == ACTION_FISH) {
+    if (creature.get_action() == ACTION_FISH) {
         process_fishing(creature);
     }
 
@@ -232,7 +232,7 @@ void process_player(CreatureEntity &creature)
         rfu.set_flag(StatusRecalculatingFlag::BONUS);
     }
 
-    if (creature.action == ACTION_LEARN) {
+    if (creature.get_action() == ACTION_LEARN) {
         int32_t cost = 0L;
         uint32_t cost_frac = (creature.get_msp() + 30L) * 256L;
         s64b_lshift(&cost, &cost_frac, 16);
@@ -259,9 +259,9 @@ void process_player(CreatureEntity &creature)
     /*** Handle actual user input ***/
     while (creature.energy_need <= 0) {
         rfu.set_flag(SubWindowRedrawingFlag::PLAYER);
-        creature.sutemi = false;
+        creature.set_sutemi(false);
         creature.counter = false;
-        creature.now_damaged = false;
+        creature.set_now_damaged(false);
 
         update_monsters(creature, false);
         handle_stuff(creature);
@@ -285,10 +285,10 @@ void process_player(CreatureEntity &creature)
             process_command(creature);
         } else if ((is_paralyzed || is_knocked_out) && !cheat_immortal) {
             energy.set_player_turn_energy(100);
-        } else if (creature.action == ACTION_REST) {
-            if (creature.resting > 0) {
-                creature.resting--;
-                if (!creature.resting) {
+        } else if (creature.get_action() == ACTION_REST) {
+            if (creature.get_resting() > 0) {
+                creature.set_resting(creature.get_resting() - 1);
+                if (!creature.get_resting()) {
                     set_action(creature, ACTION_NONE);
                 }
 
@@ -296,9 +296,9 @@ void process_player(CreatureEntity &creature)
             }
 
             energy.set_player_turn_energy(100);
-        } else if (creature.action == ACTION_FISH) {
+        } else if (creature.get_action() == ACTION_FISH) {
             energy.set_player_turn_energy(100);
-        } else if (creature.running) {
+        } else if (creature.get_running()) {
             run_step(creature, Direction::none());
         } else if (auto &travel = Travel::get_instance(); travel.is_ongoing()) {
             travel.step(creature);
@@ -329,7 +329,7 @@ void process_player(CreatureEntity &creature)
 
         pack_overflow(creature);
         if (creature.energy_use) {
-            if (creature.timewalk || creature.energy_use > 400) {
+            if (creature.is_timewalking() || creature.energy_use > 400) {
                 creature.energy_need += creature.energy_use * TURNS_PER_TICK / 10;
             } else {
                 creature.energy_need += (int16_t)((int32_t)creature.energy_use * ENERGY_NEED() / 100L);
@@ -392,13 +392,13 @@ void process_player(CreatureEntity &creature)
                 rfu.set_flag(MainWindowRedrawingFlag::IMITATION);
             }
 
-            if (creature.action == ACTION_LEARN) {
+            if (creature.get_action() == ACTION_LEARN) {
                 auto mane_data = CreatureClass(creature).get_specific_data<bluemage_data_type>();
                 mane_data->new_magic_learned = false;
                 rfu.set_flag(MainWindowRedrawingFlag::ACTION);
             }
 
-            if (creature.timewalk && (creature.energy_need > -1000)) {
+            if (creature.is_timewalking() && (creature.energy_need > -1000)) {
                 rfu.set_flag(MainWindowRedrawingFlag::MAP);
                 rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
                 static constexpr auto flags_swrf = {
@@ -408,15 +408,15 @@ void process_player(CreatureEntity &creature)
                 rfu.set_flags(flags_swrf);
                 msg_print(_("「時は動きだす…」", "You feel time flowing around you once more."));
                 msg_erase();
-                creature.timewalk = false;
+                creature.set_timewalking(false);
                 creature.energy_need = ENERGY_NEED();
 
                 handle_stuff(creature);
             }
         }
 
-        if (!creature.playing || creature.is_dead()) {
-            creature.timewalk = false;
+        if (!creature.is_playing() || creature.is_dead()) {
+            creature.set_timewalking(false);
             break;
         }
 
@@ -425,7 +425,7 @@ void process_player(CreatureEntity &creature)
             reset_concentration(creature, true);
         }
 
-        if (creature.leaving) {
+        if (creature.is_leaving()) {
             break;
         }
     }
@@ -438,7 +438,7 @@ void process_player(CreatureEntity &creature)
  */
 void process_upkeep_with_speed(CreatureEntity &creature)
 {
-    if (!load && creature.enchant_energy_need > 0 && !creature.leaving) {
+    if (!load && creature.enchant_energy_need > 0 && !creature.is_leaving()) {
         creature.enchant_energy_need -= speed_to_energy(static_cast<byte>(creature.get_speed()));
     }
 

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -105,7 +105,7 @@ void process_dungeon(CreatureEntity &creature, bool load_game)
     auto &world = AngbandWorld::get_instance();
     floor.base_level = floor.dun_level;
     world.is_loading_now = false;
-    creature.leaving = false;
+    creature.set_leaving(false);
 
     command_cmd = 0;
     command_rep = 0;
@@ -178,7 +178,7 @@ void process_dungeon(CreatureEntity &creature, bool load_game)
         set_singing_song_effect(creature, MUSIC_DETECT);
     }
 
-    if (!creature.playing || creature.is_dead()) {
+    if (!creature.is_playing() || creature.is_dead()) {
         return;
     }
 
@@ -236,7 +236,7 @@ void process_dungeon(CreatureEntity &creature, bool load_game)
             term_fresh_force();
         }
 
-        if (!creature.playing || creature.is_dead()) {
+        if (!creature.is_playing() || creature.is_dead()) {
             break;
         }
 
@@ -248,7 +248,7 @@ void process_dungeon(CreatureEntity &creature, bool load_game)
             term_fresh_force();
         }
 
-        if (!creature.playing || creature.is_dead()) {
+        if (!creature.is_playing() || creature.is_dead()) {
             break;
         }
 
@@ -260,7 +260,7 @@ void process_dungeon(CreatureEntity &creature, bool load_game)
             term_fresh_force();
         }
 
-        if (!creature.playing || creature.is_dead() || wc_ptr->is_blown_away()) {
+        if (!creature.is_playing() || creature.is_dead() || wc_ptr->is_blown_away()) {
             break;
         }
 
@@ -276,7 +276,7 @@ void process_dungeon(CreatureEntity &creature, bool load_game)
 
         prevent_turn_overflow(creature);
 
-        if (creature.leaving) {
+        if (creature.is_leaving()) {
             break;
         }
 
@@ -289,7 +289,7 @@ void process_dungeon(CreatureEntity &creature, bool load_game)
         monrace_questor.misc_flags.reset(MonsterMiscType::QUESTOR);
     }
 
-    if (creature.playing && !creature.is_dead()) {
+    if (creature.is_playing() && !creature.is_dead()) {
         /*
          * Maintain Unique monsters and artifact, save current
          * floor, then prepare next floor

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -421,7 +421,7 @@ void exe_enter_quest(CreatureEntity &creature, QuestId quest_id)
         creature.get_floor()->dun_level = 1;
     }
     creature.get_floor()->quest_number = quest_id;
-    creature.leaving = true;
+    creature.set_leaving(true);
 }
 
 /*!

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -502,5 +502,5 @@ void jump_floor(CreatureEntity &creature, DungeonId dun_idx, DEPTH depth)
     PlayerEnergy(creature).reset_player_turn();
     creature.energy_need = 0;
     fcms->set(FloorChangeMode::FIRST_FLOOR);
-    creature.leaving = true;
+    creature.set_leaving(true);
 }

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -95,7 +95,7 @@ void pattern_teleport(CreatureEntity &creature)
 
     check_random_quest_auto_failure(creature);
 
-    creature.leaving = true;
+    creature.set_leaving(true);
 }
 
 /*!

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -549,7 +549,7 @@ void wilderness_gen(CreatureEntity &creature)
         }
     }
 
-    if (creature.teleport_town) {
+    if (creature.is_teleport_town()) {
         for (const auto &pos : floor.get_area()) {
             auto &grid = floor.get_grid(pos);
             const auto &terrain = grid.get_terrain();
@@ -569,7 +569,7 @@ void wilderness_gen(CreatureEntity &creature)
             creature.oldpx = pos.x;
         }
 
-        creature.teleport_town = false;
+        creature.set_teleport_town(false);
     } else if (floor.is_leaving_dungeon()) {
         for (const auto &pos : floor.get_area()) {
             auto &grid = floor.get_grid(pos);
@@ -585,7 +585,7 @@ void wilderness_gen(CreatureEntity &creature)
             creature.oldpx = pos.x;
         }
 
-        creature.teleport_town = false;
+        creature.set_teleport_town(false);
     }
 
     if (!creature.try_set_position(creature.get_old_position())) {
@@ -840,7 +840,7 @@ bool change_wild_mode(CreatureEntity &creature, bool encount)
 {
 
     generate_encounter = encount;
-    if (creature.leaving) {
+    if (creature.is_leaving()) {
         return false;
     }
 
@@ -855,7 +855,7 @@ bool change_wild_mode(CreatureEntity &creature, bool encount)
         wilderness.set_player_position(creature.get_position());
         creature.energy_need = 0;
         world.set_wild_mode(false);
-        creature.leaving = true;
+        creature.set_leaving(true);
         return true;
     }
 
@@ -898,6 +898,6 @@ bool change_wild_mode(CreatureEntity &creature, bool encount)
 
     set_action(creature, ACTION_NONE);
     world.set_wild_mode(true);
-    creature.leaving = true;
+    creature.set_leaving(true);
     return true;
 }

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -686,7 +686,7 @@ void update_flow(CreatureEntity &creature)
 
     /* The last way-point is on the map */
     const Pos2D flow(flow_y, flow_x);
-    if (creature.running && floor.contains(flow, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
+    if (creature.get_running() && floor.contains(flow, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
         /* The way point is in sight - do not update.  (Speedup) */
         if (floor.get_grid(flow).info & CAVE_VIEW) {
             return;

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -333,7 +333,7 @@ void hit_trap(CreatureEntity &creature, bool break_trap)
 
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 0, _("落とし戸に落ちた", "fell through a trap door!"));
         FloorChangeModesStore::get_instace()->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::DOWN, FloorChangeMode::RANDOM_PLACE, FloorChangeMode::RANDOM_CONNECT });
-        creature.leaving = true;
+        creature.set_leaving(true);
         break;
     }
     case TrapType::PIT:

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -405,7 +405,7 @@ void process_player_hp_mp(CreatureEntity &creature)
     regen_amount = compute_regen_amount(creature);
 
     upkeep_factor = calculate_upkeep(creature);
-    if ((creature.action == ACTION_LEARN) || (creature.action == ACTION_HAYAGAKE) || pc.samurai_stance_is(SamuraiStanceType::KOUKIJIN)) {
+    if ((creature.get_action() == ACTION_LEARN) || (creature.get_action() == ACTION_HAYAGAKE) || pc.samurai_stance_is(SamuraiStanceType::KOUKIJIN)) {
         upkeep_factor += 100;
     }
 

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -55,7 +55,7 @@ int compute_regen_amount(CreatureEntity &creature)
 
     regen_amount = creature.apply_state_regen_modifier(regen_amount);
 
-    if ((creature.action == ACTION_SEARCH) || (creature.action == ACTION_REST)) {
+    if ((creature.get_action() == ACTION_SEARCH) || (creature.get_action() == ACTION_REST)) {
         regen_amount = regen_amount * 2;
     }
 
@@ -78,7 +78,7 @@ bool PlayerType::should_skip_natural_regen() const
     if (pc.samurai_stance_is(SamuraiStanceType::KOUKIJIN)) {
         return true;
     }
-    return this->action == ACTION_HAYAGAKE;
+    return this->get_action() == ACTION_HAYAGAKE;
 }
 
 int PlayerType::get_base_natural_regen_amount() const
@@ -121,7 +121,7 @@ void regenhp(CreatureEntity &creature, int percent)
     if (CreatureClass(creature).samurai_stance_is(SamuraiStanceType::KOUKIJIN)) {
         return;
     }
-    if (creature.action == ACTION_HAYAGAKE) {
+    if (creature.get_action() == ACTION_HAYAGAKE) {
         return;
     }
 

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -476,7 +476,7 @@ static void curse_megaton_coin(CreatureEntity &creature)
         FloorChangeMode::RANDOM_PLACE,
         FloorChangeMode::RANDOM_CONNECT });
 
-    creature.leaving = true;
+    creature.set_leaving(true);
 }
 
 static void occur_curse_effects(CreatureEntity &creature)

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -303,7 +303,7 @@ void process_command(CreatureEntity &creature)
         break;
     }
     case 'S': {
-        if (creature.action == ACTION_SEARCH) {
+        if (creature.get_action() == ACTION_SEARCH) {
             set_action(creature, ACTION_NONE);
         } else {
             set_action(creature, ACTION_SEARCH);

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -345,7 +345,7 @@ static void interpret_xy_token(CreatureEntity &creature, std::string_view buf)
 
         int os = option.flag_position;
         int ob = option.offset;
-        if ((creature.playing || world.character_xtra) && (GameOptionPage::BIRTH == option.page) && !world.wizard) {
+        if ((creature.is_playing() || world.character_xtra) && (GameOptionPage::BIRTH == option.page) && !world.wizard) {
             msg_print(_("初期オプションは変更できません! '{}'", "Birth options can not be changed! '{}'"), buf);
             msg_erase();
             return;

--- a/src/io/signal-handlers.cpp
+++ b/src/io/signal-handlers.cpp
@@ -82,11 +82,11 @@ static void handle_signal_simple(int sig)
         floor.forget_lite();
         floor.forget_view();
         floor.forget_mon_lite();
-        creature.playing = false;
+        creature.set_playing(false);
         if (!cheat_immortal) {
             creature.is_dead_ = true;
         }
-        creature.leaving = true;
+        creature.set_leaving(true);
         close_game(creature);
         quit(_("強制終了", "interrupt"));
     } else if (signal_count >= 4) {

--- a/src/load/load-zangband.cpp
+++ b/src/load/load-zangband.cpp
@@ -6,6 +6,6 @@
 void set_zangband_action(CreatureEntity &creature)
 {
     if (rd_byte() != 0) {
-        creature.action = ACTION_LEARN;
+        creature.set_action(ACTION_LEARN);
     }
 }

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -127,7 +127,7 @@ static void load_player_world(CreatureEntity &creature)
     rd_extra(creature);
 
     if (creature.energy_need < -999) {
-        creature.timewalk = true;
+        creature.set_timewalking(true);
     }
 
     load_note(_("特別情報をロードしました", "Loaded extra information"));

--- a/src/load/player-attack-loader.cpp
+++ b/src/load/player-attack-loader.cpp
@@ -17,12 +17,12 @@ void rd_special_attack(CreatureEntity &creature)
 void rd_special_action(CreatureEntity &creature)
 {
     if (!CreatureClass(creature).monk_stance_is(MonkStanceType::NONE)) {
-        creature.action = ACTION_MONK_STANCE;
+        creature.set_action(ACTION_MONK_STANCE);
         return;
     }
 
     if (!CreatureClass(creature).samurai_stance_is(SamuraiStanceType::NONE)) {
-        creature.action = ACTION_SAMURAI_STANCE;
+        creature.set_action(ACTION_SAMURAI_STANCE);
     }
 }
 
@@ -35,6 +35,6 @@ void rd_special_defense(CreatureEntity &creature)
 void rd_action(CreatureEntity &creature)
 {
     strip_bytes(1);
-    creature.action = rd_byte();
+    creature.set_action(rd_byte());
     set_zangband_action(creature);
 }

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -158,7 +158,7 @@ void rd_skills(CreatureEntity &creature)
     std::visit(PlayerClassSpecificDataLoader(), creature.class_specific_data);
 
     if (music_singing_any(creature)) {
-        creature.action = ACTION_SING;
+        creature.set_action(ACTION_SING);
     }
 }
 

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -66,7 +66,7 @@ static bool check_battle_metal_babble(CreatureEntity &creature)
     reset_tim_flags(creature);
     FloorChangeModesStore::get_instace()->set(FloorChangeMode::SAVE_FLOORS);
     creature.get_floor()->inside_arena = true;
-    creature.leaving = true;
+    creature.set_leaving(true);
     return true;
 }
 
@@ -104,7 +104,7 @@ static bool go_to_arena(CreatureEntity &creature)
     reset_tim_flags(creature);
     FloorChangeModesStore::get_instace()->set(FloorChangeMode::SAVE_FLOORS);
     creature.get_floor()->inside_arena = true;
-    creature.leaving = true;
+    creature.set_leaving(true);
     return true;
 }
 

--- a/src/market/melee-arena.cpp
+++ b/src/market/melee-arena.cpp
@@ -109,7 +109,7 @@ bool melee_arena_comm(CreatureEntity &creature)
 
     FloorChangeModesStore::get_instace()->set(FloorChangeMode::SAVE_FLOORS);
     AngbandSystem::get_instance().set_phase_out(true);
-    creature.leaving = true;
+    creature.set_leaving(true);
     screen_load();
     return true;
 }

--- a/src/melee/melee-spell-flags-checker.cpp
+++ b/src/melee/melee-spell-flags-checker.cpp
@@ -358,7 +358,7 @@ static bool set_melee_spell_set(CreatureEntity &creature, melee_spell_type *ms_p
 
     EnumClassFlagGroup<MonsterAbilityType>::get_flags(ms_ptr->ability_flags, std::back_inserter(ms_ptr->spells));
 
-    return !ms_ptr->spells.empty() && creature.playing && !creature.is_dead() && !creature.leaving;
+    return !ms_ptr->spells.empty() && creature.is_playing() && !creature.is_dead() && !creature.is_leaving();
 }
 
 bool check_melee_spell_set(CreatureEntity &creature, melee_spell_type *ms_ptr)

--- a/src/mind/mind-monk.cpp
+++ b/src/mind/mind-monk.cpp
@@ -61,7 +61,7 @@ bool choose_monk_stance(CreatureEntity &creature)
         }
 
         if ((choice == 'a') || (choice == 'A')) {
-            if (creature.action == ACTION_MONK_STANCE) {
+            if (creature.get_action() == ACTION_MONK_STANCE) {
                 set_action(creature, ACTION_NONE);
             } else {
                 msg_print(_("もともと構えていない。", "You are not in a special stance."));

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -274,7 +274,7 @@ void calc_surprise_attack_damage(CreatureEntity &creature, player_attack_type *p
 bool hayagake(CreatureEntity &creature)
 {
     PlayerEnergy energy(creature);
-    if (creature.action == ACTION_HAYAGAKE) {
+    if (creature.get_action() == ACTION_HAYAGAKE) {
         set_action(creature, ACTION_NONE);
         energy.reset_player_turn();
         return true;

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -404,7 +404,7 @@ bool choose_samurai_stance(CreatureEntity &creature)
             screen_load();
             return false;
         } else if ((choice == 'a') || (choice == 'A')) {
-            if (creature.action == ACTION_SAMURAI_STANCE) {
+            if (creature.get_action() == ACTION_SAMURAI_STANCE) {
                 set_action(creature, ACTION_NONE);
             } else {
                 msg_print(_("もともと構えていない。", "You are not in a special stance."));
@@ -468,7 +468,7 @@ int calc_attack_quality(CreatureEntity &creature, player_attack_type *pa_ptr)
         chance += 150;
     }
 
-    if (creature.sutemi) {
+    if (creature.is_sutemi()) {
         chance = std::max(chance * 3 / 2, chance + 60);
     }
 

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -607,7 +607,7 @@ static bool cast_sniper_spell(CreatureEntity &creature, int spell)
     command_cmd = 'f';
     do_cmd_fire(creature, snipe_type);
 
-    return creature.is_fired;
+    return creature.is_fired();
 }
 
 /*!

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -266,7 +266,7 @@ bool MonsterAttackPlayer::check_monster_continuous_attack()
     }
 
     const auto is_neighbor = Grid::calc_distance(creature.get_position(), this->m_ptr->get_position()) <= 1;
-    return creature.playing && !creature.is_dead() && is_neighbor && !creature.leaving;
+    return creature.is_playing() && !creature.is_dead() && is_neighbor && !creature.is_leaving();
 }
 
 /*!

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -1594,7 +1594,7 @@ void sweep_monster_process(CreatureEntity &creature)
     for (const auto m_idx : valid_m_idx_list) {
         auto &monster = floor.get_monster(m_idx);
 
-        if (creature.leaving) {
+        if (creature.is_leaving()) {
             return;
         }
 
@@ -1675,7 +1675,7 @@ void sweep_monster_process(CreatureEntity &creature)
             monster.set_constant_flag(MonsterConstantFlagType::NOFLOW);
         }
 
-        if (!creature.playing || creature.is_dead() || creature.leaving) {
+        if (!creature.is_playing() || creature.is_dead() || creature.is_leaving()) {
             return;
         }
     }

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -169,7 +169,7 @@ static bool check_mspell_continuation(CreatureEntity &creature, msa_type *msa_pt
     }
 
     set_mspell_list(msa_ptr);
-    if (msa_ptr->mspells.empty() || !creature.playing || creature.is_dead() || creature.leaving) {
+    if (msa_ptr->mspells.empty() || !creature.is_playing() || creature.is_dead() || creature.is_leaving()) {
         return false;
     }
 

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -100,7 +100,7 @@ static void dispel_player(CreatureEntity &creature)
             msg_print(_("呪文が途切れた。", "Your casting is interrupted."));
         }
 
-        creature.action = ACTION_NONE;
+        creature.set_action(ACTION_NONE);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         static constexpr auto flags_srf = {
             StatusRecalculatingFlag::BONUS,

--- a/src/object-activation/activation-teleport.cpp
+++ b/src/object-activation/activation-teleport.cpp
@@ -52,7 +52,7 @@ bool activate_escape(CreatureEntity &creature)
             do_cmd_save_game(creature, true);
         }
 
-        creature.leaving = true;
+        creature.set_leaving(true);
         return true;
     }
 }

--- a/src/object-use/quaff/quaff-execution.cpp
+++ b/src/object-use/quaff/quaff-execution.cpp
@@ -108,7 +108,7 @@ bool ObjectQuaffEntity::can_influence()
 
 bool ObjectQuaffEntity::can_quaff()
 {
-    if (this->creature.timewalk) {
+    if (this->creature.is_timewalking()) {
         if (flush_failure) {
             flush();
         }

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -425,7 +425,7 @@ bool CreatureClass::lose_balance()
         MainWindowRedrawingFlag::TIMED_EFFECT,
     };
     rfu.set_flags(flags_mwrf);
-    creature.action = ACTION_NONE;
+    creature.set_action(ACTION_NONE);
     return true;
 }
 

--- a/src/player-info/self-info.cpp
+++ b/src/player-info/self-info.cpp
@@ -259,7 +259,7 @@ void self_knowledge(CreatureEntity &subject)
     set_curse_info(subject, self_ptr);
     set_body_improvement_info_1(subject, self_ptr);
     set_special_attack_info(subject, self_ptr);
-    switch (subject.action) {
+    switch (subject.get_action()) {
     case ACTION_SEARCH:
         self_ptr->info_list.emplace_back(_("あなたはひじょうに注意深く周囲を見渡している。", "You are looking around very carefully."));
         break;

--- a/src/player-status/player-speed.cpp
+++ b/src/player-status/player-speed.cpp
@@ -339,7 +339,7 @@ int16_t PlayerSpeed::inventory_weight_bonus()
 int16_t PlayerSpeed::action_bonus()
 {
     int16_t bonus = 0;
-    if (this->creature.action == ACTION_SEARCH) {
+    if (this->creature.get_action() == ACTION_SEARCH) {
         bonus -= 10;
     }
 

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -304,7 +304,7 @@ int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_
         return 0;
     }
 
-    if (creature.sutemi) {
+    if (creature.is_sutemi()) {
         damage *= 2;
     }
 
@@ -315,7 +315,7 @@ int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_
     if (damage_type != DAMAGE_USELIFE) {
         disturb(creature, true, true);
         if (auto_more) {
-            creature.now_damaged = true;
+            creature.set_now_damaged(true);
         }
     }
 
@@ -383,7 +383,7 @@ int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_
         }
 
         if (auto_more) {
-            creature.now_damaged = true;
+            creature.set_now_damaged(true);
         }
 
         msg_print(_("*** 警告:低ヒット・ポイント！ ***", "*** LOW HITPOINT WARNING! ***"));
@@ -391,7 +391,7 @@ int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_
         flush();
     }
 
-    if (world.is_wild_mode() && !creature.leaving && (creature.hp < std::max(hp_warning_threshold, creature.maxhp / 5))) {
+    if (world.is_wild_mode() && !creature.is_leaving() && (creature.hp < std::max(hp_warning_threshold, creature.maxhp / 5))) {
         change_wild_mode(creature, false);
     }
 
@@ -477,7 +477,7 @@ void PlayerType::on_death(std::string_view cause)
     sound(SoundKind::DEATH);
     chg_virtue(*this, Virtue::SACRIFICE, 10);
     handle_stuff(*this);
-    this->leaving = true;
+    this->set_leaving(true);
     this->is_dead_ = true;
 
     const auto &floor = *this->get_floor();

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -200,7 +200,7 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
         }
 
         using Tc = TerrainCharacteristics;
-        if ((creature.action == ACTION_HAYAGAKE) && (terrain_new.flags.has_not(Tc::PROJECTION) || (!creature.has_levitation() && terrain_new.flags.has(Tc::DEEP)))) {
+        if ((creature.get_action() == ACTION_HAYAGAKE) && (terrain_new.flags.has_not(Tc::PROJECTION) || (!creature.has_levitation() && terrain_new.flags.has(Tc::DEEP)))) {
             msg_print(_("ここでは素早く動けない。", "You cannot run in here."));
             set_action(creature, ACTION_NONE);
         }
@@ -222,7 +222,7 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
     if (mpe_mode & MPE_ENERGY_USE) {
         if (music_singing(creature, MUSIC_WALL)) {
             (void)project(creature, 0, 0, creature.y, creature.x, (60 + creature.get_level()), AttributeType::DISINTEGRATE, PROJECT_KILL | PROJECT_ITEM);
-            if (!creature.is_located_at(pos) || creature.is_dead() || creature.leaving) {
+            if (!creature.is_located_at(pos) || creature.is_dead() || creature.is_leaving()) {
                 return false;
             }
         }
@@ -231,7 +231,7 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
             search(creature);
         }
 
-        if (creature.action == ACTION_SEARCH) {
+        if (creature.get_action() == ACTION_SEARCH) {
             search(creature);
         }
     }
@@ -241,7 +241,7 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
     }
 
     // 自動拾い/自動破壊により床上のアイテムリストが変化した可能性があるので表示を更新
-    if (!creature.running) {
+    if (!creature.get_running()) {
         static constexpr auto flags_swrf = {
             SubWindowRedrawingFlag::FLOOR_ITEMS,
             SubWindowRedrawingFlag::FOUND_ITEMS,
@@ -276,7 +276,7 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
         }
         creature.oldpx = 0;
         creature.oldpy = 0;
-        creature.leaving = true;
+        creature.set_leaving(true);
     } else if (terrain_new.flags.has(TerrainCharacteristics::HIT_TRAP) && !(mpe_mode & MPE_STAYING)) {
         disturb(creature, false, true);
         if (grid_new.mimic || terrain_new.flags.has(TerrainCharacteristics::SECRET)) {
@@ -285,7 +285,7 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
         }
 
         hit_trap(creature, any_bits(mpe_mode, MPE_BREAK_TRAP));
-        if (!creature.is_located_at(pos) || creature.is_dead() || creature.leaving) {
+        if (!creature.is_located_at(pos) || creature.is_dead() || creature.is_leaving()) {
             return false;
         }
     }
@@ -303,7 +303,7 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
         }
     }
 
-    return creature.is_located_at(pos) && !creature.is_dead() && !creature.leaving;
+    return creature.is_located_at(pos) && !creature.is_dead() && !creature.is_leaving();
 }
 
 /*!

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -283,7 +283,7 @@ static void update_bonuses(CreatureEntity &creature)
     creature.set_bless_blade(has_bless_blade(creature));
     creature.easy_2weapon = creature.has_easy2_weapon();
     creature.down_saving = creature.has_down_saving();
-    creature.yoiyami = creature.has_no_ac();
+    creature.set_yoiyami(creature.has_no_ac());
     creature.set_mighty_throw(has_mighty_throw(creature));
     creature.set_dec_mana(has_dec_mana(creature));
     creature.set_see_nocto(has_see_nocto(creature));
@@ -467,7 +467,7 @@ static void update_max_hitpoints(CreatureEntity &creature)
     }
 
 #ifdef JP
-    if (creature.level_up_message && (mhp > creature.maxhp)) {
+    if (creature.has_level_up_message() && (mhp > creature.maxhp)) {
         msg_format("最大ヒット・ポイントが %d 増加した！", (mhp - creature.maxhp));
     }
 #endif
@@ -901,7 +901,7 @@ static void update_max_mana(CreatureEntity &creature)
         }
 
 #ifdef JP
-        if (creature.level_up_message && (msp > creature.get_msp())) {
+        if (creature.has_level_up_message() && (msp > creature.get_msp())) {
             msg_format("最大マジック・ポイントが %d 増加した！", (msp - creature.get_msp()));
         }
 #endif
@@ -1624,7 +1624,7 @@ static int16_t calc_to_magic_chance(CreatureEntity &creature)
 static ARMOUR_CLASS calc_base_ac(CreatureEntity &creature)
 {
     ARMOUR_CLASS ac = 0;
-    if (creature.yoiyami) {
+    if (creature.get_yoiyami()) {
         return 0;
     }
 
@@ -1672,7 +1672,7 @@ static ARMOUR_CLASS calc_base_ac(CreatureEntity &creature)
 static ARMOUR_CLASS calc_to_ac(CreatureEntity &creature, bool is_real_value)
 {
     ARMOUR_CLASS ac = 0;
-    if (creature.yoiyami) {
+    if (creature.get_yoiyami()) {
         return 0;
     }
 
@@ -2025,7 +2025,7 @@ void put_equipment_warning(CreatureEntity &creature)
     }
 
     CreatureClass pc(creature);
-    if ((pc.is_martial_arts_pro() || pc.equals(PlayerClassType::NINJA)) && (heavy_armor(creature) != creature.monk_notify_aux)) {
+    if ((pc.is_martial_arts_pro() || pc.equals(PlayerClassType::NINJA)) && (heavy_armor(creature) != creature.get_monk_notify_aux())) {
         if (heavy_armor(creature)) {
             msg_print(_("装備が重くてバランスを取れない。", "The weight of your armor disrupts your balance."));
             if (AngbandWorld::get_instance().is_loading_now) {
@@ -2035,7 +2035,7 @@ void put_equipment_warning(CreatureEntity &creature)
             msg_print(_("バランスがとれるようになった。", "You regain your balance."));
         }
 
-        creature.monk_notify_aux = heavy_armor(creature);
+        creature.set_monk_notify_aux(heavy_armor(creature));
     }
 }
 
@@ -2862,10 +2862,10 @@ void check_experience(CreatureEntity &creature)
             SubWindowRedrawingFlag::INVENTORY,
         };
         rfu.set_flags(flags_swrf_levelup);
-        creature.level_up_message = true;
+        creature.set_level_up_message(true);
         handle_stuff(creature);
 
-        creature.level_up_message = false;
+        creature.set_level_up_message(false);
         if (level_inc_stat) {
             if (!(creature.get_max_plv() % 10)) {
                 int choice;

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -252,7 +252,7 @@ bool switch_class_racial_execution(CreatureEntity &creature, const int32_t comma
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
         return true;
     case PlayerClassType::BLUE_MAGE:
-        set_action(creature, creature.action == ACTION_LEARN ? ACTION_NONE : ACTION_LEARN);
+        set_action(creature, creature.get_action() == ACTION_LEARN ? ACTION_NONE : ACTION_LEARN);
         PlayerEnergy(creature).reset_player_turn();
         return true;
     case PlayerClassType::CAVALRY:

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -739,7 +739,7 @@ tl::optional<std::string> do_hex_spell(CreatureEntity &creature, spell_hex_type 
     if (cast && should_continue) {
         SpellHex spell_hex(creature);
         spell_hex.set_casting_flag(spell);
-        if (creature.action != ACTION_SPELL) {
+        if (creature.get_action() != ACTION_SPELL) {
             set_action(creature, ACTION_SPELL);
         }
     }

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -384,7 +384,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
                 return tl::nullopt;
             }
-            creature.sutemi = true;
+            creature.set_sutemi(true);
         }
         break;
 

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -297,7 +297,7 @@ void wr_player(CreatureEntity &creature)
     wr_byte(creature.knowledge);
     wr_bool(creature.autopick_autoregister);
     wr_byte(0);
-    wr_byte((byte)creature.action);
+    wr_byte((byte)creature.get_action());
     wr_byte(0);
     wr_bool(preserve_mode);
     wr_bool(system.is_awaiting_report_status());

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -156,7 +156,7 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
             fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::UP, FloorChangeMode::RANDOM_PLACE, FloorChangeMode::RANDOM_CONNECT });
             leave_quest_check(creature);
             floor.quest_number = QuestId::NONE;
-            creature.leaving = true;
+            creature.set_leaving(true);
         }
     } else if (go_up) {
 #ifdef JP
@@ -179,7 +179,7 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
             }
 
             fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::UP, FloorChangeMode::RANDOM_PLACE, FloorChangeMode::RANDOM_CONNECT });
-            creature.leaving = true;
+            creature.set_leaving(true);
         }
     } else {
 #ifdef JP
@@ -201,7 +201,7 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
             }
 
             fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::DOWN, FloorChangeMode::RANDOM_PLACE, FloorChangeMode::RANDOM_CONNECT });
-            creature.leaving = true;
+            creature.set_leaving(true);
         }
     }
 
@@ -329,8 +329,8 @@ bool tele_town(CreatureEntity &creature)
         }
     }
 
-    creature.leaving = true;
-    creature.teleport_town = true;
+    creature.set_leaving(true);
+    creature.set_teleport_town(true);
     screen_load();
     return true;
 }

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -55,7 +55,7 @@ void SpellHex::stop_all_spells()
     }
 
     this->spell_hex_data->casting_spells.clear();
-    if (this->creature.action == ACTION_SPELL) {
+    if (this->creature.get_action() == ACTION_SPELL) {
         set_action(this->creature, ACTION_NONE);
     }
 
@@ -231,7 +231,7 @@ bool SpellHex::process_mana_cost(const bool need_restart)
     }
 
     msg_print(_("詠唱を再開した。", "You restart casting."));
-    this->creature.action = ACTION_SPELL;
+    this->creature.set_action(ACTION_SPELL);
     static constexpr auto flags_srf = {
         StatusRecalculatingFlag::BONUS,
         StatusRecalculatingFlag::HP,

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -60,7 +60,7 @@ void check_music(CreatureEntity &creature)
         set_singing_song_effect(creature, interupting_song_effect);
         set_interrupting_song_effect(creature, MUSIC_NONE);
         msg_print(_("歌を再開した。", "You resume singing."));
-        creature.action = ACTION_SING;
+        creature.set_action(ACTION_SING);
         static constexpr auto flags_srf = {
             StatusRecalculatingFlag::BONUS,
             StatusRecalculatingFlag::HP,
@@ -151,7 +151,7 @@ void stop_singing(CreatureEntity &creature)
         return;
     }
 
-    if (creature.action == ACTION_SING) {
+    if (creature.get_action() == ACTION_SING) {
         set_action(creature, ACTION_NONE);
     }
 

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -201,12 +201,12 @@ bool time_walk(CreatureEntity &creature)
         return false;
     }
 
-    if (creature.timewalk) {
+    if (creature.is_timewalking()) {
         msg_print(_("既に時は止まっている。", "Time is already stopped."));
         return false;
     }
 
-    creature.timewalk = true;
+    creature.set_timewalking(true);
     msg_print(_("「時よ！」", "You yell 'Time!'"));
     //	msg_print(_("「『ザ・ワールド』！時は止まった！」", "You yell 'The World! Time has stopped!'"));
     msg_erase();
@@ -584,7 +584,7 @@ bool fishing(CreatureEntity &creature)
     }
 
     const auto pos = creature.get_neighbor(dir);
-    creature.fishing_dir = dir.dir();
+    creature.set_fishing_dir(dir.dir());
     const auto &floor = *creature.get_floor();
     if (!floor.has_terrain_characteristics(pos, TerrainCharacteristics::WATER)) {
         msg_print(_("そこは水辺ではない。", "You can't fish here."));

--- a/src/status/action-setter.cpp
+++ b/src/status/action-setter.cpp
@@ -33,7 +33,7 @@
  */
 void set_action(CreatureEntity &creature, uint8_t typ)
 {
-    auto prev_typ = creature.action;
+    auto prev_typ = creature.get_action();
     if (typ == prev_typ) {
         return;
     }
@@ -45,7 +45,7 @@ void set_action(CreatureEntity &creature, uint8_t typ)
         rfu.set_flag(MainWindowRedrawingFlag::SPEED);
         break;
     case ACTION_REST:
-        creature.resting = 0;
+        creature.set_resting(0);
         break;
     case ACTION_LEARN: {
         msg_print(_("学習をやめた。", "You stop learning."));
@@ -75,7 +75,7 @@ void set_action(CreatureEntity &creature, uint8_t typ)
         break;
     }
 
-    creature.action = typ;
+    creature.set_action(typ);
 
     /* If we are requested other action, stop singing */
     if (prev_typ == ACTION_SING) {
@@ -89,7 +89,7 @@ void set_action(CreatureEntity &creature, uint8_t typ)
         }
     }
 
-    switch (creature.action) {
+    switch (creature.get_action()) {
     case ACTION_SEARCH:
         msg_print(_("注意深く歩き始めた。", "You begin to walk carefully."));
         rfu.set_flag(MainWindowRedrawingFlag::SPEED);

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -126,20 +126,20 @@ bool BadStatusSetter::set_confusion(const TIME_EFFECT tmp_v)
     if (v > 0) {
         if (!is_confused) {
             msg_print(_("あなたは混乱した！", "You are confused!"));
-            if (this->creature.action == ACTION_LEARN) {
+            if (this->creature.get_action() == ACTION_LEARN) {
                 msg_print(_("学習が続けられない！", "You cannot continue learning!"));
                 auto bluemage_data = CreatureClass(this->creature).get_specific_data<bluemage_data_type>();
                 bluemage_data->new_magic_learned = false;
                 rfu.set_flag(MainWindowRedrawingFlag::ACTION);
-                this->creature.action = ACTION_NONE;
+                this->creature.set_action(ACTION_NONE);
             }
-            if (this->creature.action == ACTION_MONK_STANCE) {
+            if (this->creature.get_action() == ACTION_MONK_STANCE) {
                 msg_print(_("構えがとけた。", "You lose your stance."));
                 CreatureClass(this->creature).set_monk_stance(MonkStanceType::NONE);
                 rfu.set_flag(StatusRecalculatingFlag::BONUS);
                 rfu.set_flag(MainWindowRedrawingFlag::ACTION);
-                this->creature.action = ACTION_NONE;
-            } else if (this->creature.action == ACTION_SAMURAI_STANCE) {
+                this->creature.set_action(ACTION_NONE);
+            } else if (this->creature.get_action() == ACTION_SAMURAI_STANCE) {
                 msg_print(_("型が崩れた。", "You lose your stance."));
                 CreatureClass(this->creature).lose_balance();
             }

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -77,7 +77,7 @@ void reset_tim_flags(CreatureEntity &creature)
     creature.set_timed_effect(CreatureTimedEffect::LIGHTSPEED, 0);
     creature.set_timed_effect(CreatureTimedEffect::ELE_ATTACK, 0);
     creature.set_timed_effect(CreatureTimedEffect::ELE_IMMUNE, 0);
-    creature.action = ACTION_NONE;
+    creature.set_action(ACTION_NONE);
 
     creature.set_timed_effect(CreatureTimedEffect::OPPOSE_ACID, 0);
     creature.set_timed_effect(CreatureTimedEffect::OPPOSE_ELEC, 0);
@@ -89,7 +89,7 @@ void reset_tim_flags(CreatureEntity &creature)
     creature.set_timed_effect(CreatureTimedEffect::ALTER_REALITY, 0);
 
     // 非 CreatureTimedEffect のリセット
-    creature.sutemi = false;
+    creature.set_sutemi(false);
     creature.counter = false;
     creature.set_special_attack_flags(0L);
     creature.set_special_defense_flags(0L);
@@ -98,7 +98,7 @@ void reset_tim_flags(CreatureEntity &creature)
         creature.set_energy_need(creature.get_energy_need() + ENERGY_NEED());
     }
 
-    creature.timewalk = false;
+    creature.set_timewalking(false);
 
     if (creature.get_riding()) {
         (void)set_monster_fast(*creature.get_floor(), creature.get_riding(), 0);

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1567,6 +1567,124 @@ public:
         this->old_monlite = value;
     }
 
+    // [提案 43] 行動・状態フラグ群の virtual API。
+    // action / running / resting / is_fired / level_up_message /
+    // timewalk / now_damaged / playing / leaving / monk_notify_aux /
+    // teleport_town / yoiyami / sutemi / fishing_dir を private 化し
+    // get/set virtual 経由でアクセス。
+    virtual byte get_action() const
+    {
+        return this->action;
+    }
+    virtual void set_action(byte value)
+    {
+        this->action = value;
+    }
+    virtual int16_t get_running() const
+    {
+        return this->running;
+    }
+    virtual void set_running(int16_t value)
+    {
+        this->running = value;
+    }
+    virtual GAME_TURN get_resting() const
+    {
+        return this->resting;
+    }
+    virtual void set_resting(GAME_TURN value)
+    {
+        this->resting = value;
+    }
+    virtual bool is_fired() const
+    {
+        return this->fired;
+    }
+    virtual void set_is_fired(bool value)
+    {
+        this->fired = value;
+    }
+    virtual bool has_level_up_message() const
+    {
+        return this->level_up_message;
+    }
+    virtual void set_level_up_message(bool value)
+    {
+        this->level_up_message = value;
+    }
+    virtual bool is_timewalking() const
+    {
+        return this->timewalk;
+    }
+    virtual void set_timewalking(bool value)
+    {
+        this->timewalk = value;
+    }
+    virtual bool is_now_damaged() const
+    {
+        return this->now_damaged;
+    }
+    virtual void set_now_damaged(bool value)
+    {
+        this->now_damaged = value;
+    }
+    virtual bool is_playing() const
+    {
+        return this->playing;
+    }
+    virtual void set_playing(bool value)
+    {
+        this->playing = value;
+    }
+    virtual bool is_leaving() const
+    {
+        return this->leaving;
+    }
+    virtual void set_leaving(bool value)
+    {
+        this->leaving = value;
+    }
+    virtual bool get_monk_notify_aux() const
+    {
+        return this->monk_notify_aux;
+    }
+    virtual void set_monk_notify_aux(bool value)
+    {
+        this->monk_notify_aux = value;
+    }
+    virtual bool is_teleport_town() const
+    {
+        return this->teleport_town;
+    }
+    virtual void set_teleport_town(bool value)
+    {
+        this->teleport_town = value;
+    }
+    virtual BIT_FLAGS get_yoiyami() const
+    {
+        return this->yoiyami;
+    }
+    virtual void set_yoiyami(BIT_FLAGS value)
+    {
+        this->yoiyami = value;
+    }
+    virtual bool is_sutemi() const
+    {
+        return this->sutemi;
+    }
+    virtual void set_sutemi(bool value)
+    {
+        this->sutemi = value;
+    }
+    virtual DIRECTION get_fishing_dir() const
+    {
+        return this->fishing_dir;
+    }
+    virtual void set_fishing_dir(DIRECTION value)
+    {
+        this->fishing_dir = value;
+    }
+
     /*!
      * @brief パック内の所持品数を inventory[] から計算する (提案 25)
      * @details inventory[0..INVEN_PACK) の有効アイテム数を返す。
@@ -3542,9 +3660,13 @@ public:
     int alignment{}; /*!< 善悪の属性 / Good/evil/neutral */
 
     // 行動状態関連
+    // [提案 43] action / running は private 化済。
+    // get_action() / set_action() / get_running() / set_running() 経由。
+private:
     byte action{}; /*!< クリーチャーが現在取っている常時行動のID / Currently action */
     int16_t running{}; /*!< 現在の走行カウンタ / Current counter for running, if any */
 
+public:
     // 所持金関連
     // [提案 32b] private 化済。get_au() / set_au() / add_au() / sub_au() / divide_au() 経由。
 private:
@@ -3595,9 +3717,15 @@ private:
 public:
     // 装備・能力関連フラグ / Equipment and ability flags
     bool hack_mutation{};
-    bool is_fired{};
+
+    // [提案 43] is_fired (フィールド名 fired にリネーム) / level_up_message は
+    // private 化済。is_fired() / set_is_fired() / has_level_up_message() /
+    // set_level_up_message() 経由。
+private:
+    bool fired{};
     bool level_up_message{};
 
+public:
     // [提案 33] 装備由来 BIT_FLAGS 群。
     // 全て has_X() / set_X() 経由でアクセス。
     // [提案 44] cursed / cursed_special も private 化済。
@@ -3724,12 +3852,18 @@ public:
 
     uint32_t count{};
 
+    // [提案 43] timewalk / resting は private 化済。
+    // is_timewalking() / set_timewalking() / get_resting() / set_resting() 経由。
+private:
     bool timewalk{};
 
+public:
 #define COMMAND_ARG_REST_UNTIL_DONE -2 /*!<休憩コマンド引数 … 必要な分だけ回復 */
 #define COMMAND_ARG_REST_FULL_HEALING -1 /*!<休憩コマンド引数 … HPとMPが全回復するまで */
+private:
     GAME_TURN resting{}; /* Current counter for resting, if any */
 
+public:
     DungeonId recall_dungeon{}; /* Dungeon set to be recalled */
 
     ENERGY enchant_energy_need{}; /* Energy needed for next upkeep effect	 */
@@ -3823,8 +3957,12 @@ public:
     char history[4][60]{}; /* Textual "history" for the Player */
 
     bool is_dead_{}; /* Player is dead */
+
+    // [提案 43] now_damaged は private 化済。is_now_damaged() / set_now_damaged() 経由。
+private:
     bool now_damaged{};
 
+public:
 #define KNOW_STAT 0x01
 #define KNOW_HPRATE 0x02
     BIT_FLAGS8 knowledge{}; /* Knowledge about yourself */
@@ -3856,14 +3994,23 @@ public:
 
     bool select_ring_slot{};
 
+    // [提案 43] playing / leaving / monk_notify_aux / teleport_town は private 化済。
+    // is_playing() / set_playing() / is_leaving() / set_leaving() /
+    // get_monk_notify_aux() / set_monk_notify_aux() /
+    // is_teleport_town() / set_teleport_town() 経由。
+private:
     bool playing{}; /* True if player is playing */
     bool leaving{}; /* True if player is leaving */
+
+public:
     bool vanish_stairs_flag{}; /* True if stairs should vanish after floor change */
 
+private:
     bool monk_notify_aux{};
 
     bool teleport_town{};
 
+public:
     short tracking_bi_id{}; /* Object kind trackee */
 
     int16_t new_spells{}; /* Number of spells available */
@@ -3903,15 +4050,26 @@ private:
     bool monlite{};
 
 public:
+    // [提案 43] yoiyami / sutemi / fishing_dir は private 化済。
+    // get_yoiyami() / set_yoiyami() / is_sutemi() / set_sutemi() /
+    // get_fishing_dir() / set_fishing_dir() 経由。
+private:
     BIT_FLAGS yoiyami{};
+
+public:
     BIT_FLAGS easy_2weapon{};
     BIT_FLAGS down_saving{};
 
+private:
     bool sutemi{};
+
+public:
     bool counter{};
 
+private:
     DIRECTION fishing_dir{};
 
+public:
     // [提案 40] ペット/騎乗ターゲット m_idx は private 化済。
     // get_pet_t_m_idx() / set_pet_t_m_idx() / get_riding_t_m_idx() /
     // set_riding_t_m_idx() 経由。

--- a/src/target/target-checker.cpp
+++ b/src/target/target-checker.cpp
@@ -54,7 +54,7 @@ void verify_panel(CreatureEntity &creature)
 
     int prow_min;
     int pcol_min;
-    if (center_player && (center_running || !creature.running)) {
+    if (center_player && (center_running || !creature.get_running())) {
         prow_min = y - hgt / 2;
         if (prow_min < 0) {
             prow_min = 0;

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -349,7 +349,7 @@ tl::optional<uint8_t> get_monochrome_display_color(CreatureEntity &creature)
     if (AngbandWorld::get_instance().timewalk_m_idx) {
         return TERM_DARK;
     }
-    if (creature.is_invulnerable() || creature.timewalk) {
+    if (creature.is_invulnerable() || creature.is_timewalking()) {
         return TERM_WHITE;
     }
     if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {

--- a/src/view/display-messages.cpp
+++ b/src/view/display-messages.cpp
@@ -174,7 +174,7 @@ static void msg_flush(CreatureEntity &creature, int x)
     byte a = TERM_L_BLUE;
     bool show_more = (num_more >= 0);
 
-    if (auto_more && !creature.now_damaged) {
+    if (auto_more && !creature.is_now_damaged()) {
         show_more = is_msg_window_flowed();
     }
 
@@ -182,8 +182,8 @@ static void msg_flush(CreatureEntity &creature, int x)
         show_more = false;
     }
 
-    creature.now_damaged = false;
-    if (!creature.playing || show_more) {
+    creature.set_now_damaged(false);
+    if (!creature.is_playing() || show_more) {
         term_putstr(x, 0, -1, a, _("-続く-", "-more-"));
         while (true) {
             int cmd = inkey();

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -341,7 +341,7 @@ void display_player_middle(CreatureEntity &creature)
     display_player_one_line(ENTRY_BASE_AC, format("[%d,%+d]", creature.get_dis_ac(), creature.get_dis_to_a()), TERM_L_BLUE);
 
     int base_speed = creature.get_speed() - 110;
-    if (creature.action == ACTION_SEARCH) {
+    if (creature.get_action() == ACTION_SEARCH) {
         base_speed += 10;
     }
 

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -307,7 +307,7 @@ static int calculate_mp_regen_rate(CreatureEntity &creature)
     int upkeep_factor = calculate_upkeep(creature);
     if (creature.is_player()) {
         CreatureClass pc(creature);
-        if ((creature.action == ACTION_LEARN) || (creature.action == ACTION_HAYAGAKE) || pc.samurai_stance_is(SamuraiStanceType::KOUKIJIN)) {
+        if ((creature.get_action() == ACTION_LEARN) || (creature.get_action() == ACTION_HAYAGAKE) || pc.samurai_stance_is(SamuraiStanceType::KOUKIJIN)) {
             upkeep_factor += 100;
         }
     }

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -160,17 +160,17 @@ void print_state(CreatureEntity &creature)
         return;
     }
 
-    switch (creature.action) {
+    switch (creature.get_action()) {
     case ACTION_SEARCH: {
         text = _("探索", "Sear");
         break;
     }
     case ACTION_REST:
-        if (creature.resting > 0) {
-            text = format("%4d", creature.resting);
-        } else if (creature.resting == COMMAND_ARG_REST_FULL_HEALING) {
+        if (creature.get_resting() > 0) {
+            text = format("%4d", creature.get_resting());
+        } else if (creature.get_resting() == COMMAND_ARG_REST_FULL_HEALING) {
             text = "****";
-        } else if (creature.resting == COMMAND_ARG_REST_UNTIL_DONE) {
+        } else if (creature.get_resting() == COMMAND_ARG_REST_UNTIL_DONE) {
             text = "&&&&";
         } else {
             text = "    ";

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -851,7 +851,7 @@ void cheat_death(CreatureEntity &creature, bool no_penalty)
     }
 
     world.set_wild_mode(false);
-    creature.leaving = true;
+    creature.set_leaving(true);
     constexpr auto note = _("                            しかし、生き返った。", "                            but revived.");
     exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, note);
     leave_floor(creature);

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -94,7 +94,7 @@ void execute_recall(CreatureEntity &creature)
         leave_quest_check(creature);
         leave_tower_check(creature);
         floor.quest_number = QuestId::NONE;
-        creature.leaving = true;
+        creature.set_leaving(true);
         sound(SoundKind::TPLEVEL);
         return;
     }
@@ -134,7 +134,7 @@ void execute_recall(CreatureEntity &creature)
      * and create a first saved floor
      */
     FloorChangeModesStore::get_instace()->set(FloorChangeMode::FIRST_FLOOR);
-    creature.leaving = true;
+    creature.set_leaving(true);
 
     check_random_quest_auto_failure(creature);
     sound(SoundKind::TPLEVEL);
@@ -174,7 +174,7 @@ void execute_floor_reset(CreatureEntity &creature)
         }
 
         FloorChangeModesStore::get_instace()->set(FloorChangeMode::FIRST_FLOOR);
-        creature.leaving = true;
+        creature.set_leaving(true);
     } else {
         msg_print(_("世界が少しの間変化したようだ。", "The world seems to change for a moment!"));
     }

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -167,12 +167,12 @@ void WorldTurnProcessor::process_downward()
     FloorChangeModesStore::get_instace()->set({ FloorChangeMode::FIRST_FLOOR, FloorChangeMode::RANDOM_PLACE });
     floor.inside_arena = false;
     AngbandWorld::get_instance().set_wild_mode(false);
-    this->creature.leaving = true;
+    this->creature.set_leaving(true);
 }
 
 void WorldTurnProcessor::process_monster_arena()
 {
-    if (!AngbandSystem::get_instance().is_phase_out() || this->creature.leaving) {
+    if (!AngbandSystem::get_instance().is_phase_out() || this->creature.is_leaving()) {
         return;
     }
 
@@ -296,7 +296,7 @@ void WorldTurnProcessor::process_world_monsters()
         regenerate_captured_monsters(this->creature);
     }
 
-    if (this->creature.leaving) {
+    if (this->creature.is_leaving()) {
         return;
     }
 


### PR DESCRIPTION
CreatureEntity 直下に「現在の行動状態」を示すスカラー / bool フラグ
14 個を private 化し、操作意図を明示する virtual API に統一。

対象フィールド:
- action (常時行動 ID、ACTION_LEARN/HAYAGAKE/REST/SEARCH/SING 等)
- running (走行カウンタ)
- resting (休息カウンタ、GAME_TURN)
- fired (旧 is_fired、メソッド名衝突回避でリネーム)
- level_up_message (レベルアップメッセージ要求)
- timewalk (時間停止中)
- now_damaged (直近ダメージ受領)
- playing (プレイ中)
- leaving (フロア離脱中)
- monk_notify_aux (修行僧の重装備通知済)
- teleport_town (街テレポート要求)
- yoiyami (宵闇 BIT_FLAGS)
- sutemi (捨て身)
- fishing_dir (釣り方向)

API (28 個の virtual):
- scalar 系は get_X()/set_X()
- bool 系は is_X() / has_X() / set_X() で意図明示
- yoiyami は set_yoiyami(BIT_FLAGS) で raw 代入

73 ファイル約 180 サイトを migration:
- .action 名前空間衝突に注意深い扱い (TerrainCharacteristics / autopick_list / cmd 関数ポインタ / DungeonDefinition 等は対象外)
- ++/-- compound assignment は set_X(get_X() ± 1) に展開
- this->X (CreatureEntity 派生メソッド内) も同様に migration

合計 private 化フィールド数: 115 → 129