### PR TITLE
refactor: アーティファクト実行時状態を ArtifactRecords に分離（基盤フェーズ1）

### DIFF
--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
@@ -877,6 +877,7 @@
     <ClCompile Include="..\..\src\mspell\mspell-special.cpp" />
     <ClCompile Include="..\..\src\mspell\mspell-status.cpp" />
     <ClCompile Include="..\..\src\system\artifact-type-definition.cpp" />
+    <ClCompile Include="..\..\src\system\artifact\artifact-record.cpp" />
     <ClCompile Include="..\..\src\autopick\autopick-command-menu.cpp" />
     <ClCompile Include="..\..\src\autopick\autopick-describer.cpp" />
     <ClCompile Include="..\..\src\autopick\autopick-destroyer.cpp" />
@@ -1828,6 +1829,7 @@
     <ClInclude Include="..\..\src\mspell\mspell-special.h" />
     <ClInclude Include="..\..\src\mspell\mspell-status.h" />
     <ClInclude Include="..\..\src\system\artifact-type-definition.h" />
+    <ClInclude Include="..\..\src\system\artifact\artifact-record.h" />
     <ClInclude Include="..\..\src\autopick\autopick-command-menu.h" />
     <ClInclude Include="..\..\src\autopick\autopick-commands-table.h" />
     <ClInclude Include="..\..\src\autopick\autopick-describer.h" />

--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
@@ -1556,6 +1556,9 @@
     <ClCompile Include="..\..\src\system\artifact-type-definition.cpp">
       <Filter>system</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\system\artifact\artifact-record.cpp">
+      <Filter>system\artifact</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\view\display-store.cpp">
       <Filter>view</Filter>
     </ClCompile>
@@ -4594,6 +4597,9 @@
     <ClInclude Include="..\..\src\system\artifact-type-definition.h">
       <Filter>system</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\system\artifact\artifact-record.h">
+      <Filter>system\artifact</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\view\display-store.h">
       <Filter>view</Filter>
     </ClInclude>
@@ -6363,6 +6369,9 @@
     </Filter>
     <Filter Include="system\dungeon">
       <UniqueIdentifier>{1894220d-5f9a-4d37-b853-abc0076e56bc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="system\artifact">
+      <UniqueIdentifier>{2a5b7c3e-4d8f-4a1b-9c6d-7e8f9a0b1c2d}</UniqueIdentifier>
     </Filter>
     <Filter Include="system\monrace">
       <UniqueIdentifier>{aeee8301-7122-495a-938a-9425333f0414}</UniqueIdentifier>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1354,6 +1354,7 @@ hengband_SOURCES = \
 	system/angband-system.h system/angband-system.cpp \
 	system/angband-version.cpp system/angband-version.h \
 	system/artifact-type-definition.cpp system/artifact-type-definition.h \
+	system/artifact/artifact-record.cpp system/artifact/artifact-record.h \
 	system/building-type-definition.cpp system/building-type-definition.h \
 	system/creature-entity.cpp system/creature-entity.h \
 	system/grid-type-definition.cpp system/grid-type-definition.h \

--- a/src/artifact/fixed-art-generator.cpp
+++ b/src/artifact/fixed-art-generator.cpp
@@ -20,6 +20,7 @@
 #include "player-base/player-class.h"
 #include "specific-object/bloody-moon.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
 
@@ -260,6 +261,6 @@ bool create_named_art(CreatureEntity &creature, FixedArtifactId a_idx, POSITION 
         return false;
     }
 
-    artifact.is_generated = true;
+    ArtifactRecords::get_instance().set_generated(a_idx, true);
     return true;
 }

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -14,6 +14,7 @@
 #include "player/digestion-processor.h"
 #include "player/player-spell-status.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
 #include "system/building-type-definition.h"
@@ -57,7 +58,7 @@ void player_wipe_without_name(CreatureEntity &creature)
         creature.inventory[i]->wipe();
     }
 
-    ArtifactList::get_instance().reset_generated_flags();
+    ArtifactRecords::get_instance().reset_generated_flags();
     BaseitemList::get_instance().reset_identification_flags();
     for (auto &[_, monrace] : MonraceList::get_instance()) {
         if (!monrace->is_valid()) {

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -17,6 +17,7 @@
 #include "object-enchant/item-magic-applier.h"
 #include "sv-definition/sv-scroll-types.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
 #include "system/creature-entity.h"
@@ -70,8 +71,7 @@ static void generate_artifact(CreatureEntity &creature, qtwg_type *qtwg_ptr, con
         return;
     }
 
-    const auto &artifact = ArtifactList::get_instance().get_artifact(a_idx);
-    if (!artifact.is_generated && create_named_art(creature, a_idx, *qtwg_ptr->y, *qtwg_ptr->x)) {
+    if (!ArtifactRecords::get_instance().get_generated(a_idx) && create_named_art(creature, a_idx, *qtwg_ptr->y, *qtwg_ptr->x)) {
         return;
     }
 
@@ -240,14 +240,13 @@ static bool parse_qtw_QR(QuestType *q_ptr, const std::vector<std::string> &token
 
     int count = 0;
     auto reward_idx = FixedArtifactId::NONE;
-    auto &artifacts = ArtifactList::get_instance();
     for (auto idx = 2; idx < num; idx++) {
         const auto fa_id = i2enum<FixedArtifactId>(std::stoi(tokens[idx]));
         if (fa_id == FixedArtifactId::NONE) {
             continue;
         }
 
-        if (artifacts.get_artifact(fa_id).is_generated) {
+        if (ArtifactRecords::get_instance().get_generated(fa_id)) {
             continue;
         }
 

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -33,6 +33,7 @@
 #include "player-base/player-class.h"
 #include "spell-kind/spells-floor.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/creature-entity.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/enums/dungeon/dungeon-id.h"
@@ -203,7 +204,7 @@ static void update_unique_artifact(const FloorType &floor, int16_t cur_floor_id)
         }
 
         if (item_ptr->is_fixed_artifact()) {
-            item_ptr->get_fixed_artifact().floor_id = cur_floor_id;
+            ArtifactRecords::get_instance().set_floor_id(item_ptr->fa_id, cur_floor_id);
         }
     }
 }
@@ -293,9 +294,8 @@ static void new_floor_allocation(CreatureEntity &creature, saved_floor_type *sf_
             continue;
         }
 
-        auto &artifact = item_ptr->get_fixed_artifact();
-        if (artifact.floor_id == new_floor_id) {
-            artifact.is_generated = true;
+        if (ArtifactRecords::get_instance().get_floor_id(item_ptr->fa_id) == new_floor_id) {
+            ArtifactRecords::get_instance().set_generated(item_ptr->fa_id, true);
         } else {
             delete_i_idx_list.push_back(static_cast<OBJECT_IDX>(i_idx));
         }

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -24,6 +24,7 @@
 #include "spell-class/spells-mirror-master.h"
 #include "system/angband-system.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/creature-entity.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/dungeon/quest-definition.h"
@@ -301,7 +302,7 @@ static void preserve_info(CreatureEntity &creature)
         }
 
         if (o_ptr->is_fixed_artifact()) {
-            o_ptr->get_fixed_artifact().floor_id = 0;
+            ArtifactRecords::get_instance().set_floor_id(o_ptr->fa_id, 0);
         }
     }
 }

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -25,6 +25,7 @@
 #include "object/object-kind-hook.h"
 #include "perception/object-perception.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/baseitem/baseitem-allocation.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
@@ -115,8 +116,7 @@ static void handle_item_disappearance(CreatureEntity &creature, ItemEntity &disa
     }
 
     if (disappearing_item.is_fixed_artifact() && !disappearing_item.is_known() && preserve_mode) {
-        auto &artifact = disappearing_item.get_fixed_artifact();
-        artifact.is_generated = false;
+        ArtifactRecords::get_instance().set_generated(disappearing_item.fa_id, false);
     }
 }
 
@@ -465,8 +465,7 @@ short drop_near(CreatureEntity &subject, ItemEntity &drop_item, const Pos2D &pos
     }
 
     if (drop_item.is_fixed_artifact() && world.character_dungeon && subject.is_player()) {
-        auto &artifact = drop_item.get_fixed_artifact();
-        artifact.floor_id = subject.floor_id;
+        ArtifactRecords::get_instance().set_floor_id(drop_item.fa_id, subject.floor_id);
     }
 
     note_spot(subject, pos_drop);

--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -26,6 +26,7 @@
 #include "room/lake-types.h"
 #include "spell-kind/spells-floor.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/creature-entity.h"
 #include "system/dungeon/dungeon-data-definition.h"
 #include "system/dungeon/dungeon-definition.h"
@@ -305,7 +306,7 @@ void build_streamer(CreatureEntity &creature, FEAT_IDX feat, int chance)
 
                     /* Hack -- Preserve unknown artifacts */
                     if (item.is_fixed_artifact()) {
-                        item.get_fixed_artifact().is_generated = false;
+                        ArtifactRecords::get_instance().set_generated(item.fa_id, false);
                         if (cheat_peek) {
                             const auto item_name = describe_flavor(creature, item, (OD_NAME_ONLY | OD_STORE));
                             msg_format(_("伝説のアイテム (%s) はストリーマーにより削除された。", "Artifact (%s) was deleted by streamer."), item_name.data());

--- a/src/floor/floor-util.cpp
+++ b/src/floor/floor-util.cpp
@@ -9,6 +9,7 @@
 #include "floor/line-of-sight.h"
 #include "game-option/birth-options.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/creature-entity.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/dungeon/quest-definition.h"
@@ -121,7 +122,7 @@ void wipe_o_list(FloorType &floor)
 
         if (!AngbandWorld::get_instance().character_dungeon || preserve_mode) {
             if (item_ptr->is_fixed_artifact() && !item_ptr->is_known()) {
-                item_ptr->get_fixed_artifact().is_generated = false;
+                ArtifactRecords::get_instance().set_generated(item_ptr->fa_id, false);
             }
         }
 

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -20,6 +20,7 @@
 #include "perception/identification.h"
 #include "perception/object-perception.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
 #include "system/creature-entity.h"
@@ -46,7 +47,8 @@ auto collect_known_fixed_artifacts(CreatureEntity &creature)
     const auto comparer = [&artifacts](auto id1, auto id2) { return artifacts.order(id1, id2); };
     std::set<FixedArtifactId, decltype(comparer)> fa_ids(comparer);
     for (const auto &[fa_id, artifact] : artifacts) {
-        if (!artifact.is_generated) {
+        (void)artifact;
+        if (!ArtifactRecords::get_instance().get_generated(fa_id)) {
             continue;
         }
 

--- a/src/load/item/item-loader-base.cpp
+++ b/src/load/item/item-loader-base.cpp
@@ -2,6 +2,7 @@
 #include "artifact/fixed-art-types.h"
 #include "load/load-util.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
 #include "util/bit-flags-calculator.h"
@@ -33,9 +34,9 @@ void ItemLoaderBase::load_artifact()
     auto loading_max_a_idx = rd_u16b();
     for (auto i = 0U; i < loading_max_a_idx; i++) {
         const auto a_idx = i2enum<FixedArtifactId>(i);
-        auto &artifact = ArtifactList::get_instance().get_artifact(a_idx);
-        artifact.is_generated = rd_bool();
-        artifact.floor_id = rd_s16b();
+        auto &records = ArtifactRecords::get_instance();
+        records.set_generated(a_idx, rd_bool());
+        records.set_floor_id(a_idx, rd_s16b());
     }
 
     load_note(_("伝説のアイテムをロードしました", "Loaded Artifacts"));

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -33,6 +33,7 @@
 #include "sv-definition/sv-scroll-types.h"
 #include "system/angband-system.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
 #include "system/building-type-definition.h"
@@ -195,8 +196,7 @@ static void drop_artifact_from_unique(CreatureEntity &creature, MonsterDeath *md
  */
 bool drop_single_artifact(CreatureEntity &creature, MonsterDeath *md_ptr, FixedArtifactId a_idx)
 {
-    auto &artifact = ArtifactList::get_instance().get_artifact(a_idx);
-    if (artifact.is_generated) {
+    if (ArtifactRecords::get_instance().get_generated(a_idx)) {
         return false;
     }
 
@@ -213,8 +213,7 @@ static tl::optional<short> drop_dungeon_final_artifact(CreatureEntity &creature,
     }
 
     const auto a_idx = dungeon.final_artifact;
-    const auto &artifact = ArtifactList::get_instance().get_artifact(a_idx);
-    if (artifact.is_generated) {
+    if (ArtifactRecords::get_instance().get_generated(a_idx)) {
         return bi_id;
     }
 

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -31,6 +31,7 @@
 #include "sv-definition/sv-protector-types.h"
 #include "sv-definition/sv-weapon-types.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/baseitem/baseitem-allocation.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
@@ -359,8 +360,7 @@ static void on_dead_sacred_treasures(CreatureEntity &killer, MonsterDeath *md_pt
     std::vector<FixedArtifactId> candidates;
     std::copy_if(namake_equipments.begin(), namake_equipments.end(), std::back_inserter(candidates),
         [](FixedArtifactId a_idx) {
-            const auto &artifact = ArtifactList::get_instance().get_artifact(a_idx);
-            return !artifact.is_generated;
+            return !ArtifactRecords::get_instance().get_generated(a_idx);
         });
 
     if (candidates.empty()) {

--- a/src/object-enchant/item-magic-applier.cpp
+++ b/src/object-enchant/item-magic-applier.cpp
@@ -13,6 +13,7 @@
 #include "object-enchant/special-object-flags.h"
 #include "player/player-status-flags.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/creature-entity.h"
 #include "system/dungeon/dungeon-definition.h"
@@ -196,7 +197,7 @@ bool ItemMagicApplier::set_fixed_artifact_generation_info()
     }
 
     apply_artifact(this->creature, this->o_ptr);
-    this->o_ptr->get_fixed_artifact().is_generated = true;
+    ArtifactRecords::get_instance().set_generated(this->o_ptr->fa_id, true);
     return true;
 }
 

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -30,6 +30,7 @@
 #include "save/player-writer.h"
 #include "save/save-util.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/creature-entity.h"
 #include "system/dungeon/quest-definition.h"
 #include "system/floor/floor-info.h"
@@ -173,9 +174,9 @@ static bool wr_savefile_new(CreatureEntity &creature)
     wr_u16b(tmp16u);
     for (auto i = 0U; i < tmp16u; i++) {
         const auto a_idx = i2enum<FixedArtifactId>(i);
-        const auto &artifact = artifacts.get_artifact(a_idx);
-        wr_bool(artifact.is_generated);
-        wr_s16b(artifact.floor_id);
+        const auto &records = ArtifactRecords::get_instance();
+        wr_bool(records.get_generated(a_idx));
+        wr_s16b(records.get_floor_id(a_idx));
     }
 
     wr_u32b(world.sf_play_time);

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -24,6 +24,7 @@
 #include "spell-kind/spells-teleport.h"
 #include "status/bad-status-setter.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/creature-entity.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/dungeon/quest-definition.h"
@@ -338,7 +339,7 @@ bool destroy_area(CreatureEntity &creature, const POSITION y1, const POSITION x1
                 for (const auto this_o_idx : grid.o_idx_list) {
                     auto &item = *floor.o_list[this_o_idx];
                     if (item.is_fixed_artifact() && (!item.is_known() || in_generate)) {
-                        item.get_fixed_artifact().is_generated = false;
+                        ArtifactRecords::get_instance().set_generated(item.fa_id, false);
 
                         if (in_generate && cheat_peek) {
                             const auto item_name = describe_flavor(creature, item, (OD_NAME_ONLY | OD_STORE));

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -32,6 +32,7 @@
 #include "sv-definition/sv-scroll-types.h"
 #include "sv-definition/sv-weapon-types.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/baseitem/baseitem-key.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
@@ -106,11 +107,11 @@ struct AmusementRewardItemVisitor {
 
     tl::optional<ItemEntity> operator()(const FixedArtifactId &fa_id) const
     {
-        const auto &artifact = ArtifactList::get_instance().get_artifact(fa_id);
-        if (artifact.is_generated) {
+        if (ArtifactRecords::get_instance().get_generated(fa_id)) {
             return tl::nullopt;
         }
 
+        const auto &artifact = ArtifactList::get_instance().get_artifact(fa_id);
         ItemEntity item(artifact.bi_key);
         item.fa_id = fa_id;
         ItemMagicApplier(creature, &item, 1, AM_NO_FIXED_ART).execute();

--- a/src/system/artifact-type-definition.cpp
+++ b/src/system/artifact-type-definition.cpp
@@ -1,6 +1,7 @@
 #include "system/artifact-type-definition.h"
 #include "artifact/fixed-art-types.h"
 #include "object/tval-types.h"
+#include "system/artifact/artifact-record.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
 #include "system/item-entity.h"
@@ -15,9 +16,9 @@ ArtifactType::ArtifactType()
  * @param bi_key 生成しようとするアーティファクトのベースアイテムキー
  * @param level プレイヤーが今いる階層
  */
-bool ArtifactType::can_generate(const BaseitemKey &generaing_bi_key) const
+bool ArtifactType::can_generate(FixedArtifactId fa_id, const BaseitemKey &generaing_bi_key) const
 {
-    if (this->is_generated) {
+    if (ArtifactRecords::get_instance().get_generated(fa_id)) {
         return false;
     }
 
@@ -38,9 +39,9 @@ bool ArtifactType::can_generate(const BaseitemKey &generaing_bi_key) const
  * @param fa_id 固定アーティファクトID
  * @return 生成に成功したらそのアイテム、失敗したらnullopt
  */
-tl::optional<BaseitemKey> ArtifactType::try_make_instant_artifact(int making_level) const
+tl::optional<BaseitemKey> ArtifactType::try_make_instant_artifact(FixedArtifactId fa_id, int making_level) const
 {
-    if (!this->can_make_instant_artifact()) {
+    if (!this->can_make_instant_artifact(fa_id)) {
         return tl::nullopt;
     }
 
@@ -64,9 +65,9 @@ tl::optional<BaseitemKey> ArtifactType::try_make_instant_artifact(int making_lev
  * @return 生成可否
  * @details 生成済、クエスト属性付き、非INSTA_ARTはfalse、普通のINSTA_ARTはtrue
  */
-bool ArtifactType::can_make_instant_artifact() const
+bool ArtifactType::can_make_instant_artifact(FixedArtifactId fa_id) const
 {
-    auto can_make = !this->is_generated;
+    auto can_make = !ArtifactRecords::get_instance().get_generated(fa_id);
     can_make &= this->gen_flags.has_not(ItemGenerationTraitType::QUESTITEM);
     can_make &= this->gen_flags.has(ItemGenerationTraitType::INSTA_ART);
     return can_make;
@@ -166,17 +167,10 @@ void ArtifactList::emplace(const FixedArtifactId fa_id, ArtifactType &&artifact)
     this->artifacts.emplace(fa_id, std::move(artifact));
 }
 
-void ArtifactList::reset_generated_flags()
-{
-    for (auto &[_, artifact] : this->artifacts) {
-        artifact.is_generated = false;
-    }
-}
-
 tl::optional<ItemEntity> ArtifactList::try_make_instant_artifact(int making_level) const
 {
     for (const auto &[fa_id, artifact] : this->artifacts) {
-        const auto bi_key = artifact.try_make_instant_artifact(making_level);
+        const auto bi_key = artifact.try_make_instant_artifact(fa_id, making_level);
         if (bi_key) {
             ItemEntity instant_artifact(*bi_key);
             instant_artifact.fa_id = fa_id;

--- a/src/system/artifact-type-definition.h
+++ b/src/system/artifact-type-definition.h
@@ -13,7 +13,7 @@
 /*!
  * @class ArtifactType
  * @brief 固定アーティファクト情報の構造体 / Artifact structure.
- * @details is_generated とfloor_id フィールドのみセーブファイルへの保存対象
+ * @details 実行時可変な生成状態 (is_generated / floor_id) は ArtifactRecords に分離している
  */
 enum class FixedArtifactId : short;
 enum class RandomArtActType : short;
@@ -40,16 +40,14 @@ public:
     EnumClassFlagGroup<ItemGenerationTraitType> gen_flags; /*! アイテム生成フラグ / flags for generate */
     DEPTH level{}; /*! 基本生成階 / Artifact level */
     RARITY rarity{}; /*! レアリティ / Artifact rarity */
-    bool is_generated{}; /*! 生成済か否か (生成済でも、「保存モードON」かつ「帰還等で鑑定前に消滅」したら未生成状態に戻る) */
-    FLOOR_IDX floor_id{}; /*! アイテムを落としたフロアのID / Leaved on this location last time */
     RandomArtActType act_idx{}; /*! 発動能力ID / Activative ability index */
     PERCENTAGE broken_rate; /*!< 発動破損率 */
 
-    bool can_generate(const BaseitemKey &bi_key) const;
-    tl::optional<BaseitemKey> try_make_instant_artifact(int making_level) const;
+    bool can_generate(FixedArtifactId fa_id, const BaseitemKey &bi_key) const;
+    tl::optional<BaseitemKey> try_make_instant_artifact(FixedArtifactId fa_id, int making_level) const;
 
 private:
-    bool can_make_instant_artifact() const;
+    bool can_make_instant_artifact(FixedArtifactId fa_id) const;
     bool evaluate_shallow_instant_artifact(int making_level) const;
     bool evaluate_rarity() const;
     bool evaluate_shallow_baseitem(int making_level) const;
@@ -70,7 +68,6 @@ public:
 
     bool order(const FixedArtifactId id1, const FixedArtifactId id2) const;
     void emplace(const FixedArtifactId fa_id, ArtifactType &&artifact);
-    void reset_generated_flags();
     tl::optional<ItemEntity> try_make_instant_artifact(int making_level) const;
 
 private:

--- a/src/system/artifact/artifact-record.cpp
+++ b/src/system/artifact/artifact-record.cpp
@@ -1,0 +1,57 @@
+#include "system/artifact/artifact-record.h"
+
+bool ArtifactRecord::get_generated() const
+{
+    return this->is_generated;
+}
+
+FLOOR_IDX ArtifactRecord::get_floor_id() const
+{
+    return this->floor_id;
+}
+
+void ArtifactRecord::set_generated(bool new_state)
+{
+    this->is_generated = new_state;
+}
+
+void ArtifactRecord::set_floor_id(FLOOR_IDX new_floor_id)
+{
+    this->floor_id = new_floor_id;
+}
+
+ArtifactRecords ArtifactRecords::instance{};
+
+ArtifactRecords &ArtifactRecords::get_instance()
+{
+    return instance;
+}
+
+bool ArtifactRecords::get_generated(FixedArtifactId fa_id) const
+{
+    const auto it = this->records.find(fa_id);
+    return (it != this->records.end()) && it->second.get_generated();
+}
+
+FLOOR_IDX ArtifactRecords::get_floor_id(FixedArtifactId fa_id) const
+{
+    const auto it = this->records.find(fa_id);
+    return (it != this->records.end()) ? it->second.get_floor_id() : 0;
+}
+
+void ArtifactRecords::set_generated(FixedArtifactId fa_id, bool new_state)
+{
+    this->records[fa_id].set_generated(new_state);
+}
+
+void ArtifactRecords::set_floor_id(FixedArtifactId fa_id, FLOOR_IDX new_floor_id)
+{
+    this->records[fa_id].set_floor_id(new_floor_id);
+}
+
+void ArtifactRecords::reset_generated_flags()
+{
+    for (auto &[_, record] : this->records) {
+        record.set_generated(false);
+    }
+}

--- a/src/system/artifact/artifact-record.h
+++ b/src/system/artifact/artifact-record.h
@@ -1,0 +1,58 @@
+#pragma once
+
+/*!
+ * @file artifact-record.h
+ * @brief ゲーム中可変な固定アーティファクト情報 (ArtifactType から分離した実行時状態)
+ * @details ArtifactType から is_generated / floor_id を分離して保持する。
+ *          上流 hengband の ArtifactRecord/ArtifactRecords (PR #5436 系) に相当するが、
+ *          bakabakaband は ArtifactType を維持しているため FixedArtifactId をキーに保持する。
+ */
+
+#include "system/angband.h"
+#include "util/abstract-map-wrapper.h"
+#include <map>
+
+class ArtifactRecord {
+public:
+    ArtifactRecord() = default;
+
+    bool get_generated() const;
+    FLOOR_IDX get_floor_id() const;
+
+    void set_generated(bool new_state);
+    void set_floor_id(FLOOR_IDX new_floor_id);
+
+private:
+    bool is_generated = false; //!< 生成済か否か (生成済でも、「保存モードON」かつ「帰還等で鑑定前に消滅」したら未生成状態に戻る)
+    FLOOR_IDX floor_id = 0; //!< アイテムを落としたフロアのID
+};
+
+enum class FixedArtifactId : short;
+class ArtifactRecords : public util::AbstractMapWrapper<FixedArtifactId, ArtifactRecord> {
+public:
+    ArtifactRecords(ArtifactRecords &&) = delete;
+    ArtifactRecords(const ArtifactRecords &) = delete;
+    ArtifactRecords &operator=(const ArtifactRecords &) = delete;
+    ArtifactRecords &operator=(ArtifactRecords &&) = delete;
+    ~ArtifactRecords() = default;
+
+    static ArtifactRecords &get_instance();
+
+    bool get_generated(FixedArtifactId fa_id) const;
+    FLOOR_IDX get_floor_id(FixedArtifactId fa_id) const;
+
+    void set_generated(FixedArtifactId fa_id, bool new_state);
+    void set_floor_id(FixedArtifactId fa_id, FLOOR_IDX new_floor_id);
+    void reset_generated_flags();
+
+private:
+    ArtifactRecords() = default;
+    static ArtifactRecords instance;
+
+    std::map<FixedArtifactId, ArtifactRecord> records;
+
+    std::map<FixedArtifactId, ArtifactRecord> &get_inner_container() override
+    {
+        return this->records;
+    }
+};

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -1385,7 +1385,7 @@ bool ItemEntity::try_become_artifact(int dungeon_level)
     }
 
     for (const auto &[a_idx, artifact] : ArtifactList::get_instance()) {
-        if (!artifact.can_generate(this->bi_key)) {
+        if (!artifact.can_generate(a_idx, this->bi_key)) {
             continue;
         }
 

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -25,6 +25,7 @@
 #include "spell-kind/spells-perception.h"
 #include "spell/spells-object.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/baseitem/baseitem-allocation.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
@@ -224,7 +225,7 @@ void wiz_restore_aware_flag_of_fixed_arfifact(FixedArtifactId reset_artifact_idx
     const auto max_a_idx = enum2i(artifacts.rbegin()->first);
     const auto message = aware ? "Modified." : "Restored.";
     if (reset_artifact_idx != FixedArtifactId::NONE) {
-        artifacts.get_artifact(reset_artifact_idx).is_generated = aware;
+        ArtifactRecords::get_instance().set_generated(reset_artifact_idx, aware);
         msg_print(message);
         return;
     }
@@ -234,7 +235,7 @@ void wiz_restore_aware_flag_of_fixed_arfifact(FixedArtifactId reset_artifact_idx
         return;
     }
 
-    artifacts.get_artifact(*input_artifact_id).is_generated = aware;
+    ArtifactRecords::get_instance().set_generated(*input_artifact_id, aware);
     msg_print(message);
 }
 
@@ -465,7 +466,7 @@ static void wiz_statistics(CreatureEntity &creature, ItemEntity *o_ptr)
 {
     constexpr auto prompt = "Roll for [n]ormal, [g]ood, or [e]xcellent treasure? ";
     if (o_ptr->is_fixed_artifact()) {
-        o_ptr->get_fixed_artifact().is_generated = false;
+        ArtifactRecords::get_instance().set_generated(o_ptr->fa_id, false);
     }
 
     auto rolls = 1000000;
@@ -524,7 +525,7 @@ static void wiz_statistics(CreatureEntity &creature, ItemEntity *o_ptr)
             }
 
             if (item->is_fixed_artifact()) {
-                item->get_fixed_artifact().is_generated = false;
+                ArtifactRecords::get_instance().set_generated(item->fa_id, false);
             }
 
             if (o_ptr->bi_key != item->bi_key) {
@@ -549,7 +550,7 @@ static void wiz_statistics(CreatureEntity &creature, ItemEntity *o_ptr)
     }
 
     if (o_ptr->is_fixed_artifact()) {
-        o_ptr->get_fixed_artifact().is_generated = true;
+        ArtifactRecords::get_instance().set_generated(o_ptr->fa_id, true);
     }
 }
 
@@ -615,7 +616,7 @@ static void wiz_reroll_item(CreatureEntity &creature, ItemEntity *o_ptr)
         const auto command = input_command(prompt);
         if (!command) {
             if (item.is_fixed_artifact()) {
-                item.get_fixed_artifact().is_generated = false;
+                ArtifactRecords::get_instance().set_generated(item.fa_id, false);
                 item.fa_id = FixedArtifactId::NONE;
             }
 
@@ -629,7 +630,7 @@ static void wiz_reroll_item(CreatureEntity &creature, ItemEntity *o_ptr)
         }
 
         if (item.is_fixed_artifact()) {
-            item.get_fixed_artifact().is_generated = false;
+            ArtifactRecords::get_instance().set_generated(item.fa_id, false);
             item.fa_id = FixedArtifactId::NONE;
         }
 
@@ -1071,8 +1072,7 @@ WishResultType do_cmd_wishing(CreatureEntity &creature, int prob, bool allow_art
     const auto &artifacts = ArtifactList::get_instance();
     if (!wishing_fa_ids.empty()) {
         const auto wishing_fa_id = *wishing_fa_ids.begin();
-        const auto &artifact = artifacts.get_artifact(wishing_fa_id);
-        if (must || (ok_art && !artifact.is_generated)) {
+        if (must || (ok_art && !ArtifactRecords::get_instance().get_generated(wishing_fa_id))) {
             (void)create_named_art(creature, wishing_fa_id, creature.y, creature.x);
         } else {
             wishing_puff_of_smoke();
@@ -1102,8 +1102,7 @@ WishResultType do_cmd_wishing(CreatureEntity &creature, int prob, bool allow_art
         }
 
         if (a_idx != FixedArtifactId::NONE) {
-            const auto &artifact = artifacts.get_artifact(a_idx);
-            if (must || (ok_art && !artifact.is_generated)) {
+            if (must || (ok_art && !ArtifactRecords::get_instance().get_generated(a_idx))) {
                 (void)create_named_art(creature, a_idx, creature.y, creature.x);
             } else {
                 wishing_puff_of_smoke();

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -57,6 +57,7 @@
 #include "spell/spells-status.h"
 #include "status/bad-status-setter.h"
 #include "system/artifact-type-definition.h"
+#include "system/artifact/artifact-record.h"
 #include "system/creature-entity.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/dungeon/dungeon-list.h"
@@ -270,8 +271,7 @@ void wiz_create_named_art(CreatureEntity &creature)
     }
 
     screen_load();
-    const auto &artifact = ArtifactList::get_instance().get_artifact(*created_fa_id);
-    if (artifact.is_generated) {
+    if (ArtifactRecords::get_instance().get_generated(*created_fa_id)) {
         msg_print("It's already allocated.");
         return;
     }


### PR DESCRIPTION
固定アーティファクトの実行時可変状態 (生成済フラグ・落下フロアID) を
ArtifactType から ArtifactRecord/ArtifactRecords に分離する。上流 hengband の ArtifactRecords 系リファクタ (PR #5436 系クラスタの基盤) を、bakabakaband が 維持する ArtifactType 構造の上に適応した最初のフェーズ (方針 A)。

- 新規: system/artifact/artifact-record.{cpp,h}
  - ArtifactRecord: is_generated / floor_id を保持
  - ArtifactRecords: FixedArtifactId をキーにしたシングルトン。 get/set_generated, get/set_floor_id, reset_generated_flags を提供
- ArtifactType から is_generated / floor_id フィールドを削除
- ArtifactType::can_generate / try_make_instant_artifact / can_make_instant_artifact は FixedArtifactId を受け取り ArtifactRecords を 参照する形に変更
- ArtifactList::reset_generated_flags は ArtifactRecords へ移設
- is_generated / floor_id への全アクセス約30箇所 (floor / wizard / spell / monster-death / knowledge / 生成 / セーブ・ロード) を ArtifactRecords API 経由に移行
- セーブ形式は不変 (wr_bool + wr_s16b を同順で維持) のためバージョン据置・ 後方互換

備考: floor-save 系の floor_id (saved_floor_type::floor_id / CreatureEntity::floor_id) は別概念のため対象外。known/identified/quest_reward 等の拡充 (#5436) と fullname (#5443/#5447) / reader クラス化 (#5444) / 契約導入 (#5417) は後続フェーズで対応予定。