### PR TITLE
merge: MonraceRecords の参照を軽量化（hengband#5433 相当）

### DIFF
--- a/src/system/monrace/monrace-records.cpp
+++ b/src/system/monrace/monrace-records.cpp
@@ -14,16 +14,17 @@ MonraceRecords MonraceRecords::instance{};
  */
 void MonraceRecords::initialize(size_t size)
 {
-    if (!this->records.empty()) {
-        for (auto &[_, record] : this->records) {
-            record->reset_all();
+    if (this->records.size() < size) {
+        this->records.reserve(size);
+        while (this->records.size() < size) {
+            this->records.emplace_back(std::make_shared<MonraceRecord>());
         }
-
-        return;
+    } else if (this->records.size() > size) {
+        this->records.resize(size);
     }
 
-    for (size_t i = 0; i < size; i++) {
-        this->records.emplace(static_cast<MonraceId>(i), std::make_shared<MonraceRecord>());
+    for (auto &record : this->records) {
+        record->reset_all();
     }
 }
 
@@ -34,53 +35,60 @@ MonraceRecords &MonraceRecords::get_instance()
 
 std::shared_ptr<const MonraceRecord> MonraceRecords::get_record(MonraceId monrace_id) const
 {
-    this->check_monrace_id(monrace_id);
-    return this->records.at(monrace_id);
+    return this->get_record_ref(monrace_id);
 }
 
 bool MonraceRecords::has_been_seen(MonraceId monrace_id) const
 {
-    this->check_monrace_id(monrace_id);
     if (monrace_id == MonraceId::PLAYER) {
         return false;
     }
 
-    return this->records.at(monrace_id)->has_been_seen();
+    return this->get_record_ref(monrace_id)->has_been_seen();
 }
 
 void MonraceRecords::increment_seen_count(MonraceId monrace_id)
 {
-    this->check_monrace_id(monrace_id);
     if (monrace_id == MonraceId::PLAYER) {
         return;
     }
 
-    this->records.at(monrace_id)->increment_seen_count();
+    this->get_record_ref(monrace_id)->increment_seen_count();
 }
 
 short MonraceRecords::get_seen_count(MonraceId monrace_id) const
 {
-    this->check_monrace_id(monrace_id);
     if (monrace_id == MonraceId::PLAYER) {
         return 0;
     }
 
-    return this->records.at(monrace_id)->get_seen_count();
+    return this->get_record_ref(monrace_id)->get_seen_count();
 }
 
 void MonraceRecords::set_seen_count(MonraceId monrace_id, short count)
 {
-    this->check_monrace_id(monrace_id);
     if (monrace_id == MonraceId::PLAYER) {
         return;
     }
 
-    this->records.at(monrace_id)->set_seen_count(count);
+    this->get_record_ref(monrace_id)->set_seen_count(count);
 }
 
-void MonraceRecords::check_monrace_id(MonraceId monrace_id) const
+std::shared_ptr<MonraceRecord> &MonraceRecords::get_record_ref(MonraceId monrace_id)
 {
-    if ((monrace_id < MonraceId::PLAYER) || (enum2i(monrace_id) >= static_cast<short>(this->records.size()))) {
-        THROW_EXCEPTION(std::out_of_range, fmt::format("Invalid monrace_id: {}", enum2i(monrace_id)));
+    this->validate_monrace_id(monrace_id);
+    return this->records[enum2i(monrace_id)];
+}
+
+const std::shared_ptr<MonraceRecord> &MonraceRecords::get_record_ref(MonraceId monrace_id) const
+{
+    this->validate_monrace_id(monrace_id);
+    return this->records[enum2i(monrace_id)];
+}
+
+void MonraceRecords::validate_monrace_id(MonraceId monrace_id) const
+{
+    if ((monrace_id <= MonraceId::PLAYER) || monrace_id >= i2enum<MonraceId>(this->records.size())) {
+        THROW_EXCEPTION(std::out_of_range, fmt::format("Invalid Monrace ID: {}", enum2i(monrace_id)));
     }
 }

--- a/src/system/monrace/monrace-records.h
+++ b/src/system/monrace/monrace-records.h
@@ -1,17 +1,17 @@
 #pragma once
 
 /*!
- * @brief モンスター種族に関するプレイ中の動的な記録を集合論的に取り扱うクラス
+ * @brief モンスター種族に関するプレイ中の動的な記録を集合論的に取り扱うリポジトリ
  * @author Hourier
  * @date 2026/05/26
  */
 
 #include "system/enums/monrace/monrace-id.h"
-#include "util/abstract-map-wrapper.h"
 #include <memory>
+#include <vector>
 
 class MonraceRecord;
-class MonraceRecords : public util::AbstractMapWrapper<MonraceId, std::shared_ptr<MonraceRecord>> {
+class MonraceRecords {
 public:
     MonraceRecords(MonraceRecords &&) = delete;
     MonraceRecords(const MonraceRecords &) = delete;
@@ -32,11 +32,9 @@ private:
 
     static MonraceRecords instance;
 
-    std::map<MonraceId, std::shared_ptr<MonraceRecord>> records;
-    std::map<MonraceId, std::shared_ptr<MonraceRecord>> &get_inner_container() override
-    {
-        return this->records;
-    }
+    std::vector<std::shared_ptr<MonraceRecord>> records;
 
-    void check_monrace_id(MonraceId monrace_id) const;
+    std::shared_ptr<MonraceRecord> &get_record_ref(MonraceId monrace_id);
+    const std::shared_ptr<MonraceRecord> &get_record_ref(MonraceId monrace_id) const;
+    void validate_monrace_id(MonraceId monrace_id) const;
 };


### PR DESCRIPTION
変愚蛮怒 PR #5433 ([Fix] MonraceRecords の参照を軽量化) を取り込み:
- MonraceRecords の内部ストレージを std::map<MonraceId, ...> から std::vector<std::shared_ptr<MonraceRecord>> に変更し、enum2i(monrace_id) の インデックスアクセス (get_record_ref) で参照を軽量化。
- initialize() を vector の reserve/resize ベースに変更。
- validate_monrace_id の境界を (< PLAYER) から (<= PLAYER) に修正し PLAYER を 有効範囲から除外。

bakabakaband 適応: baka 既存の検証メソッド名 check_monrace_id は上流 #5433 の validate_monrace_id に統一 (外部参照なし)。直前にマージした #5416 の
MonraceRecords を直接の前提とする。

上流コミット: 008dc348c8 (hengband/develop)