### PR TITLE
refactor: 町訪問記録を TownRecords / TownId に分離 (hengband#5454 前提)

### DIFF
--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
@@ -463,6 +463,7 @@
     <ClCompile Include="..\..\src\system\dungeon\dungeon-list.cpp" />
     <ClCompile Include="..\..\src\system\dungeon\dungeon-record.cpp" />
     <ClCompile Include="..\..\src\system\floor\town-list.cpp" />
+    <ClCompile Include="..\..\src\system\floor\town-records.cpp" />
     <ClCompile Include="..\..\src\system\inner-game-data.cpp" />
     <ClCompile Include="..\..\src\system\monrace\monrace-list.cpp" />
     <ClCompile Include="..\..\src\system\redrawing-flags-updater.cpp" />
@@ -1677,6 +1678,7 @@
     <ClInclude Include="..\..\src\store\sell-order.h" />
     <ClInclude Include="..\..\src\store\service-checker.h" />
     <ClInclude Include="..\..\src\system\floor\town-list.h" />
+    <ClInclude Include="..\..\src\system\floor\town-records.h" />
     <ClInclude Include="..\..\src\system\monrace\monrace-allocation.h" />
     <ClInclude Include="..\..\src\system\angband-exceptions.h" />
     <ClInclude Include="..\..\src\system\angband-system.h" />

--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
@@ -2525,6 +2525,9 @@
     <ClCompile Include="..\..\src\system\floor\town-list.cpp">
       <Filter>system\floor</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\system\floor\town-records.cpp">
+      <Filter>system\floor</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\system\terrain\terrain-definition.cpp">
       <Filter>system\terrain</Filter>
     </ClCompile>
@@ -5749,6 +5752,9 @@
       <Filter>system\floor</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\system\floor\town-list.h">
+      <Filter>system\floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\floor\town-records.h">
       <Filter>system\floor</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\system\enums\terrain\terrain-tag.h">

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1402,6 +1402,7 @@ hengband_SOURCES = \
 	system/floor/floor-list.cpp system/floor/floor-list.h \
 	system/floor/town-info.cpp system/floor/town-info.h \
 	system/floor/town-list.cpp system/floor/town-list.h \
+	system/floor/town-records.cpp system/floor/town-records.h \
 	system/floor/wilderness-grid.cpp system/floor/wilderness-grid.h \
 	\
 	system/monrace/body-structure-types.h \

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -25,6 +25,7 @@
 #include "system/enums/dungeon/dungeon-id.h"
 #include "system/floor/floor-info.h"
 #include "system/floor/floor-list.h"
+#include "system/floor/town-records.h"
 #include "system/floor/wilderness-grid.h"
 #include "system/inner-game-data.h"
 #include "system/item-entity.h"
@@ -109,7 +110,7 @@ void player_wipe_without_name(CreatureEntity &creature)
     creature.set_pet_follow_distance(PET_FOLLOW_DIST);
     creature.set_pet_extra_flags(PF_TELEPORT | PF_ATTACK_SPELL | PF_SUMMON_SPELL);
     DungeonRecords::get_instance().reset_all();
-    creature.visit = 1;
+    TownRecords::get_instance().initialize();
     world.set_wild_mode(false);
     WildernessGrids::get_instance().initialize_position();
 

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -41,11 +41,13 @@
 #include "system/enums/terrain/wilderness-terrain.h"
 #include "system/floor/floor-info.h"
 #include "system/floor/town-list.h"
+#include "system/floor/town-records.h"
 #include "system/floor/wilderness-grid.h"
 #include "system/grid-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "util/bit-flags-calculator.h"
+#include "util/enum-converter.h"
 #include "view/display-messages.h"
 #include "window/main-window-util.h"
 #include "world/world.h"
@@ -308,7 +310,7 @@ static void generate_area(CreatureEntity &creature, const Pos2D &pos, bool is_bo
         }
 
         if (!is_corner && !is_border) {
-            creature.visit |= (1UL << (creature.get_town_num() - 1));
+            TownRecords::get_instance().set_visited(i2enum<TownId>(creature.get_town_num() - 1));
         }
     } else {
         generate_wilderness_area(floor, wg, is_corner);

--- a/src/load/extra-loader.cpp
+++ b/src/load/extra-loader.cpp
@@ -11,6 +11,7 @@
 #include "load/world-loader.h"
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
+#include "system/floor/town-records.h"
 #include "util/enum-converter.h"
 #include "world/world.h"
 
@@ -27,7 +28,17 @@ void rd_extra(CreatureEntity &creature)
     auto &world = AngbandWorld::get_instance();
     world.play_time = ElapsedTime(rd_u32b());
 
-    creature.visit = rd_u32b();
+    // 訪問済みの町情報。旧来の creature.visit ビットマスク (u32) を TownRecords に移行する。
+    // セーブフォーマットは互換のため u32 ビットマスクのまま (bit N = TownId N)。
+    const auto visit_flags = rd_u32b();
+    EnumClassFlagGroup<TownId> visited_towns;
+    for (auto i = 0; i < enum2i(TownId::MAX); i++) {
+        if ((visit_flags & (1U << i)) != 0) {
+            visited_towns.set(i2enum<TownId>(i));
+        }
+    }
+
+    TownRecords::get_instance().set_ids(visited_towns);
     creature.count = rd_u32b();
 
     // [モンスタープレイヤー] プレイヤーがモンスター化している場合の種族 ID を復元する。

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -19,7 +19,9 @@
 #include "system/dungeon/dungeon-list.h"
 #include "system/dungeon/dungeon-record.h"
 #include "system/floor/floor-info.h"
+#include "system/floor/town-records.h"
 #include "system/inner-game-data.h"
+#include "util/enum-converter.h"
 #include "world/world.h"
 #include <variant>
 
@@ -263,7 +265,18 @@ void wr_player(CreatureEntity &creature)
     /* Save temporary preserved pets (obsolated) */
     wr_s16b(0);
     wr_u32b(world.play_time.elapsed_sec());
-    wr_s32b(creature.visit);
+
+    // 訪問済みの町情報。TownRecords を旧来の creature.visit ビットマスク (u32) に変換して書き出す
+    // (bit N = TownId N)。セーブフォーマット互換のため形式は不変。
+    uint32_t visit_flags = 0;
+    const auto visited_towns = TownRecords::get_instance().get_ids();
+    for (auto i = 0; i < enum2i(TownId::MAX); i++) {
+        if (visited_towns.has(i2enum<TownId>(i))) {
+            visit_flags |= 1U << i;
+        }
+    }
+
+    wr_s32b(visit_flags);
     wr_u32b(creature.count);
 
     // [モンスタープレイヤー] プレイヤーがモンスター化している場合の種族 ID を保存する。

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -32,6 +32,7 @@
 #include "system/floor/floor-info.h"
 #include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
+#include "system/floor/town-records.h"
 #include "system/floor/wilderness-grid.h"
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
@@ -43,6 +44,7 @@
 #include "target/target-types.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"
+#include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -285,7 +287,7 @@ bool tele_town(CreatureEntity &creature)
     auto num = 0;
     const int towns_size = TownList::get_instance().size();
     for (auto i = 1; i < towns_size; i++) {
-        if ((i == VALID_TOWNS) || (i == SECRET_TOWN) || (i == creature.get_town_num()) || !(creature.visit & (1UL << (i - 1)))) {
+        if ((i == VALID_TOWNS) || (i == SECRET_TOWN) || (i == creature.get_town_num()) || !TownRecords::get_instance().has_visited(i2enum<TownId>(i - 1))) {
             continue;
         }
 
@@ -316,7 +318,7 @@ bool tele_town(CreatureEntity &creature)
         }
 
         const auto town_num = key - 'a' + 1;
-        if ((town_num == creature.get_town_num()) || (town_num == VALID_TOWNS) || (town_num == SECRET_TOWN) || !(creature.visit & (1UL << (key - 'a')))) {
+        if ((town_num == creature.get_town_num()) || (town_num == VALID_TOWNS) || (town_num == SECRET_TOWN) || !TownRecords::get_instance().has_visited(i2enum<TownId>(key - 'a'))) {
             continue;
         }
 

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -15,6 +15,7 @@
 #include "system/dungeon/dungeon-record.h"
 #include "system/enums/dungeon/dungeon-id.h"
 #include "system/floor/town-list.h"
+#include "system/floor/town-records.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
 #include "system/monrace/monrace-records.h"
@@ -199,9 +200,10 @@ public:
         const auto &town_name = TownList::get_instance().get_town(town_rumor.t_idx).get_name();
         this->print_rumor(town_name);
 
-        const uint32_t visit = (1U << (town_rumor.t_idx - 1));
-        if ((town_rumor.t_idx != SECRET_TOWN) && !(this->creature.visit & visit)) {
-            this->creature.visit |= visit;
+        const auto town_id = i2enum<TownId>(town_rumor.t_idx - 1);
+        auto &town_records = TownRecords::get_instance();
+        if ((town_rumor.t_idx != SECRET_TOWN) && !town_records.has_visited(town_id)) {
+            town_records.set_visited(town_id);
             msg_erase();
             msg_print(_("{}に行ったことがある気がする。", "You feel you have been to {}."), town_name);
         }

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -4194,7 +4194,6 @@ public:
 #define KNOW_STAT 0x01
 #define KNOW_HPRATE 0x02
     BIT_FLAGS8 knowledge{}; /* Knowledge about yourself */
-    BIT_FLAGS visit{}; /* Visited towns */
 
     // [提案 42] old_race1/2 / old_realm は private 化済。
     // get_old_race_flags1/2() / set_old_race_flags1/2() / get_old_realm() / set_old_realm() 経由。

--- a/src/system/floor/town-list.cpp
+++ b/src/system/floor/town-list.cpp
@@ -4,6 +4,7 @@
 #include "store/store.h"
 #include "system/angband-exceptions.h"
 #include "system/baseitem/baseitem-list.h"
+#include "system/floor/town-records.h"
 #include "util/angband-files.h"
 #include <filesystem>
 #include <fmt/format.h>
@@ -57,6 +58,24 @@ TownInfo &TownList::get_town(size_t index)
     }
 
     return this->towns[index];
+}
+
+const TownInfo &TownList::get_town(TownId town_id) const
+{
+    if ((town_id < TownId::OUTPOST) || (town_id >= TownId::MAX)) {
+        THROW_EXCEPTION(std::out_of_range, fmt::format("Invalid town ID: {}", static_cast<int>(town_id)));
+    }
+
+    return this->get_town(static_cast<size_t>(town_id) + 1);
+}
+
+TownInfo &TownList::get_town(TownId town_id)
+{
+    if ((town_id < TownId::OUTPOST) || (town_id >= TownId::MAX)) {
+        THROW_EXCEPTION(std::out_of_range, fmt::format("Invalid town ID: {}", static_cast<int>(town_id)));
+    }
+
+    return this->get_town(static_cast<size_t>(town_id) + 1);
 }
 
 /*!

--- a/src/system/floor/town-list.h
+++ b/src/system/floor/town-list.h
@@ -7,6 +7,7 @@
 constexpr short VALID_TOWNS = 6; // @details 旧海底都市クエストのマップを除外する. 有効な町に差し替え完了したら不要になるので注意.
 constexpr auto SECRET_TOWN = 5; // @details ズルの町番号.
 
+enum class TownId;
 class TownList : public util::AbstractVectorWrapper<TownInfo> {
 public:
     TownList(TownList &&) = delete;
@@ -21,6 +22,8 @@ public:
 
     const TownInfo &get_town(size_t index) const;
     TownInfo &get_town(size_t index);
+    const TownInfo &get_town(TownId town_id) const;
+    TownInfo &get_town(TownId town_id);
 
 private:
     TownList() = default;

--- a/src/system/floor/town-records.cpp
+++ b/src/system/floor/town-records.cpp
@@ -1,0 +1,57 @@
+#include "system/floor/town-records.h"
+#include "system/angband-exceptions.h"
+#include "system/floor/town-list.h"
+#include "util/enum-converter.h"
+#include <fmt/format.h>
+
+TownRecords TownRecords::instance{};
+
+TownRecords &TownRecords::get_instance()
+{
+    return instance;
+}
+
+bool TownRecords::has_visited(TownId town_id) const
+{
+    this->validate_town_id(town_id);
+
+    // @details SECRET_TOWN は 1 オリジンの町番号、TownId は 0 オリジンのため +1 して比較する.
+    if (enum2i(town_id) + 1 == SECRET_TOWN) {
+        return false;
+    }
+
+    return this->visited_ids.has(town_id);
+}
+
+void TownRecords::set_visited(TownId town_id)
+{
+    this->validate_town_id(town_id);
+    if (enum2i(town_id) + 1 == SECRET_TOWN) {
+        return;
+    }
+
+    this->visited_ids.set(town_id);
+}
+
+void TownRecords::initialize()
+{
+    this->visited_ids.clear();
+    this->visited_ids.set(TownId::OUTPOST);
+}
+
+void TownRecords::set_ids(const EnumClassFlagGroup<TownId> &loaded_data)
+{
+    this->visited_ids = loaded_data;
+}
+
+EnumClassFlagGroup<TownId> TownRecords::get_ids() const
+{
+    return this->visited_ids;
+}
+
+void TownRecords::validate_town_id(TownId town_id) const
+{
+    if ((town_id < TownId::OUTPOST) || (town_id >= TownId::MAX)) {
+        THROW_EXCEPTION(std::out_of_range, fmt::format("Invalid Town ID: {}", enum2i(town_id)));
+    }
+}

--- a/src/system/floor/town-records.h
+++ b/src/system/floor/town-records.h
@@ -1,0 +1,45 @@
+#pragma once
+
+/*!
+ * @brief 町の記録を管理するクラス
+ * @author Hourier
+ * @date 2026/05/29
+ */
+
+#include "util/flag-group.h"
+
+enum class TownId {
+    OUTPOST = 0,
+    TELMORA = 1,
+    MORIVANT = 2,
+    ANGWIL = 3,
+    ZUL = 4,
+    RLYEH = 5,
+    MAX,
+};
+
+class TownRecords {
+public:
+    TownRecords(TownRecords &&) = delete;
+    TownRecords(const TownRecords &) = delete;
+    TownRecords &operator=(const TownRecords &) = delete;
+    TownRecords &operator=(TownRecords &&) = delete;
+
+    static TownRecords &get_instance();
+
+    bool has_visited(TownId town_id) const;
+    void set_visited(TownId town_id);
+    void initialize();
+
+    void set_ids(const EnumClassFlagGroup<TownId> &loaded_data); //!< for load only.
+    EnumClassFlagGroup<TownId> get_ids() const; //!< for save only.
+
+private:
+    TownRecords() = default;
+
+    static TownRecords instance;
+
+    EnumClassFlagGroup<TownId> visited_ids;
+
+    void validate_town_id(TownId town_id) const;
+};


### PR DESCRIPTION
変愚蛮怒 PR #5454 (噂システム再設計) のマージに必要な前提リファクタ。
上流で先行導入された TownId enum と TownRecords クラスを bakabakaband に移植し、 従来 CreatureEntity::visit ビットマスクで管理していた「訪問済みの町」を
TownRecords に集約する。

- 新規 src/system/floor/town-records.{h,cpp}: TownId enum (OUTPOST..RLYEH) と TownRecords (has_visited / set_visited / initialize / set_ids / get_ids)。 SECRET_TOWN は town-list.h の既存定義 (1 オリジン町番号) を流用し、 TownId (0 オリジン) との +1 差を考慮して除外判定する。
- TownList に get_town(TownId) オーバーロードを追加 (index = TownId + 1)。
- CreatureEntity::visit フィールドを廃止し、訪問判定を TownRecords 経由へ移行 (wild.cpp / spells-world.cpp / game-play-initializer.cpp / store/rumor.cpp)。
- セーブ互換: savefile は従来通り u32 ビットマスク (bit N = TownId N) を読み書きし、 load 時に TownRecords へ展開、save 時にビットマスクへ畳み込む。バージョン bump 不要。

ビルド (g++ 日本語版) ・clang-format-18・include-style・BOM・newline チェック通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized “visited town” tracking into a dedicated town records system, replacing per-player bitmask handling.
  * Updated town-related game logic (teleport town availability, wilderness town processing, and visit rumors) to rely on the centralized tracking.
* **Save/Load Compatibility**
  * Kept the existing on-disk format while migrating visited-town state to the new system during load and save.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->