### PR TITLE
merge: リリースワークフローでビルド失敗を確実に検出する (hengband #5410)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -41,6 +41,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: Bakabakaband-*.zip
+          fail_on_unmatched_files: true
           name: ${{ steps.get_version.outputs.version }}
           tag_name: ${{ steps.get_version.outputs.version }}
           generate_release_notes: true

--- a/Build-Windows-Release-Package.ps1
+++ b/Build-Windows-Release-Package.ps1
@@ -13,9 +13,12 @@ function BuildPackage ($package_name, $package_unique_files, $build_conf) {
     # バイナリをリビルド
     MSBuild.exe .\VisualStudio\Bakabakaband.sln /t:Rebuild /p:Configuration=$build_conf
 
-    if ($LASTEXITCODE -ne 0) {
-        # ビルド失敗ならスクリプトを中断する
-        exit
+    # ビルド失敗ならスクリプトを中断する ($? も併用して MSBuild の起動失敗にも対応)
+    if (-not $? -or $LASTEXITCODE -ne 0) {
+        if ($LASTEXITCODE -eq $null) {
+            exit 1
+        }
+        exit $LASTEXITCODE
     }
 
     # 作業用テンポラリフォルダ


### PR DESCRIPTION
- Build-Windows-Release-Package.ps1: MSBuild 失敗時に引数なし exit で抜けて 終了コード 0 になり、ジョブが緑のまま空リリースが publish される問題を修正。 $? と $LASTEXITCODE を伝播するよう変更。
- create-release.yml: action-gh-release に fail_on_unmatched_files: true を付与し、 ZIP が無い場合にジョブを失敗させる。

上流の VS2026 preview ランナー切替 (windows-2022→windows-2025-vs2026) は bakabakaband 環境固有・暫定対応のため除外。

変愚蛮怒 #5410 相当 (bakabakaband #8419)。