### PR TITLE
feat: セーブ/ロード統合フェーズ2 — プレイヤー経路を共通シリアライザへ移行

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,11 +485,11 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
   開始 (`apply_monrace_personality()` で対話選択をスキップ) でも同一。
 - 性格適用は `CreatureEntity::set_personality(player_personality_type)` に集約。
 
-### セーブ/ロードの統合 (CreatureEntity 共通シリアライズ) — フェーズ 1
+### セーブ/ロードの統合 (CreatureEntity 共通シリアライズ) — フェーズ 1・2
 
 旧 PlayerType / 旧 MonsterEntity に分かれていたセーブ/ロード処理を、
 `CreatureEntity` 基底フィールド単位で 1 箇所に統合していく方針。
-**セーブデータバージョンは 50** に更新済み。
+**セーブデータバージョンは 51** に更新済み (フェーズ1 で 50、フェーズ2 で 51)。
 
 - 共通基底シリアライザ:
   - 書込: `wr_creature_common(const CreatureEntity &)` (`src/save/creature-common-writer.{h,cpp}`)
@@ -505,18 +505,30 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
   pclass / インベントリ) を書く。旧ビットマスク方式
   (`SaveDataMonsterFlagType` / `write_monster_flags` / `write_monster_info`)
   は廃止。
-- **後方互換**: v49 以前のセーブは `MonsterLoader50::rd_monster_legacy()`
-  (旧コードそのまま) で読む。v50 以降は `rd_monster_v50()`
-  (`rd_creature_common()` + 固有フィールド)。`rd_monster()` が
-  `loading_savefile_version_is_older_than(50)` で分岐。
+- **プレイヤー経路も統合済み (フェーズ2)**: `wr_player()` は先頭で
+  `wr_creature_common()` を呼び、共通基底フィールドを集約する。以降の
+  プレイヤー固有フィールドは共通フィールドを除いて従来の相対順序を保つ。
+  ロード側 (`player-info-loader.cpp`) は v51 以降で `rd_base_info()` 先頭の
+  `rd_creature_common()` で共通基底を読み、各共通フィールドの旧読込箇所
+  (name / ht / wt / au / exp / maxhp / hp / dealt_damage / energy_need /
+  CONFUSION / ACCELERATION / DECELERATION / FEAR / STUN / INVULNERABILITY の
+  15 箇所) を `loading_savefile_version_is_older_than(51)` でガードして
+  v50 以前のみ読む。プレイヤー固有フィールドの相対順序は不変。
+- **モンスターフォーマットは v50 と v51 で同一** (`wr_creature_common` 不変)。
+  そのため `rd_monster()` の分岐は `older_than(50)` のままでよく、v50/v51
+  どちらも `rd_monster_v50()` で読む。
+- **後方互換**: v49 以前のモンスターは `rd_monster_legacy()`、v50/v51 は
+  `rd_monster_v50()`。プレイヤーは v50 以前が旧個別読込、v51 以降が
+  `rd_creature_common()` + ガード済み個別読込。
 - 書込/読込は完全対称が前提。共通ブロックのフィールド追加・順序変更時は
-  writer/loader 双方を同時更新し、必要ならバージョンを再度更新すること。
-  `prace`/`pclass` は `NONE` (-1) を取り得るため符号付き `s16b` で保存する
-  (byte 保存は -1 が 255 になり復元不能なので不可)。
-- **残タスク (後続フェーズ)**: プレイヤー経路 (`wr_player` / `rd_player_info`)
-  を `wr_creature_common()` / `rd_creature_common()` に移行し、共通基底を
-  完全に 1 経路へ統合する。さらに stat 配列・MP (`csp`/`msp`)・各種 frac・
-  全時限効果 map の共通化を進める。
+  writer/loader 双方 (および利用する全経路) を同時更新し、必要なら
+  バージョンを再度更新すること。`prace`/`pclass` は `NONE` (-1) を取り得る
+  ため符号付き `s16b` で保存する (byte 保存は -1 が 255 になり復元不能)。
+  共通ブロックの拡張 (`wr_creature_common` へのフィールド追加) はモンスター
+  フォーマットも変えるため、その際は monster reader のバージョン分岐も追加する。
+- **残タスク (後続フェーズ)**: 共通基底のさらなる拡張 (stat 配列・MP
+  (`csp`/`msp`)・各種 frac・全時限効果 map の共通化)。これらは現状まだ
+  プレイヤー固有 / モンスター固有として個別に保存している。
 
 ---
 

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -3,6 +3,7 @@
 #include "combat/martial-arts-style.h"
 #include "load/angband-version-comparer.h"
 #include "load/birth-loader.h"
+#include "load/creature-common-loader.h"
 #include "load/dummy-loader.h"
 #include "load/load-util.h"
 #include "load/load-zangband.h"
@@ -63,9 +64,18 @@ static void rd_realms(CreatureEntity &creature)
  */
 void rd_base_info(CreatureEntity &creature)
 {
-    creature.name = rd_string();
-    if (creature.name.length() > 40) {
-        creature.name.resize(40);
+    // セーブデータバージョン 51 以降: CreatureEntity 共通基底フィールドを
+    // 先頭でまとめて読み込む (wr_player 先頭の wr_creature_common() と対称)。
+    if (!loading_savefile_version_is_older_than(51)) {
+        rd_creature_common(creature);
+        if (creature.name.length() > 40) {
+            creature.name.resize(40);
+        }
+    } else {
+        creature.name = rd_string();
+        if (creature.name.length() > 40) {
+            creature.name.resize(40);
+        }
     }
     creature.died_from = rd_string();
     creature.last_message = rd_string();
@@ -92,8 +102,11 @@ void rd_base_info(CreatureEntity &creature)
 
     creature.death_count = rd_s32b();
     creature.set_age(rd_s16b());
-    creature.set_ht(rd_s16b());
-    creature.set_wt(rd_s16b());
+    // ht / wt は v51 以降 rd_creature_common() で読込済み
+    if (loading_savefile_version_is_older_than(51)) {
+        creature.set_ht(rd_s16b());
+        creature.set_wt(rd_s16b());
+    }
 
     // 死亡履歴のロード（バージョン44以降）
     if (loading_savefile_version_is_older_than(44)) {
@@ -121,7 +134,10 @@ void rd_experience(CreatureEntity &creature)
     creature.set_max_exp(rd_s32b());
     creature.set_max_max_exp(rd_s32b());
 
-    creature.set_exp(rd_s32b());
+    // exp は v51 以降 rd_creature_common() で読込済み
+    if (loading_savefile_version_is_older_than(51)) {
+        creature.set_exp(rd_s32b());
+    }
     creature.exp_frac = rd_u32b();
 
     creature.set_level(rd_s16b());
@@ -295,15 +311,21 @@ static void rd_arena(CreatureEntity &creature)
  */
 static void rd_hp(CreatureEntity &creature)
 {
-    creature.maxhp = rd_s32b();
-    creature.hp = rd_s32b();
+    // maxhp / hp は v51 以降 rd_creature_common() で読込済み
+    if (loading_savefile_version_is_older_than(51)) {
+        creature.maxhp = rd_s32b();
+        creature.hp = rd_s32b();
+    }
     creature.hp_frac = rd_u32b();
 
-    // セーブファイルバージョン35以降で与ダメージ蓄積を読み込み
-    if (!loading_savefile_version_is_older_than(35)) {
-        creature.set_dealt_damage(rd_s32b());
-    } else {
-        creature.set_dealt_damage(0);
+    // dealt_damage は v51 以降 rd_creature_common() で読込済み。
+    // v35〜v50 は s32b で保存、v34 以前は未保存 (0)。
+    if (loading_savefile_version_is_older_than(51)) {
+        if (!loading_savefile_version_is_older_than(35)) {
+            creature.set_dealt_damage(rd_s32b());
+        } else {
+            creature.set_dealt_damage(0);
+        }
     }
 }
 
@@ -327,14 +349,20 @@ static void rd_bad_status(CreatureEntity &creature)
     strip_bytes(2); /* Old "rest" */
     creature.set_timed_effect(CreatureTimedEffect::BLINDNESS, rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::PARALYSIS, rd_s16b());
-    creature.set_timed_effect(CreatureTimedEffect::CONFUSION, rd_s16b());
+    // CONFUSION は v51 以降 rd_creature_common() で読込済み
+    if (loading_savefile_version_is_older_than(51)) {
+        creature.set_timed_effect(CreatureTimedEffect::CONFUSION, rd_s16b());
+    }
     creature.set_food(rd_s16b());
     strip_bytes(4); /* Old "food_digested" / "protection" */
 }
 
 static void rd_energy(CreatureEntity &creature)
 {
-    creature.energy_need = rd_s16b();
+    // energy_need は v51 以降 rd_creature_common() で読込済み
+    if (loading_savefile_version_is_older_than(51)) {
+        creature.energy_need = rd_s16b();
+    }
     creature.set_enchant_energy_need(rd_s16b());
 }
 
@@ -345,15 +373,24 @@ static void rd_energy(CreatureEntity &creature)
  */
 static void rd_status(CreatureEntity &creature)
 {
-    creature.set_timed_effect(CreatureTimedEffect::ACCELERATION, rd_s16b());
-    creature.set_timed_effect(CreatureTimedEffect::DECELERATION, rd_s16b());
-    creature.set_timed_effect(CreatureTimedEffect::FEAR, rd_s16b());
+    // ACCELERATION / DECELERATION / FEAR / STUN / INVULNERABILITY は
+    // v51 以降 rd_creature_common() で読込済み。残りはプレイヤー固有として読む。
+    const auto is_pre_v51 = loading_savefile_version_is_older_than(51);
+    if (is_pre_v51) {
+        creature.set_timed_effect(CreatureTimedEffect::ACCELERATION, rd_s16b());
+        creature.set_timed_effect(CreatureTimedEffect::DECELERATION, rd_s16b());
+        creature.set_timed_effect(CreatureTimedEffect::FEAR, rd_s16b());
+    }
     creature.set_timed_effect(CreatureTimedEffect::CUT, rd_s16b());
-    creature.set_timed_effect(CreatureTimedEffect::STUN, rd_s16b());
+    if (is_pre_v51) {
+        creature.set_timed_effect(CreatureTimedEffect::STUN, rd_s16b());
+    }
     creature.set_timed_effect(CreatureTimedEffect::POISON, rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::HALLUCINATION, rd_s16b());
     creature.set_timed_effect(CreatureTimedEffect::PROTECTION, rd_s16b());
-    creature.set_timed_effect(CreatureTimedEffect::INVULNERABILITY, rd_s16b());
+    if (is_pre_v51) {
+        creature.set_timed_effect(CreatureTimedEffect::INVULNERABILITY, rd_s16b());
+    }
     creature.set_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE, rd_s16b());
 }
 
@@ -445,7 +482,10 @@ static void rd_player_status(CreatureEntity &creature)
 {
     rd_base_status(creature);
     strip_bytes(24);
-    creature.set_au(rd_s32b());
+    // au は v51 以降 rd_creature_common() で読込済み
+    if (loading_savefile_version_is_older_than(51)) {
+        creature.set_au(rd_s32b());
+    }
     rd_experience(creature);
     rd_skills(creature);
     set_race(creature);

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -8,6 +8,7 @@
 #include "player-base/player-class.h"
 #include "player/player-realm.h"
 #include "player/player-skill.h"
+#include "save/creature-common-writer.h"
 #include "save/info-writer.h"
 #include "save/player-class-specific-data-writer.h"
 #include "save/save-util.h"
@@ -45,7 +46,11 @@ void wr_player(CreatureEntity &creature)
 {
     auto &system = AngbandSystem::get_instance();
 
-    wr_string(creature.name.data());
+    // セーブデータバージョン 51 以降: CreatureEntity 共通基底フィールドを
+    // wr_creature_common() に集約する。以降のプレイヤー固有フィールドは
+    // 共通フィールドを除いて従来の相対順序を保つ。
+    wr_creature_common(creature);
+
     wr_string(creature.died_from);
     wr_string(creature.last_message);
 
@@ -66,8 +71,7 @@ void wr_player(CreatureEntity &creature)
 
     wr_s32b(creature.death_count);
     wr_s16b(creature.get_age());
-    wr_s16b(creature.get_ht());
-    wr_s16b(creature.get_wt());
+    // ht / wt は wr_creature_common() で保存済み
 
     // 死亡履歴のセーブ
     wr_u32b(static_cast<uint32_t>(creature.death_history.size()));
@@ -97,10 +101,10 @@ void wr_player(CreatureEntity &creature)
         wr_s16b(0);
     }
 
-    wr_u32b(creature.get_au());
+    // au は wr_creature_common() で保存済み
     wr_u32b(creature.get_max_exp());
     wr_u32b(creature.get_max_max_exp());
-    wr_u32b(creature.get_exp());
+    // exp は wr_creature_common() で保存済み
     wr_u32b(creature.exp_frac);
     wr_s16b(creature.get_level());
 
@@ -159,10 +163,8 @@ void wr_player(CreatureEntity &creature)
     wr_s16b((int16_t)creature.oldpy);
 
     wr_s16b(0);
-    wr_s32b(creature.maxhp);
-    wr_s32b(creature.hp);
+    // maxhp / hp / dealt_damage は wr_creature_common() で保存済み
     wr_u32b(creature.hp_frac);
-    wr_s32b(creature.get_dealt_damage()); // セーブファイルバージョン35以降で与ダメージ蓄積を保存
     wr_s32b(creature.get_msp());
     wr_s32b(creature.get_csp());
     wr_u32b(creature.csp_frac);
@@ -184,21 +186,19 @@ void wr_player(CreatureEntity &creature)
     wr_s16b(0); /* old "rest" */
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::BLINDNESS));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::PARALYSIS));
-    wr_s16b(creature.get_timed_effect(CreatureTimedEffect::CONFUSION));
+    // CONFUSION は wr_creature_common() で保存済み
     wr_s16b(creature.get_food());
     wr_s16b(0); /* old "food_digested" */
     wr_s16b(0); /* old "protection" */
-    wr_s16b(creature.energy_need);
+    // energy_need は wr_creature_common() で保存済み
     wr_s16b(creature.get_enchant_energy_need());
-    wr_s16b(creature.get_timed_effect(CreatureTimedEffect::ACCELERATION));
-    wr_s16b(creature.get_timed_effect(CreatureTimedEffect::DECELERATION));
-    wr_s16b(creature.get_timed_effect(CreatureTimedEffect::FEAR));
+    // ACCELERATION / DECELERATION / FEAR は wr_creature_common() で保存済み
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::CUT));
-    wr_s16b(creature.get_timed_effect(CreatureTimedEffect::STUN));
+    // STUN は wr_creature_common() で保存済み
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::POISON));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::HALLUCINATION));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::PROTECTION));
-    wr_s16b(creature.get_timed_effect(CreatureTimedEffect::INVULNERABILITY));
+    // INVULNERABILITY は wr_creature_common() で保存済み
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::HERO));
     wr_s16b(creature.get_timed_effect(CreatureTimedEffect::BERSERK));

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -28,7 +28,7 @@ constexpr std::string_view VARIANT_NAME("Bakabaka");
  *     player_hp 配列が PY_MAX_LEVEL (件数非保持) で保存されるため、
  *     旧バージョン (<49) は 50 件として読む差分処理が必要。
  */
-constexpr uint32_t SAVEFILE_VERSION = 50;
+constexpr uint32_t SAVEFILE_VERSION = 51;
 
 /*!
  * @brief バージョンが開発版が安定版かを返す(廃止予定)


### PR DESCRIPTION
プレイヤーのセーブ/ロードを CreatureEntity 共通シリアライザ
(wr_creature_common / rd_creature_common) に載せ替え。セーブデータ バージョンを 50→51 に更新。

writer (wr_player):
- 先頭で wr_creature_common(creature) を呼び、共通基底フィールドを集約。
- 共通フィールドの個別書込 15 箇所 (name / ht / wt / au / exp / maxhp / hp / dealt_damage / energy_need / CONFUSION / ACCELERATION / DECELERATION / FEAR / STUN / INVULNERABILITY) を削除。プレイヤー固有フィールドの 相対順序は不変。

loader (player-info-loader):
- rd_base_info 先頭で v51 以降 rd_creature_common() を呼ぶ。
- 上記15フィールドの旧読込を loading_savefile_version_is_older_than(51) で ガードし、v50 以前のみ読む。非共通フィールドは無変更。

後方互換:
- v50 以前のプレイヤーセーブは従来の個別読込経路で読める。
- モンスターフォーマットは v50/v51 で同一 (wr_creature_common 不変) のため rd_monster() の older_than(50) 分岐はそのままで両対応。

writer/reader は完全対称。共通ブロックの全エンコードは旧プレイヤー
フォーマットとバイト互換 (au/exp/dealt_damage の s32b/u32b は同一バイト)。

残: 共通基底の拡張 (stat 配列 / MP / frac / 全時限効果 map) は後続フェーズ。