### PR TITLE
refactor: その他小規模フィールドを private 化 (提案 47)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,13 @@ API 経由に統一された。一部フィールド (r_idx / ap_r_idx / riding)
   メソッド名衝突回避のため `is_fired` フィールドを `fired` にリネーム。
   `.action` / `.running` / `.leaving` の他構造体での同名フィールドは慎重に
   除外。**合計 private 化フィールド数: 115 → 129**
+- **提案 47**: その他小規模フィールド 6 個 (`dealt_damage` /
+  `run_py` / `run_px` / `vanish_stairs_flag` / `suppress_multi_reward` /
+  `tracking_bi_id`) を private 化。15 個の virtual API (scalar/bool 系の
+  get/set、`dealt_damage` には `+=` パターン用 `add_dealt_damage(delta)`)
+  を整備し、10 ファイル約 24 サイトを migration。さらにデッドフィールド
+  `tval_xtra` (Unused、宣言以外で未使用) を削除。**合計 private 化
+  フィールド数: 129 → 135**
 - **提案 1/2**: プレイヤー専用フィールドのモンスター運用化基盤完了。
   種族 (`prace`) / 職業 (`pclass`) / 魔法領域 (`realm1` / `realm2` /
   `element_realm`) / パトロン (`patron`) / 変身形態 (`mimic_form`)

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -66,11 +66,12 @@ Phase 1-8 完了後に残存している統合作業項目を整理したもの�
 | [44](#提案-44-突然変異呪い系フラグの-private-化--完了) | 突然変異/呪い系フラグ private 化 | ✅ 完了 | **+5 = 99 個** (muta / cursed / patron 等) |
 | [45](#提案-45-pet_t_m_idx--riding_t_m_idx-系を-target-pos2d-に統合) | pet_t_m_idx / riding_t_m_idx 統合 | 🚧 | Pos2D ベース |
 | [46](#提案-46-esp--装備集計の差分検出を-update_creature-内-raw-access-に閉じる) | ESP / 装備集計の差分検出を内部に閉じる | 🚧 | get_X_flags() 公開撤廃検討 |
+| [47](#提案-47-その他小規模フィールドの-private-化--完了) | その他小規模フィールドまとめ | ✅ 完了 | **+6 = 135 個** (dealt_damage / run_py/px / vanish_stairs_flag / suppress_multi_reward / tracking_bi_id、tval_xtra 削除) |
 
 **累計 private 化フィールド数 (主要マイルストーン):**
 - 提案 29 (3 個) → 32 (10 個) → 32b (37 個) → 33 (72 個) → 34 (77 個) →
   41 (83 個) → 39 (94 個) → 44 (99 個) → 40 (103 個) → 42 (115 個) →
-  **43 (129 個)**
+  43 (129 個) → **47 (135 個)**
 
 未完了の提案 6 / 40 / 42 / 43 / 45 / 46 を全完了で **130+ 個** に到達見込み。
 
@@ -2129,6 +2130,66 @@ CreatureEntity 共通化。**規模**: 10-15 サイト
 提案 33 で telepathy/esp_* は private 化済だが、`get_X_flags()` が
 差分検出キャッシュ用に依然外部公開。これを `update_creature()`
 内部完結に閉じる試み。
+
+---
+
+## 提案 47: その他小規模フィールドの private 化 ✅ 完了
+
+### 背景
+
+CreatureEntity 直下に public で残存していた小規模 (アクセスサイト 10
+以下) のフィールド群をまとめて private 化。単独で提案を立てるほど
+規模は大きくないが、フィールドカプセル化の徹底のため一括処理した。
+
+### 完了内容
+
+#### API 整備
+
+15 個の virtual を追加:
+
+| メソッド | 役割 |
+|---|---|
+| `get_dealt_damage() / set_dealt_damage() / add_dealt_damage()` | 累積与ダメージ (プレイヤー・モンスター共通) |
+| `get_run_py() / set_run_py()` | 走行目標 Y 座標 |
+| `get_run_px() / set_run_px()` | 走行目標 X 座標 |
+| `is_vanish_stairs_flag() / set_vanish_stairs_flag()` | 階段消去フラグ |
+| `is_suppress_multi_reward() / set_suppress_multi_reward()` | パトロン報酬多重防止 |
+| `get_tracking_bi_id() / set_tracking_bi_id()` | アイテム種類トラッキング ID |
+
+`dealt_damage` には compound assignment 用に `add_dealt_damage(delta)` も
+整備 (`this->dealt_damage += damage` パターン対応)。
+
+#### 移行
+
+10 ファイル、約 24 サイトを migration:
+
+- `player/player-damage.cpp`: `dealt_damage` の `+=` / 上限クリップ
+- `monster/monster-{damage,processor,status}.cpp` / `monster-floor/
+  one-monster-placer.cpp` / `core/game-play.cpp`: モンスター `dealt_damage`
+  の初期化・参照
+- `save/monster-writer.cpp` / `save/player-writer.cpp` /
+  `load/player-info-loader.cpp` / `load/old/monster-loader-savefile50.cpp`:
+  savefile 経路 (MonsterLoader50 / MonsterWriter は MonsterProfile の
+  friend のみで CreatureEntity の friend ではないため、virtual API 経由)
+- `action/run-execution.cpp`: `run_py` / `run_px` 設定・クリア
+- `floor/floor-changer.cpp` / `cmd-action/cmd-move.cpp`:
+  `vanish_stairs_flag`
+- `player/patron.cpp` / `core/magic-effects-timeout-reducer.cpp`:
+  `suppress_multi_reward`
+- `core/stuff-handler.cpp`: `tracking_bi_id`
+
+#### Private 化と削除
+
+- 6 フィールド (`dealt_damage` / `run_py` / `run_px` / `vanish_stairs_flag` /
+  `suppress_multi_reward` / `tracking_bi_id`) を完全 private 化
+- `tval_xtra` (Unused) を完全削除 (デッドフィールド)
+
+### 効果
+
+- **合計 private 化フィールド数: 129 → 135**
+- 小規模フィールドのカプセル化により、CreatureEntity のフィールド
+  アクセス契約が virtual API 経由でほぼ完全に統一
+- デッドフィールド削除によりオブジェクトサイズ若干削減
 
 ---
 

--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -96,8 +96,8 @@ static void run_init(CreatureEntity &creature, const Direction &dir)
     find_openarea = true;
     find_breakright = find_breakleft = false;
     const auto pos = creature.get_position();
-    creature.run_py = pos.y;
-    creature.run_px = pos.x;
+    creature.set_run_py(pos.y);
+    creature.set_run_px(pos.x);
     const auto pos_neighbor = creature.get_neighbor(dir);
     ignore_avoid_run = creature.get_floor()->has_terrain_characteristics(pos_neighbor, TerrainCharacteristics::AVOID_RUN);
     const auto dir_left45 = dir.rotated_45degree(1);
@@ -387,8 +387,8 @@ void run_step(CreatureEntity &creature, const Direction &dir)
     PlayerEnergy(creature).set_player_turn_energy(100);
     exe_movement(creature, find_current, false, false);
     if (creature.is_located_at_running_destination()) {
-        creature.run_py = 0;
-        creature.run_px = 0;
+        creature.set_run_py(0);
+        creature.set_run_px(0);
         disturb(creature, false, false);
     }
 }

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -188,7 +188,7 @@ void do_cmd_go_up(CreatureEntity &creature)
         const auto p_pos = creature.get_position();
         const auto floor_terrain_id = dungeon.select_floor_terrain_id();
         set_terrain_id_to_grid(creature, p_pos, floor_terrain_id);
-        creature.vanish_stairs_flag = true; // 移動後のフロアでも階段を消す
+        creature.set_vanish_stairs_flag(true); // 移動後のフロアでも階段を消す
     }
 
     if (up_num == floor.dun_level) {
@@ -343,7 +343,7 @@ void do_cmd_go_down(CreatureEntity &creature)
         const auto p_pos = creature.get_position();
         const auto floor_terrain_id = dungeon.select_floor_terrain_id();
         set_terrain_id_to_grid(creature, p_pos, floor_terrain_id);
-        creature.vanish_stairs_flag = true; // 移動後のフロアでも階段を消す
+        creature.set_vanish_stairs_flag(true); // 移動後のフロアでも階段を消す
     }
 
     if (is_fall_trap) {

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -329,7 +329,7 @@ static void init_riding_pet(CreatureEntity &creature, bool new_game)
     monster.maxhp = monrace.hit_dice.floored_expected_value();
     monster.max_maxhp = monster.maxhp;
     monster.hp = monrace.hit_dice.floored_expected_value();
-    monster.dealt_damage = 0;
+    monster.set_dealt_damage(0);
     monster.energy_need = ENERGY_NEED() + ENERGY_NEED();
 }
 

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -42,8 +42,8 @@ void reduce_magic_effects_timeout(CreatureEntity &creature)
         (void)set_tim_invis(creature, creature.get_timed_effect(CreatureTimedEffect::TIM_INVIS) - 1, true);
     }
 
-    if (creature.suppress_multi_reward) {
-        creature.suppress_multi_reward = false;
+    if (creature.is_suppress_multi_reward()) {
+        creature.set_suppress_multi_reward(false);
     }
 
     if (creature.get_timed_effect(CreatureTimedEffect::TIM_ESP)) {

--- a/src/core/stuff-handler.cpp
+++ b/src/core/stuff-handler.cpp
@@ -41,7 +41,7 @@ void monster_race_track(CreatureEntity &creature, MonraceId r_idx)
  */
 void object_kind_track(CreatureEntity &creature, short bi_id)
 {
-    creature.tracking_bi_id = bi_id;
+    creature.set_tracking_bi_id(bi_id);
     RedrawingFlagsUpdater::get_instance().set_flag(SubWindowRedrawingFlag::ITEM_KNOWLEDGE);
 }
 

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -450,8 +450,8 @@ void change_floor(CreatureEntity &creature)
     fcms->clear();
 
     // 移動後のフロアで階段を消去する処理
-    if (creature.vanish_stairs_flag) {
-        creature.vanish_stairs_flag = false;
+    if (creature.is_vanish_stairs_flag()) {
+        creature.set_vanish_stairs_flag(false);
         const auto &dungeon = floor.get_dungeon_definition();
         if (dungeon.flags.has(DungeonFeatureType::VANISH_STAIRS) && floor.is_underground()) {
             const auto p_pos = creature.get_position();

--- a/src/load/old/monster-loader-savefile50.cpp
+++ b/src/load/old/monster-loader-savefile50.cpp
@@ -43,7 +43,7 @@ void MonsterLoader50::rd_monster(CreatureEntity &monster)
         monster.max_maxhp = rd_s32b();
     }
 
-    monster.dealt_damage = rd_s32b();
+    monster.set_dealt_damage(rd_s32b());
 
     monster.set_ap_r_idx(any_bits(flags, SaveDataMonsterFlagType::AP_R_IDX) ? i2enum<MonraceId>(rd_s16b()) : monster.get_r_idx());
     monster.set_sub_align(any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN) ? rd_byte() : 0);

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -301,9 +301,9 @@ static void rd_hp(CreatureEntity &creature)
 
     // セーブファイルバージョン35以降で与ダメージ蓄積を読み込み
     if (!loading_savefile_version_is_older_than(35)) {
-        creature.dealt_damage = rd_s32b();
+        creature.set_dealt_damage(rd_s32b());
     } else {
-        creature.dealt_damage = 0;
+        creature.set_dealt_damage(0);
     }
 }
 

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -542,7 +542,7 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
         m_ptr->hp = m_ptr->maxhp;
     }
 
-    m_ptr->dealt_damage = 0;
+    m_ptr->set_dealt_damage(0);
     if (monrace.suicide_dice_num && monrace.suicide_dice_side) {
         m_ptr->set_death_count(Dice::roll(monrace.suicide_dice_num, monrace.suicide_dice_side));
     }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -109,7 +109,7 @@ bool MonsterDamageProcessor::mon_take_hit(std::string_view note)
     monster.apply_raw_damage(this->dam);
 
     if (AngbandWorld::get_instance().wizard) {
-        msg_format(_("合計%d/%dのダメージを与えた。", "You do %d (out of %d) damage."), monster.dealt_damage, monster.maxhp);
+        msg_format(_("合計%d/%dのダメージを与えた。", "You do %d (out of %d) damage."), monster.get_dealt_damage(), monster.maxhp);
     }
 
     if (this->process_dead_exp_virtue(note, exp_mon)) {
@@ -459,8 +459,8 @@ void MonsterDamageProcessor::get_exp_from_mon(const CreatureEntity &target, int 
     }
 
     /* Special penalty for rest_and_shoot exp scum */
-    if ((target.dealt_damage > target.max_maxhp) && (target.hp >= 0)) {
-        int over_damage = target.dealt_damage / target.max_maxhp;
+    if ((target.get_dealt_damage() > target.max_maxhp) && (target.hp >= 0)) {
+        int over_damage = target.get_dealt_damage() / target.max_maxhp;
         if (over_damage > 32) {
             over_damage = 32;
         }

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -867,7 +867,7 @@ void process_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
             monster.maxhp = 1;
         }
         monster.hp = monster.hp * monster.max_maxhp / old_maxhp;
-        monster.dealt_damage = 0;
+        monster.set_dealt_damage(0);
     }
 
     auto &monrace = monster.get_monrace();

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -400,7 +400,7 @@ void monster_gain_exp(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId mon
     monster.hp = old_hp * monster.maxhp / old_maxhp;
 
     /* dealt damage is 0 at initial*/
-    monster.dealt_damage = 0;
+    monster.set_dealt_damage(0);
 
     /* Extract the monster base speed */
     monster.set_individual_speed(floor.inside_arena);

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -161,10 +161,10 @@ void Patron::gain_level_reward(CreatureEntity &creature, int chosen_reward)
     int count = 0;
 
     if (!chosen_reward) {
-        if (creature.suppress_multi_reward) {
+        if (creature.is_suppress_multi_reward()) {
             return;
         } else {
-            creature.suppress_multi_reward = true;
+            creature.set_suppress_multi_reward(true);
         }
     }
 

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -404,9 +404,9 @@ int take_hit(CreatureEntity &creature, int damage_type, int damage, std::string_
  */
 void PlayerType::on_take_hit(int damage)
 {
-    this->dealt_damage += damage;
-    if (this->dealt_damage > 999999999) {
-        this->dealt_damage = 999999999;
+    this->add_dealt_damage(damage);
+    if (this->get_dealt_damage() > 999999999) {
+        this->set_dealt_damage(999999999);
     }
 }
 

--- a/src/save/monster-writer.cpp
+++ b/src/save/monster-writer.cpp
@@ -29,7 +29,7 @@ void MonsterWriter::write_to_savedata() const
     wr_s32b(this->monster.hp);
     wr_s32b(this->monster.maxhp);
     wr_s32b(this->monster.max_maxhp);
-    wr_u32b(this->monster.dealt_damage);
+    wr_u32b(this->monster.get_dealt_damage());
 
     if (any_bits(flags, SaveDataMonsterFlagType::AP_R_IDX)) {
         wr_s16b(enum2i(this->monster.get_ap_r_idx()));

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -162,7 +162,7 @@ void wr_player(CreatureEntity &creature)
     wr_s32b(creature.maxhp);
     wr_s32b(creature.hp);
     wr_u32b(creature.hp_frac);
-    wr_s32b(creature.dealt_damage); // セーブファイルバージョン35以降で与ダメージ蓄積を保存
+    wr_s32b(creature.get_dealt_damage()); // セーブファイルバージョン35以降で与ダメージ蓄積を保存
     wr_s32b(creature.get_msp());
     wr_s32b(creature.get_csp());
     wr_u32b(creature.csp_frac);

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1685,6 +1685,60 @@ public:
         this->fishing_dir = value;
     }
 
+    // [提案 47] その他の小規模フィールドの virtual API。
+    virtual int32_t get_dealt_damage() const
+    {
+        return this->dealt_damage;
+    }
+    virtual void set_dealt_damage(int32_t value)
+    {
+        this->dealt_damage = value;
+    }
+    virtual void add_dealt_damage(int32_t delta)
+    {
+        this->dealt_damage += delta;
+    }
+    virtual POSITION get_run_py() const
+    {
+        return this->run_py;
+    }
+    virtual void set_run_py(POSITION value)
+    {
+        this->run_py = value;
+    }
+    virtual POSITION get_run_px() const
+    {
+        return this->run_px;
+    }
+    virtual void set_run_px(POSITION value)
+    {
+        this->run_px = value;
+    }
+    virtual bool is_vanish_stairs_flag() const
+    {
+        return this->vanish_stairs_flag;
+    }
+    virtual void set_vanish_stairs_flag(bool value)
+    {
+        this->vanish_stairs_flag = value;
+    }
+    virtual bool is_suppress_multi_reward() const
+    {
+        return this->suppress_multi_reward;
+    }
+    virtual void set_suppress_multi_reward(bool value)
+    {
+        this->suppress_multi_reward = value;
+    }
+    virtual short get_tracking_bi_id() const
+    {
+        return this->tracking_bi_id;
+    }
+    virtual void set_tracking_bi_id(short value)
+    {
+        this->tracking_bi_id = value;
+    }
+
     /*!
      * @brief パック内の所持品数を inventory[] から計算する (提案 25)
      * @details inventory[0..INVEN_PACK) の有効アイテム数を返す。
@@ -3499,9 +3553,12 @@ private:
     MonraceId ap_r_idx{}; /*!< モンスターの外見種族ID（あやしい影、たぬき、ジュラル星人誤認などにより変化する）Monster race appearance index */
 
 public:
+    // [提案 47] dealt_damage は private 化済。get_dealt_damage() / set_dealt_damage() / add_dealt_damage() 経由。
+private:
     // 与ダメージ蓄積（プレイヤー・モンスター共通）
     int32_t dealt_damage{}; /*!< これまでに蓄積して与えてきたダメージ / Sum of damages dealt by player or to monster */
 
+public:
     // 種族・職業・性格情報（参照風アクセス用）
     const player_race_info *race{}; /*!< 現在の種族情報 / Current race info */
     const player_personality *personality{}; /*!< 現在の性格情報 / Current personality info (accessed like reference) */
@@ -3523,10 +3580,12 @@ private:
     ACTION_SKILL_POWER skill_tht{}; /*!< 行動技能値:投射命中能力 / Skill: To hit (throwing) */
     ACTION_SKILL_POWER skill_dig{}; /*!< 行動技能値:掘削 / Skill: Digging */
 
-public:
+    // [提案 47] run_py / run_px は private 化済。get_run_py() / set_run_py() / get_run_px() / set_run_px() 経由。
+private:
     POSITION run_py{}; /*!< 走行中の目標Y座標 / Target Y position while running */
     POSITION run_px{}; /*!< 走行中の目標X座標 / Target X position while running */
 
+public:
     Pos2D target{}; /*!< 攻撃目標座標 (0,0 は未設定) / Attack target position ({0,0} means none) */
 
     tl::optional<MonsterProfile> monster_profile{}; /*!< モンスター固有データ (モンスターの場合のみ有効) */
@@ -4002,17 +4061,17 @@ private:
     bool playing{}; /* True if player is playing */
     bool leaving{}; /* True if player is leaving */
 
-public:
+    // [提案 47] vanish_stairs_flag は private 化済。is_vanish_stairs_flag() / set_vanish_stairs_flag() 経由。
     bool vanish_stairs_flag{}; /* True if stairs should vanish after floor change */
 
-private:
     bool monk_notify_aux{};
 
     bool teleport_town{};
 
-public:
+    // [提案 47] tracking_bi_id は private 化済。get_tracking_bi_id() / set_tracking_bi_id() 経由。
     short tracking_bi_id{}; /* Object kind trackee */
 
+public:
     int16_t new_spells{}; /* Number of spells available */
 
     // [提案 42] 差分検出キャッシュ (old_*) は private 化済。
@@ -4080,13 +4139,16 @@ private:
 public:
     /*** Extracted fields ***/
 
+    // [提案 47] suppress_multi_reward は private 化済。is_suppress_multi_reward() / set_suppress_multi_reward() 経由。
+    // tval_xtra は宣言以外で未使用のデッドフィールドだったため削除。
+private:
     bool suppress_multi_reward{}; /*!< 複数レベルアップ時のパトロンからの報酬多重受け取りを防止 */
 
+public:
     Dice damage_dice_bonus[2]{}; /* Extra damage dice num/sides */
 
     bool no_flowed{};
 
-    byte tval_xtra{}; /* (Unused)Correct xtra tval */
     ItemKindType tval_ammo{}; /* Correct ammo tval */
 
     ENERGY energy_use{}; /*!< 直近のターンに消費したエネルギー / Energy use this turn */


### PR DESCRIPTION
CreatureEntity 直下に public で残存していた小規模 (アクセスサイト 10
以下) のフィールド群をまとめて private 化。

対象フィールド (6 個):
- dealt_damage (累積与ダメージ、プレイヤー・モンスター共通)
- run_py / run_px (走行目標座標)
- vanish_stairs_flag (階段消去フラグ)
- suppress_multi_reward (パトロン報酬多重防止)
- tracking_bi_id (アイテム種類トラッキング ID)

削除フィールド:
- tval_xtra (Unused、宣言以外で未使用のデッドフィールド)

API (15 個の virtual):
- get/set 系
- dealt_damage には += パターン用 add_dealt_damage(delta) も整備
- bool 系は is_X() / set_X() で意図明示

10 ファイル約 24 サイトを migration:
- player/player-damage.cpp の dealt_damage 累積 (+= / 上限クリップ)
- monster/{damage,processor,status,floor/one-monster-placer}.cpp / core/game-play.cpp のモンスター dealt_damage 初期化・参照
- savefile load/save (MonsterLoader50/MonsterWriter は MonsterProfile の friend のみで CreatureEntity の friend ではない ため virtual API 経由)
- action/run-execution.cpp の run_py / run_px
- floor/floor-changer.cpp / cmd-action/cmd-move.cpp の vanish_stairs_flag
- player/patron.cpp / core/magic-effects-timeout-reducer.cpp の suppress_multi_reward
- core/stuff-handler.cpp の tracking_bi_id

合計 private 化フィールド数: 129 → 135