### PR TITLE
merge: アイテムスロット範囲を EnumRange で処理する (hengband#5461 相当)

### DIFF
--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -161,8 +161,8 @@ bool exe_mutation_power(CreatureEntity &creature, PlayerMutationType power)
         (void)lite_area(creature, Dice::roll(2, (lvl / 2)), (lvl / 10) + 1);
         return true;
     case PlayerMutationType::DET_CURSE:
-        for (int i = 0; i < INVEN_TOTAL; i++) {
-            auto *o_ptr = creature.inventory[i].get();
+        for (const auto i_idx : INVEN_ALL_SLOTS) {
+            auto *o_ptr = creature.inventory[i_idx].get();
             if (!o_ptr->is_valid() || !o_ptr->is_cursed()) {
                 continue;
             }

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -345,13 +345,13 @@ bool is_autopick_match(CreatureEntity &creature, const ItemEntity *o_ptr, const 
         return true;
     }
 
-    for (int j = 0; j < INVEN_PACK; j++) {
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
         /*
          * 'Collecting' means the item must be absorbed
          * into an inventory slot.
          * But an item can not be absorbed into itself!
          */
-        if ((creature.inventory[j].get() != o_ptr) && creature.inventory[j]->is_similar(*o_ptr)) {
+        if ((creature.inventory[i_idx].get() != o_ptr) && creature.inventory[i_idx]->is_similar(*o_ptr)) {
             return true;
         }
     }

--- a/src/autopick/autopick.cpp
+++ b/src/autopick/autopick.cpp
@@ -33,6 +33,7 @@
 #include "term/screen-processor.h"
 #include "view/display-messages.h"
 #include "window/display-sub-windows.h"
+#include <range/v3/view.hpp>
 #include <sstream>
 
 /*!
@@ -64,7 +65,7 @@ static void autopick_delayed_alter_aux(CreatureEntity &creature, INVENTORY_IDX i
  */
 void autopick_delayed_alter(CreatureEntity &creature)
 {
-    for (INVENTORY_IDX i_idx = INVEN_TOTAL - 1; i_idx >= 0; i_idx--) {
+    for (const auto i_idx : INVEN_ALL_SLOTS | ranges::views::reverse) {
         autopick_delayed_alter_aux(creature, i_idx);
     }
 

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -55,8 +55,8 @@ void player_wipe_without_name(CreatureEntity &creature)
     }
 
     QuestList::get_instance().reset_all();
-    for (int i = 0; i < INVEN_TOTAL; i++) {
-        creature.inventory[i]->wipe();
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        creature.inventory[i_idx]->wipe();
     }
 
     ArtifactRecords::get_instance().reset_generated_flags();

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -34,6 +34,7 @@
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
 #include "util/enum-converter.h"
+#include <range/v3/view.hpp>
 #include <tuple>
 
 /*!
@@ -42,7 +43,7 @@
 void wield_all(CreatureEntity &creature)
 {
 
-    for (INVENTORY_IDX i_idx = INVEN_PACK - 1; i_idx >= 0; i_idx--) {
+    for (const auto i_idx : INVEN_PACK_SLOTS | ranges::views::reverse) {
         const auto &item = *creature.inventory[i_idx];
         if (!item.is_valid()) {
             continue;

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -301,14 +301,14 @@ void do_cmd_bash(CreatureEntity &creature)
  */
 static bool get_spike(CreatureEntity &creature, INVENTORY_IDX *ip)
 {
-    for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        auto *o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        auto *o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
 
         if (o_ptr->bi_key.tval() == ItemKindType::SPIKE) {
-            *ip = i;
+            *ip = i_idx;
             return true;
         }
     }

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -295,8 +295,8 @@ static void preserve_info(CreatureEntity &creature)
         delete_monster_idx(creature, i);
     }
 
-    for (short i = 0; i < INVEN_PACK; i++) {
-        auto *o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        auto *o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -308,8 +308,8 @@ void regenerate_monsters(CreatureEntity &creature)
 void regenerate_captured_monsters(CreatureEntity &creature)
 {
     bool heal = false;
-    for (int i = 0; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        auto *o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -31,6 +31,7 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"
+#include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
 #include "view/display-inventory.h"
@@ -114,7 +115,8 @@ static std::pair<tl::optional<short>, char> get_floor_item_tag_inventory(Creatur
  */
 static std::pair<tl::optional<short>, char> check_floor_item_tag_inventory(CreatureEntity &creature, FloorItemSelection &fis, short i_idx, char prev_tag, const ItemTester &item_tester)
 {
-    if ((!fis.inven || (i_idx < 0) || (i_idx >= INVEN_PACK)) && (!fis.equip || (i_idx < INVEN_MAIN_HAND) || (i_idx >= INVEN_TOTAL))) {
+    const auto slot = i2enum<inventory_slot_type>(i_idx);
+    if ((!fis.inven || !INVEN_PACK_SLOTS.contains(slot)) && (!fis.equip || !INVEN_WIELDING_SLOTS.contains(slot))) {
         return { tl::nullopt, prev_tag };
     }
 
@@ -175,8 +177,8 @@ static void test_inventory_floor(CreatureEntity &creature, FloorItemSelection *f
         return;
     }
 
-    for (int i = 0; i < INVEN_PACK; i++) {
-        if (item_tester.okay(creature.inventory[i].get()) || (fis_ptr->mode & USE_FULL)) {
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        if (item_tester.okay(creature.inventory[i_idx].get()) || (fis_ptr->mode & USE_FULL)) {
             fis_ptr->max_inven++;
         }
     }
@@ -198,9 +200,9 @@ static void test_equipment_floor(CreatureEntity &creature, FloorItemSelection *f
         return;
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        if (creature.select_ring_slot ? is_ring_slot(i)
-                                      : item_tester.okay(creature.inventory[i].get()) || (fis_ptr->mode & USE_FULL)) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        if (creature.select_ring_slot ? is_ring_slot(i_idx)
+                                      : item_tester.okay(creature.inventory[i_idx].get()) || (fis_ptr->mode & USE_FULL)) {
             fis_ptr->max_equip++;
         }
     }

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -176,15 +176,15 @@ ItemEntity *choose_cursed_obj_name(CreatureEntity &creature, CurseTraitType flag
         return nullptr;
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto *o_ptr = creature.inventory[i_idx].get();
         if (o_ptr->curse_flags.has(flag)) {
-            choices[number] = i;
+            choices[number] = i_idx;
             number++;
             continue;
         }
 
-        choise_cursed_item(flag, o_ptr, choices, &number, i);
+        choise_cursed_item(flag, o_ptr, choices, &number, i_idx);
     }
 
     return creature.inventory[choices[randint0(number)]].get();
@@ -201,8 +201,8 @@ static void curse_teleport(CreatureEntity &creature)
     }
 
     int i_keep = 0, count = 0;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto &item = *creature.inventory[i];
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        const auto &item = *creature.inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }
@@ -219,7 +219,7 @@ static void curse_teleport(CreatureEntity &creature)
 
         count++;
         if (one_in_(count)) {
-            i_keep = i;
+            i_keep = i_idx;
         }
     }
 

--- a/src/inventory/inventory-damage.cpp
+++ b/src/inventory/inventory-damage.cpp
@@ -13,6 +13,7 @@
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
 #include "view/display-messages.h"
+#include <range/v3/view.hpp>
 
 /*!
  * @brief 手持ちのアイテムを指定確率で破損させる /
@@ -33,8 +34,8 @@ void inventory_damage(CreatureEntity &creature, const ObjectBreaker &breaker, in
     }
 
     /* Scan through the slots backwards */
-    for (short i = 0; i < INVEN_PACK; i++) {
-        auto &item = *creature.inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS | ranges::views::reverse) {
+        auto &item = *creature.inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }
@@ -65,9 +66,9 @@ void inventory_damage(CreatureEntity &creature, const ObjectBreaker &breaker, in
 
         msg_format(_("%s(%c)が%s壊れてしまった！", "%sour %s (%c) %s destroyed!"),
 #ifdef JP
-            item_name.data(), index_to_label(i), ((item.number > 1) ? ((amt == item.number) ? "全部" : (amt > 1 ? "何個か" : "一個")) : ""));
+            item_name.data(), index_to_label(i_idx), ((item.number > 1) ? ((amt == item.number) ? "全部" : (amt > 1 ? "何個か" : "一個")) : ""));
 #else
-            ((item.number > 1) ? ((amt == item.number) ? "All of y" : (amt > 1 ? "Some of y" : "One of y")) : "Y"), item_name.data(), index_to_label(i),
+            ((item.number > 1) ? ((amt == item.number) ? "All of y" : (amt > 1 ? "Some of y" : "One of y")) : "Y"), item_name.data(), index_to_label(i_idx),
             ((amt > 1) ? "were" : "was"));
 #endif
 
@@ -96,7 +97,7 @@ void inventory_damage(CreatureEntity &creature, const ObjectBreaker &breaker, in
 
         /* Destroy "amt" items */
 
-        inven_item_increase(creature, i, -amt);
-        inven_item_optimize(creature, i);
+        inven_item_increase(creature, i_idx, -amt);
+        inven_item_optimize(creature, i_idx);
     }
 }

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -14,10 +14,12 @@
 #include "system/creature-entity.h"
 #include "system/item-entity.h"
 #include "system/redrawing-flags-updater.h"
+#include "util/enum-converter.h"
 #include "util/object-sort.h"
 #include "view/display-messages.h"
 #include "view/object-describer.h"
 #include <algorithm>
+#include <range/v3/algorithm.hpp>
 
 void vary_item(CreatureEntity &creature, INVENTORY_IDX i_idx, ITEM_NUMBER num)
 {
@@ -263,7 +265,7 @@ void reorder_pack(CreatureEntity &creature)
  */
 int16_t store_item_to_inventory(CreatureEntity &creature, ItemEntity *o_ptr)
 {
-    INVENTORY_IDX i, j;
+    INVENTORY_IDX i;
     INVENTORY_IDX n = -1;
 
     ItemEntity *j_ptr;
@@ -272,18 +274,18 @@ int16_t store_item_to_inventory(CreatureEntity &creature, ItemEntity *o_ptr)
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::PLAYER,
     };
-    for (j = 0; j < INVEN_PACK; j++) {
-        j_ptr = creature.inventory[j].get();
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        j_ptr = creature.inventory[i_idx].get();
         if (!j_ptr->is_valid()) {
             continue;
         }
 
-        n = j;
+        n = enum2i(i_idx);
         if (j_ptr->is_similar(*o_ptr)) {
             j_ptr->absorb(*o_ptr);
             rfu.set_flag(StatusRecalculatingFlag::BONUS);
             rfu.set_flags(flags_swrf);
-            return j;
+            return enum2i(i_idx);
         }
     }
 
@@ -291,6 +293,7 @@ int16_t store_item_to_inventory(CreatureEntity &creature, ItemEntity *o_ptr)
         return -1;
     }
 
+    INVENTORY_IDX j;
     for (j = 0; j <= INVEN_PACK; j++) {
         j_ptr = creature.inventory[j].get();
         if (!j_ptr->is_valid()) {
@@ -300,13 +303,10 @@ int16_t store_item_to_inventory(CreatureEntity &creature, ItemEntity *o_ptr)
 
     i = j;
     if (i < INVEN_PACK && n >= 0) {
-        for (j = 0; j < INVEN_PACK; j++) {
-            if (object_sort_comp(creature, *o_ptr, *creature.inventory[j])) {
-                break;
-            }
-        }
-
-        i = j;
+        const auto sort_it = ranges::find_if(INVEN_PACK_SLOTS, [&](const auto s) {
+            return object_sort_comp(creature, *o_ptr, *creature.inventory[s]);
+        });
+        i = enum2i(sort_it != INVEN_PACK_SLOTS.end() ? *sort_it : INVEN_PACK);
         auto begin = creature.inventory.begin();
         std::rotate(begin + i, begin + n + 1, begin + n + 2);
     }
@@ -349,8 +349,8 @@ bool check_store_item_to_inventory(const CreatureEntity &creature, const ItemEnt
         return true;
     }
 
-    for (int j = 0; j < INVEN_PACK; j++) {
-        const auto *j_ptr = creature.inventory[j].get();
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto *j_ptr = creature.inventory[i_idx].get();
         if (!j_ptr->is_valid()) {
             continue;
         }

--- a/src/inventory/inventory-slot-types.h
+++ b/src/inventory/inventory-slot-types.h
@@ -27,5 +27,17 @@ enum inventory_slot_type : short {
     INVEN_FORCE = 1111, /*!< inventory slot for selecting force (hard-coded). */
 };
 
+/*!
+ * 所持品スロットの範囲
+ * @note 0-22番を使用。INVEN_PACK(23番)のスロットは特殊な用途で使用される
+ */
+constexpr auto INVEN_PACK_SLOTS = EnumRange(static_cast<inventory_slot_type>(0), INVEN_PACK);
+
 /** 装備スロットの範囲  */
 constexpr auto INVEN_WIELDING_SLOTS = EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_ASSHOLE);
+
+/** 装備スロットのうち、武器(近接・遠隔)スロットの範囲 */
+constexpr auto INVEN_WEAPON_SLOTS = EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_BOW);
+
+/** 所持品と装備を合わせた全スロットの範囲  */
+constexpr auto INVEN_ALL_SLOTS = EnumRange(static_cast<inventory_slot_type>(0), INVEN_TOTAL);

--- a/src/inventory/inventory-util.cpp
+++ b/src/inventory/inventory-util.cpp
@@ -16,6 +16,7 @@
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
 #include "util/bit-flags-calculator.h"
+#include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
 #include <sstream>
@@ -65,13 +66,13 @@ tl::optional<short> get_tag_floor(const FloorType &floor, char tag, const std::v
     return floor_item_indice;
 }
 
-static tl::optional<std::pair<short, short>> get_inventory_range(BIT_FLAGS mode)
+static tl::optional<EnumRange<inventory_slot_type>> get_inventory_range(BIT_FLAGS mode)
 {
     switch (mode) {
     case USE_EQUIP:
-        return std::make_pair(INVEN_MAIN_HAND, INVEN_TOTAL);
+        return INVEN_WIELDING_SLOTS.to_enum_range();
     case USE_INVEN:
-        return std::make_pair(static_cast<short>(0), INVEN_PACK);
+        return INVEN_PACK_SLOTS;
     default:
         return tl::nullopt;
     }
@@ -99,10 +100,9 @@ tl::optional<short> get_tag(CreatureEntity &creature, char tag, BIT_FLAGS mode, 
         return tl::nullopt;
     }
 
-    const auto &[start, end] = *range;
-    tl::optional<short> i_idx;
-    for (auto i = start; i < end; i++) {
-        const auto &item = *creature.inventory[i];
+    tl::optional<short> result;
+    for (const auto i_idx : *range) {
+        const auto &item = *creature.inventory[i_idx];
         if (!item.is_valid() || !item.is_inscribed()) {
             continue;
         }
@@ -114,18 +114,18 @@ tl::optional<short> get_tag(CreatureEntity &creature, char tag, BIT_FLAGS mode, 
         auto sv = extract_suffix(*item.inscription, '@');
         while (sv) {
             if ((sv->length() > 2) && (sv->at(1) == command_cmd) && (sv->at(2) == tag)) {
-                return i;
+                return i_idx;
             }
 
-            if (!i_idx && is_numeric(tag) && (sv->length() > 1) && (sv->at(1) == tag)) {
-                i_idx = i;
+            if (!result && is_numeric(tag) && (sv->length() > 1) && (sv->at(1) == tag)) {
+                result = i_idx;
             }
 
             sv = extract_suffix(sv->substr(1), '@');
         }
     }
 
-    return i_idx;
+    return result;
 }
 
 /*!
@@ -136,7 +136,7 @@ tl::optional<short> get_tag(CreatureEntity &creature, char tag, BIT_FLAGS mode, 
  */
 bool get_item_okay(CreatureEntity &creature, OBJECT_IDX i, const ItemTester &item_tester)
 {
-    if ((i < 0) || (i >= INVEN_TOTAL)) {
+    if (!INVEN_ALL_SLOTS.contains(i2enum<inventory_slot_type>(i))) {
         return false;
     }
 
@@ -194,7 +194,7 @@ INVENTORY_IDX label_to_equipment(CreatureEntity &creature, int c)
 {
     INVENTORY_IDX i = (INVENTORY_IDX)(islower(c) ? A2I(c) : -1) + INVEN_MAIN_HAND;
 
-    if ((i < INVEN_MAIN_HAND) || (i >= INVEN_TOTAL)) {
+    if (!INVEN_WIELDING_SLOTS.contains(i2enum<inventory_slot_type>(i))) {
         return -1;
     }
 
@@ -221,7 +221,7 @@ INVENTORY_IDX label_to_inventory(CreatureEntity &creature, int c)
 {
     INVENTORY_IDX i = (INVENTORY_IDX)(islower(c) ? A2I(c) : -1);
 
-    if ((i < 0) || (i > INVEN_PACK) || !creature.inventory[i]->is_valid()) {
+    if (!INVEN_PACK_SLOTS.contains(i2enum<inventory_slot_type>(i)) || !creature.inventory[i]->is_valid()) {
         return -1;
     }
 

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -49,8 +49,8 @@
  */
 bool can_get_item(CreatureEntity &creature, const ItemTester &item_tester)
 {
-    for (int j = 0; j < INVEN_TOTAL; j++) {
-        if (item_tester.okay(creature.inventory[j].get())) {
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        if (item_tester.okay(creature.inventory[i_idx].get())) {
             return true;
         }
     }

--- a/src/inventory/recharge-processor.cpp
+++ b/src/inventory/recharge-processor.cpp
@@ -52,11 +52,9 @@ static void recharged_notice(CreatureEntity &creature, const ItemEntity &item)
  */
 void recharge_magic_items(CreatureEntity &creature)
 {
-    int i;
-    bool changed;
-
-    for (changed = false, i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        auto &item = *creature.inventory[i];
+    bool changed = false;
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto &item = *creature.inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }
@@ -81,8 +79,9 @@ void recharge_magic_items(CreatureEntity &creature)
      * and each charging rod in a stack decreases the stack's timeout by
      * one per turn. -LM-
      */
-    for (changed = false, i = 0; i < INVEN_PACK; i++) {
-        auto &item = *creature.inventory[i];
+    changed = false;
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        auto &item = *creature.inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -497,28 +497,28 @@ static void dump_aux_equipment_inventory(CreatureEntity &creature, FILE *fff)
 {
     if (creature.get_equip_cnt()) {
         fmt::println(fff, _("  [キャラクタの装備]\n", "  [Character Equipment]\n"));
-        for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-            auto item_name = describe_flavor(creature, *creature.inventory[i], 0);
-            auto is_two_handed = ((i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(creature));
-            is_two_handed |= ((i == INVEN_SUB_HAND) && can_attack_with_main_hand(creature));
+        for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+            auto item_name = describe_flavor(creature, *creature.inventory[i_idx], 0);
+            auto is_two_handed = ((i_idx == INVEN_MAIN_HAND) && can_attack_with_sub_hand(creature));
+            is_two_handed |= ((i_idx == INVEN_SUB_HAND) && can_attack_with_main_hand(creature));
             if (is_two_handed && creature.has_two_handed_weapons()) {
                 item_name = _("(武器を両手持ち)", "(wielding with two-hands)");
             }
 
-            fmt::println(fff, "{}) {}", index_to_label(i), item_name);
+            fmt::println(fff, "{}) {}", index_to_label(i_idx), item_name);
         }
 
         fmt::println(fff, "\n");
     }
 
     fmt::println(fff, _("  [キャラクタの持ち物]\n", "  [Character Inventory]\n"));
-    for (auto i = 0; i < INVEN_PACK; i++) {
-        if (!creature.inventory[i]->is_valid()) {
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        if (!creature.inventory[i_idx]->is_valid()) {
             break;
         }
 
-        const auto item_name = describe_flavor(creature, *creature.inventory[i], 0);
-        fmt::println(fff, "{}) {}", index_to_label(i), item_name);
+        const auto item_name = describe_flavor(creature, *creature.inventory[i_idx], 0);
+        fmt::println(fff, "{}) {}", index_to_label(i_idx), item_name);
     }
 
     fmt::println(fff, "\n");

--- a/src/io-dump/random-art-info-dumper.cpp
+++ b/src/io-dump/random-art-info-dumper.cpp
@@ -82,13 +82,13 @@ void spoil_random_artifact(CreatureEntity &creature)
     spoiler_underline("Random artifacts list.\r", ofs);
     for (const auto &[tval_list, name] : group_artifact_list) {
         for (auto tval : tval_list) {
-            for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-                auto &item = *creature.inventory[i];
+            for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+                auto &item = *creature.inventory[i_idx];
                 spoil_random_artifact_aux(creature, item, tval, ofs);
             }
 
-            for (int i = 0; i < INVEN_PACK; i++) {
-                auto &item = *creature.inventory[i];
+            for (const auto i_idx : INVEN_PACK_SLOTS) {
+                auto &item = *creature.inventory[i_idx];
                 spoil_random_artifact_aux(creature, item, tval, ofs);
             }
 

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -305,8 +305,8 @@ int InputKeyRequestor::get_caret_command() const
 void InputKeyRequestor::sweep_confirmation_equipments()
 {
     auto caret_command = this->get_caret_command();
-    for (auto i = enum2i(INVEN_MAIN_HAND); i < INVEN_TOTAL; i++) {
-        auto &item = *this->creature_ptr->inventory[i];
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto &item = *this->creature_ptr->inventory[i_idx];
         if (!item.is_valid() || !item.is_inscribed()) {
             continue;
         }

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -177,8 +177,8 @@ static void pad_and_print_header(int label_number, FILE *fff)
 static int show_wearing_equipment_resistances(CreatureEntity &creature, ItemKindType tval, int label_number_initial, FILE *fff)
 {
     auto label_number = label_number_initial;
-    for (short i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto &item = *creature.inventory[i];
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        const auto &item = *creature.inventory[i_idx];
         if (!item.has_knowledge(tval)) {
             continue;
         }
@@ -201,8 +201,8 @@ static int show_wearing_equipment_resistances(CreatureEntity &creature, ItemKind
 static int show_holding_equipment_resistances(CreatureEntity &creature, ItemKindType tval, int label_number_initial, FILE *fff)
 {
     auto label_number = label_number_initial;
-    for (short i = 0; i < INVEN_PACK; i++) {
-        const auto &item = *creature.inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &item = *creature.inventory[i_idx];
         if (!item.has_knowledge(tval)) {
             continue;
         }

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -71,8 +71,8 @@ auto collect_known_fixed_artifacts(CreatureEntity &creature)
         }
     }
 
-    for (auto i = 0; i < INVEN_TOTAL; i++) {
-        const auto &item = *creature.inventory[i];
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        const auto &item = *creature.inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -34,6 +34,7 @@
 #include "view/display-messages.h"
 #include "world/world.h"
 #include <algorithm>
+#include <range/v3/view.hpp>
 
 /*!
  * @brief 賞金首の引き換え処理 / Get prize
@@ -69,8 +70,8 @@ bool exchange_cash(CreatureEntity &creature)
         vary_item(creature, i, -item.number);
     }
 
-    for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto &item = *creature.inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &item = *creature.inventory[i_idx];
         if (!item.is_corpse()) {
             continue;
         }
@@ -89,11 +90,11 @@ bool exchange_cash(CreatureEntity &creature)
         msg_format(fmt_reward, reward_money);
         creature.add_au(reward_money);
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(creature, i, -item.number);
+        vary_item(creature, i_idx, -item.number);
     }
 
-    for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto &item = *creature.inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &item = *creature.inventory[i_idx];
         if (item.bi_key != BaseitemKey(ItemKindType::MONSTER_REMAINS, SV_SKELETON)) {
             continue;
         }
@@ -112,12 +113,12 @@ bool exchange_cash(CreatureEntity &creature)
         msg_format(fmt_reward, reward_money);
         creature.add_au(reward_money);
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(creature, i, -item.number);
+        vary_item(creature, i_idx, -item.number);
     }
 
     auto &world = AngbandWorld::get_instance();
-    for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto &item = *creature.inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &item = *creature.inventory[i_idx];
         const auto &monrace = world.get_today_bounty();
         if (!item.is_corpse() || (item.get_monrace().name != monrace.name)) {
             continue;
@@ -133,11 +134,11 @@ bool exchange_cash(CreatureEntity &creature)
         msg_format(fmt_reward, reward_money);
         creature.add_au(reward_money);
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(creature, i, -item.number);
+        vary_item(creature, i_idx, -item.number);
     }
 
-    for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto &item = *creature.inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &item = *creature.inventory[i_idx];
         const auto &monrace = world.get_today_bounty();
         if ((item.bi_key != BaseitemKey(ItemKindType::MONSTER_REMAINS, SV_SKELETON)) || (item.get_monrace().name != monrace.name)) {
             continue;
@@ -153,7 +154,7 @@ bool exchange_cash(CreatureEntity &creature)
         msg_format(fmt_reward, reward_money);
         creature.add_au(reward_money);
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(creature, i, -item.number);
+        vary_item(creature, i_idx, -item.number);
     }
 
     for (auto &[monrace_id, is_achieved] : world.bounties) {
@@ -161,8 +162,8 @@ bool exchange_cash(CreatureEntity &creature)
             continue;
         }
 
-        for (INVENTORY_IDX i = INVEN_PACK - 1; i >= 0; i--) {
-            auto &item = *creature.inventory[i];
+        for (const auto i_idx : INVEN_PACK_SLOTS | ranges::views::reverse) {
+            auto &item = *creature.inventory[i_idx];
             if ((item.bi_key.tval() != ItemKindType::MONSTER_REMAINS) || (item.get_monrace().idx != monrace_id)) {
                 continue;
             }
@@ -177,7 +178,7 @@ bool exchange_cash(CreatureEntity &creature)
                 continue;
             }
 
-            vary_item(creature, i, -item.number);
+            vary_item(creature, i_idx, -item.number);
             chg_virtue(creature, Virtue::JUSTICE, 5);
             is_achieved = true;
 

--- a/src/market/building-recharger.cpp
+++ b/src/market/building-recharger.cpp
@@ -176,8 +176,8 @@ void building_recharge_all(CreatureEntity &creature)
 
     auto price = 0;
     auto total_cost = 0;
-    for (short i = 0; i < INVEN_PACK; i++) {
-        const auto &item = *creature.inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &item = *creature.inventory[i_idx];
         if (!item.can_recharge()) {
             continue;
         }
@@ -228,15 +228,15 @@ void building_recharge_all(CreatureEntity &creature)
         return;
     }
 
-    for (short i = 0; i < INVEN_PACK; i++) {
-        auto *o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        auto *o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->can_recharge()) {
             continue;
         }
 
         if (!o_ptr->is_known()) {
             identify_item(creature, o_ptr);
-            autopick_alter_item(creature, i, false);
+            autopick_alter_item(creature, i_idx, false);
         }
 
         const auto base_pval = o_ptr->get_baseitem_pval();

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -9,6 +9,7 @@
 #include "floor/floor-util.h"
 #include "game-option/disturbance-options.h"
 #include "grid/grid.h"
+#include "inventory/inventory-slot-types.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
 #include "mind/mind-mirror-master.h"
@@ -49,7 +50,9 @@
 #include "target/projection-path-calculator.h"
 #include "target/target-checker.h"
 #include "target/target-getter.h"
+#include "util/enum-converter.h"
 #include "view/display-messages.h"
+#include <range/v3/algorithm.hpp>
 
 /*!
  * @brief 変わり身処理
@@ -417,15 +420,11 @@ bool cast_ninja_spell(CreatureEntity &creature, MindNinjaType spell)
         return rush_attack(creature, nullptr);
     case MindNinjaType::SYURIKEN_SPREADING: {
         for (int i = 0; i < 8; i++) {
-            OBJECT_IDX slot;
+            const auto it = ranges::find_if(INVEN_PACK_SLOTS, [&](const auto s) {
+                return creature.inventory[s]->bi_key.tval() == ItemKindType::SPIKE;
+            });
 
-            for (slot = 0; slot < INVEN_PACK; slot++) {
-                if (creature.inventory[slot]->bi_key.tval() == ItemKindType::SPIKE) {
-                    break;
-                }
-            }
-
-            if (slot == INVEN_PACK) {
+            if (it == INVEN_PACK_SLOTS.end()) {
                 if (!i) {
                     msg_print(_("くさびを持っていない。", "You have no Iron Spikes."));
                 } else {
@@ -435,7 +434,7 @@ bool cast_ninja_spell(CreatureEntity &creature, MindNinjaType spell)
                 return false;
             }
 
-            (void)ThrowCommand(creature).do_cmd_throw(1, false, slot);
+            (void)ThrowCommand(creature).do_cmd_throw(1, false, enum2i(*it));
             PlayerEnergy(creature).set_player_turn_energy(100);
         }
 

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -111,7 +111,7 @@ static void calc_blow_un_power(CreatureEntity &creature, MonsterAttackPlayer *mo
 
     int max_draining_item = is_magic_mastery ? 5 : 10;
     for (int i = 0; i < max_draining_item; i++) {
-        auto i_idx = randnum0<short>(INVEN_PACK);
+        const auto i_idx = rand_choice(INVEN_PACK_SLOTS);
         monap_ptr->o_ptr = creature.inventory[i_idx].get();
         if (!monap_ptr->o_ptr->is_valid()) {
             continue;

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -9,6 +9,7 @@
 #include "flavor/flavor-describer.h"
 #include "flavor/object-flavor-types.h"
 #include "inventory/inventory-object.h"
+#include "inventory/inventory-slot-types.h"
 #include "mind/mind-mirror-master.h"
 #include "monster-attack/monster-attack-player.h"
 #include "object/object-info.h"
@@ -126,7 +127,7 @@ static void move_item_to_monster(MonsterAttackPlayer *monap_ptr)
 void process_eat_item(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
     for (int i = 0; i < 10; i++) {
-        auto i_idx = randnum0<short>(INVEN_PACK);
+        const auto i_idx = rand_choice(INVEN_PACK_SLOTS);
         monap_ptr->o_ptr = creature.inventory[i_idx].get();
         if (!monap_ptr->o_ptr->is_valid()) {
             continue;
@@ -155,7 +156,7 @@ void process_eat_item(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 void process_eat_food(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
     for (int i = 0; i < 10; i++) {
-        auto i_idx = randnum0<short>(INVEN_PACK);
+        const auto i_idx = rand_choice(INVEN_PACK_SLOTS);
         monap_ptr->o_ptr = creature.inventory[i_idx].get();
         if (!monap_ptr->o_ptr->is_valid()) {
             continue;

--- a/src/object-hook/hook-magic.cpp
+++ b/src/object-hook/hook-magic.cpp
@@ -58,8 +58,8 @@ bool item_tester_hook_use(CreatureEntity &creature, const ItemEntity *o_ptr)
             return false;
         }
 
-        for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-            if ((creature.inventory[i].get() == o_ptr) && o_ptr->get_flags().has(TR_ACTIVATE)) {
+        for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+            if ((creature.inventory[i_idx].get() == o_ptr) && o_ptr->get_flags().has(TR_ACTIVATE)) {
                 return true;
             }
         }

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -32,10 +32,10 @@ std::shared_ptr<ItemEntity> choose_warning_item(CreatureEntity &creature)
     }
 
     std::vector<int> candidates;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto &item = creature.inventory[i];
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        const auto &item = creature.inventory[i_idx];
         if (item->get_flags().has(TR_WARNING)) {
-            candidates.push_back(i);
+            candidates.push_back(i_idx);
         }
     }
 

--- a/src/perception/simple-perception.cpp
+++ b/src/perception/simple-perception.cpp
@@ -278,8 +278,8 @@ void sense_inventory1(CreatureEntity &creature)
         heavy = true;
     }
 
-    for (INVENTORY_IDX i = 0; i < INVEN_TOTAL; i++) {
-        o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        o_ptr = creature.inventory[i_idx].get();
 
         if (!o_ptr->is_valid()) {
             continue;
@@ -315,7 +315,7 @@ void sense_inventory1(CreatureEntity &creature)
             continue;
         }
 
-        if ((i < INVEN_MAIN_HAND) && (0 != randint0(5))) {
+        if ((i_idx < INVEN_MAIN_HAND) && (0 != randint0(5))) {
             continue;
         }
 
@@ -323,7 +323,7 @@ void sense_inventory1(CreatureEntity &creature)
             heavy = true;
         }
 
-        sense_inventory_aux(creature, i, heavy);
+        sense_inventory_aux(creature, i_idx, heavy);
     }
 }
 
@@ -406,9 +406,9 @@ void sense_inventory2(CreatureEntity &creature)
         break;
     }
 
-    for (INVENTORY_IDX i = 0; i < INVEN_TOTAL; i++) {
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
         bool okay = false;
-        o_ptr = creature.inventory[i].get();
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -430,11 +430,11 @@ void sense_inventory2(CreatureEntity &creature)
             continue;
         }
 
-        if ((i < INVEN_MAIN_HAND) && (0 != randint0(5))) {
+        if ((i_idx < INVEN_MAIN_HAND) && (0 != randint0(5))) {
             continue;
         }
 
-        sense_inventory_aux(creature, i, true);
+        sense_inventory_aux(creature, i_idx, true);
     }
 }
 

--- a/src/player-info/base-status-info.cpp
+++ b/src/player-info/base-status-info.cpp
@@ -8,8 +8,8 @@
 
 void set_equipment_influence(CreatureEntity &creature, self_info_type *self_ptr)
 {
-    for (int k = INVEN_MAIN_HAND; k < INVEN_TOTAL; k++) {
-        auto *o_ptr = creature.inventory[k].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto *o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/player-status/player-status-base.cpp
+++ b/src/player-status/player-status-base.cpp
@@ -210,15 +210,15 @@ void PlayerStatusBase::set_locals()
 BIT_FLAGS PlayerStatusBase::equipments_flags(tr_type check_flag)
 {
     BIT_FLAGS flags = 0;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = this->creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto *o_ptr = this->creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
 
         const auto o_flags = o_ptr->get_flags();
         if (o_flags.has(check_flag)) {
-            set_bits(flags, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
+            set_bits(flags, convert_inventory_slot_type_to_flag_cause(i_idx));
         }
     }
 
@@ -233,8 +233,8 @@ BIT_FLAGS PlayerStatusBase::equipments_flags(tr_type check_flag)
 BIT_FLAGS PlayerStatusBase::equipments_bad_flags(tr_type check_flag)
 {
     BIT_FLAGS flags = 0;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = this->creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto *o_ptr = this->creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -242,7 +242,7 @@ BIT_FLAGS PlayerStatusBase::equipments_bad_flags(tr_type check_flag)
         const auto o_flags = o_ptr->get_flags();
         if (o_flags.has(check_flag)) {
             if (o_ptr->pval < 0) {
-                set_bits(flags, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
+                set_bits(flags, convert_inventory_slot_type_to_flag_cause(i_idx));
             }
         }
     }
@@ -258,8 +258,8 @@ int16_t PlayerStatusBase::equipments_bonus()
 {
     this->set_locals(); /* 計算前に値のセット。派生クラスの値がセットされる。*/
     int16_t bonus = 0;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto *o_ptr = this->creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        const auto *o_ptr = this->creature.inventory[i_idx].get();
         const auto o_flags = o_ptr->get_flags();
         if (!o_ptr->is_valid()) {
             continue;

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -103,6 +103,8 @@ BIT_FLAGS convert_inventory_slot_type_to_flag_cause(inventory_slot_type inventor
         return FLAG_CAUSE_INVEN_ARMS;
     case INVEN_FEET:
         return FLAG_CAUSE_INVEN_FEET;
+    case INVEN_ASSHOLE:
+        return FLAG_CAUSE_INVEN_ASSHOLE;
 
     default:
         return 0;
@@ -116,8 +118,8 @@ BIT_FLAGS check_equipment_flags(CreatureEntity &creature, tr_type tr_flag)
 {
     ItemEntity *o_ptr;
     BIT_FLAGS result = 0L;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -125,7 +127,7 @@ BIT_FLAGS check_equipment_flags(CreatureEntity &creature, tr_type tr_flag)
         const auto flags = o_ptr->get_flags();
 
         if (flags.has(tr_flag)) {
-            set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
+            set_bits(result, convert_inventory_slot_type_to_flag_cause(i_idx));
         }
     }
 
@@ -766,8 +768,8 @@ void check_no_flowed(CreatureEntity &creature)
         return;
     }
 
-    for (int i = 0; i < INVEN_PACK; i++) {
-        const auto &bi_key = creature.inventory[i]->bi_key;
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &bi_key = creature.inventory[i_idx]->bi_key;
         if (bi_key == BaseitemKey(ItemKindType::NATURE_BOOK, 2)) {
             has_sw = true;
         }
@@ -835,8 +837,8 @@ BIT_FLAGS has_warning(CreatureEntity &creature)
     BIT_FLAGS result = 0L;
     ItemEntity *o_ptr;
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -845,7 +847,7 @@ BIT_FLAGS has_warning(CreatureEntity &creature)
 
         if (flags.has(TR_WARNING)) {
             if (!o_ptr->is_inscribed() || !angband_strchr(o_ptr->inscription->data(), '$')) {
-                set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
+                set_bits(result, convert_inventory_slot_type_to_flag_cause(i_idx));
             }
         }
     }
@@ -1109,8 +1111,8 @@ void update_curses(CreatureEntity &creature)
         creature.add_curse(CurseTraitType::AGGRAVATE);
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1222,17 +1224,17 @@ void update_extra_blows(CreatureEntity &creature)
     const melee_type melee_type = player_melee_type(creature);
     const bool two_handed = (melee_type == MELEE_TYPE_WEAPON_TWOHAND || melee_type == MELEE_TYPE_BAREHAND_TWO);
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
 
         const auto flags = o_ptr->get_flags();
         if (flags.has(TR_BLOWS)) {
-            if ((i == INVEN_MAIN_HAND || i == INVEN_MAIN_RING) && !two_handed) {
+            if ((i_idx == INVEN_MAIN_HAND || i_idx == INVEN_MAIN_RING) && !two_handed) {
                 creature.extra_blows[0] += o_ptr->pval;
-            } else if ((i == INVEN_SUB_HAND || i == INVEN_SUB_RING) && !two_handed) {
+            } else if ((i_idx == INVEN_SUB_HAND || i_idx == INVEN_SUB_RING) && !two_handed) {
                 creature.extra_blows[1] += o_ptr->pval;
             } else {
                 creature.extra_blows[0] += o_ptr->pval;
@@ -1525,8 +1527,8 @@ BIT_FLAGS has_vuln_curse(CreatureEntity &creature)
 {
     ItemEntity *o_ptr;
     BIT_FLAGS result = 0L;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1534,7 +1536,7 @@ BIT_FLAGS has_vuln_curse(CreatureEntity &creature)
         const auto flags = o_ptr->get_flags();
 
         if (flags.has(TR_VUL_CURSE) || o_ptr->curse_flags.has(CurseTraitType::VUL_CURSE)) {
-            set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
+            set_bits(result, convert_inventory_slot_type_to_flag_cause(i_idx));
         }
     }
 
@@ -1550,8 +1552,8 @@ BIT_FLAGS has_heavy_vuln_curse(CreatureEntity &creature)
 {
     ItemEntity *o_ptr;
     BIT_FLAGS result = 0L;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1559,7 +1561,7 @@ BIT_FLAGS has_heavy_vuln_curse(CreatureEntity &creature)
         const auto flags = o_ptr->get_flags();
 
         if ((flags.has(TR_VUL_CURSE) || o_ptr->curse_flags.has(CurseTraitType::VUL_CURSE)) && o_ptr->curse_flags.has(CurseTraitType::HEAVY_CURSE)) {
-            set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
+            set_bits(result, convert_inventory_slot_type_to_flag_cause(i_idx));
         }
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -19,6 +19,7 @@
 #include "game-option/birth-options.h"
 #include "grid/grid.h"
 #include "inventory/inventory-object.h"
+#include "inventory/inventory-slot-types.h"
 #include "io/input-key-acceptor.h"
 #include "io/write-diary.h"
 #include "main/sound-definitions-table.h"
@@ -188,8 +189,8 @@ static bool is_heavy_shoot(CreatureEntity &creature, const ItemEntity *o_ptr)
 int calc_inventory_weight(CreatureEntity &creature)
 {
     auto weight = 0;
-    for (int i = 0; i < INVEN_TOTAL; i++) {
-        const auto &item = *creature.inventory[i];
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        const auto &item = *creature.inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }
@@ -983,14 +984,14 @@ short calc_num_fire(CreatureEntity &creature, const ItemEntity *o_ptr)
 {
     int extra_shots = 0;
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         ItemEntity *q_ptr;
-        q_ptr = creature.inventory[i].get();
+        q_ptr = creature.inventory[i_idx].get();
         if (!q_ptr->is_valid()) {
             continue;
         }
 
-        if (i == INVEN_BOW) {
+        if (i_idx == INVEN_BOW) {
             continue;
         }
 
@@ -1103,9 +1104,9 @@ static ACTION_SKILL_POWER calc_device_ability(CreatureEntity &creature)
     pow = tmp_race_ptr->r_dev + player_class.c_dev + player_personality.a_dev;
     pow += ((player_class.x_dev * creature.get_level() / 10) + ((*creature.get_personality_info()).a_dev * creature.get_level() / 50));
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
-        o_ptr = creature.inventory[i].get();
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1231,9 +1232,9 @@ static ACTION_SKILL_POWER calc_search(CreatureEntity &creature)
     pow = tmp_race_ptr->r_srh + player_class.c_srh + player_personality.a_srh;
     pow += (player_class.x_srh * creature.get_level() / 10);
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
-        o_ptr = creature.inventory[i].get();
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1280,9 +1281,9 @@ static ACTION_SKILL_POWER calc_search_freq(CreatureEntity &creature)
     pow = tmp_race_ptr->r_fos + player_class.c_fos + player_personality.a_fos;
     pow += (player_class.x_fos * creature.get_level() / 10);
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
-        o_ptr = creature.inventory[i].get();
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1416,8 +1417,8 @@ static ACTION_SKILL_POWER calc_skill_dig(CreatureEntity &creature)
         pow += (100 + creature.get_level() * 8);
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1634,9 +1635,9 @@ static int16_t calc_to_magic_chance(CreatureEntity &creature)
         chance += 5;
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
-        o_ptr = creature.inventory[i].get();
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1659,9 +1660,9 @@ static ARMOUR_CLASS calc_base_ac(CreatureEntity &creature)
         return 0;
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
-        o_ptr = creature.inventory[i].get();
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1740,8 +1741,8 @@ static ARMOUR_CLASS calc_to_ac(CreatureEntity &creature, bool is_real_value)
         ac -= 50;
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto *o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        const auto *o_ptr = creature.inventory[i_idx].get();
         const auto flags = o_ptr->get_flags();
         if (!o_ptr->is_valid()) {
             continue;
@@ -1762,7 +1763,7 @@ static ARMOUR_CLASS calc_to_ac(CreatureEntity &creature, bool is_real_value)
             }
         }
 
-        if ((i == INVEN_SUB_HAND) && flags.has(TR_SUPPORTIVE)) {
+        if ((i_idx == INVEN_SUB_HAND) && flags.has(TR_SUPPORTIVE)) {
             ac += 5;
         }
     }
@@ -2134,15 +2135,15 @@ static short calc_to_damage(CreatureEntity &creature, INVENTORY_IDX slot, bool i
         }
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         int bonus_to_d = 0;
-        o_ptr = creature.inventory[i].get();
-        const auto has_melee = has_melee_weapon(creature, i);
+        o_ptr = creature.inventory[i_idx].get();
+        const auto has_melee = has_melee_weapon(creature, i_idx);
         if (!o_ptr->is_valid() || (o_ptr->bi_key.tval() == ItemKindType::CAPTURE)) {
             continue;
         }
 
-        if (((i == INVEN_MAIN_HAND) && has_melee) || ((i == INVEN_SUB_HAND) && has_melee) || (i == INVEN_BOW)) {
+        if (((i_idx == INVEN_MAIN_HAND) && has_melee) || ((i_idx == INVEN_SUB_HAND) && has_melee) || (i_idx == INVEN_BOW)) {
             continue;
         }
 
@@ -2167,30 +2168,30 @@ static short calc_to_damage(CreatureEntity &creature, INVENTORY_IDX slot, bool i
 
         case MELEE_TYPE_BAREHAND_MAIN:
         case MELEE_TYPE_WEAPON_MAIN:
-            if ((calc_hand == PLAYER_HAND_MAIN) && (i != INVEN_SUB_RING)) {
+            if ((calc_hand == PLAYER_HAND_MAIN) && (i_idx != INVEN_SUB_RING)) {
                 damage += (int16_t)bonus_to_d;
             }
             break;
 
         case MELEE_TYPE_BAREHAND_SUB:
         case MELEE_TYPE_WEAPON_SUB:
-            if ((calc_hand == PLAYER_HAND_SUB) && (i != INVEN_MAIN_RING)) {
+            if ((calc_hand == PLAYER_HAND_SUB) && (i_idx != INVEN_MAIN_RING)) {
                 damage += (int16_t)bonus_to_d;
             }
             break;
 
         case MELEE_TYPE_WEAPON_DOUBLE:
             if (calc_hand == PLAYER_HAND_MAIN) {
-                if (i == INVEN_MAIN_RING) {
+                if (i_idx == INVEN_MAIN_RING) {
                     damage += (int16_t)bonus_to_d;
-                } else if (i != INVEN_SUB_RING) {
+                } else if (i_idx != INVEN_SUB_RING) {
                     damage += (bonus_to_d > 0) ? (bonus_to_d + 1) / 2 : bonus_to_d;
                 }
             }
             if (calc_hand == PLAYER_HAND_SUB) {
-                if (i == INVEN_SUB_RING) {
+                if (i_idx == INVEN_SUB_RING) {
                     damage += (int16_t)bonus_to_d;
-                } else if (i != INVEN_MAIN_RING) {
+                } else if (i_idx != INVEN_MAIN_RING) {
                     damage += (bonus_to_d > 0) ? bonus_to_d / 2 : bonus_to_d;
                 }
             }
@@ -2374,16 +2375,16 @@ static short calc_to_hit(CreatureEntity &creature, INVENTORY_IDX slot, bool is_r
     }
 
     /* Bonuses from inventory */
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto *o_ptr = creature.inventory[i_idx].get();
 
         /* Ignore empty hands, handed weapons, bows and capture balls */
-        const auto has_melee = has_melee_weapon(creature, i);
+        const auto has_melee = has_melee_weapon(creature, i_idx);
         if (!o_ptr->is_valid() || o_ptr->bi_key.tval() == ItemKindType::CAPTURE) {
             continue;
         }
 
-        if (((i == INVEN_MAIN_HAND) && has_melee) || ((i == INVEN_SUB_HAND) && has_melee) || (i == INVEN_BOW)) {
+        if (((i_idx == INVEN_MAIN_HAND) && has_melee) || ((i_idx == INVEN_SUB_HAND) && has_melee) || (i_idx == INVEN_BOW)) {
             continue;
         }
 
@@ -2411,30 +2412,30 @@ static short calc_to_hit(CreatureEntity &creature, INVENTORY_IDX slot, bool is_r
 
         case MELEE_TYPE_BAREHAND_MAIN:
         case MELEE_TYPE_WEAPON_MAIN:
-            if ((calc_hand == PLAYER_HAND_MAIN) && (i != INVEN_SUB_RING)) {
+            if ((calc_hand == PLAYER_HAND_MAIN) && (i_idx != INVEN_SUB_RING)) {
                 hit += (int16_t)bonus_to_h;
             }
             break;
 
         case MELEE_TYPE_BAREHAND_SUB:
         case MELEE_TYPE_WEAPON_SUB:
-            if ((calc_hand == PLAYER_HAND_SUB) && (i != INVEN_MAIN_RING)) {
+            if ((calc_hand == PLAYER_HAND_SUB) && (i_idx != INVEN_MAIN_RING)) {
                 hit += (int16_t)bonus_to_h;
             }
             break;
 
         case MELEE_TYPE_WEAPON_DOUBLE:
             if (calc_hand == PLAYER_HAND_MAIN) {
-                if (i == INVEN_MAIN_RING) {
+                if (i_idx == INVEN_MAIN_RING) {
                     hit += (int16_t)bonus_to_h;
-                } else if (i != INVEN_SUB_RING) {
+                } else if (i_idx != INVEN_SUB_RING) {
                     hit += (bonus_to_h > 0) ? (bonus_to_h + 1) / 2 : bonus_to_h;
                 }
             }
             if (calc_hand == PLAYER_HAND_SUB) {
-                if (i == INVEN_SUB_RING) {
+                if (i_idx == INVEN_SUB_RING) {
                     hit += (int16_t)bonus_to_h;
-                } else if (i != INVEN_MAIN_RING) {
+                } else if (i_idx != INVEN_MAIN_RING) {
                     hit += (bonus_to_h > 0) ? bonus_to_h / 2 : bonus_to_h;
                 }
             }
@@ -2515,15 +2516,15 @@ static int16_t calc_to_hit_bow(CreatureEntity &creature, bool is_real_value)
     }
 
     // 武器以外の装備による修正
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         int bonus_to_h;
-        o_ptr = creature.inventory[i].get();
-        const auto has_melee = has_melee_weapon(creature, i);
+        o_ptr = creature.inventory[i_idx].get();
+        const auto has_melee = has_melee_weapon(creature, i_idx);
         if (!o_ptr->is_valid() || (o_ptr->bi_key.tval() == ItemKindType::CAPTURE)) {
             continue;
         }
 
-        if (((i == INVEN_MAIN_HAND) && has_melee) || ((i == INVEN_SUB_HAND) && has_melee) || (i == INVEN_BOW)) {
+        if (((i_idx == INVEN_MAIN_HAND) && has_melee) || ((i_idx == INVEN_SUB_HAND) && has_melee) || (i_idx == INVEN_BOW)) {
             continue;
         }
 
@@ -2551,8 +2552,8 @@ static int16_t calc_to_damage_misc(CreatureEntity &creature)
 
     int16_t to_dam = 0;
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -2581,8 +2582,8 @@ static int16_t calc_to_hit_misc(CreatureEntity &creature)
 
     int16_t to_hit = 0;
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -2749,8 +2750,8 @@ void update_creature(CreatureEntity &creature)
  */
 bool player_has_no_spellbooks(CreatureEntity &creature)
 {
-    for (int i = 0; i < INVEN_PACK; i++) {
-        const auto *o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto *o_ptr = creature.inventory[i_idx].get();
         if (o_ptr->is_valid() && check_book_realm(creature, o_ptr->bi_key)) {
             return false;
         }

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -300,8 +300,8 @@ void print_monster_tomb(CreatureEntity &creature, CreatureEntity &target)
 static void inventory_aware(CreatureEntity &creature)
 {
     ItemEntity *o_ptr;
-    for (int i = 0; i < INVEN_TOTAL; i++) {
-        o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/player/race-resistances.cpp
+++ b/src/player/race-resistances.cpp
@@ -83,8 +83,8 @@ void known_obj_immunity(CreatureEntity &creature, TrFlags &flags)
 {
     flags.clear();
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto *o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        const auto *o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/racial/racial-android.cpp
+++ b/src/racial/racial-android.cpp
@@ -64,12 +64,12 @@ void calc_android_exp(CreatureEntity &creature)
         return;
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto *o_ptr = creature.inventory[i_idx].get();
         uint32_t value, exp;
         DEPTH level = std::max(o_ptr->get_baseitem_level() - 8, 1);
 
-        if ((i == INVEN_MAIN_RING) || (i == INVEN_SUB_RING) || (i == INVEN_NECK) || (i == INVEN_LITE)) {
+        if ((i_idx == INVEN_MAIN_RING) || (i_idx == INVEN_SUB_RING) || (i_idx == INVEN_NECK) || (i_idx == INVEN_LITE)) {
             continue;
         }
         if (!o_ptr->is_valid()) {
@@ -155,12 +155,12 @@ void calc_android_exp(CreatureEntity &creature)
                 exp += (value - 100000L) / 4 * level;
             }
         }
-        if ((((i == INVEN_MAIN_HAND) || (i == INVEN_SUB_HAND)) && (has_melee_weapon(creature, i))) || (i == INVEN_BOW)) {
+        if ((((i_idx == INVEN_MAIN_HAND) || (i_idx == INVEN_SUB_HAND)) && (has_melee_weapon(creature, i_idx))) || (i_idx == INVEN_BOW)) {
             total_exp += exp / 48;
         } else {
             total_exp += exp / 16;
         }
-        if (i == INVEN_BODY) {
+        if (i_idx == INVEN_BODY) {
             total_exp += exp / 32;
         }
     }

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -207,13 +207,13 @@ static bool wr_savefile_new(CreatureEntity &creature)
         wr_byte(static_cast<byte>(spell_id));
     }
 
-    for (int i = 0; i < INVEN_TOTAL; i++) {
-        const auto &item = *creature.inventory[i];
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        const auto &item = *creature.inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }
 
-        wr_u16b((uint16_t)i);
+        wr_u16b((uint16_t)i_idx);
         wr_item(item);
     }
 

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -71,8 +71,8 @@ void torch_lost_fuel(ItemEntity *o_ptr)
 void update_lite_radius(CreatureEntity &creature)
 {
     POSITION cur_lite = 0;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto *o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        const auto *o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/spell-kind/spells-curse-removal.cpp
+++ b/src/spell-kind/spells-curse-removal.cpp
@@ -20,8 +20,8 @@ static int exe_curse_removal(CreatureEntity &creature, int all)
 {
     auto count = 0;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto *o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid() || !o_ptr->is_cursed()) {
             continue;
         }

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -38,14 +38,14 @@
  */
 void identify_pack(CreatureEntity &creature)
 {
-    for (INVENTORY_IDX i = 0; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        auto *o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
 
         identify_item(creature, o_ptr);
-        autopick_alter_item(creature, i, false);
+        autopick_alter_item(creature, i_idx, false);
     }
 }
 

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -532,11 +532,8 @@ void teleport_away_followable(CreatureEntity &creature, MONSTER_IDX m_idx)
     if (creature.get_mutations().has(PlayerMutationType::VTELEPORT) || CreatureClass(creature).equals(PlayerClassType::IMITATOR)) {
         follow = true;
     } else {
-        ItemEntity *o_ptr;
-        INVENTORY_IDX i;
-
-        for (i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-            o_ptr = creature.inventory[i].get();
+        for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+            const auto *o_ptr = creature.inventory[i_idx].get();
             if (o_ptr->is_valid() && !o_ptr->is_cursed() && o_ptr->get_flags().has(TR_TELEPORT)) {
                 follow = true;
                 break;

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -310,8 +310,8 @@ bool curse_weapon_object(CreatureEntity &creature, bool force, ItemEntity &item)
 void brand_bolts(CreatureEntity &creature)
 {
 
-    for (auto i = 0; i < INVEN_PACK; i++) {
-        auto &item = *creature.inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        auto &item = *creature.inventory[i_idx];
         if (item.bi_key.tval() != ItemKindType::BOLT) {
             continue;
         }

--- a/src/status/base-status.cpp
+++ b/src/status/base-status.cpp
@@ -305,8 +305,8 @@ bool lose_all_info(CreatureEntity &creature)
 {
     chg_virtue(creature, Virtue::KNOWLEDGE, -5);
     chg_virtue(creature, Virtue::ENLIGHTEN, -5);
-    for (int i = 0; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        auto *o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid() || o_ptr->is_fully_known()) {
             continue;
         }

--- a/src/util/enum-range.h
+++ b/src/util/enum-range.h
@@ -20,9 +20,9 @@ public:
     class iterator {
     public:
         // std::iterator_traits に対応するための定義
-        using difference_type = int;
+        using difference_type = ptrdiff_t;
         using value_type = EnumType;
-        using iterator_concept = std::input_iterator_tag;
+        using iterator_concept = std::bidirectional_iterator_tag;
 
         constexpr iterator() noexcept = default;
 
@@ -66,6 +66,29 @@ public:
         {
             auto old = *this;
             ++*this;
+            return old;
+        }
+
+        /*!
+         * @brief イテレータを前置デクリメントする
+         *
+         * @return *this の参照
+         */
+        constexpr iterator &operator--() noexcept
+        {
+            --index;
+            return *this;
+        }
+
+        /*!
+         * @brief イテレータを後置デクリメントする
+         *
+         * @return インクリメント前のイテレータのコピー
+         */
+        constexpr iterator operator--(int) noexcept
+        {
+            auto old = *this;
+            --*this;
             return old;
         }
 
@@ -213,6 +236,16 @@ public:
     constexpr auto size() const noexcept
     {
         return range.size();
+    }
+
+    /*!
+     * @brief 閉区間の範囲を半開区間の EnumRange に変換する
+     *
+     * @return 同じ範囲を表す EnumRange<EnumType>
+     */
+    constexpr EnumRange<EnumType> to_enum_range() const noexcept
+    {
+        return range;
     }
 
 private:

--- a/src/view/display-characteristic.cpp
+++ b/src/view/display-characteristic.cpp
@@ -107,9 +107,9 @@ static std::array<tr_type, 6> lite_flags = {
  */
 static void process_cursed_equipment_characteristics(CreatureEntity &creature, uint16_t mode, char_stat &char_stat)
 {
-    int max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
-    for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
-        auto *o_ptr = creature.inventory[i].get();
+    const auto range = (mode & DP_WP) ? INVEN_WEAPON_SLOTS : INVEN_WIELDING_SLOTS;
+    for (const auto i_idx : range) {
+        auto *o_ptr = creature.inventory[i_idx].get();
         auto is_known = o_ptr->is_known();
         auto is_sensed = is_known || o_ptr->ident.has(IdentificationFlag::SENSE);
         auto flags = o_ptr->get_flags_known();
@@ -156,9 +156,9 @@ static void process_cursed_equipment_characteristics(CreatureEntity &creature, u
  */
 static void process_light_equipment_characteristics(CreatureEntity &creature, all_player_flags *f, uint16_t mode, char_stat &char_stat)
 {
-    int max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
-    for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
-        auto *o_ptr = creature.inventory[i].get();
+    const auto range = (mode & DP_WP) ? INVEN_WEAPON_SLOTS : INVEN_WIELDING_SLOTS;
+    for (const auto i_idx : range) {
+        auto *o_ptr = creature.inventory[i_idx].get();
         auto flags = o_ptr->get_flags_known();
 
         auto b = false;
@@ -211,9 +211,9 @@ static void process_light_equipment_characteristics(CreatureEntity &creature, al
  */
 static void process_inventory_characteristic(CreatureEntity &creature, tr_type flag, all_player_flags *f, uint16_t mode, char_stat &char_stat)
 {
-    int max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
-    for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
-        auto *o_ptr = creature.inventory[i].get();
+    const auto range = (mode & DP_WP) ? INVEN_WEAPON_SLOTS : INVEN_WIELDING_SLOTS;
+    for (const auto i_idx : range) {
+        auto *o_ptr = creature.inventory[i_idx].get();
         auto flags = o_ptr->get_flags_known();
 
         auto f_imm = flag_to_greater_flag.find(flag);

--- a/src/view/display-inventory.cpp
+++ b/src/view/display-inventory.cpp
@@ -29,7 +29,6 @@
  */
 COMMAND_CODE show_inventory(CreatureEntity &creature, int target_item, BIT_FLAGS mode, const ItemTester &item_tester)
 {
-    COMMAND_CODE i;
     int k, l, z = 0;
     COMMAND_CODE out_index[23]{};
     TERM_COLOR out_color[23]{};
@@ -38,15 +37,16 @@ COMMAND_CODE show_inventory(CreatureEntity &creature, int target_item, BIT_FLAGS
     auto col = command_gap;
     const auto &[wid, hgt] = term_get_size();
     auto len = wid - col - 1;
-    for (i = 0; i < INVEN_PACK; i++) {
-        const auto &item = *creature.inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &item = *creature.inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }
 
-        z = i + 1;
+        z = enum2i(i_idx) + 1;
     }
 
+    COMMAND_CODE i;
     const auto inven_label = prepare_label_string(creature, USE_INVEN, item_tester);
     for (k = 0, i = 0; i < z; i++) {
         auto &item = *creature.inventory[i];
@@ -134,22 +134,22 @@ COMMAND_CODE show_inventory(CreatureEntity &creature, int target_item, BIT_FLAGS
  */
 void display_inventory(CreatureEntity &creature, const ItemTester &item_tester)
 {
-    int i, z = 0;
+    int z = 0;
     TERM_COLOR attr = TERM_WHITE;
     if (creature.inventory.empty()) {
         return;
     }
 
     const auto &[wid, hgt] = term_get_size();
-    for (i = 0; i < INVEN_PACK; i++) {
-        auto o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        auto o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
-        z = i + 1;
+        z = enum2i(i_idx) + 1;
     }
 
-    for (i = 0; i < z; i++) {
+    for (auto i = 0; i < z; i++) {
         if (i >= hgt) {
             break;
         }
@@ -191,7 +191,7 @@ void display_inventory(CreatureEntity &creature, const ItemTester &item_tester)
         }
     }
 
-    for (i = z; i < hgt; i++) {
+    for (auto i = z; i < hgt; i++) {
         term_erase(0, i);
     }
 }

--- a/src/view/display-player-stat-info.cpp
+++ b/src/view/display-player-stat-info.cpp
@@ -202,9 +202,9 @@ static DisplaySymbol compensate_stat_by_weapon(uint8_t color, ItemEntity *o_ptr,
  */
 static void display_equipments_compensation(CreatureEntity &creature, int row, int *col)
 {
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
-        o_ptr = creature.inventory[i].get();
+        o_ptr = creature.inventory[i_idx].get();
         auto flags = o_ptr->get_flags_known();
         for (int stat = 0; stat < A_MAX; stat++) {
             DisplaySymbol symbol(TERM_SLATE, '.');

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -416,15 +416,15 @@ tl::optional<int> display_player(CreatureEntity &creature, const int tmp_mode)
  */
 void display_player_equippy(CreatureEntity &creature, TERM_LEN y, TERM_LEN x, BIT_FLAGS16 mode)
 {
-    const auto max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
-    for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
-        const auto &item = *creature.inventory[i];
+    const auto range = (mode & DP_WP) ? INVEN_WEAPON_SLOTS : INVEN_WIELDING_SLOTS;
+    for (const auto i_idx : range) {
+        const auto &item = *creature.inventory[i_idx];
         auto symbol = item.get_symbol();
         if (!equippy_chars || !item.is_valid()) {
             symbol.color = TERM_DARK;
             symbol.character = ' ';
         }
 
-        term_putch(x + i - INVEN_MAIN_HAND, y, symbol);
+        term_putch(x + i_idx - INVEN_MAIN_HAND, y, symbol);
     }
 }

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -4,6 +4,7 @@
 #include "game-option/special-options.h"
 #include "game-option/text-display-options.h"
 #include "inventory/inventory-describer.h"
+#include "inventory/inventory-slot-types.h"
 #include "inventory/inventory-util.h"
 #include "locale/japanese.h"
 #include "main/sound-of-music.h"
@@ -311,18 +312,18 @@ static void display_equipment(CreatureEntity &creature, const ItemTester &item_t
     const auto &[wid, hgt] = term_get_size();
     const auto &empty_symbol = BaseitemService::get_dummy_symbol();
     byte attr = TERM_WHITE;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        int cur_row = i - INVEN_MAIN_HAND;
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        int cur_row = i_idx - INVEN_MAIN_HAND;
         if (cur_row >= hgt) {
             break;
         }
 
-        const auto &item = *creature.inventory[i];
-        auto do_disp = creature.select_ring_slot ? is_ring_slot(i) : item_tester.okay(&item);
+        const auto &item = *creature.inventory[i_idx];
+        auto do_disp = creature.select_ring_slot ? is_ring_slot(i_idx) : item_tester.okay(&item);
         std::string tmp_val = "   ";
 
         if (do_disp) {
-            tmp_val[0] = index_to_label(i);
+            tmp_val[0] = index_to_label(i_idx);
             tmp_val[1] = ')';
         }
 
@@ -331,8 +332,8 @@ static void display_equipment(CreatureEntity &creature, const ItemTester &item_t
         term_putstr(0, cur_row, cur_col, TERM_WHITE, tmp_val);
 
         std::string item_name;
-        auto is_two_handed = (i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(creature);
-        is_two_handed |= (i == INVEN_SUB_HAND) && can_attack_with_main_hand(creature);
+        auto is_two_handed = (i_idx == INVEN_MAIN_HAND) && can_attack_with_sub_hand(creature);
+        is_two_handed |= (i_idx == INVEN_SUB_HAND) && can_attack_with_main_hand(creature);
         if (is_two_handed && creature.has_two_handed_weapons()) {
             item_name = _("(武器を両手持ち)", "(wielding with two-hands)");
             attr = TERM_WHITE;
@@ -365,7 +366,7 @@ static void display_equipment(CreatureEntity &creature, const ItemTester &item_t
 
         if (show_labels) {
             term_putstr(wid - 20, cur_row, -1, TERM_WHITE, " <-- ");
-            prt(mention_use(creature, i), cur_row, wid - 15);
+            prt(mention_use(creature, i_idx), cur_row, wid - 15);
         }
     }
 

--- a/src/window/main-window-equipments.cpp
+++ b/src/window/main-window-equipments.cpp
@@ -33,7 +33,6 @@
  */
 COMMAND_CODE show_equipment(CreatureEntity &creature, int target_item, BIT_FLAGS mode, const ItemTester &item_tester)
 {
-    COMMAND_CODE i;
     int j, k, l;
     COMMAND_CODE out_index[23]{};
     TERM_COLOR out_color[23]{};
@@ -42,11 +41,12 @@ COMMAND_CODE show_equipment(CreatureEntity &creature, int target_item, BIT_FLAGS
     auto col = command_gap;
     const auto &[wid, hgt] = term_get_size();
     auto len = wid - col - 1;
-    for (k = 0, i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto &item = *creature.inventory[i];
-        auto only_slot = !(creature.select_ring_slot ? is_ring_slot(i) : (item_tester.okay(&item) || any_bits(mode, USE_FULL)));
-        auto is_any_hand = (i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(creature);
-        is_any_hand |= (i == INVEN_SUB_HAND) && can_attack_with_main_hand(creature);
+    k = 0;
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        const auto &item = *creature.inventory[i_idx];
+        auto only_slot = !(creature.select_ring_slot ? is_ring_slot(i_idx) : (item_tester.okay(&item) || any_bits(mode, USE_FULL)));
+        auto is_any_hand = (i_idx == INVEN_MAIN_HAND) && can_attack_with_sub_hand(creature);
+        is_any_hand |= (i_idx == INVEN_SUB_HAND) && can_attack_with_main_hand(creature);
         auto is_two_handed = is_any_hand && creature.has_two_handed_weapons();
         only_slot &= !is_two_handed || any_bits(mode, IGNORE_BOTHHAND_SLOT);
         if (only_slot) {
@@ -62,7 +62,7 @@ COMMAND_CODE show_equipment(CreatureEntity &creature, int target_item, BIT_FLAGS
             out_color[k] = tval_to_attr[enum2i(item.bi_key.tval()) % 128];
         }
 
-        out_index[k] = i;
+        out_index[k] = i_idx;
         if (item.timeout) {
             out_color[k] = TERM_L_DARK;
         }
@@ -91,7 +91,7 @@ COMMAND_CODE show_equipment(CreatureEntity &creature, int target_item, BIT_FLAGS
     const auto equip_label = prepare_label_string(creature, USE_EQUIP, item_tester);
     const auto &empty_symbol = BaseitemService::get_dummy_symbol();
     for (j = 0; j < k; j++) {
-        i = out_index[j];
+        const auto i = out_index[j];
         const auto &item = *creature.inventory[i];
         prt("", j + 1, col ? col - 2 : col);
         std::string head;

--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -40,6 +40,7 @@
 #include "world/world.h"
 
 #include <algorithm>
+#include <range/v3/view.hpp>
 #include <sstream>
 #include <string>
 #include <tuple>
@@ -278,9 +279,9 @@ bool exe_cmd_debug(CreatureEntity &creature, char cmd)
         gain_exp(creature, command_arg ? command_arg : (creature.get_exp() + 1));
         return true;
     case 'X':
-        for (INVENTORY_IDX i = INVEN_TOTAL - 1; i >= 0; i--) {
-            if (creature.inventory[i]->is_valid()) {
-                drop_from_inventory(creature, i, 999);
+        for (const auto i_idx : INVEN_ALL_SLOTS | ranges::views::reverse) {
+            if (creature.inventory[i_idx]->is_valid()) {
+                drop_from_inventory(creature, i_idx, 999);
             }
         }
         player_outfit(creature);

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -270,8 +270,8 @@ void wiz_modify_item_activation(CreatureEntity &creature)
  */
 void wiz_identify_full_inventory(CreatureEntity &creature)
 {
-    for (int i = 0; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = creature.inventory[i].get();
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        auto *o_ptr = creature.inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }


### PR DESCRIPTION
変愚蛮怒 PR #5461 を bakabakaband 構造へ適応してマージ。生のインデックス整数 ループで扱っていたアイテムスロット範囲を、型安全な EnumRange 定数の range-based for ループに置き換える。

core:
- util/enum-range.h: EnumRange::iterator を双方向イテレータ化 (operator-- 追加、 iterator_concept を bidirectional_iterator_tag に)、EnumRangeInclusive に to_enum_range() を追加。
- inventory/inventory-slot-types.h: スロット範囲定数を追加。 INVEN_PACK_SLOTS (所持品 0..INVEN_PACK-1) / INVEN_WEAPON_SLOTS (近接・遠隔武器) / INVEN_ALL_SLOTS (全スロット 0..INVEN_TOTAL-1)。 既存の INVEN_WIELDING_SLOTS は bakabakaband 固有スロット INVEN_ASSHOLE まで 含む定義をそのまま活用 (上流の INVEN_FEET と異なるが、定数経由のため ループは正しく追従する)。

約49ファイルのスロットループを上流diffに従って range-based for へ変換:
- for (int i = 0; i < INVEN_TOTAL; i++)        → INVEN_ALL_SLOTS
- for (int i = 0; i < INVEN_PACK; i++)         → INVEN_PACK_SLOTS
- for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) → INVEN_WIELDING_SLOTS
- 武器スロット限定ループ                       → INVEN_WEAPON_SLOTS
- ループ変数を i_idx に統一、整数演算が必要な箇所は enum2i(i_idx)、
  逆順ループは ranges::views::reverse を使用。

bakabakaband 構造への適応:
- 上流 player_ptr->inventory[i] は bakabakaband では creature.inventory[i_idx] (CreatureEntity&)。アクセサ形を保持しループ部のみ変換。
- 上流が load.cpp で変換した collect_known_fixed_artifacts 相当は bakabakaband では knowledge-items.cpp に存在するため、そちらを変換 (load.cpp は対象関数なし)。
- bakabakaband 固有のループ (INVEN_MAIN_HAND<=INVEN_FEET 等、上流非対象) は温存。

ビルド (g++ 日本語版、-Werror -Wall -Wextra で警告 0) ・clang-format-18・ include-style・BOM・newline チェック通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized inventory traversal across the game to use predefined slot groups (pack, wielding, weapons, all slots) instead of raw numeric ranges, improving consistency and reducing the risk of edge-case misses during inventory-related actions.
  * Updated bidirectional slot-range utilities to better support reverse and range-based iteration patterns.
* **User-facing improvements**
  * Inventory scanning behavior used by features like auto-pick, curse handling, item selection in UIs, and inventory rendering should now be more consistent across all slot types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->