### PR TITLE
feat: cコマンド詳細1ページに所属アライアンスを表示

### DIFF
--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "view/display-player.h"
+#include "alliance/alliance.h"
 #include "dungeon/quest.h"
 #include "floor/floor-util.h"
 #include "game-option/text-display-options.h"
@@ -361,6 +362,14 @@ tl::optional<int> display_player(CreatureEntity &creature, const int tmp_mode)
         display_player_one_line(ENTRY_PATRON, patron_list[creature.get_patron()].name, TERM_L_BLUE);
     } else {
         display_player_one_line(ENTRY_PATRON, _("なし", "None"), TERM_SLATE);
+    }
+
+    // 所属アライアンスを表示する (プレイヤー・モンスター共通)
+    const auto alliance_idx = creature.get_alliance_idx();
+    if (alliance_idx != AllianceType::NONE) {
+        display_player_one_line(ENTRY_ALLIANCE, alliance_list.at(alliance_idx)->name, TERM_L_BLUE);
+    } else {
+        display_player_one_line(ENTRY_ALLIANCE, _("無所属", "None"), TERM_SLATE);
     }
 
     // 実際の種族と見かけの種族を表示

--- a/src/view/display-util.cpp
+++ b/src/view/display-util.cpp
@@ -66,6 +66,7 @@ const std::vector<disp_player_line> disp_player_lines = {
     { 26, 2, -1, _("擬態   : ", "App.Category : ") },
     { 29, 11, 21, _("HP回復/100T", "HP Regen/100T") },
     { 29, 12, 21, _("MP回復/100T", "MP Regen/100T") },
+    { 1, 8, -1, _("所属     : ", "Alliance : ") },
 };
 }
 

--- a/src/view/status-first-page.h
+++ b/src/view/status-first-page.h
@@ -56,6 +56,7 @@
 #define ENTRY_APPARENT_RACE 49
 #define ENTRY_HP_REGEN 50
 #define ENTRY_MP_REGEN 51
+#define ENTRY_ALLIANCE 52
 
 class CreatureEntity;
 void display_player_various(CreatureEntity &creature);


### PR DESCRIPTION
プレイヤー・NPC(モンスター)問わず、c コマンドの詳細1ページに
所属アライアンスを追加表示する。表示位置はパトロンの下 (左カラム 8 行目)。

- ENTRY_ALLIANCE (52) を追加し、disp_player_lines に行8/列1の項目を登録
- display_player() でアライアンス名を表示 (無所属時は「無所属」)
- 表示経路はプレイヤー・モンスター共通の display_player() のため両対応