### PR TITLE
merge: フロアサイズ選択オプションの英語表記を更新 (hengband#5425 相当)

### DIFF
--- a/src/game-option/birth-options.cpp
+++ b/src/game-option/birth-options.cpp
@@ -5,7 +5,7 @@ bool smart_cheat; /* Monsters exploit players weaknesses (*) */
 bool vanilla_town; /* Use 'vanilla' town without quests and wilderness */
 bool lite_town; /* Use 'lite' town without a wilderness */
 bool ironman_shops; /* Stores are permanently closed (*) */
-bool ironman_smallest_floor; /* Always create unusually small dungeon levels (*) */
+bool ironman_smallest_floor; /* Always generate the smallest dungeon floors (*) */
 bool ironman_downward; /* Disable recall and use of up stairs (*) */
 bool ironman_force_arena_floor; /* Always create empty 'on_defeat_arena_monster' levels (*) */
 bool ironman_rooms; /* Always generate very unusual rooms (*) */

--- a/src/game-option/birth-options.h
+++ b/src/game-option/birth-options.h
@@ -7,7 +7,7 @@ extern bool smart_cheat; /* Monsters exploit players weaknesses (*) */
 extern bool vanilla_town; /* Use 'vanilla' town without quests and wilderness */
 extern bool lite_town; /* Use 'lite' town without a wilderness */
 extern bool ironman_shops; /* Stores are permanently closed (*) */
-extern bool ironman_smallest_floor; /* Always create unusually small dungeon levels (*) */
+extern bool ironman_smallest_floor; /* Always generate the smallest dungeon floors (*) */
 extern bool ironman_downward; /* Disable recall and use of up stairs (*) */
 extern bool ironman_force_arena_floor; /* Always create empty 'on_defeat_arena_monster' levels (*) */
 extern bool ironman_rooms; /* Always generate very unusual rooms (*) */

--- a/src/game-option/option-types-table.cpp
+++ b/src/game-option/option-types-table.cpp
@@ -190,15 +190,15 @@ const std::vector<GameOption> option_info = validate_option_info({
 
     { &expand_list, true, GameOptionType::EXPAND_LIST, "expand_list", _("「一覧」コマンドを拡張する", "Expand the power of the list commands"), GameOptionPage::GAMEPLAY },
 
-    { &allow_smallest_floor, true, GameOptionType::ALLOW_SMALLEST_FLOOR, "allow_smallest_floor", _("非常に小さいフロアの生成を可能にする", "Allow unusually small dungeon levels"), GameOptionPage::GAMEPLAY },
+    { &allow_smallest_floor, true, GameOptionType::ALLOW_SMALLEST_FLOOR, "allow_smallest_floor", _("非常に小さいフロアの生成を可能にする", "Allow extremely small floor"), GameOptionPage::GAMEPLAY },
 
     { &always_small_floor, false, GameOptionType::ALWAYS_SMALL_FLOOR, "always_small_floor",
-        _("常に小さめのフロアを生成する", "Always create unusually small dungeon levels"), GameOptionPage::GAMEPLAY },
+        _("常に小さめのフロアを生成する", "Always generate small dungeon floor"), GameOptionPage::GAMEPLAY },
 
-    { &allow_largest_floor, false, GameOptionType::ALLOW_LARGEST_FLOOR, "allow_largest_floor", _("非常に大きいフロアの生成を可能にする", "Allow unusually large dungeon levels"), GameOptionPage::GAMEPLAY },
+    { &allow_largest_floor, false, GameOptionType::ALLOW_LARGEST_FLOOR, "allow_largest_floor", _("非常に大きいフロアの生成を可能にする", "Allow extremely large floor"), GameOptionPage::GAMEPLAY },
 
     { &always_large_floor, false, GameOptionType::ALWAYS_LARGE_FLOOR, "always_large_floor",
-        _("常に大きめのフロアを生成する", "Always create unusually large dungeon levels"), GameOptionPage::GAMEPLAY },
+        _("常に大きめのフロアを生成する", "Always generate large dungeon floor"), GameOptionPage::GAMEPLAY },
 
     { &allow_arena_floor, true, GameOptionType::ALLOW_ARENA_FLOOR, "allow_arena_floor", _("空っぽの「アリーナ」レベルの生成を可能にする", "Allow empty 'arena' levels"), GameOptionPage::GAMEPLAY },
 
@@ -272,7 +272,7 @@ const std::vector<GameOption> option_info = validate_option_info({
     { &ironman_shops, false, GameOptionType::IRONMAN_SHOPS, "ironman_shops", _("(鉄人用)店を使用しない(*)", "Stores are permanently closed (*)"), GameOptionPage::BIRTH },
 
     { &ironman_smallest_floor, false, GameOptionType::IRONMAN_SMALLEST_FLOOR, "ironman_smallest_floor",
-        _("(鉄人用)常に非常に小さいフロアを生成(*)", "Always create unusually small dungeon levels (*)"), GameOptionPage::BIRTH },
+        _("(鉄人用)常に非常に小さいフロアを生成(*)", "Always generate the smallest dungeon floor (*)"), GameOptionPage::BIRTH },
 
     { &ironman_downward, false, GameOptionType::IRONMAN_DOWNWARD, "ironman_downward", _("(鉄人用)帰還と上り階段なし(*)", "Disable recall and use of up stairs (*)"), GameOptionPage::BIRTH },
 


### PR DESCRIPTION
変愚蛮怒 PR #5425 のうち UI 文字列部分を bakabakaband に適応。

- option-types-table.cpp: allow_smallest_floor / allow_largest_floor / always_small_floor / always_large_floor / ironman_smallest_floor の 英語ラベルを上流の改善表記に更新 (例: "Allow unusually small dungeon levels" → "Allow extremely small floor")
- birth-options.{cpp,h}: ironman_smallest_floor のコメントを更新

オプション既定値・日本語表記・help txt は baka 側で既に適応済みのため変更なし。

上流コミット: a4be409272 (hengband/develop)