### PR TITLE
merge: terrain.power を door/trap/tunnel 用途別 power へ分解 (hengband #5389 相当)

### DIFF
--- a/src/action/open-close-execution.cpp
+++ b/src/action/open-close-execution.cpp
@@ -53,7 +53,7 @@ bool exe_open(CreatureEntity &creature, POSITION y, POSITION x)
         return false;
     }
 
-    if (!terrain.power) {
+    if (!terrain.door_power) {
         cave_alter_feat(creature, y, x, TerrainCharacteristics::OPEN);
         sound(SoundKind::OPENDOOR);
         creature.plus_incident_tree("OPEN_DOOR", 1);
@@ -69,7 +69,7 @@ bool exe_open(CreatureEntity &creature, POSITION y, POSITION x)
         i = i / 10;
     }
 
-    int j = terrain.power;
+    int j = terrain.door_power;
     j = i - (j * 4);
     if (j < 2) {
         j = 2;
@@ -161,7 +161,7 @@ bool easy_open_door(CreatureEntity &creature, const Pos2D &pos)
     if (terrain.flags.has_not(TerrainCharacteristics::OPEN)) {
         constexpr auto fmt = _("%sはがっちりと閉じられているようだ。", "The %s appears to be stuck.");
         msg_format(fmt, grid.get_terrain(TerrainKind::MIMIC).name.data());
-    } else if (terrain.power) {
+    } else if (terrain.door_power) {
         auto power_disarm = creature.get_skill_disarm();
         if (creature.is_blind() || no_lite(creature)) {
             power_disarm = power_disarm / 10;
@@ -171,7 +171,7 @@ bool easy_open_door(CreatureEntity &creature, const Pos2D &pos)
             power_disarm = power_disarm / 10;
         }
 
-        auto power_terrain = terrain.power;
+        int power_terrain = terrain.door_power;
         power_terrain = power_disarm - (power_terrain * 4);
         if (power_terrain < 2) {
             power_terrain = 2;
@@ -279,7 +279,7 @@ bool exe_disarm(CreatureEntity &creature, POSITION y, POSITION x, const Directio
     const auto &grid = creature.get_floor()->get_grid(pos);
     const auto &terrain = grid.get_terrain();
     const auto &name = terrain.name;
-    int power = terrain.power;
+    int power = terrain.trap_power;
     int i = creature.get_skill_disarm();
     PlayerEnergy(creature).set_player_turn_energy(100);
     if (creature.is_blind() || no_lite(creature)) {
@@ -343,7 +343,7 @@ bool exe_bash(CreatureEntity &creature, POSITION y, POSITION x, const Direction 
     const auto &grid = floor.get_grid(pos);
     const auto &terrain = grid.get_terrain();
     int bash = adj_str_blow[creature.get_stat_index(A_STR)];
-    int power = terrain.power;
+    int power = terrain.door_power;
     const auto &name = grid.get_terrain(TerrainKind::MIMIC).name;
     PlayerEnergy(creature).set_player_turn_energy(100);
     msg_format(_("%sに体当たりをした！", "You smash into the %s!"), name.data());

--- a/src/action/tunnel-execution.cpp
+++ b/src/action/tunnel-execution.cpp
@@ -63,7 +63,7 @@ bool exe_tunnel(CreatureEntity &creature, POSITION y, POSITION x)
 
     PlayerEnergy(creature).set_player_turn_energy(100);
     const auto &terrain = grid.get_terrain();
-    const auto power = terrain.power;
+    const int power = terrain.tunnel_power;
     const auto &terrain_mimic = grid.get_terrain(TerrainKind::MIMIC);
     const auto &name = terrain_mimic.name;
     if (command_rep == 0) {

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -190,7 +190,7 @@ bool affect_feature(CreatureEntity &creature, MONSTER_IDX src_idx, POSITION r, P
             cave_alter_feat(creature, y, x, TerrainCharacteristics::DISARM);
         }
 
-        if (floor.has_closed_door_at(pos) && terrain.power && terrain.flags.has(TerrainCharacteristics::OPEN)) {
+        if (floor.has_closed_door_at(pos) && terrain.door_power && terrain.flags.has(TerrainCharacteristics::OPEN)) {
             FEAT_IDX old_feat = grid.feat;
             cave_alter_feat(creature, y, x, TerrainCharacteristics::DISARM);
             if (known && (old_feat != grid.feat)) {

--- a/src/info-reader/terrain-reader.cpp
+++ b/src/info-reader/terrain-reader.cpp
@@ -135,6 +135,9 @@ errr parse_terrains_json_info(nlohmann::json &element, angband_header *)
     terrain.mimic = s;
     terrain.destroyed = s;
     terrain.gold_drop = Dice{};
+    terrain.door_power = 0;
+    terrain.trap_power = 0;
+    terrain.tunnel_power = 0;
     for (auto j = 0; j < MAX_FEAT_STATES; j++) {
         terrain.state[j].action = TerrainCharacteristics::MAX;
         terrain.state[j].result_tag.clear();
@@ -169,6 +172,7 @@ errr parse_terrains_json_info(nlohmann::json &element, angband_header *)
     }
 
     std::optional<uint8_t> specific_type;
+    std::optional<uint8_t> terrain_power;
     for (const auto &f_obj : flags_obj) {
         if (!f_obj.is_string()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
@@ -186,7 +190,9 @@ errr parse_terrains_json_info(nlohmann::json &element, angband_header *)
             continue;
         }
         if (f.starts_with("POWER_")) {
-            info_set_value(terrain.power, std::string(f.substr(sizeof("POWER_") - 1)));
+            uint8_t parsed_power{};
+            info_set_value(parsed_power, std::string(f.substr(sizeof("POWER_") - 1)));
+            terrain_power = parsed_power;
             continue;
         }
         // bakabakaband 独自フラグプレフィックス
@@ -205,6 +211,19 @@ errr parse_terrains_json_info(nlohmann::json &element, angband_header *)
     }
     if (specific_type && !terrain.set_specific_type(*specific_type)) {
         return PARSE_ERROR_INVALID_FLAG;
+    }
+
+    // 単一の POWER 値を、地形が持つ特性フラグに応じて用途別 power へ割り当てる。
+    if (terrain_power) {
+        if (terrain.flags.has(TerrainCharacteristics::DOOR)) {
+            terrain.door_power = *terrain_power;
+        }
+        if (terrain.flags.has(TerrainCharacteristics::TRAP)) {
+            terrain.trap_power = *terrain_power;
+        }
+        if (terrain.flags.has(TerrainCharacteristics::TUNNEL)) {
+            terrain.tunnel_power = *terrain_power;
+        }
     }
 
     // bakabakaband 独自: 確率的ランダム地形変化 (R: ディレクティブ相当)

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -122,13 +122,13 @@ static bool bash_normal_door(CreatureEntity &creature, turn_flags *turn_flags_pt
         return true;
     }
 
-    if (terrain.power == 0) {
+    if (terrain.door_power == 0) {
         turn_flags_ptr->did_open_door = true;
         turn_flags_ptr->do_turn = true;
         return false;
     }
 
-    if (randint0(monster.hp / 10) > terrain.power) {
+    if (randint0(monster.hp / 10) > terrain.door_power) {
         cave_alter_feat(creature, pos.y, pos.x, Tc::DISARM);
         turn_flags_ptr->do_turn = true;
         return false;
@@ -157,7 +157,7 @@ static void bash_glass_door(CreatureEntity &creature, turn_flags *turn_flags_ptr
         return;
     }
 
-    if (!check_hp_for_terrain_destruction(terrain, monster) || (randint0(monster.hp / 10) <= terrain.power)) {
+    if (!check_hp_for_terrain_destruction(terrain, monster) || (randint0(monster.hp / 10) <= terrain.door_power)) {
         return;
     }
 

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -479,8 +479,8 @@ TerrainTag FloorType::select_random_trap() const
         const auto tag = terrains.select_normal_trap();
         const auto &terrain = terrains.get_terrain(tag);
 
-        // POWER値による階層制限チェック
-        if (terrain.power > 0 && this->dun_level < terrain.power) {
+        // 罠の強度による階層制限チェック
+        if (terrain.trap_power > 0 && this->dun_level < terrain.trap_power) {
             continue;
         }
 

--- a/src/system/h-type.h
+++ b/src/system/h-type.h
@@ -151,7 +151,6 @@ typedef int TERM_LEN; /*!< コンソール表示座標の型定義 */
 typedef byte TERM_COLOR; /*!< テキスト表示色の型定義 */
 typedef int32_t SPELL_IDX; /*!< 各魔法領域/職業能力ごとの呪文ID型定義 */
 typedef int16_t PROB; /*!< 確率の重みの型定義 */
-typedef byte FEAT_POWER; /*!< 地形強度の型定義 */
 
 typedef int QUANTITY; /*!< インターフェース上の指定個数 */
 

--- a/src/system/terrain/terrain-definition.h
+++ b/src/system/terrain/terrain-definition.h
@@ -10,6 +10,7 @@
 #include "util/dice.h"
 #include "util/flag-group.h"
 #include "view/display-symbol.h"
+#include <cstdint>
 #include <map>
 
 /* Number of feats we change to (Excluding default). Used in TerrainDefinitions.txt. */
@@ -72,7 +73,9 @@ public:
     BuildingType building_type = BuildingType::NONE; /*!< 施設種別 */
     TerrainConversionType conversion_type = TerrainConversionType::NONE; /*!< 変換地形種別 */
     int stream_index = -1; /*!< 川地形種別 */
-    FEAT_POWER power{}; /*!< 地形強度 */
+    uint8_t door_power{}; /*!< 扉の強度 */
+    uint8_t trap_power{}; /*!< 罠の解除難易度 */
+    uint8_t tunnel_power{}; /*!< トンネル掘削難易度 */
     std::map<int, DisplaySymbol> symbol_definitions; //!< デフォルトの地形シンボル (色/文字).
     std::map<int, DisplaySymbol> symbol_configs; //!< 設定変更後の地形シンボル (色/文字).
     int change_priority;


### PR DESCRIPTION


変愚蛮怒 PR #5389 (terrain.power の分解整理) を bakabakaband 構造に適応してマージ。

上流 PR は単一の terrain.power を用途別の door_power / trap_power / tunnel_power の 3 つへ分割するもの。bakabakaband は単一 FEAT_POWER power を保持したままだったため、これを 3 フィールドへ分解する。

変換内容:
- TerrainType の `FEAT_POWER power` を `uint8_t door_power / trap_power / tunnel_power` の 3 フィールドへ置換 (未使用となった typedef FEAT_POWER も削除)
- terrain-reader.cpp: POWER_N フラグを一旦 optional に退避し、フラグ ループ完了後に地形の DOOR / TRAP / TUNNEL 特性フラグの有無に応じて 対応する用途別 power へ割り当てる (上流の中間実装と同一のヒューリスティック)
- 各消費側を意味に応じた用途別 power へ移行:
  - monster-move.cpp (扉破壊判定)        -> door_power
  - open-close-execution.cpp (開錠/体当り) -> door_power
  - open-close-execution.cpp (罠解除)      -> trap_power
  - tunnel-execution.cpp (掘削)            -> tunnel_power
  - effect-feature.cpp (扉の魔法解錠)      -> door_power
  - floor-info.cpp (罠の階層制限: 独自処理) -> trap_power

データ互換性: 既存の TerrainDefinitions.jsonc は POWER_N フラグ形式の まま据え置く。POWER_N>0 の全 103 地形が DOOR/TRAP/TUNNEL いずれかの 特性フラグを持つため、フラグ有無ヒューリスティックでの割り当ては従来
挙動を完全保存する (扉+掘削 28 / 罠 13 / 掘削 62)。上流の用途別
power 個別指定 (door≠trap≠tunnel) を行う 955 行のデータ書換は、
bakabakaband 独自地形を含むため別タスクとして見送る。