### PR TITLE
merge: 自動拾いのコメント行で先頭スペースをトリミング (hengband #5407)

### DIFF
--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -310,12 +310,14 @@ bool autopick_new_entry(autopick_type *entry, std::string_view line_input, bool 
 
     if (sv.starts_with(':')) {
         sv.remove_prefix(1);
+        sv = ltrim_sv(sv);
         return true;
     }
 
 #ifdef JP
     if (sv.starts_with(kanji_colon)) {
         sv.remove_prefix(kanji_colon.length());
+        sv = ltrim_sv(sv);
         return true;
     }
 #endif


### PR DESCRIPTION
':' / 全角コロン除去後に ltrim_sv を適用。変愚蛮怒 #5407 相当 (bakabakaband #8418)。