### PR TITLE
merge: 最大フロア生成オプションを追加 (hengband #5423)

### DIFF
--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -345,7 +345,7 @@ static tl::optional<std::string> level_gen(CreatureEntity &creature, tl::optiona
     if (dungeon.flags.has(DungeonFeatureType::ALWAY_MAX_SIZE)) {
         level_height = MAX_HGT / SCREEN_HGT;
         level_width = MAX_WID / SCREEN_WID;
-    } else if (always_small_floor || ironman_smallest_floor || (allow_smallest_floor && one_in_(chance_small_floor)) || dungeon.flags.has(DungeonFeatureType::SMALLEST)) {
+    } else if (always_small_floor || ironman_smallest_floor || (allow_smallest_floor && !always_large_floor && one_in_(chance_small_floor)) || dungeon.flags.has(DungeonFeatureType::SMALLEST)) {
         level_height = MIN_HGT_MULTIPLE;
         level_width = MIN_WID_MULTIPLE;
         // 鉄人「常に最小フロア」+ 鉄人「常に普通でない部屋」+ NO_VAULT 無し の組み合わせで
@@ -355,6 +355,11 @@ static tl::optional<std::string> level_gen(CreatureEntity &creature, tl::optiona
             level_height = MIN_HGT_MULTIPLE * 2;
             level_width = MIN_WID_MULTIPLE;
         }
+    } else if (always_large_floor) {
+        // 常に大きめのフロアを生成する (上流 #5423 相当)。
+        // always_small_floor 等の「小さめ」系が優先されるよう、それらより後に判定する。
+        level_height = MAX_HGT / SCREEN_HGT;
+        level_width = MAX_WID / SCREEN_WID;
     } else if (dungeon.flags.has(DungeonFeatureType::BEGINNER)) {
         level_height = MIN_HGT_MULTIPLE * 2;
         level_width = MIN_WID_MULTIPLE * 2;
@@ -370,12 +375,13 @@ static tl::optional<std::string> level_gen(CreatureEntity &creature, tl::optiona
             level_width = randint1(MAX_WID / SCREEN_WID / 3);
         }
         bool is_first_level_area = true;
-        bool is_max_area = (level_height == MAX_HGT / SCREEN_HGT) && (level_width == MAX_WID / SCREEN_WID);
+        // allow_largest_floor が ON の場合は最大面積フロアを除外しない (上流 #5423 相当)。
+        bool is_max_area = !allow_largest_floor && (level_height == MAX_HGT / SCREEN_HGT) && (level_width == MAX_WID / SCREEN_WID);
         while (is_first_level_area || is_max_area) {
             level_height = randint1(MAX_HGT / SCREEN_HGT);
             level_width = randint1(MAX_WID / SCREEN_WID);
             is_first_level_area = false;
-            is_max_area = (level_height == MAX_HGT / SCREEN_HGT) && (level_width == MAX_WID / SCREEN_WID);
+            is_max_area = !allow_largest_floor && (level_height == MAX_HGT / SCREEN_HGT) && (level_width == MAX_WID / SCREEN_WID);
         }
     }
     floor.height = level_height * SCREEN_HGT;

--- a/src/game-option/game-play-options.cpp
+++ b/src/game-option/game-play-options.cpp
@@ -5,6 +5,8 @@ bool stack_force_costs; /* Merge discounts when stacking */
 bool expand_list; /* Expand the power of the list commands */
 bool allow_smallest_floor; /* Allow unusually small dungeon levels */
 bool always_small_floor; /* Always create unusually small dungeon levels */
+bool allow_largest_floor; /* Allow unusually large dungeon levels */
+bool always_large_floor; /* Always create unusually large dungeon levels */
 bool allow_arena_floor; /* Allow empty 'on_defeat_arena_monster' levels */
 bool bound_walls_perm; /* Boundary walls become 'permanent wall' */
 bool last_words; /* Leave last words when your character dies */

--- a/src/game-option/game-play-options.h
+++ b/src/game-option/game-play-options.h
@@ -7,6 +7,8 @@ extern bool stack_force_costs; /* Merge discounts when stacking */
 extern bool expand_list; /* Expand the power of the list commands */
 extern bool allow_smallest_floor; /* Allow unusually small dungeon levels */
 extern bool always_small_floor; /* Always create unusually small dungeon levels */
+extern bool allow_largest_floor; //!< 最大面積のフロアを他ダンジョンでも生成可能にする.
+extern bool always_large_floor; //!< 常に大きいフロアを生成する.
 extern bool allow_arena_floor; /* Allow empty 'on_defeat_arena_monster' levels */
 extern bool bound_walls_perm; /* Boundary walls become 'permanent wall' */
 extern bool last_words; /* Leave last words when your character dies */

--- a/src/game-option/option-types-table.cpp
+++ b/src/game-option/option-types-table.cpp
@@ -193,7 +193,12 @@ const std::vector<GameOption> option_info = validate_option_info({
     { &allow_smallest_floor, true, GameOptionType::ALLOW_SMALLEST_FLOOR, "allow_smallest_floor", _("非常に小さいフロアの生成を可能にする", "Allow unusually small dungeon levels"), GameOptionPage::GAMEPLAY },
 
     { &always_small_floor, false, GameOptionType::ALWAYS_SMALL_FLOOR, "always_small_floor",
-        _("常に非常に小さいフロアを生成する", "Always create unusually small dungeon levels"), GameOptionPage::GAMEPLAY },
+        _("常に小さめのフロアを生成する", "Always create unusually small dungeon levels"), GameOptionPage::GAMEPLAY },
+
+    { &allow_largest_floor, false, GameOptionType::ALLOW_LARGEST_FLOOR, "allow_largest_floor", _("非常に大きいフロアの生成を可能にする", "Allow unusually large dungeon levels"), GameOptionPage::GAMEPLAY },
+
+    { &always_large_floor, false, GameOptionType::ALWAYS_LARGE_FLOOR, "always_large_floor",
+        _("常に大きめのフロアを生成する", "Always create unusually large dungeon levels"), GameOptionPage::GAMEPLAY },
 
     { &allow_arena_floor, true, GameOptionType::ALLOW_ARENA_FLOOR, "allow_arena_floor", _("空っぽの「アリーナ」レベルの生成を可能にする", "Allow empty 'arena' levels"), GameOptionPage::GAMEPLAY },
 

--- a/src/game-option/option-types-table.h
+++ b/src/game-option/option-types-table.h
@@ -77,12 +77,12 @@ enum class GameOptionType : int {
     BOUND_WALLS_PERM = 65,
     MONSTER_TOMBSTONES = 66, /*!< bakabakaband 独自: モンスターが死ぬ度に墓石を立てる(ジョーク) */
     ALWAYS_SMALL_FLOOR = 67, /*!< 上流 #5360 で ALWAYS_SMALL_FLOOR に改名予定 */
-    // 68
+    ALWAYS_LARGE_FLOOR = 68, /*!< 常に大きいフロアを生成する (上流 #5423 相当。上流の 68 と一致) */
     TARGET_PET = 69,
     AUTO_MORE = 70,
     COMMAND_MENU = 71,
     DISPLAY_PATH = 72,
-    // 73
+    ALLOW_LARGEST_FLOOR = 73, /*!< 最大フロアの生成を可能にする (上流 #5423 相当。上流は 66 だが bakabakaband は MONSTER_TOMBSTONES と衝突するため 73 を使用) */
     ABBREV_EXTRA = 74,
     ABBREV_ALL = 75,
     EXP_NEED = 76,

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -205,6 +205,14 @@ static void dump_aux_options(FILE *fff)
         fmt::print(fff, _("\n 小さいダンジョン:   OFF", "\n Small Levels:       OFF"));
     }
 
+    if (always_large_floor) {
+        fmt::print(fff, _("\n 大きいダンジョン:   ON", "\n Large Levels:       ON"));
+    } else if (allow_largest_floor) {
+        fmt::print(fff, _("\n 大きいダンジョン:   ENABLED", "\n Large Levels:       ENABLED"));
+    } else {
+        fmt::print(fff, _("\n 大きいダンジョン:   OFF", "\n Large Levels:       OFF"));
+    }
+
     if (vanilla_town) {
         fmt::print(fff, _("\n 元祖の町のみ:       ON", "\n Vanilla Town:       ON"));
     } else if (lite_town) {


### PR DESCRIPTION
allow_largest_floor / always_large_floor の 2 オプションを追加。

bakabakaband 適応:
- 上流は FloorType::select_floor_size_* (floor-info.cpp) の block 選択 リファクタ前提だが、bakabakaband は floor サイズ決定が floor-generator.cpp の 独自ブロックモデル (level_height/width) のため、そちらへ移植実装した。
  - allow_largest_floor: 通常生成で除外している最大面積フロアを許可する。
  - always_large_floor: 常に最大サイズのフロアを生成する (always_small 系が優先)。
- GameOptionType の ID は上流 (ALLOW_LARGEST_FLOOR=66) が bakabakaband 独自の MONSTER_TOMBSTONES=66 と衝突するため、ALLOW_LARGEST_FLOOR=73 (空き) を使用。 ALWAYS_LARGE_FLOOR=68 は上流と一致 (空き)。
- allow_largest_floor の既定値は上流 (true) ではなく false とした。bakabakaband は 従来最大フロアを生成しない仕様であり、既定挙動を変えないためのオプトイン。
- character-dump に大きいダンジョンの状態出力を追加。

注: floor サイズモデルが上流と異なるため挙動は等価ではない。要プレイテスト。

変愚蛮怒 #5423 相当 (bakabakaband #8470)。