### PR TITLE
merge: 地形生成時の確率的地形変化 (generation_changes) を実装 (hengband#5393 相当)

### DIFF
--- a/lib/edit/TerrainDefinitions.jsonc
+++ b/lib/edit/TerrainDefinitions.jsonc
@@ -1694,6 +1694,18 @@
         "DESTROYED": "*FLOOR*",
         "SECRET": "QUARTZ_TREASURE",
       },
+      "generation": {
+        "changes": [
+          {
+            "terrain": "QUARTZ_HIDDEN_2",
+            "probability": 4,
+          },
+          {
+            "terrain": "QUARTZ_HIDDEN_3",
+            "probability": 1,
+          },
+        ],
+      },
     },
     {
       "id": 54,
@@ -1753,6 +1765,18 @@
       "interactions": {
         "DESTROYED": "*FLOOR*",
         "ENSECRET": "QUARTZ_HIDDEN",
+      },
+      "generation": {
+        "changes": [
+          {
+            "terrain": "QUARTZ_TREASURE_2",
+            "probability": 4,
+          },
+          {
+            "terrain": "QUARTZ_TREASURE_3",
+            "probability": 1,
+          },
+        ],
       },
     },
     {
@@ -7971,6 +7995,128 @@
       "interactions": {
         "DESTROYED": "*FLOOR*",
         "HIT_TRAP": "*FLOOR*",
+      },
+    },
+    {
+      "id": 341,
+      "key": "QUARTZ_TREASURE_2",
+      "name": {
+        "ja": "豊かな財宝を含有した石英の鉱脈",
+        "en": "quartz vein with rich treasure",
+      },
+      "symbol": {
+        "character": "*",
+        "color": "Orange",
+        "lit": true,
+      },
+      "mimic": null,
+      "map_priority": 2,
+      "DROP_GOLD": "3d3",
+      "flags": [
+        "POWER_20",
+        "REMEMBER",
+        "TUNNEL",
+        "HAS_GOLD",
+        "WALL",
+        "HURT_ROCK",
+        "CAN_PASS",
+        "HURT_DISI",
+      ],
+      "interactions": {
+        "DESTROYED": "*FLOOR*",
+        "ENSECRET": "QUARTZ_HIDDEN_2",
+      },
+    },
+    {
+      "id": 342,
+      "key": "QUARTZ_TREASURE_3",
+      "name": {
+        "ja": "莫大な財宝を含有した石英の鉱脈",
+        "en": "quartz vein with vast treasure",
+      },
+      "symbol": {
+        "character": "*",
+        "color": "Orange",
+        "lit": true,
+      },
+      "mimic": null,
+      "map_priority": 2,
+      "DROP_GOLD": "4d4",
+      "flags": [
+        "POWER_20",
+        "REMEMBER",
+        "TUNNEL",
+        "HAS_GOLD",
+        "WALL",
+        "HURT_ROCK",
+        "CAN_PASS",
+        "HURT_DISI",
+      ],
+      "interactions": {
+        "DESTROYED": "*FLOOR*",
+        "ENSECRET": "QUARTZ_HIDDEN_3",
+      },
+    },
+    {
+      "id": 343,
+      "key": "QUARTZ_HIDDEN_2",
+      "name": {
+        "ja": "石英の鉱脈(隠された豊かな財宝を含有)",
+        "en": "quartz vein with hidden rich treasure",
+      },
+      "symbol": {
+        "character": "%",
+        "color": "White",
+        "lit": true,
+      },
+      "mimic": "QUARTZ_VEIN",
+      "map_priority": 2,
+      "DROP_GOLD": "3d3",
+      "flags": [
+        "POWER_20",
+        "SECRET",
+        "REMEMBER",
+        "TUNNEL",
+        "HAS_GOLD",
+        "WALL",
+        "HURT_ROCK",
+        "CAN_PASS",
+        "HURT_DISI",
+      ],
+      "interactions": {
+        "DESTROYED": "*FLOOR*",
+        "SECRET": "QUARTZ_TREASURE_2",
+      },
+    },
+    {
+      "id": 344,
+      "key": "QUARTZ_HIDDEN_3",
+      "name": {
+        "ja": "石英の鉱脈(隠された莫大な財宝を含有)",
+        "en": "quartz vein with hidden vast treasure",
+      },
+      "symbol": {
+        "character": "%",
+        "color": "White",
+        "lit": true,
+      },
+      "mimic": "QUARTZ_VEIN",
+      "map_priority": 2,
+      "DROP_GOLD": "4d4",
+      "flags": [
+        "POWER_20",
+        "SECRET",
+        "REMEMBER",
+        "TUNNEL",
+        "HAS_GOLD",
+        "WALL",
+        "HURT_ROCK",
+        "CAN_PASS",
+        "HURT_DISI",
+      ],
+      "interactions": {
+        "DESTROYED": "*FLOOR*",
+        "SECRET": "QUARTZ_TREASURE_3",
       },
     },
   ],

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -3,6 +3,7 @@
 #include "dungeon/quest-monster-placer.h"
 #include "floor/dungeon-tunnel-util.h"
 #include "floor/floor-allocation-types.h"
+#include "floor/floor-generator.h"
 #include "floor/floor-streams.h"
 #include "floor/geometry.h"
 #include "floor/object-allocator.h"
@@ -604,6 +605,7 @@ tl::optional<std::string> cave_gen(CreatureEntity &creature, tl::optional<uint32
 
     make_aqua_streams(creature, &dd, dungeon);
     make_perm_walls(creature);
+    apply_terrain_generation_changes(floor);
 
     // 環状水路の生成（WATERWAYフラグを持つダンジョンで1/8の確率）
     constexpr int waterway_chance = 8;

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -50,6 +50,7 @@
 #include "system/monrace/monrace-list.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
+#include "term/z-rand.h"
 #include "util/bit-flags-calculator.h"
 #include "util/rng-xoshiro.h"
 #include "view/display-messages.h"
@@ -399,6 +400,37 @@ static tl::optional<std::string> level_gen(CreatureEntity &creature, tl::optiona
     return result;
 }
 
+static FEAT_IDX select_terrain_generation_change(FEAT_IDX terrain_id)
+{
+    const auto &terrain = TerrainList::get_instance().get_terrain(terrain_id);
+    if (terrain.generation_changes.empty()) {
+        return terrain_id;
+    }
+
+    const auto chance = randint1(100);
+    auto cumulative_probability = 0;
+    for (const auto &change : terrain.generation_changes) {
+        cumulative_probability += change.probability;
+        if (chance <= cumulative_probability) {
+            return change.result;
+        }
+    }
+
+    return terrain_id;
+}
+
+/*!
+ * @brief 生成時の確率的な地形変化をフロア全体に適用する (上流 #5393 相当)
+ * @param floor フロアへの参照
+ */
+void apply_terrain_generation_changes(FloorType &floor)
+{
+    for (const auto &pos : floor.get_area()) {
+        auto &grid = floor.get_grid(pos);
+        grid.feat = select_terrain_generation_change(grid.feat);
+    }
+}
+
 /*!
  * @brief フロアに存在する全マスの記憶状態を初期化する / Wipe all unnecessary flags after grid_array generation
  */
@@ -584,6 +616,7 @@ void generate_floor(CreatureEntity &creature)
     const auto is_wild_mode = AngbandWorld::get_instance().is_wild_mode();
     for (int num = 0; true; num++) {
         tl::optional<std::string> why;
+        auto should_apply_terrain_generation_changes = true;
         clear_cave(creature);
         creature.x = creature.y = 0;
         if (floor.inside_arena) {
@@ -600,6 +633,11 @@ void generate_floor(CreatureEntity &creature)
             }
         } else {
             why = level_gen(creature);
+            should_apply_terrain_generation_changes = false;
+        }
+
+        if (!why && should_apply_terrain_generation_changes) {
+            apply_terrain_generation_changes(floor);
         }
 
         if (creature.is_sushi_eater()) {

--- a/src/floor/floor-generator.h
+++ b/src/floor/floor-generator.h
@@ -3,5 +3,6 @@
 class CreatureEntity;
 class FloorType;
 void wipe_generate_random_floor_flags(FloorType &floor);
+void apply_terrain_generation_changes(FloorType &floor);
 void clear_cave(CreatureEntity &creature);
 void generate_floor(CreatureEntity &creature);

--- a/src/info-reader/terrain-reader.cpp
+++ b/src/info-reader/terrain-reader.cpp
@@ -89,6 +89,58 @@ static errr set_terrain_symbol(const nlohmann::json &symbol_obj, TerrainType &te
 }
 
 /*!
+ * @brief 生成時の確率的地形変化 (generation.changes) を読み取る (上流 #5393 相当)
+ * @param generation_obj generation を表す JSON 値
+ * @param terrain 地形情報への参照
+ * @return エラーコード
+ */
+static errr set_terrain_generation(const nlohmann::json &generation_obj, TerrainType &terrain)
+{
+    if (generation_obj.is_null()) {
+        return PARSE_ERROR_NONE;
+    }
+    if (!generation_obj.is_object()) {
+        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    }
+
+    const auto &changes_obj = generation_obj["changes"];
+    if (!changes_obj.is_array()) {
+        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    }
+
+    auto probability_sum = 0;
+    for (const auto &change_obj : changes_obj) {
+        if (!change_obj.is_object()) {
+            return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+        }
+
+        const auto &terrain_obj = change_obj["terrain"];
+        if (!terrain_obj.is_string()) {
+            return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+        }
+
+        auto change = TerrainGenerationChange{};
+        change.result_tag = terrain_obj.get<std::string>();
+        if (change.result_tag.empty()) {
+            return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+        }
+
+        if (auto err = info_set_integer(change_obj["probability"], change.probability, true, Range(1, 100))) {
+            return err;
+        }
+
+        probability_sum += change.probability;
+        if (probability_sum > 100) {
+            return PARSE_ERROR_INVALID_FLAG;
+        }
+
+        terrain.generation_changes.push_back(change);
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
+/*!
  * @brief JSON Object から地形情報を 1 エントリ分読み取る
  * @param element 地形情報の JSON Object
  * @param head 使用しない
@@ -135,6 +187,7 @@ errr parse_terrains_json_info(nlohmann::json &element, angband_header *)
     terrain.mimic = s;
     terrain.destroyed = s;
     terrain.gold_drop = Dice{};
+    terrain.generation_changes.clear();
     terrain.door_power = 0;
     terrain.trap_power = 0;
     terrain.tunnel_power = 0;
@@ -244,6 +297,11 @@ errr parse_terrains_json_info(nlohmann::json &element, angband_header *)
 
     // 財宝地形 (HAS_GOLD) を掘った際に生成する財宝数 (省略時は従来通り 1 個)
     if (auto err = info_set_dice(element["DROP_GOLD"], terrain.gold_drop, false)) {
+        return err;
+    }
+
+    // 生成時の確率的地形変化 (上流 #5393 相当)
+    if (auto err = set_terrain_generation(element["generation"], terrain)) {
         return err;
     }
 

--- a/src/system/terrain/terrain-definition.h
+++ b/src/system/terrain/terrain-definition.h
@@ -12,6 +12,8 @@
 #include "view/display-symbol.h"
 #include <cstdint>
 #include <map>
+#include <string>
+#include <vector>
 
 /* Number of feats we change to (Excluding default). Used in TerrainDefinitions.txt. */
 constexpr auto MAX_FEAT_STATES = 8;
@@ -30,6 +32,14 @@ enum class TerrainAction {
     NO_DROP = 2,
     CRASH_GLASS = 3,
     MAX,
+};
+
+class TerrainGenerationChange {
+public:
+    TerrainGenerationChange() = default;
+    std::string result_tag{}; /*!< 生成時の変化先地形タグ */
+    FEAT_IDX result{}; /*!< 生成時の変化先地形ID */
+    int probability{}; /*!< 変化確率(%) */
 };
 
 /*!
@@ -87,6 +97,7 @@ public:
     FEAT_IDX random_change = 0; /*!< ランダム変化先地形ID */
 
     Dice gold_drop{}; /*!< 財宝地形 (HAS_GOLD) を掘った際に生成する財宝数 (上流 #5393 相当) */
+    std::vector<TerrainGenerationChange> generation_changes; /*!< 生成時の変化候補 (上流 #5393 相当) */
 
     static bool has(TerrainCharacteristics tc, TerrainAction ta);
 

--- a/src/system/terrain/terrain-list.cpp
+++ b/src/system/terrain/terrain-list.cpp
@@ -111,6 +111,9 @@ void TerrainList::retouch()
         for (auto &ts : terrain.state) {
             ts.result = this->search_real_terrain(ts.result_tag).value_or(ts.result);
         }
+        for (auto &change : terrain.generation_changes) {
+            change.result = this->search_real_terrain(change.result_tag).value_or(change.result);
+        }
         // ランダム変化先タグの解決
         if (!terrain.random_change_tag.empty()) {
             terrain.random_change = this->search_real_terrain(terrain.random_change_tag).value_or(0);


### PR DESCRIPTION
変愚蛮怒 PR #5393 のうち、財宝ドロップ数定義 (gold_drop) は baka に導入済みの ため、未実装だった「生成時の確率的地形変化」機能を移植。

エンジン:
- TerrainGenerationChange クラスと TerrainType::generation_changes を追加
- terrain-reader.cpp: JSON "generation":{"changes":[{terrain,probability}]} を 読み取る set_terrain_generation() を追加
- terrain-list.cpp retouch(): generation_changes のタグ→ID 解決を追加
- floor-generator.cpp: select_terrain_generation_change() / apply_terrain_generation_changes() を実装。cave_gen 経路は cave-generator.cpp 内で適用、その他フロア種別は generate_floor() で適用 (二重適用防止フラグ付き)。PlayerType* は baka の CreatureEntity& 化済み シグネチャに合わせて適応

データ (TerrainDefinitions.jsonc):
- 上流の新規地形 ID 240-243 は baka が既に使用済み (240-340) のため衝突回避で ID 341-344 に再割当て
- 石英鉱脈の上位ティア QUARTZ_TREASURE_2/3・QUARTZ_HIDDEN_2/3 を追加。gold は baka の既存鉱脈 (QUARTZ_TREASURE=2d2) より上位になるよう 3d3/4d4 に調整
- QUARTZ_HIDDEN / QUARTZ_TREASURE に generation テーブル (4%/1%) を付与
- 上流は interactions 内に DROP_GOLD を持つが baka はトップレベル DROP_GOLD
  + interactions(SECRET/ENSECRET/DESTROYED) 形式のため schema を適応
- baka に schema/TerrainDefinitions.schema.json は存在しないため schema 変更は対象外

上流コミット: f3c2e1236e (hengband/develop)