### PR TITLE
merge: 一時ファイル格納クラスを作りアーティファクト一覧表示を差し替え (hengband #5420 相当)

### DIFF
--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
@@ -2012,6 +2012,7 @@
     <ClCompile Include="..\..\src\core\scores.cpp" />
     <ClCompile Include="..\..\src\player-info\self-info.cpp" />
     <ClCompile Include="..\..\src\io\signal-handlers.cpp" />
+    <ClCompile Include="..\..\src\io\temp-file.cpp" />
     <ClCompile Include="..\..\src\mind\mind-sniper.cpp" />
     <ClCompile Include="..\..\src\target\target-sorter.cpp" />
     <ClCompile Include="..\..\src\spell\spells-diceroll.cpp" />
@@ -2191,6 +2192,7 @@
     <ClInclude Include="..\..\src\player\race-resistances.h" />
     <ClInclude Include="..\..\src\player\temporary-resistances.h" />
     <ClInclude Include="..\..\src\io\signal-handlers.h" />
+    <ClInclude Include="..\..\src\io\temp-file.h" />
     <ClInclude Include="..\..\src\io\uid-checker.h" />
     <ClInclude Include="..\..\src\spell-realm\spells-song.h" />
     <ClInclude Include="..\..\src\effect\effect-processor.h" />

--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
@@ -146,6 +146,9 @@
     <ClCompile Include="..\..\src\io\signal-handlers.cpp">
       <Filter>io</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\io\temp-file.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\io\uid-checker.cpp">
       <Filter>io</Filter>
     </ClCompile>
@@ -2963,6 +2966,9 @@
       <Filter>autopick</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\io\signal-handlers.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\temp-file.h">
       <Filter>io</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\io\uid-checker.h">

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -732,6 +732,7 @@ hengband_SOURCES = \
 	io/report.cpp io/report.h \
 	io/screen-util.cpp io/screen-util.h \
 	io/signal-handlers.cpp io/signal-handlers.h \
+	io/temp-file.cpp io/temp-file.h \
 	io/tokenizer.cpp io/tokenizer.h \
 	io/uid-checker.cpp io/uid-checker.h \
 	io/write-diary.cpp io/write-diary.h \

--- a/src/io/temp-file.cpp
+++ b/src/io/temp-file.cpp
@@ -1,0 +1,116 @@
+#include "io/temp-file.h"
+#include "locale/language-switcher.h"
+#include "system/angband-exceptions.h"
+#include <cstdio>
+#include <cstdlib>
+#include <fmt/format.h>
+#include <fstream>
+#include <system_error>
+#ifdef _WIN32
+#include <io.h>
+#include <windows.h>
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+TempFile::TempFile()
+{
+    std::error_code ec;
+    const auto temp_dir = std::filesystem::temp_directory_path(ec);
+    if (ec) {
+        constexpr auto fmt = _("一時ファイル格納先フォルダの取得に失敗しました: {}", "Failed to get temporary directory path: {}");
+        this->error_message = fmt::format(fmt, ec.message());
+        return;
+    }
+
+#ifdef _WIN32
+    wchar_t temp_file_path[MAX_PATH]{};
+    if (GetTempFileNameW(temp_dir.wstring().data(), L"tmp", 0, temp_file_path) == 0) {
+        this->error_message = _("一時ファイルの作成に失敗しました", "Failed to create temporary file name");
+        return;
+    }
+
+    this->path = temp_file_path;
+#else
+    auto temp_file_path = (temp_dir / "tempfile_XXXXXX").string();
+    const auto fd = mkstemp(&temp_file_path[0]);
+    if (fd == -1) {
+        constexpr auto fmt = _("一時ファイルの作成に失敗しました: {}", "Failed to create temporary file name: {}");
+        this->error_message = fmt::format(fmt, temp_file_path);
+        return;
+    }
+
+    fchmod(fd, S_IRUSR | S_IWUSR);
+    close(fd);
+    this->path = temp_file_path;
+#endif
+}
+
+TempFile::TempFile(const std::filesystem::path &path)
+    : path(path)
+{
+}
+
+TempFile::~TempFile()
+{
+    if (!this->path.empty()) {
+        std::error_code ec;
+        std::filesystem::remove(this->path, ec);
+    }
+}
+
+const std::filesystem::path &TempFile::get_path() const
+{
+    return this->path;
+}
+
+const tl::optional<std::string> &TempFile::get_error_message() const
+{
+    return this->error_message;
+}
+
+/*!
+ * @details 日本語版ならばシフトJIS or EUC-JPでエンコードされた文字列しか書き込まないはずなので、再び読み込む時は何もしない.
+ */
+std::vector<std::string> TempFile::read_all()
+{
+    constexpr auto fmt = _("一時ファイルの読み込みに失敗しました: {}", "Failed to read contents of the temporary file: {}");
+    std::ifstream ifs(this->path);
+    if (!ifs) {
+        this->error_message = fmt::format(fmt, this->path.string());
+        return {};
+    }
+
+    std::vector<std::string> lines;
+    std::string line;
+    while (std::getline(ifs, line)) {
+        lines.push_back(line);
+    }
+
+    if (ifs.bad() || (ifs.fail() && !ifs.eof())) {
+        this->error_message = fmt::format(fmt, this->path.string());
+        return {};
+    }
+
+    return lines;
+}
+
+void TempFile::write_lines(const std::vector<std::string> &lines)
+{
+    constexpr auto fmt = _("一時ファイルの書き込みに失敗しました: {}", "Failed to write contents of the temporary file: {}");
+    std::ofstream ofs(this->path, std::ios::app);
+    if (!ofs) {
+        this->error_message = fmt::format(fmt, this->path.string());
+        return;
+    }
+
+    for (const auto &line : lines) {
+        ofs << line << '\n';
+    }
+
+    if (ofs.fail()) {
+        this->error_message = fmt::format(fmt, this->path.string());
+        return;
+    }
+}

--- a/src/io/temp-file.h
+++ b/src/io/temp-file.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <tl/optional.hpp>
+#include <vector>
+
+class TempFile {
+public:
+    TempFile();
+    TempFile(const std::filesystem::path &path);
+    TempFile(const TempFile &) = delete;
+    TempFile(TempFile &&) = delete;
+    TempFile &operator=(const TempFile &) = delete;
+    TempFile &operator=(TempFile &&) = delete;
+    ~TempFile();
+
+    const std::filesystem::path &get_path() const;
+    const tl::optional<std::string> &get_error_message() const;
+    std::vector<std::string> read_all();
+    void write_lines(const std::vector<std::string> &lines);
+
+private:
+    std::filesystem::path path;
+    tl::optional<std::string> error_message;
+};

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -13,6 +13,7 @@
 #include "inventory/inventory-slot-types.h"
 #include "io-dump/dump-util.h"
 #include "io/input-key-acceptor.h"
+#include "io/temp-file.h"
 #include "knowledge/item-group-table.h"
 #include "object-enchant/special-object-flags.h"
 #include "object/tval-types.h"
@@ -33,6 +34,7 @@
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include "world/world.h"
+#include <fmt/format.h>
 #include <numeric>
 #include <set>
 #include <vector>
@@ -91,27 +93,32 @@ auto collect_known_fixed_artifacts(CreatureEntity &creature)
  */
 void do_cmd_knowledge_artifacts(CreatureEntity &creature)
 {
-    FILE *fff = nullptr;
-    GAME_TEXT file_name[FILE_NAME_SIZE];
-    if (!open_temporary_file(&fff, file_name)) {
+    TempFile temp_file;
+    if (const auto &error_message = temp_file.get_error_message(); error_message) {
+        msg_print(*error_message);
         return;
     }
 
+    std::vector<std::string> lines;
     const auto &artifacts = ArtifactList::get_instance();
     const auto fa_ids = collect_known_fixed_artifacts(creature);
     for (const auto fa_id : fa_ids) {
         const auto &artifact = artifacts.get_artifact(fa_id);
-        constexpr auto template_basename = _("     %s\n", "     The %s\n");
+        constexpr auto template_basename = _("     {}", "     The {}");
         ItemEntity item(artifact.bi_key);
         item.fa_id = fa_id;
         item.ident.set(IdentificationFlag::STORE);
         const auto item_name = describe_flavor(creature, item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-        fprintf(fff, template_basename, item_name.data());
+        lines.push_back(fmt::format(template_basename, item_name));
     }
 
-    angband_fclose(fff);
-    FileDisplayer(creature.name).display(true, file_name, 0, 0, _("既知の伝説のアイテム", "Artifacts Seen"));
-    fd_kill(file_name);
+    temp_file.write_lines(lines);
+    if (const auto &error_message = temp_file.get_error_message(); error_message) {
+        msg_print(*error_message);
+        return;
+    }
+
+    FileDisplayer(creature.name).display(true, temp_file.get_path().string(), 0, 0, _("既知の伝説のアイテム", "Artifacts Seen"));
 }
 
 /*!


### PR DESCRIPTION
変愚蛮怒 PR #5420 の内容を bakabakaband 構造に適応してマージ。

一時ファイルの作成・読み書き・自動削除を RAII で管理する TempFile クラス
(io/temp-file.{cpp,h}) を新設し、do_cmd_knowledge_artifacts() の一時ファイル 処理を差し替え。作成失敗時はエラーメッセージを表示して中断する。

- io/temp-file.{cpp,h} を新規追加 (作成失敗時に error_message を保持、 デストラクタでファイルを自動削除)
- knowledge-items.cpp の do_cmd_knowledge_artifacts() を TempFile ベースに 書き換え (open_temporary_file/fprintf/angband_fclose/fd_kill を廃し、 行を vector に集約して write_lines、表示は get_path() 経由)
- Makefile.am / VisualStudio プロジェクトに temp-file を登録

bakabakaband 適応:
- do_cmd_knowledge_artifacts() は既に CreatureEntity & 化済みのため player_ptr → creature を維持
- STORE 識別フラグ設定は bakabakaband の EnumClassFlagGroup 形式 (item.ident.set(IdentificationFlag::STORE)) を維持

上流コミット: 1466ea667 / 77f3d41fd / 9008d194b (hengband/develop)