### PR TITLE
merge: 英語名のtypo修正 (hengband #5418, #5430)

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -56007,7 +56007,7 @@
       "id": 890,
       "name": {
         "ja": "デイドラ・グリーン・ドラゴン",
-        "en": "Daedra Green Draon",
+        "en": "Daedra Green Dragon",
       },
       "symbol": {
         "character": "D",
@@ -89597,7 +89597,7 @@
       "id": 1415,
       "name": {
         "ja": "溶岩の怪物『ヨガン』",
-        "en": "Magman,Lava monster",
+        "en": "Magman, Lava monster",
       },
       "symbol": {
         "character": "~",


### PR DESCRIPTION
- "Daedra Green Draon" → "Daedra Green Dragon" (#5418)
- "Magman,Lava monster" → "Magman, Lava monster" (カンマ後スペース, #5430)

変愚蛮怒 #5418/#5430 相当 (bakabakaband #8453/#8481)。