### PR TITLE
merge: 未使用システム情報を削除し勝敗/プレイ時間/noscore を InnerGameData へ集約 (hengband#5402 相当)

### DIFF
--- a/src/birth/birth-select-class.cpp
+++ b/src/birth/birth-select-class.cpp
@@ -4,12 +4,12 @@
 #include "player-info/class-info.h"
 #include "player-info/race-info.h"
 #include "system/creature-entity.h"
+#include "system/inner-game-data.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
-#include "world/world.h"
 #include <sstream>
 #include <vector>
 
@@ -77,7 +77,7 @@ static void enumerate_class_list(CreatureEntity &creature, char *sym, const std:
         }
 
         auto cs = i2enum<PlayerClassType>(raw);
-        c_put_str(AngbandWorld::get_instance().get_birth_class_color(cs), birth_class_label(creature, display_index, sym, playables), 13 + (display_index / 4), 2 + 19 * (display_index % 4));
+        c_put_str(InnerGameData::get_instance().get_birth_class_color(cs), birth_class_label(creature, display_index, sym, playables), 13 + (display_index / 4), 2 + 19 * (display_index % 4));
     }
 }
 
@@ -89,7 +89,7 @@ static std::string display_class_stat(CreatureEntity &creature, int cs, int *os,
 
     const auto count = static_cast<int>(playables.size());
     auto pclass = i2enum<PlayerClassType>(*os < count ? playables[*os] : 0);
-    c_put_str(AngbandWorld::get_instance().get_birth_class_color(pclass), cur, 13 + (*os / 4), 2 + 19 * (*os % 4));
+    c_put_str(InnerGameData::get_instance().get_birth_class_color(pclass), cur, 13 + (*os / 4), 2 + 19 * (*os % 4));
     put_str("                                   ", 3, 40);
     auto result = birth_class_label(creature, cs, sym, playables);
     if (cs == count) {

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -103,7 +103,7 @@ void player_wipe_without_name(CreatureEntity &creature)
     auto &system = AngbandSystem::get_instance();
     system.set_panic_save(false);
 
-    world.noscore = 0;
+    InnerGameData::get_instance().initialize_no_score();
     world.wizard = false;
     system.set_awaiting_report_score(false);
     creature.set_pet_follow_distance(PET_FOLLOW_DIST);

--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -33,6 +33,7 @@
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
+#include "system/inner-game-data.h"
 #include "system/redrawing-flags-updater.h"
 #include "system/terrain/terrain-definition.h"
 #include "target/target-getter.h"
@@ -127,7 +128,7 @@ void do_cmd_alter(CreatureEntity &creature)
  */
 static bool decide_suicide()
 {
-    if (AngbandWorld::get_instance().noscore) {
+    if (InnerGameData::get_instance().is_no_score()) {
         return true;
     }
 
@@ -192,7 +193,7 @@ void do_cmd_suicide(CreatureEntity &creature)
     creature.set_leaving(true);
     if (world.total_winner) {
         accept_winner_message(creature);
-        world.add_retired_class(creature.pclass);
+        InnerGameData::get_instance().add_retired_class(creature.pclass);
     } else {
         play_music(TERM_XTRA_MUSIC_BASIC, MUSIC_BASIC_GAMEOVER);
         const auto &floor = *creature.get_floor();

--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -16,6 +16,7 @@
 #include "io/write-diary.h"
 #include "main/sound-of-music.h"
 #include "system/creature-entity.h"
+#include "system/inner-game-data.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
@@ -369,13 +370,13 @@ static void do_cmd_options_cheat(const FloorType &floor, std::string_view player
         case 'y':
         case 'Y':
         case '6': {
-            auto &world = AngbandWorld::get_instance();
-            if (!world.noscore) {
+            auto &igd = InnerGameData::get_instance();
+            if (!igd.is_no_score()) {
                 exe_write_diary(floor, DiaryKind::DESCRIPTION, 0,
                     _("詐欺オプションをONにして、スコアを残せなくなった。", "gave up sending score to use cheating options."));
             }
 
-            world.noscore |= cheat.flag_position * 256 + cheat.offset;
+            igd.add_no_score(cheat.flag_position * 256 + cheat.offset);
             *cheat.value = true;
             k = (k + 1) % n;
             break;
@@ -431,7 +432,7 @@ void do_cmd_options(CreatureEntity &creature)
     const auto &world = AngbandWorld::get_instance();
     while (true) {
         auto n = std::ssize(option_fields);
-        if (!world.noscore && !allow_debug_opts) {
+        if (!InnerGameData::get_instance().is_no_score() && !allow_debug_opts) {
             n--;
         }
 
@@ -533,7 +534,7 @@ void do_cmd_options(CreatureEntity &creature)
         }
         case 'C':
         case 'c': {
-            if (!world.noscore && !allow_debug_opts) {
+            if (!InnerGameData::get_instance().is_no_score() && !allow_debug_opts) {
                 bell();
                 break;
             }

--- a/src/core/game-closer.cpp
+++ b/src/core/game-closer.cpp
@@ -25,6 +25,7 @@
 #include "save/save.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
+#include "system/inner-game-data.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "util/angband-files.h"
@@ -172,7 +173,7 @@ void close_game(CreatureEntity &creature)
     auto do_send = true;
     if (!cheat_save || input_check(_("死んだデータをセーブしますか？ ", "Save death? "))) {
         world.play_time.update();
-        world.sf_play_time += world.play_time.elapsed_sec();
+        InnerGameData::get_instance().add_play_time(world.play_time.elapsed_sec());
 
         if (!save_player(creature, SaveType::CLOSE_GAME)) {
             msg_print(_("セーブ失敗！", "death save failed!"));

--- a/src/core/scores.cpp
+++ b/src/core/scores.cpp
@@ -454,7 +454,7 @@ bool check_score(CreatureEntity &creature)
 
     /* Wizard-mode pre-empts scoring */
     auto &world = AngbandWorld::get_instance();
-    const auto no_score = world.noscore;
+    const auto no_score = InnerGameData::get_instance().get_no_score();
     if (no_score & 0x000F) {
         msg_print(_("ウィザード・モードではスコアが記録されません。", "Score not registered for wizards."));
         msg_erase();

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -245,7 +245,7 @@ static void dump_aux_options(FILE *fff)
     }
 
     fmt::print(fff, "\n");
-    if (AngbandWorld::get_instance().noscore) {
+    if (InnerGameData::get_instance().is_no_score()) {
         fmt::println(fff, _("\n 何か不正なことをしてしまっています。", "\n You have done something illegal."));
     }
 

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -90,6 +90,7 @@
 #include "system/creature-entity.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/floor/floor-info.h"
+#include "system/inner-game-data.h"
 #include "system/item-entity.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
@@ -110,8 +111,8 @@
  */
 bool enter_wizard_mode(const FloorType &floor)
 {
-    auto &world = AngbandWorld::get_instance();
-    if (!world.noscore) {
+    auto &igd = InnerGameData::get_instance();
+    if (!igd.is_no_score()) {
         if (!allow_debug_opts) {
             msg_print(_("ウィザードモードは許可されていません。 ", "Wizard mode is not permitted."));
             return false;
@@ -126,7 +127,7 @@ bool enter_wizard_mode(const FloorType &floor)
 
         constexpr auto mes = _("ウィザードモードに突入してスコアを残せなくなった。", "gave up recording score to enter wizard mode.");
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 0, mes);
-        world.noscore |= 0x0002;
+        igd.add_no_score(0x0002);
     }
 
     return true;
@@ -140,8 +141,8 @@ bool enter_wizard_mode(const FloorType &floor)
  */
 static bool enter_debug_mode(const FloorType &floor)
 {
-    auto &world = AngbandWorld::get_instance();
-    if (!world.noscore) {
+    auto &igd = InnerGameData::get_instance();
+    if (!igd.is_no_score()) {
         if (!allow_debug_opts) {
             msg_print(_("デバッグコマンドは許可されていません。 ", "Use of debug command is not permitted."));
             return false;
@@ -156,7 +157,7 @@ static bool enter_debug_mode(const FloorType &floor)
 
         constexpr auto mes = _("デバッグモードに突入してスコアを残せなくなった。", "gave up sending score to use debug commands.");
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 0, mes);
-        world.noscore |= 0x0008;
+        igd.add_no_score(0x0008);
     }
 
     return true;

--- a/src/knowledge/knowledge-self.cpp
+++ b/src/knowledge/knowledge-self.cpp
@@ -22,6 +22,7 @@
 #include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
 #include "system/floor/wilderness-grid.h"
+#include "system/inner-game-data.h"
 #include "system/item-entity.h"
 #include "util/angband-files.h"
 #include "util/buffer-shaper.h"
@@ -102,8 +103,8 @@ static void dump_yourself(CreatureEntity &creature, FILE *fff)
  */
 static void dump_winner_classes(FILE *fff)
 {
-    const auto &world = AngbandWorld::get_instance();
-    const int n = world.sf_winner.count();
+    const auto &igd = InnerGameData::get_instance();
+    const int n = static_cast<int>(igd.get_won_classes_count());
     concptr ss = n > 1 ? _("", "s") : "";
     fprintf(fff, _("*勝利*済みの職業%s : %d\n", "Class of *Winner%s* : %d\n"), ss, n);
     if (n == 0) {
@@ -115,13 +116,13 @@ static void dump_winner_classes(FILE *fff)
     std::string l = "";
     for (int c = 0; c < PLAYER_CLASS_TYPE_MAX; c++) {
         const auto pclass_enum = i2enum<PlayerClassType>(c);
-        if (world.sf_winner.has_not(pclass_enum)) {
+        if (igd.has_not_won_class(pclass_enum)) {
             continue;
         }
 
         auto &player_class = class_info.at(i2enum<PlayerClassType>(c));
         std::string t = player_class.title.string();
-        if (world.sf_retired.has_not(pclass_enum)) {
+        if (igd.has_not_retired_class(pclass_enum)) {
             t = "(" + t + ")";
         }
 
@@ -155,7 +156,7 @@ void do_cmd_knowledge_stat(CreatureEntity &creature)
     auto &world = AngbandWorld::get_instance();
     world.play_time.update();
     const auto play_time = world.play_time.elapsed_sec();
-    const auto all_time = world.sf_play_time + play_time;
+    const auto all_time = InnerGameData::get_instance().get_total_play_time() + play_time;
     fprintf(fff, _("現在のプレイ時間 : %d:%02d:%02d\n", "Current Play Time is %d:%02d:%02d\n"), play_time / (60 * 60), (play_time / 60) % 60, play_time % 60);
     fprintf(fff, _("合計のプレイ時間 : %d:%02d:%02d\n", "  Total play Time is %d:%02d:%02d\n"), all_time / (60 * 60), (all_time / 60) % 60, all_time % 60);
     fputs("\n", fff);

--- a/src/load/info-loader.cpp
+++ b/src/load/info-loader.cpp
@@ -50,11 +50,10 @@ void rd_version_info(void)
         system.set_version({ major, minor, patch, extra });
     }
 
-    auto &world = AngbandWorld::get_instance();
-    world.sf_system = rd_u32b();
-    world.sf_when = rd_u32b();
-    world.sf_lives = rd_u16b();
-    world.sf_saves = rd_u16b();
+    // 旧 sf_system / sf_when / sf_lives / sf_saves の領域 (計 12 バイト)。
+    // 上流 hengband#5402 で未使用フィールドとして廃止された。bakabakaband では
+    // セーブフォーマット互換のため常にこの 12 バイトを書き出しているため読み飛ばす。
+    strip_bytes(12);
 
     loading_savefile_version = rd_u32b();
 

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -85,7 +85,7 @@ static void rd_total_play_time()
         return;
     }
 
-    AngbandWorld::get_instance().sf_play_time = rd_u32b();
+    InnerGameData::get_instance().set_total_play_time(rd_u32b());
 }
 
 /*!
@@ -110,8 +110,13 @@ static void rd_winner_class()
         return;
     }
 
-    rd_FlagGroup(AngbandWorld::get_instance().sf_winner, rd_byte);
-    rd_FlagGroup(AngbandWorld::get_instance().sf_retired, rd_byte);
+    auto &igd = InnerGameData::get_instance();
+    EnumClassFlagGroup<PlayerClassType> winner_classes{};
+    rd_FlagGroup(winner_classes, rd_byte);
+    igd.set_won_classes(winner_classes);
+    EnumClassFlagGroup<PlayerClassType> retired_classes{};
+    rd_FlagGroup(retired_classes, rd_byte);
+    igd.set_retired_classes(retired_classes);
 }
 
 static void load_player_world(CreatureEntity &creature)
@@ -291,7 +296,6 @@ static bool reset_save_data(CreatureEntity &creature, bool *new_game)
 {
     *new_game = true;
     creature.is_dead_ = false;
-    AngbandWorld::get_instance().sf_lives++;
     return true;
 }
 

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -105,7 +105,7 @@ void rd_global_configurations(CreatureEntity &creature)
     system.set_panic_save(rd_u16b() > 0);
     auto &world = AngbandWorld::get_instance();
     world.total_winner = rd_u16b();
-    world.noscore = rd_u16b();
+    InnerGameData::get_instance().add_no_score(rd_u16b());
 
     creature.is_dead_ = rd_bool();
 

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -41,6 +41,7 @@
 #include "system/dungeon/dungeon-definition.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "system/floor/floor-info.h"
+#include "system/inner-game-data.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
@@ -252,7 +253,7 @@ static void on_defeat_last_boss(CreatureEntity &creature)
 {
     auto &world = AngbandWorld::get_instance();
     world.total_winner = true;
-    world.add_winner_class(creature.pclass);
+    InnerGameData::get_instance().add_winner_class(creature.pclass);
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TITLE);
     play_music(TERM_XTRA_MUSIC_BASIC, MUSIC_BASIC_FINAL_QUEST_CLEAR);
     exe_write_diary(*creature.get_floor(), DiaryKind::DESCRIPTION, 0, _("見事に馬鹿馬鹿蛮怒の勝利者となった！", "finally became *WINNER* of Bakabakaband!"));

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -62,6 +62,7 @@
 #include "system/dungeon/quest-definition.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "system/floor/floor-info.h"
+#include "system/inner-game-data.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/player-type-definition.h"
@@ -535,7 +536,7 @@ void PlayerType::on_death(std::string_view cause)
 
     world.total_winner = false;
     if (is_seppuku_by_won) {
-        world.add_retired_class(this->pclass);
+        InnerGameData::get_instance().add_retired_class(this->pclass);
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 0, _("勝利の後切腹した。", "committed seppuku after the winning."));
     } else {
         std::string place;

--- a/src/save/info-writer.cpp
+++ b/src/save/info-writer.cpp
@@ -12,6 +12,7 @@
 #include "store/store-util.h"
 #include "system/angband-system.h"
 #include "system/angband.h"
+#include "system/inner-game-data.h"
 #include "system/item-entity.h"
 #include "util/enum-converter.h"
 #include "world/world.h"
@@ -214,7 +215,7 @@ void save_quick_start(void)
 
     /* UNUSED : Was number of random quests */
     wr_byte(0);
-    if (AngbandWorld::get_instance().noscore) {
+    if (InnerGameData::get_instance().is_no_score()) {
         previous_char.quick_ok = false;
     }
 

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -246,7 +246,7 @@ void wr_player(CreatureEntity &creature)
     wr_u32b(system.get_seed_town());
     wr_u16b(system.is_panic_save_executed() ? 1 : 0);
     wr_u16b(world.total_winner);
-    wr_u16b(world.noscore);
+    wr_u16b(InnerGameData::get_instance().get_no_score());
     wr_bool(creature.is_dead());
     const auto &df = DungeonFeeling::get_instance();
     wr_byte(static_cast<uint8_t>(df.get_feeling()));

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -36,6 +36,7 @@
 #include "system/floor/floor-info.h"
 #include "system/floor/town-list.h"
 #include "system/floor/wilderness-grid.h"
+#include "system/inner-game-data.h"
 #include "system/monrace/monrace-list.h"
 #include "util/angband-files.h"
 #include "view/display-messages.h"
@@ -57,11 +58,7 @@ static bool wr_savefile_new(CreatureEntity &creature)
 {
     compact_monsters(creature, 0);
 
-    uint32_t now = (uint32_t)time((time_t *)0);
     auto &world = AngbandWorld::get_instance();
-    world.sf_system = 0L;
-    world.sf_when = now;
-    world.sf_saves++;
 
     save_xor_byte = 0;
     auto variant_length = VARIANT_NAME.length();
@@ -82,10 +79,13 @@ static bool wr_savefile_new(CreatureEntity &creature)
     v_stamp = 0L;
     x_stamp = 0L;
 
-    wr_u32b(world.sf_system);
-    wr_u32b(world.sf_when);
-    wr_u16b(world.sf_lives);
-    wr_u16b(world.sf_saves);
+    // 旧 sf_system / sf_when / sf_lives / sf_saves の領域 (計 12 バイト)。
+    // 上流 hengband#5402 で未使用フィールドとして廃止されたが、セーブフォーマット
+    // 互換性維持のため予約領域として書き出す (Godot 用 save-file-scanner も同オフセット依存)。
+    wr_u32b(0);
+    wr_u32b(static_cast<uint32_t>(time((time_t *)0)));
+    wr_u16b(0);
+    wr_u16b(0);
 
     wr_u32b(SAVEFILE_VERSION);
     wr_u16b(0);
@@ -179,10 +179,11 @@ static bool wr_savefile_new(CreatureEntity &creature)
         wr_s16b(records.get_floor_id(a_idx));
     }
 
-    wr_u32b(world.sf_play_time);
+    const auto &igd = InnerGameData::get_instance();
+    wr_u32b(igd.get_total_play_time());
     wr_s32b(wc_ptr->collapse_degree);
-    wr_FlagGroup(world.sf_winner, wr_byte);
-    wr_FlagGroup(world.sf_retired, wr_byte);
+    wr_FlagGroup(igd.get_won_classes(), wr_byte);
+    wr_FlagGroup(igd.get_retired_classes(), wr_byte);
 
     wr_alliance_base_power();
 

--- a/src/system/inner-game-data.cpp
+++ b/src/system/inner-game-data.cpp
@@ -7,6 +7,7 @@
 #include "system/inner-game-data.h"
 #include "player-info/race-types.h"
 #include "system/gamevalue.h"
+#include "term/term-color-types.h"
 
 InnerGameData InnerGameData::instance{};
 
@@ -67,4 +68,131 @@ int InnerGameData::get_real_turns(int turns) const
     default:
         return turns;
     }
+}
+
+uint32_t InnerGameData::get_total_play_time() const
+{
+    return this->total_play_time;
+}
+
+void InnerGameData::set_total_play_time(uint32_t time)
+{
+    this->total_play_time = time;
+}
+
+void InnerGameData::add_play_time(uint32_t time)
+{
+    this->total_play_time += time;
+}
+
+bool InnerGameData::is_no_score() const
+{
+    return this->noscore > 0;
+}
+
+uint16_t InnerGameData::get_no_score() const
+{
+    return this->noscore;
+}
+
+void InnerGameData::initialize_no_score()
+{
+    this->noscore = 0;
+}
+
+void InnerGameData::add_no_score(uint16_t new_state)
+{
+    this->noscore |= new_state;
+}
+
+term_color_type InnerGameData::get_birth_class_color(PlayerClassType c) const
+{
+    if (c >= PlayerClassType::MAX) {
+        return TERM_WHITE;
+    }
+
+    if (this->is_retired_class(c)) {
+        return TERM_L_DARK;
+    }
+
+    return this->is_winner_class(c) ? TERM_SLATE : TERM_WHITE;
+}
+
+size_t InnerGameData::get_won_classes_count() const
+{
+    return this->won_classes.count();
+}
+
+bool InnerGameData::has_not_won_class(PlayerClassType pc) const
+{
+    return this->won_classes.has_not(pc);
+}
+
+const EnumClassFlagGroup<PlayerClassType> &InnerGameData::get_won_classes() const
+{
+    return this->won_classes;
+}
+
+void InnerGameData::set_won_classes(const EnumClassFlagGroup<PlayerClassType> &classes)
+{
+    this->won_classes = classes;
+}
+
+/*!
+ * @brief 勝利したクラスを追加する
+ */
+void InnerGameData::add_winner_class(PlayerClassType c)
+{
+    if (!this->noscore) {
+        this->won_classes.set(c);
+    }
+}
+
+bool InnerGameData::has_not_retired_class(PlayerClassType pc) const
+{
+    return this->retired_classes.has_not(pc);
+}
+
+const EnumClassFlagGroup<PlayerClassType> &InnerGameData::get_retired_classes() const
+{
+    return this->retired_classes;
+}
+
+/*!
+ * @brief 引退したクラスを追加する
+ */
+void InnerGameData::add_retired_class(PlayerClassType c)
+{
+    if (!this->noscore) {
+        this->retired_classes.set(c);
+    }
+}
+
+void InnerGameData::set_retired_classes(const EnumClassFlagGroup<PlayerClassType> &classes)
+{
+    this->retired_classes = classes;
+}
+
+/*!
+ * @brief 勝利したクラスか判定する
+ */
+bool InnerGameData::is_winner_class(PlayerClassType c) const
+{
+    if (c >= PlayerClassType::MAX) {
+        return false;
+    }
+
+    return this->won_classes.has(c);
+}
+
+/*!
+ * @brief 引退したクラスか判定する
+ */
+bool InnerGameData::is_retired_class(PlayerClassType c) const
+{
+    if (c >= PlayerClassType::MAX) {
+        return false;
+    }
+
+    return this->retired_classes.has(c);
 }

--- a/src/system/inner-game-data.h
+++ b/src/system/inner-game-data.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include "player-info/class-types.h"
+#include "util/flag-group.h"
+#include <cstddef>
+#include <cstdint>
+
+enum term_color_type : unsigned char;
 enum class PlayerRaceType : int;
 class InnerGameData {
 public:
@@ -16,10 +22,39 @@ public:
     void set_start_race(PlayerRaceType race);
     void init_turn_limit();
 
+    uint32_t get_total_play_time() const;
+    void set_total_play_time(uint32_t time);
+    void add_play_time(uint32_t time);
+
+    bool is_no_score() const;
+    uint16_t get_no_score() const;
+    void initialize_no_score();
+    void add_no_score(uint16_t new_state);
+
+    term_color_type get_birth_class_color(PlayerClassType c) const;
+
+    size_t get_won_classes_count() const;
+    bool has_not_won_class(PlayerClassType pc) const;
+    const EnumClassFlagGroup<PlayerClassType> &get_won_classes() const;
+    void add_winner_class(PlayerClassType c);
+    void set_won_classes(const EnumClassFlagGroup<PlayerClassType> &classes);
+
+    bool has_not_retired_class(PlayerClassType pc) const;
+    const EnumClassFlagGroup<PlayerClassType> &get_retired_classes() const;
+    void add_retired_class(PlayerClassType c);
+    void set_retired_classes(const EnumClassFlagGroup<PlayerClassType> &classes);
+
 private:
     InnerGameData();
     static InnerGameData instance;
 
     PlayerRaceType start_race; //!< ゲーム開始時の種族.
     int game_turn_limit = 0; //!< 最大ゲームターン
+    uint32_t total_play_time = 0; //!< このセーブファイルで遊んだ合計のプレイ時間.
+    uint16_t noscore = 0; //!< ゲーム内デバッグモードのON／OFF
+    EnumClassFlagGroup<PlayerClassType> won_classes{}; //!< このセーブファイルで*勝利*した職業
+    EnumClassFlagGroup<PlayerClassType> retired_classes{}; //!< このセーブファイルで引退した職業
+
+    bool is_winner_class(PlayerClassType c) const;
+    bool is_retired_class(PlayerClassType c) const;
 };

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -66,6 +66,7 @@
 #include "system/floor/floor-info.h"
 #include "system/floor/wilderness-grid.h"
 #include "system/grid-type-definition.h"
+#include "system/inner-game-data.h"
 #include "system/item-entity.h"
 #include "system/redrawing-flags-updater.h"
 #include "system/terrain/terrain-definition.h"
@@ -859,8 +860,7 @@ void cheat_death(CreatureEntity &creature, bool no_penalty)
         }
     }
 
-    auto &world = AngbandWorld::get_instance();
-    world.noscore |= 0x0001;
+    InnerGameData::get_instance().add_no_score(0x0001);
     msg_erase();
 
     creature.is_dead_ = false;
@@ -893,7 +893,7 @@ void cheat_death(CreatureEntity &creature, bool no_penalty)
         creature.oldpx = 131;
     }
 
-    world.set_wild_mode(false);
+    AngbandWorld::get_instance().set_wild_mode(false);
     creature.set_leaving(true);
     constexpr auto note = _("                            しかし、生き返った。", "                            but revived.");
     exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, note);

--- a/src/world/world.cpp
+++ b/src/world/world.cpp
@@ -80,39 +80,6 @@ std::tuple<int, int, int> AngbandWorld::extract_date_time(PlayerRaceType start_r
     return { day, hour, min };
 }
 
-/*!
- * @brief 勝利したクラスを追加する
- */
-void AngbandWorld::add_winner_class(PlayerClassType c)
-{
-    if (!this->noscore) {
-        this->sf_winner.set(c);
-    }
-}
-
-/*!
- * @brief 引退したクラスを追加する
- */
-void AngbandWorld::add_retired_class(PlayerClassType c)
-{
-    if (!this->noscore) {
-        this->sf_retired.set(c);
-    }
-}
-
-term_color_type AngbandWorld::get_birth_class_color(PlayerClassType c) const
-{
-    if (c >= PlayerClassType::MAX) {
-        return TERM_WHITE;
-    }
-
-    if (this->is_retired_class(c)) {
-        return TERM_L_DARK;
-    }
-
-    return this->is_winner_class(c) ? TERM_SLATE : TERM_WHITE;
-}
-
 MonraceDefinition &AngbandWorld::get_today_bounty()
 {
     return MonraceList::get_instance().get_monrace(this->today_mon);
@@ -127,30 +94,6 @@ bool AngbandWorld::is_player_true_winner() const
 {
     const auto &entries = ArenaEntryList::get_instance();
     return (this->total_winner > 0) && (entries.is_player_true_victor());
-}
-
-/*!
- * @brief 勝利したクラスか判定する
- */
-bool AngbandWorld::is_winner_class(PlayerClassType c) const
-{
-    if (c == PlayerClassType::MAX) {
-        return false;
-    }
-
-    return this->sf_winner.has(c);
-}
-
-/*!
- * @brief 引退したクラスか判定する
- */
-bool AngbandWorld::is_retired_class(PlayerClassType c) const
-{
-    if (c == PlayerClassType::MAX) {
-        return false;
-    }
-
-    return this->sf_retired.has(c);
 }
 
 /*!

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -28,7 +28,6 @@ public:
     GAME_TURN dungeon_turn{}; /*!< NASTY生成の計算に関わる内部ターン値 / Game turn in dungeon */
     GAME_TURN dungeon_turn_limit{}; /*!< dungeon_turnの最大値 / Limit of game_turn in dungeon */
     GAME_TURN arena_start_turn{}; /*!< 闘技場賭博の開始ターン値 */
-    uint16_t noscore{}; /* Cheating flags */
     uint16_t total_winner{}; /* Total winner */
 
     MONSTER_IDX timewalk_m_idx{}; /*!< 現在時間停止を行っているモンスターのID */
@@ -40,14 +39,6 @@ public:
     ElapsedTime play_time{}; /*!< 実プレイ時間 */
 
     bool is_loading_now{}; /*!< ロード処理中フラグ...ロード直後にcalc_bonus()時の徳変化、及びsanity_blast()による異常を抑止する */
-
-    uint32_t sf_system{}; //!< OS情報 / OS information
-    uint32_t sf_when{}; //!< 作成日時 / Created Date
-    uint16_t sf_lives{}; //!< このセーブファイルで何人プレイしたか / Number of past "lives" with this file
-    uint16_t sf_saves{}; //!< 現在のプレイで何回セーブしたか / Number of "saves" during this life
-    uint32_t sf_play_time{}; //!< このセーブファイルで遊んだ合計のプレイ時間
-    EnumClassFlagGroup<PlayerClassType> sf_winner{}; //!< このセーブファイルで*勝利*した職業
-    EnumClassFlagGroup<PlayerClassType> sf_retired{}; //!< このセーブファイルで引退した職業
 
     bool character_generated{}; /* The character exists */
     bool character_dungeon{}; /* The character has a dungeon */
@@ -67,9 +58,6 @@ public:
     bool get_arena() const;
     std::tuple<int, int, int> extract_date_time(PlayerRaceType start_race) const;
     bool is_daytime() const;
-    void add_winner_class(PlayerClassType c);
-    void add_retired_class(PlayerClassType c);
-    term_color_type get_birth_class_color(PlayerClassType c) const;
     MonraceDefinition &get_today_bounty();
     const MonraceDefinition &get_today_bounty() const;
     bool is_player_true_winner() const;
@@ -83,7 +71,4 @@ private:
 
     bool is_out_arena = false; // アリーナ外部にいる時だけtrue.
     bool wild_mode = false;
-
-    bool is_winner_class(PlayerClassType c) const;
-    bool is_retired_class(PlayerClassType c) const;
 };


### PR DESCRIPTION


変愚蛮怒 PR #5402 (Remove-Unnecessary-System-Info) の内容を bakabakaband 構造に 適応してマージ。AngbandWorld に散在していたセーブファイル付随情報を整理する。

主な変更:
- sf_play_time / sf_winner / sf_retired / noscore を AngbandWorld から InnerGameData へ移動
  - total_play_time (get/set/add) / noscore (is/get/initialize/add) / won_classes / retired_classes (count/has_not/get/add/set) と get_birth_class_color() / is_winner_class() / is_retired_class() を InnerGameData に集約
- 未使用フィールド sf_system / sf_when / sf_lives / sf_saves を AngbandWorld から削除
- 約20ファイルの read/write site を InnerGameData 経由へ移行

セーブフォーマット互換性 (互換優先方針):
- 上流は未使用 12 バイト (sf_system/when/lives/saves) をフォーマットから削除するが、 bakabakaband はバリアントバージョンが 0.0.1.x のため上流の h_older_than(3,0,2,3) ゲートが流用できず、また Godot 用 save-file-scanner が同オフセットに依存する。 そのため 12 バイトは予約領域として従来通り書込/読飛ばし (strip_bytes(12)) し、 セーブフォーマットとセーブデータ互換性を完全維持する。バージョン bump も不要。

ビルド (g++ 日本語版) ・clang-format-18・include-style・BOM・newline チェック通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal game state management for play time, cheating/debug modes, and character class victory/retirement tracking to improve code maintainability and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->