### PR TITLE
merge: 装備がない時の表示がヌル文字になっていたのを修正 (hengband#5460 相当)

### DIFF
--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -25,6 +25,7 @@
 #include "system/baseitem/baseitem-configs.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
+#include "system/baseitem/baseitem-service.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
@@ -197,6 +198,7 @@ static void display_object_list(int col, int row, int per_page, const std::vecto
     const auto is_wizard = AngbandWorld::get_instance().wizard;
     const auto &baseitems = BaseitemList::get_instance();
     const auto &baseitem_configs = BaseitemConfigs::get_instance();
+    const auto &empty_symbol = BaseitemService::get_dummy_symbol();
     int i;
     for (i = 0; i < per_page && (object_idx[object_top + i] >= 0); i++) {
         const auto bi_id = object_idx[object_top + i];
@@ -218,7 +220,8 @@ static void display_object_list(int col, int row, int per_page, const std::vecto
             c_prt(attr, format("%d", bi_id), row + i, 70);
         }
 
-        term_queue_bigchar(use_bigtile ? 76 : 77, row + i, { flavor_config.get_symbol(), {} });
+        const auto ds = flavor_baseitem.is_valid() ? flavor_config.get_symbol() : empty_symbol;
+        term_queue_bigchar(use_bigtile ? 76 : 77, row + i, { ds, {} });
     }
 
     for (; i < per_page; i++) {

--- a/src/system/baseitem/baseitem-service.cpp
+++ b/src/system/baseitem/baseitem-service.cpp
@@ -4,6 +4,7 @@
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
 #include "term/z-rand.h"
+#include "view/display-symbol.h"
 #include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/view.hpp>
 
@@ -39,4 +40,9 @@ const BaseitemConfig &BaseitemService::pick_one_at_random()
             return baseitem_configs.get_config(bi_id);
         }
     }
+}
+
+const DisplaySymbol &BaseitemService::get_dummy_symbol()
+{
+    return BaseitemConfigs::get_instance().get_config(0).get_symbol();
 }

--- a/src/system/baseitem/baseitem-service.h
+++ b/src/system/baseitem/baseitem-service.h
@@ -1,5 +1,6 @@
 #pragma once
 
+class DisplaySymbol;
 class BaseitemConfig;
 class BaseitemService {
 public:
@@ -8,4 +9,5 @@ public:
     static void initialize_baseitem_configs();
     static void reset_all_visuals();
     static const BaseitemConfig &pick_one_at_random();
+    static const DisplaySymbol &get_dummy_symbol();
 };

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -24,6 +24,7 @@
 #include "player/player-status-table.h"
 #include "player/player-status.h"
 #include "spell/spells-execution.h"
+#include "system/baseitem/baseitem-service.h"
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "system/enums/terrain/terrain-tag.h"
@@ -308,6 +309,7 @@ static void display_equipment(CreatureEntity &creature, const ItemTester &item_t
     }
 
     const auto &[wid, hgt] = term_get_size();
+    const auto &empty_symbol = BaseitemService::get_dummy_symbol();
     byte attr = TERM_WHITE;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         int cur_row = i - INVEN_MAIN_HAND;
@@ -345,7 +347,8 @@ static void display_equipment(CreatureEntity &creature, const ItemTester &item_t
         }
 
         if (show_item_graph) {
-            term_queue_bigchar(cur_col, cur_row, { item.get_symbol(), {} });
+            const auto ds = item.is_valid() ? item.get_symbol() : empty_symbol;
+            term_queue_bigchar(cur_col, cur_row, { ds, {} });
             if (use_bigtile) {
                 cur_col++;
             }

--- a/src/window/main-window-equipments.cpp
+++ b/src/window/main-window-equipments.cpp
@@ -11,6 +11,7 @@
 #include "object/item-use-flags.h"
 #include "object/object-info.h"
 #include "player/player-status-flags.h"
+#include "system/baseitem/baseitem-service.h"
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
 #include "term/gameterm.h"
@@ -88,6 +89,7 @@ COMMAND_CODE show_equipment(CreatureEntity &creature, int target_item, BIT_FLAGS
 
     col = (len > wid - _(6, 4)) ? 0 : (wid - len - 1);
     const auto equip_label = prepare_label_string(creature, USE_EQUIP, item_tester);
+    const auto &empty_symbol = BaseitemService::get_dummy_symbol();
     for (j = 0; j < k; j++) {
         i = out_index[j];
         const auto &item = *creature.inventory[i];
@@ -109,7 +111,8 @@ COMMAND_CODE show_equipment(CreatureEntity &creature, int target_item, BIT_FLAGS
         put_str(head, j + 1, col);
         int cur_col = col + 3;
         if (show_item_graph) {
-            term_queue_bigchar(cur_col, j + 1, { item.get_symbol(), {} });
+            const auto ds = item.is_valid() ? item.get_symbol() : empty_symbol;
+            term_queue_bigchar(cur_col, j + 1, { ds, {} });
             if (use_bigtile) {
                 cur_col++;
             }


### PR DESCRIPTION
変愚蛮怒 PR #5460 を bakabakaband 構造へ適応してマージ (#5459 BaseitemConfig 分離が前提)。無効なベースアイテム (空き装備スロット等) の表示シンボルが
ヌル文字になり表示が乱れていたのを、ダミーシンボル (ID 0「異常アイテム」の
シンボル) で代替するよう修正する。

- BaseitemService::get_dummy_symbol() を追加 (ID 0 の BaseitemConfig シンボルを返す)。
- 無効アイテム表示時に get_dummy_symbol() を使うよう修正:
  - knowledge-items.cpp (既知アイテム一覧、flavor_baseitem.is_valid() で分岐)
  - display-sub-windows.cpp / main-window-equipments.cpp (装備表示、item.is_valid() で分岐)

ビルド (g++ 日本語版) ・clang-format-18・include-style チェック通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering when equipment or item references are invalid. The game now uses a consistent fallback placeholder symbol instead of attempting to derive a symbol from invalid data, preventing display glitches. This applies across equipment sub-windows, equipment views, and object/inventory list rendering, while preserving normal symbols for valid items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->