### PR TITLE
merge: format.cc が再コンパイルされない問題の修正 (hengband #5435)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1588,6 +1588,7 @@ stdafx.h.gch: stdafx.h stdafx.cpp Makefile
 	fi
 
 $(hengband_SOURCES:.cpp=.$(OBJEXT)): stdafx.h.gch
+$(hengband_SOURCES:.cc=.$(OBJEXT)): stdafx.h.gch
 endif
 
 install-exec-hook:


### PR DESCRIPTION
PCH (stdafx.h.gch) 更新時に拡張子 .cc のファイル (external-lib/fmt/format.cc) が再コンパイルされずリンクエラーになることがある問題を修正。
$(hengband_SOURCES:.cc=.$(OBJEXT)): stdafx.h.gch を追加。

変愚蛮怒 #5435 相当 (bakabakaband #8484)。