### PR TITLE
feat: モンスター(NPC)生成時に最大MPを算出しMP自然回復を機能させる

### DIFF
--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -34,6 +34,7 @@
 #include "monster/monster-util.h"
 #include "object/warning.h"
 #include "player-ability/player-ability-types.h"
+#include "player/digestion-processor.h"
 #include "player/player-sex.h"
 #include "player/player-status.h"
 #include "system/creature-entity.h"
@@ -463,6 +464,15 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
 
     // 所持金を初期化（能力値に基づいて計算）
     get_money_for_creature(*m_ptr);
+
+    // 満腹度を常に満腹状態 (食べ過ぎにはならない最大値) にする
+    m_ptr->set_food(PY_FOOD_MAX - 1);
+
+    // 最大MPを算出して満タンで開始する。プレイヤーと同じ calc_creature_mana()
+    // (レベル・INT ベースの基礎MP) を用いる。これにより regenerate_monsters() の
+    // 自然回復 (regenmana) が機能し、種族固有能力の行使にMPを使える。
+    m_ptr->set_msp(calc_creature_mana(*m_ptr));
+    m_ptr->set_csp(m_ptr->get_msp());
 
     m_ptr->set_visible_on_map(false);
     if (any_bits(mode, PM_FORCE_PET)) {

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -692,13 +692,19 @@ static void update_num_of_spells(CreatureEntity &creature)
  * @details 〈烙印者〉(プレイヤー) / モンスターは職業を問わず常に 0 以外の MP を持つ。
  *          モンスター固有能力 (種族のブレス・魔法等) の行使に使用するため、
  *          無魔法職 (戦士等) でもレベルと INT に応じた MP を保証する。
+ *          プレイヤー・モンスター共通で使用できる (グローバル mp_ptr 非依存)。
  */
-static int calc_innate_baseline_mana(CreatureEntity &creature)
+int calc_creature_mana(CreatureEntity &creature)
 {
     const auto stat_index = creature.get_stat_index(A_INT);
     const int msp = adj_mag_mana[stat_index] * (creature.get_level() + 3) / 4;
     const int floor_value = std::max(static_cast<int>(creature.get_level()), 1);
     return std::max(msp, floor_value);
+}
+
+static int calc_innate_baseline_mana(CreatureEntity &creature)
+{
+    return calc_creature_mana(creature);
 }
 
 static void update_max_mana(CreatureEntity &creature)

--- a/src/player/player-status.h
+++ b/src/player/player-status.h
@@ -18,6 +18,7 @@ int calc_inventory_weight(CreatureEntity &creature);
 
 short calc_num_fire(CreatureEntity &creature, const ItemEntity *o_ptr);
 int calc_weight_limit(CreatureEntity &creature);
+int calc_creature_mana(CreatureEntity &creature);
 void update_creature(CreatureEntity &creature);
 bool player_has_no_spellbooks(CreatureEntity &creature);
 


### PR DESCRIPTION
MP自然回復 (regenerate_monsters → regenmana) は CreatureEntity 共通実装で モンスターにも対応済みだったが、msp が 0 のままだと回復が no-op となり
実質機能していなかった。生成時に最大MPを算出して機能させる。

- calc_innate_baseline_mana() を public 関数 calc_creature_mana() として公開 (グローバル mp_ptr 非依存、レベル・INT ベースのプレイヤー共通基礎MP計算)
- one-monster-placer.cpp の place_monster_one() で set_msp(calc_creature_mana())
  + set_csp(get_msp()) を行い、満タンで開始
- 以後 regenerate_monsters() の既存 regenmana() 経由でプレイヤーと同式の 自然回復が機能する (compute_regen_amount による回復係数も共通)