### PR TITLE
feat: モンスターの一般ドロップ品を死亡時生成から生成時所持に移行

### DIFF
--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
@@ -798,6 +798,7 @@
     <ClCompile Include="..\..\src\main\sound-of-music.cpp" />
     <ClCompile Include="..\..\src\monster-floor\monster-summon.cpp" />
     <ClCompile Include="..\..\src\monster-floor\one-monster-placer.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-drop-generator.cpp" />
     <ClCompile Include="..\..\src\monster\monster-compaction.cpp" />
     <ClCompile Include="..\..\src\monster-floor\monster-death.cpp" />
     <ClCompile Include="..\..\src\lore\monster-lore.cpp" />
@@ -1727,6 +1728,7 @@
     <ClInclude Include="..\..\src\mind\snipe-types.h" />
     <ClInclude Include="..\..\src\monster-floor\monster-summon.h" />
     <ClInclude Include="..\..\src\monster-floor\one-monster-placer.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-drop-generator.h" />
     <ClInclude Include="..\..\src\monster\monster-compaction.h" />
     <ClInclude Include="..\..\src\monster-floor\monster-death.h" />
     <ClInclude Include="..\..\src\lore\monster-lore.h" />

--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
@@ -1121,6 +1121,9 @@
     <ClCompile Include="..\..\src\monster-floor\one-monster-placer.cpp">
       <Filter>monster-floor</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-drop-generator.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\monster-floor\monster-summon.cpp">
       <Filter>monster-floor</Filter>
     </ClCompile>
@@ -4076,6 +4079,9 @@
       <Filter>monster-floor</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\monster-floor\one-monster-placer.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-drop-generator.h">
       <Filter>monster-floor</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\monster-floor\monster-summon.h">

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -941,6 +941,7 @@ hengband_SOURCES = \
 	monster-floor/monster-lite.cpp monster-floor/monster-lite.h \
 	monster-floor/monster-lite-util.cpp monster-floor/monster-lite-util.h \
 	monster-floor/one-monster-placer.cpp monster-floor/one-monster-placer.h \
+	monster-floor/monster-drop-generator.cpp monster-floor/monster-drop-generator.h \
 	monster-floor/place-monster-types.h \
 	monster-floor/quantum-effect.cpp monster-floor/quantum-effect.h \
 	monster-floor/special-death-switcher.cpp monster-floor/special-death-switcher.h \

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -245,97 +245,6 @@ static void drop_artifacts(CreatureEntity &creature, MonsterDeath *md_ptr)
     msg_format(_("あなたは%sを制覇した！", "You have conquered %s!"), dungeon.name.data());
 }
 
-static void decide_drop_quality(MonsterDeath *md_ptr)
-{
-    md_ptr->mo_mode = 0L;
-    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_GOOD)) {
-        md_ptr->mo_mode |= AM_GOOD;
-    }
-
-    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_GREAT)) {
-        md_ptr->mo_mode |= (AM_GOOD | AM_GREAT);
-    }
-
-    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_NASTY)) {
-        md_ptr->mo_mode |= AM_NASTY;
-    }
-}
-
-static int decide_drop_numbers(MonsterDeath *md_ptr, const bool drop_item, const bool inside_arena)
-{
-    int drop_numbers = 0;
-    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_60) && evaluate_percent(60)) {
-        drop_numbers++;
-    }
-
-    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_90) && evaluate_percent(90)) {
-        drop_numbers++;
-    }
-
-    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_1D2)) {
-        drop_numbers += Dice::roll(1, 2);
-    }
-
-    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_2D2)) {
-        drop_numbers += Dice::roll(2, 2);
-    }
-
-    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_3D2)) {
-        drop_numbers += Dice::roll(3, 2);
-    }
-
-    if (md_ptr->monrace->drop_flags.has(MonsterDropType::DROP_4D2)) {
-        drop_numbers += Dice::roll(4, 2);
-    }
-
-    if (md_ptr->cloned && md_ptr->monrace->kind_flags.has_not(MonsterKindType::UNIQUE)) {
-        drop_numbers = 0;
-    }
-
-    if (md_ptr->m_ptr->is_pet() || AngbandSystem::get_instance().is_phase_out() || inside_arena) {
-        drop_numbers = 0;
-    }
-
-    if (!drop_item && !md_ptr->monrace->symbol_char_is_any_of("$")) {
-        drop_numbers = 0;
-    }
-
-    if (md_ptr->monrace->misc_flags.has(MonsterMiscType::MULTIPLY) && (md_ptr->monrace->r_akills > 1024)) {
-        drop_numbers = 0;
-    }
-
-    return drop_numbers;
-}
-
-static void drop_items_golds(CreatureEntity &creature, MonsterDeath *md_ptr, int drop_numbers)
-{
-    auto dump_item = 0;
-    auto dump_gold = 0;
-    auto &floor = *creature.get_floor();
-    const auto &monraces = MonraceList::get_instance();
-    for (auto i = 0; i < drop_numbers; i++) {
-        if (md_ptr->do_gold && (!md_ptr->do_item || one_in_(2))) {
-            const auto &monrace = monraces.get_monrace(md_ptr->m_ptr->get_r_idx());
-            const auto bi_key = BaseitemMonraceService::lookup_fixed_gold_drop(monrace.drop_flags);
-            auto item = floor.make_gold(bi_key);
-            (void)drop_near(creature, item, md_ptr->get_position());
-            dump_gold++;
-        } else {
-            if (auto item = make_object(creature, md_ptr->mo_mode)) {
-                (void)drop_near(creature, *item, md_ptr->get_position());
-                dump_item++;
-            }
-        }
-    }
-
-    floor.object_level = floor.base_level;
-    auto visible = md_ptr->m_ptr->is_visible_on_map() && !creature.is_hallucinated();
-    visible |= (md_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE));
-    if (visible && (dump_item || dump_gold)) {
-        md_ptr->m_ptr->make_lore_treasure(dump_item, dump_gold);
-    }
-}
-
 /*!
  * @brief 最終ボス(混沌のサーペント)を倒したときの処理
  * @param creature クリーチャーへの参照
@@ -442,13 +351,16 @@ void monster_death(CreatureEntity &creature, MONSTER_IDX m_idx, bool drop_item, 
     }
 
     drop_corpse(creature, &md);
-    md.m_ptr->drop_all_inventory(creature);
-    decide_drop_quality(&md);
+    // [ドロップ品移行] 一般ドロップ品はモンスター生成時に所持品として前生成済み。
+    // 死亡時は drop_all_inventory() でまとめて床へ放出する。ただし drop_item が
+    // false のケース (量子消失・モンスター同士の戦闘・一部効果死) では従来同様に
+    // ドロップを抑制する (モンスターピット等での床溢れ防止)。
+    if (drop_item) {
+        md.m_ptr->drop_all_inventory(creature);
+    }
+
     switch_special_death(creature, &md, attribute_flags);
     drop_artifacts(creature, &md);
-    const auto drop_numbers = decide_drop_numbers(&md, drop_item, floor.inside_arena);
-    floor.object_level = (floor.dun_level + md.monrace->level) / 2;
-    drop_items_golds(creature, &md, drop_numbers);
     if ((md.monrace->misc_flags.has_not(MonsterMiscType::QUESTOR)) || AngbandSystem::get_instance().is_phase_out() || (md.m_ptr->get_r_idx() != MonraceId::SERPENT) || md.cloned) {
         return;
     }

--- a/src/monster-floor/monster-drop-generator.cpp
+++ b/src/monster-floor/monster-drop-generator.cpp
@@ -1,0 +1,121 @@
+/*!
+ * @file monster-drop-generator.cpp
+ * @brief モンスター生成時にドロップ品を所持品として生成する処理の実装
+ */
+
+#include "monster-floor/monster-drop-generator.h"
+#include "floor/floor-object.h"
+#include "monster-race/race-drop-flags.h"
+#include "monster-race/race-kind-flags.h"
+#include "monster-race/race-misc-flags.h"
+#include "object-enchant/item-apply-magic.h"
+#include "system/angband-system.h"
+#include "system/creature-entity.h"
+#include "system/floor/floor-info.h"
+#include "system/monrace/monrace-definition.h"
+#include "system/services/baseitem-monrace-service.h"
+#include "util/dice.h"
+#include "util/enum-converter.h"
+#include "util/probability-table.h"
+
+namespace {
+/*!
+ * @brief drop_flags からアイテム生成品質モード (AM_GOOD 等) を決める
+ */
+BIT_FLAGS decide_drop_quality_mode(const MonraceDefinition &monrace)
+{
+    BIT_FLAGS mode = 0L;
+    if (monrace.drop_flags.has(MonsterDropType::DROP_GOOD)) {
+        mode |= AM_GOOD;
+    }
+    if (monrace.drop_flags.has(MonsterDropType::DROP_GREAT)) {
+        mode |= (AM_GOOD | AM_GREAT);
+    }
+    if (monrace.drop_flags.has(MonsterDropType::DROP_NASTY)) {
+        mode |= AM_NASTY;
+    }
+    return mode;
+}
+
+/*!
+ * @brief drop_flags からドロップ個数を決める
+ * @details monster_death() 時の decide_drop_numbers() と同等。生成時点で
+ *          確定しているクローン/ペット/アリーナ等の抑制条件も反映する。
+ */
+int decide_drop_numbers(const CreatureEntity &monster, const MonraceDefinition &monrace, bool inside_arena)
+{
+    int drop_numbers = 0;
+    if (monrace.drop_flags.has(MonsterDropType::DROP_60) && evaluate_percent(60)) {
+        drop_numbers++;
+    }
+    if (monrace.drop_flags.has(MonsterDropType::DROP_90) && evaluate_percent(90)) {
+        drop_numbers++;
+    }
+    if (monrace.drop_flags.has(MonsterDropType::DROP_1D2)) {
+        drop_numbers += Dice::roll(1, 2);
+    }
+    if (monrace.drop_flags.has(MonsterDropType::DROP_2D2)) {
+        drop_numbers += Dice::roll(2, 2);
+    }
+    if (monrace.drop_flags.has(MonsterDropType::DROP_3D2)) {
+        drop_numbers += Dice::roll(3, 2);
+    }
+    if (monrace.drop_flags.has(MonsterDropType::DROP_4D2)) {
+        drop_numbers += Dice::roll(4, 2);
+    }
+
+    const auto cloned = monster.has_constant_flag(MonsterConstantFlagType::CLONED);
+    if (cloned && monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {
+        drop_numbers = 0;
+    }
+    if (monster.is_pet() || AngbandSystem::get_instance().is_phase_out() || inside_arena) {
+        drop_numbers = 0;
+    }
+    if (monrace.misc_flags.has(MonsterMiscType::MULTIPLY) && (monrace.r_akills > 1024)) {
+        drop_numbers = 0;
+    }
+    return drop_numbers;
+}
+}
+
+void generate_monster_drop_items(CreatureEntity &player, CreatureEntity &monster)
+{
+    auto &floor = *player.get_floor();
+    const auto &monrace = monster.get_monrace();
+
+    const auto do_gold = monrace.drop_flags.has_none_of({
+        MonsterDropType::ONLY_ITEM,
+        MonsterDropType::DROP_GOOD,
+        MonsterDropType::DROP_GREAT,
+    });
+    auto do_item = monrace.drop_flags.has_not(MonsterDropType::ONLY_GOLD);
+    do_item |= monrace.drop_flags.has_any_of({ MonsterDropType::DROP_GOOD, MonsterDropType::DROP_GREAT });
+
+    auto drop_numbers = decide_drop_numbers(monster, monrace, floor.inside_arena);
+    if (!do_item && !monrace.symbol_char_is_any_of("$")) {
+        drop_numbers = 0;
+    }
+    if (drop_numbers <= 0) {
+        return;
+    }
+
+    const auto mo_mode = decide_drop_quality_mode(monrace);
+
+    // 死亡時 (monster_death) と同様に、生成基準階をモンスター種族レベルで底上げする。
+    const auto backup_object_level = floor.object_level;
+    floor.object_level = (floor.dun_level + monrace.level) / 2;
+
+    for (auto i = 0; i < drop_numbers; i++) {
+        if (do_gold && (!do_item || one_in_(2))) {
+            const auto bi_key = BaseitemMonraceService::lookup_fixed_gold_drop(monrace.drop_flags);
+            auto item = floor.make_gold(bi_key);
+            monster.acquire_item(item);
+        } else {
+            if (auto item = make_object(player, mo_mode)) {
+                monster.acquire_item(*item);
+            }
+        }
+    }
+
+    floor.object_level = backup_object_level;
+}

--- a/src/monster-floor/monster-drop-generator.h
+++ b/src/monster-floor/monster-drop-generator.h
@@ -1,0 +1,21 @@
+/*!
+ * @file monster-drop-generator.h
+ * @brief モンスター生成時にドロップ品を所持品として生成する処理
+ */
+
+#pragma once
+
+class CreatureEntity;
+
+/*!
+ * @brief モンスターの一般ドロップ品 (drop_flags に基づくアイテム/金) を
+ *        生成し、そのモンスターの所持品 (inventory) に追加する。
+ * @param player プレイヤーへの参照 (生成基準・フロア取得用)
+ * @param monster ドロップ品を持たせる対象モンスター
+ * @details 従来は monster_death() 時に生成・床散布していた一般ドロップを、
+ *          モンスター生成時に所持品として前生成する方式へ移行したもの。
+ *          死亡時は drop_all_inventory() により所持品ごと床へ放出される。
+ *          固定アーティファクト・クエスト品・死体ドロップ等の特殊処理は
+ *          引き続き死亡時に行う。
+ */
+void generate_monster_drop_items(CreatureEntity &player, CreatureEntity &monster);

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -18,6 +18,7 @@
 #include "grid/grid.h"
 #include "monster-attack/monster-attack-player.h"
 #include "monster-attack/monster-attack-table.h"
+#include "monster-floor/monster-drop-generator.h"
 #include "monster-floor/monster-move.h"
 #include "monster-floor/place-monster-types.h"
 #include "monster-race/monster-kind-mask.h"
@@ -597,6 +598,10 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
 
     update_monster(const_cast<CreatureEntity &>(player), g_ptr->m_idx, true);
     m_ptr->get_real_monrace().increment_current_numbers();
+
+    // [ドロップ品移行] 一般ドロップ品を生成時に所持品として前生成する。
+    // 死亡時は drop_all_inventory() でまとめて床へ放出される。
+    generate_monster_drop_items(const_cast<CreatureEntity &>(player), *m_ptr);
 
     if (any_bits(mode, PM_AMBUSH)) {
         auto m_name = monster_desc(player, *m_ptr, 0);


### PR DESCRIPTION
ユーザー要望: モンスターのドロップ品を死亡時に生成するのではなく、
モンスター生成時に所持品 (inventory) として追加する方式へ移行。

新規 monster-floor/monster-drop-generator.{h,cpp}:
- generate_monster_drop_items(player, monster): drop_flags に基づく 一般ドロップ (DROP_60/90/1D2..4D2、ONLY_GOLD/ITEM、DROP_GOOD/GREAT/ NASTY) と金を生成し、monster.acquire_item() で所持品に追加
- 品質モード (AM_GOOD 等) / ドロップ個数 / 抑制条件 (クローン非ユニーク・ ペット・アリーナ・phase_out・多産個体の多数撃破) は従来の monster_death() ロジックを踏襲
- 生成基準階は従来同様 (dun_level + monrace.level) / 2 に底上げ

one-monster-placer.cpp::place_monster_one():
- init_extended_inventory / update_monster 後に generate_monster_drop_items を呼び、生成時に所持品を前生成

monster-death.cpp::monster_death():
- 死亡時の一般ドロップ生成 (decide_drop_quality / decide_drop_numbers / drop_items_golds) を削除。これらの static 関数も削除
- drop_all_inventory() で所持品 (前生成ドロップ含む) を床へ放出
- drop_item == false (量子消失・モンスター同士の戦闘・一部効果死) では drop_all_inventory を抑制し、従来同様ドロップしない (床溢れ防止)

- 死体/スケルトン/魂ドロップ (drop_corpse)
- 固定アーティファクト・ダンジョン最終アーティファクト (drop_artifacts)
- クエスト品・種族別特殊死亡処理 (switch_special_death)

- ドロップロア (r_drop_item / r_drop_gold) の更新は現状未対応 (make_lore_treasure 呼出が死亡時生成と共に外れたため)。別途対応予定
- 生成時に所持品を持つためメモリ/生成コストが僅かに増加