### PR TITLE
merge: =gを刻んだアイテムの自動拾いを復旧 (hengband#5442 相当)

### DIFF
--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -299,15 +299,6 @@ bool autopick_new_entry(autopick_type *entry, std::string_view line_input, bool 
         entry->action = act;
         entry->insc = std::move(inscription);
     });
-    if (!previous_flag) {
-        if (sv.empty()) {
-            entry->add(FLG_ITEMS);
-            previous_flag = FLG_ITEMS;
-        }
-
-        return true;
-    }
-
     if (sv.starts_with(':')) {
         sv.remove_prefix(1);
         sv = ltrim_sv(sv);
@@ -321,6 +312,15 @@ bool autopick_new_entry(autopick_type *entry, std::string_view line_input, bool 
         return true;
     }
 #endif
+
+    if (!previous_flag) {
+        if (sv.empty()) {
+            entry->add(FLG_ITEMS);
+            previous_flag = FLG_ITEMS;
+        }
+
+        return true;
+    }
 
     if (sv.empty()) {
         return true;

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -329,13 +329,15 @@ bool is_autopick_match(CreatureEntity &creature, const ItemEntity *o_ptr, const 
         return false;
     }
 
-    if (entry.name[0] == '^') {
-        if (!item_name.starts_with(std::string_view(entry.name).substr(1))) {
-            return false;
-        }
-    } else {
-        if (!str_find(std::string(item_name), entry.name)) {
-            return false;
+    if (!entry.name.empty()) {
+        if (entry.name[0] == '^') {
+            if (!item_name.starts_with(std::string_view(entry.name).substr(1))) {
+                return false;
+            }
+        } else {
+            if (!str_find(std::string(item_name), entry.name)) {
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
変愚蛮怒 PR #5442 を bakabakaband 構造に適応してマージ。

- autopick-entry.cpp: previous_flag 未設定時の早期 return を ':' プレフィックス 処理の後ろへ移動し、=g 等の刻みインスクリプションが復旧するよう修正
- autopick-matcher.cpp: entry.name 参照前に空チェックを追加

上流コミット: 6eb607b252 (hengband/develop)