### PR TITLE
refactor: 最大HP下限保証 (レベル+1) をプレイヤー・モンスター共通化

### DIFF
--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -558,10 +558,10 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     }
 
     // 耐久(CON)に基づく最大HP補正をプレイヤーと共通の式で常に適用する。
-    // 低CON個体では負値となり得るため、最低1HPを保証する。
+    // 低CON個体では負値となり得るため、プレイヤーと共通の下限 (レベル+1) を保証する。
     {
         auto hp = m_ptr->max_maxhp + m_ptr->calc_max_hp_con_bonus();
-        m_ptr->max_maxhp = std::clamp(hp, 1, MONSTER_MAXHP);
+        m_ptr->max_maxhp = std::clamp(hp, m_ptr->calc_min_max_hp(), MONSTER_MAXHP);
     }
 
     m_ptr->maxhp = m_ptr->max_maxhp;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -441,8 +441,8 @@ static void update_max_hitpoints(CreatureEntity &creature)
         mhp = mhp * (110 + (((creature.get_level() + 40) * (creature.get_level() + 40) - 1550) / 110)) / 100;
     }
 
-    if (mhp < creature.get_level() + 1) {
-        mhp = creature.get_level() + 1;
+    if (mhp < creature.calc_min_max_hp()) {
+        mhp = creature.calc_min_max_hp();
     }
     if (creature.is_hero()) {
         mhp += 10;

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -222,6 +222,16 @@ public:
     int calc_max_hp_con_bonus() const;
 
     /*!
+     * @brief 最大HPの下限値を返す (プレイヤー・モンスター共通)
+     * @return レベル + 1
+     * @details 各種補正の結果が極端に小さくなっても、最低でもこの値を最大HPとして保証する。
+     */
+    int calc_min_max_hp() const
+    {
+        return this->get_level() + 1;
+    }
+
+    /*!
      * @brief クリーチャーの速度を取得
      * @return 速度値
      */


### PR DESCRIPTION
HP算出統合の第二工程として、最大HPの下限値保証を CreatureEntity の
共通メソッドに集約する。

- CreatureEntity::calc_min_max_hp(): 最大HPの下限 (get_level() + 1) を 返す共通メソッドを追加。
- player-status.cpp update_max_hitpoints(): 旧来のインライン下限保証 (mhp < level + 1) を calc_min_max_hp() 呼出に置換 (結果は従来と一致)。
- one-monster-placer.cpp place_monster_one(): CON補正後のクランプ下限を 従来の固定値 1 から共通の calc_min_max_hp() (レベル+1) に変更。 これによりモンスターもプレイヤーと同じ下限保証となる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized minimum health point calculations across monsters and characters to use a consistent, level-dependent formula instead of fixed thresholds, improving fairness for creatures with lower attribute values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->