### PR TITLE
merge: ダメージ地形への走り込み処理の修正 (hengband #5398)

### DIFF
--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -73,6 +73,54 @@ static bool see_wall(CreatureEntity &creature, const Direction &dir, const Pos2D
 }
 
 /*!
+ * @brief ダメージ地形をダッシュ中に無視 (素通り) してよいか判定する
+ * @param creature クリーチャーへの参照
+ * @param terrain 判定対象の地形
+ * @return 無視してよければ true (走行を止めない)
+ */
+static bool can_ignore_damaging_terrain(CreatureEntity &creature, const TerrainType &terrain)
+{
+    if (creature.is_invulnerable()) {
+        return true;
+    }
+
+    const auto &flags = terrain.flags;
+    if (flags.has(TerrainCharacteristics::LAVA) && !creature.has_immune_fire()) {
+        return false;
+    }
+
+    // 虚空 (VOID) は無敵以外では無視不可 (bakabakaband 独自地形)
+    if (flags.has(TerrainCharacteristics::VOID)) {
+        return false;
+    }
+
+    if (flags.has(TerrainCharacteristics::COLD_PUDDLE) && !creature.has_immune_cold()) {
+        return false;
+    }
+
+    if (flags.has(TerrainCharacteristics::ELEC_PUDDLE) && !creature.has_immune_elec()) {
+        return false;
+    }
+
+    if (flags.has(TerrainCharacteristics::ACID_PUDDLE) && !creature.has_immune_acid()) {
+        return false;
+    }
+
+    if (flags.has(TerrainCharacteristics::POISON_PUDDLE)) {
+        return false;
+    }
+
+    if (flags.has_all_of({ TerrainCharacteristics::WATER, TerrainCharacteristics::DEEP })) {
+        const auto can_ignore_water = creature.has_levitation() || creature.has_can_swim() || creature.has_resist_water() || (calc_inventory_weight(creature) <= calc_weight_limit(creature));
+        if (!can_ignore_water) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/*!
  * @brief ダッシュ処理の導入 /
  * Initialize the running algorithm for a new direction.
  * @param creature	クリーチャーへの参照
@@ -228,17 +276,14 @@ static bool run_test(CreatureEntity &creature)
         auto inv = true;
         if (grid.is_mark()) {
             const auto &terrain = grid.get_terrain(TerrainKind::MIMIC);
-            auto notice = terrain.flags.has(TerrainCharacteristics::NOTICE);
+            const auto is_damaging = terrain.can_damage_player();
+            auto notice = terrain.flags.has(TerrainCharacteristics::NOTICE) || is_damaging;
             if (notice && terrain.flags.has(TerrainCharacteristics::MOVE)) {
                 if (find_ignore_doors && terrain.flags.has_all_of({ TerrainCharacteristics::DOOR, TerrainCharacteristics::CLOSE })) {
                     notice = false;
                 } else if (find_ignore_stairs && terrain.flags.has(TerrainCharacteristics::STAIRS)) {
                     notice = false;
-                } else if (terrain.flags.has(TerrainCharacteristics::LAVA) && (creature.has_immune_fire() || creature.is_invulnerable())) {
-                    notice = false;
-                } else if (terrain.flags.has(TerrainCharacteristics::VOID) && creature.is_invulnerable()) {
-                    notice = false;
-                } else if (terrain.flags.has_all_of({ TerrainCharacteristics::WATER, TerrainCharacteristics::DEEP }) && (creature.has_levitation() || creature.has_can_swim() || (calc_inventory_weight(creature) <= calc_weight_limit(creature)))) {
+                } else if (is_damaging && can_ignore_damaging_terrain(creature, terrain)) {
                     notice = false;
                 }
             }

--- a/src/system/terrain/terrain-definition.cpp
+++ b/src/system/terrain/terrain-definition.cpp
@@ -48,6 +48,19 @@ bool TerrainType::is_permanent_wall() const
     return this->flags.has_all_of({ TerrainCharacteristics::WALL, TerrainCharacteristics::PERMANENT });
 }
 
+bool TerrainType::can_damage_player() const
+{
+    return this->flags.has_any_of({
+               TerrainCharacteristics::LAVA,
+               TerrainCharacteristics::VOID,
+               TerrainCharacteristics::COLD_PUDDLE,
+               TerrainCharacteristics::ELEC_PUDDLE,
+               TerrainCharacteristics::ACID_PUDDLE,
+               TerrainCharacteristics::POISON_PUDDLE,
+           }) ||
+           this->flags.has_all_of({ TerrainCharacteristics::WATER, TerrainCharacteristics::DEEP });
+}
+
 /*!
  * @brief ドアやカーテンが開いているかを調べる
  * @return 閉じる機能の有無

--- a/src/system/terrain/terrain-definition.h
+++ b/src/system/terrain/terrain-definition.h
@@ -85,6 +85,7 @@ public:
     static bool has(TerrainCharacteristics tc, TerrainAction ta);
 
     bool is_permanent_wall() const;
+    bool can_damage_player() const;
     bool is_open() const;
     bool is_closed_door() const;
     bool has(TerrainCharacteristics tc) const;


### PR DESCRIPTION
ダッシュ中にダメージ地形 (溶岩/各属性溜まり/深水) で停止すべき判定を整理。
TerrainType::can_damage_player() を追加し、run_test では is_damaging を notice に反映、can_ignore_damaging_terrain() で耐性/無敵/浮遊/泳ぎ等を考慮。

bakabakaband 適応:
- PlayerType* → CreatureEntity&、has_immune_*/has_resist_water/has_levitation/ has_can_swim/is_invulnerable は virtual メソッド経由
- bakabakaband 独自の VOID 地形 (無敵以外で無視不可) を can_damage_player() と can_ignore_damaging_terrain() の双方で保持

変愚蛮怒 #5398 相当 (bakabakaband #8414)。