### PR TITLE
fix: 性格「なし」の時は詳細表示で二つ名を一切付けない

### DIFF
--- a/src/view/display-player-misc-info.cpp
+++ b/src/view/display-player-misc-info.cpp
@@ -18,7 +18,11 @@
 void display_player_name(CreatureEntity &creature, bool name_only)
 {
     std::stringstream ss;
-    if (!name_only && creature.personality != nullptr) {
+    // 性格が「なし」(未設定の NONE / 無心 EMPTY、いずれも表示名「なし」) の場合は
+    // 二つ名 (「○○の」) を一切付けない。
+    const auto ppersonality = creature.get_ppersonality();
+    const auto has_personality_title = (creature.personality != nullptr) && (ppersonality != PERSONALITY_NONE) && (ppersonality != PERSONALITY_EMPTY);
+    if (!name_only && has_personality_title) {
         ss << (*creature.get_personality_info()).title << _((*creature.get_personality_info()).no == 1 ? "の" : "", " ");
     }
     // 無名モンスター（または匿名プレイヤー）の場合は「名無し」表記へフォールバック


### PR DESCRIPTION
EMPTY_MIND モンスター等の性格が「なし」(PERSONALITY_EMPTY、表示名「なし」) の場合、詳細表示 (display_player_name) で名前の前に「なしの」と二つ名が
付いていた。性格が未設定 (NONE) または「なし」(EMPTY) の場合は二つ名を
一切表示しないようにした。