### PR TITLE
merge: ダンプのユニーク撃破時間の桁を揃える (hengband #5427 相当)

### DIFF
--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -48,6 +48,7 @@
 #include "world/world.h"
 #include <fmt/format.h>
 #include <numeric>
+#include <range/v3/algorithm.hpp>
 #include <range/v3/view.hpp>
 #include <string>
 
@@ -351,16 +352,26 @@ static void dump_aux_monsters(FILE *fff)
     fmt::println(fff, "You have defeated {} {} including {} unique monster{} in total.", norm_total, norm_total == 1 ? "enemy" : "enemies", uniq_total, (uniq_total == 1 ? "" : "s"));
 #endif
 
-    std::stable_sort(monrace_ids.begin(), monrace_ids.end(), [&monraces](auto x, auto y) { return monraces.order(x, y); });
-    fmt::println(fff, _("\n《上位{}体のユニーク・モンスター》", "\n< Unique monsters top {} >"), std::min(uniq_total, 10));
-    for (auto it = monrace_ids.rbegin(); it != monrace_ids.rend() && std::distance(monrace_ids.rbegin(), it) < 10; it++) {
-        const auto &monrace = monraces.get_monrace(*it);
+    ranges::stable_sort(monrace_ids, [&monraces](auto x, auto y) { return monraces.order(x, y); });
+    ranges::reverse(monrace_ids);
+
+    const auto id_to_monrace = [&monraces](auto id) -> const MonraceDefinition & { return monraces.get_monrace(id); };
+    const auto top_display_num = std::min(uniq_total, 10);
+    const auto top_monraces = monrace_ids | ranges::views::take(top_display_num) | ranges::views::transform(id_to_monrace);
+    const auto max_defeat_time = ranges::max(top_monraces | ranges::views::transform(&MonraceDefinition::defeat_time));
+    const auto max_hour_digits = count_digits(max_defeat_time / (60 * 60));
+
+    fmt::println(fff, _("\n《上位{}体のユニーク・モンスター》", "\n< Unique monsters top {} >"), top_display_num);
+    for (const auto &monrace : top_monraces) {
         const auto defeat_level = monrace.defeat_level;
         const auto defeat_time = monrace.defeat_time;
         std::string defeat_info;
         if ((defeat_level > 0) && (defeat_time > 0)) {
-            constexpr auto fmt = _(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d");
-            defeat_info = format(fmt, defeat_level, defeat_time / (60 * 60), (defeat_time / 60) % 60, defeat_time % 60);
+            const auto defeat_hour = defeat_time / (60 * 60);
+            const auto defeat_minute = (defeat_time / 60) % 60;
+            const auto defeat_second = defeat_time % 60;
+            constexpr auto fmt = _(" - レベル{:2} - {:>{}}:{:02}:{:02}", " - level {:2} - {:>{}}:{:02}:{:02}");
+            defeat_info = fmt::format(fmt, defeat_level, defeat_hour, max_hour_digits, defeat_minute, defeat_second);
         }
 
         const auto names = str_separate(monrace.name, 40);

--- a/src/util/string-processor.cpp
+++ b/src/util/string-processor.cpp
@@ -626,6 +626,29 @@ tl::optional<std::string_view> extract_suffix(std::string_view str, std::string_
     return tl::nullopt;
 }
 
+/*!
+ * @brief 整数の桁数を数える
+ *
+ * @param value 数える整数
+ * @param base 桁数を数える基数(省略した場合のデフォルト値は10)
+ * @return 整数の桁数。基数が不正(2未満)な場合は0を返す。
+ */
+int count_digits(int value, int base)
+{
+    if (base < 2) {
+        return 0;
+    }
+
+    int count = 0;
+
+    do {
+        value /= base;
+        count++;
+    } while (value != 0);
+
+    return count;
+}
+
 char hexify_upper(uint8_t value)
 {
     return hex_symbol_table.at(value / 16);

--- a/src/util/string-processor.h
+++ b/src/util/string-processor.h
@@ -33,6 +33,7 @@ std::set<int> str_find_all_multibyte_chars(std::string_view str);
 tl::optional<int> str_to_int(std::string_view str, int base = 10);
 tl::optional<std::string_view> extract_suffix(std::string_view str, char find);
 tl::optional<std::string_view> extract_suffix(std::string_view str, std::string_view find);
+int count_digits(int value, int base = 10);
 char hexify_upper(uint8_t value);
 char hexify_lower(uint8_t value);
 char octify(uint8_t i);


### PR DESCRIPTION
変愚蛮怒 PR #5427 の内容を bakabakaband 構造に適応してマージ。

キャラクタダンプのユニーク・モンスター上位一覧で、撃破時間の「時」部分の
桁数を上位陣の最大値に合わせて右詰めし、表示を揃える。

- 整数の桁数を返す count_digits() を string-processor に追加
- character-dump.cpp の上位ユニーク一覧を range-v3 ベースに整理し、 最大時間の桁数で時表示を右詰め (fmt の動的幅指定 {:>{}} を使用)

補足: count_digits は #5437 マージ (文字コード処理再構成) の際に
bakabakaband 側で未使用として一旦削除していたが、本 PR の正規の利用
箇所が入ったため整合的に再導入する形となる。

上流コミット: 304412fdc / a5f3e4911 (hengband/develop)