### PR TITLE
feat: C コマンド装備表示で該当なし部位を消去し通常枠/拡張枠を統合

### DIFF
--- a/src/view/display-player-inventory-page.cpp
+++ b/src/view/display-player-inventory-page.cpp
@@ -29,50 +29,42 @@ void put_section_header(int row, int col, std::string_view title)
     c_put_str(TERM_L_BLUE, title, row, col);
 }
 
-int display_equipment_section(CreatureEntity &creature)
+void display_equipment_section(CreatureEntity &creature)
 {
     put_section_header(HEADER_ROW, EQUIPMENT_COL, _("== 装備 ==", "== Equipment =="));
     int row = HEADER_ROW + 1;
-    for (auto slot = static_cast<int>(INVEN_MAIN_HAND); slot < INVEN_TOTAL; ++slot, ++row) {
-        const auto &item = *creature.inventory[slot];
-        const auto label = format("%-12s :", mention_use(creature, slot));
-        // 体構造的に装備不可なスロットは灰色で「該当なし」表記
+
+    // 通常装備スロット: 体構造的に装備可能な部位のみ表示する (該当なしは消去)
+    for (auto slot = static_cast<int>(INVEN_MAIN_HAND); slot < INVEN_TOTAL; ++slot) {
         if (!creature.can_equip_to(slot)) {
-            c_put_str(TERM_L_DARK, label, row, EQUIPMENT_COL);
-            c_put_str(TERM_L_DARK, _("(該当なし)", "(no slot)"), row, EQUIPMENT_COL + 14);
             continue;
         }
+        const auto &item = *creature.inventory[slot];
+        const auto label = format("%-12s :", mention_use(creature, slot));
         c_put_str(TERM_WHITE, label, row, EQUIPMENT_COL);
         if (!item.is_valid()) {
             c_put_str(TERM_L_DARK, _("(なし)", "(empty)"), row, EQUIPMENT_COL + 14);
-            continue;
+        } else {
+            const auto desc = describe_flavor(creature, item, OD_OMIT_PREFIX | OD_NAME_AND_ENCHANT);
+            c_put_str(TERM_L_GREEN, desc.substr(0, 24), row, EQUIPMENT_COL + 14);
         }
-
-        const auto desc = describe_flavor(creature, item, OD_OMIT_PREFIX | OD_NAME_AND_ENCHANT);
-        c_put_str(TERM_L_GREEN, desc.substr(0, 24), row, EQUIPMENT_COL + 14);
+        ++row;
     }
-    return row;
-}
 
-void display_extended_slots_section(CreatureEntity &creature, int start_row)
-{
+    // 拡張装備スロット (尾の指輪・翼装飾 等) を通常枠と統合して同じリストに表示
     const auto slot_count = creature.get_extended_slot_count();
-    if (slot_count == 0) {
-        return;
-    }
-    put_section_header(start_row, EQUIPMENT_COL, _("== 拡張部位 ==", "== Extended =="));
-    int row = start_row + 1;
-    for (size_t i = 0; i < slot_count; ++i, ++row) {
+    for (size_t i = 0; i < slot_count; ++i) {
         const auto slot_type = creature.get_extended_slot_type(i);
         const auto name = get_extended_slot_name(slot_type);
         const auto label = format("%-12s :", name.empty() ? "" : name.data());
         c_put_str(TERM_WHITE, label, row, EQUIPMENT_COL);
         if (i >= creature.extended_inventory.size() || !creature.extended_inventory[i] || !creature.extended_inventory[i]->is_valid()) {
             c_put_str(TERM_L_DARK, _("(なし)", "(empty)"), row, EQUIPMENT_COL + 14);
-            continue;
+        } else {
+            const auto desc = describe_flavor(creature, *creature.extended_inventory[i], OD_OMIT_PREFIX | OD_NAME_AND_ENCHANT);
+            c_put_str(TERM_L_GREEN, desc.substr(0, 24), row, EQUIPMENT_COL + 14);
         }
-        const auto desc = describe_flavor(creature, *creature.extended_inventory[i], OD_OMIT_PREFIX | OD_NAME_AND_ENCHANT);
-        c_put_str(TERM_L_GREEN, desc.substr(0, 24), row, EQUIPMENT_COL + 14);
+        ++row;
     }
 }
 
@@ -109,7 +101,6 @@ void display_player_inventory_page(CreatureEntity &creature)
     const auto summary = format(_(" - 所持: %d / 装備: %d", " - Carried: %d / Equipped: %d"), cnt_inven, cnt_equip);
     c_put_str(TERM_SLATE, summary, 1, 25);
 
-    const auto next_row = display_equipment_section(creature);
-    display_extended_slots_section(creature, next_row + 1);
+    display_equipment_section(creature);
     display_inventory_section(creature);
 }


### PR DESCRIPTION
ユーザー要望:
- 該当のない装備部位はグレーアウトではなく消去する
- 通常装備枠と拡張装備枠を分けずに統合表示する

- display_equipment_section():
  - 体構造的に装備不可なスロット (can_equip_to == false) は 「(該当なし)」のグレー表記をやめ、行ごと描画しない (消去)
  - 拡張装備スロット (尾の指輪・翼装飾 等) を別セクション (== 拡張部位 ==) にせず、通常装備リストの続きに統合表示
- display_extended_slots_section() を削除 (装備セクションに統合)
- 返り値が不要になったため display_equipment_section を void 化

これにより四足獣・ヘビ型等の非 HUMANOID プレイヤーでは、実際に装備
可能な部位のみが連続した 1 リストとして表示される。