### PR TITLE
merge: 財宝地形の財宝ドロップ数を定義可能にする (hengband #5393 のうち gold_drop のみ)

### DIFF
--- a/lib/edit/TerrainDefinitions.jsonc
+++ b/lib/edit/TerrainDefinitions.jsonc
@@ -1647,6 +1647,7 @@
       },
       "mimic": "MAGMA_VEIN",
       "map_priority": 2,
+      "DROP_GOLD": "1d2",
       "flags": [
         "POWER_10",
         "SECRET",
@@ -1677,6 +1678,7 @@
       },
       "mimic": "QUARTZ_VEIN",
       "map_priority": 2,
+      "DROP_GOLD": "1d2",
       "flags": [
         "POWER_20",
         "SECRET",
@@ -1707,6 +1709,7 @@
       },
       "mimic": null,
       "map_priority": 2,
+      "DROP_GOLD": "2d2",
       "flags": [
         "POWER_20",
         "REMEMBER",
@@ -1736,6 +1739,7 @@
       },
       "mimic": null,
       "map_priority": 2,
+      "DROP_GOLD": "2d2",
       "flags": [
         "POWER_20",
         "REMEMBER",

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -799,8 +799,9 @@ void cave_alter_feat(CreatureEntity &creature, POSITION y, POSITION x, TerrainCh
 
         /* Handle gold */
         if (old_terrain.flags.has(TerrainCharacteristics::HAS_GOLD) && new_terrain.flags.has_not(TerrainCharacteristics::HAS_GOLD)) {
-            /* Place some gold */
-            place_gold(creature, pos);
+            /* Place some gold (財宝地形に DROP_GOLD 指定があればその個数、無ければ従来通り 1 個) */
+            const auto drop_count = old_terrain.gold_drop.is_valid() ? old_terrain.gold_drop.roll() : 1;
+            place_gold(creature, pos, drop_count);
             found = true;
         }
 

--- a/src/grid/object-placer.cpp
+++ b/src/grid/object-placer.cpp
@@ -42,6 +42,25 @@ void place_gold(CreatureEntity &creature, const Pos2D &pos)
 }
 
 /*!
+ * @brief 指定位置に複数個の財宝を生成して床に散布する (財宝地形の DROP_GOLD 用)
+ * @param creature クリーチャーへの参照
+ * @param pos 生成位置
+ * @param drop_count 生成する財宝の個数
+ */
+void place_gold(CreatureEntity &creature, const Pos2D &pos, int drop_count)
+{
+    if (drop_count <= 0) {
+        return;
+    }
+
+    auto &floor = *creature.get_floor();
+    for (auto i = 0; i < drop_count; i++) {
+        auto item = floor.make_gold();
+        (void)drop_near(creature, item, pos, false);
+    }
+}
+
+/*!
  * @brief フロアの指定位置に生成階に応じたベースアイテムの生成を行う
  * @param creature クリーチャーへの参照
  * @param pos 配置したい座標

--- a/src/grid/object-placer.h
+++ b/src/grid/object-placer.h
@@ -6,4 +6,5 @@
 #include <cstdint>
 
 void place_gold(CreatureEntity &creature, const Pos2D &pos);
+void place_gold(CreatureEntity &creature, const Pos2D &pos, int drop_count);
 void place_object(CreatureEntity &creature, const Pos2D &pos, uint32_t mode, BaseitemRestrict restrict = nullptr);

--- a/src/info-reader/terrain-reader.cpp
+++ b/src/info-reader/terrain-reader.cpp
@@ -134,6 +134,7 @@ errr parse_terrains_json_info(nlohmann::json &element, angband_header *)
 
     terrain.mimic = s;
     terrain.destroyed = s;
+    terrain.gold_drop = Dice{};
     for (auto j = 0; j < MAX_FEAT_STATES; j++) {
         terrain.state[j].action = TerrainCharacteristics::MAX;
         terrain.state[j].result_tag.clear();
@@ -220,6 +221,11 @@ errr parse_terrains_json_info(nlohmann::json &element, angband_header *)
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
         terrain.random_change_tag = tag_obj.get<std::string>();
+    }
+
+    // 財宝地形 (HAS_GOLD) を掘った際に生成する財宝数 (省略時は従来通り 1 個)
+    if (auto err = info_set_dice(element["DROP_GOLD"], terrain.gold_drop, false)) {
+        return err;
     }
 
     const auto &inter_obj = element["interactions"];

--- a/src/system/terrain/terrain-definition.h
+++ b/src/system/terrain/terrain-definition.h
@@ -7,6 +7,7 @@
 #include "system/enums/terrain/terrain-characteristics.h"
 #include "system/enums/terrain/terrain-conversion-type.h"
 #include "system/enums/terrain/trap.h"
+#include "util/dice.h"
 #include "util/flag-group.h"
 #include "view/display-symbol.h"
 #include <map>
@@ -81,6 +82,8 @@ public:
     int random_change_prob = 0; /*!< ランダム変化確率の逆数 (0=変化しない, 100なら1/100の確率) */
     std::string random_change_tag{}; /*!< ランダム変化先地形タグ */
     FEAT_IDX random_change = 0; /*!< ランダム変化先地形ID */
+
+    Dice gold_drop{}; /*!< 財宝地形 (HAS_GOLD) を掘った際に生成する財宝数 (上流 #5393 相当) */
 
     static bool has(TerrainCharacteristics tc, TerrainAction ta);
 


### PR DESCRIPTION
変愚蛮怒 PR #5393 のうち、財宝地形 (HAS_GOLD) を掘削した際の財宝生成数を
地形定義のダイスで指定できる gold_drop 機能のみを取り込む。
(同 PR の generation_changes による地形派生は bakabakaband 既存の random_change 機構と重複するため取り込まない。ユーザー判断: 選択肢 a)

実装:
- TerrainType に Dice gold_drop を追加。terrain-reader が地形定義の "DROP_GOLD" (例 "2d2") を info_set_dice で読み込む (省略時は従来通り 1 個)。
- place_gold(creature, pos, drop_count) オーバーロードを追加し、drop_near で 指定個数の財宝を散布する。
- cave_alter_feat の HAS_GOLD 処理を gold_drop.roll() ベースに変更。
- TerrainDefinitions.jsonc の財宝鉱脈に DROP_GOLD を付与 (可視財宝 MAGMA/QUARTZ_TREASURE = 2d2、隠し財宝 *_HIDDEN = 1d2。要バランス調整)。

変愚蛮怒 #5393 相当 (bakabakaband #8411、gold_drop 部のみ)。