### PR TITLE
refactor: 一時状態による最大HP補正をプレイヤー・モンスター共通化

### DIFF
--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -564,6 +564,13 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
         m_ptr->max_maxhp = std::clamp(hp, m_ptr->calc_min_max_hp(), MONSTER_MAXHP);
     }
 
+    // 一時状態(英雄化/狂戦士化/つよし/呪術)による最大HP補正も共通式で適用する。
+    // 生成直後の通常モンスターは該当状態を持たないため通常は 0。
+    {
+        auto hp = m_ptr->max_maxhp + m_ptr->calc_max_hp_status_bonus();
+        m_ptr->max_maxhp = std::min(MONSTER_MAXHP, hp);
+    }
+
     m_ptr->maxhp = m_ptr->max_maxhp;
     if (new_monrace.cur_hp_per != 0) {
         m_ptr->hp = m_ptr->maxhp * new_monrace.cur_hp_per / 100;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -444,21 +444,7 @@ static void update_max_hitpoints(CreatureEntity &creature)
     if (mhp < creature.calc_min_max_hp()) {
         mhp = creature.calc_min_max_hp();
     }
-    if (creature.is_hero()) {
-        mhp += 10;
-    }
-    if (creature.is_shero()) {
-        mhp += 30;
-    }
-    if (creature.get_timed_effect(CreatureTimedEffect::TSUYOSHI)) {
-        mhp += 50;
-    }
-    if (SpellHex(creature).is_spelling_specific(HEX_XTRA_MIGHT)) {
-        mhp += 15;
-    }
-    if (SpellHex(creature).is_spelling_specific(HEX_BUILDING)) {
-        mhp += 60;
-    }
+    mhp += creature.calc_max_hp_status_bonus();
     if (creature.maxhp == mhp) {
         return;
     }

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -32,8 +32,10 @@
 #include "player/player-status-flags.h"
 #include "player/player-status-table.h"
 #include "player/race-info-table.h"
+#include "realm/realm-hex-numbers.h"
 #include "realm/realm-song-numbers.h"
 #include "realm/realm-types.h"
+#include "spell-realm/spells-hex.h"
 #include "system/angband-system.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
@@ -538,7 +540,12 @@ bool CreatureEntity::is_hero() const
 
 bool CreatureEntity::is_shero() const
 {
-    return this->get_timed_effect(CreatureTimedEffect::BERSERK) > 0 || this->pclass == PlayerClassType::BERSERKER;
+    if (this->get_timed_effect(CreatureTimedEffect::BERSERK) > 0) {
+        return true;
+    }
+    // BERSERKER クラスのパッシブはプレイヤー固有。モンスターは pclass を持ち得ても
+    // クラスに紐づく常時シェロ化の意味論は持たないため、is_player() で限定する。
+    return this->is_player() && this->pclass == PlayerClassType::BERSERKER;
 }
 
 bool CreatureEntity::is_echizen() const
@@ -2220,4 +2227,29 @@ int CreatureEntity::calc_max_hp_con_bonus() const
 {
     const auto index = stat_value_to_table_index(this->get_stat_use(A_CON));
     return (static_cast<int>(adj_con_mhp[index]) - 128) * this->get_level() / 4;
+}
+
+int CreatureEntity::calc_max_hp_status_bonus()
+{
+    int bonus = 0;
+    if (this->is_hero()) {
+        bonus += 10;
+    }
+    if (this->is_shero()) {
+        bonus += 30;
+    }
+    if (this->get_timed_effect(CreatureTimedEffect::TSUYOSHI) > 0) {
+        bonus += 50;
+    }
+
+    // 呪術 (HEX) はプレイヤー専用。モンスターでは spell_hex_data が無く常に false。
+    SpellHex spell_hex(*this);
+    if (spell_hex.is_spelling_specific(HEX_XTRA_MIGHT)) {
+        bonus += 15;
+    }
+    if (spell_hex.is_spelling_specific(HEX_BUILDING)) {
+        bonus += 60;
+    }
+
+    return bonus;
 }

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -232,6 +232,15 @@ public:
     }
 
     /*!
+     * @brief 一時的な状態による最大HP補正値を計算する (プレイヤー・モンスター共通)
+     * @return 加算HP (英雄化 +10 / 狂戦士化 +30 / つよしスペシャル +50 /
+     *         呪術 HEX_XTRA_MIGHT +15 / HEX_BUILDING +60 の合計)
+     * @details 呪術 (HEX) はプレイヤー専用のため、モンスターでは spell_hex_data が
+     *          無く常に 0 となる。英雄化等の時限効果は timed_effects_map で共通管理。
+     */
+    int calc_max_hp_status_bonus();
+
+    /*!
      * @brief クリーチャーの速度を取得
      * @return 速度値
      */


### PR DESCRIPTION
HP算出統合の第三工程として、一時的な状態による最大HP補正を
CreatureEntity の共通メソッドに集約し、モンスターにも適用する。

- CreatureEntity::calc_max_hp_status_bonus(): 英雄化(+10)/狂戦士化(+30)/ つよしスペシャル(+50)/呪術 HEX_XTRA_MIGHT(+15)/HEX_BUILDING(+60) の 合計補正を返す共通メソッドを追加。英雄化等は timed_effects_map で 共通管理されるためモンスターでも判定可能。HEX 呪術はプレイヤー専用 (get_specific_data がモンスターで nullptr のため SpellHex は安全に 常時 false を返す)。
- player-status.cpp update_max_hitpoints(): 旧来の5つのインライン状態 判定を calc_max_hp_status_bonus() 呼出に置換 (結果は従来と一致)。
- one-monster-placer.cpp place_monster_one(): CON補正・下限保証の後に 状態補正を加算し MONSTER_MAXHP でクランプ。生成直後の通常モンスターは 該当状態を持たないため通常 0 だが、経路を共通化し将来の再計算に備える。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Maximum HP now consistently includes temporary status-based bonuses (hero/shero states, TSUYOSHI, and relevant HEX effects) in more situations.
  * Newly generated monsters now apply these status bonuses during max-HP generation while still respecting the overall max-HP limit.
* **Refactor**
  * Consolidated the temporary max-HP bonus calculation into a shared computation to keep player and monster behavior aligned.
  * Updated berserker/“shero” determination to better reflect active timed effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->