### PR TITLE
feat: モンスターの構成材質に応じた金銭ドロップ補正を追加 (#7346)

### DIFF
--- a/src/monster-floor/monster-drop-generator.cpp
+++ b/src/monster-floor/monster-drop-generator.cpp
@@ -17,6 +17,8 @@
 #include "util/dice.h"
 #include "util/enum-converter.h"
 #include "util/probability-table.h"
+#include <algorithm>
+#include <limits>
 
 namespace {
 /*!
@@ -109,6 +111,12 @@ void generate_monster_drop_items(CreatureEntity &player, CreatureEntity &monster
         if (do_gold && (!do_item || one_in_(2))) {
             const auto bi_key = BaseitemMonraceService::lookup_fixed_gold_drop(monrace.drop_flags);
             auto item = floor.make_gold(bi_key);
+            // 構成材質に応じて金銭額を増減させる (貴金属系は増、紙・糞は減)。
+            const auto gold_percent = monster.get_material_gold_drop_percent();
+            if (gold_percent != 100) {
+                const auto scaled = static_cast<int>(item.pval) * gold_percent / 100;
+                item.pval = static_cast<PARAMETER_VALUE>(std::clamp(scaled, 1, static_cast<int>(std::numeric_limits<PARAMETER_VALUE>::max())));
+            }
             monster.acquire_item(item);
         } else {
             if (auto item = make_object(player, mo_mode)) {

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -928,6 +928,18 @@ int CreatureEntity::get_material_ac_modifier() const
     return total;
 }
 
+int CreatureEntity::get_material_gold_drop_percent() const
+{
+    if (this->materials.empty()) {
+        return 100;
+    }
+    auto percent = 0;
+    for (const auto material : this->materials) {
+        percent = std::max(percent, get_material_definition(material).gold_drop_percent);
+    }
+    return percent;
+}
+
 void CreatureEntity::apply_material_stat_modifiers()
 {
     for (auto stat = 0; stat < A_MAX; ++stat) {

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -2740,6 +2740,13 @@ public:
     virtual int get_material_ac_modifier() const;
 
     /*!
+     * @brief 材質に基づく金銭ドロップ額の倍率 (% 単位) を取得する
+     * @return 保持する材質のうち最も高い gold_drop_percent。材質を持たなければ 100
+     * @details 複数材質を持つ場合は最も貴重な材質の倍率を採用する (合算しない)。
+     */
+    virtual int get_material_gold_drop_percent() const;
+
+    /*!
      * @brief モンスター種族定義の材質指定および材質系 kind_flags に基づいて材質を初期化する
      * @details モンスター以外では何もしない。
      */

--- a/src/system/material-type-definition.h
+++ b/src/system/material-type-definition.h
@@ -7,6 +7,8 @@
  * 能力値修正 (6 能力値) と AC 修正を持つ。鉄や金などモンスターの構成材質を
  * 種族とは独立した軸として表現する。能力値修正は表示単位 (1 = +1.0) で
  * 記述し、適用時に内部 10 単位へ変換する。AC 修正は素の AC 値への加算。
+ * gold_drop_percent は当該材質で構成されたモンスターが落とす金銭額の倍率
+ * (% 単位、100 = 等倍)。貴金属系ほど高く、紙や糞は低い。
  */
 
 #include "locale/localized-string.h"
@@ -37,6 +39,7 @@ struct MaterialDefinition {
     LocalizedString name; //!< 材質名
     std::array<int, A_MAX> stat_modifiers; //!< 能力値修正 (表示単位、1 = +1.0)
     int ac_modifier; //!< AC 修正 (素の AC への加算)
+    int gold_drop_percent; //!< 金銭ドロップ額の倍率 (% 単位、100 = 等倍)
 };
 
 /*!
@@ -48,20 +51,20 @@ inline const MaterialDefinition &get_material_definition(CreatureMaterialType ma
 {
     // 添字は CreatureMaterialType の値と一致させること。
     static const std::array<MaterialDefinition, MATERIAL_TYPE_MAX> definitions = { {
-        // name,                          STR INT WIS DEX CON CHR    AC
-        { { "肉", "Flesh" }, { 0, 0, 0, 0, 0, 0 }, 0 },
-        { { "木", "Wood" }, { 1, 0, 0, -1, 1, 0 }, 3 },
-        { { "紙", "Paper" }, { -3, 0, 0, 2, -3, 0 }, -3 },
-        { { "石", "Stone" }, { 3, -2, 0, -3, 4, 0 }, 15 },
-        { { "鉄", "Iron" }, { 4, -2, 0, -3, 5, 0 }, 25 },
-        { { "銅", "Copper" }, { 3, -1, 0, -2, 4, 0 }, 18 },
-        { { "銀", "Silver" }, { 3, 1, 0, -1, 3, 2 }, 20 },
-        { { "金", "Gold" }, { 2, 0, 0, -4, 3, 4 }, 22 },
-        { { "ミスリル", "Mithril" }, { 5, 1, 0, 0, 5, 2 }, 30 },
-        { { "アダマンタイト", "Adamantite" }, { 7, -1, 0, -2, 7, 0 }, 40 },
-        { { "漆黒鋼", "Darksteel" }, { 6, 0, 0, -1, 6, 0 }, 35 },
-        { { "歪魂石", "Warpstone" }, { 4, 3, -2, 0, 3, -2 }, 28 },
-        { { "糞", "Feces" }, { -2, -3, -2, -2, -2, -5 }, -5 },
+        // name,                          STR INT WIS DEX CON CHR    AC  gold%
+        { { "肉", "Flesh" }, { 0, 0, 0, 0, 0, 0 }, 0, 100 },
+        { { "木", "Wood" }, { 1, 0, 0, -1, 1, 0 }, 3, 100 },
+        { { "紙", "Paper" }, { -3, 0, 0, 2, -3, 0 }, -3, 80 },
+        { { "石", "Stone" }, { 3, -2, 0, -3, 4, 0 }, 15, 110 },
+        { { "鉄", "Iron" }, { 4, -2, 0, -3, 5, 0 }, 25, 130 },
+        { { "銅", "Copper" }, { 3, -1, 0, -2, 4, 0 }, 18, 160 },
+        { { "銀", "Silver" }, { 3, 1, 0, -1, 3, 2 }, 20, 220 },
+        { { "金", "Gold" }, { 2, 0, 0, -4, 3, 4 }, 22, 500 },
+        { { "ミスリル", "Mithril" }, { 5, 1, 0, 0, 5, 2 }, 30, 350 },
+        { { "アダマンタイト", "Adamantite" }, { 7, -1, 0, -2, 7, 0 }, 40, 280 },
+        { { "漆黒鋼", "Darksteel" }, { 6, 0, 0, -1, 6, 0 }, 35, 200 },
+        { { "歪魂石", "Warpstone" }, { 4, 3, -2, 0, 3, -2 }, 28, 180 },
+        { { "糞", "Feces" }, { -2, -3, -2, -2, -2, -5 }, -5, 50 },
     } };
 
     return definitions[static_cast<int>(material)];


### PR DESCRIPTION
素材フラグ (CreatureMaterialType) を活用し、モンスターの構成材質に応じて
落とす金銭額を増減させる。貴金属系 (金 500% / ミスリル 350% / アダマンタイト
280% / 銀 220% / 漆黒鋼・歪魂石 200% / 銅 160% / 鉄 130% / 石 110%) は増加、 紙 80% / 糞 50% は減少。肉・木は等倍 (100%)。

- material-type-definition.h: MaterialDefinition に gold_drop_percent を追加し 全 13 材質に倍率値を設定
- creature-entity.{h,cpp}: get_material_gold_drop_percent() virtual を追加。 複数材質を持つ場合は最も貴重な材質の倍率を採用 (合算しない)。材質なしは 100
- monster-drop-generator.cpp: generate_monster_drop_items() の金銭生成時に pval へ倍率を適用 (int16_t 上限でクランプ)

金銭ドロップは spawn 時に所持品として先行生成される単一経路のため、
本変更で死亡時ドロップを含む全経路を網羅する。Issue #7346 の「素材に応じて
ドロップ等を変化させる」の第一弾として金銭額補正を実装。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monsters now drop variable amounts of gold based on their material composition, with certain materials yielding higher or lower gold rewards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->