### PR TITLE
feat: 武器装備NPCがスレイ/ブランド効果付きで武器攻撃しメッセージを表示

### DIFF
--- a/src/melee/melee-util.h
+++ b/src/melee/melee-util.h
@@ -40,6 +40,7 @@ struct mam_type {
     bool known = false;
     bool fear = false;
     bool dead = false;
+    short weapon_slot_for_blow = -1; //!< 当該打撃で使用する武器スロット (-1 = 武器なし)
 };
 
 mam_type *initialize_mam_type(CreatureEntity &creature, mam_type *mam_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx);

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -6,12 +6,17 @@
 
 #include "melee/monster-attack-monster.h"
 #include "combat/attack-accuracy.h"
+#include "combat/combat-options-type.h"
 #include "combat/hallucination-attacks-table.h"
+#include "combat/slaying.h"
 #include "core/disturbance.h"
 #include "dungeon/dungeon-flag-types.h"
 #include "effect/attribute-types.h"
 #include "effect/effect-characteristics.h"
 #include "effect/effect-processor.h"
+#include "flavor/flavor-describer.h"
+#include "flavor/object-flavor-types.h"
+#include "inventory/inventory-slot-types.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
 #include "melee/melee-postprocess.h"
@@ -30,6 +35,7 @@
 #include "system/creature-entity.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/floor/floor-info.h"
+#include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "tracking/health-bar-tracker.h"
@@ -214,6 +220,30 @@ static void describe_silly_melee(mam_type *mam_ptr)
 #endif
 }
 
+/*!
+ * @brief 武器を装備したモンスターの打撃に「〜で攻撃した」という追加メッセージを表示する
+ * @details weapon_slot_for_blow が有効 (物理打撃かつ武器装備時) かつ視認可能な場合のみ表示する。
+ */
+static void describe_weapon_melee(mam_type *mam_ptr)
+{
+    if ((mam_ptr->weapon_slot_for_blow < 0) || !mam_ptr->see_either) {
+        return;
+    }
+
+    const auto &weapon = *mam_ptr->m_ptr->inventory[mam_ptr->weapon_slot_for_blow];
+    if (!weapon.is_valid()) {
+        return;
+    }
+
+    const auto weapon_name = describe_flavor(*mam_ptr->m_ptr, weapon, OD_NAME_ONLY | OD_OMIT_PREFIX | OD_NO_PLURAL);
+    msg_format(_("%s^は%sで%sを攻撃した。", "%s^ attacks %s with %s."),
+#ifdef JP
+        mam_ptr->m_name, weapon_name.data(), mam_ptr->t_name);
+#else
+        mam_ptr->m_name, mam_ptr->t_name, weapon_name.data());
+#endif
+}
+
 static void process_monster_attack_effect(CreatureEntity &creature, mam_type *mam_ptr)
 {
     if (mam_ptr->pt == AttributeType::NONE) {
@@ -247,8 +277,18 @@ static void process_melee(CreatureEntity &creature, mam_type *mam_ptr)
     redraw_health_bar(mam_ptr);
     describe_melee_method(mam_ptr);
     describe_silly_melee(mam_ptr);
+    describe_weapon_melee(mam_ptr);
     mam_ptr->obvious = true;
     mam_ptr->damage = mam_ptr->damage_dice.roll();
+
+    // 武器を装備している場合、プレイヤーと共通の calc_attack_damage_with_slay() で
+    // スレイ・ブランド効果を反映したダメージを加算する。
+    if (!mam_ptr->explode && (mam_ptr->weapon_slot_for_blow >= 0)) {
+        auto &weapon = *mam_ptr->m_ptr->inventory[mam_ptr->weapon_slot_for_blow];
+        const auto base_dam = weapon.damage_dice.roll();
+        mam_ptr->damage += calc_attack_damage_with_slay(*mam_ptr->m_ptr, &weapon, base_dam, *mam_ptr->t_ptr, HISSATSU_NONE, false) + weapon.to_d;
+    }
+
     mam_ptr->attribute = BlowEffectType::NONE;
     mam_ptr->pt = AttributeType::MONSTER_MELEE;
     decide_monster_attack_effect(creature, mam_ptr);
@@ -307,6 +347,30 @@ static void repeat_melee(CreatureEntity &creature, mam_type *mam_ptr)
         mam_ptr->effect = monrace.blows[ap_cnt].effect;
         mam_ptr->method = monrace.blows[ap_cnt].method;
         mam_ptr->damage_dice = monrace.blows[ap_cnt].damage_dice;
+
+        // 物理打撃 (HIT/PUNCH/SLASH/STING) かつ武器装備時は当該打撃で使う武器スロットを決める。
+        // 二刀流なら blow index で交互、片手のみならそちら、武器なしなら -1。
+        // (monster-attack-player.cpp の処理と揃える)
+        mam_ptr->weapon_slot_for_blow = -1;
+        switch (mam_ptr->method) {
+        case RaceBlowMethodType::HIT:
+        case RaceBlowMethodType::PUNCH:
+        case RaceBlowMethodType::SLASH:
+        case RaceBlowMethodType::STING: {
+            const bool main_valid = monster.inventory[INVEN_MAIN_HAND]->is_valid() && monster.inventory[INVEN_MAIN_HAND]->is_melee_weapon();
+            const bool sub_valid = monster.inventory[INVEN_SUB_HAND]->is_valid() && monster.inventory[INVEN_SUB_HAND]->is_melee_weapon();
+            if (main_valid && sub_valid) {
+                mam_ptr->weapon_slot_for_blow = (ap_cnt % 2 == 0) ? INVEN_MAIN_HAND : INVEN_SUB_HAND;
+            } else if (main_valid) {
+                mam_ptr->weapon_slot_for_blow = INVEN_MAIN_HAND;
+            } else if (sub_valid) {
+                mam_ptr->weapon_slot_for_blow = INVEN_SUB_HAND;
+            }
+            break;
+        }
+        default:
+            break;
+        }
 
         if (!monster.is_valid()) {
             break;

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -12,8 +12,11 @@
 #include "combat/aura-counterattack.h"
 #include "combat/combat-options-type.h"
 #include "combat/hallucination-attacks-table.h"
+#include "combat/slaying.h"
 #include "core/disturbance.h"
 #include "dungeon/dungeon-flag-types.h"
+#include "flavor/flavor-describer.h"
+#include "flavor/object-flavor-types.h"
 #include "inventory/inventory-slot-types.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
@@ -288,6 +291,7 @@ bool MonsterAttackPlayer::process_monster_attack_hit()
     this->do_stun = 0;
     describe_monster_attack_method(this);
     this->describe_silly_attacks();
+    this->describe_weapon_attack();
     this->obvious = true;
     this->damage = this->damage_dice.roll();
     if (this->explode) {
@@ -297,9 +301,11 @@ bool MonsterAttackPlayer::process_monster_attack_hit()
     // [フェーズ B-2b / 二刀流対応] 装備武器によるダメージボーナス
     // weapon_slot_for_blow は process_monster_blows() で設定され、
     // 物理打撃 (HIT/PUNCH/SLASH/STING) かつ武器装備時のみ有効
+    // スレイ・ブランド等はプレイヤーと共通の calc_attack_damage_with_slay() を再利用する。
     if (!this->explode && this->weapon_slot_for_blow >= 0) {
-        const auto &weapon = *this->m_ptr->inventory[this->weapon_slot_for_blow];
-        this->damage += weapon.damage_dice.roll() + weapon.to_d;
+        auto &weapon = *this->m_ptr->inventory[this->weapon_slot_for_blow];
+        const auto base_dam = weapon.damage_dice.roll();
+        this->damage += calc_attack_damage_with_slay(*this->m_ptr, &weapon, base_dam, creature, HISSATSU_NONE, false) + weapon.to_d;
     }
 
     switch_monster_blow_to_player(creature, this);
@@ -368,6 +374,25 @@ void MonsterAttackPlayer::describe_silly_attacks()
 #else
     msg_format("%s^ %s%s", this->m_name, this->act, this->do_silly_attack ? " you." : "");
 #endif
+}
+
+/*!
+ * @brief 武器を装備したモンスターの打撃に「〜で攻撃された」という追加メッセージを表示する
+ * @details weapon_slot_for_blow が有効 (物理打撃かつ武器装備時) の場合のみ表示する。
+ */
+void MonsterAttackPlayer::describe_weapon_attack()
+{
+    if (this->weapon_slot_for_blow < 0) {
+        return;
+    }
+
+    const auto &weapon = *this->m_ptr->inventory[this->weapon_slot_for_blow];
+    if (!weapon.is_valid()) {
+        return;
+    }
+
+    const auto weapon_name = describe_flavor(*this->creature_ptr, weapon, OD_NAME_ONLY | OD_OMIT_PREFIX | OD_NO_PLURAL);
+    msg_format(_("%s^は%sで攻撃してきた。", "%s^ attacks you with %s."), this->m_name, weapon_name.data());
 }
 
 /*!

--- a/src/monster-attack/monster-attack-player.h
+++ b/src/monster-attack/monster-attack-player.h
@@ -50,6 +50,7 @@ private:
     bool process_monster_attack_hit();
     bool effect_protecion_from_evil();
     void describe_silly_attacks();
+    void describe_weapon_attack();
     void select_cut_stun();
     void calc_player_cut();
     void process_player_stun();


### PR DESCRIPTION
装備武器を持つモンスター(NPC)が、プレイヤーと同じスレイ・ブランド等の
付随効果を伴って武器で攻撃するようにした。対プレイヤー・対モンスターの
両経路に対応し、武器使用時は「〜で攻撃された/した」メッセージを表示する。

- 武器ダメージ計算をプレイヤー共通の calc_attack_damage_with_slay() に置換 (従来は raw な damage_dice + to_d のみでスレイ/ブランド未反映だった)
- 対プレイヤー (monster-attack-player.cpp): describe_weapon_attack() を追加し 「%sは%sで攻撃してきた。」を表示
- 対モンスター (monster-attack-monster.cpp): mam_type に weapon_slot_for_blow を 追加、repeat_melee() で武器スロット決定 (二刀流は交互)、process_melee() で スレイ込みダメージ加算、describe_weapon_melee() で「%sは%sで%sを攻撃した。」表示
- 武器名は describe_flavor(OD_NAME_ONLY|OD_OMIT_PREFIX|OD_NO_PLURAL) で取得