### PR TITLE
feat: JSON でモンスターの性格 (personality) を固定指定可能にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,6 +461,30 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
 `get_psex()` / `get_ppersonality()` は `CreatureEntity` の virtual アクセサ
 (将来モンスター固有のオーバーライド余地)。
 
+### モンスターの性格指定 (`personality`)
+
+`MonraceDefinition` に `player_personality_type personality`
+(`src/system/monrace/monrace-definition.h`) を持ち、JSON
+`lib/edit/MonraceDefinitions.jsonc` で個別モンスターの性格を固定指定できる。
+
+```jsonc
+"personality": "LUCKY"
+```
+
+指定可能なトークンは `r_info_personality`
+(`src/info-reader/race-info-tokens-table.cpp`) を参照:
+`ORDINARY` / `MIGHTY` / `SHREWD` / `PIOUS` / `NIMBLE` / `FEARLESS` /
+`COMBAT` / `LAZY` / `SEXY` / `LUCKY` / `PATIENT` / `MUNCHKIN` /
+`CHARGEMAN` / `TOUGH` / `SUSHI_EATER` / `MESUGAKI`。
+
+- 未指定 (キー省略 = `PERSONALITY_NONE`) の場合は従来通り。モンスター生成時は
+  `CreatureEntity::assign_random_personality()` でランダム (いかさま除外)、
+  プレイヤー運用開始時は対話選択。
+- 指定がある場合は**常にその性格が適用**される。モンスター生成
+  (`assign_random_personality()` 内の固定指定チェック) でも、プレイヤー運用
+  開始 (`apply_monrace_personality()` で対話選択をスキップ) でも同一。
+- 性格適用は `CreatureEntity::set_personality(player_personality_type)` に集約。
+
 ---
 
 ## 開発フロー

--- a/src/birth/monster-birth.cpp
+++ b/src/birth/monster-birth.cpp
@@ -308,6 +308,26 @@ void apply_monrace_race(CreatureEntity &creature, MonraceId monrace_id)
 }
 
 /*!
+ * @brief モンスター種族に性格が固定指定されていればプレイヤーに反映する
+ * @details JSON の "personality" で指定された性格があれば常にそれを適用し、
+ *          プレイヤーによる対話的な性格選択を省略する。未指定の場合は
+ *          何もせず false を返し、呼び出し側で通常の選択処理に委ねる。
+ * @param creature クリーチャーへの参照
+ * @param monrace_id 開始モンスターの種族ID
+ * @return 固定指定を適用したら true、未指定なら false
+ */
+bool apply_monrace_personality(CreatureEntity &creature, MonraceId monrace_id)
+{
+    const auto &monrace = MonraceList::get_instance().get_monrace(monrace_id);
+    if (monrace.personality == PERSONALITY_NONE) {
+        return false;
+    }
+
+    creature.set_personality(monrace.personality);
+    return true;
+}
+
+/*!
  * @brief モンスター種族定義の性別をプレイヤーの性別に反映する
  * @details one-monster-placer.cpp のモンスター生成時と同じ判定を用いる。
  *          データソースは kind_flags の MALE/FEMALE と MonraceDefinition::sex
@@ -538,11 +558,14 @@ bool player_birth_as_monster(CreatureEntity &creature)
     // (HP/MP 計算に影響するため get_extra() より前に確定させる)
     apply_monrace_class(creature, *monrace_id);
 
-    // 性格を通常キャラ作成と同様にプレイヤーが選択する
+    // 性格: モンスター種族に固定指定があれば常にそれを使い、
+    // なければ通常キャラ作成と同様にプレイヤーが選択する
     // (能力値・ボーナスに影響するため get_stats() より前に確定させる)
-    term_clear();
-    if (!select_player_personality(creature)) {
-        return false;
+    if (!apply_monrace_personality(creature, *monrace_id)) {
+        term_clear();
+        if (!select_player_personality(creature)) {
+            return false;
+        }
     }
 
     // プレイヤー作成と同じローラーで基礎能力値を振る

--- a/src/info-reader/race-info-tokens-table.cpp
+++ b/src/info-reader/race-info-tokens-table.cpp
@@ -691,6 +691,25 @@ const std::unordered_map<std::string_view, MonsterSex> r_info_sex = {
     { "FEMALE", MonsterSex::FEMALE },
 };
 
+const std::unordered_map<std::string_view, player_personality_type> r_info_personality = {
+    { "ORDINARY", PERSONALITY_ORDINARY },
+    { "MIGHTY", PERSONALITY_MIGHTY },
+    { "SHREWD", PERSONALITY_SHREWD },
+    { "PIOUS", PERSONALITY_PIOUS },
+    { "NIMBLE", PERSONALITY_NIMBLE },
+    { "FEARLESS", PERSONALITY_FEARLESS },
+    { "COMBAT", PERSONALITY_COMBAT },
+    { "LAZY", PERSONALITY_LAZY },
+    { "SEXY", PERSONALITY_SEXY },
+    { "LUCKY", PERSONALITY_LUCKY },
+    { "PATIENT", PERSONALITY_PATIENT },
+    { "MUNCHKIN", PERSONALITY_MUNCHKIN },
+    { "CHARGEMAN", PERSONALITY_CHARGEMAN },
+    { "TOUGH", PERSONALITY_TOUGH },
+    { "SUSHI_EATER", PERSONALITY_SUSHI_EATER },
+    { "MESUGAKI", PERSONALITY_MESUGAKI },
+};
+
 const std::unordered_map<std::string_view, BodyStructureType> r_info_body_structure = {
     { "HUMANOID", BodyStructureType::HUMANOID },
     { "BIPEDAL", BodyStructureType::BIPEDAL },

--- a/src/info-reader/race-info-tokens-table.h
+++ b/src/info-reader/race-info-tokens-table.h
@@ -18,6 +18,7 @@
 #include "monster-race/race-special-flags.h"
 #include "monster-race/race-visual-flags.h"
 #include "monster-race/race-wilderness-flags.h"
+#include "player/player-personality-types.h"
 #include "system/angband.h"
 #include "system/monrace/body-structure-types.h"
 #include "system/monrace/extended-slot.h"
@@ -64,6 +65,7 @@ extern const std::unordered_map<std::string_view, MonsterMessageType> r_info_mes
 extern const std::unordered_map<std::string_view, MonsterBrightnessType> r_info_brightness_flags;
 extern const std::unordered_map<std::string_view, MonsterSpecialType> r_info_special_flags;
 extern const std::unordered_map<std::string_view, MonsterSex> r_info_sex;
+extern const std::unordered_map<std::string_view, player_personality_type> r_info_personality;
 extern const std::unordered_map<std::string_view, MonsterMiscType> r_info_misc_flags;
 extern const std::unordered_map<std::string_view, BodyStructureType> r_info_body_structure;
 extern const std::unordered_map<std::string_view, ExtendedSlotType> r_info_extended_slot;

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -308,6 +308,31 @@ static errr set_mon_sex(const nlohmann::json &sex_data, MonraceDefinition &monra
 }
 
 /*!
+ * @brief JSON Objectからモンスターの性格をセットする
+ * @param personality_data 性格情報の格納されたJSON Object
+ * @param monrace 保管先のモンスター種族構造体
+ * @return エラーコード
+ * @details 未指定 (null) の場合は PERSONALITY_NONE のまま (生成時ランダム)。
+ *          指定された場合はその性格が常に適用される。
+ */
+static errr set_mon_personality(const nlohmann::json &personality_data, MonraceDefinition &monrace)
+{
+    if (personality_data.is_null()) {
+        return PARSE_ERROR_NONE;
+    }
+    if (!personality_data.is_string()) {
+        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    }
+
+    uint32_t personality;
+    if (!info_grab_one_const(personality, r_info_personality, personality_data.get<std::string>())) {
+        return PARSE_ERROR_INVALID_FLAG;
+    }
+    monrace.personality = static_cast<player_personality_type>(personality);
+    return PARSE_ERROR_NONE;
+}
+
+/*!
  * @brief JSON Object からモンスターの体構造をセットする
  * @param body_data 体構造情報の格納された JSON Object (string)
  * @param monrace 保管先のモンスター種族構造体
@@ -1333,6 +1358,12 @@ errr parse_monraces_info(nlohmann::json &mon_data, angband_header *)
     err = set_mon_sex(mon_data["sex"], monrace);
     if (err) {
         msg_format(_("モンスター性別読込失敗。ID: '%d'。", "Failed to load monster sex. ID: '%d'."), error_idx);
+        return err;
+    }
+
+    err = set_mon_personality(mon_data["personality"], monrace);
+    if (err) {
+        msg_format(_("モンスター性格読込失敗。ID: '%d'。", "Failed to load monster personality. ID: '%d'."), error_idx);
         return err;
     }
     err = info_set_integer(mon_data["odds_correction_ratio"], monrace.arena_ratio, false, Range(1, 9999));

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -1040,16 +1040,30 @@ void CreatureEntity::initialize_equivalent_player_classes()
     }
 }
 
+void CreatureEntity::set_personality(player_personality_type value)
+{
+    this->ppersonality = value;
+    this->personality = &personality_info[value];
+}
+
 void CreatureEntity::assign_random_personality()
 {
+    // モンスター種族に性格が固定指定されている場合は常にそれを使う
+    if (this->has_monster_profile()) {
+        const auto fixed = this->get_monrace().personality;
+        if (fixed != PERSONALITY_NONE) {
+            this->set_personality(fixed);
+            return;
+        }
+    }
+
     const auto psex_value = static_cast<int>(this->get_psex());
     int k;
     do {
         k = randint0(MAX_PERSONALITIES);
     } while ((k == PERSONALITY_MUNCHKIN) || ((personality_info[k].sex != 0) && (personality_info[k].sex != (psex_value + 1))));
 
-    this->ppersonality = static_cast<player_personality_type>(k);
-    this->personality = &personality_info[this->ppersonality];
+    this->set_personality(static_cast<player_personality_type>(k));
 }
 
 void CreatureEntity::assign_random_realm()

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -2696,9 +2696,17 @@ public:
     virtual void initialize_equivalent_player_classes();
 
     /*!
+     * @brief 性格を指定値に設定する
+     * @details ppersonality と personality ポインタの双方を更新する。
+     * @param value 設定する性格
+     */
+    void set_personality(player_personality_type value);
+
+    /*!
      * @brief 性格をランダムに設定する (いかさまは除外)
      * @details 性別制限のある性格は psex に合致する場合のみ選ばれる。
      *          ppersonality と personality ポインタの双方を更新する。
+     *          モンスター種族に性格が固定指定されている場合は常にそれを使う。
      */
     void assign_random_personality();
 

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -22,6 +22,7 @@
 #include "monster-race/race-visual-flags.h"
 #include "monster-race/race-wilderness-flags.h"
 #include "player-ability/player-ability-types.h"
+#include "player/player-personality-types.h"
 #include "system/angband.h"
 #include "system/monrace/body-structure-types.h"
 #include "system/monrace/extended-slot.h"
@@ -123,6 +124,7 @@ public:
     EXP mexp{}; //!< 殺害時基本経験値 / Exp value for kill
     RARITY freq_spell{}; //!< 魔法＆特殊能力仕様頻度(1/n) /  Spell frequency
     MonsterSex sex{}; //!< 性別 / Sex
+    player_personality_type personality = PERSONALITY_NONE; //!< 性格固定指定 (PERSONALITY_NONE で未指定=生成時ランダム) / Fixed personality (PERSONALITY_NONE means unspecified)
     EnumClassFlagGroup<MonsterFeedType> meat_feed_flags;
     EnumClassFlagGroup<MonsterAbilityType> ability_flags; //!< 能力フラグ(魔法/ブレス) / Ability Flags
     EnumClassFlagGroup<MonsterAuraType> aura_flags; //!< オーラフラグ / Aura Flags


### PR DESCRIPTION
MonraceDefinitions.jsonc の "personality" でモンスター個別の性格を指定 できるようにした。未指定なら従来通り (生成時ランダム / プレイヤー運用時は
対話選択)、指定があれば常にその性格を適用する。

- MonraceDefinition::personality (player_personality_type, 既定 PERSONALITY_NONE)
- r_info_personality トークンテーブルと set_mon_personality パーサを追加
- CreatureEntity::set_personality() を新設し性格適用を集約
- assign_random_personality() は固定指定があればそれを優先 (モンスター生成)
- player_birth_as_monster() は apply_monrace_personality() で固定指定時に 対話選択をスキップ
- CLAUDE.md に独自仕様として記載

注: 先行コミット e3911eb は monrace-definition.h / tokens-table.cpp の 変更が欠落しビルド不能だったため、本コミットで完全な変更に置き換える。