### PR TITLE
merge: 街リストの TownList クラス化と TownInfo::name の private 化（hengband#5411部分相当）

### DIFF
--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -174,7 +174,7 @@ void player_birth(CreatureEntity &creature, std::optional<QuestId> initial_quest
     }
 
     write_birth_diary(creature);
-    for (size_t i = 1; i < towns_info.size(); i++) {
+    for (size_t i = 1; i < TownList::get_instance().size(); i++) {
         for (auto sst : STORE_SALE_TYPE_LIST) {
             store_init(i, sst);
         }

--- a/src/cmd-io/cmd-dump.cpp
+++ b/src/cmd-io/cmd-dump.cpp
@@ -252,7 +252,7 @@ void do_cmd_feeling(CreatureEntity &creature)
     }
 
     if (creature.get_town_num() && !floor.is_underground()) {
-        if (towns_info[creature.get_town_num()].name == _("荒野", "wilderness")) {
+        if (TownList::get_instance().get_town(creature.get_town_num()).get_name() == _("荒野", "wilderness")) {
             msg_print(_("何かありそうな荒野のようだ。", "Looks like a strange wilderness."));
             return;
         }

--- a/src/core/turn-compensator.cpp
+++ b/src/core/turn-compensator.cpp
@@ -6,7 +6,6 @@
 #include "store/store.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
-#include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
 #include "system/inner-game-data.h"
 #include "system/item-entity.h"
@@ -54,9 +53,10 @@ void prevent_turn_overflow(CreatureEntity &creature)
         df.set_turns(1);
     }
 
-    for (size_t i = 1; i < towns_info.size(); i++) {
+    auto &towns = TownList::get_instance();
+    for (size_t i = 1; i < towns.size(); i++) {
         for (auto sst : STORE_SALE_TYPE_LIST) {
-            auto &store = towns_info[i].get_store(sst);
+            auto &store = towns.get_town(i).get_store(sst);
             if (store.last_visit > -10L * TURNS_PER_TICK * STORE_TICKS) {
                 store.last_visit -= rollback_turns;
                 if (store.last_visit < -10L * TURNS_PER_TICK * STORE_TICKS) {

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -22,7 +22,6 @@
 #include "system/creature-entity.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/floor/floor-info.h"
-#include "system/floor/town-info.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"

--- a/src/floor/floor-util.cpp
+++ b/src/floor/floor-util.cpp
@@ -191,7 +191,7 @@ std::string map_name(CreatureEntity &creature)
     } else if (AngbandSystem::get_instance().is_phase_out()) {
         return _("闘技場", "Monster Arena");
     } else if (!floor.is_underground() && creature.get_town_num()) {
-        return towns_info[creature.get_town_num()].name;
+        return TownList::get_instance().get_town(creature.get_town_num()).get_name();
     } else {
         return floor.get_dungeon_definition().name;
     }

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -40,7 +40,6 @@
 #include "system/enums/terrain/terrain-tag.h"
 #include "system/enums/terrain/wilderness-terrain.h"
 #include "system/floor/floor-info.h"
-#include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
 #include "system/floor/wilderness-grid.h"
 #include "system/grid-type-definition.h"
@@ -741,7 +740,7 @@ tl::expected<Pos2D, parse_error_type> parse_line_wilderness(char *line, int xmin
             int id = s[0];
             const auto &letter = letters.get_grid(id);
             wilderness.get_grid(pos).initialize(letter);
-            towns_info[letter.get_town()].name = letter.get_name();
+            TownList::get_instance().get_town(letter.get_town()).init_name(letter.get_name());
         }
 
         pos.y++;

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -31,7 +31,6 @@
 #include "system/building-type-definition.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
-#include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
 #include "system/inner-game-data.h"
 #include "system/item-entity.h"
@@ -531,7 +530,8 @@ static void dump_aux_equipment_inventory(CreatureEntity &creature, FILE *fff)
  */
 static void dump_aux_home_museum(CreatureEntity &creature, FILE *fff)
 {
-    const auto &home = towns_info[1].get_store(StoreSaleType::HOME);
+    const auto &outpost = TownList::get_instance().get_town(1);
+    const auto &home = outpost.get_store(StoreSaleType::HOME);
     if (home.stock_num) {
         fmt::println(fff, _("  [我が家のアイテム]", "  [Home Inventory]"));
         auto page = 1;
@@ -547,7 +547,7 @@ static void dump_aux_home_museum(CreatureEntity &creature, FILE *fff)
         fmt::println(fff, "\n");
     }
 
-    const auto &museum = towns_info[1].get_store(StoreSaleType::MUSEUM);
+    const auto &museum = outpost.get_store(StoreSaleType::MUSEUM);
     if (museum.stock_num == 0) {
         return;
     }

--- a/src/io-dump/random-art-info-dumper.cpp
+++ b/src/io-dump/random-art-info-dumper.cpp
@@ -92,13 +92,13 @@ void spoil_random_artifact(CreatureEntity &creature)
                 spoil_random_artifact_aux(creature, item, tval, ofs);
             }
 
-            const auto &home = towns_info[1].get_store(StoreSaleType::HOME);
+            const auto &home = TownList::get_instance().get_town(1).get_store(StoreSaleType::HOME);
             for (int i = 0; i < home.stock_num; i++) {
                 auto &item = *home.stock[i];
                 spoil_random_artifact_aux(creature, item, tval, ofs);
             }
 
-            const auto &museum = towns_info[1].get_store(StoreSaleType::MUSEUM);
+            const auto &museum = TownList::get_instance().get_town(1).get_store(StoreSaleType::MUSEUM);
             for (int i = 0; i < museum.stock_num; i++) {
                 auto &item = *museum.stock[i];
                 spoil_random_artifact_aux(creature, item, tval, ofs);

--- a/src/io/screen-util.cpp
+++ b/src/io/screen-util.cpp
@@ -24,7 +24,6 @@
 #include "player-info/mimic-info-table.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/floor/floor-info.h"
-#include "system/floor/town-info.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/target-checker.h"

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -225,7 +225,7 @@ static int show_holding_equipment_resistances(CreatureEntity &creature, ItemKind
 static int show_home_equipment_resistances(CreatureEntity &creature, ItemKindType tval, int label_number_initial, FILE *fff)
 {
     auto label_number = label_number_initial;
-    const auto &store = towns_info[1].get_store(StoreSaleType::HOME);
+    const auto &store = TownList::get_instance().get_town(1).get_store(StoreSaleType::HOME);
     for (short i = 0; i < store.stock_num; i++) {
         const auto &item = *store.stock[i];
         if (!item.has_knowledge(tval)) {

--- a/src/knowledge/knowledge-self.cpp
+++ b/src/knowledge/knowledge-self.cpp
@@ -199,7 +199,7 @@ void do_cmd_knowledge_home(CreatureEntity &creature)
     }
 
     constexpr auto home_inventory = _("我が家のアイテム", "Home Inventory");
-    const auto &store = towns_info[1].get_store(StoreSaleType::HOME);
+    const auto &store = TownList::get_instance().get_town(1).get_store(StoreSaleType::HOME);
     if (store.stock_num == 0) {
         angband_fclose(fff);
         FileDisplayer(creature.name).display(true, file_name, 0, 0, home_inventory);

--- a/src/load/quest-loader.cpp
+++ b/src/load/quest-loader.cpp
@@ -8,19 +8,19 @@
 #include "object-enchant/trg-types.h"
 #include "system/artifact-type-definition.h"
 #include "system/floor/floor-info.h"
-#include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
 #include "system/monrace/monrace-definition.h"
 #include "util/enum-converter.h"
+#include <fmt/format.h>
 
 errr load_town(void)
 {
-    auto max_towns_load = rd_u16b();
-    if (max_towns_load <= towns_info.size()) {
+    size_t max_towns_load = rd_u16b();
+    if (max_towns_load <= TownList::get_instance().size()) {
         return 0;
     }
 
-    load_note(format(_("町が多すぎる(%u)！", "Too many (%u) towns!"), max_towns_load));
+    load_note(fmt::format(_("町が多すぎる({})！", "Too many ({}) towns!"), max_towns_load));
     return 23;
 }
 

--- a/src/load/store-loader.cpp
+++ b/src/load/store-loader.cpp
@@ -65,7 +65,7 @@ static void home_carry_load(CreatureEntity &creature, Store *store_ptr, ItemEnti
 static void rd_store(CreatureEntity &creature, int town_number_initial, StoreSaleType store_number)
 {
     const auto town_number = town_number_initial;
-    auto &store = towns_info[town_number].get_store(store_number);
+    auto &store = TownList::get_instance().get_town(town_number).get_store(store_number);
     auto sort = store.stock_num > 0;
     store.store_open = rd_s32b();
     store.insult_cur = rd_s16b();

--- a/src/main-unix/unix-music.cpp
+++ b/src/main-unix/unix-music.cpp
@@ -1,4 +1,3 @@
-
 /*!
  * @file unix-music.cpp
  * @brief unix用のBGM処理
@@ -35,7 +34,6 @@
 #include "main/sound-of-music.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/dungeon/dungeon-list.h"
-#include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
 #include "system/monrace/monrace-list.h"
 #include "term/z-term.h"
@@ -131,7 +129,7 @@ static tl::optional<std::string> quest_key_at(int index)
  */
 static tl::optional<std::string> town_key_at(int index)
 {
-    if (index >= static_cast<int>(towns_info.size())) {
+    if (index >= static_cast<int>(TownList::get_instance().size())) {
         return tl::nullopt;
     }
 

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -16,7 +16,6 @@
 #include "main/sound-of-music.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/dungeon/dungeon-list.h"
-#include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
 #include "system/monrace/monrace-list.h"
 #include "term/z-term.h"
@@ -99,7 +98,7 @@ static tl::optional<std::string> quest_key_at(int index)
  */
 static tl::optional<std::string> town_key_at(int index)
 {
-    if (index >= static_cast<int>(towns_info.size())) {
+    if (index >= static_cast<int>(TownList::get_instance().size())) {
         return tl::nullopt;
     }
 

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -27,6 +27,7 @@
 #include "system/angband-system.h"
 #include "system/creature-entity.h"
 #include "system/dungeon/dungeon-definition.h"
+#include "system/floor/town-list.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/services/baseitem-monrace-service.h"
 #include "system/system-variables.h"
@@ -227,7 +228,7 @@ void init_angband(CreatureEntity &creature, bool no_term)
     init_wilderness();
 
     init_note(_("[配列を初期化しています... (街)]", "[Initializing arrays... (towns)]"));
-    init_towns();
+    TownList::get_instance().initialize();
 
     init_note(_("[配列を初期化しています... (建物)]", "[Initializing arrays... (buildings)]"));
     init_buildings();

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -37,6 +37,7 @@
 #include "system/creature-party/creature-party-list.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/dungeon/dungeon-list.h"
+#include "system/floor/town-list.h"
 #include "system/floor/wilderness-grid.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"

--- a/src/market/building-initializer.cpp
+++ b/src/market/building-initializer.cpp
@@ -1,109 +1,30 @@
 #include "market/building-initializer.h"
-#include "io/files-util.h"
 #include "player-info/class-types.h"
+#include "player-info/race-types.h"
 #include "realm/realm-types.h"
-#include "store/articles-on-sale.h"
-#include "store/store-owners.h"
-#include "store/store-util.h"
-#include "store/store.h"
-#include "system/angband.h"
-#include "system/baseitem/baseitem-definition.h"
-#include "system/baseitem/baseitem-list.h"
 #include "system/building-type-definition.h"
-#include "system/floor/town-info.h"
-#include "system/floor/town-list.h"
-#include "system/item-entity.h"
-#include "util/angband-files.h"
-#include <filesystem>
-#include <set>
-#include <utility>
-#include <vector>
 
 /*!
- * @brief ユニークな町の数を数える
- * @return ユニークな町の数
- * @details 町定義ファイル名の先頭2文字は番号であることを利用してカウントする.
- * 辺境の地を表すファイルは(01_*.txt) は3つあるのでユニークではない. また町番号は1から始まるので最後に加算する.
+ * @brief 店情報初期化のメインルーチン
  */
-static int count_town_numbers()
-{
-    const auto path = path_build(ANGBAND_DIR_EDIT, "towns");
-    std::set<std::string> unique_towns;
-    for (const auto &entry : std::filesystem::directory_iterator(path)) {
-        const auto &filename = entry.path().filename().string();
-        if (!filename.ends_with(".txt")) {
-            continue;
-        }
-
-        unique_towns.insert(filename.substr(0, 2));
-    }
-
-    return unique_towns.size() + 1;
-}
-
-/*!
- * @brief 町情報読み込みのメインルーチン /
- * Initialize town array
- * @details 「我が家を拡張する」オプションのON/OFFとは無関係に、ON時の容量を確保しておく.
- */
-void init_towns(void)
-{
-    const auto &baseitems = BaseitemList::get_instance();
-    const auto town_numbers = count_town_numbers();
-    towns_info = std::vector<TownInfo>(town_numbers);
-    for (auto i = 1; i < town_numbers; i++) {
-        auto &town = towns_info[i];
-        for (auto sst : STORE_SALE_TYPE_LIST) {
-            auto &store = town.emplace(sst);
-            if ((i > 1) && (sst == StoreSaleType::MUSEUM || sst == StoreSaleType::HOME)) {
-                continue;
-            }
-
-            store.stock_size = store_get_stock_max(sst);
-            std::vector<std::unique_ptr<ItemEntity>> stock;
-            for (auto j = 0; j < store.stock_size; j++) {
-                stock.push_back(std::make_unique<ItemEntity>());
-            }
-
-            store.stock = std::move(stock);
-            if ((sst == StoreSaleType::BLACK) || (sst == StoreSaleType::HOME) || (sst == StoreSaleType::MUSEUM)) {
-                continue;
-            }
-
-            for (const auto &bi_key : store_regular_sale_table.at(sst)) {
-                const auto bi_id = baseitems.lookup_baseitem_id(bi_key);
-                store.regular.push_back(bi_id);
-            }
-
-            for (const auto &bi_key : store_sale_table.at(sst)) {
-                const auto bi_id = baseitems.lookup_baseitem_id(bi_key);
-                store.table.push_back(bi_id);
-            }
-        }
-    }
-}
-
-/*!
- * @brief 店情報初期化のメインルーチン /
- * Initialize buildings
- */
-void init_buildings(void)
+void init_buildings()
 {
     for (auto i = 0; i < MAX_BUILDINGS; i++) {
-        buildings[i].name[0] = '\0';
-        buildings[i].owner_name[0] = '\0';
-        buildings[i].owner_race[0] = '\0';
+        auto &building = buildings[i];
+        building.name[0] = '\0';
+        building.owner_name[0] = '\0';
+        building.owner_race[0] = '\0';
         for (auto j = 0; j < 8; j++) {
-            buildings[i].act_names[j][0] = '\0';
-            buildings[i].member_costs[j] = 0;
-            buildings[i].other_costs[j] = 0;
-            buildings[i].letters[j] = 0;
-            buildings[i].actions[j] = 0;
-            buildings[i].action_restr[j] = 0;
+            building.act_names[j][0] = '\0';
+            building.member_costs[j] = 0;
+            building.other_costs[j] = 0;
+            building.letters[j] = 0;
+            building.actions[j] = 0;
+            building.action_restr[j] = 0;
         }
 
-        buildings[i].member_class.assign(PLAYER_CLASS_TYPE_MAX, static_cast<short>(PlayerClassType::WARRIOR));
-        buildings[i].member_race.assign(MAX_RACES, static_cast<short>(PlayerRaceType::HUMAN));
-        buildings[i].member_realm.assign(MAX_MAGIC + 1, 0);
+        building.member_class.assign(PLAYER_CLASS_TYPE_MAX, static_cast<short>(PlayerClassType::WARRIOR));
+        building.member_race.assign(MAX_RACES, static_cast<short>(PlayerRaceType::HUMAN));
+        building.member_realm.assign(MAX_MAGIC + 1, 0);
     }
 }

--- a/src/market/building-initializer.h
+++ b/src/market/building-initializer.h
@@ -1,4 +1,3 @@
 #pragma once
 
-void init_towns(void);
-void init_buildings(void);
+void init_buildings();

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -317,8 +317,8 @@ static void inventory_aware(CreatureEntity &creature)
  */
 static void home_aware(CreatureEntity &creature)
 {
-    for (size_t i = 1; i < towns_info.size(); i++) {
-        const auto &store = towns_info[i].get_store(StoreSaleType::HOME);
+    for (size_t i = 1; i < TownList::get_instance().size(); i++) {
+        const auto &store = TownList::get_instance().get_town(i).get_store(StoreSaleType::HOME);
         for (auto j = 0; j < store.stock_num; j++) {
             auto &item = *store.stock[j];
             if (!item.is_valid()) {
@@ -366,8 +366,8 @@ static bool show_dead_player_items(CreatureEntity &creature)
  */
 static void show_dead_home_items(CreatureEntity &creature)
 {
-    for (size_t l = 1; l < towns_info.size(); l++) {
-        const auto &store = towns_info[l].get_store(StoreSaleType::HOME);
+    for (size_t l = 1; l < TownList::get_instance().size(); l++) {
+        const auto &store = TownList::get_instance().get_town(l).get_store(StoreSaleType::HOME);
         if (store.stock_num == 0) {
             continue;
         }

--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -26,7 +26,6 @@
 #include "system/dungeon/dungeon-definition.h"
 #include "system/enums/terrain/terrain-tag.h"
 #include "system/floor/floor-info.h"
-#include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"

--- a/src/save/info-writer.cpp
+++ b/src/save/info-writer.cpp
@@ -17,20 +17,20 @@
 #include "world/world.h"
 
 /*!
- * @brief セーブデータに店舗情報を書き込む / Write a "store" record
- * @param store_ptr 店舗情報の参照ポインタ
+ * @brief セーブデータに店舗情報を書き込む
+ * @param store_ptr 店舗情報の参照
  */
-void wr_store(Store *store_ptr)
+void wr_store(const Store &store)
 {
-    wr_u32b(store_ptr->store_open);
-    wr_s16b(store_ptr->insult_cur);
-    wr_byte(store_ptr->owner);
-    wr_s16b(store_ptr->stock_num);
-    wr_s16b(store_ptr->good_buy);
-    wr_s16b(store_ptr->bad_buy);
-    wr_s32b(store_ptr->last_visit);
-    for (int j = 0; j < store_ptr->stock_num; j++) {
-        wr_item(*store_ptr->stock[j]);
+    wr_u32b(store.store_open);
+    wr_s16b(store.insult_cur);
+    wr_byte(store.owner);
+    wr_s16b(store.stock_num);
+    wr_s16b(store.good_buy);
+    wr_s16b(store.bad_buy);
+    wr_s32b(store.last_visit);
+    for (int j = 0; j < store.stock_num; j++) {
+        wr_item(*store.stock[j]);
     }
 }
 

--- a/src/save/info-writer.h
+++ b/src/save/info-writer.h
@@ -3,7 +3,7 @@
 enum class SaveType;
 class Store;
 
-void wr_store(Store *store_ptr);
+void wr_store(const Store &store);
 void wr_randomizer();
 void wr_options();
 void wr_ghost(void);

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -33,7 +33,6 @@
 #include "system/artifact-type-definition.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
-#include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
 #include "system/floor/wilderness-grid.h"
 #include "system/monrace/monrace-list.h"
@@ -118,7 +117,9 @@ static bool wr_savefile_new(CreatureEntity &creature)
         wr_perception(bi_id);
     }
 
-    tmp16u = static_cast<uint16_t>(towns_info.size());
+    const auto &towns = TownList::get_instance();
+    const auto towns_size = static_cast<uint16_t>(towns.size());
+    tmp16u = towns_size;
     wr_u16b(tmp16u);
 
     const auto &quests = QuestList::get_instance();
@@ -215,14 +216,13 @@ static bool wr_savefile_new(CreatureEntity &creature)
     }
 
     wr_u16b(0xFFFF);
-    tmp16u = static_cast<uint16_t>(towns_info.size());
-    wr_u16b(tmp16u);
+    wr_u16b(towns_size);
 
     tmp16u = MAX_STORES;
     wr_u16b(tmp16u);
-    for (size_t i = 1; i < towns_info.size(); i++) {
+    for (uint16_t i = 1; i < towns_size; i++) {
         for (auto sst : STORE_SALE_TYPE_LIST) {
-            wr_store(&towns_info[i].get_store(sst));
+            wr_store(towns.get_town(i).get_store(sst));
         }
     }
 

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -282,13 +282,13 @@ bool tele_town(CreatureEntity &creature)
     clear_bldg(4, 10);
 
     auto num = 0;
-    const int towns_size = towns_info.size();
+    const int towns_size = TownList::get_instance().size();
     for (auto i = 1; i < towns_size; i++) {
         if ((i == VALID_TOWNS) || (i == SECRET_TOWN) || (i == creature.get_town_num()) || !(creature.visit & (1UL << (i - 1)))) {
             continue;
         }
 
-        const auto buf = format("%c) %-20s", I2A(i - 1), towns_info[i].name.data());
+        const auto buf = format("%c) %-20s", I2A(i - 1), TownList::get_instance().get_town(i).get_name().data());
         prt(buf, 5 + i, 5);
         num++;
     }

--- a/src/store/black-market.cpp
+++ b/src/store/black-market.cpp
@@ -1,7 +1,6 @@
 #include "store/black-market.h"
 #include "store/store-owners.h"
 #include "store/store-util.h"
-#include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
 #include "system/item-entity.h"
 
@@ -35,7 +34,7 @@ bool black_market_crap(int town_num, const ItemEntity &item)
         return false;
     }
 
-    const auto &town = towns_info[town_num];
+    const auto &town = TownList::get_instance().get_town(town_num);
     for (auto sst : STORE_SALE_TYPE_LIST) {
         if ((sst == StoreSaleType::HOME) || (sst == StoreSaleType::MUSEUM)) {
             continue;

--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -92,7 +92,7 @@ void do_cmd_store(CreatureEntity &creature, std::optional<StoreSaleType> specifi
     }
 
     inner_town_num = creature.get_town_num();
-    auto &town = towns_info[creature.get_town_num()];
+    auto &town = TownList::get_instance().get_town(creature.get_town_num());
     auto &store = town.get_store(store_num);
     auto &world = AngbandWorld::get_instance();
     if ((store.store_open >= world.game_turn) || ironman_shops) {
@@ -119,7 +119,7 @@ void do_cmd_store(CreatureEntity &creature, std::optional<StoreSaleType> specifi
     command_new = 0;
     get_com_no_macros = true;
     cur_store_feat = grid.feat;
-    st_ptr = &towns_info[creature.get_town_num()].get_store(store_num);
+    st_ptr = &TownList::get_instance().get_town(creature.get_town_num()).get_store(store_num);
     ot_ptr = &owners.at(store_num)[st_ptr->owner];
     store_top = 0;
 

--- a/src/store/home.cpp
+++ b/src/store/home.cpp
@@ -159,7 +159,7 @@ bool combine_and_reorder_home(CreatureEntity &creature, const StoreSaleType stor
     auto old_stack_force_notes = stack_force_notes;
     auto old_stack_force_costs = stack_force_costs;
     auto *old_st_ptr = st_ptr;
-    st_ptr = &towns_info[1].get_store(store_num);
+    st_ptr = &TownList::get_instance().get_town(1).get_store(store_num);
     auto flag = false;
     if (store_num != StoreSaleType::HOME) {
         stack_force_notes = false;

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -14,7 +14,6 @@
 #include "system/dungeon/dungeon-list.h"
 #include "system/dungeon/dungeon-record.h"
 #include "system/enums/dungeon/dungeon-id.h"
-#include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
@@ -113,7 +112,7 @@ public:
         const auto &town_name = tokens[1];
         while (true) {
             this->t_idx = get_rumor_num<int>(town_name, VALID_TOWNS);
-            if (!towns_info[this->t_idx].name.empty()) {
+            if (!TownList::get_instance().get_town(this->t_idx).get_name().empty()) {
                 return;
             }
         }
@@ -195,7 +194,7 @@ public:
 
     void operator()(const TownRumor &town_rumor)
     {
-        const auto &town_name = towns_info[town_rumor.t_idx].name;
+        const auto &town_name = TownList::get_instance().get_town(town_rumor.t_idx).get_name();
         this->print_rumor(town_name);
 
         const uint32_t visit = (1U << (town_rumor.t_idx - 1));

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -179,7 +179,7 @@ void store_sell(CreatureEntity &creature, StoreSaleType store_num)
             }
 
             inven_item_optimize(creature, i_idx);
-            auto &store = towns_info[creature.get_town_num()].get_store(store_num);
+            auto &store = TownList::get_instance().get_town(creature.get_town_num()).get_store(store_num);
             const auto item_pos = store.carry(sold_item);
             if (item_pos) {
                 store_top = (*item_pos / store_bottom) * store_bottom;

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -363,7 +363,7 @@ void store_maintenance(CreatureEntity &creature, int town_num, StoreSaleType sto
         return;
     }
 
-    st_ptr = &towns_info[town_num].get_store(store_num);
+    st_ptr = &TownList::get_instance().get_town(town_num).get_store(store_num);
     ot_ptr = &owners.at(store_num)[st_ptr->owner];
     st_ptr->insult_cur = 0;
     if (store_num == StoreSaleType::BLACK) {
@@ -443,8 +443,8 @@ void store_maintenance(CreatureEntity &creature, int town_num, StoreSaleType sto
 void store_init(int town_num, StoreSaleType store_num)
 {
     int owner_num = owners.at(store_num).size();
-    st_ptr = &towns_info[town_num].get_store(store_num);
-    const int towns_size = towns_info.size();
+    st_ptr = &TownList::get_instance().get_town(town_num).get_store(store_num);
+    const int towns_size = TownList::get_instance().size();
     while (true) {
         st_ptr->owner = randnum0<uint8_t>(owner_num);
 
@@ -457,7 +457,7 @@ void store_init(int town_num, StoreSaleType store_num)
             if (i == town_num) {
                 continue;
             }
-            if (st_ptr->owner == towns_info[i].get_store(store_num).owner) {
+            if (st_ptr->owner == TownList::get_instance().get_town(i).get_store(store_num).owner) {
                 break;
             }
         }

--- a/src/system/floor/town-info.cpp
+++ b/src/system/floor/town-info.cpp
@@ -1,5 +1,15 @@
 #include "system/floor/town-info.h"
 
+void TownInfo::init_name(std::string_view name)
+{
+    this->town_name = name;
+}
+
+const std::string &TownInfo::get_name() const
+{
+    return this->town_name;
+}
+
 Store &TownInfo::get_store(StoreSaleType sst)
 {
     return this->stores.at(sst);

--- a/src/system/floor/town-info.h
+++ b/src/system/floor/town-info.h
@@ -13,12 +13,14 @@ class TownInfo {
 public:
     TownInfo() = default;
 
-    std::string name;
+    void init_name(std::string_view name);
+    const std::string &get_name() const;
 
     Store &get_store(StoreSaleType sst);
     const Store &get_store(StoreSaleType sst) const;
     Store &emplace(StoreSaleType sst);
 
 private:
+    std::string town_name;
     std::map<StoreSaleType, Store> stores;
 };

--- a/src/system/floor/town-list.cpp
+++ b/src/system/floor/town-list.cpp
@@ -1,4 +1,101 @@
 #include "system/floor/town-list.h"
-#include "system/floor/town-info.h"
+#include "io/files-util.h"
+#include "store/articles-on-sale.h"
+#include "store/store.h"
+#include "system/angband-exceptions.h"
+#include "system/baseitem/baseitem-list.h"
+#include "util/angband-files.h"
+#include <filesystem>
+#include <fmt/format.h>
+#include <set>
+#include <string>
 
-std::vector<TownInfo> towns_info;
+namespace {
+/*!
+ * @brief ユニークな町の数を数える
+ * @return ユニークな町の数
+ * @details 町定義ファイル名の先頭2文字は番号であることを利用してカウントする.
+ * 辺境の地を表すファイルは(01_*.txt) は3つあるのでユニークではない. また町番号は1から始まるので最後に加算する.
+ */
+int count_town_numbers()
+{
+    const auto path = path_build(ANGBAND_DIR_EDIT, "towns");
+    std::set<std::string> unique_towns;
+    for (const auto &entry : std::filesystem::directory_iterator(path)) {
+        const auto &filename = entry.path().filename().string();
+        if (!filename.ends_with(".txt")) {
+            continue;
+        }
+
+        unique_towns.insert(filename.substr(0, 2));
+    }
+
+    return unique_towns.size() + 1;
+}
+}
+
+TownList TownList::instance{};
+
+TownList &TownList::get_instance()
+{
+    return instance;
+}
+
+const TownInfo &TownList::get_town(size_t index) const
+{
+    if (index >= this->size()) {
+        THROW_EXCEPTION(std::out_of_range, fmt::format("Invalid town index: {}", index));
+    }
+
+    return this->towns[index];
+}
+
+TownInfo &TownList::get_town(size_t index)
+{
+    if (index >= this->size()) {
+        THROW_EXCEPTION(std::out_of_range, fmt::format("Invalid town index: {}", index));
+    }
+
+    return this->towns[index];
+}
+
+/*!
+ * @brief 町情報読み込みのメインルーチン
+ * @details 「我が家を拡張する」オプションのON/OFFとは無関係に、ON時の容量を確保しておく.
+ */
+void TownList::initialize()
+{
+    const auto &baseitems = BaseitemList::get_instance();
+    const auto town_numbers = count_town_numbers();
+    this->towns = std::vector<TownInfo>(town_numbers);
+    for (auto i = 1; i < town_numbers; i++) {
+        auto &town = this->towns[i];
+        for (auto sst : STORE_SALE_TYPE_LIST) {
+            auto &store = town.emplace(sst);
+            if ((i > 1) && (sst == StoreSaleType::MUSEUM || sst == StoreSaleType::HOME)) {
+                continue;
+            }
+
+            store.stock_size = store_get_stock_max(sst);
+            std::vector<std::unique_ptr<ItemEntity>> stock;
+            for (auto j = 0; j < store.stock_size; j++) {
+                stock.push_back(std::make_unique<ItemEntity>());
+            }
+
+            store.stock = std::move(stock);
+            if ((sst == StoreSaleType::BLACK) || (sst == StoreSaleType::HOME) || (sst == StoreSaleType::MUSEUM)) {
+                continue;
+            }
+
+            for (const auto &bi_key : store_regular_sale_table.at(sst)) {
+                const auto bi_id = baseitems.lookup_baseitem_id(bi_key);
+                store.regular.push_back(bi_id);
+            }
+
+            for (const auto &bi_key : store_sale_table.at(sst)) {
+                const auto bi_id = baseitems.lookup_baseitem_id(bi_key);
+                store.table.push_back(bi_id);
+            }
+        }
+    }
+}

--- a/src/system/floor/town-list.h
+++ b/src/system/floor/town-list.h
@@ -1,9 +1,35 @@
 #pragma once
 
+#include "system/floor/town-info.h"
+#include "util/abstract-vector-wrapper.h"
 #include <vector>
 
 constexpr short VALID_TOWNS = 6; // @details 旧海底都市クエストのマップを除外する. 有効な町に差し替え完了したら不要になるので注意.
 constexpr auto SECRET_TOWN = 5; // @details ズルの町番号.
 
-class TownInfo;
-extern std::vector<TownInfo> towns_info;
+class TownList : public util::AbstractVectorWrapper<TownInfo> {
+public:
+    TownList(TownList &&) = delete;
+    TownList(const TownList &) = delete;
+    TownList &operator=(const TownList &) = delete;
+    TownList &operator=(TownList &&) = delete;
+    ~TownList() = default;
+
+    static TownList &get_instance();
+
+    void initialize();
+
+    const TownInfo &get_town(size_t index) const;
+    TownInfo &get_town(size_t index);
+
+private:
+    TownList() = default;
+
+    static TownList instance;
+    std::vector<TownInfo> towns;
+
+    std::vector<TownInfo> &get_inner_container() override
+    {
+        return this->towns;
+    }
+};

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -25,9 +25,9 @@
 #include "system/enums/grid-flow.h"
 #include "system/enums/terrain/terrain-tag.h"
 #include "system/floor/floor-info.h"
-#include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
 #include "system/grid-type-definition.h"
+#include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/system-variables.h"
 #include "system/terrain/terrain-definition.h"
@@ -520,7 +520,7 @@ static std::string decide_target_floor(CreatureEntity &creature, GridExamination
     }
 
     if (ge_ptr->terrain_ptr->flags.has(TerrainCharacteristics::TOWN)) {
-        return towns_info[ge_ptr->g_ptr->special].name;
+        return TownList::get_instance().get_town(ge_ptr->g_ptr->special).get_name();
     }
 
     if (AngbandWorld::get_instance().is_wild_mode() && (ge_ptr->matches_terrain(TerrainTag::FLOOR))) {


### PR DESCRIPTION
変愚蛮怒 PR #5411 (Add-Initialize-TownName) のうち、構造リファクタ部分を bakabakaband 構造に適応してマージ:
- TownInfo::name を private 化し get_name() / init_name() に集約 (上流 49e3916)
- グローバル towns_info ベクタを TownList クラス (AbstractVectorWrapper 派生・ シングルトン) に作り変え、get_town(index) / size() / initialize() を提供 (上流 ae27547)
- init_towns() を TownList::initialize() に移し、building-initializer から分離
- 全 towns_info[...] アクセスを TownList::get_instance().get_town(...) に変換

bakabakaband 独自方針による不採用:
- PlayerType::town_num の AngbandWorld 移動 (上流 9dec42c) は不採用。baka では town_num は CreatureEntity の private フィールド (get/set_town_num) として維持。
- 街名初期化の起動時移動 (上流 8cd611) および荒野なしオプション修正 (上流 d18112) は不採用。baka は wild.cpp の W:F: 形式パースで既に街名を初期化しており、上流の W:J/W:E 形式 (info-initializer) とはデータ形式・コード経路が非互換のため。

上流コミット: 49e3916, ae27547 (hengband/develop)
主な bakabakaband 適応:
- player_ptr->town_num → creature.get_town_num()
- creature.visit によるビジット管理を維持 (上流 TownRecords は baka 未導入)
- system/item/item-entity.h → system/item-entity.h