### PR TITLE
merge: ItemEntity::ident をEnumClassFlagGroup化 (hengband #5390 のうち enum化本体)

### DIFF
--- a/src/artifact/fixed-art-generator.cpp
+++ b/src/artifact/fixed-art-generator.cpp
@@ -188,7 +188,7 @@ static void fixed_artifact_random_abilities(CreatureEntity &creature, const Arti
 static void invest_curse_to_fixed_artifact(const ArtifactType &artifact, ItemEntity *o_ptr)
 {
     if (!artifact.cost) {
-        set_bits(o_ptr->ident, IDENT_BROKEN);
+        o_ptr->ident.set(IdentificationFlag::BROKEN);
     }
 
     if (artifact.gen_flags.has(ItemGenerationTraitType::CURSED)) {

--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -372,7 +372,7 @@ static std::string name_unnatural_random_artifact(CreatureEntity &creature, Item
     constexpr auto prompt = _("このアーティファクトを何と名付けますか？", "What do you want to call the artifact? ");
     object_aware(creature, *o_ptr);
     o_ptr->mark_as_known();
-    o_ptr->ident |= IDENT_FULL_KNOWN;
+    o_ptr->ident.set(IdentificationFlag::FULL_KNOWN);
     o_ptr->randart_name.reset();
     (void)screen_object(creature, *o_ptr, 0L);
 

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -351,7 +351,7 @@ void autopick_entry_from_object(CreatureEntity &creature, autopick_type *entry, 
         entry->add(FLG_UNAWARE);
         should_add_hat_mark = true;
     } else if (!o_ptr->is_known()) {
-        if (!(o_ptr->ident & IDENT_SENSE)) {
+        if (!(o_ptr->ident.has(IdentificationFlag::SENSE))) {
             entry->add(FLG_UNIDENTIFIED);
             should_add_hat_mark = true;
         } else {

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -132,7 +132,7 @@ bool is_autopick_match(CreatureEntity &creature, const ItemEntity *o_ptr, const 
         return false;
     }
 
-    if (entry.has(FLG_UNIDENTIFIED) && (o_ptr->is_known() || (o_ptr->ident & IDENT_SENSE))) {
+    if (entry.has(FLG_UNIDENTIFIED) && (o_ptr->is_known() || (o_ptr->ident.has(IdentificationFlag::SENSE)))) {
         return false;
     }
 
@@ -195,7 +195,7 @@ bool is_autopick_match(CreatureEntity &creature, const ItemEntity *o_ptr, const 
         if (!o_ptr->is_ego()) {
             return false;
         }
-        const auto sensed_excellent = (o_ptr->ident & IDENT_SENSE) && o_ptr->feeling == FEEL_EXCELLENT;
+        const auto sensed_excellent = (o_ptr->ident.has(IdentificationFlag::SENSE)) && o_ptr->feeling == FEEL_EXCELLENT;
         if (!o_ptr->is_known() && !sensed_excellent) {
             return false;
         }
@@ -209,7 +209,7 @@ bool is_autopick_match(CreatureEntity &creature, const ItemEntity *o_ptr, const 
             if (!o_ptr->is_nameless() || (o_ptr->to_a <= 0 && (o_ptr->to_h + o_ptr->to_d) <= 0)) {
                 return false;
             }
-        } else if (o_ptr->ident & IDENT_SENSE) {
+        } else if (o_ptr->ident.has(IdentificationFlag::SENSE)) {
             if (o_ptr->feeling != FEEL_GOOD) {
                 return false;
             }
@@ -226,7 +226,7 @@ bool is_autopick_match(CreatureEntity &creature, const ItemEntity *o_ptr, const 
             if (!o_ptr->is_nameless()) {
                 return false;
             }
-        } else if (o_ptr->ident & IDENT_SENSE) {
+        } else if (o_ptr->ident.has(IdentificationFlag::SENSE)) {
             switch (o_ptr->feeling) {
             case FEEL_AVERAGE:
             case FEEL_GOOD:
@@ -250,7 +250,7 @@ bool is_autopick_match(CreatureEntity &creature, const ItemEntity *o_ptr, const 
             if (!o_ptr->is_nameless() || o_ptr->is_cursed() || o_ptr->is_broken() || o_ptr->to_a > 0 || (o_ptr->to_h + o_ptr->to_d) > 0) {
                 return false;
             }
-        } else if (o_ptr->ident & IDENT_SENSE) {
+        } else if (o_ptr->ident.has(IdentificationFlag::SENSE)) {
             if (o_ptr->feeling != FEEL_AVERAGE) {
                 return false;
             }

--- a/src/autopick/autopick-registry.cpp
+++ b/src/autopick/autopick-registry.cpp
@@ -127,7 +127,7 @@ bool autopick_autoregister(CreatureEntity &creature, const ItemEntity *o_ptr)
         return false;
     }
 
-    if ((o_ptr->is_known() && o_ptr->is_fixed_or_random_artifact()) || ((o_ptr->ident & IDENT_SENSE) && (o_ptr->feeling == FEEL_TERRIBLE || o_ptr->feeling == FEEL_SPECIAL))) {
+    if ((o_ptr->is_known() && o_ptr->is_fixed_or_random_artifact()) || ((o_ptr->ident.has(IdentificationFlag::SENSE)) && (o_ptr->feeling == FEEL_TERRIBLE || o_ptr->feeling == FEEL_SPECIAL))) {
         const auto item_name = describe_flavor(creature, *o_ptr, 0);
         msg_format(_("%sは破壊不能だ。", "You cannot auto-destroy %s."), item_name.data());
         return false;

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -493,7 +493,7 @@ static bool exe_eat_charge_of_magic_device(CreatureEntity &creature, ItemEntity 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     if (o_ptr->pval == 0) {
         msg_format(_("この%sにはもう魔力が残っていない。", "The %s has no charges left."), staff);
-        o_ptr->ident |= IDENT_EMPTY;
+        o_ptr->ident.set(IdentificationFlag::EMPTY);
         rfu.set_flag(SubWindowRedrawingFlag::INVENTORY);
         return true;
     }

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -250,7 +250,7 @@ void do_cmd_wield(CreatureEntity &creature)
     }
 
     auto should_equip_cursed = item_chosen->is_cursed() && item_chosen->is_known();
-    should_equip_cursed |= any_bits(item_chosen->ident, IDENT_SENSE) && (FEEL_BROKEN <= item_chosen->feeling) && (item_chosen->feeling <= FEEL_CURSED);
+    should_equip_cursed |= item_chosen->ident.has(IdentificationFlag::SENSE) && (FEEL_BROKEN <= item_chosen->feeling) && (item_chosen->feeling <= FEEL_CURSED);
     should_equip_cursed &= confirm_wear;
     if (should_equip_cursed) {
         const auto item_name = describe_flavor(creature, *item_chosen, (OD_OMIT_PREFIX | OD_NAME_ONLY));
@@ -346,7 +346,7 @@ void do_cmd_wield(CreatureEntity &creature)
     if (wield_slot_item.is_cursed()) {
         msg_print(_("うわ！ すさまじく冷たい！", "Oops! It feels deathly cold!"));
         chg_virtue(creature, Virtue::HARMONY, -1);
-        wield_slot_item.ident |= (IDENT_SENSE);
+        wield_slot_item.ident.set(IdentificationFlag::SENSE);
     }
 
     do_curse_on_equip(slot, wield_slot_item, creature);
@@ -400,7 +400,7 @@ void do_cmd_takeoff(CreatureEntity &creature)
 
         if ((item->curse_flags.has(CurseTraitType::HEAVY_CURSE) && one_in_(7)) || one_in_(4)) {
             msg_print(_("呪われた装備を力づくで剥がした！", "You tore off a piece of cursed equipment by sheer strength!"));
-            item->ident |= (IDENT_SENSE);
+            item->ident.set(IdentificationFlag::SENSE);
             item->curse_flags.clear();
             item->feeling = FEEL_NONE;
             rfu.set_flag(StatusRecalculatingFlag::BONUS);

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -688,7 +688,7 @@ static void postprocess_by_taking_photo(CreatureEntity &creature, EffectMonster 
 
     ItemEntity item({ ItemKindType::STATUE, SV_PHOTO });
     item.pval = em_ptr->photo;
-    item.ident |= (IDENT_FULL_KNOWN);
+    item.ident.set(IdentificationFlag::FULL_KNOWN);
     (void)drop_near(creature, item, creature.get_position());
 }
 

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -446,7 +446,7 @@ static std::string describe_item_feeling(const ItemEntity &item, const describe_
         return game_inscriptions[item.feeling];
     }
 
-    if (item.is_cursed() && (opt.known || any_bits(item.ident, IDENT_SENSE))) {
+    if (item.is_cursed() && (opt.known || item.ident.has(IdentificationFlag::SENSE))) {
         return _("呪われている", "cursed");
     }
 
@@ -455,11 +455,11 @@ static std::string describe_item_feeling(const ItemEntity &item, const describe_
     unidentifiable |= tval == ItemKindType::AMULET;
     unidentifiable |= tval == ItemKindType::LITE;
     unidentifiable |= tval == ItemKindType::FIGURINE;
-    if (unidentifiable && opt.aware && !opt.known && none_bits(item.ident, IDENT_SENSE)) {
+    if (unidentifiable && opt.aware && !opt.known && !item.ident.has(IdentificationFlag::SENSE)) {
         return _("未鑑定", "unidentified");
     }
 
-    if (!opt.known && any_bits(item.ident, IDENT_EMPTY)) {
+    if (!opt.known && item.ident.has(IdentificationFlag::EMPTY)) {
         return _("空", "empty");
     }
 
@@ -494,7 +494,7 @@ static std::string describe_player_inscription(const ItemEntity &item)
 
 static std::string describe_item_discount(const ItemEntity &item, bool hide_discount)
 {
-    if ((item.discount == 0) || (hide_discount && none_bits(item.ident, IDENT_STORE))) {
+    if ((item.discount == 0) || (hide_discount && !item.ident.has(IdentificationFlag::STORE))) {
         return "";
     }
 
@@ -557,7 +557,7 @@ static describe_option_type decide_describe_option(const ItemEntity &item, BIT_F
         opt.flavor = false;
     }
 
-    if (any_bits(mode, OD_STORE) || any_bits(item.ident, IDENT_STORE)) {
+    if (any_bits(mode, OD_STORE) || item.ident.has(IdentificationFlag::STORE)) {
         opt.flavor = false;
         opt.aware = true;
         opt.known = true;

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -158,7 +158,7 @@ static int get_dungeon_feeling(const auto &floor)
 
     for (const auto &item_ptr : floor.o_list) {
         auto delta = 0;
-        if (!item_ptr->is_valid() || (item_ptr->is_known() && item_ptr->marked.has(OmType::TOUCHED)) || ((item_ptr->ident & IDENT_SENSE) != 0)) {
+        if (!item_ptr->is_valid() || (item_ptr->is_known() && item_ptr->marked.has(OmType::TOUCHED)) || ((item_ptr->ident.has(IdentificationFlag::SENSE)) != 0)) {
             continue;
         }
 

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -55,7 +55,7 @@ static void object_mention(CreatureEntity &creature, ItemEntity &item)
 
     object_aware(creature, item);
     item.mark_as_known();
-    item.ident |= (IDENT_FULL_KNOWN);
+    item.ident.set(IdentificationFlag::FULL_KNOWN);
     const auto item_name = describe_flavor(creature, item, 0);
     msg_format_wizard(creature, CHEAT_OBJECT, _("%sを生成しました。", "%s was generated."), item_name.data());
 }

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -104,7 +104,7 @@ void do_cmd_knowledge_artifacts(CreatureEntity &creature)
         constexpr auto template_basename = _("     %s\n", "     The %s\n");
         ItemEntity item(artifact.bi_key);
         item.fa_id = fa_id;
-        item.ident |= IDENT_STORE;
+        item.ident.set(IdentificationFlag::STORE);
         const auto item_name = describe_flavor(creature, item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         fprintf(fff, template_basename, item_name.data());
     }
@@ -223,7 +223,7 @@ static void desc_obj_fake(CreatureEntity &creature, short bi_id)
     o_ptr->wipe();
     o_ptr->generate(bi_id);
 
-    o_ptr->ident |= IDENT_KNOWN;
+    o_ptr->ident.set(IdentificationFlag::KNOWN);
     handle_stuff(creature);
 
     if (screen_object(creature, *o_ptr, SCROBJ_FAKE_OBJECT | SCROBJ_FORCE_DETAIL)) {

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -104,7 +104,7 @@ static void do_cmd_knowledge_quests_current(CreatureEntity &creature, FILE *fff)
                     if (quest.has_reward()) {
                         ItemEntity item(quest.get_reward_bi_id());
                         item.fa_id = quest.get_reward().value_or(FixedArtifactId::NONE);
-                        item.ident = IDENT_STORE;
+                        item.ident.set(IdentificationFlag::STORE);
                         item_name = describe_flavor(creature, item, OD_NAME_ONLY);
                     }
 

--- a/src/load/old/item-loader-savefile50.cpp
+++ b/src/load/old/item-loader-savefile50.cpp
@@ -45,7 +45,16 @@ void ItemLoader50::rd_item(ItemEntity *o_ptr)
     o_ptr->ac = any_bits(flags, SaveDataItemFlagType::AC) ? rd_s16b() : 0;
     o_ptr->damage_dice.num = any_bits(flags, SaveDataItemFlagType::DD) ? rd_byte() : 0;
     o_ptr->damage_dice.sides = any_bits(flags, SaveDataItemFlagType::DS) ? rd_byte() : 0;
-    o_ptr->ident = any_bits(flags, SaveDataItemFlagType::IDENT) ? rd_byte() : 0;
+    o_ptr->ident.clear();
+    if (any_bits(flags, SaveDataItemFlagType::IDENT)) {
+        // 旧 byte ident とビット互換のバイトから鑑定フラグを復元する (セーブ形式不変)
+        const auto ident_byte = rd_byte();
+        for (auto i = 0; i < enum2i(IdentificationFlag::MAX); i++) {
+            if (any_bits<uint8_t>(ident_byte, static_cast<uint8_t>(1U << i))) {
+                o_ptr->ident.set(i2enum<IdentificationFlag>(i));
+            }
+        }
+    }
     o_ptr->marked.clear();
     if (any_bits(flags, SaveDataItemFlagType::MARKED)) {
         rd_FlagGroup_bytes(o_ptr->marked, rd_byte, 1);

--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -290,7 +290,7 @@ static PRICE repair_broken_weapon_aux(CreatureEntity &creature, PRICE bcost)
     }
 
     display_repair_success_message(creature, *item_broken, cost);
-    item_broken->ident &= ~(IDENT_BROKEN);
+    item_broken->ident.reset(IdentificationFlag::BROKEN);
     item_broken->discount = 99;
 
     calc_android_exp(creature);

--- a/src/market/building-recharger.cpp
+++ b/src/market/building-recharger.cpp
@@ -138,7 +138,7 @@ void building_recharge(CreatureEntity &creature)
 
         price *= charges;
         item->pval += static_cast<short>(charges);
-        item->ident &= ~(IDENT_EMPTY);
+        item->ident.reset(IdentificationFlag::EMPTY);
     }
 
     const auto item_name = describe_flavor(creature, *item, 0);
@@ -249,14 +249,14 @@ void building_recharge_all(CreatureEntity &creature)
                 o_ptr->pval = base_pval;
             }
 
-            o_ptr->ident &= ~(IDENT_EMPTY);
+            o_ptr->ident.reset(IdentificationFlag::EMPTY);
             break;
         case ItemKindType::WAND:
             if (o_ptr->pval < o_ptr->number * base_pval) {
                 o_ptr->pval = o_ptr->number * base_pval;
             }
 
-            o_ptr->ident &= ~(IDENT_EMPTY);
+            o_ptr->ident.reset(IdentificationFlag::EMPTY);
             break;
         default:
             break;

--- a/src/mind/mind-mage.cpp
+++ b/src/mind/mind-mage.cpp
@@ -80,7 +80,7 @@ bool eat_magic(CreatureEntity &creature, int power)
             }
 
             if (!item->pval) {
-                item->ident |= IDENT_EMPTY;
+                item->ident.set(IdentificationFlag::EMPTY);
             }
         }
     }

--- a/src/mind/mind-mindcrafter.cpp
+++ b/src/mind/mind-mindcrafter.cpp
@@ -77,7 +77,7 @@ bool psychometry(CreatureEntity &creature)
     msg_format("You feel that the %s %s %s...", item_name.data(), ((item->number == 1) ? "is" : "are"), game_inscriptions[feel]);
 #endif
 
-    set_bits(item->ident, IDENT_SENSE);
+    item->ident.set(IdentificationFlag::SENSE);
     item->feeling = feel;
     item->marked.set(OmType::TOUCHED);
 

--- a/src/mind/mind-priest.cpp
+++ b/src/mind/mind-priest.cpp
@@ -58,7 +58,7 @@ bool bless_weapon(CreatureEntity &creature)
         msg_format("A malignant aura leaves %s %s.", ((i_idx >= 0) ? "your" : "the"), item_name.data());
 #endif
         item->curse_flags.clear();
-        set_bits(item->ident, IDENT_SENSE);
+        item->ident.set(IdentificationFlag::SENSE);
         item->feeling = FEEL_NONE;
         rfu.set_flag(StatusRecalculatingFlag::BONUS);
         static constexpr auto flags = {

--- a/src/object-enchant/item-magic-applier.cpp
+++ b/src/object-enchant/item-magic-applier.cpp
@@ -210,7 +210,7 @@ void ItemMagicApplier::apply_cursed()
     }
 
     if (this->o_ptr->is_worthless()) {
-        set_bits(this->o_ptr->ident, IDENT_BROKEN);
+        this->o_ptr->ident.set(IdentificationFlag::BROKEN);
     }
 
     const auto &baseitem = this->o_ptr->get_baseitem();

--- a/src/object-enchant/object-ego.cpp
+++ b/src/object-enchant/object-ego.cpp
@@ -259,7 +259,7 @@ void apply_ego(ItemEntity *o_ptr, DEPTH lev)
     ego_interpret_extra_abilities(o_ptr, ego, gen_flags);
 
     if (!ego.cost) {
-        o_ptr->ident |= (IDENT_BROKEN);
+        o_ptr->ident.set(IdentificationFlag::BROKEN);
     }
 
     ego_invest_curse(o_ptr, gen_flags);

--- a/src/object-enchant/others/apply-magic-amulet.cpp
+++ b/src/object-enchant/others/apply-magic-amulet.cpp
@@ -79,7 +79,7 @@ void AmuletEnchanter::sval_enchant()
     case SV_AMULET_CHARISMA:
         this->o_ptr->pval = 1 + (PARAMETER_VALUE)m_bonus(5, this->level);
         if (this->power < 0) {
-            set_bits(this->o_ptr->ident, IDENT_BROKEN);
+            this->o_ptr->ident.set(IdentificationFlag::BROKEN);
             this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
             this->o_ptr->pval = 0 - this->o_ptr->pval;
         }
@@ -92,7 +92,7 @@ void AmuletEnchanter::sval_enchant()
         }
 
         if (this->power < 0) {
-            set_bits(this->o_ptr->ident, IDENT_BROKEN);
+            this->o_ptr->ident.set(IdentificationFlag::BROKEN);
             this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
             this->o_ptr->pval = 0 - this->o_ptr->pval;
         }
@@ -122,7 +122,7 @@ void AmuletEnchanter::sval_enchant()
             break;
         }
 
-        set_bits(this->o_ptr->ident, IDENT_BROKEN);
+        this->o_ptr->ident.set(IdentificationFlag::BROKEN);
         this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
         this->o_ptr->pval = 0 - (this->o_ptr->pval);
         break;
@@ -132,7 +132,7 @@ void AmuletEnchanter::sval_enchant()
         add_esp_weak(this->o_ptr, false);
         break;
     case SV_AMULET_DOOM:
-        set_bits(this->o_ptr->ident, IDENT_BROKEN);
+        this->o_ptr->ident.set(IdentificationFlag::BROKEN);
         this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
         this->o_ptr->pval = 0 - (randint1(5) + (PARAMETER_VALUE)m_bonus(5, this->level));
         this->o_ptr->to_a = 0 - (randint1(5) + (ARMOUR_CLASS)m_bonus(5, this->level));
@@ -147,7 +147,7 @@ void AmuletEnchanter::sval_enchant()
             break;
         }
 
-        set_bits(this->o_ptr->ident, IDENT_BROKEN);
+        this->o_ptr->ident.set(IdentificationFlag::BROKEN);
         this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
         this->o_ptr->pval = 0 - this->o_ptr->pval;
         break;
@@ -383,6 +383,6 @@ void AmuletEnchanter::give_cursed()
         }
     }
 
-    set_bits(this->o_ptr->ident, IDENT_BROKEN);
+    this->o_ptr->ident.set(IdentificationFlag::BROKEN);
     this->o_ptr->curse_flags.set({ CurseTraitType::CURSED, CurseTraitType::HEAVY_CURSE });
 }

--- a/src/object-enchant/others/apply-magic-ring.cpp
+++ b/src/object-enchant/others/apply-magic-ring.cpp
@@ -84,7 +84,7 @@ void RingEnchanter::sval_enchant()
         }
 
         if (this->power < 0) {
-            set_bits(this->o_ptr->ident, IDENT_BROKEN);
+            this->o_ptr->ident.set(IdentificationFlag::BROKEN);
             this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
             this->o_ptr->pval = 0 - (this->o_ptr->pval);
         }
@@ -95,7 +95,7 @@ void RingEnchanter::sval_enchant()
     case SV_RING_DEX:
         this->o_ptr->pval = 1 + (PARAMETER_VALUE)m_bonus(5, this->level);
         if (this->power < 0) {
-            set_bits(this->o_ptr->ident, IDENT_BROKEN);
+            this->o_ptr->ident.set(IdentificationFlag::BROKEN);
             this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
             this->o_ptr->pval = 0 - (this->o_ptr->pval);
         }
@@ -108,7 +108,7 @@ void RingEnchanter::sval_enchant()
         }
 
         if (this->power < 0) {
-            set_bits(this->o_ptr->ident, IDENT_BROKEN);
+            this->o_ptr->ident.set(IdentificationFlag::BROKEN);
             this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
             this->o_ptr->pval = 0 - (this->o_ptr->pval);
             break;
@@ -131,7 +131,7 @@ void RingEnchanter::sval_enchant()
     case SV_RING_SEARCHING:
         this->o_ptr->pval = 1 + (PARAMETER_VALUE)m_bonus(5, this->level);
         if (this->power < 0) {
-            set_bits(this->o_ptr->ident, IDENT_BROKEN);
+            this->o_ptr->ident.set(IdentificationFlag::BROKEN);
             this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
             this->o_ptr->pval = 0 - (this->o_ptr->pval);
         }
@@ -145,7 +145,7 @@ void RingEnchanter::sval_enchant()
         break;
     case SV_RING_WEAKNESS:
     case SV_RING_STUPIDITY:
-        set_bits(this->o_ptr->ident, IDENT_BROKEN);
+        this->o_ptr->ident.set(IdentificationFlag::BROKEN);
         this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
         this->o_ptr->pval = 0 - (1 + (PARAMETER_VALUE)m_bonus(5, this->level));
         if (this->power > 0) {
@@ -154,7 +154,7 @@ void RingEnchanter::sval_enchant()
 
         break;
     case SV_RING_WOE:
-        set_bits(this->o_ptr->ident, IDENT_BROKEN);
+        this->o_ptr->ident.set(IdentificationFlag::BROKEN);
         this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
         this->o_ptr->to_a = 0 - (5 + (ARMOUR_CLASS)m_bonus(10, this->level));
         this->o_ptr->pval = 0 - (1 + (PARAMETER_VALUE)m_bonus(5, this->level));
@@ -166,7 +166,7 @@ void RingEnchanter::sval_enchant()
     case SV_RING_DAMAGE:
         this->o_ptr->to_d = 1 + randint1(5) + (int)m_bonus(16, this->level);
         if (this->power < 0) {
-            set_bits(this->o_ptr->ident, IDENT_BROKEN);
+            this->o_ptr->ident.set(IdentificationFlag::BROKEN);
             this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
             this->o_ptr->to_d = 0 - this->o_ptr->to_d;
         }
@@ -175,7 +175,7 @@ void RingEnchanter::sval_enchant()
     case SV_RING_ACCURACY:
         this->o_ptr->to_h = 1 + randint1(5) + (HIT_PROB)m_bonus(16, this->level);
         if (this->power < 0) {
-            set_bits(this->o_ptr->ident, IDENT_BROKEN);
+            this->o_ptr->ident.set(IdentificationFlag::BROKEN);
             this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
             this->o_ptr->to_h = 0 - this->o_ptr->to_h;
         }
@@ -184,7 +184,7 @@ void RingEnchanter::sval_enchant()
     case SV_RING_PROTECTION:
         this->o_ptr->to_a = 5 + randint1(8) + (ARMOUR_CLASS)m_bonus(10, this->level);
         if (this->power < 0) {
-            set_bits(this->o_ptr->ident, IDENT_BROKEN);
+            this->o_ptr->ident.set(IdentificationFlag::BROKEN);
             this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
             this->o_ptr->to_a = 0 - this->o_ptr->to_a;
         }
@@ -195,7 +195,7 @@ void RingEnchanter::sval_enchant()
         this->o_ptr->to_h = randint1(5) + (HIT_PROB)m_bonus(12, this->level);
 
         if (this->power < 0) {
-            set_bits(this->o_ptr->ident, IDENT_BROKEN);
+            this->o_ptr->ident.set(IdentificationFlag::BROKEN);
             this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
             this->o_ptr->to_h = 0 - this->o_ptr->to_h;
             this->o_ptr->to_d = 0 - this->o_ptr->to_d;
@@ -210,14 +210,14 @@ void RingEnchanter::sval_enchant()
         }
 
         if (this->power < 0) {
-            set_bits(this->o_ptr->ident, IDENT_BROKEN);
+            this->o_ptr->ident.set(IdentificationFlag::BROKEN);
             this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
             this->o_ptr->pval = 0 - this->o_ptr->pval;
         }
 
         break;
     case SV_RING_AGGRAVATION:
-        set_bits(this->o_ptr->ident, IDENT_BROKEN);
+        this->o_ptr->ident.set(IdentificationFlag::BROKEN);
         this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
         if (this->power > 0) {
             this->power = 0 - this->power;
@@ -540,6 +540,6 @@ void RingEnchanter::give_cursed()
         }
     }
 
-    set_bits(this->o_ptr->ident, IDENT_BROKEN);
+    this->o_ptr->ident.set(IdentificationFlag::BROKEN);
     this->o_ptr->curse_flags.set({ CurseTraitType::CURSED, CurseTraitType::HEAVY_CURSE });
 }

--- a/src/object-hook/hook-expendable.cpp
+++ b/src/object-hook/hook-expendable.cpp
@@ -70,7 +70,7 @@ bool can_player_destroy_object(ItemEntity *o_ptr)
         }
 
         o_ptr->feeling = feel;
-        o_ptr->ident |= IDENT_SENSE;
+        o_ptr->ident.set(IdentificationFlag::SENSE);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         rfu.set_flag(StatusRecalculatingFlag::COMBINATION);
         static constexpr auto flags = {

--- a/src/object-use/use-execution.cpp
+++ b/src/object-use/use-execution.cpp
@@ -88,7 +88,7 @@ void ObjectUseEntity::execute()
         }
 
         msg_print(_("この杖にはもう魔力が残っていない。", "The staff has no charges left."));
-        item->ident |= IDENT_EMPTY;
+        item->ident.set(IdentificationFlag::EMPTY);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         static constexpr auto flags = {
             StatusRecalculatingFlag::COMBINATION,

--- a/src/object-use/zapwand-execution.cpp
+++ b/src/object-use/zapwand-execution.cpp
@@ -92,7 +92,7 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX i_idx)
         }
 
         msg_print(_("この魔法棒にはもう魔力が残っていない。", "The wand has no charges left."));
-        item->ident |= IDENT_EMPTY;
+        item->ident.set(IdentificationFlag::EMPTY);
         static constexpr auto flags = {
             StatusRecalculatingFlag::COMBINATION,
             StatusRecalculatingFlag::REORDER,

--- a/src/perception/simple-perception.cpp
+++ b/src/perception/simple-perception.cpp
@@ -35,7 +35,7 @@
 static void sense_inventory_aux(CreatureEntity &creature, INVENTORY_IDX slot, bool heavy)
 {
     auto &item = *creature.inventory[slot];
-    if (any_bits(item.ident, IDENT_SENSE) || item.is_known()) {
+    if (item.ident.has(IdentificationFlag::SENSE) || item.is_known()) {
         return;
     }
 
@@ -113,7 +113,7 @@ static void sense_inventory_aux(CreatureEntity &creature, INVENTORY_IDX slot, bo
 #endif
     }
 
-    item.ident |= (IDENT_SENSE);
+    item.ident.set(IdentificationFlag::SENSE);
     item.feeling = feel;
 
     autopick_alter_item(creature, slot, destroy_feeling);

--- a/src/save/item-writer.cpp
+++ b/src/save/item-writer.cpp
@@ -59,7 +59,7 @@ static BIT_FLAGS write_item_flags(const ItemEntity &item)
         set_bits(flags, SaveDataItemFlagType::DS);
     }
 
-    if (item.ident) {
+    if (item.ident.any()) {
         set_bits(flags, SaveDataItemFlagType::IDENT);
     }
 
@@ -171,7 +171,14 @@ static void write_item_info(const ItemEntity &item, const BIT_FLAGS flags)
     }
 
     if (any_bits(flags, SaveDataItemFlagType::IDENT)) {
-        wr_byte(item.ident);
+        // 旧 byte ident とビット互換のバイトに変換して保存する (セーブ形式不変)
+        uint8_t ident_byte = 0;
+        for (auto i = 0; i < enum2i(IdentificationFlag::MAX); i++) {
+            if (item.ident.has(i2enum<IdentificationFlag>(i))) {
+                ident_byte |= static_cast<uint8_t>(1U << i);
+            }
+        }
+        wr_byte(ident_byte);
     }
 
     if (any_bits(flags, SaveDataItemFlagType::MARKED)) {

--- a/src/smith/object-smith.cpp
+++ b/src/smith/object-smith.cpp
@@ -360,7 +360,7 @@ Smith::DrainEssenceResult Smith::drain_essence(ItemEntity *o_ptr)
         o_ptr->timeout = old_o.timeout;
     }
 
-    o_ptr->ident |= (IDENT_FULL_KNOWN);
+    o_ptr->ident.set(IdentificationFlag::FULL_KNOWN);
     object_aware(this->creature, *o_ptr);
     o_ptr->mark_as_known();
 

--- a/src/spell-kind/magic-item-recharger.cpp
+++ b/src/spell-kind/magic-item-recharger.cpp
@@ -107,8 +107,8 @@ bool recharge(CreatureEntity &creature, int power)
             }
 
             item->pval += recharge_amount;
-            item->ident &= ~(IDENT_KNOWN);
-            item->ident &= ~(IDENT_EMPTY);
+            item->ident.reset(IdentificationFlag::KNOWN);
+            item->ident.reset(IdentificationFlag::EMPTY);
         }
     }
 

--- a/src/spell-kind/spells-curse-removal.cpp
+++ b/src/spell-kind/spells-curse-removal.cpp
@@ -36,7 +36,7 @@ static int exe_curse_removal(CreatureEntity &creature, int all)
         }
 
         o_ptr->curse_flags.clear();
-        o_ptr->ident |= IDENT_SENSE;
+        o_ptr->ident.set(IdentificationFlag::SENSE);
         o_ptr->feeling = FEEL_NONE;
         rfu.set_flag(StatusRecalculatingFlag::BONUS);
         rfu.set_flag(SubWindowRedrawingFlag::EQUIPMENT);

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -59,7 +59,7 @@ void identify_pack(CreatureEntity &creature)
 bool identify_item(CreatureEntity &creature, ItemEntity *o_ptr)
 {
     const auto known_item_name = describe_flavor(creature, *o_ptr, 0);
-    const auto old_known = any_bits(o_ptr->ident, IDENT_KNOWN);
+    const auto old_known = o_ptr->ident.has(IdentificationFlag::KNOWN);
     if (!o_ptr->is_fully_known()) {
         if (o_ptr->is_fixed_or_random_artifact() || one_in_(5)) {
             chg_virtue(creature, Virtue::KNOWLEDGE, 1);
@@ -180,7 +180,7 @@ bool identify_fully(CreatureEntity &creature, bool only_equip)
     }
 
     auto old_known = identify_item(creature, item.get());
-    item->ident |= (IDENT_FULL_KNOWN);
+    item->ident.set(IdentificationFlag::FULL_KNOWN);
     window_stuff(creature);
     const auto item_name = describe_flavor(creature, *item, 0);
     if (i_idx >= INVEN_MAIN_HAND) {

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -232,7 +232,7 @@ bool curse_armor(CreatureEntity &creature)
     item.damage_dice = Dice(0, 0);
     item.art_flags.clear();
     item.curse_flags.set(CurseTraitType::CURSED);
-    item.ident |= IDENT_BROKEN;
+    item.ident.set(IdentificationFlag::BROKEN);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
         StatusRecalculatingFlag::BONUS,
@@ -286,7 +286,7 @@ bool curse_weapon_object(CreatureEntity &creature, bool force, ItemEntity &item)
     item.damage_dice = Dice(0, 0);
     item.art_flags.clear();
     item.curse_flags.set(CurseTraitType::CURSED);
-    item.ident |= IDENT_BROKEN;
+    item.ident.set(IdentificationFlag::BROKEN);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
         StatusRecalculatingFlag::BONUS,
@@ -354,7 +354,7 @@ static void break_curse(ItemEntity &item)
 
     msg_print(_("かけられていた呪いが打ち破られた！", "The curse is broken!"));
     item.curse_flags.clear();
-    item.ident |= IDENT_SENSE;
+    item.ident.set(IdentificationFlag::SENSE);
     item.feeling = FEEL_NONE;
 }
 

--- a/src/status/base-status.cpp
+++ b/src/status/base-status.cpp
@@ -312,9 +312,9 @@ bool lose_all_info(CreatureEntity &creature)
         }
 
         o_ptr->feeling = FEEL_NONE;
-        o_ptr->ident &= ~(IDENT_EMPTY);
-        o_ptr->ident &= ~(IDENT_KNOWN);
-        o_ptr->ident &= ~(IDENT_SENSE);
+        o_ptr->ident.reset(IdentificationFlag::EMPTY);
+        o_ptr->ident.reset(IdentificationFlag::KNOWN);
+        o_ptr->ident.reset(IdentificationFlag::SENSE);
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -279,7 +279,7 @@ void store_purchase(CreatureEntity &creature, StoreSaleType store_num)
 
     item.inscription.reset();
     item.feeling = FEEL_NONE;
-    item.ident &= ~(IDENT_STORE);
+    item.ident.reset(IdentificationFlag::STORE);
 
     const auto idx = find_autopick_list(creature, &item);
     auto_inscribe_item(&item, idx);

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -162,7 +162,7 @@ public:
     {
         ItemEntity item(artifact_rumor.bi_id);
         item.fa_id = artifact_rumor.fa_id;
-        item.ident = IDENT_STORE;
+        item.ident.set(IdentificationFlag::STORE);
         const auto artifact_name = describe_flavor(this->creature, item, OD_NAME_ONLY);
         this->print_rumor(artifact_name);
     }

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -150,7 +150,7 @@ void store_sell(CreatureEntity &creature, StoreSaleType store_num)
             identify_item(creature, item.get());
             auto sold_item = item->clone();
             sold_item.number = amt;
-            sold_item.ident |= IDENT_STORE;
+            sold_item.ident.set(IdentificationFlag::STORE);
 
             if (item->is_wand_rod()) {
                 sold_item.pval = item->pval * amt / item->number;
@@ -199,7 +199,7 @@ void store_sell(CreatureEntity &creature, StoreSaleType store_num)
         }
 
         identify_item(creature, &selling_item);
-        selling_item.ident |= IDENT_FULL_KNOWN;
+        selling_item.ident.set(IdentificationFlag::FULL_KNOWN);
 
         distribute_charges(item.get(), &selling_item, amt);
         msg_format(_("%sを置いた。(%c)", "You drop %s (%c)."), museum_item_name.data(), index_to_label(i_idx));

--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -161,7 +161,7 @@ tl::optional<int> Store::carry(ItemEntity &item)
         return tl::nullopt;
     }
 
-    item.ident |= IDENT_FULL_KNOWN;
+    item.ident.set(IdentificationFlag::FULL_KNOWN);
     item.inscription.reset();
     item.feeling = FEEL_NONE;
     for (auto slot = 0; slot < this->stock_num; slot++) {

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -327,7 +327,7 @@ static void store_create(CreatureEntity &creature, short fix_k_idx, StoreSaleTyp
         }
 
         q_ptr->mark_as_known();
-        q_ptr->ident |= IDENT_STORE;
+        q_ptr->ident.set(IdentificationFlag::STORE);
         if (tval == ItemKindType::CHEST) {
             continue;
         }

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -110,7 +110,7 @@ void ItemEntity::generate(short new_bi_id)
         }
 
         if (this->is_worthless()) {
-            this->ident |= (IDENT_BROKEN);
+            this->ident.set(IdentificationFlag::BROKEN);
         }
 
         if (baseitem.gen_flags.has(ItemGenerationTraitType::CURSED)) {
@@ -393,7 +393,7 @@ bool ItemEntity::is_valid() const
 
 bool ItemEntity::is_broken() const
 {
-    return any_bits(this->ident, IDENT_BROKEN);
+    return this->ident.has(IdentificationFlag::BROKEN);
 }
 
 bool ItemEntity::is_cursed() const
@@ -413,12 +413,12 @@ bool ItemEntity::is_held_by_monster() const
 bool ItemEntity::is_known() const
 {
     const auto &baseitem = this->get_baseitem();
-    return any_bits(this->ident, IDENT_KNOWN) || (baseitem.easy_know && baseitem.aware);
+    return this->ident.has(IdentificationFlag::KNOWN) || (baseitem.easy_know && baseitem.aware);
 }
 
 bool ItemEntity::is_fully_known() const
 {
-    return any_bits(this->ident, IDENT_FULL_KNOWN);
+    return this->ident.has(IdentificationFlag::FULL_KNOWN);
 }
 
 /*!
@@ -641,7 +641,7 @@ int ItemEntity::calc_price() const
 
         value = object_value_real(this);
     } else {
-        if (any_bits(this->ident, IDENT_SENSE) && is_worthless) {
+        if (this->ident.has(IdentificationFlag::SENSE) && is_worthless) {
             return 0;
         }
 
@@ -1034,7 +1034,7 @@ int ItemEntity::is_similar_part(const ItemEntity &other) const
     case ItemKindType::SCROLL:
         break;
     case ItemKindType::STAFF:
-        if ((none_bits(this->ident, IDENT_EMPTY) && !this->is_known()) || (none_bits(other.ident, IDENT_EMPTY) && !other.is_known())) {
+        if ((!this->ident.has(IdentificationFlag::EMPTY) && !this->is_known()) || (!other.ident.has(IdentificationFlag::EMPTY) && !other.is_known())) {
             return 0;
         }
 
@@ -1044,7 +1044,7 @@ int ItemEntity::is_similar_part(const ItemEntity &other) const
 
         break;
     case ItemKindType::WAND:
-        if ((none_bits(this->ident, IDENT_EMPTY) && !this->is_known()) || (none_bits(other.ident, IDENT_EMPTY) && !other.is_known())) {
+        if ((!this->ident.has(IdentificationFlag::EMPTY) && !this->is_known()) || (!other.ident.has(IdentificationFlag::EMPTY) && !other.is_known())) {
             return 0;
         }
 
@@ -1129,7 +1129,7 @@ int ItemEntity::is_similar_part(const ItemEntity &other) const
         return 0;
     }
 
-    if (any_bits(this->ident, IDENT_BROKEN) != any_bits(other.ident, IDENT_BROKEN)) {
+    if (this->ident.has(IdentificationFlag::BROKEN) != other.ident.has(IdentificationFlag::BROKEN)) {
         return 0;
     }
 
@@ -1353,9 +1353,9 @@ std::string ItemEntity::build_activation_description() const
 void ItemEntity::mark_as_known()
 {
     this->feeling = FEEL_NONE;
-    this->ident &= ~(IDENT_SENSE);
-    this->ident &= ~(IDENT_EMPTY);
-    this->ident |= (IDENT_KNOWN);
+    this->ident.reset(IdentificationFlag::SENSE);
+    this->ident.reset(IdentificationFlag::EMPTY);
+    this->ident.set(IdentificationFlag::KNOWN);
 }
 
 /*!
@@ -1418,18 +1418,18 @@ void ItemEntity::absorb(ItemEntity &other)
         this->mark_as_known();
     }
 
-    if (((this->ident & IDENT_STORE) || (other.ident & IDENT_STORE)) && (!((this->ident & IDENT_STORE) && (other.ident & IDENT_STORE)))) {
-        if (other.ident & IDENT_STORE) {
-            other.ident &= 0xEF;
+    if (((this->ident.has(IdentificationFlag::STORE)) || (other.ident.has(IdentificationFlag::STORE))) && (!((this->ident.has(IdentificationFlag::STORE)) && (other.ident.has(IdentificationFlag::STORE))))) {
+        if (other.ident.has(IdentificationFlag::STORE)) {
+            other.ident.reset(IdentificationFlag::STORE);
         }
 
-        if (this->ident & IDENT_STORE) {
-            this->ident &= 0xEF;
+        if (this->ident.has(IdentificationFlag::STORE)) {
+            this->ident.reset(IdentificationFlag::STORE);
         }
     }
 
     if (other.is_fully_known()) {
-        this->ident |= (IDENT_FULL_KNOWN);
+        this->ident.set(IdentificationFlag::FULL_KNOWN);
     }
 
     if (other.is_inscribed()) {

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -14,6 +14,7 @@
 #include "object/object-mark-types.h"
 #include "system/angband.h"
 #include "system/baseitem/baseitem-key.h"
+#include "system/item/identification-flags.h"
 #include "system/system-variables.h"
 #include "util/dice.h"
 #include "util/flag-group.h"
@@ -77,7 +78,7 @@ public:
 
     Dice damage_dice{}; /*!< Damage dice */
     TIME_EFFECT timeout{}; /*!< Timeout Counter */
-    byte ident{}; /*!< Special flags  */
+    EnumClassFlagGroup<IdentificationFlag> ident{}; /*!< 鑑定状態フラグ (旧 byte ident) */
     EnumClassFlagGroup<OmType> marked{}; /*!< Object is marked */
     tl::optional<std::string> inscription{}; /*!< Inscription */
     tl::optional<std::string> randart_name{}; /*!< Artifact name (random artifacts) */

--- a/src/system/item/identification-flags.h
+++ b/src/system/item/identification-flags.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+
+/*!
+ * @brief アイテムの鑑定状態フラグ (旧 IDENT_* ビットフラグ。ビット位置は
+ *        special-object-flags.h の旧定数と一致させてある (セーブ互換のため))
+ */
+enum class IdentificationFlag : uint8_t {
+    SENSE = 0, //!< 簡易鑑定 (旧 IDENT_SENSE = 0x01)
+    XXX01 = 1, //!< 予約 (旧 IDENT_XXX02 = 0x02)
+    EMPTY = 2, //!< 魔道具の空判定 (旧 IDENT_EMPTY = 0x04)
+    KNOWN = 3, //!< 鑑定済 (旧 IDENT_KNOWN = 0x08)
+    STORE = 4, //!< 店頭購入 (注: 宝物庫報酬で使い回している) (旧 IDENT_STORE = 0x10)
+    FULL_KNOWN = 5, //!< *鑑定* 済 (旧 IDENT_FULL_KNOWN = 0x20)
+    XXX06 = 6, //!< 予約 (旧 0x40)
+    BROKEN = 7, //!< 呪い・マイナスエゴなど無価値品 (旧 IDENT_BROKEN = 0x80)
+    MAX,
+};

--- a/src/view/display-characteristic.cpp
+++ b/src/view/display-characteristic.cpp
@@ -111,7 +111,7 @@ static void process_cursed_equipment_characteristics(CreatureEntity &creature, u
     for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
         auto *o_ptr = creature.inventory[i].get();
         auto is_known = o_ptr->is_known();
-        auto is_sensed = is_known || o_ptr->ident & IDENT_SENSE;
+        auto is_sensed = is_known || o_ptr->ident.has(IdentificationFlag::SENSE);
         auto flags = o_ptr->get_flags_known();
 
         if (flags.has(TR_ADD_L_CURSE) || flags.has(TR_ADD_H_CURSE)) {

--- a/src/wizard/items-spoiler.cpp
+++ b/src/wizard/items-spoiler.cpp
@@ -104,7 +104,7 @@ static ItemEntity prepare_item_for_obj_desc(short bi_id)
 {
     ItemEntity item;
     item.generate(bi_id);
-    item.ident |= IDENT_KNOWN;
+    item.ident.set(IdentificationFlag::KNOWN);
     switch (item.bi_key.tval()) {
     case ItemKindType::FIGURINE:
     case ItemKindType::STATUE:

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -277,7 +277,8 @@ void wiz_identify_full_inventory(CreatureEntity &creature)
 
         auto &baseitem = o_ptr->get_baseitem();
         baseitem.mark_awareness(true); //!< @note 記録には残さない.
-        set_bits(o_ptr->ident, IDENT_KNOWN | IDENT_FULL_KNOWN);
+        o_ptr->ident.set(IdentificationFlag::KNOWN);
+        o_ptr->ident.set(IdentificationFlag::FULL_KNOWN);
         o_ptr->marked.set(OmType::TOUCHED);
     }
 
@@ -402,7 +403,13 @@ static void wiz_display_item(CreatureEntity &creature, ItemEntity *o_ptr)
     prt(format("number = %-3d  wgt = %-6d  ac = %-5d    damage = %s", o_ptr->number, o_ptr->weight, o_ptr->ac, o_ptr->damage_dice.to_string().data()), ++line, j);
     prt(format("pval = %-5d  toac = %-5d  tohit = %-4d  todam = %-4d", o_ptr->pval, o_ptr->to_a, o_ptr->to_h, o_ptr->to_d), ++line, j);
     prt(format("fixed_artifact_id = %-4d  ego_idx = %-4d  cost = %d", enum2i(o_ptr->fa_id), enum2i(o_ptr->ego_idx), object_value_real(o_ptr)), ++line, j);
-    prt(format("ident = %04x  activation_id = %-4d  timeout = %-d", o_ptr->ident, enum2i(o_ptr->activation_id), o_ptr->timeout), ++line, j);
+    uint8_t ident_byte = 0;
+    for (auto i = 0; i < enum2i(IdentificationFlag::MAX); i++) {
+        if (o_ptr->ident.has(i2enum<IdentificationFlag>(i))) {
+            ident_byte |= static_cast<uint8_t>(1U << i);
+        }
+    }
+    prt(format("ident = %04x  activation_id = %-4d  timeout = %-d", ident_byte, enum2i(o_ptr->activation_id), o_ptr->timeout), ++line, j);
     prt(format("chest_level = %-4d  fuel = %-d", o_ptr->chest_level, o_ptr->fuel), ++line, j);
     prt(format("smith_hit = %-4d  smith_damage = %-4d", o_ptr->smith_hit, o_ptr->smith_damage), ++line, j);
     prt(format("cursed  = %-d  captured_monster_speed = %-4d", o_ptr->curse_flags, o_ptr->captured_monster_speed), ++line, j);


### PR DESCRIPTION


変愚蛮怒 PR #5390 のうち、ident ビットフラグの EnumClassFlagGroup 化を取り込む。 (同 PR の item-entity.cpp/h の system/item/ への移動 (286ファイルの大半の正体)
 は bakabakaband では見送り、ファイルは src/system/item-entity.h のまま)

実装:
- 新規 system/item/identification-flags.h に enum class IdentificationFlag を定義。 ビット位置は旧 special-object-flags.h の IDENT_* と一致させてある。
- ItemEntity::ident を byte → EnumClassFlagGroup<IdentificationFlag> に変更。
- 全 IDENT_* 使用 (43ファイル/約95箇所) を .has()/.set()/.reset()/.any()/.none() 等のメソッド呼出に置換 (any_bits/set_bits/reset_bits/none_bits、|=、&=~、& 、 生 0xEF マスク、= IDENT_X 代入を含む)。

セーブ互換:
- 上流は 8→16bit 拡張に伴いセーブ版数を bump しているが、bakabakaband では 8bit のまま enum 化したため byte 表現は不変。item-writer/loader で FlagGroup<->byte をビット位置互換で変換し、**セーブ形式・版数は変更しない** (既存セーブはそのまま読める)。

検証: autotools フルビルド (g++ -Werror -Wall -Wextra) で全体コンパイル成功。

注: 旧 special-object-flags.h の IDENT_* マクロは未使用化したが、54ファイルの include 整理は churn 回避のため残置 (デッドマクロ整理は別途)。

変愚蛮怒 #5390 相当 (bakabakaband #8410、enum化本体)。