### PR TITLE
merge: 生存ユニーク一覧で撃破レベル・時間を表示しないよう修正 (hengband#5455 相当)

### DIFF
--- a/src/knowledge/knowledge-uniques.cpp
+++ b/src/knowledge/knowledge-uniques.cpp
@@ -109,7 +109,7 @@ static void display_uniques(UniqueList *unique_list_ptr, FILE *fff)
     for (auto monrace_id : unique_list_ptr->monrace_ids) {
         const auto &monrace = monraces.get_monrace(monrace_id);
         std::string details;
-        if (monrace.defeat_level && monrace.defeat_time) {
+        if (!unique_list_ptr->is_alive && monrace.defeat_level && monrace.defeat_time) {
             details = format(_(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), monrace.defeat_level, monrace.defeat_time / (60 * 60),
                 (monrace.defeat_time / 60) % 60, monrace.defeat_time % 60);
         }


### PR DESCRIPTION
変愚蛮怒 PR #5455 ([Fix] habu1010) を適応してマージ。

ユニークモンスターの撃破レベル・時間 (defeat_level / defeat_time) は
ゲームリセット時にクリアされないため、生きている既知のユニーク一覧で
前回ゲームまでの最後の撃破時の値が表示されてしまっていた。
生存ユニーク一覧 (is_alive) では撃破レベル・時間を表示しないようにする。

上流コミット: 75db4f390b (hengband/develop)
変更: display_uniques() の表示条件に !unique_list_ptr->is_alive を追加。 bakabakaband 側は構造差分なし (UniqueList::is_alive がそのまま存在)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where defeat information for unique creatures was displayed incorrectly. Defeat details now only appear in the dead uniques listing, not in the alive uniques listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->