### PR TITLE
fix: モンスター recall (r コマンド) の打撃表示で blows 可変長 vector を範囲外参照していた問題を修正

### DIFF
--- a/src/lore/lore-store.cpp
+++ b/src/lore/lore-store.cpp
@@ -41,8 +41,12 @@ int lore_do_probe(CreatureEntity &creature, MonraceId r_idx)
     }
     monrace.r_wake = monrace.r_ignore = MAX_UCHAR;
 
-    for (auto i = 0; i < 4; i++) {
+    // blows / r_blows は可変長 vector のため、実サイズで走査する。
+    for (size_t i = 0; i < monrace.blows.size(); i++) {
         if (monrace.blows[i].effect != RaceBlowEffectType::NONE || monrace.blows[i].method != RaceBlowMethodType::NONE) {
+            if (i >= monrace.r_blows.size()) {
+                monrace.r_blows.resize(i + 1, 0);
+            }
             if (monrace.r_blows[i] != MAX_UCHAR) {
                 n++;
             }

--- a/src/view/display-lore-attacks.cpp
+++ b/src/view/display-lore-attacks.cpp
@@ -162,7 +162,12 @@ void display_monster_melee_summary_line(lore_type *lore_ptr)
     const auto saved_pc = lore_ptr->pc;
     const auto saved_qc = lore_ptr->qc;
 
-    const int max_attack_numbers = 4;
+    // blows / r_blows は可変長 vector のため、固定回数ではなく実サイズで走査する。
+    const auto max_attack_numbers = static_cast<int>(lore_ptr->monrace->blows.size());
+    const auto blow_seen_at = [lore_ptr](int m) {
+        const auto &r_blows = lore_ptr->monrace->r_blows;
+        return (static_cast<size_t>(m) < r_blows.size()) && (r_blows[m] != 0);
+    };
     bool any = false;
 
     hooked_roff(_("[打撃] ", "[Melee] "));
@@ -173,7 +178,7 @@ void display_monster_melee_summary_line(lore_type *lore_ptr)
             continue;
         }
 
-        if (!lore_ptr->know_everything && (lore_ptr->monrace->r_blows[m] == 0)) {
+        if (!lore_ptr->know_everything && !blow_seen_at(m)) {
             continue;
         }
 
@@ -192,7 +197,7 @@ void display_monster_melee_summary_line(lore_type *lore_ptr)
         // 手段（pc）
         hook_c_roff(lore_ptr->pc, method_abbrev);
 
-        const bool blow_seen = lore_ptr->know_everything || (lore_ptr->monrace->r_blows[m] != 0);
+        const bool blow_seen = lore_ptr->know_everything || blow_seen_at(m);
         const bool dmg_known = lore_ptr->know_everything || lore_ptr->is_blow_damage_known(m);
 
         // ダイスあり
@@ -325,20 +330,26 @@ void display_monster_blow(lore_type *lore_ptr, int m, int attack_numbers)
  */
 void display_monster_blows(lore_type *lore_ptr)
 {
-    const int max_attack_numbers = 4;
-    for (int m = 0; m < max_attack_numbers; m++) {
+    // blows / r_blows は可変長 vector のため、固定回数ではなく実サイズで走査する。
+    const auto blow_count = static_cast<int>(lore_ptr->monrace->blows.size());
+    const auto seen_blow = [lore_ptr](int m) {
+        const auto &r_blows = lore_ptr->monrace->r_blows;
+        return (static_cast<size_t>(m) < r_blows.size()) && (r_blows[m] != 0);
+    };
+
+    for (int m = 0; m < blow_count; m++) {
         if (lore_ptr->monrace->blows[m].method == RaceBlowMethodType::NONE) {
             continue;
         }
 
-        if (lore_ptr->monrace->r_blows[m] || lore_ptr->know_everything) {
+        if (seen_blow(m) || lore_ptr->know_everything) {
             lore_ptr->count++;
         }
     }
 
     int attack_numbers = 0;
-    for (int m = 0; m < max_attack_numbers; m++) {
-        if (lore_ptr->monrace->blows[m].method == RaceBlowMethodType::NONE || (((lore_ptr->monrace->r_blows[m] == 0) && !lore_ptr->know_everything))) {
+    for (int m = 0; m < blow_count; m++) {
+        if (lore_ptr->monrace->blows[m].method == RaceBlowMethodType::NONE || (!seen_blow(m) && !lore_ptr->know_everything)) {
             continue;
         }
 


### PR DESCRIPTION
ユーザー報告: モンスターの r コマンド (思い出表示) で
display_monster_blows() がランタイムエラー (MSVC の vector 範囲外 アサート)。

MonraceDefinition::blows / r_blows は可変長 std::vector だが、 打撃表示・probe 処理が固定 4 回ループで operator[] アクセスしており、
打撃が 4 未満のモンスター (大多数) で blows[3] 等が範囲外参照と
なっていた。さらに r_blows は blows と同サイズとは限らず (未観測時は
より短い) 範囲外アクセスの恐れがあった。

- view/display-lore-attacks.cpp:
  - display_monster_blows(): 固定 4 回ループを blows.size() ベースに変更。 r_blows アクセスはサイズチェック付きラムダ (seen_blow) 経由に
  - display_monster_melee_summary_line(): 同様に blows.size() ベース化、 r_blows アクセスをサイズチェック付き (blow_seen_at) に
- lore/lore-store.cpp:
  - lore_do_probe(): 固定 4 回ループを blows.size() ベースに変更し、 r_blows が短い場合は resize(i+1, 0) してから書き込む

その他の blows[ap_cnt] / blows[m] アクセスは既に blows.size() で 境界される呼出か resize ガード済みであることを確認。