### PR TITLE
feat: ウィザードモードに現在フロアのダンプ機能を追加 (#7484)

### DIFF
--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -48,7 +48,7 @@
 /*!
  * @brief デバグコマンド一覧表
  * @details
- * 空き: A,B,E,I,J,k,K,L,q,Q,R,T,U,V,W,y,Y
+ * 空き: A,B,E,I,J,k,K,L,q,Q,R,T,U,W,y,Y
  */
 constexpr std::array debug_menu_table = {
     std::make_tuple('a', _("全状態回復", "Restore all status")),
@@ -83,6 +83,7 @@ constexpr std::array debug_menu_table = {
     std::make_tuple('t', _("テレポート", "Teleport self")),
     std::make_tuple('u', _("啓蒙(忍者以外)", "Wiz-lite all floor except Ninja")),
     std::make_tuple('v', _("時空崩壊度設定", "Set world collapsion degree")),
+    std::make_tuple('V', _("現在のフロアをファイルにダンプ", "Dump current floor to a file")),
     std::make_tuple('w', _("啓蒙(忍者配慮)", "Wiz-lite all floor")),
     std::make_tuple('x', _("経験値を得る(指定可)", "Get experience")),
     std::make_tuple('X', _("所持品を初期状態に戻す", "Return inventory to initial")),
@@ -267,6 +268,9 @@ bool exe_cmd_debug(CreatureEntity &creature, char cmd)
             return false;
         }
     }
+    case 'V':
+        wiz_dump_current_floor(creature);
+        return true;
     case 'w':
         wiz_lite(creature, CreatureClass(creature).equals(PlayerClassType::NINJA));
         return true;

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -711,6 +711,58 @@ void wiz_dump_options()
 }
 
 /*!
+ * @brief 現在のフロアの地形をテキストファイルにダンプする
+ * @param creature クリーチャーへの参照
+ * @details Vault 定義 (VaultDefinitions) と同じ N:/X:/D: 形式で出力し、後で
+ *          vault-editor で編集しやすい形に整える土台とする。各グリッドには
+ *          その地形の標準表示文字 (TerrainKind::NORMAL の F_LIT_STANDARD) を割り当てる。
+ */
+void wiz_dump_current_floor(CreatureEntity &creature)
+{
+    const auto &floor = *creature.get_floor();
+    const auto path = path_build(ANGBAND_DIR_USER, "floor-dump.txt");
+    const auto &filename = path.string();
+    std::ofstream ofs(path);
+    if (ofs.bad()) {
+        msg_format(_("ファイル %s を開けませんでした。", "Failed to open file %s."), filename.data());
+        msg_erase();
+        return;
+    }
+
+    const auto height = floor.height;
+    const auto width = floor.width;
+    ofs << "# Current floor dump\n";
+    ofs << format("# Dungeon Level: %d\n", floor.dun_level);
+    ofs << format("# Size (rows x cols): %d x %d\n", height, width);
+    ofs << "# Player position (y, x): " << format("%d, %d\n", creature.y, creature.x);
+    ofs << "#\n";
+    ofs << "# Vault 定義と同じ N:/X:/D: 形式で出力している。各文字は地形の標準表示文字。\n";
+    ofs << "\n";
+    ofs << "N:0:Floor Dump\n";
+    ofs << format("X:0:0:%d:%d\n", height, width);
+
+    for (auto y = 0; y < height; y++) {
+        std::string row;
+        row.reserve(width);
+        for (auto x = 0; x < width; x++) {
+            const auto &terrain = floor.get_grid({ y, x }).get_terrain(TerrainKind::NORMAL);
+            const auto ch = terrain.symbol_definitions.at(F_LIT_STANDARD).character;
+            row.push_back(ch == '\0' ? ' ' : ch);
+        }
+
+        ofs << "D:" << row << '\n';
+    }
+
+    if (ofs.bad()) {
+        msg_format(_("ファイル %s への書き込みに失敗しました。", "Failed to write to file %s."), filename.data());
+        msg_erase();
+        return;
+    }
+
+    msg_format(_("現在のフロアをファイル %s に書き出しました。", "Current floor dump saved to file %s."), filename.data());
+}
+
+/*!
  * @brief プレイヤー近辺の全モンスターを消去する / Delete all nearby monsters
  */
 void wiz_zap_surrounding_monsters(CreatureEntity &creature)

--- a/src/wizard/wizard-special-process.h
+++ b/src/wizard/wizard-special-process.h
@@ -14,6 +14,7 @@ void wiz_reset_race(CreatureEntity &creature);
 void wiz_reset_class(CreatureEntity &creature);
 void wiz_reset_realms(CreatureEntity &creature);
 void wiz_dump_options();
+void wiz_dump_current_floor(CreatureEntity &creature);
 void wiz_zap_surrounding_monsters(CreatureEntity &creature);
 void wiz_zap_floor_monsters(CreatureEntity &creature);
 void cheat_death(CreatureEntity &creature, bool no_penalty);


### PR DESCRIPTION
デバッグコマンド 'V' を追加。現在のフロアの地形を Vault 定義
(VaultDefinitions) と同じ N:/X:/D: 形式でユーザディレクトリの
floor-dump.txt に書き出す。各グリッドにはその地形の標準表示文字
(TerrainKind::NORMAL の F_LIT_STANDARD シンボル) を割り当てる。

後で vault-editor で編集しやすい形に整理するための土台。ヘッダに
ダンジョン階層・サイズ・プレイヤー位置を併記する。

- wizard-special-process.cpp: wiz_dump_current_floor() を実装
- cmd-wizard.cpp: デバッグコマンド 'V' とメニュー項目を追加、 空きキー一覧コメントを更新