### PR TITLE
fix: 神王アンナタールの御目(id=270)から ACTIVATE フラグを除去

### DIFF
--- a/lib/edit/ArtifactDefinitions.jsonc
+++ b/lib/edit/ArtifactDefinitions.jsonc
@@ -9976,7 +9976,6 @@
       "ac_bonus": 0,
       "flags": [
         "FULL_NAME",
-        "ACTIVATE",
         "SEE_INVIS",
         "RES_BLIND",
         "HOLD_EXP",

--- a/lib/edit/ArtifactDefinitions.txt
+++ b/lib/edit/ArtifactDefinitions.txt
@@ -4535,7 +4535,7 @@ E:the Eye of Annatar the God Lord.
 I:39:12:5
 W:105:150:5:180000
 P:40:1d1:0:0:0
-F:FULL_NAME | ACTIVATE | SEE_INVIS | RES_BLIND | HOLD_EXP | RES_NETHER | RES_CHAOS | RES_NEXUS | LITE_3 | 
+F:FULL_NAME | SEE_INVIS | RES_BLIND | HOLD_EXP | RES_NETHER | RES_CHAOS | RES_NEXUS | LITE_3 |
 F:INSTA_ART | WIS | INT | CHR | TELEPATHY
 D:アルダの東側でメルドールの神王とされる「運命を与たう君」アンナタールは、
 D:神々の主宰でありながら、同時に途方もないトリックスターであり、


### PR DESCRIPTION
発動可能フラグ(ACTIVATE)が付与されているが発動内容が未定義のため、
当面 ACTIVATE フラグを外す。jsonc と legacy txt の双方を更新。