### PR TITLE
refactor: 追加の小規模フィールドを private 化 (提案 48)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,6 +363,13 @@ API 経由に統一された。一部フィールド (r_idx / ap_r_idx / riding)
   を整備し、10 ファイル約 24 サイトを migration。さらにデッドフィールド
   `tval_xtra` (Unused、宣言以外で未使用) を削除。**合計 private 化
   フィールド数: 129 → 135**
+- **提案 48**: 追加の小規模フィールド 6 個 (`tval_ammo` / `dtrap` /
+  `autopick_autoregister` / `recall_dungeon` / `enchant_energy_need` /
+  `energy_use`) を private 化。18 個の virtual API を整備し (ENERGY 系
+  は compound assignment 用に `add_X/sub_X/mul_X/div_X` も整備)、25
+  ファイル約 61 サイトを migration。`PlayerEnergy` ラッパークラスの
+  内部実装も virtual API 経由に切替え、フィールド直接アクセスを完全
+  排除。**合計 private 化フィールド数: 135 → 141**
 - **提案 1/2**: プレイヤー専用フィールドのモンスター運用化基盤完了。
   種族 (`prace`) / 職業 (`pclass`) / 魔法領域 (`realm1` / `realm2` /
   `element_realm`) / パトロン (`patron`) / 変身形態 (`mimic_form`)

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -67,11 +67,12 @@ Phase 1-8 完了後に残存している統合作業項目を整理したもの�
 | [45](#提案-45-pet_t_m_idx--riding_t_m_idx-系を-target-pos2d-に統合) | pet_t_m_idx / riding_t_m_idx 統合 | 🚧 | Pos2D ベース |
 | [46](#提案-46-esp--装備集計の差分検出を-update_creature-内-raw-access-に閉じる) | ESP / 装備集計の差分検出を内部に閉じる | 🚧 | get_X_flags() 公開撤廃検討 |
 | [47](#提案-47-その他小規模フィールドの-private-化--完了) | その他小規模フィールドまとめ | ✅ 完了 | **+6 = 135 個** (dealt_damage / run_py/px / vanish_stairs_flag / suppress_multi_reward / tracking_bi_id、tval_xtra 削除) |
+| [48](#提案-48-追加の小規模フィールドの-private-化--完了) | 追加の小規模フィールドまとめ | ✅ 完了 | **+6 = 141 個** (tval_ammo / dtrap / autopick_autoregister / recall_dungeon / enchant_energy_need / energy_use) |
 
 **累計 private 化フィールド数 (主要マイルストーン):**
 - 提案 29 (3 個) → 32 (10 個) → 32b (37 個) → 33 (72 個) → 34 (77 個) →
   41 (83 個) → 39 (94 個) → 44 (99 個) → 40 (103 個) → 42 (115 個) →
-  43 (129 個) → **47 (135 個)**
+  43 (129 個) → 47 (135 個) → **48 (141 個)**
 
 未完了の提案 6 / 40 / 42 / 43 / 45 / 46 を全完了で **130+ 個** に到達見込み。
 
@@ -2190,6 +2191,73 @@ CreatureEntity 直下に public で残存していた小規模 (アクセスサ�
 - 小規模フィールドのカプセル化により、CreatureEntity のフィールド
   アクセス契約が virtual API 経由でほぼ完全に統一
 - デッドフィールド削除によりオブジェクトサイズ若干削減
+
+---
+
+## 提案 48: 追加の小規模フィールドの private 化 ✅ 完了
+
+### 背景
+
+提案 47 で残った小規模フィールドのうち、コンパウンド代入 (`+=`, `-=`,
+`*=`, `/=`) を含む 2 個と、単純な scalar/bool/enum 系 4 個を一括 private
+化する 2 巡目。
+
+### 完了内容
+
+#### API 整備
+
+18 個の virtual を追加:
+
+| メソッド | 役割 |
+|---|---|
+| `get_tval_ammo() / set_tval_ammo()` | 弾種 ItemKindType |
+| `is_dtrap() / set_dtrap()` | トラップ安全地帯フラグ |
+| `is_autopick_autoregister() / set_autopick_autoregister()` | 自動登録モード |
+| `get_recall_dungeon() / set_recall_dungeon()` | 帰還ダンジョン DungeonId |
+| `get_enchant_energy_need() / set_enchant_energy_need() / add_enchant_energy_need(delta) / sub_enchant_energy_need(delta)` | 次のエンチャント効果までのエネルギー |
+| `get_energy_use() / set_energy_use() / add_energy_use(delta) / sub_energy_use(delta) / mul_energy_use(factor) / div_energy_use(divisor)` | 今ターンのエネルギー消費 |
+
+`energy_use` は `PlayerEnergy` クラスのラッパー (`+=`, `-=`, `*=`, `/=`)
+が既に存在するため、CreatureEntity 側にも対応する compound assignment
+virtual を追加し、PlayerEnergy はそれらを呼び出す形に切替え。
+
+#### 移行
+
+25 ファイル、約 61 サイトを migration:
+
+- `combat/shoot.cpp` / `player/player-status.cpp` 等の `tval_ammo`
+  読取 (4 + 4 + 1 + 1 = 10 サイト)
+- `floor/floor-changer.cpp` / `spell-kind/spells-detection.cpp` /
+  `action/run-execution.cpp` / `action/travel-execution.cpp` /
+  `player/player-move.cpp` の `dtrap` (8 サイト)
+- `load/world-loader.cpp` / `save/player-writer.cpp` /
+  `autopick/autopick-registry.cpp` / `autopick/pref-file-expressor.cpp` の
+  `autopick_autoregister` (8 サイト、savefile 経由も含む)
+- `floor/floor-leaver.cpp` / `wizard/wizard-special-process.cpp` /
+  `load/player-info-loader.cpp` / `load/world-loader.cpp` /
+  `save/player-writer.cpp` / `world/world-movement-processor.cpp` /
+  `io-dump/player-status-dump-json.cpp` / `spell-kind/spells-world.cpp` /
+  `birth/game-play-initializer.cpp` の `recall_dungeon` (13 サイト)
+- `core/player-processor.cpp` 等の `enchant_energy_need`
+  (5 サイトの compound assignment を含む 7 サイト)
+- `player-attack/player-attack.cpp` / `player-status/player-energy.cpp` /
+  `cmd-action/cmd-move.cpp` / `io/input-key-processor.cpp` /
+  `core/player-processor.cpp` の `energy_use` (15 サイト、
+  PlayerEnergy ラッパーの `=`/`+=`/`-=`/`*=`/`/=` を含む)
+
+#### Private 化
+
+6 フィールド (`tval_ammo` / `dtrap` / `autopick_autoregister` /
+`recall_dungeon` / `enchant_energy_need` / `energy_use`) を完全 private 化。
+
+### 効果
+
+- **合計 private 化フィールド数: 135 → 141**
+- ENERGY 系フィールド (`enchant_energy_need` / `energy_use`) の
+  compound assignment を意図明示形 (`add_X(delta)` / `sub_X(delta)` /
+  `mul_X(factor)` / `div_X(divisor)`) に統一
+- `PlayerEnergy` ラッパークラスの内部実装も virtual API 経由に
+  切替え、フィールド直接アクセスを完全排除
 
 ---
 

--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -189,8 +189,8 @@ static bool run_test(CreatureEntity &creature)
     const auto &floor = *creature.get_floor();
     const auto p_pos = creature.get_position();
     const auto &p_grid = floor.get_grid(p_pos);
-    if ((disturb_trap_detect || alert_trap_detect) && creature.dtrap && !(p_grid.info & CAVE_IN_DETECT)) {
-        creature.dtrap = false;
+    if ((disturb_trap_detect || alert_trap_detect) && creature.is_dtrap() && !(p_grid.info & CAVE_IN_DETECT)) {
+        creature.set_dtrap(false);
         if (!(p_grid.info & CAVE_UNSAFE)) {
             if (alert_trap_detect) {
                 msg_print(_("* 注意:この先はトラップの感知範囲外です！ *", "*Leaving trap detect region!*"));

--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -137,8 +137,8 @@ Direction decide_travel_step_dir(CreatureEntity &creature, const Direction &prev
     auto &floor = *creature.get_floor();
     const auto &p_grid = floor.get_grid(p_pos);
     if (creature.is_player()) {
-        if ((disturb_trap_detect || alert_trap_detect) && creature.dtrap && none_bits(p_grid.info, CAVE_IN_DETECT)) {
-            creature.dtrap = false;
+        if ((disturb_trap_detect || alert_trap_detect) && creature.is_dtrap() && none_bits(p_grid.info, CAVE_IN_DETECT)) {
+            creature.set_dtrap(false);
             if (none_bits(p_grid.info, CAVE_UNSAFE)) {
                 if (alert_trap_detect) {
                     msg_print(_("* 注意:この先はトラップの感知範囲外です！ *", "*Leaving trap detect region!*"));

--- a/src/autopick/autopick-registry.cpp
+++ b/src/autopick/autopick-registry.cpp
@@ -133,7 +133,7 @@ bool autopick_autoregister(CreatureEntity &creature, const ItemEntity *o_ptr)
         return false;
     }
 
-    if (!creature.autopick_autoregister) {
+    if (!creature.is_autopick_autoregister()) {
         if (!clear_auto_register(creature.base_name)) {
             return false;
         }
@@ -146,12 +146,12 @@ bool autopick_autoregister(CreatureEntity &creature, const ItemEntity *o_ptr)
         while (true) {
             const auto buf = angband_fgets(pref_fff, MAX_LINELEN);
             if (!buf) {
-                creature.autopick_autoregister = false;
+                creature.set_autopick_autoregister(false);
                 break;
             }
 
             if (streq(*buf, autoregister_header)) {
-                creature.autopick_autoregister = true;
+                creature.set_autopick_autoregister(true);
                 break;
             }
         }
@@ -162,7 +162,7 @@ bool autopick_autoregister(CreatureEntity &creature, const ItemEntity *o_ptr)
          * File could not be opened for reading.  Assume header not
          * present.
          */
-        creature.autopick_autoregister = false;
+        creature.set_autopick_autoregister(false);
     }
 
     /* ファイルが存在しなかった場合はプレイヤー個別の新規ファイルを作成する */
@@ -175,14 +175,14 @@ bool autopick_autoregister(CreatureEntity &creature, const ItemEntity *o_ptr)
         return false;
     }
 
-    if (!creature.autopick_autoregister) {
+    if (!creature.is_autopick_autoregister()) {
         fprintf(pref_fff, "%s\n", autoregister_header);
 
         fprintf(pref_fff, "%s\n", _("# *警告!!* 以降の行は自動登録されたものです。", "# *Warning!* The lines below will be deleted later."));
         fprintf(pref_fff, "%s\n",
             _("# 後で自動的に削除されますので、必要な行は上の方へ移動しておいてください。",
                 "# Keep it by cut & paste if you need these lines for future characters."));
-        creature.autopick_autoregister = true;
+        creature.set_autopick_autoregister(true);
     }
 
     autopick_entry_from_object(creature, entry, o_ptr);

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -133,9 +133,9 @@ void player_wipe_without_name(CreatureEntity &creature)
     creature.virtues.clear();
 
     if (vanilla_town || ironman_downward) {
-        creature.recall_dungeon = DungeonId::ANGBAND;
+        creature.set_recall_dungeon(DungeonId::ANGBAND);
     } else {
-        creature.recall_dungeon = DungeonId::GALGALS;
+        creature.set_recall_dungeon(DungeonId::GALGALS);
     }
 
     creature.name = backup_name;

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -406,7 +406,7 @@ void do_cmd_walk(CreatureEntity &creature, bool pickup)
         }
 
         if (creature.get_action() == ACTION_HAYAGAKE) {
-            auto energy_use = (ENERGY)(creature.energy_use * (45 - (creature.get_level() / 2)) / 100);
+            auto energy_use = (ENERGY)(creature.get_energy_use() * (45 - (creature.get_level() / 2)) / 100);
             energy.set_player_turn_energy(energy_use);
         }
 

--- a/src/cmd-action/cmd-shoot.cpp
+++ b/src/cmd-action/cmd-shoot.cpp
@@ -56,7 +56,7 @@ void do_cmd_fire(CreatureEntity &creature, SPELL_IDX snipe_type)
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
     constexpr auto q = _("どれを撃ちますか? ", "Fire which item? ");
     constexpr auto s = _("発射されるアイテムがありません。", "You have nothing to fire.");
-    const auto &[ammo, ammo_idx] = choose_item(creature, q, s, USE_INVEN | USE_FLOOR, TvalItemTester(creature.tval_ammo));
+    const auto &[ammo, ammo_idx] = choose_item(creature, q, s, USE_INVEN | USE_FLOOR, TvalItemTester(creature.get_tval_ammo()));
     if (!ammo) {
         flush();
         return;

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -1058,7 +1058,7 @@ int critical_shot(CreatureEntity &creature, WEIGHT weight, int plus_ammo, int pl
     } else {
         const auto sval = *item.bi_key.sval();
         const auto weapon_exp = weapon_exps[sval];
-        if (creature.tval_ammo == ItemKindType::BOLT) {
+        if (creature.get_tval_ammo() == ItemKindType::BOLT) {
             power = (creature.get_skill_to_hit_bow() + (weapon_exp / xbow_magnification + bonus) * BTH_PLUS_ADJ);
         } else {
             power = creature.get_skill_to_hit_bow() + ((weapon_exp - median_skill_exp) / bow_magnification + bonus) * BTH_PLUS_ADJ;
@@ -1071,7 +1071,7 @@ int critical_shot(CreatureEntity &creature, WEIGHT weight, int plus_ammo, int pl
 
     /* Snipers can shot more critically with crossbows */
     power += ((power * sniper_concent) / 5);
-    if (pc.equals(PlayerClassType::SNIPER) && (creature.tval_ammo == ItemKindType::BOLT)) {
+    if (pc.equals(PlayerClassType::SNIPER) && (creature.get_tval_ammo() == ItemKindType::BOLT)) {
         power *= 2;
     }
 
@@ -1112,7 +1112,7 @@ int calc_crit_ratio_shot(CreatureEntity &creature, int plus_ammo, int plus_bow)
     auto i = creature.get_to_h_b() + plus_ammo;
     const auto tval = j_ptr->bi_key.tval();
     const auto sval = *j_ptr->bi_key.sval();
-    if (creature.tval_ammo == ItemKindType::BOLT) {
+    if (creature.get_tval_ammo() == ItemKindType::BOLT) {
         i = (creature.get_skill_to_hit_bow() + (creature.get_weapon_exp(tval, sval) / 400 + i) * BTH_PLUS_ADJ);
     } else {
         i = (creature.get_skill_to_hit_bow() + ((creature.get_weapon_exp(tval, sval) - (PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER) / 2)) / 200 + i) * BTH_PLUS_ADJ);
@@ -1124,7 +1124,7 @@ int calc_crit_ratio_shot(CreatureEntity &creature, int plus_ammo, int plus_bow)
 
     /* Snipers can shot more critically with crossbows */
     i += ((i * sniper_concent) / 5);
-    if (pc.equals(PlayerClassType::SNIPER) && (creature.tval_ammo == ItemKindType::BOLT)) {
+    if (pc.equals(PlayerClassType::SNIPER) && (creature.get_tval_ammo() == ItemKindType::BOLT)) {
         i *= 2;
     }
 

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -328,11 +328,11 @@ void process_player(CreatureEntity &creature)
         }
 
         pack_overflow(creature);
-        if (creature.energy_use) {
-            if (creature.is_timewalking() || creature.energy_use > 400) {
-                creature.energy_need += creature.energy_use * TURNS_PER_TICK / 10;
+        if (creature.get_energy_use()) {
+            if (creature.is_timewalking() || creature.get_energy_use() > 400) {
+                creature.energy_need += creature.get_energy_use() * TURNS_PER_TICK / 10;
             } else {
-                creature.energy_need += (int16_t)((int32_t)creature.energy_use * ENERGY_NEED() / 100L);
+                creature.energy_need += (int16_t)((int32_t)creature.get_energy_use() * ENERGY_NEED() / 100L);
             }
 
             if (creature.is_hallucinated()) {
@@ -421,7 +421,7 @@ void process_player(CreatureEntity &creature)
         }
 
         auto sniper_data = CreatureClass(creature).get_specific_data<SniperData>();
-        if (creature.energy_use && sniper_data && sniper_data->reset_concent) {
+        if (creature.get_energy_use() && sniper_data && sniper_data->reset_concent) {
             reset_concentration(creature, true);
         }
 
@@ -438,15 +438,15 @@ void process_player(CreatureEntity &creature)
  */
 void process_upkeep_with_speed(CreatureEntity &creature)
 {
-    if (!load && creature.enchant_energy_need > 0 && !creature.is_leaving()) {
-        creature.enchant_energy_need -= speed_to_energy(static_cast<byte>(creature.get_speed()));
+    if (!load && creature.get_enchant_energy_need() > 0 && !creature.is_leaving()) {
+        creature.sub_enchant_energy_need(speed_to_energy(static_cast<byte>(creature.get_speed())));
     }
 
-    if (creature.enchant_energy_need > 0) {
+    if (creature.get_enchant_energy_need() > 0) {
         return;
     }
 
-    while (creature.enchant_energy_need <= 0) {
+    while (creature.get_enchant_energy_need() <= 0) {
         if (!load) {
             check_music(creature);
         }
@@ -468,6 +468,6 @@ void process_upkeep_with_speed(CreatureEntity &creature)
             spell_hex.continue_revenge();
         }
 
-        creature.enchant_energy_need += ENERGY_NEED();
+        creature.add_enchant_energy_need(ENERGY_NEED());
     }
 }

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -423,7 +423,7 @@ void change_floor(CreatureEntity &creature)
 
     auto &world = AngbandWorld::get_instance();
     world.character_dungeon = false;
-    creature.dtrap = false;
+    creature.set_dtrap(false);
     panel_row_min = 0;
     panel_row_max = 0;
     panel_col_min = 0;

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -374,7 +374,7 @@ static void exit_to_wilderness(CreatureEntity &creature)
         WildernessGrids::get_instance().set_player_position(dungeon.get_position());
     }
 
-    creature.recall_dungeon = floor.dungeon_id;
+    creature.set_recall_dungeon(floor.dungeon_id);
     creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, 0);
     floor.reset_dungeon_index();
     FloorChangeModesStore::get_instace()->reset(FloorChangeMode::SAVE_FLOORS);

--- a/src/io-dump/player-status-dump-json.cpp
+++ b/src/io-dump/player-status-dump-json.cpp
@@ -131,7 +131,7 @@ static void add_status_to_json(nlohmann::json &j, CreatureEntity &creature)
 
     // ダンジョン情報
     j["status"]["dungeon_level"] = creature.get_floor()->dun_level;
-    const auto &dungeon_record = DungeonRecords::get_instance().get_record(creature.recall_dungeon);
+    const auto &dungeon_record = DungeonRecords::get_instance().get_record(creature.get_recall_dungeon());
     j["status"]["max_dungeon_level"] = dungeon_record.get_max_level();
 
     // ターン数

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -721,7 +721,7 @@ void process_command(CreatureEntity &creature)
     }
     }
 
-    if (!creature.energy_use && !now_message) {
+    if (!creature.get_energy_use() && !now_message) {
         now_message = old_now_message;
     }
 }

--- a/src/io/pref-file-expressor.cpp
+++ b/src/io/pref-file-expressor.cpp
@@ -190,7 +190,7 @@ std::string process_pref_file_expr(CreatureEntity &creature, char **sp, char *fp
     } else if (streq(b + 1, "LEVEL")) {
         v = format("%02d", creature.get_level());
     } else if (streq(b + 1, "AUTOREGISTER")) {
-        if (creature.autopick_autoregister) {
+        if (creature.is_autopick_autoregister()) {
             v = "1";
         } else {
             v = "0";

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -335,7 +335,7 @@ static void rd_bad_status(CreatureEntity &creature)
 static void rd_energy(CreatureEntity &creature)
 {
     creature.energy_need = rd_s16b();
-    creature.enchant_energy_need = rd_s16b();
+    creature.set_enchant_energy_need(rd_s16b());
 }
 
 /*!
@@ -477,7 +477,7 @@ static void rd_player_status(CreatureEntity &creature)
     creature.set_timed_effect(CreatureTimedEffect::BLESSED, rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::TIM_INVIS, rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, rd_s16b());
-    creature.recall_dungeon = i2enum<DungeonId>(rd_s16b());
+    creature.set_recall_dungeon(i2enum<DungeonId>(rd_s16b()));
     creature.set_timed_effect(CreatureTimedEffect::ALTER_REALITY, rd_s16b());
     creature.set_infravision(rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::TIM_INFRA, rd_s16b());

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -55,7 +55,7 @@ void rd_dungeons(CreatureEntity &creature)
  */
 void rd_alter_reality(CreatureEntity &creature)
 {
-    creature.recall_dungeon = i2enum<DungeonId>(rd_s16b());
+    creature.set_recall_dungeon(i2enum<DungeonId>(rd_s16b()));
     creature.set_timed_effect(CreatureTimedEffect::ALTER_REALITY, rd_s16b());
 }
 
@@ -76,7 +76,7 @@ void set_gambling_monsters()
  */
 void rd_autopick(CreatureEntity &creature)
 {
-    creature.autopick_autoregister = rd_bool();
+    creature.set_autopick_autoregister(rd_bool());
 }
 
 static void rd_world_info(CreatureEntity &creature)

--- a/src/object-hook/hook-magic.cpp
+++ b/src/object-hook/hook-magic.cpp
@@ -40,7 +40,7 @@ bool object_is_activatable(const ItemEntity *o_ptr)
 bool item_tester_hook_use(CreatureEntity &creature, const ItemEntity *o_ptr)
 {
     const auto tval = o_ptr->bi_key.tval();
-    if (tval == creature.tval_ammo) {
+    if (tval == creature.get_tval_ammo()) {
         return true;
     }
 

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -440,19 +440,19 @@ static bool check_fear_death(CreatureEntity &creature, player_attack_type *pa_pt
     }
 
     *(pa_ptr->mdeath) = true;
-    if (CreatureClass(creature).equals(PlayerClassType::BERSERKER) && creature.energy_use) {
+    if (CreatureClass(creature).equals(PlayerClassType::BERSERKER) && creature.get_energy_use()) {
         PlayerEnergy energy(creature);
         if (can_attack_with_main_hand(creature) && can_attack_with_sub_hand(creature)) {
             ENERGY energy_use;
             if (pa_ptr->hand) {
-                energy_use = creature.energy_use * 3 / 5 + creature.energy_use * num * 2 / (creature.get_num_blow(pa_ptr->hand) * 5);
+                energy_use = creature.get_energy_use() * 3 / 5 + creature.get_energy_use() * num * 2 / (creature.get_num_blow(pa_ptr->hand) * 5);
             } else {
-                energy_use = creature.energy_use * num * 3 / (creature.get_num_blow(pa_ptr->hand) * 5);
+                energy_use = creature.get_energy_use() * num * 3 / (creature.get_num_blow(pa_ptr->hand) * 5);
             }
 
             energy.set_player_turn_energy(energy_use);
         } else {
-            auto energy_use = (ENERGY)(creature.energy_use * num / creature.get_num_blow(pa_ptr->hand));
+            auto energy_use = (ENERGY)(creature.get_energy_use() * num / creature.get_num_blow(pa_ptr->hand));
             energy.set_player_turn_energy(energy_use);
         }
     }

--- a/src/player-status/player-energy.cpp
+++ b/src/player-status/player-energy.cpp
@@ -20,27 +20,27 @@ PlayerEnergy::PlayerEnergy(CreatureEntity &creature)
  */
 void PlayerEnergy::set_player_turn_energy(ENERGY need_cost)
 {
-    this->creature_ptr->energy_use = need_cost;
+    this->creature_ptr->set_energy_use(need_cost);
 }
 
 void PlayerEnergy::add_player_turn_energy(ENERGY need_cost)
 {
-    this->creature_ptr->energy_use += need_cost;
+    this->creature_ptr->add_energy_use(need_cost);
 }
 
 void PlayerEnergy::sub_player_turn_energy(ENERGY need_cost)
 {
-    this->creature_ptr->energy_use -= need_cost;
+    this->creature_ptr->sub_energy_use(need_cost);
 }
 
 void PlayerEnergy::mul_player_turn_energy(ENERGY need_cost)
 {
-    this->creature_ptr->energy_use *= need_cost;
+    this->creature_ptr->mul_energy_use(need_cost);
 }
 
 void PlayerEnergy::div_player_turn_energy(ENERGY need_cost)
 {
-    this->creature_ptr->energy_use /= need_cost;
+    this->creature_ptr->div_energy_use(need_cost);
 }
 
 void PlayerEnergy::reset_player_turn()

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -290,8 +290,8 @@ bool move_player_effect(CreatureEntity &creature, POSITION ny, POSITION nx, BIT_
         }
     }
 
-    if (!(mpe_mode & MPE_STAYING) && (disturb_trap_detect || alert_trap_detect) && creature.dtrap && !(grid_new.info & CAVE_IN_DETECT)) {
-        creature.dtrap = false;
+    if (!(mpe_mode & MPE_STAYING) && (disturb_trap_detect || alert_trap_detect) && creature.is_dtrap() && !(grid_new.info & CAVE_IN_DETECT)) {
+        creature.set_dtrap(false);
         if (!(grid_new.info & CAVE_UNSAFE)) {
             if (alert_trap_detect) {
                 msg_print(_("* 注意:この先はトラップの感知範囲外です！ *", "*Leaving trap detect region!*"));

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -315,7 +315,7 @@ static void update_bonuses(CreatureEntity &creature)
     update_ability_scores(creature);
     o_ptr = creature.inventory[INVEN_BOW].get();
     if (o_ptr->is_valid()) {
-        creature.tval_ammo = o_ptr->get_arrow_kind();
+        creature.set_tval_ammo(o_ptr->get_arrow_kind());
         creature.set_num_fire(calc_num_fire(creature, o_ptr));
     }
 
@@ -1929,7 +1929,7 @@ static int16_t calc_riding_bow_penalty(CreatureEntity &creature)
     int16_t penalty = 0;
 
     if (CreatureClass(creature).is_tamer()) {
-        if (creature.tval_ammo != ItemKindType::ARROW) {
+        if (creature.get_tval_ammo() != ItemKindType::ARROW) {
             penalty = 5;
         }
     } else {
@@ -1940,7 +1940,7 @@ static int16_t calc_riding_bow_penalty(CreatureEntity &creature)
         }
     }
 
-    if (creature.tval_ammo == ItemKindType::BOLT) {
+    if (creature.get_tval_ammo() == ItemKindType::BOLT) {
         penalty *= 2;
     }
 
@@ -2477,7 +2477,7 @@ static int16_t calc_to_hit_bow(CreatureEntity &creature, bool is_real_value)
 
     if (o_ptr->is_valid()) {
         if (!is_heavy_shoot(creature, creature.inventory[INVEN_BOW].get())) {
-            if (CreatureClass(creature).equals(PlayerClassType::SNIPER) && (creature.tval_ammo == ItemKindType::BOLT)) {
+            if (CreatureClass(creature).equals(PlayerClassType::SNIPER) && (creature.get_tval_ammo() == ItemKindType::BOLT)) {
                 pow += (10 + (creature.get_level() / 5));
             }
         }

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -189,7 +189,7 @@ void wr_player(CreatureEntity &creature)
     wr_s16b(0); /* old "food_digested" */
     wr_s16b(0); /* old "protection" */
     wr_s16b(creature.energy_need);
-    wr_s16b(creature.enchant_energy_need);
+    wr_s16b(creature.get_enchant_energy_need());
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::ACCELERATION));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::DECELERATION));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::FEAR));
@@ -206,7 +206,7 @@ void wr_player(CreatureEntity &creature)
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::BLESSED));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::TIM_INVIS));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::WORD_RECALL));
-    wr_s16b(static_cast<int16_t>(creature.recall_dungeon));
+    wr_s16b(static_cast<int16_t>(creature.get_recall_dungeon()));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::ALTER_REALITY));
     wr_s16b(creature.get_infravision());
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::TIM_INFRA));
@@ -295,7 +295,7 @@ void wr_player(CreatureEntity &creature)
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::ELE_IMMUNE));
     wr_u32b(creature.get_special_defense_flags());
     wr_byte(creature.knowledge);
-    wr_bool(creature.autopick_autoregister);
+    wr_bool(creature.is_autopick_autoregister());
     wr_byte(0);
     wr_byte((byte)creature.get_action());
     wr_byte(0);

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -90,7 +90,7 @@ bool detect_traps(CreatureEntity &creature, POSITION range, bool known)
     }
 
     if (known || detect) {
-        creature.dtrap = true;
+        creature.set_dtrap(true);
     }
 
     if (music_singing(creature, MUSIC_DETECT) && get_singing_count(creature) > 0) {

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -112,7 +112,7 @@ void teleport_level(CreatureEntity &creature, MONSTER_IDX m_idx)
 #endif
         if (m_idx <= 0) {
             if (!floor.is_underground()) {
-                floor.set_dungeon_index(ironman_downward ? DungeonId::ANGBAND : creature.recall_dungeon);
+                floor.set_dungeon_index(ironman_downward ? DungeonId::ANGBAND : creature.get_recall_dungeon());
                 creature.oldpy = creature.y;
                 creature.oldpx = creature.x;
             }
@@ -468,7 +468,7 @@ bool recall_player(CreatureEntity &creature, TIME_EFFECT turns)
             return false;
         }
 
-        creature.recall_dungeon = *select_dungeon;
+        creature.set_recall_dungeon(*select_dungeon);
     }
 
     creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, turns);
@@ -504,10 +504,10 @@ bool free_level_recall(CreatureEntity &creature)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::WORD_RECALL, 1);
-    creature.recall_dungeon = *select_dungeon;
+    creature.set_recall_dungeon(*select_dungeon);
     const auto dun_level = (amt > dungeon.maxdepth) ? dungeon.maxdepth : (amt < dungeon.mindepth) ? dungeon.mindepth
                                                                                                   : amt;
-    auto &dungeon_record = DungeonRecords::get_instance().get_record(creature.recall_dungeon);
+    auto &dungeon_record = DungeonRecords::get_instance().get_record(creature.get_recall_dungeon());
     dungeon_record.set_max_level(dun_level);
     if (record_maxdepth) {
         exe_write_diary(*creature.get_floor(), DiaryKind::TRUMP, enum2i(*select_dungeon), _("トランプタワーで", "at Trump Tower"));

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1739,6 +1739,80 @@ public:
         this->tracking_bi_id = value;
     }
 
+    // [提案 48] さらなる小規模フィールドの virtual API。
+    virtual ItemKindType get_tval_ammo() const
+    {
+        return this->tval_ammo;
+    }
+    virtual void set_tval_ammo(ItemKindType value)
+    {
+        this->tval_ammo = value;
+    }
+    virtual bool is_dtrap() const
+    {
+        return this->dtrap;
+    }
+    virtual void set_dtrap(bool value)
+    {
+        this->dtrap = value;
+    }
+    virtual bool is_autopick_autoregister() const
+    {
+        return this->autopick_autoregister;
+    }
+    virtual void set_autopick_autoregister(bool value)
+    {
+        this->autopick_autoregister = value;
+    }
+    virtual DungeonId get_recall_dungeon() const
+    {
+        return this->recall_dungeon;
+    }
+    virtual void set_recall_dungeon(DungeonId value)
+    {
+        this->recall_dungeon = value;
+    }
+    virtual ENERGY get_enchant_energy_need() const
+    {
+        return this->enchant_energy_need;
+    }
+    virtual void set_enchant_energy_need(ENERGY value)
+    {
+        this->enchant_energy_need = value;
+    }
+    virtual void add_enchant_energy_need(ENERGY delta)
+    {
+        this->enchant_energy_need += delta;
+    }
+    virtual void sub_enchant_energy_need(ENERGY delta)
+    {
+        this->enchant_energy_need -= delta;
+    }
+    virtual ENERGY get_energy_use() const
+    {
+        return this->energy_use;
+    }
+    virtual void set_energy_use(ENERGY value)
+    {
+        this->energy_use = value;
+    }
+    virtual void add_energy_use(ENERGY delta)
+    {
+        this->energy_use += delta;
+    }
+    virtual void sub_energy_use(ENERGY delta)
+    {
+        this->energy_use -= delta;
+    }
+    virtual void mul_energy_use(ENERGY factor)
+    {
+        this->energy_use *= factor;
+    }
+    virtual void div_energy_use(ENERGY divisor)
+    {
+        this->energy_use /= divisor;
+    }
+
     /*!
      * @brief パック内の所持品数を inventory[] から計算する (提案 25)
      * @details inventory[0..INVEN_PACK) の有効アイテム数を返す。
@@ -3922,11 +3996,15 @@ public:
 private:
     GAME_TURN resting{}; /* Current counter for resting, if any */
 
-public:
+private:
+    // [提案 48] private 化済。get_recall_dungeon() / set_recall_dungeon() 経由。
     DungeonId recall_dungeon{}; /* Dungeon set to be recalled */
 
+    // [提案 48] private 化済。get_enchant_energy_need() / set_enchant_energy_need() /
+    // add_enchant_energy_need() / sub_enchant_energy_need() 経由。
     ENERGY enchant_energy_need{}; /* Energy needed for next upkeep effect	 */
 
+public:
     /*
      * creature.special_attackによるプレイヤーの攻撃状態の定義 / Bit flags for the "creature.special_attack" variable. -LM-
      *
@@ -4043,12 +4121,18 @@ private:
     int16_t pet_follow_distance{}; /* Length of the imaginary "leash" for pets */
     BIT_FLAGS16 pet_extra_flags{}; /* Various flags for controling pets */
 
-public:
+private:
+    // [提案 48] private 化済。is_dtrap() / set_dtrap() 経由。
     bool dtrap{}; /* Whether you are on trap-safe grids */
+
+public:
     FLOOR_IDX floor_id{}; /* Current floor location */
 
+private:
+    // [提案 48] private 化済。is_autopick_autoregister() / set_autopick_autoregister() 経由。
     bool autopick_autoregister{}; /* auto register is in-use or not */
 
+public:
     /*** Temporary fields ***/
 
     bool select_ring_slot{};
@@ -4149,10 +4233,15 @@ public:
 
     bool no_flowed{};
 
+private:
+    // [提案 48] private 化済。get_tval_ammo() / set_tval_ammo() 経由。
     ItemKindType tval_ammo{}; /* Correct ammo tval */
 
+    // [提案 48] private 化済。get_energy_use() / set_energy_use() /
+    // add_energy_use() / sub_energy_use() / mul_energy_use() / div_energy_use() 経由。
     ENERGY energy_use{}; /*!< 直近のターンに消費したエネルギー / Energy use this turn */
 
+public:
     std::string base_name{}; /*!< Stripped version of "player_name" */
 
 protected:

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -836,7 +836,7 @@ void cheat_death(CreatureEntity &creature, bool no_penalty)
     leaving_quest = QuestId::NONE;
     floor.quest_number = QuestId::NONE;
     if (floor.is_underground()) {
-        creature.recall_dungeon = floor.dungeon_id;
+        creature.set_recall_dungeon(floor.dungeon_id);
     }
 
     floor.reset_dungeon_index();

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -83,7 +83,7 @@ void execute_recall(CreatureEntity &creature)
     if (floor.is_underground() || floor.is_in_quest() || floor.is_entering_dungeon()) {
         msg_print(_("上に引っ張りあげられる感じがする！", "You feel yourself yanked upwards!"));
         if (floor.is_underground()) {
-            creature.recall_dungeon = floor.dungeon_id;
+            creature.set_recall_dungeon(floor.dungeon_id);
         }
         if (record_stair) {
             exe_write_diary(floor, DiaryKind::RECALL, floor.dun_level);
@@ -100,7 +100,7 @@ void execute_recall(CreatureEntity &creature)
     }
 
     msg_print(_("下に引きずり降ろされる感じがする！", "You feel yourself yanked downwards!"));
-    floor.set_dungeon_index(creature.recall_dungeon);
+    floor.set_dungeon_index(creature.get_recall_dungeon());
     if (record_stair) {
         exe_write_diary(floor, DiaryKind::RECALL, floor.dun_level);
     }


### PR DESCRIPTION
CreatureEntity 直下に public で残存していた小規模フィールド 6 個を
さらに private 化。compound assignment を含むものはコンパウンド系
virtual API (add_X / sub_X / mul_X / div_X) を整備。

対象フィールド:
- tval_ammo (弾種 ItemKindType)
- dtrap (トラップ安全地帯フラグ)
- autopick_autoregister (自動登録モード)
- recall_dungeon (帰還ダンジョン DungeonId)
- enchant_energy_need (次のエンチャント効果までエネルギー、+=/-= 含む)
- energy_use (今ターン消費エネルギー、=/+=/-=/*=//= 含む)

API (18 個の virtual):
- scalar/bool/enum 系の get/set
- ENERGY 系には compound 用の add_X(delta) / sub_X(delta) / mul_X(factor) / div_X(divisor) も整備

25 ファイル約 61 サイトを migration:
- combat/shoot.cpp / player-status.cpp 等の tval_ammo 読取
- floor-changer / spells-detection / run-execution / travel-execution / player-move の dtrap
- savefile + autopick-registry / pref-file-expressor の autopick_autoregister
- floor-leaver / wizard-special-process / savefile / world-movement-processor / io-dump / spells-world / game-play-initializer の recall_dungeon
- core/player-processor.cpp 等の enchant_energy_need compound
- player-attack / player-energy / cmd-move / input-key-processor / player-processor の energy_use (PlayerEnergy ラッパー内部も virtual API 経由に切替え)

合計 private 化フィールド数: 135 → 141