### PR TITLE
fix: 縦長フロアでプレイヤー視界の南東部分が欠落する不具合を修正

### DIFF
--- a/src/player/player-view.cpp
+++ b/src/player/player-view.cpp
@@ -278,7 +278,7 @@ void update_view(CreatureEntity &creature)
 
         if (xpn < x_max) {
             m = std::min(z, x_max - xpn);
-            if ((ypn <= x_max) && (i < es)) {
+            if ((ypn <= y_max) && (i < es)) {
                 for (k = i, d = 1; d <= m; d++) {
                     if (update_view_aux(creature, ypn, xpn + d, ypn - 1, xpn + d - 1, ypn, xpn + d - 1)) {
                         if (i + d >= es) {


### PR DESCRIPTION
update_view() の es オクタント (東ストリップの南側 = 南東のくさび形領域) の ガードで、行インデックス ypn (= y + i) を誤って x_max (width - 1) で 境界判定していた。ypn は行座標なので正しくは y_max (height - 1) で判定すべき。 対称位置の ws オクタント (西ストリップ南側, 同ファイル) は正しく y_max を
使用しており、これに揃える。

影響条件:
- 横長フロア (width > height) では x_max >= y_max となり、誤った境界でも 有効行は常に通過するため不具合は顕在化しない (上流 hengband でも潜在)。
- bakabakaband は MAX_HGT == MAX_WID == 242 かつ floor.height/width を独立に ランダム決定するため、縦長フロア (width < height, x_max < y_max) が生成され 得る。この場合 x_max < ypn <= y_max の行で es オクタントがスキップされ、 南東方向の視界グリッドに CAVE_VIEW が設定されず暗転する。 上流 (classic Angband: 66x198 固定で width >> height) では発生しない、 バリアント特有の発現条件のため「時折発生」していた。

副次的に、横長フロアでプレイヤーが南端付近に居る場合に発生し得た
update_view_aux 内 grid_array[...] の範囲外読み取りも本修正で解消する。