### PR TITLE
feat: プレイヤー選択不能な性格「なし」を追加しEMPTY_MINDモンスターに適用

### DIFF
--- a/src/birth/birth-select-personality.cpp
+++ b/src/birth/birth-select-personality.cpp
@@ -15,7 +15,7 @@ static std::string birth_personality_label(int cs, concptr sym)
     const char p2 = ')';
     std::stringstream ss;
 
-    if (cs < 0 || cs >= MAX_PERSONALITIES) {
+    if (cs < 0 || cs >= MAX_SELECTABLE_PERSONALITIES) {
         ss << '*' << p2 << _("ランダム", "Random");
     } else {
         ss << sym[cs] << p2 << personality_info[cs].title;
@@ -25,7 +25,7 @@ static std::string birth_personality_label(int cs, concptr sym)
 
 static void enumerate_personality_list(CreatureEntity &creature, char *sym)
 {
-    for (int n = 0; n < MAX_PERSONALITIES; n++) {
+    for (int n = 0; n < MAX_SELECTABLE_PERSONALITIES; n++) {
         if (personality_info[n].sex && (personality_info[n].sex != (creature.psex + 1))) {
             continue;
         }
@@ -49,7 +49,7 @@ static std::string display_personality_stat(int cs, int *os, const std::string &
     c_put_str(TERM_WHITE, cur, 12 + (*os / 4), 2 + 18 * (*os % 4));
     put_str("                                   ", 3, 40);
     auto result = birth_personality_label(cs, sym);
-    if (cs == MAX_PERSONALITIES) {
+    if (cs == MAX_SELECTABLE_PERSONALITIES) {
         put_str("                                   ", 4, 40);
         put_str("                                   ", 5, 40);
         put_str("                                   ", 6, 40);
@@ -90,7 +90,7 @@ static int interpret_personality_select_key_move(CreatureEntity &creature, char 
             pp_idx -= 4;
         }
 
-        if ((pp_idx >= MAX_PERSONALITIES) || !check_selected_sex(pp_idx, creature.psex)) {
+        if ((pp_idx >= MAX_SELECTABLE_PERSONALITIES) || !check_selected_sex(pp_idx, creature.psex)) {
             return pp_idx;
         }
 
@@ -106,7 +106,7 @@ static int interpret_personality_select_key_move(CreatureEntity &creature, char 
             (pp_idx)--;
         }
 
-        if ((pp_idx >= MAX_PERSONALITIES) || !check_selected_sex(pp_idx, creature.psex)) {
+        if ((pp_idx >= MAX_SELECTABLE_PERSONALITIES) || !check_selected_sex(pp_idx, creature.psex)) {
             return pp_idx;
         }
 
@@ -118,15 +118,15 @@ static int interpret_personality_select_key_move(CreatureEntity &creature, char 
 
         return pp_idx;
     case '6':
-        if (pp_idx < MAX_PERSONALITIES) {
+        if (pp_idx < MAX_SELECTABLE_PERSONALITIES) {
             (pp_idx)++;
         }
 
-        if ((pp_idx >= MAX_PERSONALITIES) || !check_selected_sex(pp_idx, creature.psex)) {
+        if ((pp_idx >= MAX_SELECTABLE_PERSONALITIES) || !check_selected_sex(pp_idx, creature.psex)) {
             return pp_idx;
         }
 
-        if ((pp_idx + 1) <= MAX_PERSONALITIES) {
+        if ((pp_idx + 1) <= MAX_SELECTABLE_PERSONALITIES) {
             (pp_idx)++;
         } else {
             (pp_idx)--;
@@ -134,15 +134,15 @@ static int interpret_personality_select_key_move(CreatureEntity &creature, char 
 
         return pp_idx;
     case '2':
-        if ((pp_idx + 4) <= MAX_PERSONALITIES) {
+        if ((pp_idx + 4) <= MAX_SELECTABLE_PERSONALITIES) {
             pp_idx += 4;
         }
 
-        if ((pp_idx >= MAX_PERSONALITIES) || !check_selected_sex(pp_idx, creature.psex)) {
+        if ((pp_idx >= MAX_SELECTABLE_PERSONALITIES) || !check_selected_sex(pp_idx, creature.psex)) {
             return pp_idx;
         }
 
-        if ((pp_idx + 4) <= MAX_PERSONALITIES) {
+        if ((pp_idx + 4) <= MAX_SELECTABLE_PERSONALITIES) {
             pp_idx += 4;
         } else {
             pp_idx -= 4;
@@ -157,7 +157,7 @@ static int interpret_personality_select_key_move(CreatureEntity &creature, char 
 static bool select_personality(CreatureEntity &creature, int *k, concptr sym)
 {
     int cs = creature.ppersonality;
-    int os = MAX_PERSONALITIES;
+    int os = MAX_SELECTABLE_PERSONALITIES;
     std::string cur = birth_personality_label(os, sym);
     while (true) {
         cur = display_personality_stat(cs, &os, cur, sym);
@@ -165,7 +165,7 @@ static bool select_personality(CreatureEntity &creature, int *k, concptr sym)
             break;
         }
 
-        const auto buf = format(_("性格を選んで下さい (%c-%c) ('='初期オプション設定): ", "Choose a personality (%c-%c) ('=' for options): "), sym[0], sym[MAX_PERSONALITIES - 1]);
+        const auto buf = format(_("性格を選んで下さい (%c-%c) ('='初期オプション設定): ", "Choose a personality (%c-%c) ('=' for options): "), sym[0], sym[MAX_SELECTABLE_PERSONALITIES - 1]);
         put_str(buf, 10, 10);
         char c = inkey();
         if (c == 'Q') {
@@ -177,9 +177,9 @@ static bool select_personality(CreatureEntity &creature, int *k, concptr sym)
         }
 
         if (c == ' ' || c == '\r' || c == '\n') {
-            if (cs == MAX_PERSONALITIES) {
+            if (cs == MAX_SELECTABLE_PERSONALITIES) {
                 do {
-                    *k = randint0(MAX_PERSONALITIES);
+                    *k = randint0(MAX_SELECTABLE_PERSONALITIES);
                 } while (personality_info[*k].sex && (personality_info[*k].sex != (creature.psex + 1)));
 
                 cs = *k;
@@ -194,7 +194,7 @@ static bool select_personality(CreatureEntity &creature, int *k, concptr sym)
         if (c == '*') {
             player_personality ppersonality{};
             do {
-                *k = randint0(MAX_PERSONALITIES);
+                *k = randint0(MAX_SELECTABLE_PERSONALITIES);
                 if (*k < 0) {
                     continue; // 静的解析対応.
                 }
@@ -207,7 +207,7 @@ static bool select_personality(CreatureEntity &creature, int *k, concptr sym)
         }
 
         *k = (islower(c) ? A2I(c) : -1);
-        if ((*k >= 0) && (*k < MAX_PERSONALITIES)) {
+        if ((*k >= 0) && (*k < MAX_SELECTABLE_PERSONALITIES)) {
             if ((personality_info[*k].sex == 0) || (personality_info[*k].sex == (creature.psex + 1))) {
                 cs = *k;
                 continue;
@@ -215,7 +215,7 @@ static bool select_personality(CreatureEntity &creature, int *k, concptr sym)
         }
 
         *k = (isupper(c) ? (26 + c - 'A') : -1);
-        if ((*k >= 26) && (*k < MAX_PERSONALITIES)) {
+        if ((*k >= 26) && (*k < MAX_SELECTABLE_PERSONALITIES)) {
             if ((personality_info[*k].sex == 0) || (personality_info[*k].sex == (creature.psex + 1))) {
                 cs = *k;
                 continue;
@@ -241,7 +241,7 @@ bool get_player_personality(CreatureEntity &creature)
         23, 5);
     put_str("                                   ", 6, 40);
 
-    char sym[MAX_PERSONALITIES];
+    char sym[MAX_SELECTABLE_PERSONALITIES];
     enumerate_personality_list(creature, sym);
     int k = -1;
     if (!select_personality(creature, &k, sym)) {

--- a/src/birth/monster-birth.cpp
+++ b/src/birth/monster-birth.cpp
@@ -17,6 +17,7 @@
 #include "io/input-key-acceptor.h"
 #include "mind/mind-elementalist.h"
 #include "monster-race/race-kind-flags.h"
+#include "monster-race/race-misc-flags.h"
 #include "monster-race/race-sex-const.h"
 #include "object-enchant/item-apply-magic.h"
 #include "object-enchant/item-magic-applier.h"
@@ -309,9 +310,11 @@ void apply_monrace_race(CreatureEntity &creature, MonraceId monrace_id)
 
 /*!
  * @brief モンスター種族に性格が固定指定されていればプレイヤーに反映する
- * @details JSON の "personality" で指定された性格があれば常にそれを適用し、
- *          プレイヤーによる対話的な性格選択を省略する。未指定の場合は
- *          何もせず false を返し、呼び出し側で通常の選択処理に委ねる。
+ * @details EMPTY_MIND (無心) のモンスターは常に性格「なし」(PERSONALITY_EMPTY) を
+ *          適用する。それ以外は JSON の "personality" で指定された性格があれば
+ *          常にそれを適用し、プレイヤーによる対話的な性格選択を省略する。
+ *          いずれにも該当しない場合は何もせず false を返し、呼び出し側で通常の
+ *          選択処理に委ねる。
  * @param creature クリーチャーへの参照
  * @param monrace_id 開始モンスターの種族ID
  * @return 固定指定を適用したら true、未指定なら false
@@ -319,6 +322,11 @@ void apply_monrace_race(CreatureEntity &creature, MonraceId monrace_id)
 bool apply_monrace_personality(CreatureEntity &creature, MonraceId monrace_id)
 {
     const auto &monrace = MonraceList::get_instance().get_monrace(monrace_id);
+    if (monrace.misc_flags.has(MonsterMiscType::EMPTY_MIND)) {
+        creature.set_personality(PERSONALITY_EMPTY);
+        return true;
+    }
+
     if (monrace.personality == PERSONALITY_NONE) {
         return false;
     }

--- a/src/player/player-personality-types.h
+++ b/src/player/player-personality-types.h
@@ -18,5 +18,7 @@ enum player_personality_type {
     PERSONALITY_TOUGH = 13,
     PERSONALITY_SUSHI_EATER = 14,
     PERSONALITY_MESUGAKI = 15,
-    MAX_PERSONALITIES = 16,
+    PERSONALITY_EMPTY = 16, //!< 無心。プレイヤーは選択不能。EMPTY_MIND モンスター専用
+    MAX_SELECTABLE_PERSONALITIES = 16, //!< プレイヤーが選択可能な性格数 (PERSONALITY_EMPTY を除く)
+    MAX_PERSONALITIES = 17,
 };

--- a/src/player/player-personality.cpp
+++ b/src/player/player-personality.cpp
@@ -87,6 +87,11 @@ const player_personality personality_info[MAX_PERSONALITIES] = {
         8, 3, -2, 2, 6, 4, -5, 5,
         0, 1, 1 },
 
+    { { "なし", "None" },
+        { 0, 0, 0, 0, 0, 0 },
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 1, 0 },
+
 };
 
 // ap_ptr is now a member named 'personality' in PlayerType

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -1048,6 +1048,12 @@ void CreatureEntity::set_personality(player_personality_type value)
 
 void CreatureEntity::assign_random_personality()
 {
+    // EMPTY_MIND (無心) のモンスターは常に性格「なし」(PERSONALITY_EMPTY) を充てる
+    if (this->has_monster_profile() && this->get_monrace().misc_flags.has(MonsterMiscType::EMPTY_MIND)) {
+        this->set_personality(PERSONALITY_EMPTY);
+        return;
+    }
+
     // モンスター種族に性格が固定指定されている場合は常にそれを使う
     if (this->has_monster_profile()) {
         const auto fixed = this->get_monrace().personality;
@@ -1060,7 +1066,7 @@ void CreatureEntity::assign_random_personality()
     const auto psex_value = static_cast<int>(this->get_psex());
     int k;
     do {
-        k = randint0(MAX_PERSONALITIES);
+        k = randint0(MAX_SELECTABLE_PERSONALITIES);
     } while ((k == PERSONALITY_MUNCHKIN) || ((personality_info[k].sex != 0) && (personality_info[k].sex != (psex_value + 1))));
 
     this->set_personality(static_cast<player_personality_type>(k));


### PR DESCRIPTION
性格 PERSONALITY_EMPTY (「なし」/None) を新設。能力修正・スキル修正は
すべて 0 で、プレイヤーのキャラ作成メニューでは選択できない。

- player-personality-types.h: PERSONALITY_EMPTY=16 を追加。選択可能数は MAX_SELECTABLE_PERSONALITIES=16、総数 MAX_PERSONALITIES=17 に分離
- personality_info[] に「なし」エントリ (全modifier 0) を追加
- birth-select-personality.cpp: 選択メニュー・ランダム選択の上限を MAX_SELECTABLE_PERSONALITIES に変更し PERSONALITY_EMPTY を除外
- assign_random_personality(): EMPTY_MIND モンスターは常に PERSONALITY_EMPTY を適用 (NPC 生成時)。ランダム選択上限も MAX_SELECTABLE_PERSONALITIES に
- apply_monrace_personality(): EMPTY_MIND モンスターをプレイヤー運用する場合も 常に PERSONALITY_EMPTY を適用し対話選択をスキップ