### PR TITLE
merge: 神の怒りの方向指定キャンセル時の不具合修正 (hengband #5396)

### DIFF
--- a/src/realm/realm-crusade.cpp
+++ b/src/realm/realm-crusade.cpp
@@ -391,6 +391,9 @@ tl::optional<std::string> do_crusade_spell(CreatureEntity &creature, SPELL_IDX s
         if (cast) {
             const POSITION rad = 7;
             const auto dir = get_aim_dir(creature);
+            if (!dir) {
+                return tl::nullopt;
+            }
             fire_ball(creature, AttributeType::DISINTEGRATE, dir, dam, rad);
         }
     } break;


### PR DESCRIPTION
case 28 (DISINTEGRATE) で get_aim_dir のキャンセル (!dir) ガードが欠落して いたため追加。変愚蛮怒 #5396 相当 (bakabakaband #8412)。