### PR TITLE
refactor: 固定アーティファクトのフルネーム出力メソッドを追加（基盤フェーズ2）

### DIFF
--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -308,8 +308,8 @@ void build_streamer(CreatureEntity &creature, FEAT_IDX feat, int chance)
                     if (item.is_fixed_artifact()) {
                         ArtifactRecords::get_instance().set_generated(item.fa_id, false);
                         if (cheat_peek) {
-                            const auto item_name = describe_flavor(creature, item, (OD_NAME_ONLY | OD_STORE));
-                            msg_format(_("伝説のアイテム (%s) はストリーマーにより削除された。", "Artifact (%s) was deleted by streamer."), item_name.data());
+                            const auto fixed_artifact_name = item.get_fixed_artifact_name();
+                            msg_format(_("伝説のアイテム (%s) はストリーマーにより削除された。", "Artifact (%s) was deleted by streamer."), fixed_artifact_name.data());
                         }
                     } else if (cheat_peek && item.is_random_artifact()) {
                         msg_print(_("ランダム・アーティファクトの1つはストリーマーにより削除された。", "One of the random artifacts was deleted by streamer."));

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -342,8 +342,8 @@ bool destroy_area(CreatureEntity &creature, const POSITION y1, const POSITION x1
                         ArtifactRecords::get_instance().set_generated(item.fa_id, false);
 
                         if (in_generate && cheat_peek) {
-                            const auto item_name = describe_flavor(creature, item, (OD_NAME_ONLY | OD_STORE));
-                            msg_format(_("伝説のアイテム (%s) は生成中に*破壊*された。", "Artifact (%s) was *destroyed* during generation."), item_name.data());
+                            const auto fixed_artifact_name = item.get_fixed_artifact_name();
+                            msg_format(_("伝説のアイテム (%s) は生成中に*破壊*された。", "Artifact (%s) was *destroyed* during generation."), fixed_artifact_name.data());
                         }
                     } else if (in_generate && cheat_peek && item.is_random_artifact()) {
                         msg_print(

--- a/src/system/artifact-type-definition.cpp
+++ b/src/system/artifact-type-definition.cpp
@@ -1,7 +1,13 @@
 #include "system/artifact-type-definition.h"
 #include "artifact/fixed-art-types.h"
+#include "object-enchant/tr-types.h"
 #include "object/tval-types.h"
 #include "system/artifact/artifact-record.h"
+#ifdef JP
+#else
+#include "util/string-processor.h"
+#include <sstream>
+#endif
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
 #include "system/item-entity.h"
@@ -31,6 +37,73 @@ bool ArtifactType::can_generate(FixedArtifactId fa_id, const BaseitemKey &genera
     }
 
     return this->bi_key == generaing_bi_key;
+}
+
+/*!
+ * @brief アーティファクトを『』も考慮しつつ完全な名前を返す
+ *
+ * 日本語版：
+ * FULL_NAMEフラグつきの場合、そのまま
+ * 例1：運命のオーブ → ★運命のオーブ
+ * 例2：トゲトゲバット『エスカリボルグ』 → ★トゲトゲバット『エスカリボルグ』
+ *
+ * FULL_NAMEフラグなしの場合、ベースアイテム名を付与する
+ * - 『』ありなら前置する
+ * - 『』なしなら後置する
+ * 例1：『ナルサンク』 → ★ダガー『ナルサンク』
+ * 例2：シヴァの化身の → ★シヴァの化身の軟革ブーツ
+ *
+ * English version:
+ * If the artifact has the FULL_NAME flag, return it as is.
+ * All fixed artifacts with "The", then it starts capital always; there must not be any name starting other than "The", such as "the".
+ * Example1: 'Excaliborg, the *thorny* bat' => The 'Excaliborg, the *thorny* bat'
+ * Example2: The Orb of Fate => The Orb of Fate
+ *
+ * If an artifact does not have the FULL_NAME flag, the baseitem name is always prefixed and the fixed artifact name is appended.
+ * Example1: 'Narthanc' => The Dagger 'Narthanc'
+ * Example2: of Corwin => The Set of Gauntlets of Corwin
+ */
+std::string ArtifactType::build_full_name() const
+{
+#ifdef JP
+    std::string full_name("★");
+    if (this->flags.has(TR_FULL_NAME)) {
+        return full_name.append(this->name);
+    }
+
+    constexpr auto start = "『";
+    const auto is_preposition = this->name.starts_with(start);
+    const auto &baseitems = BaseitemList::get_instance();
+    if (is_preposition) {
+        return full_name.append(baseitems.lookup_baseitem(this->bi_key).name).append(this->name);
+    }
+
+    return full_name.append(this->name).append(baseitems.lookup_baseitem(this->bi_key).name);
+#else
+    constexpr auto definite_article = "The";
+    if (this->flags.has(TR_FULL_NAME)) {
+        std::stringstream ss;
+        if (!this->name.starts_with(definite_article)) {
+            ss << definite_article << ' ';
+        }
+
+        ss << this->name;
+        return ss.str();
+    }
+
+    const auto &baseitems = BaseitemList::get_instance();
+    const auto &baseitem = baseitems.lookup_baseitem(this->bi_key);
+    const auto baseitem_name_without_numeral = str_replace(baseitem.name, "&", "");
+    const auto baseitem_name_singular = str_replace(baseitem_name_without_numeral, "~", "");
+    std::stringstream ss;
+    ss << definite_article;
+    if (!baseitem_name_singular.starts_with(' ')) {
+        ss << ' ';
+    }
+
+    ss << baseitem_name_singular << ' ' << this->name;
+    return ss.str();
+#endif
 }
 
 /*!

--- a/src/system/artifact-type-definition.h
+++ b/src/system/artifact-type-definition.h
@@ -45,6 +45,7 @@ public:
 
     bool can_generate(FixedArtifactId fa_id, const BaseitemKey &bi_key) const;
     tl::optional<BaseitemKey> try_make_instant_artifact(FixedArtifactId fa_id, int making_level) const;
+    std::string build_full_name() const;
 
 private:
     bool can_make_instant_artifact(FixedArtifactId fa_id) const;

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -862,6 +862,15 @@ const ArtifactType &ItemEntity::get_fixed_artifact() const
     return ArtifactList::get_instance().get_artifact(this->fa_id);
 }
 
+std::string ItemEntity::get_fixed_artifact_name() const
+{
+    if (this->fa_id == FixedArtifactId::NONE) {
+        return "";
+    }
+
+    return this->get_fixed_artifact().build_full_name();
+}
+
 TrFlags ItemEntity::get_flags() const
 {
     const auto &baseitem = this->get_baseitem();

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -167,6 +167,7 @@ public:
     EgoItemDefinition &get_ego() const;
     ArtifactType &get_fixed_artifact();
     const ArtifactType &get_fixed_artifact() const;
+    std::string get_fixed_artifact_name() const;
     TrFlags get_flags() const;
     TrFlags get_flags_known() const;
     std::string explain_activation() const;

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -808,16 +808,14 @@ void wiz_modify_item(CreatureEntity &creature)
     }
 }
 
-static std::vector<FixedArtifactId> find_wishing_fixed_artifact(CreatureEntity &creature, std::string_view pray_chars)
+static std::vector<FixedArtifactId> find_wishing_fixed_artifact(std::string_view pray_chars)
 {
     std::vector<FixedArtifactId> fa_ids;
     for (const auto &[fa_id, artifact] : ArtifactList::get_instance()) {
-        ItemEntity item(artifact.bi_key);
-        item.fa_id = fa_id;
 #ifdef JP
-        const auto item_name = describe_flavor(creature, item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+        const auto item_name = artifact.build_full_name();
 #else
-        const auto item_name = str_tolower(describe_flavor(creature, item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE)));
+        const auto item_name = str_tolower(artifact.build_full_name());
 #endif
         std::string art_description = artifact.name;
 #ifdef JP
@@ -847,7 +845,8 @@ static std::vector<FixedArtifactId> find_wishing_fixed_artifact(CreatureEntity &
 
         art_description = str_tolower(art_description);
 #endif
-        const std::string match_name(_(item_name.substr(2), item_name));
+        //!< 先頭の「★」(日本語)、「The 」(英語)を除去する.
+        const auto match_name = item_name.substr(_(2, 4));
         if (cheat_xtra) {
             msg_format("Matching artifact No.%d %s(%s)", enum2i(fa_id), art_description.data(), match_name.data());
         }
@@ -1063,7 +1062,7 @@ WishResultType do_cmd_wishing(CreatureEntity &creature, int prob, bool allow_art
         }
     }
 
-    const auto wishing_fa_ids = allow_art ? find_wishing_fixed_artifact(creature, pray_chars) : std::vector<FixedArtifactId>{};
+    const auto wishing_fa_ids = allow_art ? find_wishing_fixed_artifact(pray_chars) : std::vector<FixedArtifactId>{};
     if (AngbandWorld::get_instance().wizard && ((wishing_fa_ids.size() > 1) || (ego_ids.size() > 1))) {
         msg_print(_("候補が多すぎる！", "Too many matches!"));
         return WishResultType::FAIL;

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -189,31 +189,18 @@ void wiz_create_item(CreatureEntity &creature)
     msg_print("Allocated.");
 }
 
-/*!
- * @brief 指定したIDの固定アーティファクトの名称を取得する
- *
- * @param fa_id 固定アーティファクトのID
- * @return 固定アーティファクトの名称(Ex. ★ロング・ソード『リンギル』)を保持する std::string オブジェクト
- */
-static std::string wiz_make_named_artifact_desc(CreatureEntity &creature, FixedArtifactId fa_id)
-{
-    const auto &artifact = ArtifactList::get_instance().get_artifact(fa_id);
-    ItemEntity item(artifact.bi_key);
-    item.fa_id = fa_id;
-    return describe_flavor(creature, item, OD_NAME_ONLY | OD_STORE);
-}
-
 /**
  * @brief 固定アーティファクトをリストから選択する
  *
  * @param fa_ids 選択する候補となる固定アーティファクトのIDのリスト
  * @return 選択した固定アーティファクトのIDを返す。但しキャンセルした場合は tl::nullopt を返す。
  */
-static tl::optional<FixedArtifactId> wiz_select_named_artifact(CreatureEntity &creature, const std::vector<FixedArtifactId> &fa_ids)
+static tl::optional<FixedArtifactId> wiz_select_named_artifact(const std::vector<FixedArtifactId> &fa_ids)
 {
     CandidateSelector cs("Which artifact: ", 15);
 
-    auto describe_artifact = [&creature](FixedArtifactId fa_id) { return wiz_make_named_artifact_desc(creature, fa_id); };
+    const auto &artifacts = ArtifactList::get_instance();
+    const auto describe_artifact = [&artifacts](auto fa_id) { return artifacts.get_artifact(fa_id).build_full_name(); };
     const auto it = cs.select(fa_ids, describe_artifact);
     return (it != fa_ids.end()) ? tl::make_optional(*it) : tl::nullopt;
 }
@@ -267,7 +254,7 @@ void wiz_create_named_art(CreatureEntity &creature)
 
         auto fa_ids = wiz_collect_group_fa_ids(group_artifact_list[idx]);
         std::sort(fa_ids.begin(), fa_ids.end(), [](FixedArtifactId id1, FixedArtifactId id2) { return ArtifactList::get_instance().order(id1, id2); });
-        created_fa_id = wiz_select_named_artifact(creature, fa_ids);
+        created_fa_id = wiz_select_named_artifact(fa_ids);
     }
 
     screen_load();


### PR DESCRIPTION
変愚蛮怒 PR #5443 / #5447 相当。アーティファクトの完全な表示名
(★/『』/The/ベースアイテム名の付与) を生成するロジックを ArtifactType の
メソッドに集約し、describe_flavor 経由で名前を組み立てていた箇所を差し替えた。

- ArtifactType::build_full_name(): FULL_NAME フラグ・『』前置/後置・★/The を 考慮した完全名を返す (日本語/英語両対応)
- ItemEntity::get_fixed_artifact_name(): 固定アーティファクトの完全名を返す 薄いラッパ (非固定artなら空文字列)
- ストリーマー削除/生成中破壊メッセージ (floor-streams / spells-floor) を get_fixed_artifact_name() ベースに変更
- wizard の固定アーティファクト選択/wish 検索 (wizard-special-process / wizard-item-modifier) を build_full_name() ベースに変更し、不要になった describe_flavor 経由のダミー ItemEntity 生成・creature 引数を除去

baka 構造への適応: ArtifactDefinition→ArtifactType、tr_type::TR_FULL_NAME→ TR_FULL_NAME、PlayerType*→CreatureEntity&、msg_print({})→msg_format(%s)。 baka の ArtifactDefinitions.jsonc は英語名に ~/& を含まないため #5443 の jsonc クリーンアップは適用不要。