### PR TITLE
merge: SpellInfoList から JSON 変換処理を分離 (hengband #5439 相当)

### DIFF
--- a/src/info-reader/spell-reader.cpp
+++ b/src/info-reader/spell-reader.cpp
@@ -36,10 +36,11 @@ static errr set_realm(const nlohmann::json &spell_data, RealmType &realm)
 /*!
  * @brief JSON Objectから各呪文の詳細を取得する
  * @param spell_data 情報の格納されたJSON Object
- * @param realm_spell_list 呪文情報を格納するvector
+ * @param spell_info_list 呪文情報リスト
+ * @param realm 領域ID
  * @return エラーコード
  */
-static errr set_spell_data(const nlohmann::json &spell_data, std::vector<SpellInfo> &realm_spell_list)
+static errr set_spell_data(const nlohmann::json &spell_data, SpellInfoList &spell_info_list, RealmType realm)
 {
     if (spell_data.is_null()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
@@ -68,7 +69,7 @@ static errr set_spell_data(const nlohmann::json &spell_data, std::vector<SpellIn
         msg_format(_("呪文説明読込失敗。ID: '%d'。", "Failed to load spell description. ID: '%d'."), error_idx);
         return err;
     }
-    realm_spell_list[spell_id] = std::move(info);
+    spell_info_list.set_spell_info(realm, spell_id, std::move(info));
 
     return PARSE_ERROR_NONE;
 }
@@ -76,10 +77,11 @@ static errr set_spell_data(const nlohmann::json &spell_data, std::vector<SpellIn
 /*!
  * @brief JSON Objectから各呪文の詳細を呪文書単位で取得する
  * @param spell_data 情報の格納されたJSON Object
- * @param realm_spell_list 呪文情報を格納するvector
+ * @param spell_info_list 呪文情報リスト
+ * @param realm 領域ID
  * @return エラーコード
  */
-static errr set_book_data(const nlohmann::json &spell_data, std::vector<SpellInfo> &realm_spell_list)
+static errr set_book_data(const nlohmann::json &spell_data, SpellInfoList &spell_info_list, RealmType realm)
 {
     auto &book_obj = spell_data["books"];
     if (book_obj.is_null()) {
@@ -95,7 +97,9 @@ static errr set_book_data(const nlohmann::json &spell_data, std::vector<SpellInf
 
         for (auto &spell_element : spells_obj.items()) {
             auto &spell = spell_element.value();
-            set_spell_data(spell, realm_spell_list);
+            if (auto err = set_spell_data(spell, spell_info_list, realm)) {
+                return err;
+            }
         }
     }
     return PARSE_ERROR_NONE;
@@ -104,10 +108,10 @@ static errr set_book_data(const nlohmann::json &spell_data, std::vector<SpellInf
 /*!
  * @brief 職業魔法情報(ClassMagicDefinitions)のパース関数
  * @param buf テキスト列
- * @param spell_list パースした結果を格納する領域
+ * @param spell_info_list パースした結果を格納する領域
  * @return エラーコード
  */
-errr parse_spell_info(nlohmann::json &spell_data, std::vector<std::vector<SpellInfo>> &spell_list)
+errr parse_spell_info(nlohmann::json &spell_data, SpellInfoList &spell_info_list)
 {
     RealmType realm_id;
     if (auto err = set_realm(spell_data, realm_id)) {
@@ -115,9 +119,7 @@ errr parse_spell_info(nlohmann::json &spell_data, std::vector<std::vector<SpellI
         return err;
     }
 
-    auto &realm_spell_list = spell_list[enum2i(realm_id)];
-
-    if (auto err = set_book_data(spell_data, realm_spell_list)) {
+    if (auto err = set_book_data(spell_data, spell_info_list, realm_id)) {
         msg_format(_("呪文詳細読込失敗。ID: '%d'。", "Failed to load spell data. ID: '%d'."), error_idx);
         return err;
     }

--- a/src/info-reader/spell-reader.h
+++ b/src/info-reader/spell-reader.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "external-lib/include-json.h"
 #include "system/angband.h"
-#include <vector>
+#include <external-lib/include-json.h>
 
-class SpellInfo;
-errr parse_spell_info(nlohmann::json &spell_data, std::vector<std::vector<SpellInfo>> &spell_list);
+class SpellInfoList;
+
+errr parse_spell_info(nlohmann::json &spell_data, SpellInfoList &spell_info_list);

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -18,6 +18,7 @@
 #include "info-reader/party-reader.h"
 #include "info-reader/race-reader.h"
 #include "info-reader/skill-reader.h"
+#include "info-reader/spell-reader.h"
 #include "info-reader/terrain-reader.h"
 #include "info-reader/vault-reader.h"
 #include "io/files-util.h"
@@ -270,7 +271,7 @@ void init_spell_info()
     auto &spell_info_list = SpellInfoList::get_instance();
     spell_info_list.initialize();
     auto parser = [&spell_info_list](nlohmann::json &spell_data, angband_header *) {
-        return spell_info_list.parse(spell_data);
+        return parse_spell_info(spell_data, spell_info_list);
     };
     init_json("SpellDefinitions.jsonc", "realms", spells_header, spell_info_list, parser);
 }

--- a/src/system/spell-info-list.cpp
+++ b/src/system/spell-info-list.cpp
@@ -1,7 +1,10 @@
 #include "system/spell-info-list.h"
-#include "info-reader/spell-reader.h"
 #include "realm/realm-types.h"
+#include "system/angband-exceptions.h"
 #include <algorithm>
+#include <fmt/format.h>
+#include <stdexcept>
+#include <utility>
 
 SpellInfoList SpellInfoList::instance{};
 
@@ -33,7 +36,17 @@ const SpellInfo &SpellInfoList::get_spell_info(RealmType realm, int spell_id) co
     return this->spell_list[enum2i(realm)][spell_id];
 }
 
-errr SpellInfoList::parse(nlohmann::json &spell_data)
+void SpellInfoList::set_spell_info(RealmType realm, int spell_id, SpellInfo &&spell_info)
 {
-    return parse_spell_info(spell_data, this->spell_list);
+    const auto realm_index = enum2i(realm);
+    if (realm_index < 0 || realm_index >= static_cast<int>(this->spell_list.size())) {
+        THROW_EXCEPTION(std::out_of_range, fmt::format("Invalid realm: {}", realm_index));
+    }
+
+    auto &spells = this->spell_list[realm_index];
+    if (spell_id < 0 || spell_id >= static_cast<int>(spells.size())) {
+        THROW_EXCEPTION(std::out_of_range, fmt::format("Invalid spell ID: {}", spell_id));
+    }
+
+    spells[spell_id] = std::move(spell_info);
 }

--- a/src/system/spell-info-list.h
+++ b/src/system/spell-info-list.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "external-lib/include-json.h"
 #include "realm/realm-types.h"
 #include "system/angband.h"
 #include <string>
@@ -49,7 +48,7 @@ public:
     ~SpellInfoList() = default;
 
     void initialize();
-    errr parse(nlohmann::json &spell_data);
+    void set_spell_info(RealmType realm, int spell_id, SpellInfo &&spell_info);
 
     static SpellInfoList &get_instance();
 


### PR DESCRIPTION
変愚蛮怒 PR #5439 の内容を bakabakaband 構造に適応してマージ。

呪文情報の JSON パース責務を SpellInfoList から spell-reader へ移し、 SpellInfoList は範囲チェック付きの set_spell_info() を提供する形に整理。

- SpellInfoList::parse() を廃止し set_spell_info(realm, spell_id, info) を新設 (realm/spell_id の範囲外を THROW_EXCEPTION で検出)
- parse_spell_info() の引数を vector<vector<SpellInfo>> から SpellInfoList& へ変更
- spell-reader の set_spell_data/set_book_data に realm を引き回し
- spell-info-list.h から include-json.h 依存を除去

bakabakaband 適応:
- init_spell_info() のパーサラムダは bakabakaband 独自の (json&, angband_header*) シグネチャを維持しつつ本体を parse_spell_info(spell_data, spell_info_list) 呼出に変更

上流コミット: 108886c2c (hengband/develop)