### PR TITLE
fix: 非STUPIDモンスターが一部の召喚魔法を選択できない不具合を修正 (#7110)

### DIFF
--- a/src/mspell/mspell-selector.cpp
+++ b/src/mspell/mspell-selector.cpp
@@ -157,7 +157,7 @@ static bool spell_annoy(MonsterAbilityType spell)
  */
 static bool spell_summon(MonsterAbilityType spell)
 {
-    return spell_in_between(spell, MonsterAbilityType::S_KIN, MonsterAbilityType::S_PERVERT);
+    return RF_ABILITY_SUMMON_MASK.has(spell);
 }
 
 /*!


### PR DESCRIPTION
知的モンスターの呪文選択 (mspell-selector.cpp) の spell_summon() が、召喚魔法の 判定に固定範囲 [S_KIN, S_PERVERT] (enum 80..115) を使っていた。しかし MonsterAbilityType enum では S_PERVERT(115) より後に S_WALL(116) / S_INSECT(117) / S_FAIRY(118) / S_APE(119) / S_BIRD(120) / S_ELDRAZI(121) が追加されており、これらが 召喚として認識されていなかった。さらに範囲 80..115 の途中には召喚ではない攻撃魔法
BO_VOID..BA_GRAVITY(100..111) が挿入されており、これらを誤って召喚に分類していた。

結果として、例えばヴァーミンロード (S_INSECT のみを持つ非 STUPID モンスター) は summon カテゴリが空になり虫召喚を一切行わなかった。一方 STUPID モンスターは
呪文をランダム選択する経路 (rand_choice) を通るため S_INSECT を選べていた。これが 「STUPID でない限り虫召喚を行わない」という報告された症状の原因。

判定を正準的な RF_ABILITY_SUMMON_MASK.has() に置き換え、全召喚種別を過不足なく 分類するよう修正。隣接する spell_attack() は挿入された攻撃魔法を個別レンジで
追従済みだったが spell_summon() のみ更新漏れだった。