### PR TITLE
feat: モンスタープレイに固定ドロップ品(drop_kind)を100%所持して開始

### DIFF
--- a/src/birth/monster-birth.cpp
+++ b/src/birth/monster-birth.cpp
@@ -4,13 +4,19 @@
  */
 
 #include "birth/monster-birth.h"
+#include "artifact/random-art-generator.h"
+#include "autopick/autopick.h"
 #include "avatar/avatar.h"
 #include "birth/birth-stat.h"
 #include "birth/game-play-initializer.h"
 #include "birth/history-editor.h"
+#include "birth/inventory-initializer.h"
 #include "core/asking-player.h"
 #include "io/input-key-acceptor.h"
 #include "mind/mind-elementalist.h"
+#include "object-enchant/item-apply-magic.h"
+#include "object-enchant/item-magic-applier.h"
+#include "perception/object-perception.h"
 #include "player-ability/player-ability-types.h"
 #include "player-base/player-class.h"
 #include "player-info/class-info.h"
@@ -27,11 +33,13 @@
 #include "spell/spells-status.h"
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
+#include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"
+#include "util/dice.h"
 #include "util/enum-converter.h"
 #include "view/display-messages.h"
 #include "wizard/wizard-spells.h"
@@ -139,6 +147,79 @@ void apply_initial_level(CreatureEntity &creature, MonraceId monrace_id)
     creature.set_level(initial_plv);
     creature.set_max_plv(initial_plv);
 }
+
+/*!
+ * @brief モンスター種族の固定ドロップ指定 (drop_kind) を初期所持品として付与する
+ * @details JSON の "drop_kind" で指定された固定ドロップは、モンスターとして
+ *          ゲームを開始した場合に確率を無視して 100% 所持した状態で始める。
+ *          グレード別の魔法付与は死亡時ドロップ (on_dead_drop_kind_item) と
+ *          揃え、生成基準階はモンスター種族レベルを用いる。
+ *          付与後は wield_all() で装備可能なものを自動装備する。
+ * @param creature クリーチャーへの参照
+ * @param monrace_id 開始モンスターの種族ID
+ */
+void grant_fixed_drop_items(CreatureEntity &creature, MonraceId monrace_id)
+{
+    const auto &monrace = MonraceList::get_instance().get_monrace(monrace_id);
+    if (monrace.drop_kinds.empty()) {
+        return;
+    }
+
+    // 生成基準階はモンスター種族レベル (最低 1)。上限は ItemMagicApplier 内部で
+    // MAX_DEPTH 未満にクランプされるためここでは下限のみ担保する。
+    const auto magic_level = static_cast<DEPTH>(std::max<int>(monrace.level, 1));
+    auto granted_any = false;
+    for (const auto &kind : monrace.drop_kinds) {
+        // num/deno は出現確率の指定だが、プレイヤー運用時は無視して必ず付与する。
+        const short kind_idx = std::get<2>(kind);
+        const int grade = std::get<3>(kind);
+        const int dn = std::get<4>(kind);
+        const int ds = std::get<5>(kind);
+        const int drop_nums = Dice::roll(dn, ds);
+
+        for (int i = 0; i < drop_nums; i++) {
+            ItemEntity item;
+            item.generate(kind_idx);
+            switch (grade) {
+            case -2:
+                ItemMagicApplier(creature, &item, magic_level, AM_NO_FIXED_ART | AM_GOOD | AM_GREAT | AM_CURSED).execute();
+                break;
+            case -1:
+                ItemMagicApplier(creature, &item, magic_level, AM_NO_FIXED_ART | AM_GOOD | AM_CURSED).execute();
+                break;
+            case 0:
+                ItemMagicApplier(creature, &item, magic_level, AM_NO_FIXED_ART).execute();
+                break;
+            case 1:
+                ItemMagicApplier(creature, &item, magic_level, AM_NO_FIXED_ART | AM_GOOD).execute();
+                break;
+            case 2:
+                ItemMagicApplier(creature, &item, magic_level, AM_NO_FIXED_ART | AM_GOOD | AM_GREAT).execute();
+                break;
+            case 3:
+                ItemMagicApplier(creature, &item, magic_level, AM_GOOD | AM_GREAT | AM_SPECIAL).execute();
+                if (!item.is_fixed_artifact()) {
+                    become_random_artifact(creature, &item, false);
+                }
+                break;
+            default:
+                break;
+            }
+
+            object_aware(creature, item);
+            item.mark_as_known();
+            const auto slot = creature.store_item(item);
+            if (slot >= 0) {
+                autopick_alter_item(creature, slot, false);
+                granted_any = true;
+            }
+        }
+    }
+
+    if (granted_any) {
+        wield_all(creature);
+    }
+}
 }
 
 bool player_birth_as_monster(CreatureEntity &creature)
@@ -168,6 +249,9 @@ bool player_birth_as_monster(CreatureEntity &creature)
     // 初期レベルを「生成階層 / 2」相当に揃える (get_extra で expfact が
     // セットされた後に呼ぶ必要があるためここで実施)
     apply_initial_level(creature, *monrace_id);
+
+    // モンスター種族に固定ドロップ指定 (drop_kind) があれば 100% 所持して開始する
+    grant_fixed_drop_items(creature, *monrace_id);
 
     // プレイヤー名入力 (モンスター種族名がデフォルト)
     get_name(creature);


### PR DESCRIPTION
モンスターをプレイヤーとして開始する際、種族定義の "drop_kind"
(固定アイテムドロップ指定) があれば、出現確率を無視して 100%
所持した状態でゲームを開始するようにした。

- monster-birth.cpp に grant_fixed_drop_items() を追加し、 player_birth_as_monster() の初期レベル設定後に呼び出す
- グレード別の魔法付与は死亡時ドロップ (on_dead_drop_kind_item) と 揃え、生成基準階はモンスター種族レベルを使用
- 付与アイテムは aware/known 化し、wield_all() で自動装備