### PR TITLE
merge: モンスター目撃数を MonraceRecord/MonraceRecords に分離（hengband#5416 相当）

### DIFF
--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
@@ -757,6 +757,9 @@
     <ClCompile Include="..\..\src\system\monrace\extended-slot.cpp" />
     <ClCompile Include="..\..\src\system\monrace\monrace-definition.cpp" />
     <ClCompile Include="..\..\src\system\monrace\monrace-message.cpp" />
+    <ClCompile Include="..\..\src\system\monrace\monrace-record.cpp" />
+    <ClCompile Include="..\..\src\system\monrace\monrace-records.cpp" />
+    <ClCompile Include="..\..\src\system\monrace\monrace-service.cpp" />
     <ClCompile Include="..\..\src\system\player-type-definition.cpp" />
     <ClCompile Include="..\..\src\system\services\baseitem-monrace-service.cpp" />
     <ClCompile Include="..\..\src\system\terrain\terrain-definition.cpp" />
@@ -1859,6 +1862,9 @@
     <ClInclude Include="..\..\src\system\monrace\extended-slot.h" />
     <ClInclude Include="..\..\src\system\monrace\monrace-definition.h" />
     <ClInclude Include="..\..\src\system\monrace\monrace-message.h" />
+    <ClInclude Include="..\..\src\system\monrace\monrace-record.h" />
+    <ClInclude Include="..\..\src\system\monrace\monrace-records.h" />
+    <ClInclude Include="..\..\src\system\monrace\monrace-service.h" />
     <ClInclude Include="..\..\src\system\item-entity.h" />
     <ClInclude Include="..\..\src\object-enchant\old-ego-extra-values.h" />
     <ClInclude Include="..\..\src\object-enchant\special-object-flags.h" />

--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
@@ -2501,6 +2501,15 @@
     <ClCompile Include="..\..\src\system\monrace\monrace-message.cpp">
       <Filter>system\monrace</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\system\monrace\monrace-record.cpp">
+      <Filter>system\monrace</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\monrace\monrace-records.cpp">
+      <Filter>system\monrace</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\monrace\monrace-service.cpp">
+      <Filter>system\monrace</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\system\floor\floor-info.cpp">
       <Filter>system\floor</Filter>
     </ClCompile>
@@ -5713,6 +5722,15 @@
       <Filter>system\monrace</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\system\monrace\monrace-message.h">
+      <Filter>system\monrace</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\monrace\monrace-record.h">
+      <Filter>system\monrace</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\monrace\monrace-records.h">
+      <Filter>system\monrace</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\monrace\monrace-service.h">
       <Filter>system\monrace</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\system\floor\floor-info.h">

--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -1,0 +1,2148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="English-Debug|Win32">
+      <Configuration>English-Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="English-Release|Win32">
+      <Configuration>English-Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{C00503B6-18FF-42F1-BAC0-6C94EDE62CB2}</ProjectGuid>
+    <RootNamespace>Hengband</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v145</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'">..\..\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Configuration)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'">$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../../\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'">../../\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Configuration)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'">$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;JP;SJIS;WORLD_SCORE;WIN_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4061;4062;4127;4244;4255;4365;4514;4668;4710;4820;4996;4774;5045;5264;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ConformanceMode>true</ConformanceMode>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalIncludeDirectories>..\..\src;..\..\src\external-lib\include;libcurl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <ExceptionHandling>SyncCThrow</ExceptionHandling>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift-jis %(AdditionalOptions)</AdditionalOptions>
+      <StructMemberAlignment>16Bytes</StructMemberAlignment>
+      <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <CompileAsManaged>false</CompileAsManaged>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a_debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ShowProgress>LinkVerbose</ShowProgress>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+    <ResourceCompile>
+      <Culture>0x0411</Culture>
+      <PreprocessorDefinitions>JP</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;WIN_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4061;4062;4127;4244;4255;4365;4514;4668;4710;4820;4996;4774;5045;5264;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalIncludeDirectories>..\..\src;..\..\src\external-lib\include;libcurl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>SyncCThrow</ExceptionHandling>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift-jis %(AdditionalOptions)</AdditionalOptions>
+      <StructMemberAlignment>16Bytes</StructMemberAlignment>
+      <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <CompileAsManaged>false</CompileAsManaged>
+      <ConformanceMode>true</ConformanceMode>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX86</TargetMachine>
+      <ShowProgress>LinkVerbose</ShowProgress>
+      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a_debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;JP;SJIS;WORLD_SCORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <DisableSpecificWarnings>4061;4062;4127;4244;4255;4365;4514;4668;4710;4711;4738;4820;4996;4774;5045;5264;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalIncludeDirectories>..\..\src;..\..\src\external-lib\include;libcurl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <ExceptionHandling>SyncCThrow</ExceptionHandling>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift-jis %(AdditionalOptions)</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StructMemberAlignment>16Bytes</StructMemberAlignment>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <CompileAsManaged>false</CompileAsManaged>
+      <ConformanceMode>true</ConformanceMode>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+    <ResourceCompile>
+      <PreprocessorDefinitions>JP</PreprocessorDefinitions>
+    </ResourceCompile>
+    <ResourceCompile>
+      <Culture>0x0411</Culture>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;%(PreprocessorDefinitions);</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DisableSpecificWarnings>4061;4062;4127;4244;4255;4365;4514;4668;4710;4711;4738;4820;4996;4774;5045;5264;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalIncludeDirectories>..\..\src;..\..\src\external-lib\include;libcurl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>SyncCThrow</ExceptionHandling>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift-jis %(AdditionalOptions)</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StructMemberAlignment>16Bytes</StructMemberAlignment>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <CompileAsManaged>false</CompileAsManaged>
+      <ConformanceMode>true</ConformanceMode>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\action\action-limited.cpp" />
+    <ClCompile Include="..\..\src\action\activation-execution.cpp" />
+    <ClCompile Include="..\..\src\action\mutation-execution.cpp" />
+    <ClCompile Include="..\..\src\action\open-close-execution.cpp" />
+    <ClCompile Include="..\..\src\action\open-util.cpp" />
+    <ClCompile Include="..\..\src\action\run-execution.cpp" />
+    <ClCompile Include="..\..\src\action\travel-execution.cpp" />
+    <ClCompile Include="..\..\src\action\tunnel-execution.cpp" />
+    <ClCompile Include="..\..\src\action\weapon-shield.cpp" />
+    <ClCompile Include="..\..\src\artifact\fixed-art-generator.cpp" />
+    <ClCompile Include="..\..\src\artifact\random-art-activation.cpp" />
+    <ClCompile Include="..\..\src\artifact\random-art-characteristics.cpp" />
+    <ClCompile Include="..\..\src\artifact\random-art-generator.cpp" />
+    <ClCompile Include="..\..\src\artifact\random-art-misc.cpp" />
+    <ClCompile Include="..\..\src\artifact\random-art-resistance.cpp" />
+    <ClCompile Include="..\..\src\artifact\random-art-slay.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-keys-table.cpp" />
+    <ClCompile Include="..\..\src\avatar\avatar-changer.cpp" />
+    <ClCompile Include="..\..\src\birth\auto-roller.cpp" />
+    <ClCompile Include="..\..\src\birth\birth-body-spec.cpp" />
+    <ClCompile Include="..\..\src\birth\birth-select-class.cpp" />
+    <ClCompile Include="..\..\src\birth\birth-select-personality.cpp" />
+    <ClCompile Include="..\..\src\birth\birth-select-race.cpp" />
+    <ClCompile Include="..\..\src\birth\birth-select-realm.cpp" />
+    <ClCompile Include="..\..\src\birth\birth-stat.cpp" />
+    <ClCompile Include="..\..\src\birth\birth-util.cpp" />
+    <ClCompile Include="..\..\src\birth\birth-wizard.cpp" />
+    <ClCompile Include="..\..\src\birth\game-play-initializer.cpp" />
+    <ClCompile Include="..\..\src\birth\history-editor.cpp" />
+    <ClCompile Include="..\..\src\birth\history-generator.cpp" />
+    <ClCompile Include="..\..\src\birth\initial-equipments-table.cpp" />
+    <ClCompile Include="..\..\src\birth\inventory-initializer.cpp" />
+    <ClCompile Include="..\..\src\birth\quick-start.cpp" />
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-ball-bolt.cpp" />
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-breath.cpp" />
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-caster.cpp" />
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-spirit-curse.cpp" />
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-status.cpp" />
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-summon.cpp" />
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-util.cpp" />
+    <ClCompile Include="..\..\src\blue-magic\learnt-info.cpp" />
+    <ClCompile Include="..\..\src\blue-magic\learnt-power-getter.cpp" />
+    <ClCompile Include="..\..\src\cmd-action\cmd-attack.cpp" />
+    <ClCompile Include="..\..\src\cmd-action\cmd-move.cpp" />
+    <ClCompile Include="..\..\src\cmd-action\cmd-open-close.cpp" />
+    <ClCompile Include="..\..\src\cmd-action\cmd-racial.cpp" />
+    <ClCompile Include="..\..\src\cmd-action\cmd-shoot.cpp" />
+    <ClCompile Include="..\..\src\cmd-action\cmd-travel.cpp" />
+    <ClCompile Include="..\..\src\cmd-action\cmd-tunnel.cpp" />
+    <ClCompile Include="..\..\src\action\movement-execution.cpp" />
+    <ClCompile Include="..\..\src\core\score-util.cpp" />
+    <ClCompile Include="..\..\src\external-lib\fmt\format.cc" />
+    <ClCompile Include="..\..\src\info-reader\definition-hash-data.cpp" />
+    <ClCompile Include="..\..\src\io\macro-configurations-store.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-movement-direction-list.cpp" />
+    <ClCompile Include="..\..\src\player-info\bluemage-data.cpp" />
+    <ClCompile Include="..\..\src\system\artifact\artifact-list.cpp" />
+    <ClCompile Include="..\..\src\system\artifact\artifact-record.cpp" />
+    <ClCompile Include="..\..\src\system\artifact\artifact-service.cpp" />
+    <ClCompile Include="..\..\src\system\floor\town-records.cpp" />
+    <ClCompile Include="..\..\src\system\floor\wilderness-grid.cpp" />
+    <ClCompile Include="..\..\src\system\monrace\monrace-record.cpp" />
+    <ClCompile Include="..\..\src\system\monrace\monrace-records.cpp" />
+    <ClCompile Include="..\..\src\system\monrace\monrace-service.cpp" />
+    <ClCompile Include="..\..\src\system\services\dungeon-monrace-service.cpp" />
+    <ClCompile Include="..\..\src\system\services\dungeon-service.cpp" />
+    <ClCompile Include="..\..\src\system\floor\floor-list.cpp" />
+    <ClCompile Include="..\..\src\item-info\flavor-initializer.cpp" />
+    <ClCompile Include="..\..\src\load\item\item-loader-base.cpp" />
+    <ClCompile Include="..\..\src\load\item\item-loader-factory.cpp" />
+    <ClCompile Include="..\..\src\load\monster\monster-loader-factory.cpp" />
+    <ClCompile Include="..\..\src\load\player-class-specific-data-loader.cpp" />
+    <ClCompile Include="..\..\src\main-win\main-win-exception.cpp" />
+    <ClCompile Include="..\..\src\market\melee-arena.cpp" />
+    <ClCompile Include="..\..\src\monster-race\race-brightness-mask.cpp" />
+    <ClCompile Include="..\..\src\monster\monster-pain-describer.cpp" />
+    <ClCompile Include="..\..\src\net\curl-easy-session.cpp" />
+    <ClCompile Include="..\..\src\net\curl-slist.cpp" />
+    <ClCompile Include="..\..\src\net\http-client.cpp" />
+    <ClCompile Include="..\..\src\net\report-error.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\enchanter-factory.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-attack\abstract-mspell.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-data.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-soft-armor.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\others\apply-magic-lite.cpp" />
+    <ClCompile Include="..\..\src\monster-race\monster-kind-mask.cpp" />
+    <ClCompile Include="..\..\src\monster-race\race-resistance-mask.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\weapon\abstract-weapon-enchanter.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-hafted.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-polearm.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\weapon\melee-weapon-enchanter.cpp" />
+    <ClCompile Include="..\..\src\object-use\quaff\quaff-effects.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-arrow.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-digging.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-sword.cpp" />
+    <ClCompile Include="..\..\src\object-use\read\gbh-shirt-read-executor.cpp" />
+    <ClCompile Include="..\..\src\object-use\read\parchment-read-executor.cpp" />
+    <ClCompile Include="..\..\src\object-use\read\read-executor-factory.cpp" />
+    <ClCompile Include="..\..\src\object-use\read\ring-power-read-executor.cpp" />
+    <ClCompile Include="..\..\src\object-use\read\scroll-read-executor.cpp" />
+    <ClCompile Include="..\..\src\room\rooms-nest.cpp" />
+    <ClCompile Include="..\..\src\room\rooms-pit.cpp" />
+    <ClCompile Include="..\..\src\smith\object-smith.cpp" />
+    <ClCompile Include="..\..\src\smith\smith-info.cpp" />
+    <ClCompile Include="..\..\src\smith\smith-tables.cpp" />
+    <ClCompile Include="..\..\src\object-use\item-use-checker.cpp" />
+    <ClCompile Include="..\..\src\object-use\use-execution.cpp" />
+    <ClCompile Include="..\..\src\object-use\zaprod-execution.cpp" />
+    <ClCompile Include="..\..\src\object-use\zapwand-execution.cpp" />
+    <ClCompile Include="..\..\src\player-base\player-class.cpp" />
+    <ClCompile Include="..\..\src\player-base\player-race.cpp" />
+    <ClCompile Include="..\..\src\player-info\magic-eater-data-type.cpp" />
+    <ClCompile Include="..\..\src\save\player-class-specific-data-writer.cpp" />
+    <ClCompile Include="..\..\src\specific-object\stone-of-lore.cpp" />
+    <ClCompile Include="..\..\src\spell-class\spells-mirror-master.cpp" />
+    <ClCompile Include="..\..\src\system\angband-system.cpp" />
+    <ClCompile Include="..\..\src\system\baseitem\baseitem-allocation.cpp" />
+    <ClCompile Include="..\..\src\system\dungeon\dungeon-data-definition.cpp" />
+    <ClCompile Include="..\..\src\system\baseitem\baseitem-key.cpp" />
+    <ClCompile Include="..\..\src\system\baseitem\baseitem-list.cpp" />
+    <ClCompile Include="..\..\src\system\dungeon\dungeon-list.cpp" />
+    <ClCompile Include="..\..\src\system\dungeon\dungeon-record.cpp" />
+    <ClCompile Include="..\..\src\system\floor\town-list.cpp" />
+    <ClCompile Include="..\..\src\system\inner-game-data.cpp" />
+    <ClCompile Include="..\..\src\system\monrace\monrace-list.cpp" />
+    <ClCompile Include="..\..\src\system\redrawing-flags-updater.cpp" />
+    <ClCompile Include="..\..\src\system\floor\floor-info.cpp" />
+    <ClCompile Include="..\..\src\system\grid-type-definition.cpp" />
+    <ClCompile Include="..\..\src\main-win\commandline-win.cpp" />
+    <ClCompile Include="..\..\src\main-win\graphics-win.cpp" />
+    <ClCompile Include="..\..\src\main-win\main-win-term.cpp" />
+    <ClCompile Include="..\..\src\main-win\wav-reader.cpp" />
+    <ClCompile Include="..\..\src\main-win\stack-trace-win.cpp" />
+    <ClCompile Include="..\..\src\monster\monster-damage.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\others\apply-magic-amulet.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\protector\abstract-protector-enchanter.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-boots.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-cloak.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-crown.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-gloves.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-helm.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\others\apply-magic-ring.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-shield.cpp" />
+    <ClCompile Include="..\..\src\object\object-index-list.cpp" />
+    <ClCompile Include="..\..\src\player-info\alignment.cpp" />
+    <ClCompile Include="..\..\src\player-info\equipment-info.cpp" />
+    <ClCompile Include="..\..\src\player-status\player-energy.cpp" />
+    <ClCompile Include="..\..\src\main-win\main-win-utils.cpp" />
+    <ClCompile Include="..\..\src\store\cmd-store.cpp" />
+    <ClCompile Include="..\..\src\cmd-io\cmd-floor.cpp" />
+    <ClCompile Include="..\..\src\cmd-io\cmd-lore.cpp" />
+    <ClCompile Include="..\..\src\cmd-io\cmd-menu-content-table.cpp" />
+    <ClCompile Include="..\..\src\cmd-io\macro-util.cpp" />
+    <ClCompile Include="..\..\src\cmd-item\cmd-destroy.cpp" />
+    <ClCompile Include="..\..\src\cmd-item\cmd-equipment.cpp" />
+    <ClCompile Include="..\..\src\cmd-item\cmd-refill.cpp" />
+    <ClCompile Include="..\..\src\cmd-item\cmd-throw.cpp" />
+    <ClCompile Include="..\..\src\cmd-visual\cmd-map.cpp" />
+    <ClCompile Include="..\..\src\core\asking-player.cpp" />
+    <ClCompile Include="..\..\src\core\disturbance.cpp" />
+    <ClCompile Include="..\..\src\core\object-compressor.cpp" />
+    <ClCompile Include="..\..\src\core\visuals-reseter.cpp" />
+    <ClCompile Include="..\..\src\core\window-redrawer.cpp" />
+    <ClCompile Include="..\..\src\dungeon\quest-completion-checker.cpp" />
+    <ClCompile Include="..\..\src\dungeon\quest-monster-placer.cpp" />
+    <ClCompile Include="..\..\src\flavor\flag-inscriptions-table.cpp" />
+    <ClCompile Include="..\..\src\flavor\flavor-describer.cpp" />
+    <ClCompile Include="..\..\src\flavor\flavor-util.cpp" />
+    <ClCompile Include="..\..\src\flavor\named-item-describer.cpp" />
+    <ClCompile Include="..\..\src\flavor\tval-description-switcher.cpp" />
+    <ClCompile Include="..\..\src\floor\cave-generator.cpp" />
+    <ClCompile Include="..\..\src\floor\dungeon-tunnel-util.cpp" />
+    <ClCompile Include="..\..\src\floor\fixed-map-generator.cpp" />
+    <ClCompile Include="..\..\src\floor\floor-changer.cpp" />
+    <ClCompile Include="..\..\src\floor\floor-leaver.cpp" />
+    <ClCompile Include="..\..\src\floor\floor-mode-changer.cpp" />
+    <ClCompile Include="..\..\src\floor\floor-save-util.cpp" />
+    <ClCompile Include="..\..\src\floor\floor-util.cpp" />
+    <ClCompile Include="..\..\src\floor\line-of-sight.cpp" />
+    <ClCompile Include="..\..\src\floor\object-allocator.cpp" />
+    <ClCompile Include="..\..\src\floor\object-scanner.cpp" />
+    <ClCompile Include="..\..\src\floor\tunnel-generator.cpp" />
+    <ClCompile Include="..\..\src\game-option\auto-destruction-options.cpp" />
+    <ClCompile Include="..\..\src\game-option\birth-options.cpp" />
+    <ClCompile Include="..\..\src\game-option\cheat-options.cpp" />
+    <ClCompile Include="..\..\src\game-option\disturbance-options.cpp" />
+    <ClCompile Include="..\..\src\game-option\game-play-options.cpp" />
+    <ClCompile Include="..\..\src\game-option\input-options.cpp" />
+    <ClCompile Include="..\..\src\game-option\keymap-directory-getter.cpp" />
+    <ClCompile Include="..\..\src\game-option\map-screen-options.cpp" />
+    <ClCompile Include="..\..\src\game-option\option-flags.cpp" />
+    <ClCompile Include="..\..\src\game-option\option-types-table.cpp" />
+    <ClCompile Include="..\..\src\game-option\play-record-options.cpp" />
+    <ClCompile Include="..\..\src\game-option\runtime-arguments.cpp" />
+    <ClCompile Include="..\..\src\game-option\special-options.cpp" />
+    <ClCompile Include="..\..\src\game-option\text-display-options.cpp" />
+    <ClCompile Include="..\..\src\grid\door.cpp" />
+    <ClCompile Include="..\..\src\grid\feature-generator.cpp" />
+    <ClCompile Include="..\..\src\grid\object-placer.cpp" />
+    <ClCompile Include="..\..\src\grid\lighting-colors-table.cpp" />
+    <ClCompile Include="..\..\src\info-reader\artifact-reader.cpp" />
+    <ClCompile Include="..\..\src\info-reader\dungeon-info-tokens-table.cpp" />
+    <ClCompile Include="..\..\src\info-reader\dungeon-reader.cpp" />
+    <ClCompile Include="..\..\src\info-reader\ego-reader.cpp" />
+    <ClCompile Include="..\..\src\info-reader\feature-info-tokens-table.cpp" />
+    <ClCompile Include="..\..\src\info-reader\general-parser.cpp" />
+    <ClCompile Include="..\..\src\info-reader\info-reader-util.cpp" />
+    <ClCompile Include="..\..\src\info-reader\json-reader-util.cpp" />
+    <ClCompile Include="..\..\src\info-reader\baseitem-tokens-table.cpp" />
+    <ClCompile Include="..\..\src\info-reader\baseitem-reader.cpp" />
+    <ClCompile Include="..\..\src\info-reader\magic-reader.cpp" />
+    <ClCompile Include="..\..\src\info-reader\message-reader.cpp" />
+    <ClCompile Include="..\..\src\info-reader\race-info-tokens-table.cpp" />
+    <ClCompile Include="..\..\src\info-reader\race-reader.cpp" />
+    <ClCompile Include="..\..\src\info-reader\skill-reader.cpp" />
+    <ClCompile Include="..\..\src\info-reader\spell-reader.cpp" />
+    <ClCompile Include="..\..\src\info-reader\terrain-reader.cpp" />
+    <ClCompile Include="..\..\src\info-reader\vault-reader.cpp" />
+    <ClCompile Include="..\..\src\inventory\floor-item-getter.cpp" />
+    <ClCompile Include="..\..\src\inventory\item-selection-util.cpp" />
+    <ClCompile Include="..\..\src\inventory\inventory-describer.cpp" />
+    <ClCompile Include="..\..\src\inventory\inventory-util.cpp" />
+    <ClCompile Include="..\..\src\io-dump\random-art-info-dumper.cpp" />
+    <ClCompile Include="..\..\src\io\command-repeater.cpp" />
+    <ClCompile Include="..\..\src\io\cursor.cpp" />
+    <ClCompile Include="..\..\src\io\input-key-acceptor.cpp" />
+    <ClCompile Include="..\..\src\io\input-key-requester.cpp" />
+    <ClCompile Include="..\..\src\store\store-key-processor.cpp" />
+    <ClCompile Include="..\..\src\load\info-loader.cpp" />
+    <ClCompile Include="..\..\src\locale\utf-8.cpp" />
+    <ClCompile Include="..\..\src\main-win\main-win-cfg-reader.cpp" />
+    <ClCompile Include="..\..\src\main-win\main-win-mci.cpp" />
+    <ClCompile Include="..\..\src\main-win\main-win-music.cpp" />
+    <ClCompile Include="..\..\src\main-win\main-win-sound.cpp" />
+    <ClCompile Include="..\..\src\main-win\main-win-tokenizer.cpp" />
+    <ClCompile Include="..\..\src\main\game-data-initializer.cpp" />
+    <ClCompile Include="..\..\src\main\info-initializer.cpp" />
+    <ClCompile Include="..\..\src\main\init-error-messages-table.cpp" />
+    <ClCompile Include="..\..\src\main-win\main-win-bg.cpp" />
+    <ClCompile Include="..\..\src\main\scene-table-floor.cpp" />
+    <ClCompile Include="..\..\src\main\scene-table-monster.cpp" />
+    <ClCompile Include="..\..\src\main\scene-table.cpp" />
+    <ClCompile Include="..\..\src\market\building-initializer.cpp" />
+    <ClCompile Include="..\..\src\melee\melee-spell-flags-checker.cpp" />
+    <ClCompile Include="..\..\src\melee\melee-spell-util.cpp" />
+    <ClCompile Include="..\..\src\melee\melee-spell.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-archer.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-berserker.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-blue-mage.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-chaos-warrior.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-elementalist.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-explanations-table.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-hobbit.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-info.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-mage.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-magic-eater.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-magic-resistance.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-monk.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-power-getter.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-priest.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-weaponsmith.cpp" />
+    <ClCompile Include="..\..\src\monster-attack\monster-attack-lose.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-death-util.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-lite-util.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-lite.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\special-death-switcher.cpp" />
+    <ClCompile Include="..\..\src\monster-race\race-ability-mask.cpp" />
+    <ClCompile Include="..\..\src\monster\monster-status-setter.cpp" />
+    <ClCompile Include="..\..\src\mspell\element-resistance-checker.cpp" />
+    <ClCompile Include="..\..\src\mspell\high-resistance-checker.cpp" />
+    <ClCompile Include="..\..\src\mspell\improper-mspell-remover.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-attack-util.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-attack.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-lite.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-selector.cpp" />
+    <ClCompile Include="..\..\src\mspell\smart-mspell-util.cpp" />
+    <ClCompile Include="..\..\src\mspell\specified-summon.cpp" />
+    <ClCompile Include="..\..\src\mutation\gain-mutation-switcher.cpp" />
+    <ClCompile Include="..\..\src\mutation\lose-mutation-switcher.cpp" />
+    <ClCompile Include="..\..\src\mutation\mutation-util.cpp" />
+    <ClCompile Include="..\..\src\mutation\mutation-investor-remover.cpp" />
+    <ClCompile Include="..\..\src\object-activation\activation-bolt-ball.cpp" />
+    <ClCompile Include="..\..\src\object-activation\activation-breath.cpp" />
+    <ClCompile Include="..\..\src\object-activation\activation-charm.cpp" />
+    <ClCompile Include="..\..\src\object-activation\activation-genocide.cpp" />
+    <ClCompile Include="..\..\src\object-activation\activation-resistance.cpp" />
+    <ClCompile Include="..\..\src\object-activation\activation-teleport.cpp" />
+    <ClCompile Include="..\..\src\object-activation\activation-util.cpp" />
+    <ClCompile Include="..\..\src\player-info\base-status-info.cpp" />
+    <ClCompile Include="..\..\src\player-info\body-improvement-info.cpp" />
+    <ClCompile Include="..\..\src\player-info\class-ability-info.cpp" />
+    <ClCompile Include="..\..\src\player-info\mutation-info.cpp" />
+    <ClCompile Include="..\..\src\player-info\race-ability-info.cpp" />
+    <ClCompile Include="..\..\src\player-info\resistance-info.cpp" />
+    <ClCompile Include="..\..\src\player-info\self-info-util.cpp" />
+    <ClCompile Include="..\..\src\player-info\weapon-effect-info.cpp" />
+    <ClCompile Include="..\..\src\player-status\player-speed.cpp" />
+    <ClCompile Include="..\..\src\player-status\player-status-base.cpp" />
+    <ClCompile Include="..\..\src\player-status\player-stealth.cpp" />
+    <ClCompile Include="..\..\src\player-status\player-basic-statistics.cpp" />
+    <ClCompile Include="..\..\src\player-ability\player-strength.cpp" />
+    <ClCompile Include="..\..\src\player-ability\player-intelligence.cpp" />
+    <ClCompile Include="..\..\src\player-ability\player-wisdom.cpp" />
+    <ClCompile Include="..\..\src\player-ability\player-dexterity.cpp" />
+    <ClCompile Include="..\..\src\player-ability\player-constitution.cpp" />
+    <ClCompile Include="..\..\src\player-ability\player-charisma.cpp" />
+    <ClCompile Include="..\..\src\player-status\player-infravision.cpp" />
+    <ClCompile Include="..\..\src\player\player-status-resist.cpp" />
+    <ClCompile Include="..\..\src\room\vault-builder.cpp" />
+    <ClCompile Include="..\..\src\specific-object\blade-turner.cpp" />
+    <ClCompile Include="..\..\src\specific-object\monster-ball.cpp" />
+    <ClCompile Include="..\..\src\object-use\read\read-execution.cpp" />
+    <ClCompile Include="..\..\src\player\player-status-flags.cpp" />
+    <ClCompile Include="..\..\src\player\player-status-table.cpp" />
+    <ClCompile Include="..\..\src\player\player-spell-status.cpp" />
+    <ClCompile Include="..\..\src\player\player-view.cpp" />
+    <ClCompile Include="..\..\src\racial\class-racial-switcher.cpp" />
+    <ClCompile Include="..\..\src\racial\mutation-racial-selector.cpp" />
+    <ClCompile Include="..\..\src\action\racial-execution.cpp" />
+    <ClCompile Include="..\..\src\racial\racial-kutar.cpp" />
+    <ClCompile Include="..\..\src\mind\stances-table.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-dispel.cpp" />
+    <ClCompile Include="..\..\src\mutation\mutation-techniques.cpp" />
+    <ClCompile Include="..\..\src\artifact\random-art-pval-investor.cpp" />
+    <ClCompile Include="..\..\src\object-hook\hook-expendable.cpp" />
+    <ClCompile Include="..\..\src\object-hook\hook-magic.cpp" />
+    <ClCompile Include="..\..\src\object-hook\hook-perception.cpp" />
+    <ClCompile Include="..\..\src\object-hook\hook-weapon.cpp" />
+    <ClCompile Include="..\..\src\object-hook\hook-armor.cpp" />
+    <ClCompile Include="..\..\src\object-use\quaff\quaff-execution.cpp" />
+    <ClCompile Include="..\..\src\load\angband-version-comparer.cpp" />
+    <ClCompile Include="..\..\src\load\birth-loader.cpp" />
+    <ClCompile Include="..\..\src\load\dummy-loader.cpp" />
+    <ClCompile Include="..\..\src\load\floor-loader.cpp" />
+    <ClCompile Include="..\..\src\load\dungeon-loader.cpp" />
+    <ClCompile Include="..\..\src\load\extra-loader.cpp" />
+    <ClCompile Include="..\..\src\load\inventory-loader.cpp" />
+    <ClCompile Include="..\..\src\load\old\item-loader-savefile50.cpp" />
+    <ClCompile Include="..\..\src\load\load-util.cpp" />
+    <ClCompile Include="..\..\src\load\old\load-v1-5-0.cpp" />
+    <ClCompile Include="..\..\src\load\old\load-v1-7-0.cpp" />
+    <ClCompile Include="..\..\src\load\load-zangband.cpp" />
+    <ClCompile Include="..\..\src\load\lore-loader.cpp" />
+    <ClCompile Include="..\..\src\load\old\monster-loader-savefile50.cpp" />
+    <ClCompile Include="..\..\src\load\option-loader.cpp" />
+    <ClCompile Include="..\..\src\load\player-attack-loader.cpp" />
+    <ClCompile Include="..\..\src\load\player-info-loader.cpp" />
+    <ClCompile Include="..\..\src\load\store-loader.cpp" />
+    <ClCompile Include="..\..\src\load\world-loader.cpp" />
+    <ClCompile Include="..\..\src\racial\racial-util.cpp" />
+    <ClCompile Include="..\..\src\racial\race-racial-command-setter.cpp" />
+    <ClCompile Include="..\..\src\room\cave-filler.cpp" />
+    <ClCompile Include="..\..\src\room\door-definition.cpp" />
+    <ClCompile Include="..\..\src\room\room-generator.cpp" />
+    <ClCompile Include="..\..\src\room\room-info-table.cpp" />
+    <ClCompile Include="..\..\src\room\rooms-maze-vault.cpp" />
+    <ClCompile Include="..\..\src\room\space-finder.cpp" />
+    <ClCompile Include="..\..\src\room\treasure-deployment.cpp" />
+    <ClCompile Include="..\..\src\save\floor-writer.cpp" />
+    <ClCompile Include="..\..\src\save\info-writer.cpp" />
+    <ClCompile Include="..\..\src\save\item-writer.cpp" />
+    <ClCompile Include="..\..\src\save\monster-entity-writer.cpp" />
+    <ClCompile Include="..\..\src\save\lore-writer.cpp" />
+    <ClCompile Include="..\..\src\save\player-writer.cpp" />
+    <ClCompile Include="..\..\src\save\save-util.cpp" />
+    <ClCompile Include="..\..\src\object-activation\activation-others.cpp" />
+    <ClCompile Include="..\..\src\specific-object\bloody-moon.cpp" />
+    <ClCompile Include="..\..\src\specific-object\death-crimson.cpp" />
+    <ClCompile Include="..\..\src\specific-object\muramasa.cpp" />
+    <ClCompile Include="..\..\src\specific-object\ring-of-power.cpp" />
+    <ClCompile Include="..\..\src\specific-object\toragoroshi.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\blood-curse.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-enchant.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-equipment.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-fetcher.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-polymorph.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-world.cpp" />
+    <ClCompile Include="..\..\src\spell-realm\spells-arcane.cpp" />
+    <ClCompile Include="..\..\src\spell-realm\spells-craft.cpp" />
+    <ClCompile Include="..\..\src\spell-realm\spells-demon.cpp" />
+    <ClCompile Include="..\..\src\spell-realm\spells-nature.cpp" />
+    <ClCompile Include="..\..\src\spell-realm\spells-sorcery.cpp" />
+    <ClCompile Include="..\..\src\status\bad-status-setter.cpp" />
+    <ClCompile Include="..\..\src\status\base-status.cpp" />
+    <ClCompile Include="..\..\src\status\body-improvement.cpp" />
+    <ClCompile Include="..\..\src\status\buff-setter.cpp" />
+    <ClCompile Include="..\..\src\player\player-realm.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-curse-removal.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-perception.cpp" />
+    <ClCompile Include="..\..\src\spell-realm\spells-chaos.cpp" />
+    <ClCompile Include="..\..\src\spell\spell-info.cpp" />
+    <ClCompile Include="..\..\src\status\element-resistance.cpp" />
+    <ClCompile Include="..\..\src\status\shape-changer.cpp" />
+    <ClCompile Include="..\..\src\status\sight-setter.cpp" />
+    <ClCompile Include="..\..\src\status\experience.cpp" />
+    <ClCompile Include="..\..\src\status\temporary-resistance.cpp" />
+    <ClCompile Include="..\..\src\stdafx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\home.cpp" />
+    <ClCompile Include="..\..\src\store\museum.cpp" />
+    <ClCompile Include="..\..\src\store\pricing.cpp" />
+    <ClCompile Include="..\..\src\store\purchase-order.cpp" />
+    <ClCompile Include="..\..\src\store\sell-order.cpp" />
+    <ClCompile Include="..\..\src\store\service-checker.cpp" />
+    <ClCompile Include="..\..\src\system\angband-version.cpp" />
+    <ClCompile Include="..\..\src\system\monster-entity.cpp" />
+    <ClCompile Include="..\..\src\system\item\item-entity.cpp" />
+    <ClCompile Include="..\..\src\system\monrace\monrace-definition.cpp" />
+    <ClCompile Include="..\..\src\system\monrace\monrace-message.cpp" />
+    <ClCompile Include="..\..\src\system\player-type-definition.cpp" />
+    <ClCompile Include="..\..\src\system\services\baseitem-monrace-service.cpp" />
+    <ClCompile Include="..\..\src\system\terrain\terrain-definition.cpp" />
+    <ClCompile Include="..\..\src\system\terrain\terrain-list.cpp" />
+    <ClCompile Include="..\..\src\target\grid-selector.cpp" />
+    <ClCompile Include="..\..\src\target\projection-path-calculator.cpp" />
+    <ClCompile Include="..\..\src\target\target-describer.cpp" />
+    <ClCompile Include="..\..\src\target\target-getter.cpp" />
+    <ClCompile Include="..\..\src\target\target-preparation.cpp" />
+    <ClCompile Include="..\..\src\target\target-setter.cpp" />
+    <ClCompile Include="..\..\src\target\target.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\player-acceleration.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\player-blindness.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\player-confusion.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\player-cut.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\player-deceleration.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\player-fear.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\player-hallucination.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\player-paralysis.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\player-poison.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\player-protection.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\player-stun.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\timed-effects.cpp" />
+    <ClCompile Include="..\..\src\tracking\baseitem-tracker.cpp" />
+    <ClCompile Include="..\..\src\tracking\health-bar-tracker.cpp" />
+    <ClCompile Include="..\..\src\tracking\lore-tracker.cpp" />
+    <ClCompile Include="..\..\src\util\candidate-selector.cpp" />
+    <ClCompile Include="..\..\src\util\elapsed-time.cpp" />
+    <ClCompile Include="..\..\src\util\rng-xoshiro.cpp" />
+    <ClCompile Include="..\..\src\util\dice.cpp" />
+    <ClCompile Include="..\..\src\util\sha256.cpp" />
+    <ClCompile Include="..\..\src\view\display-inventory.cpp" />
+    <ClCompile Include="..\..\src\view\display-map.cpp" />
+    <ClCompile Include="..\..\src\view\display-self-info.cpp" />
+    <ClCompile Include="..\..\src\view\display-scores.cpp" />
+    <ClCompile Include="..\..\src\window\display-sub-windows.cpp" />
+    <ClCompile Include="..\..\src\window\main-window-left-frame.cpp" />
+    <ClCompile Include="..\..\src\window\main-window-stat-poster.cpp" />
+    <ClCompile Include="..\..\src\window\main-window-util.cpp" />
+    <ClCompile Include="..\..\src\mspell\monster-power-table.cpp" />
+    <ClCompile Include="..\..\src\system\monrace\monrace-allocation.cpp" />
+    <ClCompile Include="..\..\src\term\screen-processor.cpp" />
+    <ClCompile Include="..\..\src\util\buffer-shaper.cpp" />
+    <ClCompile Include="..\..\src\lore\combat-types-setter.cpp" />
+    <ClCompile Include="..\..\src\lore\magic-types-setter.cpp" />
+    <ClCompile Include="..\..\src\lore\lore-calculator.cpp" />
+    <ClCompile Include="..\..\src\lore\lore-util.cpp" />
+    <ClCompile Include="..\..\src\main\sound-of-music.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-summon.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\one-monster-placer.cpp" />
+    <ClCompile Include="..\..\src\monster\monster-compaction.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-death.cpp" />
+    <ClCompile Include="..\..\src\lore\monster-lore.cpp" />
+    <ClCompile Include="..\..\src\monster\monster-describer.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-generator.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-remover.cpp" />
+    <ClCompile Include="..\..\src\monster\monster-util.cpp" />
+    <ClCompile Include="..\..\src\mspell\summon-checker.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\activation-info-table.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\dragon-breaths-table.cpp" />
+    <ClCompile Include="..\..\src\perception\identification.cpp" />
+    <ClCompile Include="..\..\src\player-attack\attack-chaos-effect.cpp" />
+    <ClCompile Include="..\..\src\combat\attack-criticality.cpp" />
+    <ClCompile Include="..\..\src\combat\attack-power-table.cpp" />
+    <ClCompile Include="..\..\src\combat\hallucination-attacks-table.cpp" />
+    <ClCompile Include="..\..\src\monster-attack\insults-moans.cpp" />
+    <ClCompile Include="..\..\src\combat\martial-arts-table.cpp" />
+    <ClCompile Include="..\..\src\melee\melee-switcher.cpp" />
+    <ClCompile Include="..\..\src\melee\melee-util.cpp" />
+    <ClCompile Include="..\..\src\monster-attack\monster-attack-describer.cpp" />
+    <ClCompile Include="..\..\src\melee\monster-attack-monster.cpp" />
+    <ClCompile Include="..\..\src\monster-attack\monster-attack-player.cpp" />
+    <ClCompile Include="..\..\src\monster-attack\monster-attack-status.cpp" />
+    <ClCompile Include="..\..\src\monster-attack\monster-attack-switcher.cpp" />
+    <ClCompile Include="..\..\src\monster-attack\monster-attack-table.cpp" />
+    <ClCompile Include="..\..\src\combat\attack-accuracy.cpp" />
+    <ClCompile Include="..\..\src\monster-attack\monster-eating.cpp" />
+    <ClCompile Include="..\..\src\player-attack\player-attack.cpp" />
+    <ClCompile Include="..\..\src\combat\slaying.cpp" />
+    <ClCompile Include="..\..\src\player-attack\blood-sucking-processor.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\vorpal-weapon.cpp" />
+    <ClCompile Include="..\..\src\floor\floor-object.cpp" />
+    <ClCompile Include="..\..\src\inventory\inventory-damage.cpp" />
+    <ClCompile Include="..\..\src\inventory\inventory-object.cpp" />
+    <ClCompile Include="..\..\src\io\pref-file-expressor.cpp" />
+    <ClCompile Include="..\..\src\market\arena.cpp" />
+    <ClCompile Include="..\..\src\market\bounty-prize-table.cpp" />
+    <ClCompile Include="..\..\src\market\bounty.cpp" />
+    <ClCompile Include="..\..\src\market\building-craft-armor.cpp" />
+    <ClCompile Include="..\..\src\market\building-craft-fix.cpp" />
+    <ClCompile Include="..\..\src\market\building-craft-weapon.cpp" />
+    <ClCompile Include="..\..\src\market\building-enchanter.cpp" />
+    <ClCompile Include="..\..\src\market\building-monster.cpp" />
+    <ClCompile Include="..\..\src\market\building-quest.cpp" />
+    <ClCompile Include="..\..\src\market\building-recharger.cpp" />
+    <ClCompile Include="..\..\src\market\building-service.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-warrior-mage.cpp" />
+    <ClCompile Include="..\..\src\racial\racial-android.cpp" />
+    <ClCompile Include="..\..\src\racial\racial-balrog.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-cavalry.cpp" />
+    <ClCompile Include="..\..\src\racial\racial-draconian.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-force-trainer.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-mindcrafter.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-mirror-master.cpp" />
+    <ClCompile Include="..\..\src\mind\monk-attack.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-ninja.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-samurai.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-warrior.cpp" />
+    <ClCompile Include="..\..\src\racial\racial-vampire.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-armor.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\others\apply-magic-others.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-bow.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\item-magic-applier.cpp" />
+    <ClCompile Include="..\..\src\player\eldritch-horror.cpp" />
+    <ClCompile Include="..\..\src\object\object-stack.cpp" />
+    <ClCompile Include="..\..\src\object\object-value-calc.cpp" />
+    <ClCompile Include="..\..\src\perception\object-perception.cpp" />
+    <ClCompile Include="..\..\src\object\object-value.cpp" />
+    <ClCompile Include="..\..\src\pet\pet-fall-off.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-floor.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-attack\mspell-particularity.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-special.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-status.cpp" />
+    <ClCompile Include="..\..\src\system\artifact\artifact-definition.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-command-menu.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-describer.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-destroyer.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-drawer.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-editor-command.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-editor-util.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-entry.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-finder.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-initializer.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-inserter-killer.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-matcher.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-menu-data-table.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-pref-processor.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-reader-writer.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-registry.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick-util.cpp" />
+    <ClCompile Include="..\..\src\autopick\autopick.cpp" />
+    <ClCompile Include="..\..\src\specific-object\death-scythe.cpp" />
+    <ClCompile Include="..\..\src\specific-object\torch.cpp" />
+    <ClCompile Include="..\..\src\pet\pet-util.cpp" />
+    <ClCompile Include="..\..\src\avatar\avatar.cpp" />
+    <ClCompile Include="..\..\src\birth\character-builder.cpp" />
+    <ClCompile Include="..\..\src\birth\birth-explanations-table.cpp" />
+    <ClCompile Include="..\..\src\cmd-io\cmd-autopick.cpp" />
+    <ClCompile Include="..\..\src\cmd-io\cmd-knowledge.cpp" />
+    <ClCompile Include="..\..\src\cmd-io\cmd-process-screen.cpp" />
+    <ClCompile Include="..\..\src\io-dump\dump-util.cpp" />
+    <ClCompile Include="..\..\src\core\game-play.cpp" />
+    <ClCompile Include="..\..\src\dungeon\dungeon-processor.cpp" />
+    <ClCompile Include="..\..\src\player\digestion-processor.cpp" />
+    <ClCompile Include="..\..\src\core\player-processor.cpp" />
+    <ClCompile Include="..\..\src\inventory\pack-overflow.cpp" />
+    <ClCompile Include="..\..\src\io\input-key-processor.cpp" />
+    <ClCompile Include="..\..\src\core\game-closer.cpp" />
+    <ClCompile Include="..\..\src\hpmp\hp-mp-processor.cpp" />
+    <ClCompile Include="..\..\src\hpmp\hp-mp-regenerator.cpp" />
+    <ClCompile Include="..\..\src\core\magic-effects-timeout-reducer.cpp" />
+    <ClCompile Include="..\..\src\core\stuff-handler.cpp" />
+    <ClCompile Include="..\..\src\core\turn-compensator.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-feature.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-item.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-monster-charm.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-monster-curse.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-monster-evil.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-monster-lite-dark.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-monster-oldies.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-monster-psi.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-monster-resist-hurt.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-monster-spirit.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-monster-switcher.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-monster-util.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-monster.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-player-curse.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-player-oldies.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-player-resist-hurt.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-player-spirit.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-player-switcher.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-player.cpp" />
+    <ClCompile Include="..\..\src\effect\spells-effect-util.cpp" />
+    <ClCompile Include="..\..\src\floor\pattern-walk.cpp" />
+    <ClCompile Include="..\..\src\inventory\inventory-curse.cpp" />
+    <ClCompile Include="..\..\src\inventory\recharge-processor.cpp" />
+    <ClCompile Include="..\..\src\perception\simple-perception.cpp" />
+    <ClCompile Include="..\..\src\io-dump\dump-remover.cpp" />
+    <ClCompile Include="..\..\src\io\mutations-dump.cpp" />
+    <ClCompile Include="..\..\src\knowledge\knowledge-autopick.cpp" />
+    <ClCompile Include="..\..\src\knowledge\knowledge-features.cpp" />
+    <ClCompile Include="..\..\src\knowledge\knowledge-items.cpp" />
+    <ClCompile Include="..\..\src\knowledge\knowledge-experiences.cpp" />
+    <ClCompile Include="..\..\src\knowledge\knowledge-monsters.cpp" />
+    <ClCompile Include="..\..\src\knowledge\knowledge-mutations.cpp" />
+    <ClCompile Include="..\..\src\knowledge\knowledge-quests.cpp" />
+    <ClCompile Include="..\..\src\knowledge\knowledge-self.cpp" />
+    <ClCompile Include="..\..\src\knowledge\knowledge-uniques.cpp" />
+    <ClCompile Include="..\..\src\main\music-definitions-table.cpp" />
+    <ClCompile Include="..\..\src\main\sound-definitions-table.cpp" />
+    <ClCompile Include="..\..\src\cmd-building\cmd-building.cpp" />
+    <ClCompile Include="..\..\src\io-dump\character-dump.cpp" />
+    <ClCompile Include="..\..\src\specific-object\chest.cpp" />
+    <ClCompile Include="..\..\src\io\record-play-movie.cpp" />
+    <ClCompile Include="..\..\src\object-activation\activation-switcher.cpp" />
+    <ClCompile Include="..\..\src\cmd-action\cmd-others.cpp" />
+    <ClCompile Include="..\..\src\cmd-io\cmd-diary.cpp" />
+    <ClCompile Include="..\..\src\cmd-visual\cmd-draw.cpp" />
+    <ClCompile Include="..\..\src\cmd-io\cmd-dump.cpp" />
+    <ClCompile Include="..\..\src\cmd-item\cmd-eat.cpp" />
+    <ClCompile Include="..\..\src\cmd-io\cmd-gameoption.cpp" />
+    <ClCompile Include="..\..\src\cmd-io\cmd-help.cpp" />
+    <ClCompile Include="..\..\src\cmd-action\cmd-hissatsu.cpp" />
+    <ClCompile Include="..\..\src\cmd-building\cmd-inn.cpp" />
+    <ClCompile Include="..\..\src\knowledge\knowledge-inventory.cpp" />
+    <ClCompile Include="..\..\src\cmd-item\cmd-item.cpp" />
+    <ClCompile Include="..\..\src\cmd-io\cmd-macro.cpp" />
+    <ClCompile Include="..\..\src\cmd-item\cmd-magiceat.cpp" />
+    <ClCompile Include="..\..\src\cmd-action\cmd-mane.cpp" />
+    <ClCompile Include="..\..\src\cmd-action\cmd-pet.cpp" />
+    <ClCompile Include="..\..\src\cmd-item\cmd-quaff.cpp" />
+    <ClCompile Include="..\..\src\cmd-item\cmd-read.cpp" />
+    <ClCompile Include="..\..\src\cmd-io\cmd-save.cpp" />
+    <ClCompile Include="..\..\src\cmd-action\cmd-spell.cpp" />
+    <ClCompile Include="..\..\src\cmd-item\cmd-usestaff.cpp" />
+    <ClCompile Include="..\..\src\cmd-visual\cmd-visuals.cpp" />
+    <ClCompile Include="..\..\src\cmd-item\cmd-zaprod.cpp" />
+    <ClCompile Include="..\..\src\cmd-item\cmd-zapwand.cpp" />
+    <ClCompile Include="..\..\src\cmd-io\diary-subtitle-table.cpp" />
+    <ClCompile Include="..\..\src\floor\dungeon-feeling.cpp" />
+    <ClCompile Include="..\..\src\knowledge\lighting-level-table.cpp" />
+    <ClCompile Include="..\..\src\knowledge\monster-group-table.cpp" />
+    <ClCompile Include="..\..\src\knowledge\item-group-table.cpp" />
+    <ClCompile Include="..\..\src\melee\melee-postprocess.cpp" />
+    <ClCompile Include="..\..\src\combat\shoot.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-attack\mspell-bolt.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-attack\mspell-breath.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-attack\mspell-curse.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-damage-calculator.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-learn-checker.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-summon.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-util.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-attack\mspell-ball.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\earthquake.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-beam.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-grid.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-random.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-charm.cpp" />
+    <ClCompile Include="..\..\src\spell-realm\spells-trump.cpp" />
+    <ClCompile Include="..\..\src\spell\spells-describer.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-detection.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-genocide.cpp" />
+    <ClCompile Include="..\..\src\spell-realm\spells-hex.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-launcher.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-lite.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-neighbor.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-pet.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-sight.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-specific-bolt.cpp" />
+    <ClCompile Include="..\..\src\spell\spells-staff-only.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-teleport.cpp" />
+    <ClCompile Include="..\..\src\system\building-type-definition.cpp" />
+    <ClCompile Include="..\..\src\system\system-variables.cpp" />
+    <ClCompile Include="..\..\src\core\show-file.cpp" />
+    <ClCompile Include="..\..\src\core\speed-table.cpp" />
+    <ClCompile Include="..\..\src\info-reader\fixed-map-parser.cpp" />
+    <ClCompile Include="..\..\src\system\dungeon\dungeon-definition.cpp" />
+    <ClCompile Include="..\..\src\locale\english.cpp" />
+    <ClCompile Include="..\..\src\floor\floor-events.cpp" />
+    <ClCompile Include="..\..\src\floor\floor-generator.cpp" />
+    <ClCompile Include="..\..\src\floor\floor-save.cpp" />
+    <ClCompile Include="..\..\src\system\floor\town-info.cpp" />
+    <ClCompile Include="..\..\src\floor\geometry.cpp" />
+    <ClCompile Include="..\..\src\birth\history.cpp" />
+    <ClCompile Include="..\..\src\monster\horror-descriptions.cpp" />
+    <ClCompile Include="..\..\src\main\angband-initializer.cpp" />
+    <ClCompile Include="..\..\src\io\gf-descriptions.cpp" />
+    <ClCompile Include="..\..\src\io\interpret-pref-file.cpp" />
+    <ClCompile Include="..\..\src\io-dump\player-status-dump.cpp" />
+    <ClCompile Include="..\..\src\io\read-pref-file.cpp" />
+    <ClCompile Include="..\..\src\io-dump\special-class-dump.cpp" />
+    <ClCompile Include="..\..\src\io\tokenizer.cpp" />
+    <ClCompile Include="..\..\src\io\write-diary.cpp" />
+    <ClCompile Include="..\..\src\market\arena-entry.cpp" />
+    <ClCompile Include="..\..\src\store\articles-on-sale.cpp" />
+    <ClCompile Include="..\..\src\store\black-market.cpp" />
+    <ClCompile Include="..\..\src\market\building-util.cpp" />
+    <ClCompile Include="..\..\src\store\gold-magnification-table.cpp" />
+    <ClCompile Include="..\..\src\market\play-gamble.cpp" />
+    <ClCompile Include="..\..\src\market\poker.cpp" />
+    <ClCompile Include="..\..\src\store\say-comments.cpp" />
+    <ClCompile Include="..\..\src\store\store-owner-comments.cpp" />
+    <ClCompile Include="..\..\src\store\store-owners.cpp" />
+    <ClCompile Include="..\..\src\store\store-util.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-dist-offsets.cpp" />
+    <ClCompile Include="..\..\src\monster\monster-processor.cpp" />
+    <ClCompile Include="..\..\src\monster\monster-status.cpp" />
+    <ClCompile Include="..\..\src\monster-attack\monster-attack-processor.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-direction.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-move.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-object.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-runaway.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-safety-hiding.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\monster-sweep-grid.cpp" />
+    <ClCompile Include="..\..\src\monster\monster-update.cpp" />
+    <ClCompile Include="..\..\src\monster\monster-processor-util.cpp" />
+    <ClCompile Include="..\..\src\monster\monster-timed-effects.cpp" />
+    <ClCompile Include="..\..\src\monster-floor\quantum-effect.cpp" />
+    <ClCompile Include="..\..\src\mutation\mutation-processor.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\object-boost.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\object-curse.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\object-ego.cpp" />
+    <ClCompile Include="..\..\src\flavor\object-flavor.cpp" />
+    <ClCompile Include="..\..\src\object\item-tester-hooker.cpp" />
+    <ClCompile Include="..\..\src\system\baseitem\baseitem-definition.cpp" />
+    <ClCompile Include="..\..\src\system\spell-info-list.cpp" />
+    <ClCompile Include="..\..\src\object\object-kind-hook.cpp" />
+    <ClCompile Include="..\..\src\object\object-broken.cpp" />
+    <ClCompile Include="..\..\src\object\lite-processor.cpp" />
+    <ClCompile Include="..\..\src\player\patron.cpp" />
+    <ClCompile Include="..\..\src\player-info\class-info.cpp" />
+    <ClCompile Include="..\..\src\player\player-damage.cpp" />
+    <ClCompile Include="..\..\src\status\action-setter.cpp" />
+    <ClCompile Include="..\..\src\inventory\player-inventory.cpp" />
+    <ClCompile Include="..\..\src\player\player-personality.cpp" />
+    <ClCompile Include="..\..\src\player-info\race-info.cpp" />
+    <ClCompile Include="..\..\src\player\player-sex.cpp" />
+    <ClCompile Include="..\..\src\player\player-skill.cpp" />
+    <ClCompile Include="..\..\src\player\player-status.cpp" />
+    <ClCompile Include="..\..\src\player-info\mimic-info-table.cpp" />
+    <ClCompile Include="..\..\src\player\permanent-resistances.cpp" />
+    <ClCompile Include="..\..\src\player\process-name.cpp" />
+    <ClCompile Include="..\..\src\player\race-info-table.cpp" />
+    <ClCompile Include="..\..\src\player\race-resistances.cpp" />
+    <ClCompile Include="..\..\src\player\temporary-resistances.cpp" />
+    <ClCompile Include="..\..\src\dungeon\quest.cpp" />
+    <ClCompile Include="..\..\src\realm\realm-craft.cpp" />
+    <ClCompile Include="..\..\src\realm\realm-crusade.cpp" />
+    <ClCompile Include="..\..\src\realm\realm-demon.cpp" />
+    <ClCompile Include="..\..\src\realm\realm-death.cpp" />
+    <ClCompile Include="..\..\src\realm\realm-hissatsu.cpp" />
+    <ClCompile Include="..\..\src\realm\realm-nature.cpp" />
+    <ClCompile Include="..\..\src\realm\realm-song.cpp" />
+    <ClCompile Include="..\..\src\realm\realm-sorcery.cpp" />
+    <ClCompile Include="..\..\src\spell-realm\spells-song.cpp" />
+    <ClCompile Include="..\..\src\effect\effect-processor.cpp" />
+    <ClCompile Include="..\..\src\spell\spells-execution.cpp" />
+    <ClCompile Include="..\..\src\spell\technic-info-table.cpp" />
+    <ClCompile Include="..\..\src\combat\aura-counterattack.cpp" />
+    <ClCompile Include="..\..\src\window\main-window-equipments.cpp" />
+    <ClCompile Include="..\..\src\wizard\artifact-analyzer.cpp" />
+    <ClCompile Include="..\..\src\wizard\artifact-bias-table.cpp" />
+    <ClCompile Include="..\..\src\wizard\cmd-wizard.cpp" />
+    <ClCompile Include="..\..\src\wizard\fixed-artifacts-spoiler.cpp" />
+    <ClCompile Include="..\..\src\wizard\items-spoiler.cpp" />
+    <ClCompile Include="..\..\src\wizard\monrace-filter-debug-info.cpp" />
+    <ClCompile Include="..\..\src\wizard\monster-info-spoiler.cpp" />
+    <ClCompile Include="..\..\src\wizard\spoiler-table.cpp" />
+    <ClCompile Include="..\..\src\wizard\spoiler-util.cpp" />
+    <ClCompile Include="..\..\src\wizard\tval-descriptions-table.cpp" />
+    <ClCompile Include="..\..\src\load\quest-loader.cpp" />
+    <ClCompile Include="..\..\src\view\display-store.cpp" />
+    <ClCompile Include="..\..\src\object-use\throw-execution.cpp" />
+    <ClInclude Include="..\..\src\action\action-limited.h" />
+    <ClInclude Include="..\..\src\action\activation-execution.h" />
+    <ClInclude Include="..\..\src\action\mutation-execution.h" />
+    <ClInclude Include="..\..\src\action\open-close-execution.h" />
+    <ClInclude Include="..\..\src\action\open-util.h" />
+    <ClInclude Include="..\..\src\action\run-execution.h" />
+    <ClInclude Include="..\..\src\external-lib\include-json.h" />
+    <ClInclude Include="..\..\src\io\macro-configurations-store.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-movement-direction-list.h" />
+    <ClInclude Include="..\..\src\system\enums\store-sale-type.h" />
+    <ClInclude Include="..\..\src\system\enums\terrain\building-type.h" />
+    <ClInclude Include="..\..\src\system\enums\terrain\pattern-tile-type.h" />
+    <ClInclude Include="..\..\src\system\artifact\artifact-list.h" />
+    <ClInclude Include="..\..\src\system\artifact\artifact-record.h" />
+    <ClInclude Include="..\..\src\system\artifact\artifact-service.h" />
+    <ClInclude Include="..\..\src\system\enums\terrain\terrain-kind.h" />
+    <ClInclude Include="..\..\src\system\enums\terrain\terrain-conversion-type.h" />
+    <ClInclude Include="..\..\src\system\enums\terrain\trap.h" />
+    <ClInclude Include="..\..\src\system\enums\terrain\wilderness-terrain.h" />
+    <ClInclude Include="..\..\src\info-reader\definition-hash-data.h" />
+    <ClInclude Include="..\..\src\system\floor\town-records.h" />
+    <ClInclude Include="..\..\src\system\floor\wilderness-grid.h" />
+    <ClInclude Include="..\..\src\system\item\identification-flags.h" />
+    <ClInclude Include="..\..\src\system\monrace\monrace-record.h" />
+    <ClInclude Include="..\..\src\system\monrace\monrace-records.h" />
+    <ClInclude Include="..\..\src\system\monrace\monrace-service.h" />
+    <ClInclude Include="..\..\src\system\services\dungeon-monrace-service.h" />
+    <ClInclude Include="..\..\src\system\services\dungeon-service.h" />
+    <ClInclude Include="..\..\src\system\enums\dungeon\dungeon-id.h" />
+    <ClInclude Include="..\..\src\system\enums\monrace\monrace-hook-types.h" />
+    <ClInclude Include="..\..\src\system\floor\floor-list.h" />
+    <ClInclude Include="..\..\src\item-info\flavor-initializer.h" />
+    <ClInclude Include="..\..\src\load\item\item-loader-version-types.h" />
+    <ClInclude Include="..\..\src\load\item\item-loader-base.h" />
+    <ClInclude Include="..\..\src\load\item\item-loader-factory.h" />
+    <ClInclude Include="..\..\src\load\monster\monster-loader-base.h" />
+    <ClInclude Include="..\..\src\load\monster\monster-loader-factory.h" />
+    <ClInclude Include="..\..\src\load\monster\monster-loader-version-types.h" />
+    <ClInclude Include="..\..\src\load\old\monster-flag-types-savefile50.h" />
+    <ClInclude Include="..\..\src\load\player-class-specific-data-loader.h" />
+    <ClInclude Include="..\..\src\load\savedata-old-flag-types.h" />
+    <ClInclude Include="..\..\src\main-win\main-win-exception.h" />
+    <ClInclude Include="..\..\src\market\bounty-type-definition.h" />
+    <ClInclude Include="..\..\src\market\melee-arena.h" />
+    <ClInclude Include="..\..\src\monster-race\monster-aura-types.h" />
+    <ClInclude Include="..\..\src\monster-race\monster-kind-mask.h" />
+    <ClInclude Include="..\..\src\monster-race\race-behavior-flags.h" />
+    <ClInclude Include="..\..\src\monster-race\race-brightness-flags.h" />
+    <ClInclude Include="..\..\src\monster-race\race-brightness-mask.h" />
+    <ClInclude Include="..\..\src\monster-race\race-drop-flags.h" />
+    <ClInclude Include="..\..\src\monster-race\race-feature-flags.h" />
+    <ClInclude Include="..\..\src\monster-race\race-kind-flags.h" />
+    <ClInclude Include="..\..\src\monster-race\race-misc-flags.h" />
+    <ClInclude Include="..\..\src\monster-race\race-population-flags.h" />
+    <ClInclude Include="..\..\src\monster-race\race-resistance-mask.h" />
+    <ClInclude Include="..\..\src\monster-race\race-speak-flags.h" />
+    <ClInclude Include="..\..\src\monster-race\race-special-flags.h" />
+    <ClInclude Include="..\..\src\monster-race\race-visual-flags.h" />
+    <ClInclude Include="..\..\src\monster-race\race-wilderness-flags.h" />
+    <ClInclude Include="..\..\src\monster\monster-pain-describer.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-attack\abstract-mspell.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-data.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-result.h" />
+    <ClInclude Include="..\..\src\net\curl-easy-session.h" />
+    <ClInclude Include="..\..\src\net\curl-slist.h" />
+    <ClInclude Include="..\..\src\net\http-client.h" />
+    <ClInclude Include="..\..\src\net\report-error.h" />
+    <ClInclude Include="..\..\src\object-enchant\enchanter-factory.h" />
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-soft-armor.h" />
+    <ClInclude Include="..\..\src\object-enchant\others\apply-magic-lite.h" />
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.h" />
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.h" />
+    <ClInclude Include="..\..\src\object-enchant\weapon\abstract-weapon-enchanter.h" />
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-hafted.h" />
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-polearm.h" />
+    <ClInclude Include="..\..\src\object-enchant\weapon\melee-weapon-enchanter.h" />
+    <ClInclude Include="..\..\src\object-use\quaff\quaff-effects.h" />
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-arrow.h" />
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-digging.h" />
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-sword.h" />
+    <ClInclude Include="..\..\src\object-use\read\gbh-shirt-read-executor.h" />
+    <ClInclude Include="..\..\src\object-use\read\parchment-read-executor.h" />
+    <ClInclude Include="..\..\src\object-use\read\read-executor-base.h" />
+    <ClInclude Include="..\..\src\object-use\read\read-executor-factory.h" />
+    <ClInclude Include="..\..\src\object-use\read\ring-power-read-executor.h" />
+    <ClInclude Include="..\..\src\object-use\read\scroll-read-executor.h" />
+    <ClInclude Include="..\..\src\room\rooms-nest.h" />
+    <ClInclude Include="..\..\src\room\rooms-pit.h" />
+    <ClInclude Include="..\..\src\smith\object-smith.h" />
+    <ClInclude Include="..\..\src\smith\smith-info.h" />
+    <ClInclude Include="..\..\src\smith\smith-tables.h" />
+    <ClInclude Include="..\..\src\smith\smith-types.h" />
+    <ClInclude Include="..\..\src\object-enchant\tr-flags.h" />
+    <ClInclude Include="..\..\src\object-use\item-use-checker.h" />
+    <ClInclude Include="..\..\src\object-use\throw-execution.h" />
+    <ClInclude Include="..\..\src\action\travel-execution.h" />
+    <ClInclude Include="..\..\src\action\tunnel-execution.h" />
+    <ClInclude Include="..\..\src\action\weapon-shield.h" />
+    <ClInclude Include="..\..\src\artifact\fixed-art-types.h" />
+    <ClInclude Include="..\..\src\artifact\random-art-effects.h" />
+    <ClInclude Include="..\..\src\artifact\fixed-art-generator.h" />
+    <ClInclude Include="..\..\src\artifact\random-art-activation.h" />
+    <ClInclude Include="..\..\src\artifact\random-art-generator.h" />
+    <ClInclude Include="..\..\src\artifact\random-art-misc.h" />
+    <ClInclude Include="..\..\src\artifact\random-art-resistance.h" />
+    <ClInclude Include="..\..\src\artifact\random-art-slay.h" />
+    <ClInclude Include="..\..\src\artifact\random-art-characteristics.h" />
+    <ClInclude Include="..\..\src\avatar\avatar-changer.h" />
+    <ClInclude Include="..\..\src\birth\auto-roller.h" />
+    <ClInclude Include="..\..\src\birth\birth-body-spec.h" />
+    <ClInclude Include="..\..\src\birth\birth-select-class.h" />
+    <ClInclude Include="..\..\src\birth\birth-select-personality.h" />
+    <ClInclude Include="..\..\src\birth\birth-select-race.h" />
+    <ClInclude Include="..\..\src\birth\birth-select-realm.h" />
+    <ClInclude Include="..\..\src\birth\birth-stat.h" />
+    <ClInclude Include="..\..\src\birth\birth-util.h" />
+    <ClInclude Include="..\..\src\birth\birth-wizard.h" />
+    <ClInclude Include="..\..\src\birth\game-play-initializer.h" />
+    <ClInclude Include="..\..\src\birth\history-editor.h" />
+    <ClInclude Include="..\..\src\birth\history-generator.h" />
+    <ClInclude Include="..\..\src\birth\initial-equipments-table.h" />
+    <ClInclude Include="..\..\src\birth\inventory-initializer.h" />
+    <ClInclude Include="..\..\src\birth\quick-start.h" />
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-ball-bolt.h" />
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-breath.h" />
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-caster.h" />
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-spirit-curse.h" />
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-status.h" />
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-summon.h" />
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-util.h" />
+    <ClInclude Include="..\..\src\blue-magic\learnt-info.h" />
+    <ClInclude Include="..\..\src\blue-magic\learnt-power-getter.h" />
+    <ClInclude Include="..\..\src\cmd-action\cmd-attack.h" />
+    <ClInclude Include="..\..\src\cmd-action\cmd-move.h" />
+    <ClInclude Include="..\..\src\cmd-action\cmd-open-close.h" />
+    <ClInclude Include="..\..\src\cmd-action\cmd-racial.h" />
+    <ClInclude Include="..\..\src\cmd-action\cmd-shoot.h" />
+    <ClInclude Include="..\..\src\cmd-action\cmd-travel.h" />
+    <ClInclude Include="..\..\src\cmd-action\cmd-tunnel.h" />
+    <ClInclude Include="..\..\src\action\movement-execution.h" />
+    <ClInclude Include="..\..\src\core\score-util.h" />
+    <ClInclude Include="..\..\src\dungeon\dungeon-flag-mask.h" />
+    <ClInclude Include="..\..\src\main-win\commandline-win.h" />
+    <ClInclude Include="..\..\src\main-win\graphics-win.h" />
+    <ClInclude Include="..\..\src\main-win\main-win-term.h" />
+    <ClInclude Include="..\..\src\main-win\wav-reader.h" />
+    <ClInclude Include="..\..\src\monster\monster-damage.h" />
+    <ClInclude Include="..\..\src\object-enchant\others\apply-magic-amulet.h" />
+    <ClInclude Include="..\..\src\object-enchant\protector\abstract-protector-enchanter.h" />
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-boots.h" />
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-cloak.h" />
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-crown.h" />
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-gloves.h" />
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-helm.h" />
+    <ClInclude Include="..\..\src\object-enchant\others\apply-magic-ring.h" />
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-shield.h" />
+    <ClInclude Include="..\..\src\object-use\use-execution.h" />
+    <ClInclude Include="..\..\src\object-use\zaprod-execution.h" />
+    <ClInclude Include="..\..\src\object-use\zapwand-execution.h" />
+    <ClInclude Include="..\..\src\object\object-index-list.h" />
+    <ClInclude Include="..\..\src\player-base\player-class.h" />
+    <ClInclude Include="..\..\src\player-base\player-race.h" />
+    <ClInclude Include="..\..\src\player-info\alignment.h" />
+    <ClInclude Include="..\..\src\player-info\bard-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\bluemage-data.h" />
+    <ClInclude Include="..\..\src\player-info\class-specific-data.h" />
+    <ClInclude Include="..\..\src\player-info\equipment-info.h" />
+    <ClInclude Include="..\..\src\player-info\force-trainer-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\magic-eater-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\mane-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\monk-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\ninja-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\samurai-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\smith-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\sniper-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\spell-hex-data-type.h" />
+    <ClInclude Include="..\..\src\player-status\player-energy.h" />
+    <ClInclude Include="..\..\src\player-status\player-hand-types.h" />
+    <ClInclude Include="..\..\src\main-win\main-win-utils.h" />
+    <ClInclude Include="..\..\src\save\player-class-specific-data-writer.h" />
+    <ClInclude Include="..\..\src\specific-object\stone-of-lore.h" />
+    <ClInclude Include="..\..\src\spell-class\spells-mirror-master.h" />
+    <ClInclude Include="..\..\src\store\cmd-store.h" />
+    <ClInclude Include="..\..\src\cmd-io\cmd-floor.h" />
+    <ClInclude Include="..\..\src\cmd-io\cmd-lore.h" />
+    <ClInclude Include="..\..\src\cmd-io\cmd-menu-content-table.h" />
+    <ClInclude Include="..\..\src\cmd-io\macro-util.h" />
+    <ClInclude Include="..\..\src\cmd-item\cmd-destroy.h" />
+    <ClInclude Include="..\..\src\cmd-item\cmd-equipment.h" />
+    <ClInclude Include="..\..\src\cmd-item\cmd-refill.h" />
+    <ClInclude Include="..\..\src\cmd-item\cmd-throw.h" />
+    <ClInclude Include="..\..\src\cmd-visual\cmd-map.h" />
+    <ClInclude Include="..\..\src\core\asking-player.h" />
+    <ClInclude Include="..\..\src\core\disturbance.h" />
+    <ClInclude Include="..\..\src\core\object-compressor.h" />
+    <ClInclude Include="..\..\src\core\visuals-reseter.h" />
+    <ClInclude Include="..\..\src\core\window-redrawer.h" />
+    <ClInclude Include="..\..\src\dungeon\dungeon-flag-types.h" />
+    <ClInclude Include="..\..\src\dungeon\quest-completion-checker.h" />
+    <ClInclude Include="..\..\src\dungeon\quest-monster-placer.h" />
+    <ClInclude Include="..\..\src\flavor\flag-inscriptions-table.h" />
+    <ClInclude Include="..\..\src\flavor\flavor-describer.h" />
+    <ClInclude Include="..\..\src\flavor\flavor-util.h" />
+    <ClInclude Include="..\..\src\flavor\named-item-describer.h" />
+    <ClInclude Include="..\..\src\flavor\object-flavor-types.h" />
+    <ClInclude Include="..\..\src\flavor\tval-description-switcher.h" />
+    <ClInclude Include="..\..\src\floor\cave-generator.h" />
+    <ClInclude Include="..\..\src\floor\floor-changer.h" />
+    <ClInclude Include="..\..\src\floor\floor-leaver.h" />
+    <ClInclude Include="..\..\src\floor\floor-mode-changer.h" />
+    <ClInclude Include="..\..\src\floor\dungeon-tunnel-util.h" />
+    <ClInclude Include="..\..\src\floor\fixed-map-generator.h" />
+    <ClInclude Include="..\..\src\floor\floor-allocation-types.h" />
+    <ClInclude Include="..\..\src\floor\floor-base-definitions.h" />
+    <ClInclude Include="..\..\src\floor\floor-generator-util.h" />
+    <ClInclude Include="..\..\src\floor\floor-save-util.h" />
+    <ClInclude Include="..\..\src\floor\floor-util.h" />
+    <ClInclude Include="..\..\src\floor\line-of-sight.h" />
+    <ClInclude Include="..\..\src\floor\object-allocator.h" />
+    <ClInclude Include="..\..\src\floor\object-scanner.h" />
+    <ClInclude Include="..\..\src\floor\tunnel-generator.h" />
+    <ClInclude Include="..\..\src\game-option\auto-destruction-options.h" />
+    <ClInclude Include="..\..\src\game-option\birth-options.h" />
+    <ClInclude Include="..\..\src\game-option\cheat-options.h" />
+    <ClInclude Include="..\..\src\game-option\cheat-types.h" />
+    <ClInclude Include="..\..\src\game-option\disturbance-options.h" />
+    <ClInclude Include="..\..\src\game-option\game-play-options.h" />
+    <ClInclude Include="..\..\src\game-option\input-options.h" />
+    <ClInclude Include="..\..\src\game-option\map-screen-options.h" />
+    <ClInclude Include="..\..\src\game-option\option-flags.h" />
+    <ClInclude Include="..\..\src\game-option\option-types-table.h" />
+    <ClInclude Include="..\..\src\game-option\play-record-options.h" />
+    <ClInclude Include="..\..\src\game-option\runtime-arguments.h" />
+    <ClInclude Include="..\..\src\game-option\special-options.h" />
+    <ClInclude Include="..\..\src\game-option\text-display-options.h" />
+    <ClInclude Include="..\..\src\grid\door.h" />
+    <ClInclude Include="..\..\src\system\enums\terrain\terrain-characteristics.h" />
+    <ClInclude Include="..\..\src\grid\feature-generator.h" />
+    <ClInclude Include="..\..\src\grid\object-placer.h" />
+    <ClInclude Include="..\..\src\grid\lighting-colors-table.h" />
+    <ClInclude Include="..\..\src\info-reader\artifact-reader.h" />
+    <ClInclude Include="..\..\src\info-reader\dungeon-info-tokens-table.h" />
+    <ClInclude Include="..\..\src\info-reader\dungeon-reader.h" />
+    <ClInclude Include="..\..\src\info-reader\ego-reader.h" />
+    <ClInclude Include="..\..\src\info-reader\feature-info-tokens-table.h" />
+    <ClInclude Include="..\..\src\info-reader\general-parser.h" />
+    <ClInclude Include="..\..\src\info-reader\info-reader-util.h" />
+    <ClInclude Include="..\..\src\info-reader\json-reader-util.h" />
+    <ClInclude Include="..\..\src\info-reader\baseitem-tokens-table.h" />
+    <ClInclude Include="..\..\src\info-reader\baseitem-reader.h" />
+    <ClInclude Include="..\..\src\info-reader\magic-reader.h" />
+    <ClInclude Include="..\..\src\info-reader\message-reader.h" />
+    <ClInclude Include="..\..\src\info-reader\parse-error-types.h" />
+    <ClInclude Include="..\..\src\info-reader\race-info-tokens-table.h" />
+    <ClInclude Include="..\..\src\info-reader\race-reader.h" />
+    <ClInclude Include="..\..\src\info-reader\random-grid-effect-types.h" />
+    <ClInclude Include="..\..\src\info-reader\skill-reader.h" />
+    <ClInclude Include="..\..\src\info-reader\spell-reader.h" />
+    <ClInclude Include="..\..\src\info-reader\terrain-reader.h" />
+    <ClInclude Include="..\..\src\info-reader\vault-reader.h" />
+    <ClInclude Include="..\..\src\inventory\floor-item-getter.h" />
+    <ClInclude Include="..\..\src\inventory\inventory-slot-types.h" />
+    <ClInclude Include="..\..\src\inventory\item-selection-util.h" />
+    <ClInclude Include="..\..\src\inventory\inventory-describer.h" />
+    <ClInclude Include="..\..\src\inventory\inventory-util.h" />
+    <ClInclude Include="..\..\src\io-dump\random-art-info-dumper.h" />
+    <ClInclude Include="..\..\src\io\command-repeater.h" />
+    <ClInclude Include="..\..\src\io\cursor.h" />
+    <ClInclude Include="..\..\src\io\input-key-acceptor.h" />
+    <ClInclude Include="..\..\src\io\input-key-requester.h" />
+    <ClInclude Include="..\..\src\store\store-key-processor.h" />
+    <ClInclude Include="..\..\src\load\info-loader.h" />
+    <ClInclude Include="..\..\src\locale\character-encoding.h" />
+    <ClInclude Include="..\..\src\locale\language-switcher.h" />
+    <ClInclude Include="..\..\src\locale\utf-8.h" />
+    <ClInclude Include="..\..\src\main-win\main-win-cfg-reader.h" />
+    <ClInclude Include="..\..\src\main-win\main-win-mci.h" />
+    <ClInclude Include="..\..\src\main-win\main-win-menuitem.h" />
+    <ClInclude Include="..\..\src\main-win\main-win-mmsystem.h" />
+    <ClInclude Include="..\..\src\main-win\main-win-music.h" />
+    <ClInclude Include="..\..\src\main-win\main-win-sound.h" />
+    <ClInclude Include="..\..\src\main-win\main-win-define.h" />
+    <ClInclude Include="..\..\src\main-win\main-win-tokenizer.h" />
+    <ClInclude Include="..\..\src\main\game-data-initializer.h" />
+    <ClInclude Include="..\..\src\main\info-initializer.h" />
+    <ClInclude Include="..\..\src\main\init-error-messages-table.h" />
+    <ClInclude Include="..\..\src\main-win\main-win-bg.h" />
+    <ClInclude Include="..\..\src\main\scene-table-floor.h" />
+    <ClInclude Include="..\..\src\main\scene-table-monster.h" />
+    <ClInclude Include="..\..\src\main\scene-table.h" />
+    <ClInclude Include="..\..\src\market\building-initializer.h" />
+    <ClInclude Include="..\..\src\melee\melee-spell-flags-checker.h" />
+    <ClInclude Include="..\..\src\melee\melee-spell-util.h" />
+    <ClInclude Include="..\..\src\melee\melee-spell.h" />
+    <ClInclude Include="..\..\src\mind\mind-archer.h" />
+    <ClInclude Include="..\..\src\mind\mind-berserker.h" />
+    <ClInclude Include="..\..\src\mind\mind-blue-mage.h" />
+    <ClInclude Include="..\..\src\mind\mind-chaos-warrior.h" />
+    <ClInclude Include="..\..\src\mind\mind-elementalist.h" />
+    <ClInclude Include="..\..\src\mind\mind-explanations-table.h" />
+    <ClInclude Include="..\..\src\mind\mind-hobbit.h" />
+    <ClInclude Include="..\..\src\mind\mind-info.h" />
+    <ClInclude Include="..\..\src\mind\mind-mage.h" />
+    <ClInclude Include="..\..\src\mind\mind-magic-eater.h" />
+    <ClInclude Include="..\..\src\mind\mind-magic-resistance.h" />
+    <ClInclude Include="..\..\src\mind\mind-monk.h" />
+    <ClInclude Include="..\..\src\mind\mind-numbers.h" />
+    <ClInclude Include="..\..\src\mind\mind-power-getter.h" />
+    <ClInclude Include="..\..\src\mind\mind-priest.h" />
+    <ClInclude Include="..\..\src\mind\mind-types.h" />
+    <ClInclude Include="..\..\src\mind\mind-weaponsmith.h" />
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-lose.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-death-util.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-lite-util.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-lite.h" />
+    <ClInclude Include="..\..\src\monster-floor\special-death-switcher.h" />
+    <ClInclude Include="..\..\src\monster-race\race-ability-flags.h" />
+    <ClInclude Include="..\..\src\monster-race\race-ability-mask.h" />
+    <ClInclude Include="..\..\src\monster\monster-status-setter.h" />
+    <ClInclude Include="..\..\src\mspell\element-resistance-checker.h" />
+    <ClInclude Include="..\..\src\mspell\high-resistance-checker.h" />
+    <ClInclude Include="..\..\src\mspell\improper-mspell-remover.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-attack-util.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-attack.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-lite.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-selector.h" />
+    <ClInclude Include="..\..\src\mspell\smart-mspell-util.h" />
+    <ClInclude Include="..\..\src\mspell\specified-summon.h" />
+    <ClInclude Include="..\..\src\mutation\gain-mutation-switcher.h" />
+    <ClInclude Include="..\..\src\mutation\lose-mutation-switcher.h" />
+    <ClInclude Include="..\..\src\mutation\mutation-util.h" />
+    <ClInclude Include="..\..\src\mutation\mutation-investor-remover.h" />
+    <ClInclude Include="..\..\src\object-activation\activation-bolt-ball.h" />
+    <ClInclude Include="..\..\src\object-activation\activation-breath.h" />
+    <ClInclude Include="..\..\src\object-activation\activation-charm.h" />
+    <ClInclude Include="..\..\src\object-activation\activation-genocide.h" />
+    <ClInclude Include="..\..\src\object-activation\activation-resistance.h" />
+    <ClInclude Include="..\..\src\object-activation\activation-teleport.h" />
+    <ClInclude Include="..\..\src\object-activation\activation-util.h" />
+    <ClInclude Include="..\..\src\player-ability\player-ability-types.h" />
+    <ClInclude Include="..\..\src\player-info\base-status-info.h" />
+    <ClInclude Include="..\..\src\player-info\body-improvement-info.h" />
+    <ClInclude Include="..\..\src\player-info\class-ability-info.h" />
+    <ClInclude Include="..\..\src\player-info\mutation-info.h" />
+    <ClInclude Include="..\..\src\player-info\race-ability-info.h" />
+    <ClInclude Include="..\..\src\player-info\resistance-info.h" />
+    <ClInclude Include="..\..\src\player-info\self-info-util.h" />
+    <ClInclude Include="..\..\src\player-info\weapon-effect-info.h" />
+    <ClInclude Include="..\..\src\player-status\player-speed.h" />
+    <ClInclude Include="..\..\src\player-status\player-status-base.h" />
+    <ClInclude Include="..\..\src\player-status\player-stealth.h" />
+    <ClInclude Include="..\..\src\player-status\player-basic-statistics.h" />
+    <ClInclude Include="..\..\src\player-ability\player-strength.h" />
+    <ClInclude Include="..\..\src\player-ability\player-intelligence.h" />
+    <ClInclude Include="..\..\src\player-ability\player-wisdom.h" />
+    <ClInclude Include="..\..\src\player-ability\player-dexterity.h" />
+    <ClInclude Include="..\..\src\player-ability\player-constitution.h" />
+    <ClInclude Include="..\..\src\player-ability\player-charisma.h" />
+    <ClInclude Include="..\..\src\player-status\player-infravision.h" />
+    <ClInclude Include="..\..\src\player\player-status-resist.h" />
+    <ClInclude Include="..\..\src\room\vault-builder.h" />
+    <ClInclude Include="..\..\src\specific-object\blade-turner.h" />
+    <ClInclude Include="..\..\src\specific-object\monster-ball.h" />
+    <ClInclude Include="..\..\src\object-use\read\read-execution.h" />
+    <ClInclude Include="..\..\src\player\player-status-flags.h" />
+    <ClInclude Include="..\..\src\player\player-status-table.h" />
+    <ClInclude Include="..\..\src\player\player-spell-status.h" />
+    <ClInclude Include="..\..\src\player\player-view.h" />
+    <ClInclude Include="..\..\src\racial\class-racial-switcher.h" />
+    <ClInclude Include="..\..\src\racial\mutation-racial-selector.h" />
+    <ClInclude Include="..\..\src\racial\race-racial-command-setter.h" />
+    <ClInclude Include="..\..\src\action\racial-execution.h" />
+    <ClInclude Include="..\..\src\racial\racial-kutar.h" />
+    <ClInclude Include="..\..\src\mind\stances-table.h" />
+    <ClInclude Include="..\..\src\mspell\monster-power-table.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-dispel.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-checker.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-judgement.h" />
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-checker.h" />
+    <ClInclude Include="..\..\src\mutation\mutation-flag-types.h" />
+    <ClInclude Include="..\..\src\mutation\mutation-techniques.h" />
+    <ClInclude Include="..\..\src\artifact\random-art-pval-investor.h" />
+    <ClInclude Include="..\..\src\object-hook\hook-armor.h" />
+    <ClInclude Include="..\..\src\object-hook\hook-expendable.h" />
+    <ClInclude Include="..\..\src\object-hook\hook-magic.h" />
+    <ClInclude Include="..\..\src\object-hook\hook-perception.h" />
+    <ClInclude Include="..\..\src\object-hook\hook-weapon.h" />
+    <ClInclude Include="..\..\src\object-use\quaff\quaff-execution.h" />
+    <ClInclude Include="..\..\src\player\attack-defense-types.h" />
+    <ClInclude Include="..\..\src\load\angband-version-comparer.h" />
+    <ClInclude Include="..\..\src\load\birth-loader.h" />
+    <ClInclude Include="..\..\src\load\dummy-loader.h" />
+    <ClInclude Include="..\..\src\load\floor-loader.h" />
+    <ClInclude Include="..\..\src\load\dungeon-loader.h" />
+    <ClInclude Include="..\..\src\load\extra-loader.h" />
+    <ClInclude Include="..\..\src\load\inventory-loader.h" />
+    <ClInclude Include="..\..\src\load\old\item-loader-savefile50.h" />
+    <ClInclude Include="..\..\src\load\load-util.h" />
+    <ClInclude Include="..\..\src\load\old\load-v1-7-0.h" />
+    <ClInclude Include="..\..\src\load\old\load-v1-5-0.h" />
+    <ClInclude Include="..\..\src\load\load-zangband.h" />
+    <ClInclude Include="..\..\src\load\lore-loader.h" />
+    <ClInclude Include="..\..\src\load\old\monster-loader-savefile50.h" />
+    <ClInclude Include="..\..\src\load\old-feature-types.h" />
+    <ClInclude Include="..\..\src\load\option-loader.h" />
+    <ClInclude Include="..\..\src\load\player-attack-loader.h" />
+    <ClInclude Include="..\..\src\load\player-info-loader.h" />
+    <ClInclude Include="..\..\src\load\old\item-flag-types-savefile50.h" />
+    <ClInclude Include="..\..\src\load\store-loader.h" />
+    <ClInclude Include="..\..\src\load\world-loader.h" />
+    <ClInclude Include="..\..\src\racial\racial-util.h" />
+    <ClInclude Include="..\..\src\room\cave-filler.h" />
+    <ClInclude Include="..\..\src\room\door-definition.h" />
+    <ClInclude Include="..\..\src\room\lake-types.h" />
+    <ClInclude Include="..\..\src\room\room-generator.h" />
+    <ClInclude Include="..\..\src\room\room-info-table.h" />
+    <ClInclude Include="..\..\src\room\rooms-maze-vault.h" />
+    <ClInclude Include="..\..\src\room\space-finder.h" />
+    <ClInclude Include="..\..\src\room\treasure-deployment.h" />
+    <ClInclude Include="..\..\src\save\floor-writer.h" />
+    <ClInclude Include="..\..\src\save\info-writer.h" />
+    <ClInclude Include="..\..\src\save\item-writer.h" />
+    <ClInclude Include="..\..\src\save\monster-entity-writer.h" />
+    <ClInclude Include="..\..\src\save\lore-writer.h" />
+    <ClInclude Include="..\..\src\save\player-writer.h" />
+    <ClInclude Include="..\..\src\save\save-util.h" />
+    <ClInclude Include="..\..\src\object-activation\activation-others.h" />
+    <ClInclude Include="..\..\src\specific-object\bloody-moon.h" />
+    <ClInclude Include="..\..\src\specific-object\death-crimson.h" />
+    <ClInclude Include="..\..\src\specific-object\muramasa.h" />
+    <ClInclude Include="..\..\src\specific-object\ring-of-power.h" />
+    <ClInclude Include="..\..\src\specific-object\toragoroshi.h" />
+    <ClInclude Include="..\..\src\spell-kind\blood-curse.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-enchant.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-equipment.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-fetcher.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-polymorph.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-world.h" />
+    <ClInclude Include="..\..\src\spell-realm\spells-arcane.h" />
+    <ClInclude Include="..\..\src\spell-realm\spells-craft.h" />
+    <ClInclude Include="..\..\src\spell-realm\spells-demon.h" />
+    <ClInclude Include="..\..\src\spell-realm\spells-nature.h" />
+    <ClInclude Include="..\..\src\spell-realm\spells-sorcery.h" />
+    <ClInclude Include="..\..\src\spell\summon-types.h" />
+    <ClInclude Include="..\..\src\status\bad-status-setter.h" />
+    <ClInclude Include="..\..\src\status\base-status.h" />
+    <ClInclude Include="..\..\src\status\body-improvement.h" />
+    <ClInclude Include="..\..\src\status\buff-setter.h" />
+    <ClInclude Include="..\..\src\player\player-realm.h" />
+    <ClInclude Include="..\..\src\player\special-defense-types.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-curse-removal.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-perception.h" />
+    <ClInclude Include="..\..\src\spell-realm\spells-chaos.h" />
+    <ClInclude Include="..\..\src\spell\spell-info.h" />
+    <ClInclude Include="..\..\src\status\element-resistance.h" />
+    <ClInclude Include="..\..\src\status\shape-changer.h" />
+    <ClInclude Include="..\..\src\status\sight-setter.h" />
+    <ClInclude Include="..\..\src\status\experience.h" />
+    <ClInclude Include="..\..\src\status\temporary-resistance.h" />
+    <ClInclude Include="..\..\src\stdafx.h" />
+    <ClInclude Include="..\..\src\store\home.h" />
+    <ClInclude Include="..\..\src\store\museum.h" />
+    <ClInclude Include="..\..\src\store\pricing.h" />
+    <ClInclude Include="..\..\src\store\purchase-order.h" />
+    <ClInclude Include="..\..\src\store\sell-order.h" />
+    <ClInclude Include="..\..\src\store\service-checker.h" />
+    <ClInclude Include="..\..\src\system\floor\town-list.h" />
+    <ClInclude Include="..\..\src\system\monrace\monrace-allocation.h" />
+    <ClInclude Include="..\..\src\system\angband-exceptions.h" />
+    <ClInclude Include="..\..\src\system\angband-system.h" />
+    <ClInclude Include="..\..\src\system\baseitem\baseitem-allocation.h" />
+    <ClInclude Include="..\..\src\system\baseitem\baseitem-key.h" />
+    <ClInclude Include="..\..\src\system\baseitem\baseitem-list.h" />
+    <ClInclude Include="..\..\src\system\dungeon\dungeon-list.h" />
+    <ClInclude Include="..\..\src\system\dungeon\dungeon-record.h" />
+    <ClInclude Include="..\..\src\system\enums\grid-count-kind.h" />
+    <ClInclude Include="..\..\src\system\enums\grid-flow.h" />
+    <ClInclude Include="..\..\src\system\inner-game-data.h" />
+    <ClInclude Include="..\..\src\system\monrace\monrace-list.h" />
+    <ClInclude Include="..\..\src\system\redrawing-flags-updater.h" />
+    <ClInclude Include="..\..\src\system\dungeon\dungeon-data-definition.h" />
+    <ClInclude Include="..\..\src\system\floor\floor-info.h" />
+    <ClInclude Include="..\..\src\system\grid-type-definition.h" />
+    <ClInclude Include="..\..\src\system\player-type-definition.h" />
+    <ClInclude Include="..\..\src\system\services\baseitem-monrace-service.h" />
+    <ClInclude Include="..\..\src\system\terrain\terrain-definition.h" />
+    <ClInclude Include="..\..\src\system\enums\terrain\terrain-tag.h" />
+    <ClInclude Include="..\..\src\system\terrain\terrain-list.h" />
+    <ClInclude Include="..\..\src\target\grid-selector.h" />
+    <ClInclude Include="..\..\src\target\projection-path-calculator.h" />
+    <ClInclude Include="..\..\src\target\target-describer.h" />
+    <ClInclude Include="..\..\src\target\target-getter.h" />
+    <ClInclude Include="..\..\src\target\target-preparation.h" />
+    <ClInclude Include="..\..\src\target\target-setter.h" />
+    <ClInclude Include="..\..\src\target\target-types.h" />
+    <ClInclude Include="..\..\src\target\target.h" />
+    <ClInclude Include="..\..\src\term\screen-processor.h" />
+    <ClInclude Include="..\..\src\timed-effect\player-blindness.h" />
+    <ClInclude Include="..\..\src\timed-effect\player-confusion.h" />
+    <ClInclude Include="..\..\src\timed-effect\player-cut.h" />
+    <ClInclude Include="..\..\src\timed-effect\player-acceleration.h" />
+    <ClInclude Include="..\..\src\timed-effect\player-deceleration.h" />
+    <ClInclude Include="..\..\src\timed-effect\player-fear.h" />
+    <ClInclude Include="..\..\src\timed-effect\player-hallucination.h" />
+    <ClInclude Include="..\..\src\timed-effect\player-paralysis.h" />
+    <ClInclude Include="..\..\src\timed-effect\player-poison.h" />
+    <ClInclude Include="..\..\src\timed-effect\player-protection.h" />
+    <ClInclude Include="..\..\src\timed-effect\player-stun.h" />
+    <ClInclude Include="..\..\src\timed-effect\timed-effects.h" />
+    <ClInclude Include="..\..\src\tracking\baseitem-tracker.h" />
+    <ClInclude Include="..\..\src\tracking\health-bar-tracker.h" />
+    <ClInclude Include="..\..\src\tracking\lore-tracker.h" />
+    <ClInclude Include="..\..\src\util\abstract-map-wrapper.h" />
+    <ClInclude Include="..\..\src\util\abstract-vector-wrapper.h" />
+    <ClInclude Include="..\..\src\util\bit-flags-calculator.h" />
+    <ClInclude Include="..\..\src\util\buffer-shaper.h" />
+    <ClInclude Include="..\..\src\util\candidate-selector.h" />
+    <ClInclude Include="..\..\src\util\elapsed-time.h" />
+    <ClInclude Include="..\..\src\util\enum-converter.h" />
+    <ClInclude Include="..\..\src\util\enum-range.h" />
+    <ClInclude Include="..\..\src\util\finalizer.h" />
+    <ClInclude Include="..\..\src\util\flag-group.h" />
+    <ClInclude Include="..\..\src\util\int-char-converter.h" />
+    <ClInclude Include="..\..\src\util\point-2d.h" />
+    <ClInclude Include="..\..\src\lore\combat-types-setter.h" />
+    <ClInclude Include="..\..\src\lore\magic-types-setter.h" />
+    <ClInclude Include="..\..\src\lore\lore-calculator.h" />
+    <ClInclude Include="..\..\src\lore\lore-util.h" />
+    <ClInclude Include="..\..\src\main\sound-of-music.h" />
+    <ClInclude Include="..\..\src\mind\drs-types.h" />
+    <ClInclude Include="..\..\src\mind\snipe-types.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-summon.h" />
+    <ClInclude Include="..\..\src\monster-floor\one-monster-placer.h" />
+    <ClInclude Include="..\..\src\monster\monster-compaction.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-death.h" />
+    <ClInclude Include="..\..\src\lore\monster-lore.h" />
+    <ClInclude Include="..\..\src\monster-race\race-flags-resistance.h" />
+    <ClInclude Include="..\..\src\system\enums\monrace\monrace-id.h" />
+    <ClInclude Include="..\..\src\monster\monster-describer.h" />
+    <ClInclude Include="..\..\src\monster\monster-description-types.h" />
+    <ClInclude Include="..\..\src\monster\monster-flag-types.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-generator.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-remover.h" />
+    <ClInclude Include="..\..\src\monster\monster-timed-effects.h" />
+    <ClInclude Include="..\..\src\monster\monster-util.h" />
+    <ClInclude Include="..\..\src\monster\monster-info.h" />
+    <ClInclude Include="..\..\src\monster\monster-list.h" />
+    <ClInclude Include="..\..\src\monster-floor\place-monster-types.h" />
+    <ClInclude Include="..\..\src\monster\smart-learn-types.h" />
+    <ClInclude Include="..\..\src\mspell\summon-checker.h" />
+    <ClInclude Include="..\..\src\object-enchant\activation-info-table.h" />
+    <ClInclude Include="..\..\src\object-enchant\dragon-breaths-table.h" />
+    <ClInclude Include="..\..\src\artifact\random-art-bias-types.h" />
+    <ClInclude Include="..\..\src\object-enchant\trg-types.h" />
+    <ClInclude Include="..\..\src\perception\identification.h" />
+    <ClInclude Include="..\..\src\player-attack\attack-chaos-effect.h" />
+    <ClInclude Include="..\..\src\combat\attack-criticality.h" />
+    <ClInclude Include="..\..\src\combat\attack-power-table.h" />
+    <ClInclude Include="..\..\src\player-attack\blood-sucking-processor.h" />
+    <ClInclude Include="..\..\src\combat\combat-options-type.h" />
+    <ClInclude Include="..\..\src\combat\hallucination-attacks-table.h" />
+    <ClInclude Include="..\..\src\monster-attack\insults-moans.h" />
+    <ClInclude Include="..\..\src\combat\martial-arts-table.h" />
+    <ClInclude Include="..\..\src\melee\melee-switcher.h" />
+    <ClInclude Include="..\..\src\melee\melee-util.h" />
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-describer.h" />
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-effect.h" />
+    <ClInclude Include="..\..\src\melee\monster-attack-monster.h" />
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-player.h" />
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-status.h" />
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-switcher.h" />
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-table.h" />
+    <ClInclude Include="..\..\src\combat\attack-accuracy.h" />
+    <ClInclude Include="..\..\src\monster-attack\monster-eating.h" />
+    <ClInclude Include="..\..\src\player-attack\player-attack.h" />
+    <ClInclude Include="..\..\src\combat\slaying.h" />
+    <ClInclude Include="..\..\src\object-enchant\vorpal-weapon.h" />
+    <ClInclude Include="..\..\src\floor\floor-object.h" />
+    <ClInclude Include="..\..\src\inventory\inventory-damage.h" />
+    <ClInclude Include="..\..\src\inventory\inventory-object.h" />
+    <ClInclude Include="..\..\src\io\pref-file-expressor.h" />
+    <ClInclude Include="..\..\src\market\arena.h" />
+    <ClInclude Include="..\..\src\market\bounty-prize-table.h" />
+    <ClInclude Include="..\..\src\market\bounty.h" />
+    <ClInclude Include="..\..\src\market\building-actions-table.h" />
+    <ClInclude Include="..\..\src\market\building-craft-armor.h" />
+    <ClInclude Include="..\..\src\market\building-craft-fix.h" />
+    <ClInclude Include="..\..\src\market\building-craft-weapon.h" />
+    <ClInclude Include="..\..\src\market\building-enchanter.h" />
+    <ClInclude Include="..\..\src\market\building-monster.h" />
+    <ClInclude Include="..\..\src\market\building-quest.h" />
+    <ClInclude Include="..\..\src\market\building-recharger.h" />
+    <ClInclude Include="..\..\src\market\building-service.h" />
+    <ClInclude Include="..\..\src\mind\mind-warrior-mage.h" />
+    <ClInclude Include="..\..\src\racial\racial-android.h" />
+    <ClInclude Include="..\..\src\racial\racial-balrog.h" />
+    <ClInclude Include="..\..\src\mind\mind-cavalry.h" />
+    <ClInclude Include="..\..\src\racial\racial-draconian.h" />
+    <ClInclude Include="..\..\src\mind\mind-force-trainer.h" />
+    <ClInclude Include="..\..\src\mind\mind-mindcrafter.h" />
+    <ClInclude Include="..\..\src\mind\mind-mirror-master.h" />
+    <ClInclude Include="..\..\src\mind\monk-attack.h" />
+    <ClInclude Include="..\..\src\mind\mind-ninja.h" />
+    <ClInclude Include="..\..\src\mind\mind-samurai.h" />
+    <ClInclude Include="..\..\src\mind\mind-warrior.h" />
+    <ClInclude Include="..\..\src\racial\racial-vampire.h" />
+    <ClInclude Include="..\..\src\object-enchant\enchanter-base.h" />
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-armor.h" />
+    <ClInclude Include="..\..\src\object-enchant\others\apply-magic-others.h" />
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-bow.h" />
+    <ClInclude Include="..\..\src\object-enchant\item-magic-applier.h" />
+    <ClInclude Include="..\..\src\player\eldritch-horror.h" />
+    <ClInclude Include="..\..\src\realm\realm-types.h" />
+    <ClInclude Include="..\..\src\object\object-stack.h" />
+    <ClInclude Include="..\..\src\object\object-value-calc.h" />
+    <ClInclude Include="..\..\src\perception\object-perception.h" />
+    <ClInclude Include="..\..\src\object\object-value.h" />
+    <ClInclude Include="..\..\src\pet\pet-fall-off.h" />
+    <ClInclude Include="..\..\src\pet\pet-util.h" />
+    <ClInclude Include="..\..\src\mspell\assign-monster-spell.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-floor.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-attack\mspell-particularity.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-special.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-status.h" />
+    <ClInclude Include="..\..\src\system\artifact\artifact-definition.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-command-menu.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-commands-table.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-describer.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-destroyer.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-dirty-flags.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-drawer.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-editor-command.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-editor-util.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-entry.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-finder.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-flags-table.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-initializer.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-inserter-killer.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-keys-table.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-matcher.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-menu-data-table.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-methods-table.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-pref-processor.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-reader-writer.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-registry.h" />
+    <ClInclude Include="..\..\src\autopick\autopick-util.h" />
+    <ClInclude Include="..\..\src\autopick\autopick.h" />
+    <ClInclude Include="..\..\src\specific-object\death-scythe.h" />
+    <ClInclude Include="..\..\src\object-enchant\item-apply-magic.h" />
+    <ClInclude Include="..\..\src\object-enchant\item-feeling.h" />
+    <ClInclude Include="..\..\src\object\item-use-flags.h" />
+    <ClInclude Include="..\..\src\object\object-mark-types.h" />
+    <ClInclude Include="..\..\src\system\building-type-definition.h" />
+    <ClInclude Include="..\..\src\game-option\game-option-page.h" />
+    <ClInclude Include="..\..\src\system\monrace\monrace-definition.h" />
+    <ClInclude Include="..\..\src\system\monrace\monrace-message.h" />
+    <ClInclude Include="..\..\src\system\item\item-entity.h" />
+    <ClInclude Include="..\..\src\object-enchant\old-ego-extra-values.h" />
+    <ClInclude Include="..\..\src\realm\realm-hex-numbers.h" />
+    <ClInclude Include="..\..\src\realm\realm-song-numbers.h" />
+    <ClInclude Include="..\..\src\spell-kind\earthquake.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-beam.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-grid.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-random.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-charm.h" />
+    <ClInclude Include="..\..\src\spell-realm\spells-trump.h" />
+    <ClInclude Include="..\..\src\spell\spells-describer.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-genocide.h" />
+    <ClInclude Include="..\..\src\spell-realm\spells-hex.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-launcher.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-lite.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-neighbor.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-pet.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-sight.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-specific-bolt.h" />
+    <ClInclude Include="..\..\src\spell\spells-staff-only.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-teleport.h" />
+    <ClInclude Include="..\..\src\sv-definition\sv-amulet-types.h" />
+    <ClInclude Include="..\..\src\sv-definition\sv-armor-types.h" />
+    <ClInclude Include="..\..\src\sv-definition\sv-bow-types.h" />
+    <ClInclude Include="..\..\src\sv-definition\sv-digging-types.h" />
+    <ClInclude Include="..\..\src\sv-definition\sv-food-types.h" />
+    <ClInclude Include="..\..\src\sv-definition\sv-lite-types.h" />
+    <ClInclude Include="..\..\src\sv-definition\sv-other-types.h" />
+    <ClInclude Include="..\..\src\sv-definition\sv-potion-types.h" />
+    <ClInclude Include="..\..\src\sv-definition\sv-protector-types.h" />
+    <ClInclude Include="..\..\src\sv-definition\sv-ring-types.h" />
+    <ClInclude Include="..\..\src\sv-definition\sv-rod-types.h" />
+    <ClInclude Include="..\..\src\sv-definition\sv-scroll-types.h" />
+    <ClInclude Include="..\..\src\sv-definition\sv-staff-types.h" />
+    <ClInclude Include="..\..\src\sv-definition\sv-wand-types.h" />
+    <ClInclude Include="..\..\src\sv-definition\sv-weapon-types.h" />
+    <ClInclude Include="..\..\src\specific-object\torch.h" />
+    <ClInclude Include="..\..\src\object-enchant\tr-types.h" />
+    <ClInclude Include="..\..\src\object-enchant\trc-types.h" />
+    <ClInclude Include="..\..\src\object\tval-types.h" />
+    <ClInclude Include="..\..\src\avatar\avatar.h" />
+    <ClInclude Include="..\..\src\birth\character-builder.h" />
+    <ClInclude Include="..\..\src\birth\birth-explanations-table.h" />
+    <ClInclude Include="..\..\src\cmd-io\cmd-autopick.h" />
+    <ClInclude Include="..\..\src\cmd-io\cmd-knowledge.h" />
+    <ClInclude Include="..\..\src\cmd-io\cmd-process-screen.h" />
+    <ClInclude Include="..\..\src\io-dump\dump-util.h" />
+    <ClInclude Include="..\..\src\core\game-play.h" />
+    <ClInclude Include="..\..\src\dungeon\dungeon-processor.h" />
+    <ClInclude Include="..\..\src\player\digestion-processor.h" />
+    <ClInclude Include="..\..\src\core\player-processor.h" />
+    <ClInclude Include="..\..\src\inventory\pack-overflow.h" />
+    <ClInclude Include="..\..\src\io\input-key-processor.h" />
+    <ClInclude Include="..\..\src\core\game-closer.h" />
+    <ClInclude Include="..\..\src\hpmp\hp-mp-processor.h" />
+    <ClInclude Include="..\..\src\hpmp\hp-mp-regenerator.h" />
+    <ClInclude Include="..\..\src\core\magic-effects-timeout-reducer.h" />
+    <ClInclude Include="..\..\src\core\special-internal-keys.h" />
+    <ClInclude Include="..\..\src\core\stuff-handler.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-attack\mspell-bolt.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-attack\mspell-breath.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-attack\mspell-curse.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-damage-calculator.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-learn-checker.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-summon.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-util.h" />
+    <ClInclude Include="..\..\src\mspell\mspell-attack\mspell-ball.h" />
+    <ClInclude Include="..\..\src\player\player-personality-types.h" />
+    <ClInclude Include="..\..\src\player-info\race-types.h" />
+    <ClInclude Include="..\..\src\player-info\class-types.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-detection.h" />
+    <ClInclude Include="..\..\src\system\angband-version.h" />
+    <ClInclude Include="..\..\src\core\turn-compensator.h" />
+    <ClInclude Include="..\..\src\effect\effect-characteristics.h" />
+    <ClInclude Include="..\..\src\effect\effect-feature.h" />
+    <ClInclude Include="..\..\src\effect\effect-item.h" />
+    <ClInclude Include="..\..\src\effect\effect-monster-charm.h" />
+    <ClInclude Include="..\..\src\effect\effect-monster-curse.h" />
+    <ClInclude Include="..\..\src\effect\effect-monster-evil.h" />
+    <ClInclude Include="..\..\src\effect\effect-monster-lite-dark.h" />
+    <ClInclude Include="..\..\src\effect\effect-monster-oldies.h" />
+    <ClInclude Include="..\..\src\effect\effect-monster-psi.h" />
+    <ClInclude Include="..\..\src\effect\effect-monster-resist-hurt.h" />
+    <ClInclude Include="..\..\src\effect\effect-monster-spirit.h" />
+    <ClInclude Include="..\..\src\effect\effect-monster-switcher.h" />
+    <ClInclude Include="..\..\src\effect\effect-monster-util.h" />
+    <ClInclude Include="..\..\src\effect\effect-monster.h" />
+    <ClInclude Include="..\..\src\effect\effect-player-curse.h" />
+    <ClInclude Include="..\..\src\effect\effect-player-oldies.h" />
+    <ClInclude Include="..\..\src\effect\effect-player-resist-hurt.h" />
+    <ClInclude Include="..\..\src\effect\effect-player-spirit.h" />
+    <ClInclude Include="..\..\src\effect\effect-player-switcher.h" />
+    <ClInclude Include="..\..\src\effect\effect-player.h" />
+    <ClInclude Include="..\..\src\effect\spells-effect-util.h" />
+    <ClInclude Include="..\..\src\floor\pattern-walk.h" />
+    <ClInclude Include="..\..\src\inventory\inventory-curse.h" />
+    <ClInclude Include="..\..\src\inventory\recharge-processor.h" />
+    <ClInclude Include="..\..\src\perception\simple-perception.h" />
+    <ClInclude Include="..\..\src\io-dump\dump-remover.h" />
+    <ClInclude Include="..\..\src\io\mutations-dump.h" />
+    <ClInclude Include="..\..\src\knowledge\knowledge-autopick.h" />
+    <ClInclude Include="..\..\src\knowledge\knowledge-features.h" />
+    <ClInclude Include="..\..\src\knowledge\knowledge-items.h" />
+    <ClInclude Include="..\..\src\knowledge\knowledge-experiences.h" />
+    <ClInclude Include="..\..\src\knowledge\knowledge-monsters.h" />
+    <ClInclude Include="..\..\src\knowledge\knowledge-mutations.h" />
+    <ClInclude Include="..\..\src\knowledge\knowledge-quests.h" />
+    <ClInclude Include="..\..\src\knowledge\knowledge-self.h" />
+    <ClInclude Include="..\..\src\knowledge\knowledge-uniques.h" />
+    <ClInclude Include="..\..\src\main\music-definitions-table.h" />
+    <ClInclude Include="..\..\src\main\sound-definitions-table.h" />
+    <ClInclude Include="..\..\src\cmd-building\cmd-building.h" />
+    <ClInclude Include="..\..\src\io-dump\character-dump.h" />
+    <ClInclude Include="..\..\src\specific-object\chest.h" />
+    <ClInclude Include="..\..\src\io\record-play-movie.h" />
+    <ClCompile Include="..\..\src\player\player-move.cpp" />
+    <ClCompile Include="..\..\src\io\files-util.cpp" />
+    <ClCompile Include="..\..\src\grid\grid.cpp" />
+    <ClCompile Include="..\..\src\locale\localized-string.cpp" />
+    <ClCompile Include="..\..\src\locale\japanese.cpp" />
+    <ClCompile Include="..\..\src\load\load.cpp" />
+    <ClCompile Include="..\..\src\main-win.cpp" />
+    <ClCompile Include="..\..\src\cmd-action\cmd-mind.cpp" />
+    <ClCompile Include="..\..\src\monster\monster-info.cpp" />
+    <ClCompile Include="..\..\src\monster\monster-list.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-checker.cpp" />
+    <ClCompile Include="..\..\src\mspell\mspell-judgement.cpp" />
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-checker.cpp" />
+    <ClCompile Include="..\..\src\mspell\assign-monster-spell.cpp" />
+    <ClCompile Include="..\..\src\mutation\mutation-calculator.cpp" />
+    <ClCompile Include="..\..\src\object\object-info.cpp" />
+    <ClCompile Include="..\..\src\racial\racial-switcher.cpp" />
+    <ClCompile Include="..\..\src\realm\realm-arcane.cpp" />
+    <ClCompile Include="..\..\src\realm\realm-chaos.cpp" />
+    <ClCompile Include="..\..\src\realm\realm-hex.cpp" />
+    <ClCompile Include="..\..\src\realm\realm-life.cpp" />
+    <ClCompile Include="..\..\src\realm\realm-trump.cpp" />
+    <ClCompile Include="..\..\src\io\report.cpp" />
+    <ClCompile Include="..\..\src\room\rooms-city.cpp" />
+    <ClCompile Include="..\..\src\room\rooms-fractal.cpp" />
+    <ClCompile Include="..\..\src\room\rooms-normal.cpp" />
+    <ClCompile Include="..\..\src\room\pit-nest-util.cpp" />
+    <ClCompile Include="..\..\src\room\rooms-special.cpp" />
+    <ClCompile Include="..\..\src\room\rooms-trap.cpp" />
+    <ClCompile Include="..\..\src\room\rooms-vault.cpp" />
+    <ClCompile Include="..\..\src\room\rooms-builder.cpp" />
+    <ClCompile Include="..\..\src\store\rumor.cpp" />
+    <ClCompile Include="..\..\src\save\save.cpp" />
+    <ClCompile Include="..\..\src\core\scores.cpp" />
+    <ClCompile Include="..\..\src\player-info\self-info.cpp" />
+    <ClCompile Include="..\..\src\io\signal-handlers.cpp" />
+    <ClCompile Include="..\..\src\mind\mind-sniper.cpp" />
+    <ClCompile Include="..\..\src\target\target-sorter.cpp" />
+    <ClCompile Include="..\..\src\spell\spells-diceroll.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\spells-floor.cpp" />
+    <ClCompile Include="..\..\src\spell\spells-object.cpp" />
+    <ClCompile Include="..\..\src\spell\spells-status.cpp" />
+    <ClCompile Include="..\..\src\spell\spells-summon.cpp" />
+    <ClCompile Include="..\..\src\spell\range-calc.cpp" />
+    <ClCompile Include="..\..\src\spell-realm\spells-crusade.cpp" />
+    <ClCompile Include="..\..\src\spell-kind\magic-item-recharger.cpp" />
+    <ClCompile Include="..\..\src\io\uid-checker.cpp" />
+    <ClCompile Include="..\..\src\util\angband-files.cpp" />
+    <ClCompile Include="..\..\src\util\object-sort.cpp" />
+    <ClCompile Include="..\..\src\util\string-processor.cpp" />
+    <ClCompile Include="..\..\src\view\display-birth.cpp" />
+    <ClCompile Include="..\..\src\view\display-characteristic.cpp" />
+    <ClCompile Include="..\..\src\view\display-fruit.cpp" />
+    <ClCompile Include="..\..\src\view\display-lore-attacks.cpp" />
+    <ClCompile Include="..\..\src\view\display-lore-drops.cpp" />
+    <ClCompile Include="..\..\src\view\display-lore-magics.cpp" />
+    <ClCompile Include="..\..\src\view\display-lore-status.cpp" />
+    <ClCompile Include="..\..\src\view\display-lore.cpp" />
+    <ClCompile Include="..\..\src\view\display-player-middle.cpp" />
+    <ClCompile Include="..\..\src\view\display-player-stat-info.cpp" />
+    <ClCompile Include="..\..\src\view\display-player.cpp" />
+    <ClCompile Include="..\..\src\view\display-util.cpp" />
+    <ClCompile Include="..\..\src\player\process-death.cpp" />
+    <ClCompile Include="..\..\src\view\display-player-misc-info.cpp" />
+    <ClCompile Include="..\..\src\view\object-describer.cpp" />
+    <ClCompile Include="..\..\src\view\status-bars-table.cpp" />
+    <ClCompile Include="..\..\src\view\status-first-page.cpp" />
+    <ClCompile Include="..\..\src\store\store.cpp" />
+    <ClCompile Include="..\..\src\floor\floor-streams.cpp" />
+    <ClCompile Include="..\..\src\target\target-checker.cpp" />
+    <ClCompile Include="..\..\src\term\gameterm.cpp" />
+    <ClCompile Include="..\..\src\grid\trap.cpp" />
+    <ClCompile Include="..\..\src\io\screen-util.cpp" />
+    <ClCompile Include="..\..\src\object\warning.cpp" />
+    <ClCompile Include="..\..\src\floor\wild.cpp" />
+    <ClCompile Include="..\..\src\view\display-messages.cpp" />
+    <ClCompile Include="..\..\src\wizard\wizard-game-modifier.cpp" />
+    <ClCompile Include="..\..\src\wizard\wizard-item-modifier.cpp" />
+    <ClCompile Include="..\..\src\wizard\wizard-messages.cpp" />
+    <ClCompile Include="..\..\src\wizard\wizard-player-modifier.cpp" />
+    <ClCompile Include="..\..\src\wizard\wizard-spells.cpp" />
+    <ClCompile Include="..\..\src\wizard\wizard-spoiler.cpp" />
+    <ClCompile Include="..\..\src\wizard\wizard-special-process.cpp" />
+    <ClCompile Include="..\..\src\world\world.cpp" />
+    <ClCompile Include="..\..\src\world\world-movement-processor.cpp" />
+    <ClCompile Include="..\..\src\world\world-turn-processor.cpp" />
+    <ClCompile Include="..\..\src\term\z-form.cpp" />
+    <ClCompile Include="..\..\src\term\z-rand.cpp" />
+    <ClCompile Include="..\..\src\term\z-term.cpp" />
+    <ClCompile Include="..\..\src\term\z-util.cpp" />
+    <ClInclude Include="..\..\src\object-activation\activation-switcher.h" />
+    <ClInclude Include="..\..\src\cmd-action\cmd-others.h" />
+    <ClInclude Include="..\..\src\cmd-io\cmd-diary.h" />
+    <ClInclude Include="..\..\src\cmd-visual\cmd-draw.h" />
+    <ClInclude Include="..\..\src\cmd-io\cmd-dump.h" />
+    <ClInclude Include="..\..\src\cmd-item\cmd-eat.h" />
+    <ClInclude Include="..\..\src\cmd-io\cmd-gameoption.h" />
+    <ClInclude Include="..\..\src\cmd-io\cmd-help.h" />
+    <ClInclude Include="..\..\src\cmd-action\cmd-hissatsu.h" />
+    <ClInclude Include="..\..\src\cmd-building\cmd-inn.h" />
+    <ClInclude Include="..\..\src\knowledge\knowledge-inventory.h" />
+    <ClInclude Include="..\..\src\cmd-item\cmd-item.h" />
+    <ClInclude Include="..\..\src\cmd-io\cmd-macro.h" />
+    <ClInclude Include="..\..\src\cmd-item\cmd-magiceat.h" />
+    <ClInclude Include="..\..\src\cmd-action\cmd-mane.h" />
+    <ClInclude Include="..\..\src\cmd-action\cmd-pet.h" />
+    <ClInclude Include="..\..\src\cmd-item\cmd-quaff.h" />
+    <ClInclude Include="..\..\src\cmd-item\cmd-read.h" />
+    <ClInclude Include="..\..\src\cmd-io\cmd-save.h" />
+    <ClInclude Include="..\..\src\cmd-action\cmd-spell.h" />
+    <ClInclude Include="..\..\src\cmd-item\cmd-usestaff.h" />
+    <ClInclude Include="..\..\src\cmd-visual\cmd-visuals.h" />
+    <ClInclude Include="..\..\src\cmd-item\cmd-zaprod.h" />
+    <ClInclude Include="..\..\src\cmd-item\cmd-zapwand.h" />
+    <ClInclude Include="..\..\src\cmd-io\diary-subtitle-table.h" />
+    <ClInclude Include="..\..\src\floor\dungeon-feeling.h" />
+    <ClInclude Include="..\..\src\knowledge\lighting-level-table.h" />
+    <ClInclude Include="..\..\src\knowledge\monster-group-table.h" />
+    <ClInclude Include="..\..\src\knowledge\item-group-table.h" />
+    <ClInclude Include="..\..\src\melee\melee-postprocess.h" />
+    <ClInclude Include="..\..\src\combat\shoot.h" />
+    <ClInclude Include="..\..\src\core\show-file.h" />
+    <ClInclude Include="..\..\src\term\term-color-types.h" />
+    <ClInclude Include="..\..\src\util\angband-files.h" />
+    <ClInclude Include="..\..\src\util\object-sort.h" />
+    <ClInclude Include="..\..\src\util\rng-xoshiro.h" />
+    <ClInclude Include="..\..\src\util\dice.h" />
+    <ClInclude Include="..\..\src\util\sha256.h" />
+    <ClInclude Include="..\..\src\util\stack-trace.h" />
+    <ClInclude Include="..\..\src\util\string-processor.h" />
+    <ClInclude Include="..\..\src\view\display-symbol.h" />
+    <ClInclude Include="..\..\src\view\display-birth.h" />
+    <ClInclude Include="..\..\src\view\display-inventory.h" />
+    <ClInclude Include="..\..\src\view\display-lore-attacks.h" />
+    <ClInclude Include="..\..\src\view\display-lore-drops.h" />
+    <ClInclude Include="..\..\src\view\display-lore-magics.h" />
+    <ClInclude Include="..\..\src\view\display-lore-status.h" />
+    <ClInclude Include="..\..\src\view\display-lore.h" />
+    <ClInclude Include="..\..\src\view\display-map.h" />
+    <ClInclude Include="..\..\src\view\display-messages.h" />
+    <ClInclude Include="..\..\src\view\display-self-info.h" />
+    <ClInclude Include="..\..\src\view\display-scores.h" />
+    <ClInclude Include="..\..\src\window\display-sub-windows.h" />
+    <ClInclude Include="..\..\src\window\main-window-left-frame.h" />
+    <ClInclude Include="..\..\src\window\main-window-row-column.h" />
+    <ClInclude Include="..\..\src\window\main-window-stat-poster.h" />
+    <ClInclude Include="..\..\src\window\main-window-util.h" />
+    <ClInclude Include="..\..\src\view\object-describer.h" />
+    <ClInclude Include="..\..\src\view\status-bars-table.h" />
+    <ClInclude Include="..\..\src\window\main-window-equipments.h" />
+    <ClInclude Include="..\..\src\wizard\artifact-analyzer.h" />
+    <ClInclude Include="..\..\src\wizard\artifact-bias-table.h" />
+    <ClInclude Include="..\..\src\wizard\cmd-wizard.h" />
+    <ClInclude Include="..\..\src\wizard\fixed-artifacts-spoiler.h" />
+    <ClInclude Include="..\..\src\wizard\items-spoiler.h" />
+    <ClInclude Include="..\..\src\wizard\monrace-filter-debug-info.h" />
+    <ClInclude Include="..\..\src\wizard\monster-info-spoiler.h" />
+    <ClInclude Include="..\..\src\wizard\spoiler-table.h" />
+    <ClInclude Include="..\..\src\wizard\spoiler-util.h" />
+    <ClInclude Include="..\..\src\wizard\wizard-game-modifier.h" />
+    <ClInclude Include="..\..\src\wizard\wizard-item-modifier.h" />
+    <ClInclude Include="..\..\src\wizard\wizard-messages.h" />
+    <ClInclude Include="..\..\src\wizard\wizard-player-modifier.h" />
+    <ClInclude Include="..\..\src\wizard\wizard-spells.h" />
+    <ClInclude Include="..\..\src\locale\english.h" />
+    <ClInclude Include="..\..\src\monster\horror-descriptions.h" />
+    <ClInclude Include="..\..\src\io\gf-descriptions.h" />
+    <ClInclude Include="..\..\src\io\interpret-pref-file.h" />
+    <ClInclude Include="..\..\src\io-dump\player-status-dump.h" />
+    <ClInclude Include="..\..\src\io\read-pref-file.h" />
+    <ClInclude Include="..\..\src\io-dump\special-class-dump.h" />
+    <ClInclude Include="..\..\src\io\tokenizer.h" />
+    <ClInclude Include="..\..\src\io\write-diary.h" />
+    <ClInclude Include="..\..\src\market\arena-entry.h" />
+    <ClInclude Include="..\..\src\store\articles-on-sale.h" />
+    <ClInclude Include="..\..\src\store\black-market.h" />
+    <ClInclude Include="..\..\src\market\building-util.h" />
+    <ClInclude Include="..\..\src\store\gold-magnification-table.h" />
+    <ClInclude Include="..\..\src\market\play-gamble.h" />
+    <ClInclude Include="..\..\src\market\poker.h" />
+    <ClInclude Include="..\..\src\store\say-comments.h" />
+    <ClInclude Include="..\..\src\store\store-owner-comments.h" />
+    <ClInclude Include="..\..\src\store\store-owners.h" />
+    <ClInclude Include="..\..\src\store\store-util.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-dist-offsets.h" />
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-processor.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-direction.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-move.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-object.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-runaway.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-safety-hiding.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-sweep-grid.h" />
+    <ClInclude Include="..\..\src\monster\monster-update.h" />
+    <ClInclude Include="..\..\src\monster\monster-processor-util.h" />
+    <ClInclude Include="..\..\src\monster-floor\quantum-effect.h" />
+    <ClInclude Include="..\..\src\mutation\mutation-processor.h" />
+    <ClInclude Include="..\..\src\flavor\object-flavor.h" />
+    <ClInclude Include="..\..\src\object\lite-processor.h" />
+    <ClInclude Include="..\..\src\inventory\player-inventory.h" />
+    <ClInclude Include="..\..\src\player-info\mimic-info-table.h" />
+    <ClInclude Include="..\..\src\player\permanent-resistances.h" />
+    <ClInclude Include="..\..\src\player\process-name.h" />
+    <ClInclude Include="..\..\src\player\race-info-table.h" />
+    <ClInclude Include="..\..\src\player\race-resistances.h" />
+    <ClInclude Include="..\..\src\player\temporary-resistances.h" />
+    <ClInclude Include="..\..\src\io\signal-handlers.h" />
+    <ClInclude Include="..\..\src\io\uid-checker.h" />
+    <ClInclude Include="..\..\src\spell-realm\spells-song.h" />
+    <ClInclude Include="..\..\src\effect\effect-processor.h" />
+    <ClInclude Include="..\..\src\effect\attribute-types.h" />
+    <ClInclude Include="..\..\src\spell\spells-util.h" />
+    <ClInclude Include="..\..\src\spell\spells-execution.h" />
+    <ClInclude Include="..\..\src\spell-realm\spells-crusade.h" />
+    <ClInclude Include="..\..\src\spell-kind\magic-item-recharger.h" />
+    <ClInclude Include="..\..\src\spell\technic-info-table.h" />
+    <ClInclude Include="..\..\src\view\display-characteristic.h" />
+    <ClInclude Include="..\..\src\view\display-fruit.h" />
+    <ClInclude Include="..\..\src\view\display-player-middle.h" />
+    <ClInclude Include="..\..\src\view\display-player-stat-info.h" />
+    <ClInclude Include="..\..\src\view\display-player.h" />
+    <ClInclude Include="..\..\src\view\display-util.h" />
+    <ClInclude Include="..\..\src\player\process-death.h" />
+    <ClInclude Include="..\..\src\view\display-player-misc-info.h" />
+    <ClInclude Include="..\..\src\view\status-first-page.h" />
+    <ClInclude Include="..\..\src\wizard\wizard-special-process.h" />
+    <ClInclude Include="..\..\src\wizard\wizard-spoiler.h" />
+    <ClInclude Include="..\..\src\world\world-movement-processor.h" />
+    <ClInclude Include="..\..\src\world\world-turn-processor.h" />
+    <ClInclude Include="..\..\src\locale\localized-string.h" />
+    <ClInclude Include="..\..\src\locale\japanese.h" />
+    <ClInclude Include="..\..\src\combat\aura-counterattack.h" />
+    <ClInclude Include="..\..\src\wizard\tval-descriptions-table.h" />
+    <ClInclude Include="..\..\src\load\quest-loader.h" />
+    <ClInclude Include="..\..\src\view\display-store.h" />
+    <ClInclude Include="..\..\src\monster-race\race-sex.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\system\angband.h" />
+    <ClInclude Include="..\..\src\system\system-variables.h" />
+    <ClInclude Include="..\..\src\core\speed-table.h" />
+    <ClInclude Include="..\..\src\info-reader\fixed-map-parser.h" />
+    <ClInclude Include="..\..\src\system\dungeon\dungeon-definition.h" />
+    <ClInclude Include="..\..\src\io\files-util.h" />
+    <ClInclude Include="..\..\src\floor\floor-events.h" />
+    <ClInclude Include="..\..\src\floor\floor-generator.h" />
+    <ClInclude Include="..\..\src\floor\floor-save.h" />
+    <ClInclude Include="..\..\src\system\floor\town-info.h" />
+    <ClInclude Include="..\..\src\system\gamevalue.h" />
+    <ClInclude Include="..\..\src\floor\geometry.h" />
+    <ClInclude Include="..\..\src\grid\grid.h" />
+    <ClInclude Include="..\..\src\system\h-basic.h" />
+    <ClInclude Include="..\..\src\system\h-config.h" />
+    <ClInclude Include="..\..\src\system\h-system.h" />
+    <ClInclude Include="..\..\src\system\h-type.h" />
+    <ClInclude Include="..\..\src\birth\history.h" />
+    <ClInclude Include="..\..\src\main\angband-initializer.h" />
+    <ClInclude Include="..\..\src\load\load.h" />
+    <ClInclude Include="..\..\src\cmd-action\cmd-mind.h" />
+    <ClInclude Include="..\..\src\monster\monster-processor.h" />
+    <ClInclude Include="..\..\src\monster\monster-status.h" />
+    <ClInclude Include="..\..\src\system\monster-entity.h" />
+    <ClInclude Include="..\..\src\mutation\mutation-calculator.h" />
+    <ClInclude Include="..\..\src\object-enchant\object-boost.h" />
+    <ClInclude Include="..\..\src\object-enchant\object-curse.h" />
+    <ClInclude Include="..\..\src\object-enchant\object-ego.h" />
+    <ClInclude Include="..\..\src\object\item-tester-hooker.h" />
+    <ClInclude Include="..\..\src\object\object-broken.h" />
+    <ClInclude Include="..\..\src\object\object-info.h" />
+    <ClInclude Include="..\..\src\object\object-kind-hook.h" />
+    <ClInclude Include="..\..\src\system\baseitem\baseitem-definition.h" />
+    <ClInclude Include="..\..\src\system\spell-info-list.h" />
+    <ClInclude Include="..\..\src\player\patron.h" />
+    <ClInclude Include="..\..\src\player-info\class-info.h" />
+    <ClInclude Include="..\..\src\player\player-damage.h" />
+    <ClInclude Include="..\..\src\status\action-setter.h" />
+    <ClInclude Include="..\..\src\player\player-move.h" />
+    <ClInclude Include="..\..\src\player\player-personality.h" />
+    <ClInclude Include="..\..\src\player-info\race-info.h" />
+    <ClInclude Include="..\..\src\player\player-sex.h" />
+    <ClInclude Include="..\..\src\player\player-skill.h" />
+    <ClInclude Include="..\..\src\player\player-status.h" />
+    <ClInclude Include="..\..\src\dungeon\quest.h" />
+    <ClInclude Include="..\..\src\racial\racial-switcher.h" />
+    <ClInclude Include="..\..\src\realm\realm-arcane.h" />
+    <ClInclude Include="..\..\src\realm\realm-chaos.h" />
+    <ClInclude Include="..\..\src\realm\realm-craft.h" />
+    <ClInclude Include="..\..\src\realm\realm-crusade.h" />
+    <ClInclude Include="..\..\src\realm\realm-demon.h" />
+    <ClInclude Include="..\..\src\realm\realm-death.h" />
+    <ClInclude Include="..\..\src\realm\realm-hex.h" />
+    <ClInclude Include="..\..\src\realm\realm-hissatsu.h" />
+    <ClInclude Include="..\..\src\realm\realm-life.h" />
+    <ClInclude Include="..\..\src\realm\realm-nature.h" />
+    <ClInclude Include="..\..\src\realm\realm-song.h" />
+    <ClInclude Include="..\..\src\realm\realm-sorcery.h" />
+    <ClInclude Include="..\..\src\realm\realm-trump.h" />
+    <ClInclude Include="..\..\src\io\report.h" />
+    <ClInclude Include="..\..\src\room\rooms-city.h" />
+    <ClInclude Include="..\..\src\room\rooms-fractal.h" />
+    <ClInclude Include="..\..\src\room\rooms-normal.h" />
+    <ClInclude Include="..\..\src\room\pit-nest-util.h" />
+    <ClInclude Include="..\..\src\room\rooms-special.h" />
+    <ClInclude Include="..\..\src\room\rooms-trap.h" />
+    <ClInclude Include="..\..\src\room\rooms-vault.h" />
+    <ClInclude Include="..\..\src\room\rooms-builder.h" />
+    <ClInclude Include="..\..\src\store\rumor.h" />
+    <ClInclude Include="..\..\src\save\save.h" />
+    <ClInclude Include="..\..\src\core\scores.h" />
+    <ClInclude Include="..\..\src\player-info\self-info.h" />
+    <ClInclude Include="..\..\src\mind\mind-sniper.h" />
+    <ClInclude Include="..\..\src\target\target-sorter.h" />
+    <ClInclude Include="..\..\src\spell\spells-diceroll.h" />
+    <ClInclude Include="..\..\src\spell-kind\spells-floor.h" />
+    <ClInclude Include="..\..\src\spell\spells-object.h" />
+    <ClInclude Include="..\..\src\spell\spells-status.h" />
+    <ClInclude Include="..\..\src\spell\spells-summon.h" />
+    <ClInclude Include="..\..\src\floor\floor-streams.h" />
+    <ClInclude Include="..\..\src\spell\range-calc.h" />
+    <ClInclude Include="..\..\src\store\store.h" />
+    <ClInclude Include="..\..\src\target\target-checker.h" />
+    <ClInclude Include="..\..\src\term\gameterm.h" />
+    <ClInclude Include="..\..\src\grid\trap.h" />
+    <ClInclude Include="..\..\src\io\screen-util.h" />
+    <ClInclude Include="..\..\src\object\warning.h" />
+    <ClInclude Include="..\..\src\floor\wild.h" />
+    <ClInclude Include="..\..\src\world\world.h" />
+    <ClInclude Include="..\..\src\term\z-form.h" />
+    <ClInclude Include="..\..\src\term\z-rand.h" />
+    <ClInclude Include="..\..\src\term\z-term.h" />
+    <ClInclude Include="..\..\src\term\z-util.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\..\src\angband.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\src\wall.bmp" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -1,0 +1,5929 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\..\src\main-win.cpp" />
+    <ClCompile Include="..\..\src\combat\shoot.cpp">
+      <Filter>combat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\status-first-page.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-util.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\permanent-resistances.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\temporary-resistances.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-player.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\race-resistances.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-characteristic.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\process-death.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\gf-descriptions.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-player-stat-info.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-player-misc-info.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-player-middle.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\tokenizer.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\process-name.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\show-file.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\read-pref-file.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\interpret-pref-file.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster\monster-update.cpp">
+      <Filter>monster</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\write-diary.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\poker.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\building-util.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-fruit.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\play-gamble.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\arena-entry.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\race-info-table.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\mimic-info-table.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\sound-definitions-table.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\music-definitions-table.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\knowledge\knowledge-uniques.cpp">
+      <Filter>knowledge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\knowledge\knowledge-experiences.cpp">
+      <Filter>knowledge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object\object-kind-hook.cpp">
+      <Filter>object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\knowledge\knowledge-quests.cpp">
+      <Filter>knowledge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\knowledge\knowledge-self.cpp">
+      <Filter>knowledge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\knowledge\knowledge-monsters.cpp">
+      <Filter>knowledge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\knowledge\knowledge-items.cpp">
+      <Filter>knowledge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\knowledge\knowledge-features.cpp">
+      <Filter>knowledge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\knowledge\knowledge-autopick.cpp">
+      <Filter>knowledge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\knowledge\knowledge-inventory.cpp">
+      <Filter>knowledge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\mutations-dump.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\knowledge\knowledge-mutations.cpp">
+      <Filter>knowledge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-menu-data-table.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-entry.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-initializer.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-matcher.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-describer.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\signal-handlers.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\uid-checker.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-destroyer.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-reader-writer.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-finder.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-pref-processor.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-drawer.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-inserter-killer.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-registry.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-command-menu.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-editor-util.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-editor-command.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-util.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-feature.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-item.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\realm\realm-arcane.cpp">
+      <Filter>realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\realm\realm-chaos.cpp">
+      <Filter>realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\realm\realm-craft.cpp">
+      <Filter>realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\realm\realm-crusade.cpp">
+      <Filter>realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\realm\realm-death.cpp">
+      <Filter>realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\realm\realm-hex.cpp">
+      <Filter>realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\realm\realm-hissatsu.cpp">
+      <Filter>realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\realm\realm-life.cpp">
+      <Filter>realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\realm\realm-nature.cpp">
+      <Filter>realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\realm\realm-song.cpp">
+      <Filter>realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\realm\realm-sorcery.cpp">
+      <Filter>realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\realm\realm-trump.cpp">
+      <Filter>realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\spells-effect-util.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell\technic-info-table.cpp">
+      <Filter>spell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell\spells-execution.cpp">
+      <Filter>spell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-player.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-monster.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-monster-util.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-monster-switcher.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-player-switcher.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-monster-resist-hurt.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-monster-psi.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-monster-oldies.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-monster-charm.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-monster-lite-dark.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-monster-evil.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-monster-spirit.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-monster-curse.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-player-resist-hurt.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-player-oldies.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-player-curse.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-player-spirit.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\stuff-handler.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\birth-explanations-table.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\game-closer.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\pattern-walk.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\turn-compensator.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mutation\mutation-processor.cpp">
+      <Filter>mutation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object\lite-processor.cpp">
+      <Filter>object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\magic-effects-timeout-reducer.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\inventory\inventory-curse.cpp">
+      <Filter>inventory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\inventory\recharge-processor.cpp">
+      <Filter>inventory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\wizard-spoiler.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\wizard-special-process.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\input-key-processor.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\inventory\pack-overflow.cpp">
+      <Filter>inventory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\player-processor.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\digestion-processor.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\world\world-movement-processor.cpp">
+      <Filter>world</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\world\world-turn-processor.cpp">
+      <Filter>world</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\world\world.cpp">
+      <Filter>world</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\dungeon\dungeon-processor.cpp">
+      <Filter>dungeon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\game-play.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\floor-events.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\floor-save.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\floor-streams.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object\object-broken.cpp">
+      <Filter>object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\rooms-city.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\rooms-fractal.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\rooms-normal.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\rooms-special.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\rooms-trap.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\rooms-vault.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\pit-nest-util.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\class-info.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\player-damage.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\player-move.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\player-personality.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\player-sex.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\player-skill.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\player-status.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster\monster-status.cpp">
+      <Filter>monster</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\system-variables.cpp">
+      <Filter>system</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell\spells-diceroll.cpp">
+      <Filter>spell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell\spells-object.cpp">
+      <Filter>spell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell\spells-status.cpp">
+      <Filter>spell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell\spells-summon.cpp">
+      <Filter>spell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\locale\english.cpp">
+      <Filter>locale</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\locale\japanese.cpp">
+      <Filter>locale</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\locale\localized-string.cpp">
+      <Filter>locale</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\grid\grid.cpp">
+      <Filter>grid</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\grid\trap.cpp">
+      <Filter>grid</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster\horror-descriptions.cpp">
+      <Filter>monster</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\inventory\player-inventory.cpp">
+      <Filter>inventory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\term\gameterm.cpp">
+      <Filter>term</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\term\z-form.cpp">
+      <Filter>term</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\term\z-rand.cpp">
+      <Filter>term</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\term\z-term.cpp">
+      <Filter>term</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\term\z-util.cpp">
+      <Filter>term</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\wild.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\report.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\geometry.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\patron.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\history.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object\warning.cpp">
+      <Filter>object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\dungeon\quest.cpp">
+      <Filter>dungeon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\scores.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-damage-calculator.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-learn-checker.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-summon.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-util.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-floor.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-status.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-special.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\assign-monster-spell.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\birth-util.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\birth-select-realm.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\quick-start.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\birth-stat.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\history-generator.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\birth-body-spec.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\initial-equipments-table.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-birth.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\inventory-initializer.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\game-play-initializer.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\history-editor.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\birth-select-race.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\birth-select-class.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\birth-select-personality.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\auto-roller.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\birth-wizard.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\birth\character-builder.cpp">
+      <Filter>birth</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\files-util.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\pref-file-expressor.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\arena.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\bounty.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\bounty-prize-table.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\building-recharger.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\building-quest.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\building-service.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\building-craft-weapon.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\building-craft-armor.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\building-craft-fix.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\building-monster.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\building-enchanter.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\rumor.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\say-comments.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\store.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\store-owner-comments.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\store-owners.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\store-util.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\black-market.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\combat\attack-power-table.cpp">
+      <Filter>combat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\combat\hallucination-attacks-table.cpp">
+      <Filter>combat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\combat\martial-arts-table.cpp">
+      <Filter>combat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\combat\attack-accuracy.cpp">
+      <Filter>combat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\combat\slaying.cpp">
+      <Filter>combat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\combat\attack-criticality.cpp">
+      <Filter>combat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\inventory\inventory-damage.cpp">
+      <Filter>inventory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\monk-attack.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\combat\aura-counterattack.cpp">
+      <Filter>combat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\pet\pet-fall-off.cpp">
+      <Filter>pet</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\pet\pet-util.cpp">
+      <Filter>pet</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-item\cmd-eat.cpp">
+      <Filter>cmd-item</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-item\cmd-item.cpp">
+      <Filter>cmd-item</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-item\cmd-magiceat.cpp">
+      <Filter>cmd-item</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-item\cmd-quaff.cpp">
+      <Filter>cmd-item</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-item\cmd-read.cpp">
+      <Filter>cmd-item</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-item\cmd-usestaff.cpp">
+      <Filter>cmd-item</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-item\cmd-zaprod.cpp">
+      <Filter>cmd-item</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-item\cmd-zapwand.cpp">
+      <Filter>cmd-item</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-io\cmd-diary.cpp">
+      <Filter>cmd-io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-io\cmd-dump.cpp">
+      <Filter>cmd-io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-io\cmd-gameoption.cpp">
+      <Filter>cmd-io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-io\cmd-help.cpp">
+      <Filter>cmd-io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-io\cmd-knowledge.cpp">
+      <Filter>cmd-io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-io\cmd-macro.cpp">
+      <Filter>cmd-io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-io\cmd-menu-content-table.cpp">
+      <Filter>cmd-io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-io\cmd-process-screen.cpp">
+      <Filter>cmd-io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-io\cmd-save.cpp">
+      <Filter>cmd-io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-io\diary-subtitle-table.cpp">
+      <Filter>cmd-io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\dungeon-feeling.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-action\cmd-attack.cpp">
+      <Filter>cmd-action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-action\cmd-hissatsu.cpp">
+      <Filter>cmd-action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-action\cmd-mane.cpp">
+      <Filter>cmd-action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-action\cmd-pet.cpp">
+      <Filter>cmd-action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-action\cmd-spell.cpp">
+      <Filter>cmd-action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-io\cmd-autopick.cpp">
+      <Filter>cmd-io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\knowledge\lighting-level-table.cpp">
+      <Filter>knowledge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\knowledge\monster-group-table.cpp">
+      <Filter>knowledge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io-dump\dump-util.cpp">
+      <Filter>io-dump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io-dump\character-dump.cpp">
+      <Filter>io-dump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io-dump\dump-remover.cpp">
+      <Filter>io-dump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io-dump\player-status-dump.cpp">
+      <Filter>io-dump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io-dump\special-class-dump.cpp">
+      <Filter>io-dump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\knowledge\item-group-table.cpp">
+      <Filter>knowledge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\floor-object.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\object-describer.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\inventory\inventory-object.cpp">
+      <Filter>inventory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object\object-value.cpp">
+      <Filter>object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-building\cmd-building.cpp">
+      <Filter>cmd-building</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-building\cmd-inn.cpp">
+      <Filter>cmd-building</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\object-boost.cpp">
+      <Filter>object-enchant</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\object-curse.cpp">
+      <Filter>object-enchant</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\object-ego.cpp">
+      <Filter>object-enchant</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\item-magic-applier.cpp">
+      <Filter>object-enchant</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\perception\object-perception.cpp">
+      <Filter>perception</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\perception\simple-perception.cpp">
+      <Filter>perception</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object\object-value-calc.cpp">
+      <Filter>object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\object-sort.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object\object-stack.cpp">
+      <Filter>object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell\spells-describer.cpp">
+      <Filter>spell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell\range-calc.cpp">
+      <Filter>spell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\specific-object\chest.cpp">
+      <Filter>specific-object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\specific-object\death-scythe.cpp">
+      <Filter>specific-object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\specific-object\torch.cpp">
+      <Filter>specific-object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell\spells-staff-only.cpp">
+      <Filter>spell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-beam.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-detection.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-floor.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-genocide.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-launcher.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-lite.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-neighbor.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-pet.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-sight.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-specific-bolt.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-teleport.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-charm.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-cavalry.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-force-trainer.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-mindcrafter.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-mirror-master.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-ninja.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-samurai.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-warrior.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-warrior-mage.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-realm\spells-crusade.cpp">
+      <Filter>spell-realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-realm\spells-hex.cpp">
+      <Filter>spell-realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-random.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-grid.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\earthquake.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-realm\spells-trump.cpp">
+      <Filter>spell-realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-attack\attack-chaos-effect.cpp">
+      <Filter>player-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-attack\blood-sucking-processor.cpp">
+      <Filter>player-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-attack\player-attack.cpp">
+      <Filter>player-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-attack\insults-moans.cpp">
+      <Filter>monster-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-attack\monster-attack-describer.cpp">
+      <Filter>monster-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-attack\monster-attack-player.cpp">
+      <Filter>monster-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-attack\monster-attack-status.cpp">
+      <Filter>monster-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-attack\monster-attack-switcher.cpp">
+      <Filter>monster-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-attack\monster-attack-table.cpp">
+      <Filter>monster-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-attack\monster-eating.cpp">
+      <Filter>monster-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\melee\melee-postprocess.cpp">
+      <Filter>melee</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\melee\melee-switcher.cpp">
+      <Filter>melee</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\melee\melee-util.cpp">
+      <Filter>melee</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\melee\monster-attack-monster.cpp">
+      <Filter>melee</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\vorpal-weapon.cpp">
+      <Filter>object-enchant</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\race-info-tokens-table.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\baseitem-tokens-table.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\dungeon-info-tokens-table.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\info-reader-util.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\json-reader-util.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\feature-info-tokens-table.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\vault-reader.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\baseitem-reader.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\artifact-reader.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\ego-reader.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\dungeon-reader.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\skill-reader.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\spell-reader.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\magic-reader.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\message-reader.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\race-reader.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\terrain-reader.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\general-parser.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\fixed-map-generator.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\fixed-map-parser.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\perception\identification.cpp">
+      <Filter>perception</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\visuals-reseter.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object\object-info.cpp">
+      <Filter>object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\dragon-breaths-table.cpp">
+      <Filter>object-enchant</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\activation-info-table.cpp">
+      <Filter>object-enchant</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-sniper.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\eldritch-horror.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster\monster-processor-util.cpp">
+      <Filter>monster</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster\monster-processor.cpp">
+      <Filter>monster</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\speed-table.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster\monster-util.cpp">
+      <Filter>monster</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\summon-checker.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-io\cmd-lore.cpp">
+      <Filter>cmd-io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster\monster-info.cpp">
+      <Filter>monster</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster\monster-describer.cpp">
+      <Filter>monster</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster\monster-compaction.cpp">
+      <Filter>monster</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster\monster-list.cpp">
+      <Filter>monster</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lore\monster-lore.cpp">
+      <Filter>lore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lore\lore-util.cpp">
+      <Filter>lore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-lore.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lore\lore-calculator.cpp">
+      <Filter>lore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lore\magic-types-setter.cpp">
+      <Filter>lore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-lore-magics.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-lore-status.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-lore-drops.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lore\combat-types-setter.cpp">
+      <Filter>lore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-lore-attacks.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-attack\monster-attack-processor.cpp">
+      <Filter>monster-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-death.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-direction.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-dist-offsets.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-generator.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-move.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-object.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-remover.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-runaway.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-safety-hiding.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-sweep-grid.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\quantum-effect.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\one-monster-placer.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-summon.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\game-option\input-options.cpp">
+      <Filter>game-option</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\game-option\map-screen-options.cpp">
+      <Filter>game-option</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\game-option\text-display-options.cpp">
+      <Filter>game-option</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\game-option\game-play-options.cpp">
+      <Filter>game-option</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\game-option\disturbance-options.cpp">
+      <Filter>game-option</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\game-option\birth-options.cpp">
+      <Filter>game-option</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\game-option\auto-destruction-options.cpp">
+      <Filter>game-option</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\game-option\play-record-options.cpp">
+      <Filter>game-option</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\game-option\cheat-options.cpp">
+      <Filter>game-option</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\game-option\special-options.cpp">
+      <Filter>game-option</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\game-option\runtime-arguments.cpp">
+      <Filter>game-option</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\game-option\option-flags.cpp">
+      <Filter>game-option</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\game-option\option-types-table.cpp">
+      <Filter>game-option</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\angband-files.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\building-type-definition.cpp">
+      <Filter>system</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\string-processor.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-io\macro-util.cpp">
+      <Filter>cmd-io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\sound-of-music.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\input-key-acceptor.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-messages.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\asking-player.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\term\screen-processor.cpp">
+      <Filter>term</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\target\target-sorter.cpp">
+      <Filter>target</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\input-key-requester.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\command-repeater.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\game-option\keymap-directory-getter.cpp">
+      <Filter>game-option</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\buffer-shaper.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-realm\spells-song.cpp">
+      <Filter>spell-realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\monster-power-table.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\status-bars-table.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\window-redrawer.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-visual\cmd-map.cpp">
+      <Filter>cmd-visual</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-map.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-visual\cmd-draw.cpp">
+      <Filter>cmd-visual</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-visual\cmd-visuals.cpp">
+      <Filter>cmd-visual</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\floor-util.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\grid\lighting-colors-table.cpp">
+      <Filter>grid</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\cursor.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\screen-util.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\realm\realm-demon.cpp">
+      <Filter>realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\tval-descriptions-table.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\spoiler-table.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\wizard-spells.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-realm\spells-chaos.cpp">
+      <Filter>spell-realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-curse-removal.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-perception.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-mage.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell\spell-info.cpp">
+      <Filter>spell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-hook\hook-perception.cpp">
+      <Filter>object-hook</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-hook\hook-weapon.cpp">
+      <Filter>object-hook</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-hook\hook-armor.cpp">
+      <Filter>object-hook</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-hook\hook-expendable.cpp">
+      <Filter>object-hook</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-hook\hook-magic.cpp">
+      <Filter>object-hook</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-weaponsmith.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object\item-tester-hooker.cpp">
+      <Filter>object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\player-realm.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\status\sight-setter.cpp">
+      <Filter>status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\status\buff-setter.cpp">
+      <Filter>status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\status\bad-status-setter.cpp">
+      <Filter>status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\wizard-messages.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-realm\spells-craft.cpp">
+      <Filter>spell-realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\status\element-resistance.cpp">
+      <Filter>status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\status\temporary-resistance.cpp">
+      <Filter>status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\status\experience.cpp">
+      <Filter>status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-realm\spells-demon.cpp">
+      <Filter>spell-realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-magic-resistance.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\status\base-status.cpp">
+      <Filter>status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\status\body-improvement.cpp">
+      <Filter>status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-dispel.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\status\shape-changer.cpp">
+      <Filter>status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\status\action-setter.cpp">
+      <Filter>status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\inventory\inventory-util.cpp">
+      <Filter>inventory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\inventory\floor-item-getter.cpp">
+      <Filter>inventory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\object-scanner.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\inventory\inventory-describer.cpp">
+      <Filter>inventory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-inventory.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\inventory\item-selection-util.cpp">
+      <Filter>inventory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-fetcher.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-realm\spells-sorcery.cpp">
+      <Filter>spell-realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-equipment.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-polymorph.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mutation\mutation-techniques.cpp">
+      <Filter>mutation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\specific-object\death-crimson.cpp">
+      <Filter>specific-object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\blood-curse.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-world.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\spells-enchant.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-kind\magic-item-recharger.cpp">
+      <Filter>spell-kind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\load.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\angband-version-comparer.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\load-util.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\load-zangband.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\store-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\lore-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\option-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\birth-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\extra-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\player-info-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\dummy-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\world-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\player-attack-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\inventory-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\dungeon-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\floor-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\quest-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\flavor\flag-inscriptions-table.cpp">
+      <Filter>flavor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\flavor\flavor-util.cpp">
+      <Filter>flavor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\flavor\flavor-describer.cpp">
+      <Filter>flavor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\flavor\tval-description-switcher.cpp">
+      <Filter>flavor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\flavor\named-item-describer.cpp">
+      <Filter>flavor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\flavor\object-flavor.cpp">
+      <Filter>flavor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\action\action-limited.cpp">
+      <Filter>action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-action\cmd-move.cpp">
+      <Filter>cmd-action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\action\open-util.cpp">
+      <Filter>action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-action\cmd-open-close.cpp">
+      <Filter>cmd-action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\action\open-close-execution.cpp">
+      <Filter>action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\action\tunnel-execution.cpp">
+      <Filter>action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-action\cmd-tunnel.cpp">
+      <Filter>cmd-action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\action\movement-execution.cpp">
+      <Filter>action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-action\cmd-shoot.cpp">
+      <Filter>cmd-action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-item\cmd-throw.cpp">
+      <Filter>cmd-item</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\action\weapon-shield.cpp">
+      <Filter>action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-action\cmd-others.cpp">
+      <Filter>cmd-action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\action\run-execution.cpp">
+      <Filter>action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\action\travel-execution.cpp">
+      <Filter>action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\disturbance.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\window\main-window-equipments.cpp">
+      <Filter>window</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\window\display-sub-windows.cpp">
+      <Filter>window</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\window\main-window-left-frame.cpp">
+      <Filter>window</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\window\main-window-stat-poster.cpp">
+      <Filter>window</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\window\main-window-util.cpp">
+      <Filter>window</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-action\cmd-travel.cpp">
+      <Filter>cmd-action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\artifact\random-art-pval-investor.cpp">
+      <Filter>artifact</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\artifact-bias-table.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\artifact\random-art-resistance.cpp">
+      <Filter>artifact</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\artifact\random-art-misc.cpp">
+      <Filter>artifact</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\artifact\random-art-slay.cpp">
+      <Filter>artifact</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\artifact\random-art-activation.cpp">
+      <Filter>artifact</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\artifact\random-art-characteristics.cpp">
+      <Filter>artifact</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\artifact\random-art-generator.cpp">
+      <Filter>artifact</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\artifact\fixed-art-generator.cpp">
+      <Filter>artifact</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-store.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\home.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\purchase-order.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\sell-order.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\museum.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\pricing.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\service-checker.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\stances-table.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\racial\racial-android.cpp">
+      <Filter>racial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\racial\racial-balrog.cpp">
+      <Filter>racial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\racial\racial-draconian.cpp">
+      <Filter>racial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\racial\racial-kutar.cpp">
+      <Filter>racial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\racial\racial-vampire.cpp">
+      <Filter>racial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\racial\racial-switcher.cpp">
+      <Filter>racial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\save\save.cpp">
+      <Filter>save</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\save\save-util.cpp">
+      <Filter>save</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\save\item-writer.cpp">
+      <Filter>save</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\save\lore-writer.cpp">
+      <Filter>save</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\save\info-writer.cpp">
+      <Filter>save</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\save\player-writer.cpp">
+      <Filter>save</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\save\floor-writer.cpp">
+      <Filter>save</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\info-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\blue-magic\learnt-info.cpp">
+      <Filter>blue-magic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\blue-magic\learnt-power-getter.cpp">
+      <Filter>blue-magic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-blue-mage.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-checker.cpp">
+      <Filter>blue-magic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-caster.cpp">
+      <Filter>blue-magic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-util.cpp">
+      <Filter>blue-magic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-breath.cpp">
+      <Filter>blue-magic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\specified-summon.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-ball-bolt.cpp">
+      <Filter>blue-magic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-spirit-curse.cpp">
+      <Filter>blue-magic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-status.cpp">
+      <Filter>blue-magic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\blue-magic\blue-magic-summon.cpp">
+      <Filter>blue-magic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\melee\melee-spell.cpp">
+      <Filter>melee</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-judgement.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\melee\melee-spell-util.cpp">
+      <Filter>melee</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\melee\melee-spell-flags-checker.cpp">
+      <Filter>melee</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\improper-mspell-remover.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\smart-mspell-util.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\element-resistance-checker.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\high-resistance-checker.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-selector.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-attack.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-checker.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-attack-util.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-lite.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\player-status-flags.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\room-info-table.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\cave-filler.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\room-generator.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\treasure-deployment.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\rooms-maze-vault.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\space-finder.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\door-definition.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\rooms-builder.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\target\target-describer.cpp">
+      <Filter>target</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\target\target-preparation.cpp">
+      <Filter>target</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\target\grid-selector.cpp">
+      <Filter>target</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\target\target-setter.cpp">
+      <Filter>target</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\target\target-getter.cpp">
+      <Filter>target</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\target\target-checker.cpp">
+      <Filter>target</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-explanations-table.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-info.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-power-getter.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-berserker.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-action\cmd-mind.cpp">
+      <Filter>cmd-action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mutation\gain-mutation-switcher.cpp">
+      <Filter>mutation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mutation\mutation-util.cpp">
+      <Filter>mutation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mutation\lose-mutation-switcher.cpp">
+      <Filter>mutation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mutation\mutation-investor-remover.cpp">
+      <Filter>mutation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\action\mutation-execution.cpp">
+      <Filter>action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mutation\mutation-calculator.cpp">
+      <Filter>mutation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\cmd-wizard.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\wizard-item-modifier.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\spoiler-util.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\items-spoiler.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\artifact-analyzer.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\monster-info-spoiler.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io-dump\random-art-info-dumper.cpp">
+      <Filter>io-dump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\fixed-artifacts-spoiler.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\dungeon-tunnel-util.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\object-allocator.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\floor-generator.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\cave-generator.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\tunnel-generator.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\dungeon\quest-monster-placer.cpp">
+      <Filter>dungeon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\grid\feature-generator.cpp">
+      <Filter>grid</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-monk.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-action\cmd-racial.cpp">
+      <Filter>cmd-action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\racial\racial-util.cpp">
+      <Filter>racial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\racial\class-racial-switcher.cpp">
+      <Filter>racial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\racial\mutation-racial-selector.cpp">
+      <Filter>racial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\action\racial-execution.cpp">
+      <Filter>action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\racial\race-racial-command-setter.cpp">
+      <Filter>racial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\player-status-table.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\player-spell-status.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-lite-util.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-lite.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\dungeon\quest-completion-checker.cpp">
+      <Filter>dungeon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster\monster-status-setter.cpp">
+      <Filter>monster</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\player-view.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\floor-mode-changer.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\floor-save-util.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\floor-changer.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\floor-leaver.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\action\activation-execution.cpp">
+      <Filter>action</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-activation\activation-breath.cpp">
+      <Filter>object-activation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-activation\activation-switcher.cpp">
+      <Filter>object-activation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-activation\activation-bolt-ball.cpp">
+      <Filter>object-activation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-activation\activation-charm.cpp">
+      <Filter>object-activation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-activation\activation-resistance.cpp">
+      <Filter>object-activation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\specific-object\muramasa.cpp">
+      <Filter>specific-object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\specific-object\bloody-moon.cpp">
+      <Filter>specific-object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\specific-object\ring-of-power.cpp">
+      <Filter>specific-object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-activation\activation-others.cpp">
+      <Filter>object-activation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\specific-object\monster-ball.cpp">
+      <Filter>specific-object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-activation\activation-util.cpp">
+      <Filter>object-activation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\specific-object\blade-turner.cpp">
+      <Filter>specific-object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-activation\activation-teleport.cpp">
+      <Filter>object-activation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\specific-object\toragoroshi.cpp">
+      <Filter>specific-object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-activation\activation-genocide.cpp">
+      <Filter>object-activation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\effect\effect-processor.cpp">
+      <Filter>effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-io\cmd-floor.cpp">
+      <Filter>cmd-io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-item\cmd-equipment.cpp">
+      <Filter>cmd-item</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-item\cmd-refill.cpp">
+      <Filter>cmd-item</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\cmd-item\cmd-destroy.cpp">
+      <Filter>cmd-item</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\target\projection-path-calculator.cpp">
+      <Filter>target</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\grid\door.cpp">
+      <Filter>grid</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\floor\line-of-sight.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\vault-builder.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\grid\object-placer.cpp">
+      <Filter>grid</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\object-compressor.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\info-initializer.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\init-error-messages-table.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\building-initializer.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\game-data-initializer.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\angband-initializer.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\self-info-util.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\self-info.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\race-ability-info.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\class-ability-info.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\mutation-info.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\body-improvement-info.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\resistance-info.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\base-status-info.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-self-info.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\weapon-effect-info.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-archer.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-magic-eater.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-chaos-warrior.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-realm\spells-nature.cpp">
+      <Filter>spell-realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-realm\spells-arcane.cpp">
+      <Filter>spell-realm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-priest.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-hobbit.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-death-util.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\special-death-switcher.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player\player-status-resist.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-attack\monster-attack-lose.cpp">
+      <Filter>monster-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\record-play-movie.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-attack\monster-attack-lose.cpp">
+      <Filter>monster-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\angband-version.cpp">
+      <Filter>system</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\locale\utf-8.cpp">
+      <Filter>locale</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\wizard-game-modifier.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\wizard-player-modifier.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-status\player-speed.cpp">
+      <Filter>player-status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-status\player-status-base.cpp">
+      <Filter>player-status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-status\player-stealth.cpp">
+      <Filter>player-status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-status\player-basic-statistics.cpp">
+      <Filter>player-status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-ability\player-strength.cpp">
+      <Filter>player-ability</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-ability\player-intelligence.cpp">
+      <Filter>player-ability</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-status\player-infravision.cpp">
+      <Filter>player-status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-ability\player-wisdom.cpp">
+      <Filter>player-ability</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-ability\player-dexterity.cpp">
+      <Filter>player-ability</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-ability\player-constitution.cpp">
+      <Filter>player-ability</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-ability\player-charisma.cpp">
+      <Filter>player-ability</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mind\mind-elementalist.cpp">
+      <Filter>mind</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main-win\main-win-bg.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main-win\main-win-music.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main-win\main-win-sound.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main-win\main-win-mci.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main-win\main-win-tokenizer.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\stdafx.cpp" />
+    <ClCompile Include="..\..\src\main\scene-table.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main-win\main-win-cfg-reader.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-race\race-ability-mask.cpp">
+      <Filter>monster-race</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\articles-on-sale.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\gold-magnification-table.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\cmd-store.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\store\store-key-processor.cpp">
+      <Filter>store</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\scene-table-floor.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\scene-table-monster.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main-win\graphics-win.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\player-type-definition.cpp">
+      <Filter>system</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\hpmp\hp-mp-processor.cpp">
+      <Filter>hpmp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\hpmp\hp-mp-regenerator.cpp">
+      <Filter>hpmp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-status\player-energy.cpp">
+      <Filter>player-status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\alignment.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\equipment-info.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main-win\main-win-utils.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main-win\commandline-win.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\score-util.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\view\display-scores.cpp">
+      <Filter>view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object\object-index-list.cpp">
+      <Filter>object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main-win\main-win-term.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main-win\wav-reader.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main-win\stack-trace-win.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster\monster-damage.cpp">
+      <Filter>monster</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\grid-type-definition.cpp">
+      <Filter>system</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\avatar\avatar-changer.cpp">
+      <Filter>avatar</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\avatar\avatar.cpp">
+      <Filter>avatar</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-use\throw-execution.cpp">
+      <Filter>object-use</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\race-info.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-base\player-race.cpp">
+      <Filter>player-base</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-base\player-class.cpp">
+      <Filter>player-base</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\timed-effects.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\player-stun.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\player-cut.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\player-class-specific-data-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\save\player-class-specific-data-writer.cpp">
+      <Filter>save</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\magic-eater-data-type.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\specific-object\stone-of-lore.cpp">
+      <Filter>specific-object</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-use\use-execution.cpp">
+      <Filter>object-use</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-use\item-use-checker.cpp">
+      <Filter>object-use</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-use\zaprod-execution.cpp">
+      <Filter>object-use</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-use\zapwand-execution.cpp">
+      <Filter>object-use</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\rng-xoshiro.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\old\load-v1-5-0.cpp">
+      <Filter>load\old</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\old\load-v1-7-0.cpp">
+      <Filter>load\old</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\old\item-loader-savefile50.cpp">
+      <Filter>load\old</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\old\monster-loader-savefile50.cpp">
+      <Filter>load\old</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\item\item-loader-base.cpp">
+      <Filter>load\item</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\item\item-loader-factory.cpp">
+      <Filter>load\item</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\monster\monster-loader-factory.cpp">
+      <Filter>load\monster</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\protector\abstract-protector-enchanter.cpp">
+      <Filter>object-enchant\protector</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-armor.cpp">
+      <Filter>object-enchant\protector</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-boots.cpp">
+      <Filter>object-enchant\protector</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-cloak.cpp">
+      <Filter>object-enchant\protector</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-crown.cpp">
+      <Filter>object-enchant\protector</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-gloves.cpp">
+      <Filter>object-enchant\protector</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-helm.cpp">
+      <Filter>object-enchant\protector</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-shield.cpp">
+      <Filter>object-enchant\protector</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\weapon\abstract-weapon-enchanter.cpp">
+      <Filter>object-enchant\weapon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-bow.cpp">
+      <Filter>object-enchant\weapon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\smith\object-smith.cpp">
+      <Filter>smith</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\smith\smith-info.cpp">
+      <Filter>smith</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\smith\smith-tables.cpp">
+      <Filter>smith</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\others\apply-magic-amulet.cpp">
+      <Filter>object-enchant\others</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\others\apply-magic-ring.cpp">
+      <Filter>object-enchant\others</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\others\apply-magic-others.cpp">
+      <Filter>object-enchant\others</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\others\apply-magic-lite.cpp">
+      <Filter>object-enchant\others</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-race\monster-kind-mask.cpp">
+      <Filter>monster-race</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-race\race-resistance-mask.cpp">
+      <Filter>monster-race</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\player-confusion.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\player-hallucination.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\player-paralysis.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\player-fear.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-use\read\read-execution.cpp">
+      <Filter>object-use\read</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-use\read\read-executor-factory.cpp">
+      <Filter>object-use\read</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-use\read\scroll-read-executor.cpp">
+      <Filter>object-use\read</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-use\read\gbh-shirt-read-executor.cpp">
+      <Filter>object-use\read</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-use\read\ring-power-read-executor.cpp">
+      <Filter>object-use\read</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-use\read\parchment-read-executor.cpp">
+      <Filter>object-use\read</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\spell-class\spells-mirror-master.cpp">
+      <Filter>spell-class</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-use\quaff\quaff-execution.cpp">
+      <Filter>object-use\quaff</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-use\quaff\quaff-effects.cpp">
+      <Filter>object-use\quaff</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.cpp">
+      <Filter>object-enchant\protector</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.cpp">
+      <Filter>object-enchant\protector</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-soft-armor.cpp">
+      <Filter>object-enchant\protector</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-sword.cpp">
+      <Filter>object-enchant\weapon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-digging.cpp">
+      <Filter>object-enchant\weapon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-arrow.cpp">
+      <Filter>object-enchant\weapon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\weapon\melee-weapon-enchanter.cpp">
+      <Filter>object-enchant\weapon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-hafted.cpp">
+      <Filter>object-enchant\weapon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-polearm.cpp">
+      <Filter>object-enchant\weapon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\enchanter-factory.cpp">
+      <Filter>object-enchant</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-data.cpp">
+      <Filter>mspell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-attack\abstract-mspell.cpp">
+      <Filter>mspell\mspell-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-attack\mspell-ball.cpp">
+      <Filter>mspell\mspell-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-attack\mspell-bolt.cpp">
+      <Filter>mspell\mspell-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-attack\mspell-breath.cpp">
+      <Filter>mspell\mspell-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-attack\mspell-curse.cpp">
+      <Filter>mspell\mspell-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mspell\mspell-attack\mspell-particularity.cpp">
+      <Filter>mspell\mspell-attack</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\player-acceleration.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\player-deceleration.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\player-poison.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\player-blindness.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\monster-entity.cpp">
+      <Filter>system</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\spell-info-list.cpp">
+      <Filter>system</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-race\race-brightness-mask.cpp">
+      <Filter>monster-race</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster\monster-pain-describer.cpp">
+      <Filter>monster</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\item-info\flavor-initializer.cpp">
+      <Filter>item-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\redrawing-flags-updater.cpp">
+      <Filter>system</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\net\curl-easy-session.cpp">
+      <Filter>net</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\net\curl-slist.cpp">
+      <Filter>net</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\net\http-client.cpp">
+      <Filter>net</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\dice.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\sha256.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\net\report-error.cpp">
+      <Filter>net</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main-win\main-win-exception.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\candidate-selector.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\angband-system.cpp">
+      <Filter>system</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\rooms-pit.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\room\rooms-nest.cpp">
+      <Filter>room</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\inner-game-data.cpp">
+      <Filter>system</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\tracking\lore-tracker.cpp">
+      <Filter>tracking</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\tracking\baseitem-tracker.cpp">
+      <Filter>tracking</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\tracking\health-bar-tracker.cpp">
+      <Filter>tracking</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\market\melee-arena.cpp">
+      <Filter>market</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster\monster-timed-effects.cpp">
+      <Filter>monster</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\save\monster-entity-writer.cpp">
+      <Filter>save</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\player-protection.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\baseitem\baseitem-definition.cpp">
+      <Filter>system\baseitem</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\baseitem\baseitem-key.cpp">
+      <Filter>system\baseitem</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\baseitem\baseitem-list.cpp">
+      <Filter>system\baseitem</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\services\baseitem-monrace-service.cpp">
+      <Filter>system\services</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\dungeon\dungeon-definition.cpp">
+      <Filter>system\dungeon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\dungeon\dungeon-data-definition.cpp">
+      <Filter>system\dungeon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\dungeon\dungeon-record.cpp">
+      <Filter>system\dungeon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\dungeon\dungeon-list.cpp">
+      <Filter>system\dungeon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\baseitem\baseitem-allocation.cpp">
+      <Filter>system\baseitem</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\monrace\monrace-allocation.cpp">
+      <Filter>system\monrace</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\monrace\monrace-list.cpp">
+      <Filter>system\monrace</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\monrace\monrace-definition.cpp">
+      <Filter>system\monrace</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\monrace\monrace-message.cpp">
+      <Filter>system\monrace</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\floor\floor-info.cpp">
+      <Filter>system\floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\floor\floor-list.cpp">
+      <Filter>system\floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\floor\town-info.cpp">
+      <Filter>system\floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\floor\town-list.cpp">
+      <Filter>system\floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\terrain\terrain-definition.cpp">
+      <Filter>system\terrain</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\terrain\terrain-list.cpp">
+      <Filter>system\terrain</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\services\dungeon-service.cpp">
+      <Filter>system\services</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\wizard\monrace-filter-debug-info.cpp">
+      <Filter>wizard</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\services\dungeon-monrace-service.cpp">
+      <Filter>system\services</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\elapsed-time.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\external-lib\fmt\format.cc">
+      <Filter>external-lib\fmt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\floor\wilderness-grid.cpp">
+      <Filter>system\floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-movement-direction-list.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\target\target.cpp">
+      <Filter>target</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\macro-configurations-store.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-info\bluemage-data.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\floor\town-records.cpp">
+      <Filter>system\floor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\artifact\artifact-definition.cpp">
+      <Filter>system\artifact</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\artifact\artifact-list.cpp">
+      <Filter>system\artifact</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\artifact\artifact-record.cpp">
+      <Filter>system\artifact</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\artifact\artifact-service.cpp">
+      <Filter>system\artifact</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\item\item-entity.cpp">
+      <Filter>system\item</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\autopick\autopick-keys-table.cpp">
+      <Filter>autopick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\definition-hash-data.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\monrace\monrace-record.cpp">
+      <Filter>system\monrace</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\monrace\monrace-records.cpp">
+      <Filter>system\monrace</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\monrace\monrace-service.cpp">
+      <Filter>system\monrace</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\combat\shoot.h">
+      <Filter>combat</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\status-first-page.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-util.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\permanent-resistances.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\temporary-resistances.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-player.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\race-resistances.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-characteristic.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\process-death.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\gf-descriptions.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-player-stat-info.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-player-misc-info.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-player-middle.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\tokenizer.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\process-name.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\show-file.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\read-pref-file.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\interpret-pref-file.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\monster-update.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\write-diary.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\poker.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\building-util.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-fruit.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\play-gamble.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\arena-entry.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\race-info-table.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\mimic-info-table.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\sound-definitions-table.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\music-definitions-table.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\knowledge\knowledge-uniques.h">
+      <Filter>knowledge</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\knowledge\knowledge-experiences.h">
+      <Filter>knowledge</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object\object-kind-hook.h">
+      <Filter>object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\knowledge\knowledge-quests.h">
+      <Filter>knowledge</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\knowledge\knowledge-self.h">
+      <Filter>knowledge</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\knowledge\knowledge-monsters.h">
+      <Filter>knowledge</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\knowledge\knowledge-items.h">
+      <Filter>knowledge</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\knowledge\knowledge-features.h">
+      <Filter>knowledge</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\knowledge\knowledge-autopick.h">
+      <Filter>knowledge</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\knowledge\knowledge-inventory.h">
+      <Filter>knowledge</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\mutations-dump.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\knowledge\knowledge-mutations.h">
+      <Filter>knowledge</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-keys-table.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-flags-table.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-commands-table.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-dirty-flags.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-util.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-menu-data-table.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-methods-table.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-entry.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-initializer.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-matcher.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-describer.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\signal-handlers.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\uid-checker.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-destroyer.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-reader-writer.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-finder.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-pref-processor.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-drawer.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-inserter-killer.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-registry.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-command-menu.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-editor-util.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\autopick\autopick-editor-command.h">
+      <Filter>autopick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-feature.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-item.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-arcane.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-chaos.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-craft.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-crusade.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-death.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-hex.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-hissatsu.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-life.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-nature.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-song.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-sorcery.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-trump.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\spells-effect-util.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell\technic-info-table.h">
+      <Filter>spell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell\spells-execution.h">
+      <Filter>spell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell\spells-util.h">
+      <Filter>spell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-player.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-monster.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-monster-util.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-monster-switcher.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-player-switcher.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-monster-resist-hurt.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-monster-psi.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-monster-oldies.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-monster-charm.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-monster-lite-dark.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-monster-evil.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-monster-spirit.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-monster-curse.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-player-resist-hurt.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-player-oldies.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-player-curse.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-player-spirit.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-characteristics.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\stuff-handler.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\special-internal-keys.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\birth-explanations-table.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\game-closer.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\pattern-walk.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\turn-compensator.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mutation\mutation-processor.h">
+      <Filter>mutation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object\lite-processor.h">
+      <Filter>object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\magic-effects-timeout-reducer.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\inventory\inventory-curse.h">
+      <Filter>inventory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\inventory\recharge-processor.h">
+      <Filter>inventory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\wizard-spoiler.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\wizard-special-process.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\input-key-processor.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\inventory\pack-overflow.h">
+      <Filter>inventory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\player-processor.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\digestion-processor.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\world\world-movement-processor.h">
+      <Filter>world</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\world\world-turn-processor.h">
+      <Filter>world</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\world\world.h">
+      <Filter>world</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\dungeon\dungeon-processor.h">
+      <Filter>dungeon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\game-play.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\floor-events.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\floor-save.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\floor-streams.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object\object-broken.h">
+      <Filter>object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\rooms-city.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\rooms-fractal.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\rooms-normal.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\rooms-special.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\rooms-trap.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\rooms-vault.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\class-info.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\player-damage.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\player-move.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\player-personality.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\player-sex.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\player-skill.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\player-status.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\monster-status.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\angband.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\h-basic.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\h-config.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\h-system.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\h-type.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\system-variables.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell\spells-diceroll.h">
+      <Filter>spell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell\spells-object.h">
+      <Filter>spell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell\spells-status.h">
+      <Filter>spell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell\spells-summon.h">
+      <Filter>spell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\grid\grid.h">
+      <Filter>grid</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\grid\trap.h">
+      <Filter>grid</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\horror-descriptions.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\inventory\player-inventory.h">
+      <Filter>inventory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\term\gameterm.h">
+      <Filter>term</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\term\z-form.h">
+      <Filter>term</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\term\z-rand.h">
+      <Filter>term</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\term\z-term.h">
+      <Filter>term</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\term\z-util.h">
+      <Filter>term</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\wild.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\report.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\geometry.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\angband-version.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\gamevalue.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\patron.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object\warning.h">
+      <Filter>object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\dungeon\quest.h">
+      <Filter>dungeon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\scores.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-damage-calculator.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-learn-checker.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-summon.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-util.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-floor.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-status.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-special.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\assign-monster-spell.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\birth-util.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\birth-select-realm.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\quick-start.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\birth-stat.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\history-generator.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\birth-body-spec.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\initial-equipments-table.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-birth.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\inventory-initializer.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\game-play-initializer.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\history-editor.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\birth-select-race.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\birth-select-class.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\birth-select-personality.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\auto-roller.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\birth-wizard.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\character-builder.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\birth\history.h">
+      <Filter>birth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\files-util.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\pref-file-expressor.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\arena.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\bounty.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\bounty-prize-table.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\building-recharger.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\building-quest.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\building-service.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\building-craft-weapon.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\building-craft-armor.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\building-craft-fix.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\building-monster.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\building-enchanter.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\building-actions-table.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\say-comments.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\store.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\store-owner-comments.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\store-owners.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\rumor.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\store-util.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\black-market.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\combat\attack-power-table.h">
+      <Filter>combat</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\combat\hallucination-attacks-table.h">
+      <Filter>combat</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\combat\martial-arts-table.h">
+      <Filter>combat</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\combat\combat-options-type.h">
+      <Filter>combat</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\combat\attack-accuracy.h">
+      <Filter>combat</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\combat\slaying.h">
+      <Filter>combat</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\combat\attack-criticality.h">
+      <Filter>combat</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\inventory\inventory-damage.h">
+      <Filter>inventory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\monk-attack.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object\object-mark-types.h">
+      <Filter>object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object\item-use-flags.h">
+      <Filter>object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\combat\aura-counterattack.h">
+      <Filter>combat</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\pet\pet-util.h">
+      <Filter>pet</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\pet\pet-fall-off.h">
+      <Filter>pet</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-item\cmd-eat.h">
+      <Filter>cmd-item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-item\cmd-item.h">
+      <Filter>cmd-item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-item\cmd-magiceat.h">
+      <Filter>cmd-item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-item\cmd-quaff.h">
+      <Filter>cmd-item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-item\cmd-read.h">
+      <Filter>cmd-item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-item\cmd-usestaff.h">
+      <Filter>cmd-item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-item\cmd-zaprod.h">
+      <Filter>cmd-item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-item\cmd-zapwand.h">
+      <Filter>cmd-item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-io\cmd-diary.h">
+      <Filter>cmd-io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-io\cmd-dump.h">
+      <Filter>cmd-io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-io\cmd-gameoption.h">
+      <Filter>cmd-io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-io\cmd-help.h">
+      <Filter>cmd-io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-io\cmd-knowledge.h">
+      <Filter>cmd-io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-io\cmd-macro.h">
+      <Filter>cmd-io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-io\cmd-menu-content-table.h">
+      <Filter>cmd-io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-io\cmd-process-screen.h">
+      <Filter>cmd-io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-io\cmd-save.h">
+      <Filter>cmd-io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-io\diary-subtitle-table.h">
+      <Filter>cmd-io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\dungeon-feeling.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-action\cmd-attack.h">
+      <Filter>cmd-action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-action\cmd-hissatsu.h">
+      <Filter>cmd-action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-action\cmd-mane.h">
+      <Filter>cmd-action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-action\cmd-pet.h">
+      <Filter>cmd-action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-action\cmd-spell.h">
+      <Filter>cmd-action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-io\cmd-autopick.h">
+      <Filter>cmd-io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\knowledge\lighting-level-table.h">
+      <Filter>knowledge</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\knowledge\monster-group-table.h">
+      <Filter>knowledge</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io-dump\dump-util.h">
+      <Filter>io-dump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io-dump\character-dump.h">
+      <Filter>io-dump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io-dump\dump-remover.h">
+      <Filter>io-dump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io-dump\player-status-dump.h">
+      <Filter>io-dump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io-dump\special-class-dump.h">
+      <Filter>io-dump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\knowledge\item-group-table.h">
+      <Filter>knowledge</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\floor-object.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\object-describer.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\inventory\inventory-object.h">
+      <Filter>inventory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object\object-value.h">
+      <Filter>object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-building\cmd-building.h">
+      <Filter>cmd-building</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-building\cmd-inn.h">
+      <Filter>cmd-building</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sv-definition\sv-armor-types.h">
+      <Filter>sv-definition</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sv-definition\sv-bow-types.h">
+      <Filter>sv-definition</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sv-definition\sv-digging-types.h">
+      <Filter>sv-definition</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sv-definition\sv-food-types.h">
+      <Filter>sv-definition</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sv-definition\sv-lite-types.h">
+      <Filter>sv-definition</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sv-definition\sv-other-types.h">
+      <Filter>sv-definition</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sv-definition\sv-potion-types.h">
+      <Filter>sv-definition</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sv-definition\sv-ring-types.h">
+      <Filter>sv-definition</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sv-definition\sv-protector-types.h">
+      <Filter>sv-definition</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sv-definition\sv-rod-types.h">
+      <Filter>sv-definition</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sv-definition\sv-scroll-types.h">
+      <Filter>sv-definition</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sv-definition\sv-staff-types.h">
+      <Filter>sv-definition</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sv-definition\sv-wand-types.h">
+      <Filter>sv-definition</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sv-definition\sv-weapon-types.h">
+      <Filter>sv-definition</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\item-apply-magic.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\item-feeling.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\object-boost.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\object-curse.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\object-ego.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\old-ego-extra-values.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\item\identification-flags.h">
+      <Filter>system\item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\trc-types.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\tr-types.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sv-definition\sv-amulet-types.h">
+      <Filter>sv-definition</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object\tval-types.h">
+      <Filter>object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\enchanter-base.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\item-magic-applier.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\perception\object-perception.h">
+      <Filter>perception</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\perception\simple-perception.h">
+      <Filter>perception</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object\object-value-calc.h">
+      <Filter>object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\object-sort.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object\object-stack.h">
+      <Filter>object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell\spells-describer.h">
+      <Filter>spell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell\range-calc.h">
+      <Filter>spell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-hex-numbers.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-song-numbers.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\specific-object\chest.h">
+      <Filter>specific-object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\specific-object\death-scythe.h">
+      <Filter>specific-object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\specific-object\torch.h">
+      <Filter>specific-object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell\spells-staff-only.h">
+      <Filter>spell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-beam.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-detection.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-floor.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-genocide.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-launcher.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-lite.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-neighbor.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-pet.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-sight.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-specific-bolt.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-teleport.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-charm.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-cavalry.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-force-trainer.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-mindcrafter.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-mirror-master.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-ninja.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-samurai.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-warrior.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-warrior-mage.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-realm\spells-crusade.h">
+      <Filter>spell-realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-realm\spells-hex.h">
+      <Filter>spell-realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-random.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-grid.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\earthquake.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-realm\spells-trump.h">
+      <Filter>spell-realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-attack\attack-chaos-effect.h">
+      <Filter>player-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-attack\blood-sucking-processor.h">
+      <Filter>player-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-attack\player-attack.h">
+      <Filter>player-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-attack\insults-moans.h">
+      <Filter>monster-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-describer.h">
+      <Filter>monster-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-effect.h">
+      <Filter>monster-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-player.h">
+      <Filter>monster-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-status.h">
+      <Filter>monster-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-switcher.h">
+      <Filter>monster-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-table.h">
+      <Filter>monster-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-attack\monster-eating.h">
+      <Filter>monster-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\melee\melee-postprocess.h">
+      <Filter>melee</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\melee\melee-switcher.h">
+      <Filter>melee</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\melee\melee-util.h">
+      <Filter>melee</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\melee\monster-attack-monster.h">
+      <Filter>melee</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\vorpal-weapon.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\race-info-tokens-table.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\baseitem-tokens-table.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\dungeon-info-tokens-table.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\term\term-color-types.h">
+      <Filter>term</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\info-reader-util.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\json-reader-util.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\parse-error-types.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\feature-info-tokens-table.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\vault-reader.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\baseitem-reader.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\artifact-reader.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\ego-reader.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\dungeon-reader.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\skill-reader.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\spell-reader.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\magic-reader.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\message-reader.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\race-reader.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\terrain-reader.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\general-parser.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\random-grid-effect-types.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\fixed-map-generator.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\fixed-map-parser.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\perception\identification.h">
+      <Filter>perception</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\visuals-reseter.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\trg-types.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object\object-info.h">
+      <Filter>object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\dragon-breaths-table.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\activation-info-table.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\drs-types.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\monster-flag-types.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-sniper.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\smart-learn-types.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\pit-nest-util.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\monster-description-types.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\monster-timed-effects.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\eldritch-horror.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\monster-entity.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\monster-processor-util.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\monster-processor.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\speed-table.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\monster-util.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-flags-resistance.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\summon-checker.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-io\cmd-lore.h">
+      <Filter>cmd-io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-symbol.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\monster-info.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\monster-describer.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\monster-compaction.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\monster-list.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lore\monster-lore.h">
+      <Filter>lore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lore\lore-util.h">
+      <Filter>lore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-lore.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lore\lore-calculator.h">
+      <Filter>lore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lore\magic-types-setter.h">
+      <Filter>lore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-lore-magics.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-lore-status.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-lore-drops.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lore\combat-types-setter.h">
+      <Filter>lore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-lore-attacks.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-processor.h">
+      <Filter>monster-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-death.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-direction.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-dist-offsets.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-generator.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-move.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-object.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-remover.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-runaway.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-safety-hiding.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\place-monster-types.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-sweep-grid.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\quantum-effect.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\one-monster-placer.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-summon.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\game-option\input-options.h">
+      <Filter>game-option</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\game-option\map-screen-options.h">
+      <Filter>game-option</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\game-option\text-display-options.h">
+      <Filter>game-option</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\game-option\game-play-options.h">
+      <Filter>game-option</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\game-option\disturbance-options.h">
+      <Filter>game-option</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\game-option\birth-options.h">
+      <Filter>game-option</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\game-option\auto-destruction-options.h">
+      <Filter>game-option</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\game-option\play-record-options.h">
+      <Filter>game-option</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\game-option\cheat-options.h">
+      <Filter>game-option</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\game-option\special-options.h">
+      <Filter>game-option</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\game-option\runtime-arguments.h">
+      <Filter>game-option</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\game-option\option-flags.h">
+      <Filter>game-option</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\game-option\option-types-table.h">
+      <Filter>game-option</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\angband-files.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\building-type-definition.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\player-personality-types.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\class-types.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-types.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\string-processor.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-io\macro-util.h">
+      <Filter>cmd-io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\sound-of-music.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\input-key-acceptor.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-messages.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\locale\japanese.h">
+      <Filter>locale</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\locale\english.h">
+      <Filter>locale</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\locale\localized-string.h">
+      <Filter>locale</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\asking-player.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\term\screen-processor.h">
+      <Filter>term</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\target\target-sorter.h">
+      <Filter>target</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\input-key-requester.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\command-repeater.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\game-option\cheat-types.h">
+      <Filter>game-option</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\int-char-converter.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\bit-flags-calculator.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\buffer-shaper.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\locale\character-encoding.h">
+      <Filter>locale</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\locale\language-switcher.h">
+      <Filter>locale</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-realm\spells-song.h">
+      <Filter>spell-realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-blue-mage.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\monster-power-table.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\status-bars-table.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\window-redrawer.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-visual\cmd-map.h">
+      <Filter>cmd-visual</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-map.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-visual\cmd-draw.h">
+      <Filter>cmd-visual</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-visual\cmd-visuals.h">
+      <Filter>cmd-visual</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\floor-util.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\grid\lighting-colors-table.h">
+      <Filter>grid</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\cursor.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\screen-util.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\special-defense-types.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\realm\realm-demon.h">
+      <Filter>realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\tval-descriptions-table.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\spoiler-table.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\wizard-spells.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-realm\spells-chaos.h">
+      <Filter>spell-realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-curse-removal.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-perception.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-mage.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell\spell-info.h">
+      <Filter>spell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-hook\hook-perception.h">
+      <Filter>object-hook</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-hook\hook-weapon.h">
+      <Filter>object-hook</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-hook\hook-armor.h">
+      <Filter>object-hook</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-hook\hook-expendable.h">
+      <Filter>object-hook</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-hook\hook-magic.h">
+      <Filter>object-hook</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-weaponsmith.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object\item-tester-hooker.h">
+      <Filter>object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\player-realm.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\status\sight-setter.h">
+      <Filter>status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\status\buff-setter.h">
+      <Filter>status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\status\bad-status-setter.h">
+      <Filter>status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\wizard-messages.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-realm\spells-craft.h">
+      <Filter>spell-realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\status\element-resistance.h">
+      <Filter>status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\status\temporary-resistance.h">
+      <Filter>status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\status\experience.h">
+      <Filter>status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-realm\spells-demon.h">
+      <Filter>spell-realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-magic-resistance.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\status\base-status.h">
+      <Filter>status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\status\body-improvement.h">
+      <Filter>status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-dispel.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\status\shape-changer.h">
+      <Filter>status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\status\action-setter.h">
+      <Filter>status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\inventory\inventory-util.h">
+      <Filter>inventory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\inventory\floor-item-getter.h">
+      <Filter>inventory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\object-scanner.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\inventory\inventory-describer.h">
+      <Filter>inventory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-inventory.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\inventory\item-selection-util.h">
+      <Filter>inventory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\inventory\inventory-slot-types.h">
+      <Filter>inventory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mutation\mutation-flag-types.h">
+      <Filter>mutation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-fetcher.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-realm\spells-sorcery.h">
+      <Filter>spell-realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-equipment.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-polymorph.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mutation\mutation-techniques.h">
+      <Filter>mutation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\specific-object\death-crimson.h">
+      <Filter>specific-object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\blood-curse.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-world.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\spells-enchant.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-kind\magic-item-recharger.h">
+      <Filter>spell-kind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\load.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\old-feature-types.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\angband-version-comparer.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\load-util.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\load-zangband.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\store-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\lore-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\option-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\birth-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\extra-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\player-info-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\attack-defense-types.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\dummy-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\world-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\player-attack-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\inventory-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\dungeon-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\floor-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\quest-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\flavor\object-flavor-types.h">
+      <Filter>flavor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\flavor\flag-inscriptions-table.h">
+      <Filter>flavor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\flavor\flavor-util.h">
+      <Filter>flavor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\flavor\flavor-describer.h">
+      <Filter>flavor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\flavor\tval-description-switcher.h">
+      <Filter>flavor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\flavor\named-item-describer.h">
+      <Filter>flavor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\flavor\object-flavor.h">
+      <Filter>flavor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\action\action-limited.h">
+      <Filter>action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-action\cmd-move.h">
+      <Filter>cmd-action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\action\open-util.h">
+      <Filter>action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-action\cmd-open-close.h">
+      <Filter>cmd-action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\action\open-close-execution.h">
+      <Filter>action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\action\tunnel-execution.h">
+      <Filter>action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-action\cmd-tunnel.h">
+      <Filter>cmd-action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\action\movement-execution.h">
+      <Filter>action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-action\cmd-shoot.h">
+      <Filter>cmd-action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-item\cmd-throw.h">
+      <Filter>cmd-item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\action\weapon-shield.h">
+      <Filter>action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-action\cmd-others.h">
+      <Filter>cmd-action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\action\run-execution.h">
+      <Filter>action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\action\travel-execution.h">
+      <Filter>action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\disturbance.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\window\main-window-equipments.h">
+      <Filter>window</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\window\display-sub-windows.h">
+      <Filter>window</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\window\main-window-left-frame.h">
+      <Filter>window</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\window\main-window-row-column.h">
+      <Filter>window</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\window\main-window-stat-poster.h">
+      <Filter>window</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\window\main-window-util.h">
+      <Filter>window</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-action\cmd-travel.h">
+      <Filter>cmd-action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\artifact\random-art-pval-investor.h">
+      <Filter>artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\artifact\random-art-bias-types.h">
+      <Filter>artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\artifact-bias-table.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\artifact\random-art-resistance.h">
+      <Filter>artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\artifact\random-art-misc.h">
+      <Filter>artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\artifact\random-art-slay.h">
+      <Filter>artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\artifact\random-art-activation.h">
+      <Filter>artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\artifact\random-art-characteristics.h">
+      <Filter>artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\artifact\random-art-generator.h">
+      <Filter>artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\artifact\fixed-art-generator.h">
+      <Filter>artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-store.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\home.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\purchase-order.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\sell-order.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\museum.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\pricing.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\service-checker.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\stances-table.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\racial\racial-android.h">
+      <Filter>racial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\racial\racial-balrog.h">
+      <Filter>racial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\racial\racial-draconian.h">
+      <Filter>racial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\racial\racial-kutar.h">
+      <Filter>racial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\racial\racial-vampire.h">
+      <Filter>racial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\snipe-types.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\racial\racial-switcher.h">
+      <Filter>racial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\floor-base-definitions.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\dungeon\dungeon-flag-types.h">
+      <Filter>dungeon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\save\save.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\save\save-util.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\save\item-writer.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\save\lore-writer.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\save\info-writer.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\save\player-writer.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\save\floor-writer.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\info-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\blue-magic\learnt-info.h">
+      <Filter>blue-magic</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\blue-magic\learnt-power-getter.h">
+      <Filter>blue-magic</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-caster.h">
+      <Filter>blue-magic</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-checker.h">
+      <Filter>blue-magic</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-util.h">
+      <Filter>blue-magic</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-breath.h">
+      <Filter>blue-magic</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\specified-summon.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-ball-bolt.h">
+      <Filter>blue-magic</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-spirit-curse.h">
+      <Filter>blue-magic</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-status.h">
+      <Filter>blue-magic</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\blue-magic\blue-magic-summon.h">
+      <Filter>blue-magic</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\melee\melee-spell.h">
+      <Filter>melee</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-judgement.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\melee\melee-spell-util.h">
+      <Filter>melee</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\melee\melee-spell-flags-checker.h">
+      <Filter>melee</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\improper-mspell-remover.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\smart-mspell-util.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\element-resistance-checker.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\high-resistance-checker.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-selector.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-attack.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-checker.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-attack-util.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-lite.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\player-status-flags.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\lake-types.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\room-info-table.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\cave-filler.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\room-generator.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\treasure-deployment.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\rooms-maze-vault.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\space-finder.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\door-definition.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\rooms-builder.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\target\target-types.h">
+      <Filter>target</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\target\target-describer.h">
+      <Filter>target</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\target\target-preparation.h">
+      <Filter>target</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\target\grid-selector.h">
+      <Filter>target</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\target\target-setter.h">
+      <Filter>target</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\target\target-getter.h">
+      <Filter>target</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\target\target-checker.h">
+      <Filter>target</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-explanations-table.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-info.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-types.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-power-getter.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-berserker.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-action\cmd-mind.h">
+      <Filter>cmd-action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-numbers.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mutation\gain-mutation-switcher.h">
+      <Filter>mutation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mutation\mutation-util.h">
+      <Filter>mutation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mutation\lose-mutation-switcher.h">
+      <Filter>mutation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mutation\mutation-investor-remover.h">
+      <Filter>mutation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\action\mutation-execution.h">
+      <Filter>action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mutation\mutation-calculator.h">
+      <Filter>mutation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\cmd-wizard.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\wizard-item-modifier.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\spoiler-util.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\items-spoiler.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\artifact-analyzer.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\monster-info-spoiler.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io-dump\random-art-info-dumper.h">
+      <Filter>io-dump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\fixed-artifacts-spoiler.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\floor-allocation-types.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\dungeon-tunnel-util.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\object-allocator.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\floor-generator-util.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\floor-generator.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\cave-generator.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\tunnel-generator.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\dungeon\quest-monster-placer.h">
+      <Filter>dungeon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\grid\feature-generator.h">
+      <Filter>grid</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-monk.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-action\cmd-racial.h">
+      <Filter>cmd-action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\racial\racial-util.h">
+      <Filter>racial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\racial\class-racial-switcher.h">
+      <Filter>racial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\racial\mutation-racial-selector.h">
+      <Filter>racial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\action\racial-execution.h">
+      <Filter>action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\racial\race-racial-command-setter.h">
+      <Filter>racial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\player-status-table.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\player-spell-status.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-lite-util.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-lite.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\dungeon\quest-completion-checker.h">
+      <Filter>dungeon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\monster-status-setter.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\player-view.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\floor-mode-changer.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\floor-save-util.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\floor-changer.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\floor-leaver.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\action\activation-execution.h">
+      <Filter>action</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-activation\activation-breath.h">
+      <Filter>object-activation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-activation\activation-switcher.h">
+      <Filter>object-activation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-activation\activation-bolt-ball.h">
+      <Filter>object-activation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-activation\activation-charm.h">
+      <Filter>object-activation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-activation\activation-resistance.h">
+      <Filter>object-activation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\specific-object\muramasa.h">
+      <Filter>specific-object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\specific-object\bloody-moon.h">
+      <Filter>specific-object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\specific-object\ring-of-power.h">
+      <Filter>specific-object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-activation\activation-others.h">
+      <Filter>object-activation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\specific-object\monster-ball.h">
+      <Filter>specific-object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-activation\activation-util.h">
+      <Filter>object-activation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\specific-object\blade-turner.h">
+      <Filter>specific-object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-activation\activation-teleport.h">
+      <Filter>object-activation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\specific-object\toragoroshi.h">
+      <Filter>specific-object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-activation\activation-genocide.h">
+      <Filter>object-activation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\effect-processor.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-io\cmd-floor.h">
+      <Filter>cmd-io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-item\cmd-equipment.h">
+      <Filter>cmd-item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-item\cmd-refill.h">
+      <Filter>cmd-item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cmd-item\cmd-destroy.h">
+      <Filter>cmd-item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\target\projection-path-calculator.h">
+      <Filter>target</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\grid\door.h">
+      <Filter>grid</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\line-of-sight.h">
+      <Filter>floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\vault-builder.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\grid\object-placer.h">
+      <Filter>grid</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\object-compressor.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\info-initializer.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\init-error-messages-table.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\building-initializer.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\game-data-initializer.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\angband-initializer.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\self-info-util.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\self-info.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\base-status-info.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\race-ability-info.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\class-ability-info.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\mutation-info.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\body-improvement-info.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\resistance-info.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-self-info.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\weapon-effect-info.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-archer.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-magic-eater.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-chaos-warrior.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-realm\spells-nature.h">
+      <Filter>spell-realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-realm\spells-arcane.h">
+      <Filter>spell-realm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-priest.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-hobbit.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-death-util.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\special-death-switcher.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell\summon-types.h">
+      <Filter>spell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\player-status-resist.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-attack\monster-attack-lose.h">
+      <Filter>monster-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\record-play-movie.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\artifact\fixed-art-types.h">
+      <Filter>artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\artifact\random-art-effects.h">
+      <Filter>artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\locale\utf-8.h">
+      <Filter>locale</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\wizard-game-modifier.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\wizard-player-modifier.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-status\player-speed.h">
+      <Filter>player-status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-status\player-status-base.h">
+      <Filter>player-status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-status\player-stealth.h">
+      <Filter>player-status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-status\player-basic-statistics.h">
+      <Filter>player-status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-status\player-infravision.h">
+      <Filter>player-status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-ability\player-strength.h">
+      <Filter>player-ability</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-ability\player-intelligence.h">
+      <Filter>player-ability</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-ability\player-wisdom.h">
+      <Filter>player-ability</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-ability\player-dexterity.h">
+      <Filter>player-ability</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-ability\player-constitution.h">
+      <Filter>player-ability</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-ability\player-charisma.h">
+      <Filter>player-ability</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\flag-group.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mind\mind-elementalist.h">
+      <Filter>mind</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\main-win-bg.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\main-win-music.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\main-win-sound.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\main-win-mmsystem.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\main-win-define.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\main-win-mci.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\main-win-tokenizer.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\stdafx.h" />
+    <ClInclude Include="..\..\src\main\scene-table.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\main-win-cfg-reader.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\point-2d.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\main-win-menuitem.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\scene-table-floor.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\scene-table-monster.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-ability-flags.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-ability-mask.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\articles-on-sale.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\gold-magnification-table.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\cmd-store.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\store\store-key-processor.h">
+      <Filter>store</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\main-win-utils.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\commandline-win.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\graphics-win.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\player-type-definition.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-ability\player-ability-types.h">
+      <Filter>player-ability</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-status\player-hand-types.h">
+      <Filter>player-status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\hpmp\hp-mp-processor.h">
+      <Filter>hpmp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\hpmp\hp-mp-regenerator.h">
+      <Filter>hpmp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-status\player-energy.h">
+      <Filter>player-status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\alignment.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\equipment-info.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\score-util.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\view\display-scores.h">
+      <Filter>view</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\dungeon\dungeon-flag-mask.h">
+      <Filter>dungeon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object\object-index-list.h">
+      <Filter>object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\main-win-term.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\wav-reader.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\grid-type-definition.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\monster-damage.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\avatar\avatar-changer.h">
+      <Filter>avatar</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\avatar\avatar.h">
+      <Filter>avatar</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-use\throw-execution.h">
+      <Filter>object-use</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\enum-converter.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\enum-range.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\savedata-old-flag-types.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\tr-flags.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\race-info.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\race-types.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-base\player-race.h">
+      <Filter>player-base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-base\player-class.h">
+      <Filter>player-base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\timed-effects.h">
+      <Filter>timed-effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\player-stun.h">
+      <Filter>timed-effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\player-cut.h">
+      <Filter>timed-effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\bluemage-data.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\class-specific-data.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\force-trainer-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\smith-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\spell-hex-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\player-class-specific-data-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\save\player-class-specific-data-writer.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\magic-eater-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\bard-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\mane-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\specific-object\stone-of-lore.h">
+      <Filter>specific-object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\sniper-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-use\use-execution.h">
+      <Filter>object-use</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-use\item-use-checker.h">
+      <Filter>object-use</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-use\zaprod-execution.h">
+      <Filter>object-use</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-use\zapwand-execution.h">
+      <Filter>object-use</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\samurai-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\monk-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\ninja-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\rng-xoshiro.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\monster-aura-types.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-result.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\old\load-v1-5-0.h">
+      <Filter>load\old</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\old\load-v1-7-0.h">
+      <Filter>load\old</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\old\item-loader-savefile50.h">
+      <Filter>load\old</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\old\monster-loader-savefile50.h">
+      <Filter>load\old</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\old\item-flag-types-savefile50.h">
+      <Filter>load\old</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\old\monster-flag-types-savefile50.h">
+      <Filter>load\old</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\item\item-loader-base.h">
+      <Filter>load\item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\item\item-loader-factory.h">
+      <Filter>load\item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\item\item-loader-version-types.h">
+      <Filter>load\item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\monster\monster-loader-base.h">
+      <Filter>load\monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\monster\monster-loader-factory.h">
+      <Filter>load\monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\monster\monster-loader-version-types.h">
+      <Filter>load\monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\effect\attribute-types.h">
+      <Filter>effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-behavior-flags.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\protector\abstract-protector-enchanter.h">
+      <Filter>object-enchant\protector</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-armor.h">
+      <Filter>object-enchant\protector</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-boots.h">
+      <Filter>object-enchant\protector</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-cloak.h">
+      <Filter>object-enchant\protector</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-crown.h">
+      <Filter>object-enchant\protector</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-gloves.h">
+      <Filter>object-enchant\protector</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-helm.h">
+      <Filter>object-enchant\protector</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-shield.h">
+      <Filter>object-enchant\protector</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\weapon\abstract-weapon-enchanter.h">
+      <Filter>object-enchant\weapon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-bow.h">
+      <Filter>object-enchant\weapon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\smith\object-smith.h">
+      <Filter>smith</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\smith\smith-info.h">
+      <Filter>smith</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\smith\smith-tables.h">
+      <Filter>smith</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\smith\smith-types.h">
+      <Filter>smith</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\others\apply-magic-amulet.h">
+      <Filter>object-enchant\others</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\others\apply-magic-ring.h">
+      <Filter>object-enchant\others</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\others\apply-magic-others.h">
+      <Filter>object-enchant\others</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-visual-flags.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\others\apply-magic-lite.h">
+      <Filter>object-enchant\others</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\angband-exceptions.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-kind-flags.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\monster-kind-mask.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-resistance-mask.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\player-confusion.h">
+      <Filter>timed-effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\player-hallucination.h">
+      <Filter>timed-effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\player-paralysis.h">
+      <Filter>timed-effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\player-fear.h">
+      <Filter>timed-effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\bounty-type-definition.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-use\read\read-execution.h">
+      <Filter>object-use\read</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-use\read\read-executor-factory.h">
+      <Filter>object-use\read</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-use\read\scroll-read-executor.h">
+      <Filter>object-use\read</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-use\read\gbh-shirt-read-executor.h">
+      <Filter>object-use\read</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-use\read\ring-power-read-executor.h">
+      <Filter>object-use\read</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-use\read\parchment-read-executor.h">
+      <Filter>object-use\read</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-use\read\read-executor-base.h">
+      <Filter>object-use\read</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\spell-class\spells-mirror-master.h">
+      <Filter>spell-class</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-use\quaff\quaff-execution.h">
+      <Filter>object-use\quaff</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-use\quaff\quaff-effects.h">
+      <Filter>object-use\quaff</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-drop-flags.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.h">
+      <Filter>object-enchant\protector</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.h">
+      <Filter>object-enchant\protector</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-soft-armor.h">
+      <Filter>object-enchant\protector</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-sword.h">
+      <Filter>object-enchant\weapon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-digging.h">
+      <Filter>object-enchant\weapon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-arrow.h">
+      <Filter>object-enchant\weapon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-wilderness-flags.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\weapon\melee-weapon-enchanter.h">
+      <Filter>object-enchant\weapon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-hafted.h">
+      <Filter>object-enchant\weapon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-polearm.h">
+      <Filter>object-enchant\weapon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\enchanter-factory.h">
+      <Filter>object-enchant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-data.h">
+      <Filter>mspell</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-attack\abstract-mspell.h">
+      <Filter>mspell\mspell-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-attack\mspell-ball.h">
+      <Filter>mspell\mspell-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-attack\mspell-bolt.h">
+      <Filter>mspell\mspell-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-attack\mspell-breath.h">
+      <Filter>mspell\mspell-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-attack\mspell-curse.h">
+      <Filter>mspell\mspell-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mspell\mspell-attack\mspell-particularity.h">
+      <Filter>mspell\mspell-attack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-feature-flags.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\player-acceleration.h">
+      <Filter>timed-effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-population-flags.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-speak-flags.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\player-deceleration.h">
+      <Filter>timed-effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\player-poison.h">
+      <Filter>timed-effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\player-blindness.h">
+      <Filter>timed-effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\spell-info-list.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-brightness-flags.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-brightness-mask.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster\monster-pain-describer.h">
+      <Filter>monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\item-info\flavor-initializer.h">
+      <Filter>item-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\redrawing-flags-updater.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\net\http-client.h">
+      <Filter>net</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\net\curl-easy-session.h">
+      <Filter>net</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\net\curl-slist.h">
+      <Filter>net</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\abstract-map-wrapper.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\abstract-vector-wrapper.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\finalizer.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\dice.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\sha256.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\stack-trace.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\external-lib\include-json.h">
+      <Filter>external-lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\net\report-error.h">
+      <Filter>net</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\main-win-exception.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\candidate-selector.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\angband-system.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-sex.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-misc-flags.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-race\race-special-flags.h">
+      <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\rooms-pit.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\room\rooms-nest.h">
+      <Filter>room</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\inner-game-data.h">
+      <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\tracking\lore-tracker.h">
+      <Filter>tracking</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\tracking\baseitem-tracker.h">
+      <Filter>tracking</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\tracking\health-bar-tracker.h">
+      <Filter>tracking</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\market\melee-arena.h">
+      <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\save\monster-entity-writer.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\enums\grid-flow.h">
+      <Filter>system\enums</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\enums\store-sale-type.h">
+      <Filter>system\enums</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\player-protection.h">
+      <Filter>timed-effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\enums\monrace\monrace-id.h">
+      <Filter>system\enums\monrace</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\enums\grid-count-kind.h">
+      <Filter>system\enums</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\baseitem\baseitem-definition.h">
+      <Filter>system\baseitem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\baseitem\baseitem-key.h">
+      <Filter>system\baseitem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\baseitem\baseitem-list.h">
+      <Filter>system\baseitem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\services\baseitem-monrace-service.h">
+      <Filter>system\services</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\dungeon\dungeon-definition.h">
+      <Filter>system\dungeon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\dungeon\dungeon-data-definition.h">
+      <Filter>system\dungeon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\dungeon\dungeon-record.h">
+      <Filter>system\dungeon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\dungeon\dungeon-list.h">
+      <Filter>system\dungeon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\baseitem\baseitem-allocation.h">
+      <Filter>system\baseitem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\monrace\monrace-allocation.h">
+      <Filter>system\monrace</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\monrace\monrace-list.h">
+      <Filter>system\monrace</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\monrace\monrace-definition.h">
+      <Filter>system\monrace</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\monrace\monrace-message.h">
+      <Filter>system\monrace</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\floor\floor-info.h">
+      <Filter>system\floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\floor\floor-list.h">
+      <Filter>system\floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\floor\town-info.h">
+      <Filter>system\floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\floor\town-list.h">
+      <Filter>system\floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\enums\terrain\terrain-tag.h">
+      <Filter>system\enums\terrain</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\enums\terrain\terrain-characteristics.h">
+      <Filter>system\enums\terrain</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\game-option\game-option-page.h">
+      <Filter>game-option</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\terrain\terrain-definition.h">
+      <Filter>system\terrain</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\terrain\terrain-list.h">
+      <Filter>system\terrain</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\enums\dungeon\dungeon-id.h">
+      <Filter>system\enums\dungeon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\services\dungeon-service.h">
+      <Filter>system\services</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\enums\monrace\monrace-hook-types.h">
+      <Filter>system\enums\monrace</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\wizard\monrace-filter-debug-info.h">
+      <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\services\dungeon-monrace-service.h">
+      <Filter>system\services</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\elapsed-time.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\enums\terrain\terrain-kind.h">
+      <Filter>system\enums\terrain</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\enums\terrain\building-type.h">
+      <Filter>system\enums\terrain</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\enums\terrain\pattern-tile-type.h">
+      <Filter>system\enums\terrain</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\enums\terrain\terrain-conversion-type.h">
+      <Filter>system\enums\terrain</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\enums\terrain\trap.h">
+      <Filter>system\enums\terrain</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\enums\terrain\wilderness-terrain.h">
+      <Filter>system\enums\terrain</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\floor\wilderness-grid.h">
+      <Filter>system\floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-movement-direction-list.h">
+      <Filter>monster-floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\target\target.h">
+      <Filter>target</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\macro-configurations-store.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\floor\town-records.h">
+      <Filter>system\floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\artifact\artifact-definition.h">
+      <Filter>system\artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\artifact\artifact-list.h">
+      <Filter>system\artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\artifact\artifact-record.h">
+      <Filter>system\artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\artifact\artifact-service.h">
+      <Filter>system\artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\item\item-entity.h">
+      <Filter>system\item</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\definition-hash-data.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\monrace\monrace-record.h">
+      <Filter>system\monrace</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\monrace\monrace-records.h">
+      <Filter>system\monrace</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\monrace\monrace-service.h">
+      <Filter>system\monrace</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\src\wall.bmp" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="floor">
+      <UniqueIdentifier>{c7e2056b-fda5-410a-8d23-03ba3f11c051}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="object">
+      <UniqueIdentifier>{52a3c5b6-2312-47a9-bb95-15c0d5e95192}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="player">
+      <UniqueIdentifier>{8fc15fd9-029b-4e7f-ae0b-75b2db215ad0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="monster">
+      <UniqueIdentifier>{282dc0ea-8c5c-4253-b38c-4f4f0ad87ff9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="io">
+      <UniqueIdentifier>{1be1a971-e67f-4d7c-ace0-aab22a039851}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="combat">
+      <UniqueIdentifier>{dae7a35f-36af-4097-905f-b9b9aad50d6e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="market">
+      <UniqueIdentifier>{64225309-2ea6-4822-aeac-0e6165df9a8f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="core">
+      <UniqueIdentifier>{cbc72021-c88c-4625-b89b-ef126e300cf8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="locale">
+      <UniqueIdentifier>{4bdec353-0cac-4e25-98f9-bcc55f2c0ec3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="view">
+      <UniqueIdentifier>{95a48e4b-b55a-4e99-a3c6-e8badbd1b2cf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="main">
+      <UniqueIdentifier>{e8e836da-e12b-42cc-9c09-17432cb83432}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="knowledge">
+      <UniqueIdentifier>{0e8eb37a-0944-4897-a2fd-e6097df5e5f8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="autopick">
+      <UniqueIdentifier>{7f5cb078-a335-428e-a2db-27ee6263155b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="room">
+      <UniqueIdentifier>{318835ed-a803-4459-921e-f6afc5411baa}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="effect">
+      <UniqueIdentifier>{ed8a9f97-b54e-4204-9076-f32f646f3762}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="spell">
+      <UniqueIdentifier>{4e443fe1-9ff8-4786-b43f-7e4d106760dc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="realm">
+      <UniqueIdentifier>{c4ce5c0c-f907-4e62-abc1-5d9dbe7f1abf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="birth">
+      <UniqueIdentifier>{c2383613-69b3-4973-bb9b-6fce783afa1d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="inventory">
+      <UniqueIdentifier>{060db85f-39b1-48fd-8b5f-7409eb6209b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mutation">
+      <UniqueIdentifier>{0e652835-2887-4970-9fa2-4ba77974e921}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="wizard">
+      <UniqueIdentifier>{22328846-3669-435a-9731-f0998a1c3dfa}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="world">
+      <UniqueIdentifier>{cbd4a56f-0cd0-47a4-96be-a0a4d85ad7d1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="dungeon">
+      <UniqueIdentifier>{b37a544f-cca2-4c1f-b069-f109a6b6b119}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="system">
+      <UniqueIdentifier>{12dd43b2-8ba5-4fc4-8d11-1901ec804390}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="grid">
+      <UniqueIdentifier>{93b0c1d1-0841-44fe-8503-d6729d290350}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="term">
+      <UniqueIdentifier>{ad847f1c-b291-4640-93d2-21895fbee308}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mind">
+      <UniqueIdentifier>{235e3199-b059-4a3c-a053-dd8604c8e9fd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mspell">
+      <UniqueIdentifier>{738b47ea-2ba6-49a3-9bf8-a833ef46e218}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="store">
+      <UniqueIdentifier>{be097f30-d18c-4e9a-a13f-eac4ee7a9d9a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="util">
+      <UniqueIdentifier>{d9907626-9c01-48b8-89da-065f7b8540b5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="pet">
+      <UniqueIdentifier>{7c81caa7-dbd8-43f3-8481-9a2ae3967776}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="cmd-item">
+      <UniqueIdentifier>{7af80633-259f-406b-a33d-23f6a83013d7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="cmd-io">
+      <UniqueIdentifier>{cefa5b29-56a9-41dc-a32e-8b9568821503}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="cmd-action">
+      <UniqueIdentifier>{f578e89d-2670-4f24-8028-61896d5b733e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="io-dump">
+      <UniqueIdentifier>{739c9774-e51a-46eb-87c1-cd7cd332e97c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="sv-definition">
+      <UniqueIdentifier>{9e020507-fdf0-4cfb-9d60-d9c26cbcf325}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="object-enchant">
+      <UniqueIdentifier>{c7db74bd-7f58-4044-96c8-c5916d0ebaf1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="perception">
+      <UniqueIdentifier>{e42f1944-e95c-42a8-97bf-9f959b313142}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="specific-object">
+      <UniqueIdentifier>{d12d97f4-76e6-4f8e-9f45-9905cf3863f9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="spell-kind">
+      <UniqueIdentifier>{2ed79129-9b65-4718-b9c4-ce4ef793c81f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="spell-realm">
+      <UniqueIdentifier>{1ce2167d-011b-47b5-8934-24c6d4d036e3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="player-attack">
+      <UniqueIdentifier>{cc3a34dc-4ff0-473f-afa5-3b5ec0da5aaf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="monster-attack">
+      <UniqueIdentifier>{f197a2c1-d277-4d4d-b08b-586cf1f4f8f5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="melee">
+      <UniqueIdentifier>{642ec95b-f054-4958-a614-49ccf88cfc25}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="monster-race">
+      <UniqueIdentifier>{8de4a55f-fa83-496b-a42f-81078346c918}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="lore">
+      <UniqueIdentifier>{9db4d67c-5c55-4cc0-a9cd-643e5ffc3e73}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="monster-floor">
+      <UniqueIdentifier>{d266d557-ad7c-4751-a1b1-04ced61292a6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="game-option">
+      <UniqueIdentifier>{14acbc0e-8760-48c6-860f-4c9fd993feef}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="info-reader">
+      <UniqueIdentifier>{149ff96c-b8c9-4df9-845d-d0618427d100}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="cmd-visual">
+      <UniqueIdentifier>{30be068e-64fc-431f-a90b-07f12e2539a4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="cmd-building">
+      <UniqueIdentifier>{6982e0e0-d2db-422e-8e92-77b1276e4030}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="object-hook">
+      <UniqueIdentifier>{e466c69b-eaf4-4110-bc9d-e865b36cc732}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="status">
+      <UniqueIdentifier>{c2656391-c200-4334-8150-88f4691c6079}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="object-use">
+      <UniqueIdentifier>{3e8ea357-82a2-4978-a257-338b953d1469}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="flavor">
+      <UniqueIdentifier>{64e5a4de-e0d4-4090-93b9-314234362569}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="action">
+      <UniqueIdentifier>{52768eef-323a-49a4-a895-f0030b35f667}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="window">
+      <UniqueIdentifier>{9e0105e8-8250-4ac4-8a1c-cefd30485ecc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="artifact">
+      <UniqueIdentifier>{7554e8b1-1c3c-447b-8f1e-c18c09039419}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="racial">
+      <UniqueIdentifier>{aaa1b0db-fb73-43df-b204-45c07a934cd5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="save">
+      <UniqueIdentifier>{beb4a41a-dee4-4bdd-ac20-78da62c44fdf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="load">
+      <UniqueIdentifier>{2bfe9405-f65a-4dac-afde-56800ae04b9f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="blue-magic">
+      <UniqueIdentifier>{6b429e6d-e548-430e-9413-8bc2e0bda1ed}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="target">
+      <UniqueIdentifier>{1789a1b0-5c89-4dfc-a4ba-1c3b711705b5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="object-activation">
+      <UniqueIdentifier>{14dcf604-bbe5-4084-b4ff-124ea8c55654}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="player-info">
+      <UniqueIdentifier>{9b6116c6-24e1-4d33-b3b5-3591f58fb9e1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="main-win">
+      <UniqueIdentifier>{8175f3d1-c8b3-4f2b-8536-8631d77eb53c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="player-status">
+      <UniqueIdentifier>{ff73fd79-e082-4a2c-8c5b-9457c30d9e74}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="hpmp">
+      <UniqueIdentifier>{fb766b4b-8783-4d07-9474-059259afe7c6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="player-ability">
+      <UniqueIdentifier>{d6c9dc68-d79b-4509-bf9c-34ff9620bbf4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="avatar">
+      <UniqueIdentifier>{953acb44-db6d-4bd8-bb0b-5692524bad93}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="player-base">
+      <UniqueIdentifier>{0bd4660d-028e-44be-a5fe-c7cc7d3d00c2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="timed-effect">
+      <UniqueIdentifier>{b9e618e1-f780-4f5f-9413-d0270ac53660}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="load\old">
+      <UniqueIdentifier>{46523373-91fb-436b-89c6-14ad74b88f5d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="load\item">
+      <UniqueIdentifier>{346bc9ba-a477-404f-bc72-2ad9c1ec6daf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="load\monster">
+      <UniqueIdentifier>{ad11aaea-5034-4df2-9a9b-d63457fdad55}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="object-enchant\protector">
+      <UniqueIdentifier>{bec9d846-2241-4692-89bf-9ca8988347d8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="object-enchant\weapon">
+      <UniqueIdentifier>{67ae112a-43ae-49a3-96ab-4f60c7c51931}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="smith">
+      <UniqueIdentifier>{a69deeae-ad91-4e9e-b811-25f6d4b49aec}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="object-enchant\others">
+      <UniqueIdentifier>{8e025e92-a617-4072-9c36-ba6fc3801284}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="object-use\read">
+      <UniqueIdentifier>{b0af4dd7-335a-466f-adb9-cd217597e87b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="spell-class">
+      <UniqueIdentifier>{b03873b1-e021-4bfe-84e4-0fa1e0bc87a2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="object-use\quaff">
+      <UniqueIdentifier>{5eec2f75-7108-42ad-9aa4-85b1129354db}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mspell\mspell-attack">
+      <UniqueIdentifier>{ab971e7b-4a9e-4f88-a557-eb89840abd61}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="item-info">
+      <UniqueIdentifier>{3aefd2e8-8dd8-41dd-bc6b-7dadd75dfd6b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="net">
+      <UniqueIdentifier>{6f311bdc-4407-49b7-96ab-bc2ed187b61c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="external-lib">
+      <UniqueIdentifier>{7a77d993-afa0-4750-97c6-d52b440fafa9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="tracking">
+      <UniqueIdentifier>{a5b8bf13-a675-4500-8b4c-37ea664757eb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="system\enums">
+      <UniqueIdentifier>{31491e27-d3e4-4605-b68a-c2c00d563479}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="system\enums\monrace">
+      <UniqueIdentifier>{123780c8-0bf5-47ac-aabd-c9f3dbe74855}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="system\baseitem">
+      <UniqueIdentifier>{b1f45c00-0add-4e05-8c05-bac1f29550c6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="system\services">
+      <UniqueIdentifier>{0f6862b2-2ab3-4d92-abc2-09a28f3a17b4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="system\dungeon">
+      <UniqueIdentifier>{1894220d-5f9a-4d37-b853-abc0076e56bc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="system\monrace">
+      <UniqueIdentifier>{aeee8301-7122-495a-938a-9425333f0414}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="system\floor">
+      <UniqueIdentifier>{b3a079dd-fd7e-41d6-8dcd-667b977c7ec1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="system\enums\terrain">
+      <UniqueIdentifier>{3ceaf1e1-713b-4cfe-979d-e0ecd9949bfc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="system\terrain">
+      <UniqueIdentifier>{3a15d903-e2ff-488d-a3c8-7bf69fad0f43}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="system\enums\dungeon">
+      <UniqueIdentifier>{605bab39-a92d-4c11-ae24-56e39e302f36}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="external-lib\fmt">
+      <UniqueIdentifier>{de5173c3-9151-46e9-a937-8861a5a14c00}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="system\artifact">
+      <UniqueIdentifier>{58714fb7-9c67-4cd4-b69f-a5b0d7d7964f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="system\item">
+      <UniqueIdentifier>{f7624169-a38b-4935-92a4-9334ddd4c76a}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\..\src\angband.rc" />
+  </ItemGroup>
+</Project>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1410,6 +1410,9 @@ hengband_SOURCES = \
 	system/monrace/monrace-definition.cpp system/monrace/monrace-definition.h \
 	system/monrace/monrace-list.cpp system/monrace/monrace-list.h \
 	system/monrace/monrace-message.cpp system/monrace/monrace-message.h \
+	system/monrace/monrace-record.cpp system/monrace/monrace-record.h \
+	system/monrace/monrace-records.cpp system/monrace/monrace-records.h \
+	system/monrace/monrace-service.cpp system/monrace/monrace-service.h \
 	\
 	system/services/baseitem-monrace-service.cpp system/services/baseitem-monrace-service.h \
 	system/services/dungeon-service.cpp system/services/dungeon-service.h \

--- a/src/cmd-io/cmd-lore.cpp
+++ b/src/cmd-io/cmd-lore.cpp
@@ -8,6 +8,8 @@
 #include "system/creature-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-service.h"
+#include "system/player-type-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
@@ -16,33 +18,32 @@
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
 #include "view/display-lore.h"
+#include <fmt/format.h>
 
 namespace {
 std::pair<std::string, std::vector<MonraceId>> collect_monraces(char symbol)
 {
-    const auto &monraces = MonraceList::get_instance();
     const auto is_known_only = !cheat_know;
-
     switch (symbol) {
     case KTRL('A'): {
         constexpr auto msg = _("全モンスターのリスト", "Full monster list.");
         auto filter = [](const MonraceDefinition &) { return true; };
-        return std::make_pair(msg, monraces.search(std::move(filter), is_known_only));
+        return std::make_pair(msg, MonraceService::search(std::move(filter), is_known_only));
     }
     case KTRL('U'): {
         constexpr auto msg = _("ユニーク・モンスターのリスト", "Unique monster list.");
         auto filter = [](const MonraceDefinition &monrace) { return monrace.kind_flags.has(MonsterKindType::UNIQUE); };
-        return std::make_pair(msg, monraces.search(std::move(filter), is_known_only));
+        return std::make_pair(msg, MonraceService::search(std::move(filter), is_known_only));
     }
     case KTRL('N'): {
         constexpr auto msg = _("ユニーク外モンスターのリスト", "Non-unique monster list.");
         auto filter = [](const MonraceDefinition &monrace) { return monrace.kind_flags.has_not(MonsterKindType::UNIQUE); };
-        return std::make_pair(msg, monraces.search(std::move(filter), is_known_only));
+        return std::make_pair(msg, MonraceService::search(std::move(filter), is_known_only));
     }
     case KTRL('R'): {
         constexpr auto msg = _("乗馬可能モンスターのリスト", "Ridable monster list.");
         auto filter = [](const MonraceDefinition &monrace) { return monrace.misc_flags.has(MonsterMiscType::RIDING); };
-        return std::make_pair(msg, monraces.search(std::move(filter), is_known_only));
+        return std::make_pair(msg, MonraceService::search(std::move(filter), is_known_only));
     }
     case KTRL('M'): {
         const auto monster_name = input_string(_("名前(英語の場合小文字で可)", "Enter name:"), MAX_MONSTER_NAME);
@@ -50,8 +51,8 @@ std::pair<std::string, std::vector<MonraceId>> collect_monraces(char symbol)
             return { "", {} };
         }
 
-        auto msg = format(_("名前:%sにマッチ", "Monsters' names with \"%s\""), monster_name->data());
-        return std::make_pair(msg, monraces.search_by_name(*monster_name, is_known_only));
+        const auto msg = fmt::format(_("名前:{}にマッチ", "Monsters' names with \"{}\""), monster_name->data());
+        return std::make_pair(msg, MonraceService::search_by_name(*monster_name, is_known_only));
     }
     default: {
         int ident_i;
@@ -62,8 +63,8 @@ std::pair<std::string, std::vector<MonraceId>> collect_monraces(char symbol)
         }
 
         if (ident_info[ident_i]) {
-            auto msg = format("%c - %s.", symbol, ident_info[ident_i] + 2);
-            return std::make_pair(msg, monraces.search_by_symbol(symbol, is_known_only));
+            const auto msg = fmt::format("{} - {}.", symbol, ident_info[ident_i] + 2);
+            return std::make_pair(msg, MonraceService::search_by_symbol(symbol, is_known_only));
         }
 
         return std::make_pair(_("無効な文字", "Unknown Symbol"), std::vector<MonraceId>{});

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -22,6 +22,8 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
+#include "system/player-type-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
@@ -63,9 +65,10 @@ static std::vector<MonraceId> collect_monsters(short grp_cur, monster_lore_mode 
     const auto grp_pervert = (MONRACE_CHARACTERS_GROUP[grp_cur] == "Perverts");
 
     const auto &monraces = MonraceList::get_instance();
+    const auto &monrace_records = MonraceRecords::get_instance();
     std::vector<MonraceId> monrace_ids;
     for (const auto &[monrace_id, monrace] : monraces) {
-        if (((mode != MONSTER_LORE_DEBUG) && (mode != MONSTER_LORE_RESEARCH)) && !cheat_know && !monrace->r_sights) {
+        if (((mode != MONSTER_LORE_DEBUG) && (mode != MONSTER_LORE_RESEARCH)) && !cheat_know && !monrace_records.has_been_seen(monrace_id)) {
             continue;
         }
 

--- a/src/knowledge/knowledge-uniques.cpp
+++ b/src/knowledge/knowledge-uniques.cpp
@@ -6,10 +6,14 @@
 
 #include "knowledge/knowledge-uniques.h"
 #include "core/show-file.h"
+#include "game-option/cheat-options.h"
 #include "io-dump/dump-util.h"
 #include "system/creature-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
+#include "system/player-type-definition.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/string-processor.h"
 
@@ -34,8 +38,13 @@ UniqueList::UniqueList(bool is_alive)
 
 void UniqueList::sweep()
 {
-    auto &monraces = MonraceList::get_instance();
+    const auto &monraces = MonraceList::get_instance();
+    const auto &records = MonraceRecords::get_instance();
     for (auto &[monrace_id, monrace] : monraces) {
+        if (!cheat_know && !records.has_been_seen(monrace_id)) {
+            continue;
+        }
+
         if (!monrace->is_valid() || !monrace->should_display(this->is_alive)) {
             continue;
         }

--- a/src/load/lore-loader.cpp
+++ b/src/load/lore-loader.cpp
@@ -6,6 +6,8 @@
 #include "system/angband.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-record.h"
+#include "system/monrace/monrace-records.h"
 #include "system/system-variables.h"
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
@@ -326,7 +328,8 @@ static void migrate_old_behavior_flags(MonraceDefinition &monrace, BIT_FLAGS old
  */
 static void rd_lore(MonraceDefinition &monrace)
 {
-    monrace.r_sights = rd_s16b();
+    auto &records = MonraceRecords::get_instance();
+    records.set_seen_count(monrace.idx, rd_s16b());
     monrace.r_deaths = rd_s16b();
     monrace.r_pkills = rd_s16b();
     monrace.r_akills = rd_s16b();

--- a/src/lore/lore-util.cpp
+++ b/src/lore/lore-util.cpp
@@ -4,6 +4,7 @@
 #include "monster-attack/monster-attack-table.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 
@@ -44,6 +45,7 @@ lore_type::lore_type(MonraceId monrace_id, monster_lore_mode mode)
 {
     this->nightmare = ironman_nightmare && (mode != MONSTER_LORE_DEBUG);
     this->monrace = MonraceList::get_instance().get_monrace_shared(monrace_id);
+    this->record = MonraceRecords::get_instance().get_record(monrace_id);
     this->speed = this->nightmare ? this->monrace->speed + 5 : this->monrace->speed;
     this->drop_gold = this->monrace->r_drop_gold;
     this->drop_item = this->monrace->r_drop_item;

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -35,6 +35,7 @@ enum monster_lore_mode {
 };
 
 class MonraceDefinition;
+class MonraceRecord;
 struct lore_msg {
     lore_msg(std::string_view msg, byte color = TERM_WHITE);
     std::string msg;
@@ -69,7 +70,8 @@ struct lore_type {
     RaceBlowMethodType method;
 
     bool nightmare;
-    std::shared_ptr<MonraceDefinition> monrace;
+    std::shared_ptr<const MonraceDefinition> monrace;
+    std::shared_ptr<const MonraceRecord> record;
     byte speed;
     ITEM_NUMBER drop_gold;
     ITEM_NUMBER drop_item;

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -29,6 +29,8 @@
 #include "system/dungeon/quest-definition.h"
 #include "system/floor/town-list.h"
 #include "system/monrace/monrace-definition.h"
+#include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
 #include "system/services/baseitem-monrace-service.h"
 #include "system/system-variables.h"
 #include "term/gameterm.h"
@@ -205,6 +207,8 @@ void init_angband(CreatureEntity &creature, bool no_term)
 
     init_note(_("[データの初期化中... (モンスター)]", "[Initializing arrays... (monsters)]"));
     init_monrace_definitions();
+    const auto monraces_size = MonraceList::get_instance().size();
+    MonraceRecords::get_instance().initialize(monraces_size);
     const auto error = BaseitemMonraceService::check_specific_drop_gold_flags_duplication();
     if (error) {
         quit(*error);

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -44,6 +44,8 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
+#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "tracking/health-bar-tracker.h"
 #include "tracking/lore-tracker.h"
@@ -180,19 +182,15 @@ void MonsterDamageProcessor::death_special_flag_monster()
     auto &monster = creature.get_floor()->get_monster(this->m_idx);
     auto monrace_id = monster.get_r_idx();
     auto &monrace = monster.get_monrace();
+    auto &monrace_records = MonraceRecords::get_instance();
     if (monrace.misc_flags.has(MonsterMiscType::TANUKI)) {
         monster.set_ap_r_idx(monrace_id);
-        if (monrace.r_sights < MAX_SHORT) {
-            monrace.r_sights++;
-        }
+        monrace_records.increment_seen_count(monrace_id);
     }
 
     if (monster.is_chameleon()) {
-        auto &real_monrace = monster.get_real_monrace();
         monrace_id = monster.get_real_monrace_id();
-        if (real_monrace.r_sights < MAX_SHORT) {
-            real_monrace.r_sights++;
-        }
+        monrace_records.increment_seen_count(monrace_id);
     }
 
     if (monster.is_cloned()) {

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -9,6 +9,8 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-service.h"
+#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
@@ -133,9 +135,8 @@ static std::string get_describing_monster_name(const CreatureEntity &monster, co
         }
     }
 
-    const auto &monraces = MonraceList::get_instance();
-    const auto ids = monraces.search([](const auto &monrace) { return monrace.kind_flags.has_not(MonsterKindType::UNIQUE); });
-    return monraces.get_monrace(rand_choice(ids)).name.string();
+    const auto ids = MonraceService::search([](const auto &monrace) { return monrace.kind_flags.has_not(MonsterKindType::UNIQUE); });
+    return MonraceList::get_instance().get_monrace(rand_choice(ids)).name.string();
 }
 
 #ifdef JP

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -19,6 +19,8 @@
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-service.h"
+#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "tracking/health-bar-tracker.h"
 #include "util/bit-flags-calculator.h"
@@ -424,7 +426,7 @@ void monster_gain_exp(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId mon
         const auto is_hallucinated = creature.is_hallucinated();
         if (!ignore_unview || player_can_see_bold(creature, monster.y, monster.x)) {
             if (is_hallucinated) {
-                const auto ids = monraces.search([](const auto &monrace) { return monrace.kind_flags.has_not(MonsterKindType::UNIQUE); });
+                const auto ids = MonraceService::search([](const auto &monrace) { return monrace.kind_flags.has_not(MonsterKindType::UNIQUE); });
                 const auto &monrace_hallucinated = monraces.get_monrace(rand_choice(ids));
                 auto mes_evolution = _("%sは%sに進化した。", "%s^ evolved into %s.");
                 auto mes_degeneration = _("%sは%sに退化した。", "%s^ degenerated into %s.");

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -35,6 +35,8 @@
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
+#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/projection-path-calculator.h"
 #include "tracking/health-bar-tracker.h"
@@ -515,12 +517,10 @@ static void update_invisible_monster(CreatureEntity &creature, um_type *um_ptr, 
     }
 
     if (!creature.is_hallucinated()) {
-        auto &monrace = monster.get_monrace();
-        auto &shadower = MonraceList::get_instance().get_monrace(MonraceId::KAGE);
-        if ((monster.get_ap_r_idx() == MonraceId::KAGE) && (shadower.r_sights < MAX_SHORT)) {
-            shadower.r_sights++;
-        } else if (monster.is_original_ap() && (monrace.r_sights < MAX_SHORT)) {
-            monrace.r_sights++;
+        if (monster.get_ap_r_idx() == MonraceId::KAGE) {
+            MonraceRecords::get_instance().increment_seen_count(MonraceId::KAGE);
+        } else if (monster.is_original_ap()) {
+            monster.increment_seen_count();
         }
     }
 

--- a/src/save/lore-writer.cpp
+++ b/src/save/lore-writer.cpp
@@ -3,6 +3,7 @@
 #include "save/save-util.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
 #include "util/bit-flags-calculator.h"
 
 /*!
@@ -12,7 +13,8 @@
 void wr_lore(MonraceId monrace_id)
 {
     const auto &monrace = MonraceList::get_instance().get_monrace(monrace_id);
-    wr_s16b(static_cast<short>(monrace.r_sights));
+    const auto &monrace_records = MonraceRecords::get_instance();
+    wr_s16b(monrace_records.get_seen_count(monrace_id));
     wr_s16b(static_cast<short>(monrace.r_deaths));
     wr_s16b(static_cast<short>(monrace.r_pkills));
     wr_s16b(static_cast<short>(monrace.r_akills));

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -17,6 +17,8 @@
 #include "system/floor/town-list.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
+#include "system/player-type-definition.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -171,9 +173,9 @@ public:
         auto &monraces = MonraceList::get_instance();
         auto &monrace = monraces.get_monrace(monster_rumor.monrace_id);
         this->print_rumor(monrace.name);
-
-        if (monrace.r_sights == 0) {
-            monrace.r_sights = 1;
+        auto &monrace_records = MonraceRecords::get_instance();
+        if (!monrace_records.has_been_seen(monster_rumor.monrace_id)) {
+            monrace_records.increment_seen_count(monster_rumor.monrace_id);
         }
     }
 

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -41,6 +41,7 @@
 #include "system/monrace/extended-slot.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
 #include "system/monster-profile.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/projection-path-calculator.h"
@@ -2178,3 +2179,8 @@ bool CreatureEntity::has_anti_tele() const
     return this->anti_tele != 0;
 }
 // clang-format on
+
+void CreatureEntity::increment_seen_count() const
+{
+    MonraceRecords::get_instance().increment_seen_count(this->get_r_idx());
+}

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1400,6 +1400,8 @@ public:
         this->ap_r_idx = new_r_idx;
     }
 
+    void increment_seen_count() const;
+
     /*!
      * @brief 騎乗中のモンスター m_idx を直接設定する (提案 22)
      * @details ride_monster() と異なり mflag2/RIDING の更新を行わない低レベル

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -1,5 +1,4 @@
 #include "system/monrace/monrace-definition.h"
-#include "game-option/cheat-options.h"
 #include "monster-attack/monster-attack-table.h"
 #include "monster-race/race-ability-mask.h"
 #include "monster-race/race-resistance-mask.h"
@@ -883,15 +882,11 @@ bool MonraceDefinition::has_entity() const
  * @brief モンスターリストを走査し、生きているか死んでいるユニークだけを抽出する
  * @param is_alive 生きているユニークのリストならばTRUE、撃破したユニークのリストならばFALSE
  * @return is_aliveの条件に見合うユニークがいたらTRUE、それ以外はFALSE
- * @details 闘技場のモンスターとは再戦できないので、生きているなら表示から外す
+ * @details 闘技場のモンスターとは再戦できないので、生きているなら表示から外す.
  */
 bool MonraceDefinition::should_display(bool is_alive) const
 {
     if (this->kind_flags.has_not(MonsterKindType::UNIQUE)) {
-        return false;
-    }
-
-    if (!cheat_know && !this->r_sights) {
         return false;
     }
 

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -172,7 +172,6 @@ public:
     int32_t collapse_over = 0; //!< 生成条件：時空崩壊度加減
     int32_t plus_collapse{}; //!< 死亡時の時空崩壊度進行値
     FLOOR_IDX floor_id{}; //!< 存在している保存階ID /  Location of unique monster
-    MONSTER_NUMBER r_sights{}; //!< 見えている数 / Count sightings of this monster
     MONSTER_NUMBER r_deaths{}; //!< このモンスターに殺された人数 / Count deaths from this monster
     MONSTER_NUMBER r_pkills{}; //!< このゲームで倒すのを見た数 / Count visible monsters killed in this life
     MONSTER_NUMBER r_akills{}; //!< このゲームで倒した数 / Count all monsters killed in this life

--- a/src/system/monrace/monrace-list.cpp
+++ b/src/system/monrace/monrace-list.cpp
@@ -10,7 +10,6 @@
 #include "system/redrawing-flags-updater.h"
 #include "tracking/lore-tracker.h"
 #include "util/probability-table.h"
-#include "util/string-processor.h"
 #include <algorithm>
 
 namespace {
@@ -43,7 +42,7 @@ const std::set<MonraceId> CHAPEL_RACES = {
     MonraceId::TOPAZ_MONK,
 };
 
-//!< @details 「Aシンボルだが天使ではない」モンスターのリスト.
+//! 「Aシンボルだが天使ではない」モンスターのリスト.
 const std::set<MonraceId> NON_ANGEL_RACES = {
     MonraceId::A_GOLD,
     MonraceId::A_SILVER,
@@ -145,77 +144,6 @@ const std::vector<MonraceId> &MonraceList::get_valid_monrace_ids() const
 
     std::transform(++this->monraces.begin(), this->monraces.end(), std::back_inserter(valid_monraces), [](auto &x) { return x.first; });
     return valid_monraces;
-}
-
-/*!
- * @brief モンスターを引数で与えたフィルタ関数で検索する
- *
- * @param filter このフィルタ関数がtrueを返すモンスターを検索する
- * @param is_known_only trueならばプレイヤーが既知のモンスターのみを対象とする。falseならば全てのモンスターを対象とする。
- * @return std::vector<MonraceId> 検索結果のモンスター種族IDリスト
- */
-std::vector<MonraceId> MonraceList::search(std::function<bool(const MonraceDefinition &)> filter, bool is_known_only) const
-{
-    std::vector<MonraceId> result_ids;
-
-    for (const auto &[id, monrace] : this->monraces) {
-        if (!monrace->is_valid()) {
-            continue;
-        }
-
-        if (is_known_only && (monrace->r_sights == 0)) {
-            continue;
-        }
-
-        if (filter(*monrace)) {
-            result_ids.push_back(id);
-        }
-    }
-
-    return result_ids;
-}
-
-/*!
- * @brief モンスターを名前で検索する
- *
- * 引数で与えた名前を含む(部分一致)モンスターを検索する。
- *
- * @param name 検索するモンスターの名前
- * @param is_known_only trueならばプレイヤーが既知のモンスターのみを対象とする。falseならば全てのモンスターを対象とする。
- * @return std::vector<MonraceId> 検索結果のモンスター種族IDリスト
- */
-std::vector<MonraceId> MonraceList::search_by_name(std::string_view name, bool is_known_only) const
-{
-    std::vector<MonraceId> result_ids;
-    const auto lowered_search_name = str_tolower(name);
-
-    auto filter = [&](const MonraceDefinition &monrace) {
-        const auto lowered_en_name = str_tolower(monrace.name.en_string());
-
-#ifdef JP
-        return str_find(lowered_en_name, lowered_search_name) || str_find(monrace.name.string(), lowered_search_name);
-#else
-        return str_find(lowered_en_name, lowered_search_name);
-#endif
-    };
-
-    return this->search(std::move(filter), is_known_only);
-}
-
-/*!
- * @brief モンスターのシンボルで検索する
- *
- * @param symbol 検索するモンスターのシンボル
- * @param is_known_only trueならばプレイヤーが既知のモンスターのみを対象とする。falseならば全てのモンスターを対象とする。
- * @return std::vector<MonraceId> 検索結果のモンスター種族IDリスト
- */
-std::vector<MonraceId> MonraceList::search_by_symbol(char symbol, bool is_known_only) const
-{
-    auto filter = [&](const MonraceDefinition &monrace) {
-        return monrace.symbol_char_is_any_of(std::string(1, symbol));
-    };
-
-    return this->search(std::move(filter), is_known_only);
 }
 
 bool MonraceList::is_angel(MonraceId monrace_id) const

--- a/src/system/monrace/monrace-list.h
+++ b/src/system/monrace/monrace-list.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "util/abstract-map-wrapper.h"
-#include <functional>
 #include <map>
 #include <memory>
 #include <set>
@@ -38,9 +37,6 @@ public:
     std::shared_ptr<MonraceDefinition> get_monrace_shared(MonraceId monrace_id);
     std::shared_ptr<const MonraceDefinition> get_monrace_shared(MonraceId monrace_id) const;
     const std::vector<MonraceId> &get_valid_monrace_ids() const;
-    std::vector<MonraceId> search(std::function<bool(const MonraceDefinition &)> filter, bool is_known_only = false) const;
-    std::vector<MonraceId> search_by_name(std::string_view name, bool is_known_only = false) const;
-    std::vector<MonraceId> search_by_symbol(char symbol, bool is_known_only) const;
     bool is_angel(MonraceId monrace_id) const;
     bool can_unify_separate(MonraceId monrace_id) const;
     void kill_unified_unique(MonraceId monrace_id);

--- a/src/system/monrace/monrace-record.cpp
+++ b/src/system/monrace/monrace-record.cpp
@@ -1,0 +1,29 @@
+#include "system/monrace/monrace-record.h"
+#include <limits>
+
+void MonraceRecord::reset_all()
+{
+    this->seen_count = 0;
+}
+
+bool MonraceRecord::has_been_seen() const
+{
+    return this->seen_count > 0;
+}
+
+void MonraceRecord::increment_seen_count()
+{
+    if (this->seen_count < std::numeric_limits<short>::max()) {
+        this->seen_count++;
+    }
+}
+
+short MonraceRecord::get_seen_count() const
+{
+    return this->seen_count;
+}
+
+void MonraceRecord::set_seen_count(short count)
+{
+    this->seen_count = count;
+}

--- a/src/system/monrace/monrace-record.h
+++ b/src/system/monrace/monrace-record.h
@@ -1,0 +1,27 @@
+#pragma once
+
+/*!
+ * @brief モンスター種族に関するプレイ中の動的な記録を管理するクラス
+ * @author Hourier
+ * @date 2026/05/26
+ */
+
+class MonraceRecord {
+public:
+    MonraceRecord() = default;
+    MonraceRecord(const MonraceRecord &other) = delete;
+    MonraceRecord(MonraceRecord &&other) noexcept = delete;
+    MonraceRecord &operator=(const MonraceRecord &other) = delete;
+    MonraceRecord &operator=(MonraceRecord &&other) noexcept = delete;
+    ~MonraceRecord() = default;
+
+    void reset_all();
+
+    bool has_been_seen() const;
+    void increment_seen_count();
+    short get_seen_count() const; //!< セーブ用.
+    void set_seen_count(short count); //!< ロード用.
+
+private:
+    short seen_count = 0; //!< これまでにプレイヤーが目撃した数.
+};

--- a/src/system/monrace/monrace-records.cpp
+++ b/src/system/monrace/monrace-records.cpp
@@ -1,0 +1,86 @@
+#include "system/monrace/monrace-records.h"
+#include "system/angband-exceptions.h"
+#include "system/monrace/monrace-record.h"
+#include "util/enum-converter.h"
+#include <fmt/format.h>
+
+MonraceRecords MonraceRecords::instance{};
+
+/*!
+ * @brief レコードのmapを初期化する
+ *
+ * 起動時に一度だけ実行されるが、ドメイン仕様とは無関係に初期化処理は冪等性を担保すべきである.
+ * そのため、呼ばれる度に全てをリセットする設計とする.
+ */
+void MonraceRecords::initialize(size_t size)
+{
+    if (!this->records.empty()) {
+        for (auto &[_, record] : this->records) {
+            record->reset_all();
+        }
+
+        return;
+    }
+
+    for (size_t i = 0; i < size; i++) {
+        this->records.emplace(static_cast<MonraceId>(i), std::make_shared<MonraceRecord>());
+    }
+}
+
+MonraceRecords &MonraceRecords::get_instance()
+{
+    return instance;
+}
+
+std::shared_ptr<const MonraceRecord> MonraceRecords::get_record(MonraceId monrace_id) const
+{
+    this->check_monrace_id(monrace_id);
+    return this->records.at(monrace_id);
+}
+
+bool MonraceRecords::has_been_seen(MonraceId monrace_id) const
+{
+    this->check_monrace_id(monrace_id);
+    if (monrace_id == MonraceId::PLAYER) {
+        return false;
+    }
+
+    return this->records.at(monrace_id)->has_been_seen();
+}
+
+void MonraceRecords::increment_seen_count(MonraceId monrace_id)
+{
+    this->check_monrace_id(monrace_id);
+    if (monrace_id == MonraceId::PLAYER) {
+        return;
+    }
+
+    this->records.at(monrace_id)->increment_seen_count();
+}
+
+short MonraceRecords::get_seen_count(MonraceId monrace_id) const
+{
+    this->check_monrace_id(monrace_id);
+    if (monrace_id == MonraceId::PLAYER) {
+        return 0;
+    }
+
+    return this->records.at(monrace_id)->get_seen_count();
+}
+
+void MonraceRecords::set_seen_count(MonraceId monrace_id, short count)
+{
+    this->check_monrace_id(monrace_id);
+    if (monrace_id == MonraceId::PLAYER) {
+        return;
+    }
+
+    this->records.at(monrace_id)->set_seen_count(count);
+}
+
+void MonraceRecords::check_monrace_id(MonraceId monrace_id) const
+{
+    if ((monrace_id < MonraceId::PLAYER) || (enum2i(monrace_id) >= static_cast<short>(this->records.size()))) {
+        THROW_EXCEPTION(std::out_of_range, fmt::format("Invalid monrace_id: {}", enum2i(monrace_id)));
+    }
+}

--- a/src/system/monrace/monrace-records.h
+++ b/src/system/monrace/monrace-records.h
@@ -1,0 +1,42 @@
+#pragma once
+
+/*!
+ * @brief モンスター種族に関するプレイ中の動的な記録を集合論的に取り扱うクラス
+ * @author Hourier
+ * @date 2026/05/26
+ */
+
+#include "system/enums/monrace/monrace-id.h"
+#include "util/abstract-map-wrapper.h"
+#include <memory>
+
+class MonraceRecord;
+class MonraceRecords : public util::AbstractMapWrapper<MonraceId, std::shared_ptr<MonraceRecord>> {
+public:
+    MonraceRecords(MonraceRecords &&) = delete;
+    MonraceRecords(const MonraceRecords &) = delete;
+    MonraceRecords &operator=(const MonraceRecords &) = delete;
+    MonraceRecords &operator=(MonraceRecords &&) = delete;
+    static MonraceRecords &get_instance();
+
+    void initialize(size_t size);
+    std::shared_ptr<const MonraceRecord> get_record(MonraceId monrace_id) const;
+
+    bool has_been_seen(MonraceId monrace_id) const;
+    void increment_seen_count(MonraceId monrace_id);
+    short get_seen_count(MonraceId monrace_id) const; //!< セーブ用.
+    void set_seen_count(MonraceId monrace_id, short count); //!< ロード用.
+
+private:
+    MonraceRecords() = default;
+
+    static MonraceRecords instance;
+
+    std::map<MonraceId, std::shared_ptr<MonraceRecord>> records;
+    std::map<MonraceId, std::shared_ptr<MonraceRecord>> &get_inner_container() override
+    {
+        return this->records;
+    }
+
+    void check_monrace_id(MonraceId monrace_id) const;
+};

--- a/src/system/monrace/monrace-service.cpp
+++ b/src/system/monrace/monrace-service.cpp
@@ -1,0 +1,77 @@
+#include "system/monrace/monrace-service.h"
+#include "system/enums/monrace/monrace-id.h"
+#include "system/monrace/monrace-definition.h"
+#include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
+#include "util/string-processor.h"
+
+/*!
+ * @brief モンスターを引数で与えたフィルタ関数で検索する
+ *
+ * @param filter このフィルタ関数がtrueを返すモンスターを検索する
+ * @param is_known_only trueならばプレイヤーが既知のモンスターのみを対象とする。falseならば全てのモンスターを対象とする。
+ * @return std::vector<MonraceId> 検索結果のモンスター種族IDリスト
+ */
+std::vector<MonraceId> MonraceService::search(const std::function<bool(const MonraceDefinition &)> &filter, bool is_known_only)
+{
+    std::vector<MonraceId> result_ids;
+    const auto &records = MonraceRecords::get_instance();
+    for (const auto &[id, monrace] : MonraceList::get_instance()) {
+        if (!monrace->is_valid()) {
+            continue;
+        }
+
+        if (is_known_only && !records.has_been_seen(id)) {
+            continue;
+        }
+
+        if (filter(*monrace)) {
+            result_ids.push_back(id);
+        }
+    }
+
+    return result_ids;
+}
+
+/*!
+ * @brief モンスターを名前で検索する
+ *
+ * 引数で与えた名前を含む(部分一致)モンスターを検索する。
+ *
+ * @param name 検索するモンスターの名前
+ * @param is_known_only trueならばプレイヤーが既知のモンスターのみを対象とする。falseならば全てのモンスターを対象とする。
+ * @return std::vector<MonraceId> 検索結果のモンスター種族IDリスト
+ */
+std::vector<MonraceId> MonraceService::search_by_name(std::string_view name, bool is_known_only)
+{
+    std::vector<MonraceId> result_ids;
+    const auto lowered_search_name = str_tolower(name);
+
+    auto filter = [&](const MonraceDefinition &monrace) {
+        const auto lowered_en_name = str_tolower(monrace.name.en_string());
+
+#ifdef JP
+        return str_find(lowered_en_name, lowered_search_name) || str_find(monrace.name.string(), lowered_search_name);
+#else
+        return str_find(lowered_en_name, lowered_search_name);
+#endif
+    };
+
+    return search(std::move(filter), is_known_only);
+}
+
+/*!
+ * @brief モンスターのシンボルで検索する
+ *
+ * @param symbol 検索するモンスターのシンボル
+ * @param is_known_only trueならばプレイヤーが既知のモンスターのみを対象とする。falseならば全てのモンスターを対象とする。
+ * @return std::vector<MonraceId> 検索結果のモンスター種族IDリスト
+ */
+std::vector<MonraceId> MonraceService::search_by_symbol(char symbol, bool is_known_only)
+{
+    auto filter = [&](const MonraceDefinition &monrace) {
+        return monrace.symbol_char_is_any_of(std::string(1, symbol));
+    };
+
+    return search(std::move(filter), is_known_only);
+}

--- a/src/system/monrace/monrace-service.h
+++ b/src/system/monrace/monrace-service.h
@@ -1,0 +1,22 @@
+#pragma once
+
+/*!
+ * @brief モンスター種族定義とプレイ中の記録を組み合わせて、モンスター種族に関する動的な情報を提供するサービスクラス
+ * @author Hourier
+ * @date 2026/05/26
+ */
+
+#include <functional>
+#include <string_view>
+#include <vector>
+
+enum class MonraceId : short;
+class MonraceDefinition;
+class MonraceService {
+public:
+    MonraceService() = delete;
+
+    static std::vector<MonraceId> search(const std::function<bool(const MonraceDefinition &)> &filter, bool is_known_only = false);
+    static std::vector<MonraceId> search_by_name(std::string_view name, bool is_known_only = false);
+    static std::vector<MonraceId> search_by_symbol(char symbol, bool is_known_only);
+};

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -24,6 +24,7 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-record.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
@@ -1517,7 +1518,7 @@ void display_drop_kind_items(lore_type *lore_ptr)
 void display_monster_guardian(lore_type *lore_ptr)
 {
     bool is_kingpin = lore_ptr->misc_flags.has(MonsterMiscType::QUESTOR);
-    is_kingpin &= lore_ptr->monrace->r_sights > 0;
+    is_kingpin &= lore_ptr->record->has_been_seen();
     is_kingpin &= lore_ptr->monrace->max_num > 0;
     is_kingpin &= (lore_ptr->monrace_id == MonraceId::OBERON) || (lore_ptr->monrace_id == MonraceId::SERPENT);
     if (is_kingpin) {

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -39,6 +39,8 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-service.h"
+#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/grid-selector.h"
 #include "target/target-checker.h"
@@ -67,18 +69,16 @@ const std::vector<debug_spell_command> debug_spell_commands_list = {
 
 std::vector<MonraceId> wiz_collect_monster_candidates(char symbol)
 {
-    const auto &monraces = MonraceList::get_instance();
-
-    if (symbol == KTRL('M')) {
-        const auto monster_name = input_string("Monster name: ", MAX_MONSTER_NAME);
-        if (!monster_name || monster_name->empty()) {
-            return {};
-        }
-
-        return monraces.search_by_name(*monster_name, false);
+    if (symbol != KTRL('M')) {
+        return MonraceService::search_by_symbol(symbol, false);
     }
 
-    return monraces.search_by_symbol(symbol, false);
+    const auto monster_name = input_string("Monster name: ", MAX_MONSTER_NAME);
+    if (!monster_name || monster_name->empty()) {
+        return {};
+    }
+
+    return MonraceService::search_by_name(*monster_name, false);
 }
 
 tl::optional<MonraceId> wiz_select_summon_monrace_id()


### PR DESCRIPTION
変愚蛮怒 PR #5416 (Separate-Monrace-Sights) を bakabakaband 構造に適応してマージ:
- MonraceRecord / MonraceRecords クラスを新規定義し、MonraceDefinition を軽量化 する準備を整備 (上流 c5694a9)
- MonraceDefinition::r_sights にアクセスしていた MonraceList のメソッド (search / search_by_name / search_by_symbol) を MonraceService クラスへ分離 (上流 59f8e2f)
- MonraceDefinition::r_sights を MonraceRecord::seen_count に移し、 MonraceRecords の get/set/increment/has_been_seen でカプセル化 (上流 49fed4f)
- MonraceRecords に契約 (入力値バリデーション) を導入 (上流 1325627)

bakabakaband 独自適応:
- 上流の MonsterEntity::increment_seen_count() は、baka では MonsterEntity が CreatureEntity に統合済みのため CreatureEntity::increment_seen_count() として 実装 (get_r_idx() 経由)。
- r_sights 書込/読込サイトを baka のアクセサ (get_ap_r_idx / is_chameleon / is_hallucinated 等) を維持しつつ MonraceRecords API に移行。
- lore-loader は rd_lore(MonraceDefinition&) シグネチャに合わせ monrace.idx で seen_count を復元。savefile フォーマット (s16b 1 個) は不変で後方互換を維持。

上流コミット: c5694a9, 59f8e2f, 49fed4f, 1325627 (hengband/develop)