### PR TITLE
refactor: 最大HP(maxhp/max_maxhp)の意味をプレイヤー・モンスター共通化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,6 +451,45 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
 スケールアップ) の両方で同じ計算式を使用。さらに `c` ステータス画面 (`display_player`)
 の `ENTRY_HP_REGEN`/`ENTRY_MP_REGEN` 表示もモンスター inspect 時に同じ式で表示される。
 
+### 最大HP算出の統一 (`maxhp` / `max_maxhp` の意味統一)
+
+プレイヤーとモンスターの最大HP算出を観点ごとに `CreatureEntity` の共通メソッドへ
+集約している。各補正は **プレイヤー (`update_max_hitpoints`) とモンスター生成
+(`place_monster_one`) の両経路から同一メソッドを呼ぶ**ことで一致させる。
+
+- `calc_max_hp_con_bonus()`: CON(耐久)補正 `(adj_con_mhp[idx] - 128) * level / 4`。
+  索引は `stat_value_to_table_index()` で配列範囲にクランプ (モンスターは
+  `stat_index[]` を計算しないため `stat_use` から都度算出)。
+- `calc_min_max_hp()`: 最大HP下限 `level + 1`。
+- `calc_max_hp_status_bonus()`: 一時状態補正 (英雄化/狂戦士化/つよし/呪術)。
+  HEX はプレイヤー専用だが `SpellHex(monster)` は安全に常時 false。
+
+**`maxhp` / `max_maxhp` の意味は以下に統一済み (プレイヤー・モンスター共通):**
+
+| フィールド | 意味 |
+|---|---|
+| `max_maxhp` | 本来の最大HP (一時減少前のキャップ)。経験値計算・dealt_damage 上限・捕獲判定など一時減少に左右されるべきでない処理が参照。getter は `get_max_maxhp()` |
+| `maxhp` | 現在の最大HP (一時減少を反映した実効値)。HP回復上限・被ダメージ・表示はこちら。getter は `get_max_hp()` |
+
+旧来プレイヤーの `max_maxhp` は未設定 (0) だったが、本統一で
+`update_max_hitpoints` が `set_max_hp(mhp)` を呼び **プレイヤーでも `max_maxhp` を
+本来の最大HPとして維持**するようになった (プレイヤー専用 `on_take_hit` を持つため
+従来も実害は無かったが、意味が一貫した)。
+
+**拡張点 (将来の「最大HP一時減少」ステータス異常):**
+
+- `get_maxhp_reduction()` (virtual, 既定 0): 一時的な最大HP減少量を返す拡張シーム。
+- `set_max_hp(full)`: `max_maxhp = full` を確定し `refresh_max_hp()` を呼ぶ唯一の窓口。
+- `refresh_max_hp()`: `maxhp = max(1, max_maxhp - get_maxhp_reduction())` を反映し、
+  現在HPが超過していれば切り詰める。減少量が変化したら呼ぶ。
+
+将来「最大HP一時減少」異常を追加する際は、減少量を `get_maxhp_reduction()` が
+返すようにし (時限効果等から算出)、変化時に `refresh_max_hp()` を呼ぶだけで
+プレイヤー・モンスター双方に反映される。`maxhp = max_maxhp` の直接代入
+(polymorph/floor 変更/捕獲復元等の全回復リセット系) は現状 `reduction == 0` で
+等価のため残置しているが、動的減少を導入する場合はこれらも `refresh_max_hp()`
+経由に切り替えること。
+
 ### `psex` の SEX_NONE
 
 `player_sex::SEX_NONE = 4` (MAX_SEXES = 5) が追加され、`init_monster_profile()` で

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -571,7 +571,8 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
         m_ptr->max_maxhp = std::min(MONSTER_MAXHP, hp);
     }
 
-    m_ptr->maxhp = m_ptr->max_maxhp;
+    // 本来の最大HP (max_maxhp) を確定済み。一時減少を反映した現在の最大HP (maxhp) を導く。
+    m_ptr->refresh_max_hp();
     if (new_monrace.cur_hp_per != 0) {
         m_ptr->hp = m_ptr->maxhp * new_monrace.cur_hp_per / 100;
     } else {

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -445,21 +445,22 @@ static void update_max_hitpoints(CreatureEntity &creature)
         mhp = creature.calc_min_max_hp();
     }
     mhp += creature.calc_max_hp_status_bonus();
-    if (creature.maxhp == mhp) {
+
+    // mhp は一時減少を含まない本来の最大HP。max_maxhp / maxhp の両方が
+    // 変化しなければ再描画不要。
+    const auto old_maxhp = creature.get_max_hp();
+    if ((old_maxhp == mhp) && (creature.get_max_maxhp() == mhp)) {
         return;
     }
 
-    if (creature.hp >= mhp) {
-        creature.hp = mhp;
-        creature.hp_frac = 0;
-    }
-
 #ifdef JP
-    if (creature.has_level_up_message() && (mhp > creature.maxhp)) {
-        msg_format("最大ヒット・ポイントが %d 増加した！", (mhp - creature.maxhp));
+    if (creature.has_level_up_message() && (mhp > old_maxhp)) {
+        msg_format("最大ヒット・ポイントが %d 増加した！", (mhp - old_maxhp));
     }
 #endif
-    creature.maxhp = mhp;
+
+    // 本来の最大HP (max_maxhp) を確定し、現在の最大HP (maxhp) と現在HPを再計算する。
+    creature.set_max_hp(mhp);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::HP);

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -2229,6 +2229,24 @@ int CreatureEntity::calc_max_hp_con_bonus() const
     return (static_cast<int>(adj_con_mhp[index]) - 128) * this->get_level() / 4;
 }
 
+void CreatureEntity::set_max_hp(int full_max_hp)
+{
+    this->max_maxhp = full_max_hp;
+    this->refresh_max_hp();
+}
+
+void CreatureEntity::refresh_max_hp()
+{
+    // 本来の最大HPから一時減少を差し引いた値を現在の最大HPとする (下限1)。
+    this->maxhp = std::max(1, this->max_maxhp - this->get_maxhp_reduction());
+
+    // 現在HPが新しい最大HPに達した/上回る場合は端数を含めて切り詰める。
+    if (this->hp >= this->maxhp) {
+        this->hp = this->maxhp;
+        this->hp_frac = 0;
+    }
+}
+
 int CreatureEntity::calc_max_hp_status_bonus()
 {
     int bonus = 0;

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -205,6 +205,48 @@ public:
     }
 
     /*!
+     * @brief クリーチャーの本来の(一時減少前の)最大HPを取得する
+     * @return 本来の最大HP (max_maxhp)
+     * @details プレイヤー・モンスター共通で「一時的な最大HP減少が一切無い場合の
+     *          最大HP」を表す。経験値計算・dealt_damage 上限・捕獲判定など、
+     *          一時減少に左右されるべきでない処理はこちらを参照する。
+     */
+    virtual int get_max_maxhp() const
+    {
+        return this->max_maxhp;
+    }
+
+    /*!
+     * @brief 一時的な最大HP減少量を取得する (プレイヤー・モンスター共通の拡張点)
+     * @return 現在の最大HP減少量 (>= 0)
+     * @details 既定では減少なし (0)。将来「最大HP一時減少」のステータス異常を
+     *          追加する際は、本メソッド (あるいは派生クラスでのオーバーライド) が
+     *          減少量を返すようにすれば、set_max_hp() / refresh_max_hp() 経由で
+     *          maxhp (現在の最大HP) に自動的に反映される。
+     */
+    virtual int get_maxhp_reduction() const
+    {
+        return 0;
+    }
+
+    /*!
+     * @brief 本来の最大HP (max_maxhp) を確定し、現在の最大HP (maxhp) を再計算する
+     * @param full_max_hp 一時減少を含まない本来の最大HP
+     * @details max_maxhp と maxhp の関係を定義する唯一の窓口。
+     *          max_maxhp に full_max_hp を設定し、refresh_max_hp() で
+     *          一時減少を差し引いた値を maxhp に反映する。
+     */
+    void set_max_hp(int full_max_hp);
+
+    /*!
+     * @brief 本来の最大HP (max_maxhp) から現在の最大HP (maxhp) を再計算する
+     * @details maxhp = max(1, max_maxhp - get_maxhp_reduction()) を反映する。
+     *          一時減少量が変化した際に呼ぶ。現在HP (hp) が新しい maxhp を
+     *          超える場合は maxhp まで切り詰める。
+     */
+    void refresh_max_hp();
+
+    /*!
      * @brief 能力値の内部値 (stat_use 等) を adj_* テーブルの索引に変換する
      * @param stat_value 能力値の内部値 (30 = 表示 3.0 〜 STAT_MAX_VALUE)
      * @return 0 〜 STAT_TABLE_SIZE-1 にクランプした索引
@@ -3875,8 +3917,8 @@ public:
 
     // HP関連
     int hp{}; /*!< 現在のHP / Current Hit points */
-    int maxhp{}; /*!< 現在の最大HP / Max Hit points */
-    int max_maxhp{}; /*!< 生成時の初期最大HP / Max Max Hit points */
+    int maxhp{}; /*!< 現在の最大HP (一時減少を反映した実効値) / Effective max Hit points */
+    int max_maxhp{}; /*!< 本来の最大HP (一時減少前のキャップ。プレイヤー・モンスター共通) / Undiminished max Hit points */
     uint32_t hp_frac{}; /*!< HP小数部 / Current hit frac (times 2^16) */
 
     // 基本パラメータ（主にプレイヤー用、モンスターでは未使用）


### PR DESCRIPTION
HP算出統合の第四工程として、maxhp と max_maxhp の意味を統一し、
将来の「最大HP一時減少」ステータス異常に向けた拡張シームを整備する。

意味統一:
- max_maxhp = 本来の最大HP (一時減少前のキャップ)。経験値・dealt_damage 上限・捕獲判定など一時減少に左右されない処理が参照。
- maxhp = 現在の最大HP (一時減少を反映した実効値)。回復上限・被ダメージ・ 表示が参照。
- 旧来プレイヤーの max_maxhp は未設定(0)だったが、update_max_hitpoints が set_max_hp() 経由で本来の最大HPとして維持するよう統一 (プレイヤー専用 on_take_hit を持つため従来も実害は無かったが意味が一貫した)。

拡張シーム (CreatureEntity に追加):
- get_max_maxhp(): 本来の最大HP getter。
- get_maxhp_reduction() (virtual, 既定0): 一時的な最大HP減少量を返す拡張点。 将来の異常追加時はこれをオーバーライド/算出するだけでよい。
- set_max_hp(full): max_maxhp を確定し refresh_max_hp() を呼ぶ唯一の窓口。
- refresh_max_hp(): maxhp = max(1, max_maxhp - get_maxhp_reduction()) を反映し 現在HP超過分を切り詰める。

経路接続:
- player-status.cpp update_max_hitpoints(): creature.maxhp = mhp の直接代入を set_max_hp(mhp) に置換。早期 return 条件に max_maxhp 一致判定を追加し、 max_maxhp が確実に確定するようにした。
- one-monster-placer.cpp place_monster_one(): maxhp = max_maxhp を refresh_max_hp() に置換。

reduction == 0 の現状では全経路の挙動は従来と完全に一致する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Maximum HP handling is now consistent across player progression and monster creation.
  * Temporary maximum HP reductions are now reflected in the effective/displayed maximum HP.

* **Bug Fixes**
  * Updating maximum HP now uses a unified update path, ensuring current HP is correctly clamped when the effective maximum decreases.
  * Monster initial maximum HP now refreshes to account for any temporary HP reductions.

* **Documentation**
  * Clarified the meaning of the maximum HP values and the intended update flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->