### PR TITLE
merge: 吸血処理の武器所持判定誤りを修正 (hengband #5422)

### DIFF
--- a/src/player-attack/blood-sucking-processor.cpp
+++ b/src/player-attack/blood-sucking-processor.cpp
@@ -151,7 +151,7 @@ static void drain_result(CreatureEntity &creature, player_attack_type *pa_ptr, b
     }
 
     if (*drain_msg) {
-        if (has_melee_weapon(creature, pa_ptr->hand)) {
+        if (has_melee_weapon(creature, enum2i(INVEN_MAIN_HAND) + pa_ptr->hand)) {
             msg_format(_("刃が%sから生命力を吸い取った！", "Your weapon drains life from %s!"), pa_ptr->m_name);
         } else {
             msg_format(_("手が%sから生命力を吸い取った！", "Your hands drain life from %s!"), pa_ptr->m_name);


### PR DESCRIPTION
has_melee_weapon にスロット index ではなく hand index を渡していたバグを修正。 enum2i(INVEN_MAIN_HAND) + pa_ptr->hand に。変愚蛮怒 #5422 相当 (bakabakaband #8455)。