### PR TITLE
feat: モンスター思い出の「要約のみ表示」オプションを追加 (#7475)

### DIFF
--- a/src/game-option/option-types-table.cpp
+++ b/src/game-option/option-types-table.cpp
@@ -182,6 +182,7 @@ const std::vector<GameOption> option_info = validate_option_info({
     { &show_actual_value, true, GameOptionType::SHOW_ACTUAL_VALUE, "show_actual_value", _("技能値等に実値を並記する", "Show actual values of skills or etc."), GameOptionPage::TEXT },
 
     { &show_lore_summary, true, GameOptionType::SHOW_LORE_SUMMARY, "show_lore_summary", _("モンスターの思い出を要約表記にする", " Show a summary of monster lore."), GameOptionPage::TEXT },
+    { &lore_summary_only, false, GameOptionType::LORE_SUMMARY_ONLY, "lore_summary_only", _("モンスターの思い出を要約のみ表記にする", " Show only the summary of monster lore."), GameOptionPage::TEXT },
 
     /*** Game-Play ***/
     { &stack_force_notes, true, GameOptionType::STACK_FORCE_NOTES, "stack_force_notes", _("異なる銘のアイテムをまとめる", "Merge inscriptions when stacking"), GameOptionPage::GAMEPLAY },

--- a/src/game-option/option-types-table.h
+++ b/src/game-option/option-types-table.h
@@ -93,7 +93,8 @@ enum class GameOptionType : int {
     SHOW_ACTUAL_VALUE = 81,
     SKIP_MORE = 82,
     SHOW_LORE_SUMMARY = 83,
-    // 84-94
+    LORE_SUMMARY_ONLY = 84, /*!< bakabakaband 独自: モンスターの思い出を要約のみ表記にする */
+    // 85-94
     NUMPAD_AS_CURSORKEY = 95,
 
     // 96-127

--- a/src/game-option/text-display-options.cpp
+++ b/src/game-option/text-display-options.cpp
@@ -19,3 +19,4 @@ bool show_ammo_no_crit; /* Show No-crit damage of ammo */
 bool show_ammo_crit_ratio; /* Show critical ratio of ammo */
 bool show_actual_value; /* Show actual value of skill */
 bool show_lore_summary; /* Show lore summary in monster recall */
+bool lore_summary_only; /* Show only the summary (suppress verbose prose) in monster recall */

--- a/src/game-option/text-display-options.h
+++ b/src/game-option/text-display-options.h
@@ -21,3 +21,4 @@ extern bool show_ammo_no_crit; /* Show No-crit damage of ammo */
 extern bool show_ammo_crit_ratio; /* Show critical ratio of ammo */
 extern bool show_actual_value; /* Show actual value of skill */
 extern bool show_lore_summary; /* Show lore summary in monster recall */
+extern bool lore_summary_only; /* Show only the summary (suppress verbose prose) in monster recall */

--- a/src/lore/monster-lore.cpp
+++ b/src/lore/monster-lore.cpp
@@ -378,7 +378,7 @@ void process_monster_lore(CreatureEntity &creature, MonraceId r_idx, monster_lor
     set_race_flags(lore_ptr);
     const auto &text = lore_ptr->monrace->text;
 
-    if (show_lore_summary) {
+    if (show_lore_summary || lore_summary_only) {
         display_monster_kind_tags(lore_ptr);
         display_monster_hp_ac_summary(lore_ptr);
         display_monster_speed_summary(lore_ptr);
@@ -396,6 +396,10 @@ void process_monster_lore(CreatureEntity &creature, MonraceId r_idx, monster_lor
         display_monster_magic_tables(creature, lore_ptr);
         display_monster_resistance_table(lore_ptr);
         hook_c_roff(TERM_L_DARK, "------------------------------------------------------------\n");
+    }
+
+    if (lore_summary_only && lore_ptr->mode != MONSTER_LORE_DEBUG) {
+        return;
     }
 
     display_kill_numbers(lore_ptr);


### PR DESCRIPTION
新規ゲームオプション lore_summary_only (TEXT ページ, 既定OFF) を追加。ON のとき モンスターの思い出表示で要約表のみを表示し、長文の説明プローズを省略する
「簡易表示」を実現する。

既存の show_lore_summary は要約表を長文の上に併記する仕様だが、本オプションは
要約だけの簡潔な表示を求める用途向け。process_monster_lore() で要約表を
(show_lore_summary || lore_summary_only) の条件で出力し、lore_summary_only が ON の場合は要約表の直後に return して以降のプローズ出力を抑制する。

- option-types-table.h: GameOptionType::LORE_SUMMARY_ONLY = 84 を追加 (空き bit)
- option-types-table.cpp / text-display-options.{h,cpp}: オプション登録・実体定義
- monster-lore.cpp: 要約表の表示条件と簡易表示時の早期 return を実装

新規オプション bit は既定 OFF のため旧セーブとの互換性に影響なし。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new game option, **“Monster Recall: Lore Summary Only,”** allowing monster recollection to display only the concise lore summary.
  * When enabled, verbose narrative prose is suppressed during monster recall to keep results shorter and easier to scan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->