### PR TITLE
merge: 英語表記の誤記・不自然な言い回しを修正 (hengband#5458 相当)

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -67980,7 +67980,7 @@
       "id": 1074,
       "name": {
         "ja": "火の神『祝融』",
-        "en": "Lady Zhurong, the Avater of Flame Spirit",
+        "en": "Lady Zhurong, Avatar of the Flame Spirit",
       },
       "symbol": {
         "character": "p",

--- a/lib/edit/MonsterMessages.jsonc
+++ b/lib/edit/MonsterMessages.jsonc
@@ -4938,10 +4938,10 @@
           "message": {
             "en": [
               "trampled the wreckage of the Internet Exploder.",
-              "ridiculed when he saw the Internet Exploder.",
+              "scoffed at the Internet Exploder.",
               "is sending sensitive data without your permission.",
               "sent an ad to your email address.",
-              "was attempted to crack by someone, but the protection was not breached.",
+              "was relieved when a cracker could not breach its sandbox.",
               "grasped your propensity.",
             ],
           },

--- a/lib/file/w_low.txt
+++ b/lib/file/w_low.txt
@@ -38,7 +38,7 @@ N: 4:BIAS_COLD
 'Snow Avalanche'
 'Freeze!'
 'Freezing Blade'
-'Icy Clow'
+'Icy Claw'
 'Nimloth'
 'Bigfoot'
 of Liquid Helium
@@ -59,13 +59,13 @@ N: 5:BIAS_ACID
 N:12:BIAS_CHAOS
 'Koch'
 'Julia'
-'Cotortion Blade'
+'Contortion Blade'
 'Protean Edge'
 'cHaOs rEgIoN'
 'Schrodinger'
 'Mandelbrot'
 'Kaleidoscope'
-'Randamizer'
+'Randomizer'
 'Shapechanger'
 of Change
 of Logrus
@@ -103,7 +103,7 @@ of Holy Smoke
 N: 9:BIAS_DEX
 N:16:BIAS_ROGUE
 'Whirlwind'
-'Cat's Clow'
+'Cat's Claw'
 'Sands of Time'
 'Raid'
 'Elusiveness'

--- a/lib/file/w_med.txt
+++ b/lib/file/w_med.txt
@@ -130,7 +130,7 @@ of Soul
 N:16:BIAS_ROGUE
 'Thiefbane'
 'Quylthulg Smasher'
-'Cat's Clow'
+'Cat's Claw'
 'Shinobi'
 'Speed King'
 'Quicker'
@@ -200,7 +200,7 @@ of Marksmanship
 N:*:Default
 'Weapon Alpha'
 'Werebane'
-'Dragon Clow'
+'Dragon Claw'
 'Kraken'
 'Blue Steele'
 'Fury'


### PR DESCRIPTION
変愚蛮怒 PR #5458 (English: correct some misspellings and awkward phrasings) を そのままマージ。データファイルの英語表記のみの修正で挙動への影響なし。

- lib/file/w_low.txt: Icy Clow→Icy Claw / Cotortion Blade→Contortion Blade / Randamizer→Randomizer / Cat's Clow→Cat's Claw
- lib/file/w_med.txt: Cat's Clow→Cat's Claw / Dragon Clow→Dragon Claw
- lib/edit/MonraceDefinitions.jsonc: Lady Zhurong の英名を "Lady Zhurong, Avatar of the Flame Spirit" に修正
- lib/edit/MonsterMessages.jsonc: Internet Exploder 関連メッセージ2件の言い回しを改善

JSON スキーマ検証通過 (8/8)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spelling errors in weapon and ability names, including corrections to "Claw" variants and "Contortion Blade"
  * Corrected character description text
  * Updated localization strings for improved accuracy and consistency across game content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->