### PR TITLE
refactor: CON(耐久)による最大HP補正をプレイヤー・モンスター共通化

### DIFF
--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -557,6 +557,13 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
         m_ptr->max_maxhp = std::min(MONSTER_MAXHP, hp);
     }
 
+    // 耐久(CON)に基づく最大HP補正をプレイヤーと共通の式で常に適用する。
+    // 低CON個体では負値となり得るため、最低1HPを保証する。
+    {
+        auto hp = m_ptr->max_maxhp + m_ptr->calc_max_hp_con_bonus();
+        m_ptr->max_maxhp = std::clamp(hp, 1, MONSTER_MAXHP);
+    }
+
     m_ptr->maxhp = m_ptr->max_maxhp;
     if (new_monrace.cur_hp_per != 0) {
         m_ptr->hp = m_ptr->maxhp * new_monrace.cur_hp_per / 100;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -415,7 +415,7 @@ static void update_bonuses(CreatureEntity &creature)
  */
 static void update_max_hitpoints(CreatureEntity &creature)
 {
-    int bonus = ((int)(adj_con_mhp[creature.get_stat_index(A_CON)]) - 128) * creature.get_level() / 4;
+    int bonus = creature.calc_max_hp_con_bonus();
     int mhp = creature.player_hp[creature.get_level() - 1];
 
     CreatureClass pc(creature);

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -30,6 +30,7 @@
 #include "player/player-personality.h"
 #include "player/player-realm.h"
 #include "player/player-status-flags.h"
+#include "player/player-status-table.h"
 #include "player/race-info-table.h"
 #include "realm/realm-song-numbers.h"
 #include "realm/realm-types.h"
@@ -2195,4 +2196,28 @@ bool CreatureEntity::has_anti_tele() const
 void CreatureEntity::increment_seen_count() const
 {
     MonraceRecords::get_instance().increment_seen_count(this->get_r_idx());
+}
+
+int CreatureEntity::stat_value_to_table_index(int stat_value)
+{
+    // 内部 30-2000 -> 索引 0-197 へ変換 (PlayerBasicStatistics::update_index_status と同一式)。
+    // 30-180:   0-15  (旧 表示 3-18 相当)
+    // 190-2000: 16-197 (表示 18.0 超〜200.0 相当)
+    int index;
+    if (stat_value <= 180) {
+        index = (stat_value - 30) / 10;
+    } else if (stat_value <= STAT_MAX_VALUE) {
+        index = 15 + (stat_value - 180) / 10;
+    } else {
+        index = static_cast<int>(STAT_TABLE_SIZE) - 1;
+    }
+
+    // 表示 3.0 未満 (index < 0) や上限超過でも配列範囲に収める。
+    return std::clamp(index, 0, static_cast<int>(STAT_TABLE_SIZE) - 1);
+}
+
+int CreatureEntity::calc_max_hp_con_bonus() const
+{
+    const auto index = stat_value_to_table_index(this->get_stat_use(A_CON));
+    return (static_cast<int>(adj_con_mhp[index]) - 128) * this->get_level() / 4;
 }

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -205,6 +205,23 @@ public:
     }
 
     /*!
+     * @brief 能力値の内部値 (stat_use 等) を adj_* テーブルの索引に変換する
+     * @param stat_value 能力値の内部値 (30 = 表示 3.0 〜 STAT_MAX_VALUE)
+     * @return 0 〜 STAT_TABLE_SIZE-1 にクランプした索引
+     * @details プレイヤー・モンスター共通。表示 3.0 未満や上限超過でも
+     *          配列範囲外参照を起こさないようガードを内蔵する。
+     */
+    static int stat_value_to_table_index(int stat_value);
+
+    /*!
+     * @brief 耐久 (CON) に基づく最大HP補正値を計算する (プレイヤー・モンスター共通)
+     * @return レベルと CON に応じた加算HP
+     * @details adj_con_mhp テーブルを CON の内部値から引き、(値 - 128) * レベル / 4 を返す。
+     *          索引算出には stat_value_to_table_index() のガードを用いる。
+     */
+    int calc_max_hp_con_bonus() const;
+
+    /*!
      * @brief クリーチャーの速度を取得
      * @return 速度値
      */


### PR DESCRIPTION
HP算出統合の第一工程として、CON に基づく最大HP補正を
CreatureEntity の共通メソッドに集約し、モンスターにも常時適用する。

- CreatureEntity::calc_max_hp_con_bonus(): adj_con_mhp テーブルから CON補正HP ((値 - 128) * レベル / 4) を算出する共通メソッドを追加。
- CreatureEntity::stat_value_to_table_index(): 能力値内部値を adj_* 索引へ 変換する static ヘルパを追加。表示3.0未満(負索引)や上限超過でも配列 範囲外参照しないよう std::clamp でガード。変換式は PlayerBasicStatistics::update_index_status と同一。
- player-status.cpp update_max_hitpoints(): 旧来のインライン式 (get_stat_index 経由) を calc_max_hp_con_bonus() 呼出に置換。 モンスターは stat_index[] を計算しないため stat_use から索引を導く 共通メソッドへ統一した (プレイヤーでは結果は従来と一致)。
- one-monster-placer.cpp place_monster_one(): 全HP補正(サイズ修飾子・ ironman_nightmare)適用後に CON補正を加算。低CON個体で負値となり得る ため [1, MONSTER_MAXHP] にクランプ。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected creature maximum HP calculations to properly apply Constitution-based adjustments across both monsters and player characters, ensuring consistent stat scaling throughout the game.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->