### PR TITLE
feat: セーブ/ロードの CreatureEntity 共通シリアライズ統合 (フェーズ1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,6 +485,39 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
   開始 (`apply_monrace_personality()` で対話選択をスキップ) でも同一。
 - 性格適用は `CreatureEntity::set_personality(player_personality_type)` に集約。
 
+### セーブ/ロードの統合 (CreatureEntity 共通シリアライズ) — フェーズ 1
+
+旧 PlayerType / 旧 MonsterEntity に分かれていたセーブ/ロード処理を、
+`CreatureEntity` 基底フィールド単位で 1 箇所に統合していく方針。
+**セーブデータバージョンは 50** に更新済み。
+
+- 共通基底シリアライザ:
+  - 書込: `wr_creature_common(const CreatureEntity &)` (`src/save/creature-common-writer.{h,cpp}`)
+  - 読込: `rd_creature_common(CreatureEntity &)` (`src/load/creature-common-loader.{h,cpp}`)
+  - 対象フィールド: `name` / 座標 (`y`,`x`) / `hp`/`maxhp`/`max_maxhp` /
+    `dealt_damage` / `speed` / `energy_need` / `ac` / `exp` / `au` /
+    `ht`/`wt` / `target` / 共通時限効果 7 種 (SLEEP_OR_PARALYSIS /
+    ACCELERATION / DECELERATION / STUN / CONFUSION / FEAR /
+    INVULNERABILITY) / `materials` (材質)。プレイヤー様式の明示フォーマット。
+- **モンスター経路は統合済み**: `MonsterWriter::write_to_savedata()` は
+  `wr_creature_common()` + モンスター固有フィールド (r_idx / ap_r_idx /
+  alliance / sub_align / smart / mflag2 / parent / transform / prace /
+  pclass / インベントリ) を書く。旧ビットマスク方式
+  (`SaveDataMonsterFlagType` / `write_monster_flags` / `write_monster_info`)
+  は廃止。
+- **後方互換**: v49 以前のセーブは `MonsterLoader50::rd_monster_legacy()`
+  (旧コードそのまま) で読む。v50 以降は `rd_monster_v50()`
+  (`rd_creature_common()` + 固有フィールド)。`rd_monster()` が
+  `loading_savefile_version_is_older_than(50)` で分岐。
+- 書込/読込は完全対称が前提。共通ブロックのフィールド追加・順序変更時は
+  writer/loader 双方を同時更新し、必要ならバージョンを再度更新すること。
+  `prace`/`pclass` は `NONE` (-1) を取り得るため符号付き `s16b` で保存する
+  (byte 保存は -1 が 255 になり復元不能なので不可)。
+- **残タスク (後続フェーズ)**: プレイヤー経路 (`wr_player` / `rd_player_info`)
+  を `wr_creature_common()` / `rd_creature_common()` に移行し、共通基底を
+  完全に 1 経路へ統合する。さらに stat 配列・MP (`csp`/`msp`)・各種 frac・
+  全時限効果 map の共通化を進める。
+
 ---
 
 ## 開発フロー

--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
@@ -395,6 +395,7 @@
     <ClCompile Include="..\..\src\external-lib\fmt\format.cc" />
     <ClCompile Include="..\..\src\io\macro-configurations-store.cpp" />
     <ClCompile Include="..\..\src\load\alliance-loader.cpp" />
+    <ClCompile Include="..\..\src\load\creature-common-loader.cpp" />
     <ClCompile Include="..\..\src\monster-floor\monster-movement-direction-list.cpp" />
     <ClCompile Include="..\..\src\monster-floor\party-generator.cpp" />
     <ClCompile Include="..\..\src\monster-race\monster-era-type-name.cpp" />
@@ -700,6 +701,7 @@
     <ClCompile Include="..\..\src\room\rooms-maze-vault.cpp" />
     <ClCompile Include="..\..\src\room\space-finder.cpp" />
     <ClCompile Include="..\..\src\room\treasure-deployment.cpp" />
+    <ClCompile Include="..\..\src\save\creature-common-writer.cpp" />
     <ClCompile Include="..\..\src\save\floor-writer.cpp" />
     <ClCompile Include="..\..\src\save\info-writer.cpp" />
     <ClCompile Include="..\..\src\save\item-writer.cpp" />
@@ -1208,6 +1210,7 @@
     <ClInclude Include="..\..\src\external-lib\include-json.h" />
     <ClInclude Include="..\..\src\io\macro-configurations-store.h" />
     <ClInclude Include="..\..\src\load\alliance-loader.h" />
+    <ClInclude Include="..\..\src\load\creature-common-loader.h" />
     <ClInclude Include="..\..\src\monster-floor\monster-movement-direction-list.h" />
     <ClInclude Include="..\..\src\monster-floor\party-generator.h" />
     <ClInclude Include="..\..\src\monster-race\monster-era-type-name.h" />
@@ -1622,6 +1625,7 @@
     <ClInclude Include="..\..\src\room\rooms-maze-vault.h" />
     <ClInclude Include="..\..\src\room\space-finder.h" />
     <ClInclude Include="..\..\src\room\treasure-deployment.h" />
+    <ClInclude Include="..\..\src\save\creature-common-writer.h" />
     <ClInclude Include="..\..\src\save\floor-writer.h" />
     <ClInclude Include="..\..\src\save\info-writer.h" />
     <ClInclude Include="..\..\src\save\item-writer.h" />

--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
@@ -2450,6 +2450,9 @@
     <ClCompile Include="..\..\src\save\monster-writer.cpp">
       <Filter>save</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\save\creature-common-writer.cpp">
+      <Filter>save</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\system\baseitem\baseitem-definition.cpp">
       <Filter>system\baseitem</Filter>
     </ClCompile>
@@ -2750,6 +2753,9 @@
       <Filter>alliance</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\load\alliance-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\creature-common-loader.cpp">
       <Filter>load</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\save\alliance-writer.cpp">
@@ -5646,6 +5652,9 @@
     <ClInclude Include="..\..\src\save\monster-writer.h">
       <Filter>save</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\save\creature-common-writer.h">
+      <Filter>save</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\system\enums\grid-flow.h">
       <Filter>system\enums</Filter>
     </ClInclude>
@@ -5987,6 +5996,9 @@
       <Filter>alliance</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\load\alliance-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\creature-common-loader.h">
       <Filter>load</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\save\alliance-writer.h">

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -767,6 +767,7 @@ hengband_SOURCES = \
 	load/birth-loader.cpp load/birth-loader.h \
 	load/dummy-loader.cpp load/dummy-loader.h \
 	load/dungeon-loader.cpp load/dungeon-loader.h \
+	load/creature-common-loader.cpp load/creature-common-loader.h \
 	load/extra-loader.cpp load/extra-loader.h \
 	load/floor-loader.cpp load/floor-loader.h \
 	load/info-loader.cpp load/info-loader.h \
@@ -1232,6 +1233,7 @@ hengband_SOURCES = \
 	room/vault-flag-types.h \
 	\
 	save/alliance-writer.cpp save/alliance-writer.h \
+	save/creature-common-writer.cpp save/creature-common-writer.h \
 	save/floor-writer.cpp save/floor-writer.h \
 	save/info-writer.cpp save/info-writer.h \
 	save/item-writer.cpp save/item-writer.h \

--- a/src/load/creature-common-loader.cpp
+++ b/src/load/creature-common-loader.cpp
@@ -1,0 +1,52 @@
+#include "load/creature-common-loader.h"
+#include "load/load-util.h"
+#include "system/creature-entity.h"
+#include "system/material-type-definition.h"
+#include "util/enum-converter.h"
+#include <vector>
+
+/*!
+ * @brief CreatureEntity の共通基底フィールドをセーブデータから読み込む
+ * @param creature 復元対象クリーチャー
+ * @details wr_creature_common() と完全対称であること。
+ */
+void rd_creature_common(CreatureEntity &creature)
+{
+    creature.name = rd_string();
+
+    creature.y = rd_s16b();
+    creature.x = rd_s16b();
+
+    creature.hp = rd_s32b();
+    creature.maxhp = rd_s32b();
+    creature.max_maxhp = rd_s32b();
+    creature.set_dealt_damage(static_cast<int>(rd_u32b()));
+
+    creature.speed = rd_s16b();
+    creature.energy_need = rd_s16b();
+    creature.ac = rd_s16b();
+
+    creature.set_exp(rd_u32b());
+    creature.set_au(rd_s32b());
+    creature.set_ht(rd_s16b());
+    creature.set_wt(rd_s16b());
+
+    creature.target.y = rd_s16b();
+    creature.target.x = rd_s16b();
+
+    creature.set_timed_effect(CreatureTimedEffect::SLEEP_OR_PARALYSIS, rd_s16b());
+    creature.set_timed_effect(CreatureTimedEffect::ACCELERATION, rd_s16b());
+    creature.set_timed_effect(CreatureTimedEffect::DECELERATION, rd_s16b());
+    creature.set_timed_effect(CreatureTimedEffect::STUN, rd_s16b());
+    creature.set_timed_effect(CreatureTimedEffect::CONFUSION, rd_s16b());
+    creature.set_timed_effect(CreatureTimedEffect::FEAR, rd_s16b());
+    creature.set_timed_effect(CreatureTimedEffect::INVULNERABILITY, rd_s16b());
+
+    const auto material_count = rd_u16b();
+    std::vector<CreatureMaterialType> materials;
+    materials.reserve(material_count);
+    for (auto i = 0; i < material_count; i++) {
+        materials.push_back(i2enum<CreatureMaterialType>(rd_s16b()));
+    }
+    creature.set_materials(materials);
+}

--- a/src/load/creature-common-loader.h
+++ b/src/load/creature-common-loader.h
@@ -1,0 +1,16 @@
+#pragma once
+/*!
+ * @file creature-common-loader.h
+ * @brief プレイヤー・モンスター共通 (CreatureEntity) のロード処理
+ * @details
+ * wr_creature_common() と対称の読み込み。セーブデータバージョン 50 以降で
+ * 使用する。CreatureEntity の基底フィールドを復元する。
+ */
+
+class CreatureEntity;
+
+/*!
+ * @brief CreatureEntity の共通基底フィールドをセーブデータから読み込む
+ * @param creature 復元対象クリーチャー
+ */
+void rd_creature_common(CreatureEntity &creature);

--- a/src/load/old/monster-loader-savefile50.cpp
+++ b/src/load/old/monster-loader-savefile50.cpp
@@ -1,4 +1,5 @@
 #include "load/old/monster-loader-savefile50.h"
+#include "load/creature-common-loader.h"
 #include "load/item/item-loader-base.h"
 #include "load/item/item-loader-factory.h"
 #include "load/load-util.h"
@@ -16,9 +17,24 @@
 #include "util/enum-converter.h"
 
 /*!
- * @brief モンスターを読み込む(v3.0.0 Savefile ver50まで)
+ * @brief モンスターを読み込む
+ * @details セーブデータバージョン 50 以降はプレイヤー・モンスター共通の
+ * 統合フォーマット (rd_creature_common + モンスター固有) で読み込み、
+ * 49 以前は従来のビットマスク方式 (rd_monster_legacy) で読み込む。
  */
 void MonsterLoader50::rd_monster(CreatureEntity &monster)
+{
+    if (loading_savefile_version_is_older_than(50)) {
+        this->rd_monster_legacy(monster);
+    } else {
+        this->rd_monster_v50(monster);
+    }
+}
+
+/*!
+ * @brief モンスターを読み込む(旧フォーマット: Savefile ver49まで)
+ */
+void MonsterLoader50::rd_monster_legacy(CreatureEntity &monster)
 {
     auto flags = rd_u32b();
     monster.set_r_idx(i2enum<MonraceId>(rd_s16b()));
@@ -251,5 +267,95 @@ void MonsterLoader50::rd_monster(CreatureEntity &monster)
         monster.set_materials(materials);
     } else {
         monster.clear_materials();
+    }
+}
+
+/*!
+ * @brief モンスターを読み込む(統合フォーマット: Savefile ver50以降)
+ * @details MonsterWriter::write_to_savedata() と完全対称。共通基底フィールドは
+ * rd_creature_common() に委譲し、モンスター固有フィールドのみここで読む。
+ */
+void MonsterLoader50::rd_monster_v50(CreatureEntity &monster)
+{
+    // --- 共通基底 (CreatureEntity) フィールド ---
+    rd_creature_common(monster);
+
+    // --- モンスター固有フィールド ---
+    monster.set_r_idx(i2enum<MonraceId>(rd_s16b()));
+    monster.set_ap_r_idx(i2enum<MonraceId>(rd_s16b()));
+    monster.set_alliance_idx(i2enum<AllianceType>(rd_s32b()));
+    monster.set_sub_align(rd_byte());
+
+    // 一時フラグ (mflag) は保存しないためクリアする
+    monster.clear_temporary_flags();
+
+    monster.clear_smart_flags();
+    rd_FlagGroup(monster.get_monster_profile().smart, rd_byte);
+
+    monster.clear_constant_flags();
+    rd_FlagGroup(monster.get_monster_profile().mflag2, rd_byte);
+
+    monster.set_parent_m_idx(rd_s16b());
+
+    monster.set_transform_r_idx(i2enum<MonraceId>(rd_s16b()));
+    monster.set_transform_hp_threshold(rd_byte());
+    monster.set_has_transformed(rd_byte() != 0);
+
+    // 種族 (prace は NONE (-1) を取り得るため符号付き s16b で読む)
+    monster.prace = i2enum<PlayerRaceType>(rd_s16b());
+    if (monster.prace != PlayerRaceType::NONE && enum2i(monster.prace) < MAX_RACES) {
+        monster.race = &race_info[enum2i(monster.prace)];
+    } else {
+        monster.race = nullptr;
+    }
+
+    // 職業
+    monster.pclass = i2enum<PlayerClassType>(rd_s16b());
+    if (monster.pclass != PlayerClassType::NONE) {
+        monster.pclass_ref = &class_info.at(monster.pclass);
+    } else {
+        monster.pclass_ref = nullptr;
+    }
+
+    // 通常インベントリ (u16b スロット番号 + アイテム、0xFFFF 終端)
+    {
+        auto item_loader = ItemLoaderFactory::create_loader();
+        while (true) {
+            const auto n = rd_u16b();
+            if (n == 0xFFFF) {
+                break;
+            }
+            if (n >= monster.inventory.size()) {
+                // 範囲外: ダミー読込でストリームを進める
+                auto dummy = std::make_shared<ItemEntity>();
+                item_loader->rd_item(dummy.get());
+                continue;
+            }
+            if (!monster.inventory[n]) {
+                monster.inventory[n] = std::make_shared<ItemEntity>();
+            }
+            item_loader->rd_item(monster.inventory[n].get());
+        }
+    }
+
+    // 拡張装備スロット (同形式)
+    monster.init_extended_inventory();
+    {
+        auto item_loader = ItemLoaderFactory::create_loader();
+        while (true) {
+            const auto n = rd_u16b();
+            if (n == 0xFFFF) {
+                break;
+            }
+            if (n >= monster.extended_inventory.size()) {
+                auto dummy = std::make_shared<ItemEntity>();
+                item_loader->rd_item(dummy.get());
+                continue;
+            }
+            if (!monster.extended_inventory[n]) {
+                monster.extended_inventory[n] = std::make_shared<ItemEntity>();
+            }
+            item_loader->rd_item(monster.extended_inventory[n].get());
+        }
     }
 }

--- a/src/load/old/monster-loader-savefile50.h
+++ b/src/load/old/monster-loader-savefile50.h
@@ -5,4 +5,8 @@
 class MonsterLoader50 : public MonsterLoaderBase {
 public:
     void rd_monster(CreatureEntity &monster) override;
+
+private:
+    void rd_monster_legacy(CreatureEntity &monster); //!< セーブデータバージョン <50 の旧フォーマット読込
+    void rd_monster_v50(CreatureEntity &monster); //!< セーブデータバージョン >=50 の統合フォーマット読込
 };

--- a/src/save/creature-common-writer.cpp
+++ b/src/save/creature-common-writer.cpp
@@ -1,0 +1,54 @@
+#include "save/creature-common-writer.h"
+#include "save/save-util.h"
+#include "system/creature-entity.h"
+#include "system/material-type-definition.h"
+#include "util/enum-converter.h"
+
+/*!
+ * @brief CreatureEntity の共通基底フィールドをセーブデータに書き込む
+ * @param creature 書き込み対象クリーチャー
+ * @details
+ * 読み込みは rd_creature_common() と完全対称であること。フィールドの
+ * 追加・順序変更を行う場合は両者を同時に修正し、セーブデータバージョンを
+ * 更新すること。
+ */
+void wr_creature_common(const CreatureEntity &creature)
+{
+    wr_string(creature.name);
+
+    wr_s16b(static_cast<int16_t>(creature.y));
+    wr_s16b(static_cast<int16_t>(creature.x));
+
+    wr_s32b(creature.hp);
+    wr_s32b(creature.maxhp);
+    wr_s32b(creature.max_maxhp);
+    wr_u32b(static_cast<uint32_t>(creature.get_dealt_damage()));
+
+    wr_s16b(static_cast<int16_t>(creature.speed));
+    wr_s16b(static_cast<int16_t>(creature.energy_need));
+    wr_s16b(static_cast<int16_t>(creature.ac));
+
+    wr_u32b(creature.get_exp());
+    wr_s32b(creature.get_au());
+    wr_s16b(creature.get_ht());
+    wr_s16b(creature.get_wt());
+
+    wr_s16b(static_cast<int16_t>(creature.target.y));
+    wr_s16b(static_cast<int16_t>(creature.target.x));
+
+    // プレイヤー・モンスター共通の時限効果
+    wr_s16b(creature.get_timed_effect(CreatureTimedEffect::SLEEP_OR_PARALYSIS));
+    wr_s16b(creature.get_timed_effect(CreatureTimedEffect::ACCELERATION));
+    wr_s16b(creature.get_timed_effect(CreatureTimedEffect::DECELERATION));
+    wr_s16b(creature.get_timed_effect(CreatureTimedEffect::STUN));
+    wr_s16b(creature.get_timed_effect(CreatureTimedEffect::CONFUSION));
+    wr_s16b(creature.get_timed_effect(CreatureTimedEffect::FEAR));
+    wr_s16b(creature.get_timed_effect(CreatureTimedEffect::INVULNERABILITY));
+
+    // 材質 (副種族)
+    const auto &materials = creature.get_materials();
+    wr_u16b(static_cast<uint16_t>(materials.size()));
+    for (const auto material : materials) {
+        wr_s16b(static_cast<int16_t>(enum2i(material)));
+    }
+}

--- a/src/save/creature-common-writer.h
+++ b/src/save/creature-common-writer.h
@@ -1,0 +1,19 @@
+#pragma once
+/*!
+ * @file creature-common-writer.h
+ * @brief プレイヤー・モンスター共通 (CreatureEntity) のセーブ処理
+ * @details
+ * 旧 PlayerType / 旧 MonsterEntity のセーブ処理統合の基盤 (フェーズ 1)。
+ * CreatureEntity の基底フィールド (HP・座標・速度・時限効果・材質等) を
+ * プレイヤー様式の明示的フォーマットで 1 箇所に書き出す。セーブデータ
+ * バージョン 50 以降で使用する。現状はモンスター経路が利用し、プレイヤー
+ * 経路の移行は後続フェーズで行う。
+ */
+
+class CreatureEntity;
+
+/*!
+ * @brief CreatureEntity の共通基底フィールドをセーブデータに書き込む
+ * @param creature 書き込み対象クリーチャー
+ */
+void wr_creature_common(const CreatureEntity &creature);

--- a/src/save/monster-writer.cpp
+++ b/src/save/monster-writer.cpp
@@ -1,12 +1,9 @@
 #include "save/monster-writer.h"
-#include "load/old/monster-flag-types-savefile50.h"
-#include "player-info/class-types.h"
-#include "player-info/race-types.h"
+#include "save/creature-common-writer.h"
 #include "save/item-writer.h"
 #include "save/save-util.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
-#include "system/monrace/monrace-list.h"
 #include "util/enum-converter.h"
 
 MonsterWriter::MonsterWriter(const CreatureEntity &monster)
@@ -15,278 +12,56 @@ MonsterWriter::MonsterWriter(const CreatureEntity &monster)
 }
 
 /*!
- * @brief モンスター情報をセーブデータに書き込む
+ * @brief モンスター情報をセーブデータに書き込む (セーブデータバージョン 50 以降の統合フォーマット)
+ * @details
+ * 共通基底 (CreatureEntity) フィールドは wr_creature_common() に委譲し、
+ * モンスター固有フィールドのみをここで書き出す。読み込みは
+ * MonsterLoader50::rd_monster() の v50 経路と完全対称であること。
+ * 旧バージョン (<50) の読み込みは MonsterLoader50 のレガシー経路が担う。
  */
 void MonsterWriter::write_to_savedata() const
 {
-    const auto flags = this->write_monster_flags();
+    // --- 共通基底 (CreatureEntity) フィールド ---
+    wr_creature_common(this->monster);
 
+    // --- モンスター固有フィールド ---
     wr_s16b(enum2i(this->monster.get_r_idx()));
+    wr_s16b(enum2i(this->monster.get_ap_r_idx()));
     wr_s32b(enum2i(this->monster.get_alliance_idx()));
+    wr_byte(this->monster.get_sub_align());
 
-    wr_byte((byte)this->monster.y);
-    wr_byte((byte)this->monster.x);
-    wr_s32b(this->monster.hp);
-    wr_s32b(this->monster.maxhp);
-    wr_s32b(this->monster.max_maxhp);
-    wr_u32b(this->monster.get_dealt_damage());
+    wr_FlagGroup(this->monster.get_smart_flags(), wr_byte);
+    wr_FlagGroup(this->monster.get_monster_profile().mflag2, wr_byte);
 
-    if (any_bits(flags, SaveDataMonsterFlagType::AP_R_IDX)) {
-        wr_s16b(enum2i(this->monster.get_ap_r_idx()));
-    }
+    wr_s16b(this->monster.get_parent_m_idx());
 
-    if (any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN)) {
-        wr_byte(this->monster.get_sub_align());
-    }
+    wr_s16b(static_cast<int16_t>(enum2i(this->monster.get_transform_r_idx())));
+    wr_byte(static_cast<byte>(this->monster.get_transform_hp_threshold()));
+    wr_byte(this->monster.has_transformed() ? 1 : 0);
 
-    if (any_bits(flags, SaveDataMonsterFlagType::SLEEP)) {
-        wr_s16b(this->monster.get_timed_effect(CreatureTimedEffect::SLEEP_OR_PARALYSIS));
-    }
+    // prace / pclass は NONE (-1) を取り得るため符号付き s16b で保存する
+    wr_s16b(static_cast<int16_t>(enum2i(this->monster.prace)));
+    wr_s16b(enum2i(this->monster.pclass));
 
-    wr_byte((byte)this->monster.speed);
-    wr_s16b(this->monster.energy_need);
-    wr_s16b(this->monster.ac);
-    this->write_monster_info(flags);
-}
-
-uint32_t MonsterWriter::write_monster_flags() const
-{
-    uint32_t flags = 0x00000000;
-    if (!this->monster.is_original_ap()) {
-        set_bits(flags, SaveDataMonsterFlagType::AP_R_IDX);
-    }
-
-    if (this->monster.get_sub_align()) {
-        set_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN);
-    }
-
-    if (this->monster.is_asleep()) {
-        set_bits(flags, SaveDataMonsterFlagType::SLEEP);
-    }
-
-    if (this->monster.is_accelerated()) {
-        set_bits(flags, SaveDataMonsterFlagType::FAST);
-    }
-
-    if (this->monster.is_decelerated()) {
-        set_bits(flags, SaveDataMonsterFlagType::SLOW);
-    }
-
-    if (this->monster.is_stunned()) {
-        set_bits(flags, SaveDataMonsterFlagType::STUNNED);
-    }
-
-    if (this->monster.is_confused()) {
-        set_bits(flags, SaveDataMonsterFlagType::CONFUSED);
-    }
-
-    if (this->monster.is_fearful()) {
-        set_bits(flags, SaveDataMonsterFlagType::MONFEAR);
-    }
-
-    if (this->monster.target.y) {
-        set_bits(flags, SaveDataMonsterFlagType::TARGET_Y);
-    }
-
-    if (this->monster.target.x) {
-        set_bits(flags, SaveDataMonsterFlagType::TARGET_X);
-    }
-
-    if (this->monster.is_invulnerable()) {
-        set_bits(flags, SaveDataMonsterFlagType::INVULNER);
-    }
-
-    if (this->monster.get_smart_flags().any()) {
-        set_bits(flags, SaveDataMonsterFlagType::SMART);
-    }
-
-    if (this->monster.get_exp()) {
-        set_bits(flags, SaveDataMonsterFlagType::EXP);
-    }
-
-    if (this->monster.get_monster_profile().mflag2.any()) {
-        set_bits(flags, SaveDataMonsterFlagType::MFLAG2);
-    }
-
-    if (this->monster.is_named()) {
-        set_bits(flags, SaveDataMonsterFlagType::NICKNAME);
-    }
-
-    if (this->monster.has_parent()) {
-        set_bits(flags, SaveDataMonsterFlagType::PARENT);
-    }
-
-    if (this->monster.get_au()) {
-        set_bits(flags, SaveDataMonsterFlagType::GOLD);
-    }
-
-    if (this->monster.get_ht() || this->monster.get_wt()) {
-        set_bits(flags, SaveDataMonsterFlagType::HEIGHT_WEIGHT);
-    }
-
-    if (this->monster.prace != PlayerRaceType::NONE) {
-        set_bits(flags, SaveDataMonsterFlagType::RACE);
-    }
-
-    if (this->monster.pclass != PlayerClassType::NONE) {
-        set_bits(flags, SaveDataMonsterFlagType::CLASS);
-    }
-
-    if (MonraceList::is_valid(this->monster.get_transform_r_idx()) || this->monster.has_transformed()) {
-        set_bits(flags, SaveDataMonsterFlagType::TRANSFORM);
-    }
-
-    // インベントリがあるかチェック
-    bool has_inventory = false;
-    for (const auto &item : this->monster.inventory) {
-        if (item && item->is_valid()) {
-            has_inventory = true;
-            break;
+    // 通常インベントリ (u16b スロット番号 + アイテム、0xFFFF 終端)
+    for (size_t i = 0; i < this->monster.inventory.size(); i++) {
+        const auto &item = this->monster.inventory[i];
+        if (!item || !item->is_valid()) {
+            continue;
         }
+        wr_u16b(static_cast<uint16_t>(i));
+        wr_item(*item);
     }
-    if (has_inventory) {
-        set_bits(flags, SaveDataMonsterFlagType::INVENTORY);
-    }
+    wr_u16b(0xFFFF);
 
-    // [Phase 2] 拡張装備スロットの有効アイテムがあるかチェック
-    bool has_extended = false;
-    for (const auto &item : this->monster.extended_inventory) {
-        if (item && item->is_valid()) {
-            has_extended = true;
-            break;
+    // 拡張装備スロット (同形式)
+    for (size_t i = 0; i < this->monster.extended_inventory.size(); i++) {
+        const auto &item = this->monster.extended_inventory[i];
+        if (!item || !item->is_valid()) {
+            continue;
         }
+        wr_u16b(static_cast<uint16_t>(i));
+        wr_item(*item);
     }
-    if (has_extended) {
-        set_bits(flags, SaveDataMonsterFlagType::EXTENDED_INVENTORY);
-    }
-
-    if (!this->monster.get_materials().empty()) {
-        set_bits(flags, SaveDataMonsterFlagType::MATERIALS);
-    }
-
-    wr_u32b(flags);
-    return flags;
-}
-
-void MonsterWriter::write_monster_info(uint32_t flags) const
-{
-    byte tmp8u;
-    if (any_bits(flags, SaveDataMonsterFlagType::FAST)) {
-        tmp8u = (byte)this->monster.get_timed_effect(CreatureTimedEffect::ACCELERATION);
-        wr_byte(tmp8u);
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::SLOW)) {
-        tmp8u = (byte)this->monster.get_timed_effect(CreatureTimedEffect::DECELERATION);
-        wr_byte(tmp8u);
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::STUNNED)) {
-        tmp8u = (byte)this->monster.get_timed_effect(CreatureTimedEffect::STUN);
-        wr_byte(tmp8u);
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::CONFUSED)) {
-        tmp8u = (byte)this->monster.get_timed_effect(CreatureTimedEffect::CONFUSION);
-        wr_byte(tmp8u);
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::MONFEAR)) {
-        tmp8u = (byte)this->monster.get_timed_effect(CreatureTimedEffect::FEAR);
-        wr_byte(tmp8u);
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::TARGET_Y)) {
-        wr_s16b((int16_t)this->monster.target.y);
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::TARGET_X)) {
-        wr_s16b((int16_t)this->monster.target.x);
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::INVULNER)) {
-        tmp8u = (byte)this->monster.get_timed_effect(CreatureTimedEffect::INVULNERABILITY);
-        wr_byte(tmp8u);
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::SMART)) {
-        wr_FlagGroup(this->monster.get_smart_flags(), wr_byte);
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::EXP)) {
-        wr_u32b(this->monster.get_exp());
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::MFLAG2)) {
-        wr_FlagGroup(this->monster.get_monster_profile().mflag2, wr_byte);
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::NICKNAME)) {
-        wr_string(this->monster.name);
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::PARENT)) {
-        wr_s16b(this->monster.get_parent_m_idx());
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::GOLD)) {
-        wr_s32b(this->monster.get_au());
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::HEIGHT_WEIGHT)) {
-        wr_s16b(this->monster.get_ht());
-        wr_s16b(this->monster.get_wt());
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::RACE)) {
-        wr_byte(static_cast<byte>(enum2i(this->monster.prace)));
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::CLASS)) {
-        wr_s16b(enum2i(this->monster.pclass));
-    }
-
-    if (any_bits(flags, SaveDataMonsterFlagType::TRANSFORM)) {
-        wr_s16b(static_cast<int16_t>(enum2i(this->monster.get_transform_r_idx())));
-        wr_byte(static_cast<byte>(this->monster.get_transform_hp_threshold()));
-        wr_byte(this->monster.has_transformed() ? 1 : 0);
-    }
-
-    // インベントリの保存（PlayerTypeと同じ形式）
-    if (any_bits(flags, SaveDataMonsterFlagType::INVENTORY)) {
-        for (size_t i = 0; i < this->monster.inventory.size(); i++) {
-            const auto &item = this->monster.inventory[i];
-            if (!item || !item->is_valid()) {
-                continue;
-            }
-
-            wr_u16b(static_cast<uint16_t>(i));
-            wr_item(*item);
-        }
-        wr_u16b(0xFFFF); // 終端マーカー
-    }
-
-    // [Phase 2] 拡張装備スロットの保存。各エントリは
-    //   u16b インデックス (0xFFFF で終端) + wr_item
-    // の繰り返し。インベントリと同じ形式。
-    if (any_bits(flags, SaveDataMonsterFlagType::EXTENDED_INVENTORY)) {
-        for (size_t i = 0; i < this->monster.extended_inventory.size(); i++) {
-            const auto &item = this->monster.extended_inventory[i];
-            if (!item || !item->is_valid()) {
-                continue;
-            }
-            wr_u16b(static_cast<uint16_t>(i));
-            wr_item(*item);
-        }
-        wr_u16b(0xFFFF); // 終端マーカー
-    }
-
-    // 材質 (副種族) の保存。個数 u16b に続けて各材質 ID を s16b で書き出す。
-    if (any_bits(flags, SaveDataMonsterFlagType::MATERIALS)) {
-        const auto &materials = this->monster.get_materials();
-        wr_u16b(static_cast<uint16_t>(materials.size()));
-        for (const auto material : materials) {
-            wr_s16b(static_cast<int16_t>(enum2i(material)));
-        }
-    }
+    wr_u16b(0xFFFF);
 }

--- a/src/save/monster-writer.h
+++ b/src/save/monster-writer.h
@@ -12,7 +12,5 @@ public:
     void write_to_savedata() const;
 
 private:
-    uint32_t write_monster_flags() const;
-    void write_monster_info(uint32_t flags) const;
     const CreatureEntity &monster;
 };

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -28,7 +28,7 @@ constexpr std::string_view VARIANT_NAME("Bakabaka");
  *     player_hp 配列が PY_MAX_LEVEL (件数非保持) で保存されるため、
  *     旧バージョン (<49) は 50 件として読む差分処理が必要。
  */
-constexpr uint32_t SAVEFILE_VERSION = 49;
+constexpr uint32_t SAVEFILE_VERSION = 50;
 
 /*!
  * @brief バージョンが開発版が安定版かを返す(廃止予定)


### PR DESCRIPTION
旧 PlayerType / 旧 MonsterEntity に分離していたセーブ/ロード処理を、
CreatureEntity 基底フィールド単位で統合する基盤を導入。セーブデータ
バージョンを 49→50 に更新。

共通基底シリアライザ (新規):
- wr_creature_common() / rd_creature_common() (src/save/creature-common-writer.*, src/load/creature-common-loader.*)
- 対象: name / 座標 / hp系 / dealt_damage / speed / energy_need / ac / exp / au / ht / wt / target / 共通時限効果7種 / materials。 プレイヤー様式の明示フォーマットで1箇所に集約。

モンスター経路を統合フォーマットへ移行:
- MonsterWriter::write_to_savedata() を wr_creature_common() + モンスター固有フィールド (r_idx/ap_r_idx/alliance/sub_align/smart/ mflag2/parent/transform/prace/pclass/インベントリ) に再構成。 旧ビットマスク方式 (write_monster_flags/write_monster_info) を廃止。
- prace/pclass は NONE(-1) を取り得るため符号付き s16b で保存 (byte だと -1 が 255 になり復元不能)。

後方互換 (v49 以前):
- MonsterLoader50::rd_monster() が loading_savefile_version で分岐。 <50 は従来コードそのまま (rd_monster_legacy)、>=50 は統合読込 (rd_monster_v50 = rd_creature_common + 固有フィールド)。
- 既存セーブデータはそのままロード可能。

書込/読込は完全対称。プレイヤー経路 (wr_player/rd_player_info) の
共通シリアライザ移行、および stat 配列・MP・frac・全時限効果 map の
共通化は後続フェーズで実施予定 (CLAUDE.md に記載)。

src/Makefile.am に新規4ファイルを登録。