### PR TITLE
merge: JSON 読込で不要な items() 呼び出しを避ける (hengband#5457 相当)

### DIFF
--- a/src/info-reader/baseitem-reader.cpp
+++ b/src/info-reader/baseitem-reader.cpp
@@ -134,8 +134,7 @@ static errr set_baseitem_allocations(nlohmann::json &allocations_data, BaseitemD
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
-    for (auto i = 0; auto &element : allocations_data.items()) {
-        auto &alloc = element.value();
+    for (auto i = 0; const auto &alloc : allocations_data) {
         auto &table = baseitem.alloc_tables[i];
         if (auto err = info_set_integer(alloc["depth"], table.level, true, Range(0, 128))) {
             return err;

--- a/src/info-reader/magic-reader.cpp
+++ b/src/info-reader/magic-reader.cpp
@@ -194,9 +194,8 @@ static errr set_realm_data(const nlohmann::json &class_data, player_magic &magic
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
-    for (auto &element : class_data["realms"].items()) {
-        auto &realm = element.value();
-        auto &realm_name_obj = realm["name"];
+    for (const auto &realm : class_data["realms"]) {
+        const auto &realm_name_obj = realm["name"];
         if (!realm_name_obj.is_string()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
@@ -207,13 +206,13 @@ static errr set_realm_data(const nlohmann::json &class_data, player_magic &magic
         }
 
         const auto realm_id = realm_name->second;
-        auto &spells_info_obj = realm["spells_info"];
+        const auto &spells_info_obj = realm["spells_info"];
         if (spells_info_obj.is_null()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
-        for (auto &spell_info : spells_info_obj.items()) {
-            if (auto err = set_spell_data(spell_info.value(), magics_info, realm_id)) {
+        for (const auto &spell : spells_info_obj) {
+            if (auto err = set_spell_data(spell, magics_info, realm_id)) {
                 msg_format(_("呪文データ読込失敗。ID: '%d'。", "Failed to load spell data. ID: '%d'."), error_idx);
                 return err;
             }

--- a/src/info-reader/message-reader.cpp
+++ b/src/info-reader/message-reader.cpp
@@ -26,12 +26,12 @@ static errr set_id_list(const nlohmann::json &id_list_data, std::vector<int> &id
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
-    for (auto &id_data : id_list_data.items()) {
-        if (!id_data.value().is_number()) {
+    for (const auto &id_data : id_list_data) {
+        if (!id_data.is_number()) {
             return PARSE_ERROR_INVALID_FLAG;
         }
         int id;
-        if (auto err = info_set_integer(id_data.value(), id, true, Range(1, 9999))) {
+        if (auto err = info_set_integer(id_data, id, true, Range(1, 9999))) {
             return err;
         }
         id_list.push_back(id);
@@ -76,9 +76,9 @@ static errr set_mon_message(const nlohmann::json &group_data)
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
-    for (const auto &message : message_data.items()) {
-        const auto action_iter = message.value().find("action");
-        if (action_iter == message.value().end() || !action_iter->is_string()) {
+    for (const auto &message : message_data) {
+        const auto action_iter = message.find("action");
+        if (action_iter == message.end() || !action_iter->is_string()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
         const auto &action_data = action_iter.value();
@@ -87,8 +87,8 @@ static errr set_mon_message(const nlohmann::json &group_data)
             return PARSE_ERROR_INVALID_FLAG;
         }
 
-        const auto chance_iter = message.value().find("chance");
-        if (chance_iter == message.value().end() || !chance_iter->is_number()) {
+        const auto chance_iter = message.find("chance");
+        if (chance_iter == message.end() || !chance_iter->is_number()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
         const auto &chance_data = chance_iter.value();
@@ -98,16 +98,16 @@ static errr set_mon_message(const nlohmann::json &group_data)
         }
 
         bool use_name = true;
-        const auto use_name_iter = message.value().find("use_name");
-        if (use_name_iter != message.value().end()) {
+        const auto use_name_iter = message.find("use_name");
+        if (use_name_iter != message.end()) {
             const auto &use_name_data = use_name_iter.value();
             if (auto err = info_set_bool(use_name_data, use_name, false)) {
                 return err;
             }
         }
 
-        const auto language_iter = message.value().find("message");
-        if (language_iter == message.value().end() || !language_iter->is_object()) {
+        const auto language_iter = message.find("message");
+        if (language_iter == message.end() || !language_iter->is_object()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
         const auto &language_list = language_iter.value();
@@ -132,21 +132,21 @@ static errr set_mon_message(const nlohmann::json &group_data)
         const auto &message_list = en_list.value();
 #endif
 
-        for (const auto &message_str : message_list.items()) {
-            if (message_str.value().is_null()) {
+        for (const auto &message_str : message_list) {
+            if (message_str.is_null()) {
                 return PARSE_ERROR_TOO_FEW_ARGUMENTS;
             }
-            if (!message_str.value().is_string()) {
+            if (!message_str.is_string()) {
                 return PARSE_ERROR_INVALID_FLAG;
             }
 #ifdef JP
-            auto str_test = utf8_to_sys(message_str.value().get<std::string>());
+            auto str_test = utf8_to_sys(message_str.get<std::string>());
             if (!str_test) {
                 return PARSE_ERROR_INVALID_FLAG;
             }
             auto str = std::move(*str_test);
 #else
-            auto str = message_str.value().get<std::string>();
+            auto str = message_str.get<std::string>();
 #endif
             if (has_id_list) {
                 for (auto id : id_list) {

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -441,13 +441,13 @@ static errr set_mon_artifacts(nlohmann::json &artifact_data, MonraceDefinition &
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
-    for (auto &artifact : artifact_data.items()) {
+    for (const auto &artifact : artifact_data) {
         FixedArtifactId fa_id;
-        if (auto err = info_set_integer(artifact.value()["drop_artifact_id"], fa_id, true, Range(0, 1024))) {
+        if (auto err = info_set_integer(artifact["drop_artifact_id"], fa_id, true, Range(0, 1024))) {
             return err;
         }
         int prob;
-        if (auto err = info_set_integer(artifact.value()["drop_probability"], prob, true, Range(1, 100))) {
+        if (auto err = info_set_integer(artifact["drop_probability"], prob, true, Range(1, 100))) {
             return err;
         }
 
@@ -471,14 +471,14 @@ static errr set_mon_escorts(nlohmann::json &escort_data, MonraceDefinition &monr
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
-    for (const auto &escort : escort_data.items()) {
+    for (const auto &escort : escort_data) {
         MonraceId monrace_id;
-        if (auto err = info_set_integer(escort.value()["escorts_id"], monrace_id, true, Range(0, 8192))) {
+        if (auto err = info_set_integer(escort["escorts_id"], monrace_id, true, Range(0, 8192))) {
             return err;
         }
 
         Dice dice;
-        if (auto err = info_set_dice(escort.value()["escort_num"], dice, true)) {
+        if (auto err = info_set_dice(escort["escort_num"], dice, true)) {
             return err;
         }
 
@@ -503,9 +503,9 @@ static errr set_mon_blows(nlohmann::json &blow_data, MonraceDefinition &monrace)
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
-    for (auto &blow : blow_data.items()) {
-        const auto &blow_method = blow.value()["method"];
-        const auto &blow_effect = blow.value()["effect"];
+    for (const auto &blow : blow_data) {
+        const auto &blow_method = blow["method"];
+        const auto &blow_effect = blow["effect"];
         if (blow_method.is_null() || blow_effect.is_null()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
@@ -524,7 +524,7 @@ static errr set_mon_blows(nlohmann::json &blow_data, MonraceDefinition &monrace)
         mon_blow.method = rbm->second;
         mon_blow.effect = rbe->second;
 
-        if (auto err = info_set_dice(blow.value()["damage_dice"], mon_blow.damage_dice, false)) {
+        if (auto err = info_set_dice(blow["damage_dice"], mon_blow.damage_dice, false)) {
             return err;
         }
 
@@ -797,8 +797,8 @@ static errr set_mon_flags(const nlohmann::json &flag_data, MonraceDefinition &mo
             if (tokens.size() < 2) {
                 return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     */
-    for (auto &flag : flag_data.items()) {
-        if (!grab_one_basic_flag(monrace, flag.value().get<std::string>())) {
+    for (const auto &flag : flag_data) {
+        if (!grab_one_basic_flag(monrace, flag.get<std::string>())) {
             return PARSE_ERROR_INVALID_FLAG;
         }
     }
@@ -936,8 +936,8 @@ static errr set_mon_message(const nlohmann::json &message_data, MonraceDefinitio
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
-    for (auto &message : message_data.items()) {
-        const auto &action_str = message.value()["action"];
+    for (const auto &message : message_data) {
+        const auto &action_str = message["action"];
         if (action_str.is_null()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
@@ -947,13 +947,13 @@ static errr set_mon_message(const nlohmann::json &message_data, MonraceDefinitio
         }
 
         int chance;
-        if (auto err = info_set_integer(message.value()["chance"], chance, true, Range(1, 100))) {
+        if (auto err = info_set_integer(message["chance"], chance, true, Range(1, 100))) {
             return err;
         }
 
         bool use_name = true;
-        const auto use_name_iter = message.value().find("use_name");
-        if (use_name_iter != message.value().end()) {
+        const auto use_name_iter = message.find("use_name");
+        if (use_name_iter != message.end()) {
             const auto &use_name_data = use_name_iter.value();
             if (auto err = info_set_bool(use_name_data, use_name, false)) {
                 return err;
@@ -961,7 +961,7 @@ static errr set_mon_message(const nlohmann::json &message_data, MonraceDefinitio
         }
 
         std::string str;
-        if (auto err = info_set_string(message.value()["message"], str, false)) {
+        if (auto err = info_set_string(message["message"], str, false)) {
             return err;
         }
 

--- a/src/info-reader/spell-reader.cpp
+++ b/src/info-reader/spell-reader.cpp
@@ -87,15 +87,13 @@ static errr set_book_data(const nlohmann::json &spell_data, SpellInfoList &spell
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
-    for (auto &element : book_obj.items()) {
-        auto &book = element.value();
-        auto &spells_obj = book["spells"];
+    for (const auto &book : book_obj) {
+        const auto &spells_obj = book["spells"];
         if (spells_obj.is_null()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
-        for (auto &spell_element : spells_obj.items()) {
-            auto &spell = spell_element.value();
+        for (const auto &spell : spells_obj) {
             if (auto err = set_spell_data(spell, spell_info_list, realm)) {
                 return err;
             }


### PR DESCRIPTION
変愚蛮怒 PR #5457 を bakabakaband 構造へ適応してマージ。
nlohmann::json 配列の走査で、キー・値ペアを返す items() を介さず値を直接
range-for で受け取る形に統一する (挙動は不変、冗長な .value() を削減)。

対象: info-reader の baseitem / magic / message / race / spell の各リーダー。 bakabakaband 固有の差分 (race-reader の drop_artifacts/reinforce 周り、blow ループに blow_num カウンタ無し等) は変数名・構造を保持しつつ items() のみ置換。

ビルド (g++ 日本語版) ・clang-format-18・include-style チェック通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal JSON parsing logic across configuration readers for improved code efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->