### PR TITLE
merge: term系関数の不要な戻り値を void 化 (hengband #5399)

### DIFF
--- a/src/io/input-key-acceptor.cpp
+++ b/src/io/input-key-acceptor.cpp
@@ -26,22 +26,20 @@ int num_more = 0;
  */
 concptr inkey_next = nullptr;
 
-/* Save macro trigger string for use in inkey_special() */
-static char inkey_macro_trigger_string[1024];
+namespace {
+constexpr char GROUP_SEPARATOR = 29;
+constexpr char RECORD_SEPARATOR = 30;
+constexpr char UNIT_SEPARATOR = 31;
 
-/*
- * Local variable -- we are inside a "macro action"
- *
- * Do not match any macros until "ascii 30" is found.
- */
-static bool parse_macro = false;
+//! Save macro trigger string for use in inkey_special()
+char inkey_macro_trigger_string[1024];
 
-/*
- * Local variable -- we are inside a "macro trigger"
- *
- * Strip all keypresses until a low ascii value is found.
- */
-static bool parse_under = false;
+//! Meaning inside a "macro action", do not match any macros until Record Separator is found.
+bool parse_macro = false;
+
+//! Meaning inside a "macro trigger", strip all keypresses until a low ascii value is found.
+bool parse_under = false;
+}
 
 /*!
  * @brief 全てのウィンドウの再描画を行う
@@ -64,21 +62,15 @@ static void all_term_fresh()
 /*
  * Cancel macro action on the queue
  */
-static void forget_macro_action(void)
+static void forget_macro_action()
 {
     if (!parse_macro) {
         return;
     }
 
     while (true) {
-        char ch;
-        if (term_inkey(&ch, false, true)) {
-            break;
-        }
-        if (ch == 0) {
-            break;
-        }
-        if (ch == 30) {
+        const auto ch = term_inkey(false, true);
+        if ((ch == '\0') || (ch == RECORD_SEPARATOR)) {
             break;
         }
     }
@@ -93,9 +85,9 @@ static void forget_macro_action(void)
  *
  * We use the "term_key_push()" function to handle "failed" macros, as well
  * as "extra" keys read in while choosing the proper macro, and also to hold
- * the action for the macro, plus a special "ascii 30" character indicating
+ * the action for the macro, plus a special Record Separator indicating
  * that any macro action in progress is complete.  Embedded macros are thus
- * illegal, unless a macro action includes an explicit "ascii 30" character,
+ * illegal, unless a macro action includes an explicit Record Separator,
  * which would probably be a massive hack, and might break things.
  *
  * Only 500 (0+1+2+...+29+30) milliseconds may elapse between each key in
@@ -103,51 +95,48 @@ static void forget_macro_action(void)
  * macro trigger, 500 milliseconds must pass before the key sequence is
  * known not to be that macro trigger.
  */
-static char inkey_aux(void)
+static char inkey_aux()
 {
-    int k = 0, n, p = 0, w = 0;
-    char ch;
-    char *buf = inkey_macro_trigger_string;
-
     num_more = 0;
-
+    char ch;
     if (parse_macro) {
-        if (term_inkey(&ch, false, true)) {
+        if (ch = term_inkey(false, true); ch == '\0') {
             parse_macro = false;
         }
     } else {
-        (void)(term_inkey(&ch, true, true));
+        ch = term_inkey(true, true);
     }
 
-    if (ch == 30) {
+    if (ch == RECORD_SEPARATOR) {
         parse_macro = false;
-    }
-
-    if (ch == 30) {
-        return ch;
-    }
-    if (parse_macro) {
-        return ch;
-    }
-    if (parse_under) {
         return ch;
     }
 
+    if (parse_macro || parse_under) {
+        return ch;
+    }
+
+    char *buf = inkey_macro_trigger_string;
+    size_t p = 0;
     buf[p++] = ch;
     buf[p] = '\0';
-    k = macro_find_check(buf);
+    auto k = macro_find_check(buf);
     if (k < 0) {
         return ch;
     }
 
+    auto w = 0;
     while (true) {
         k = macro_find_maybe(buf);
-
         if (k < 0) {
             break;
         }
 
-        if (0 == term_inkey(&ch, false, true)) {
+        if (ch = term_inkey(false, true); ch != '\0') {
+            if (p >= sizeof(inkey_macro_trigger_string) - 1) {
+                break;
+            }
+
             buf[p++] = ch;
             buf[p] = '\0';
             w = 0;
@@ -161,34 +150,30 @@ static char inkey_aux(void)
         }
     }
 
-    k = macro_find_ready(buf);
-    if (k < 0) {
+    if (k = macro_find_ready(buf); k < 0) {
         while (p > 0) {
             if (term_key_push(buf[--p])) {
                 return 0;
             }
         }
 
-        (void)term_inkey(&ch, true, true);
-        return ch;
+        return term_inkey(true, true);
     }
 
-    concptr pat = macro_patterns[k].data();
-    n = strlen(pat);
-    while (p > n) {
+    const auto &pat = macro_patterns[k];
+    while (p > pat.length()) {
         if (term_key_push(buf[--p])) {
             return 0;
         }
     }
 
     parse_macro = true;
-    if (term_key_push(30)) {
+    if (term_key_push(RECORD_SEPARATOR)) {
         return 0;
     }
 
-    concptr act = macro_actions[k].data();
-
-    n = strlen(act);
+    const auto &act = macro_actions[k];
+    auto n = act.length();
     while (n > 0) {
         if (term_key_push(act[--n])) {
             return 0;
@@ -231,29 +216,32 @@ char inkey(bool do_all_term_refresh)
     }
 
     term_activate(angband_terms[0]);
-    char kk;
     while (!ch) {
-        if (!inkey_base && inkey_scan && (0 != term_inkey(&kk, false, false))) {
-            break;
+        if (!inkey_base && inkey_scan) {
+            if (const auto key = term_inkey(false, false); key == '\0') {
+                break;
+            }
         }
 
-        if (!done && (0 != term_inkey(&kk, false, false))) {
-            start_term_fresh();
-            if (do_all_term_refresh) {
-                all_term_fresh();
-            } else {
-                term_fresh();
-            }
+        if (!done) {
+            if (const auto key = term_inkey(false, false); key == '\0') {
+                start_term_fresh();
+                if (do_all_term_refresh) {
+                    all_term_fresh();
+                } else {
+                    term_fresh();
+                }
 
-            world.character_saved = false;
-            signal_count = 0;
-            done = true;
+                world.character_saved = false;
+                signal_count = 0;
+                done = true;
+            }
         }
 
         if (inkey_base) {
             int w = 0;
             if (!inkey_scan) {
-                if (0 == term_inkey(&ch, true, true)) {
+                if (ch = term_inkey(true, true); ch == '\0') {
                     break;
                 }
 
@@ -261,7 +249,7 @@ char inkey(bool do_all_term_refresh)
             }
 
             while (true) {
-                if (0 == term_inkey(&ch, false, true)) {
+                if (ch = term_inkey(false, true); ch != '\0') {
                     break;
                 } else {
                     w += 10;
@@ -277,7 +265,7 @@ char inkey(bool do_all_term_refresh)
         }
 
         ch = inkey_aux();
-        if (ch == 29) {
+        if (ch == GROUP_SEPARATOR) {
             ch = 0;
             continue;
         }
@@ -287,9 +275,9 @@ char inkey(bool do_all_term_refresh)
             parse_under = false;
         }
 
-        if (ch == 30) {
+        if (ch == RECORD_SEPARATOR) {
             ch = 0;
-        } else if (ch == 31) {
+        } else if (ch == UNIT_SEPARATOR) {
             ch = 0;
             parse_under = true;
         } else if (parse_under) {
@@ -325,7 +313,7 @@ char inkey_for_image()
     // 画面更新なしで入力を待つ
     while (!ch) {
         // 入力があるまで待機
-        if (0 == term_inkey(&ch, true, true)) {
+        if (ch = term_inkey(true, true); ch != '\0') {
             break;
         }
         // 短い遅延

--- a/src/term/z-term.cpp
+++ b/src/term/z-term.cpp
@@ -1768,14 +1768,13 @@ DisplaySymbol term_what(int x, int y, const DisplaySymbol &ds)
 /*
  * Flush and forget the input
  */
-errr term_flush(void)
+void term_flush()
 {
     /* Flush all events */
     term_xtra(TERM_XTRA_FLUSH, 0);
 
     /* Forget all keypresses */
     game_term->key_head = game_term->key_tail = 0;
-    return 0;
 }
 
 /*
@@ -1804,58 +1803,39 @@ errr term_key_push(int k)
 }
 
 /*
- * Check for a pending keypress on the key queue.
- *
- * Store the keypress, if any, in "ch", and return "0".
- * Otherwise store "zero" in "ch", and return "1".
- *
- * Wait for a keypress if "wait" is true.
- *
- * Remove the keypress if "take" is true.
+ * @brief Check for a pending keypress on the key queue.
+ * @param wait Wait for a keypress.
+ * @param take Remove the keypress.
+ * @return Keypress or zero.
  */
-errr term_inkey(char *ch, bool wait, bool take)
+char term_inkey(bool wait, bool take)
 {
-    /* Assume no key */
-    (*ch) = '\0';
-
     /* get bored */
     if (!game_term->never_bored) {
         /* Process random events */
         term_xtra(TERM_XTRA_BORED, 0);
     }
 
-    /* Wait */
     if (wait) {
-        /* Process pending events while necessary */
         while (game_term->key_head == game_term->key_tail) {
-            /* Process events (wait for one) */
             term_xtra(TERM_XTRA_EVENT, true);
         }
-    }
-
-    /* Do not Wait */
-    else {
-        /* Process pending events if necessary */
-        if (game_term->key_head == game_term->key_tail) {
-            /* Process events (do not wait) */
-            term_xtra(TERM_XTRA_EVENT, false);
-        }
+    } else if (game_term->key_head == game_term->key_tail) {
+        term_xtra(TERM_XTRA_EVENT, false);
     }
 
     /* No keys are ready */
     if (game_term->key_head == game_term->key_tail) {
-        return 1;
+        return '\0';
     }
 
-    /* Extract the next keypress */
-    (*ch) = game_term->key_queue[game_term->key_tail];
-
     /* If requested, advance the queue, wrap around if necessary */
+    const auto res = game_term->key_queue[game_term->key_tail];
     if (take && (++game_term->key_tail == game_term->key_size)) {
         game_term->key_tail = 0;
     }
 
-    return 0;
+    return res;
 }
 
 /*** Extra routines ***/
@@ -1865,12 +1845,9 @@ errr term_inkey(char *ch, bool wait, bool take)
  *
  * Every "term_save()" should match exactly one "term_load()"
  */
-errr term_save(void)
+void term_save()
 {
-    /* Push stack */
     game_term->mem_stack.push(game_term->scr->clone());
-
-    return 0;
 }
 
 /*
@@ -1878,16 +1855,15 @@ errr term_save(void)
  *
  * Every "term_save()" should match exactly one "term_load()"
  */
-errr term_load(bool load_all)
+void term_load(bool should_load_all)
 {
-    TERM_LEN w = game_term->wid;
-    TERM_LEN h = game_term->hgt;
-
+    const auto w = game_term->wid;
+    const auto h = game_term->hgt;
     if (game_term->mem_stack.empty()) {
-        return 0;
+        return;
     }
 
-    if (load_all) {
+    if (should_load_all) {
         // 残り1つを残して読み捨てる
         while (game_term->mem_stack.size() > 1) {
             game_term->mem_stack.pop();
@@ -1902,7 +1878,7 @@ errr term_load(bool load_all)
     game_term->mem_stack.pop();
 
     /* Assume change */
-    for (TERM_LEN y = 0; y < h; y++) {
+    for (auto y = 0; y < h; y++) {
         /* Assume change */
         game_term->x1[y] = 0;
         game_term->x2[y] = w - 1;
@@ -1911,57 +1887,26 @@ errr term_load(bool load_all)
     /* Assume change */
     game_term->y1 = 0;
     game_term->y2 = h - 1;
-    return 0;
-}
-
-/*
- * Exchange the "requested" screen with the "tmp" screen
- */
-errr term_exchange(void)
-{
-    TERM_LEN w = game_term->wid;
-    TERM_LEN h = game_term->hgt;
-
-    /* Create */
-    if (!game_term->tmp) {
-        /* Allocate window */
-        game_term->tmp = term_win::create(w, h);
-    }
-
-    /* Swap */
-    game_term->scr.swap(game_term->tmp);
-
-    /* Assume change */
-    for (TERM_LEN y = 0; y < h; y++) {
-        /* Assume change */
-        game_term->x1[y] = 0;
-        game_term->x2[y] = w - 1;
-    }
-
-    /* Assume change */
-    game_term->y1 = 0;
-    game_term->y2 = h - 1;
-    return 0;
 }
 
 /*
  * React to a new physical window size.
  */
-errr term_resize(TERM_LEN w, TERM_LEN h)
+void term_resize(int w, int h)
 {
     /* Resizing is forbidden */
     if (game_term->fixed_shape) {
-        return -1;
+        return;
     }
 
     /* Ignore illegal changes */
     if ((w < 1) || (h < 1)) {
-        return -1;
+        return;
     }
 
     /* Ignore non-changes */
     if ((game_term->wid == w) && (game_term->hgt == h) && (arg_bigtile == use_bigtile)) {
-        return 1;
+        return;
     }
 
     use_bigtile = arg_bigtile;
@@ -1985,7 +1930,7 @@ errr term_resize(TERM_LEN w, TERM_LEN h)
     game_term->total_erase = true;
 
     /* Assume change */
-    for (int i = 0; i < h; i++) {
+    for (auto i = 0; i < h; i++) {
         /* Assume change */
         game_term->x1[i] = 0;
         game_term->x2[i] = w - 1;
@@ -1999,8 +1944,6 @@ errr term_resize(TERM_LEN w, TERM_LEN h)
     if (game_term->resize_hook) {
         game_term->resize_hook();
     }
-
-    return 0;
 }
 
 /*
@@ -2012,11 +1955,11 @@ errr term_resize(TERM_LEN w, TERM_LEN h)
  * To "create" a valid "term", one should do "term_init(t)", then
  * set the various flags and hooks, and then do "term_activate(t)".
  */
-errr term_activate(term_type *t)
+void term_activate(term_type *t)
 {
     /* already done */
     if (game_term == t) {
-        return 1;
+        return;
     }
 
     /* Deactivate the old Term */
@@ -2045,8 +1988,6 @@ errr term_activate(term_type *t)
     if (game_term) {
         term_xtra(TERM_XTRA_LEVEL, 1);
     }
-
-    return 0;
 }
 
 /*
@@ -2055,7 +1996,7 @@ errr term_activate(term_type *t)
  * By default, the cursor starts out "invisible"
  * By default, we "erase" using "black spaces"
  */
-errr term_init(term_type *t, TERM_LEN w, TERM_LEN h, int k)
+void term_init(term_type *t, int w, int h, int k)
 {
     /* Wipe it */
     *t = term_type{};
@@ -2107,7 +2048,6 @@ errr term_init(term_type *t, TERM_LEN w, TERM_LEN h, int k)
     t->wipe_hook = term_wipe_hack;
     t->text_hook = term_text_hack;
     t->pict_hook = term_pict_hack;
-    return 0;
 }
 
 #ifdef JP

--- a/src/term/z-term.h
+++ b/src/term/z-term.h
@@ -219,20 +219,18 @@ std::pair<int, int> term_get_size();
 std::pair<int, int> term_locate();
 DisplaySymbol term_what(int x, int y, const DisplaySymbol &ds);
 
-errr term_flush(void);
+void term_flush();
 errr term_key_push(int k);
-errr term_inkey(char *ch, bool wait, bool take);
+char term_inkey(bool wait, bool take);
 
-errr term_save(void);
-errr term_load(bool load_all);
+void term_save();
+void term_load(bool should_load_all);
 
-errr term_exchange(void);
+void term_resize(int w, int h);
 
-errr term_resize(TERM_LEN w, TERM_LEN h);
+void term_activate(term_type *t);
 
-errr term_activate(term_type *t);
-
-errr term_init(term_type *t, TERM_LEN w, TERM_LEN h, int k);
+void term_init(term_type *t, int w, int h, int k);
 
 #ifdef JP
 void term_putstr_v(int x, int y_initial, size_t n, uint8_t color, std::string_view sv);


### PR DESCRIPTION
変愚蛮怒 PR #5399 を適用。term_flush/save/load/resize/activate/init の戻り値 (誰も使っていない errr) を void に変更し、term_inkey は引数の char* を廃して 戻り値 char で返すように変更。未使用の term_exchange() を削除。
term_init/term_resize の TERM_LEN 引数も int に統一。

bakabakaband 適応:
- 8 コミット分の正味差分を 3-way 適用。z-term.h の宣言部のみ手解決 (term_exchange 削除・各シグネチャの void/char 化を上流側で採用)。
- bakabakaband 独自の inkey_for_image() の term_inkey(&ch, true, true) 呼出を 新シグネチャ (ch = term_inkey(true, true)) へ手修正。
- Godot/Win 等独自バックエンドは term_init/resize/activate を statement 呼出で 戻り値未使用のため void 化に無害。CreatureEntity 統合とは無関係。
- 上流 9 コミット目の Doxygen コメント整形は bakabakaband のコメント分岐と 衝突するため取り込まない (機能に無関係)。

変愚蛮怒 #5399 相当 (bakabakaband #8415)。