### PR TITLE
refactor: player_hp[] を hp_table[] へ改名し全NPC生成時にロール

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -115,7 +115,7 @@ ESP 系 BIT_FLAGS 等）が残存している。モンスターでも将来運�
 | 熟練度 | `spell_exp[]`, `weapon_exp[][]`, `skill_exp[]` | 経験を積むモンスター・成長するボス (提案 10/36 で virtual 化済) |
 | 魔法領域 | `realm1`, `realm2`, `element_realm` | 魔法使い系モンスターのスペル選択根拠 |
 | 突然変異 | `muta`, `trait`, `patron` | 変異個体・カオスパトロン配下 |
-| キャラクタ履歴 | `old_race1/2`, `old_realm`, `history[4][60]`, `player_hp[PY_MAX_LEVEL]` | モンスターのレベル成長履歴 |
+| キャラクタ履歴 | `old_race1/2`, `old_realm`, `history[4][60]`, `hp_table[PY_MAX_LEVEL]` (旧 `player_hp`) | モンスターのレベル成長履歴 |
 | ESP/特殊能力 BIT_FLAGS | `telepathy`, `esp_*`, `cursed`, `special_defense`, `special_attack`, `dec_mana`, `easy_spell` 等 | モンスターの ESP / 呪い装備 / 特殊攻撃防御 (提案 33 で virtual 化済) |
 | 休息/旅行 | `resting`, `running`, `action` | モンスターの待機・徘徊行動状態 |
 | その他 | `class_specific_data`, `old_*` 差分検出キャッシュ | 状態キャッシュはそのままクリーチャー共通で利用 |

--- a/src/birth/birth-stat.cpp
+++ b/src/birth/birth-stat.cpp
@@ -191,7 +191,7 @@ void get_extra(CreatureEntity &creature, bool roll_hitdie)
         roll_hitdice(creature, SPOP_NO_UPDATE);
     }
 
-    creature.maxhp = creature.player_hp[0];
+    creature.maxhp = creature.hp_table[0];
 }
 
 /*!

--- a/src/birth/monster-birth.cpp
+++ b/src/birth/monster-birth.cpp
@@ -696,7 +696,7 @@ void apply_monrace_to_player(CreatureEntity &creature, MonraceId monrace_id)
         creature.set_stat_use(i, creature.get_stat_max(i));
     }
 
-    // HP ダイスをモンスター種族のものに揃える (player_hp[] は get_extra で再計算)
+    // HP ダイスをモンスター種族のものに揃える (hp_table[] は get_extra で再計算)
     creature.hit_dice = monrace.hit_dice;
 
     // 速度: モンスターの基本速度を採用 (110 = 通常)

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -111,7 +111,7 @@ void save_prev_data(CreatureEntity &creature, birther *birther_ptr)
     }
 
     for (int i = 0; i < PY_MAX_LEVEL; i++) {
-        birther_ptr->player_hp[i] = creature.player_hp[i];
+        birther_ptr->hp_table[i] = creature.hp_table[i];
     }
 
     birther_ptr->patron = creature.get_patron();
@@ -164,11 +164,11 @@ void load_prev_data(CreatureEntity &creature, bool swap)
     }
 
     for (int i = 0; i < PY_MAX_LEVEL; i++) {
-        creature.player_hp[i] = previous_char.player_hp[i];
+        creature.hp_table[i] = previous_char.hp_table[i];
     }
 
-    creature.maxhp = creature.player_hp[0];
-    creature.hp = creature.player_hp[0];
+    creature.maxhp = creature.hp_table[0];
+    creature.hp = creature.hp_table[0];
     creature.set_patron(previous_char.patron);
     creature.virtues = previous_char.virtues;
 

--- a/src/birth/quick-start.h
+++ b/src/birth/quick-start.h
@@ -30,7 +30,7 @@ struct birther {
 
     short stat_max[6]{}; /* Current "maximal" stat values */
     short stat_max_max[6]{}; /* Maximal "maximal" stat values */
-    int player_hp[PY_MAX_LEVEL]{};
+    int hp_table[PY_MAX_LEVEL]{};
 
     int16_t patron{}; /*! パトロンのID */
 

--- a/src/load/birth-loader.cpp
+++ b/src/load/birth-loader.cpp
@@ -38,7 +38,7 @@ void load_quick_start(void)
     constexpr int OLD_PY_MAX_LEVEL = 50;
     const int hp_count = loading_savefile_version_is_older_than(49) ? OLD_PY_MAX_LEVEL : PY_MAX_LEVEL;
     for (int i = 0; i < hp_count; i++) {
-        previous_char.player_hp[i] = rd_s16b();
+        previous_char.hp_table[i] = rd_s16b();
     }
 
     previous_char.patron = rd_s16b();

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -149,7 +149,7 @@ static errr load_hp(CreatureEntity &creature)
     }
 
     for (auto i = 0; i < tmp16u; i++) {
-        creature.player_hp[i] = rd_s16b();
+        creature.hp_table[i] = rd_s16b();
     }
 
     return 0;

--- a/src/main-godot/save-file-scanner.cpp
+++ b/src/main-godot/save-file-scanner.cpp
@@ -456,7 +456,11 @@ namespace {
             strip(4); // au (s32)
             strip(6 * 2); // stat_max[A_MAX=6] (s16 各)
             strip(6 * 2); // stat_max_max[A_MAX=6]
-            strip(50 * 2); // player_hp[PY_MAX_LEVEL=50] (s16 各)
+            // [セーブ ver49] 最大プレイヤーレベル拡張 (50→60) に伴い hp_table の件数が変動。
+            // birth-loader.cpp:38-42 と同じ版分岐を保持しないと後続フィールドが
+            // (60-50)*2 = 20 バイトずれて quick_ok 判定が壊れる。
+            const int hp_count = sv_older_than(49) ? 50 : 60;
+            strip(hp_count * 2); // hp_table[PY_MAX_LEVEL] (s16 各)
             strip(2); // chaos_patron
             strip(8 * 2); // vir_types[8]
             for (int i = 0; i < 4; ++i) {

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -502,6 +502,12 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
         (void)set_monster_csleep(floor, g_ptr->m_idx, (val * 2) + randint1(val * 10));
     }
 
+    // 全NPCも生成時に hit_dice をモンスター種族のものに揃え、レベル別HPテーブル
+    // hp_table[] を振る (プレイヤーと共通の土台)。現状、敵モンスターの最大HP算出
+    // には未使用 (max_maxhp は従来通り下記の単発ロールで決定する)。
+    m_ptr->hit_dice = new_monrace.hit_dice;
+    m_ptr->roll_hp_table();
+
     if (new_monrace.misc_flags.has(MonsterMiscType::FORCE_MAXHP)) {
         m_ptr->max_maxhp = new_monrace.hit_dice.maxroll();
     } else {

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -416,7 +416,7 @@ static void update_bonuses(CreatureEntity &creature)
 static void update_max_hitpoints(CreatureEntity &creature)
 {
     int bonus = creature.calc_max_hp_con_bonus();
-    int mhp = creature.player_hp[creature.get_level() - 1];
+    int mhp = creature.hp_table[creature.get_level() - 1];
 
     CreatureClass pc(creature);
     auto is_sorcerer = pc.equals(PlayerClassType::SORCERER);

--- a/src/save/info-writer.cpp
+++ b/src/save/info-writer.cpp
@@ -190,7 +190,7 @@ void save_quick_start(void)
     }
 
     for (int i = 0; i < PY_MAX_LEVEL; i++) {
-        wr_s16b((int16_t)previous_char.player_hp[i]);
+        wr_s16b((int16_t)previous_char.hp_table[i]);
     }
 
     wr_s16b(previous_char.patron);

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -191,7 +191,7 @@ static bool wr_savefile_new(CreatureEntity &creature)
     tmp16u = PY_MAX_LEVEL;
     wr_u16b(tmp16u);
     for (int i = 0; i < tmp16u; i++) {
-        wr_s16b((int16_t)creature.player_hp[i]);
+        wr_s16b((int16_t)creature.hp_table[i]);
     }
 
     wr_u32b(creature.get_spell_learned_flags(0));

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -235,30 +235,8 @@ void roll_hitdice(CreatureEntity &creature, spell_operation options)
         return;
     }
 
-    constexpr auto roll_num = 3 + PY_MAX_LEVEL - 1;
-    const auto expected_hp = creature.hit_dice.maxroll() + creature.hit_dice.floored_expected_value_multiplied_by(roll_num);
-    const auto min_value = expected_hp * 3 / 4;
-    const auto max_value = expected_hp * 5 / 4;
-
-    /* Rerate */
-    while (true) {
-        /* Pre-calculate level 1 hitdice */
-        creature.player_hp[0] = creature.hit_dice.maxroll();
-
-        for (int i = 1; i < 4; i++) {
-            creature.player_hp[0] += creature.hit_dice.roll();
-        }
-
-        /* Roll the hitpoint values */
-        for (int i = 1; i < PY_MAX_LEVEL; i++) {
-            creature.player_hp[i] = creature.player_hp[i - 1] + creature.hit_dice.roll();
-        }
-
-        /* Require "valid" hitpoints at highest level */
-        if ((creature.player_hp[PY_MAX_LEVEL - 1] >= min_value) && (creature.player_hp[PY_MAX_LEVEL - 1] <= max_value)) {
-            break;
-        }
-    }
+    // hp_table[] のロールはプレイヤー・モンスター共通の処理に集約。
+    creature.roll_hp_table();
 
     creature.knowledge &= ~(KNOW_HPRATE);
 

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -1724,7 +1724,7 @@ byte CreatureEntity::get_temporary_speed() const
 
 int CreatureEntity::calc_life_rating() const
 {
-    const auto actual_hp = this->player_hp[PY_MAX_LEVEL - 1];
+    const auto actual_hp = this->hp_table[PY_MAX_LEVEL - 1];
 
     // ダイスによる上昇回数は52回（初期3回+LV50までの49回）なので
     // 期待値計算のため2で割っても端数は出ない
@@ -2227,6 +2227,34 @@ int CreatureEntity::calc_max_hp_con_bonus() const
 {
     const auto index = stat_value_to_table_index(this->get_stat_use(A_CON));
     return (static_cast<int>(adj_con_mhp[index]) - 128) * this->get_level() / 4;
+}
+
+void CreatureEntity::roll_hp_table()
+{
+    constexpr auto roll_num = 3 + PY_MAX_LEVEL - 1;
+    const auto expected_hp = this->hit_dice.maxroll() + this->hit_dice.floored_expected_value_multiplied_by(roll_num);
+    const auto min_value = expected_hp * 3 / 4;
+    const auto max_value = expected_hp * 5 / 4;
+
+    /* Rerate */
+    while (true) {
+        /* Pre-calculate level 1 hitdice */
+        this->hp_table[0] = this->hit_dice.maxroll();
+
+        for (int i = 1; i < 4; i++) {
+            this->hp_table[0] += this->hit_dice.roll();
+        }
+
+        /* Roll the hitpoint values */
+        for (int i = 1; i < PY_MAX_LEVEL; i++) {
+            this->hp_table[i] = this->hp_table[i - 1] + this->hit_dice.roll();
+        }
+
+        /* Require "valid" hitpoints at highest level */
+        if ((this->hp_table[PY_MAX_LEVEL - 1] >= min_value) && (this->hp_table[PY_MAX_LEVEL - 1] <= max_value)) {
+            break;
+        }
+    }
 }
 
 void CreatureEntity::set_max_hp(int full_max_hp)

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -283,6 +283,15 @@ public:
     int calc_max_hp_status_bonus();
 
     /*!
+     * @brief レベル別HPテーブル hp_table[] を hit_dice から振り直す (プレイヤー・モンスター共通)
+     * @details Lv1 は hit_dice の最大値 + 3 回ロール、以降は各レベルで hit_dice を
+     *          1 回ずつ累積する。最終レベルのHPが期待値の 75%〜125% に収まるまで
+     *          振り直す。呼出側で事前に hit_dice を設定しておくこと。
+     *          UI 更新 (再描画・体力ランク表示等) は行わない純粋なロール処理。
+     */
+    void roll_hp_table();
+
+    /*!
      * @brief クリーチャーの速度を取得
      * @return 速度値
      */
@@ -4258,7 +4267,7 @@ public:
     }
     std::vector<int> spell_order_learned{}; /* order spells learned */
 
-    int player_hp[PY_MAX_LEVEL]{};
+    int hp_table[PY_MAX_LEVEL]{};
     std::string last_message = ""; /* Last message on death or retirement */
     char history[4][60]{}; /* Textual "history" for the Player */
 


### PR DESCRIPTION
HP算出統合の第五工程として、レベル別HPテーブルをプレイヤー専用名から
共通名へ改名し、全NPC(モンスター)生成時にもテーブルを振るようにする。

改名:
- CreatureEntity::player_hp[PY_MAX_LEVEL] -> hp_table[PY_MAX_LEVEL]。 Birther::player_hp (quick-start 履歴スナップショット) も hp_table に改名。 全 read/write site (birth / load / save / spell / player-status 等) および関連コメントを一括置換。savefile フォーマットは識別子変更のみで不変。

共通ローラー:
- CreatureEntity::roll_hp_table(): hit_dice から hp_table[] を振り直す純粋な ロール処理を新設 (UI 更新を含まない)。Lv1 = maxroll + 3 ロール、以降累積、 最終Lvが期待値75-125%に収まるまで再ロール。
- roll_hitdice() (spell) は roll_hp_table() を呼ぶ形に簡素化し、プレイヤー 固有の UI 更新 (体力ランク / 再描画 / handle_stuff) のみ残す。

全NPC生成:
- place_monster_one(): 生成時に m_ptr->hit_dice = monrace.hit_dice を設定し roll_hp_table() を呼んで hp_table[] を振る。

方針: 今回は「土台のみ (バランス不変)」。敵モンスターの最大HP算出は従来通り
monrace.hit_dice の単発ロール + 共通補正のままで、hp_table[] は当面未使用の groundwork として保持する (将来テーブル式へ段階移行する際の基盤)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified level-based hit point table handling for both players and monsters, including a shared reroll process.
  * Monster placement now initializes HP values directly from the selected race’s hit-dice and generates the full HP table.

* **Bug Fixes**
  * Corrected maximum HP and life-rating calculations to consistently use the shared HP table.
  * Updated quick-start and save/load serialization to persist and restore HP table values correctly, including version-aware quick-start skipping.

* **Documentation**
  * Updated roadmap/comments to reflect the renamed HP table terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->