### PR TITLE
refactor: AvatarChanger の m_ptr ポインタを参照に組み替え

### DIFF
--- a/src/avatar/avatar-changer.cpp
+++ b/src/avatar/avatar-changer.cpp
@@ -21,7 +21,7 @@
  */
 AvatarChanger::AvatarChanger(CreatureEntity &creature, const CreatureEntity &target)
     : creature(creature)
-    , m_ptr(&target)
+    , target(target)
 {
 }
 
@@ -32,8 +32,8 @@ void AvatarChanger::change_virtue()
 {
     this->change_virtue_non_beginner();
     this->change_virtue_unique();
-    const auto &r_ref = this->m_ptr->get_real_monrace();
-    if (this->m_ptr->get_r_idx() == MonraceId::BEGGAR || this->m_ptr->get_r_idx() == MonraceId::LEPER) {
+    const auto &r_ref = this->target.get_real_monrace();
+    if (this->target.get_r_idx() == MonraceId::BEGGAR || this->target.get_r_idx() == MonraceId::LEPER) {
         chg_virtue(this->creature, Virtue::COMPASSION, -1);
     }
 
@@ -57,7 +57,7 @@ void AvatarChanger::change_virtue()
 void AvatarChanger::change_virtue_non_beginner()
 {
     const auto &floor = *this->creature.get_floor();
-    const auto &monrace = this->m_ptr->get_monrace();
+    const auto &monrace = this->target.get_monrace();
     if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::BEGINNER)) {
         return;
     }
@@ -84,7 +84,7 @@ void AvatarChanger::change_virtue_non_beginner()
  */
 void AvatarChanger::change_virtue_unique()
 {
-    const auto &monrace = this->m_ptr->get_monrace();
+    const auto &monrace = this->target.get_monrace();
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {
         return;
     }
@@ -110,7 +110,7 @@ void AvatarChanger::change_virtue_unique()
 void AvatarChanger::change_virtue_good_evil()
 {
     const auto &floor = *this->creature.get_floor();
-    const auto &monrace = this->m_ptr->get_monrace();
+    const auto &monrace = this->target.get_monrace();
     if (monrace.kind_flags.has(MonsterKindType::GOOD) && ((monrace.level) / 10 + (3 * floor.dun_level) >= randint1(100))) {
         chg_virtue(this->creature, Virtue::UNLIFE, 1);
     }
@@ -141,7 +141,7 @@ void AvatarChanger::change_virtue_good_evil()
 void AvatarChanger::change_virtue_revenge()
 {
     const auto &floor = *this->creature.get_floor();
-    const auto &monrace = this->m_ptr->get_monrace();
+    const auto &monrace = this->target.get_monrace();
     if (monrace.r_deaths == 0) {
         return;
     }
@@ -162,7 +162,7 @@ void AvatarChanger::change_virtue_revenge()
 void AvatarChanger::change_virtue_wild_thief()
 {
     const auto &floor = *this->creature.get_floor();
-    const auto &monrace = this->m_ptr->get_monrace();
+    const auto &monrace = this->target.get_monrace();
     auto innocent = true;
     auto thief = false;
     for (const auto &blow : monrace.blows) {
@@ -202,7 +202,7 @@ void AvatarChanger::change_virtue_wild_thief()
  */
 void AvatarChanger::change_virtue_good_animal()
 {
-    const auto &monrace = this->m_ptr->get_monrace();
+    const auto &monrace = this->target.get_monrace();
     auto magic_ability_flags = monrace.ability_flags;
     magic_ability_flags.reset(RF_ABILITY_NOMAGIC_MASK);
     if (monrace.kind_flags.has_not(MonsterKindType::ANIMAL) || monrace.kind_flags.has(MonsterKindType::EVIL) || magic_ability_flags.any()) {

--- a/src/avatar/avatar-changer.h
+++ b/src/avatar/avatar-changer.h
@@ -15,7 +15,7 @@ public:
 
 private:
     CreatureEntity &creature;
-    const CreatureEntity *m_ptr;
+    const CreatureEntity &target;
     void change_virtue_non_beginner();
     void change_virtue_unique();
     void change_virtue_good_evil();


### PR DESCRIPTION
AvatarChanger が保持していた攻撃対象 const CreatureEntity *m_ptr を const CreatureEntity &target 参照に変更。コンストラクタで参照を直接
束縛し、全アクセス箇所 (this->m_ptr->...) を this->target. に置換。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements for enhanced maintainability and type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->