### PR TITLE
feat: 敵モンスター最大HPをテーブル式へ移行(第1段:スケール保存)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -490,6 +490,40 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
 等価のため残置しているが、動的減少を導入する場合はこれらも `refresh_max_hp()`
 経由に切り替えること。
 
+#### レベル別HPテーブル (`hp_table[]`) と敵モンスターHPのテーブル式
+
+プレイヤーとモンスターの基礎最大HPは `CreatureEntity::hp_table[PY_MAX_LEVEL]`
+(旧 `player_hp`、レベル別累積HPテーブル) を共通の土台とする。
+
+- `roll_hp_table()`: **プレイヤー (および `player_birth_as_monster` のモンスター運用)**
+  用のローラー。Lv1 = `hit_dice.maxroll()` + 3 ロール、以降は各レベルで `hit_dice`
+  を 1 回ずつ累積する前方加重型。`hit_dice` は職業・種族由来の per-level ダイス。
+  最終レベルHPが期待値の 75〜125% に収まるまで振り直す。`roll_hitdice()` (spell)
+  から呼ばれ、プレイヤー固有の UI 更新 (体力ランク / 再描画) はそちらに残す。
+- `roll_monster_hp_table(force_max)`: **敵モンスター生成 (`place_monster_one`)** 用の
+  ローラー。モンスター種族の `hit_dice` は「全HPの単発ロール」スケールなので、その
+  期待値 `num*(sides+1)/2` を実効レベル `L`(= `get_level()` = `monrace.level/2`,
+  `[1, PY_MAX_LEVEL]` にクランプ) に均等配分する per-level ダイス `1d s`
+  (`s = round(num*(sides+1)/L) - 1`, 最低 1d1) を導き、L レベル分を累積して
+  `hp_table[0..L-1]` を埋め `hp_table[L-1]` を返す。**累積HPの期待値は従来の
+  単発ロール `hit_dice.roll()` と一致し (スケール保存)、分散のみ低下する**
+  (より安定したHP)。プレイヤー用の前方加重 (Lv1 maxroll + 3 ロール) は敵HPの
+  スケールを膨らませるため**用いない**。
+
+  - サイズ補正 (`is_huge()`/`is_large()` 等)・CON 補正 (`calc_max_hp_con_bonus()`)・
+    状態補正 (`calc_max_hp_status_bonus()`)・nightmare 倍化・`MONSTER_MAXHP` クランプ
+    は従来通りこの基礎HPの**後段で**乗算/加算する (一切変更なし)。
+  - `calc_min_max_hp()` (= `level+1`) の下限クランプも従来通り後段で効く。これにより
+    「レベルに対し極端に低い `hit_dice` の特殊モンスター (例: Lv50 で 1d3)」も
+    従来と同じく `level+1` に切り上げられ、テーブル式でも実HPは不変。
+  - 実データ (約 2,300 種) での全パイプライン検証では new/old 最終HP比は
+    平均 1.00 / 中央値 1.00 / 99.4% が ±10% 以内 / 1.3 倍超ゼロ。
+
+  **段階移行ステータス:** これは「敵モンスター最大HPのテーブル式移行」の第 1 段
+  (スケール保存=バランス不変で算出経路をテーブル式に統一) である。今後の段階として、
+  per-level ダイスを JSON データ駆動化する案や、モンスターのレベルアップに伴う
+  HP 成長 (`hp_table[]` を生成時より上の添字へ伸ばす) 等が想定される。
+
 ### `psex` の SEX_NONE
 
 `player_sex::SEX_NONE = 4` (MAX_SEXES = 5) が追加され、`init_monster_profile()` で

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -502,17 +502,15 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
         (void)set_monster_csleep(floor, g_ptr->m_idx, (val * 2) + randint1(val * 10));
     }
 
-    // 全NPCも生成時に hit_dice をモンスター種族のものに揃え、レベル別HPテーブル
-    // hp_table[] を振る (プレイヤーと共通の土台)。現状、敵モンスターの最大HP算出
-    // には未使用 (max_maxhp は従来通り下記の単発ロールで決定する)。
+    // 敵モンスターの基礎最大HPをレベル別HPテーブル経由で算出する (プレイヤーと
+    // 共通の累積式)。hit_dice をモンスター種族のものに揃えたうえで
+    // roll_monster_hp_table() が per-level ダイスを較正して hp_table[] を埋め、
+    // 実効レベルの累積HP (hp_table[level-1] 相当) を返す。期待値は従来の単発ロール
+    // (hit_dice.roll()) と一致し、分散のみ低下する (スケール保存)。FORCE_MAXHP は
+    // 従来通り hit_dice.maxroll() を基礎HPとする。サイズ補正・CON補正・状態補正は
+    // 従来通り後段で乗算。
     m_ptr->hit_dice = new_monrace.hit_dice;
-    m_ptr->roll_hp_table();
-
-    if (new_monrace.misc_flags.has(MonsterMiscType::FORCE_MAXHP)) {
-        m_ptr->max_maxhp = new_monrace.hit_dice.maxroll();
-    } else {
-        m_ptr->max_maxhp = new_monrace.hit_dice.roll();
-    }
+    m_ptr->max_maxhp = m_ptr->roll_monster_hp_table(new_monrace.misc_flags.has(MonsterMiscType::FORCE_MAXHP));
 
     if (m_ptr->is_huge()) {
         m_ptr->max_maxhp *= (randint1(8) + 15) / 8;

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -2257,6 +2257,41 @@ void CreatureEntity::roll_hp_table()
     }
 }
 
+int CreatureEntity::roll_monster_hp_table(bool force_max)
+{
+    // 実効レベル (敵モンスターは get_level() = monrace.level/2)。hp_table[] の
+    // 添字に収めるため [1, PY_MAX_LEVEL] にクランプする。
+    const auto effective_level = std::clamp<int>(this->get_level(), 1, PY_MAX_LEVEL);
+
+    // per-level ダイス 1d s を導く。E[1d s] = s_avg = (s+1)/2 が
+    // monrace 全HP期待値 (num*(sides+1)/2) を level で割った値となるよう s を較正する。
+    //   (s+1)/2 = num*(sides+1)/(2*level)  =>  s = num*(sides+1)/level - 1
+    // 整数丸め (四捨五入) で算出し、最低でも 1d1 を保証する。これにより level
+    // レベル分を累積した期待値が従来の単発ロールと一致する (スケール保存)。
+    const auto numerator = this->hit_dice.num * (this->hit_dice.sides + 1);
+    const auto per_level_sides = std::max(1, (numerator + effective_level / 2) / effective_level - 1);
+    const Dice per_level_die(1, per_level_sides);
+
+    // FORCE_MAXHP は「種族 hit_dice の最大値 (maxroll() = num*sides)」を基礎HPと
+    // する従来契約 (monster-status / monster-damage / lore 表示が前提) を維持する。
+    // per-level ダイスの最大値を累積すると較正 (sides+1 / -1) のぶんだけ maxroll()
+    // からズレるため、force_max 時は maxroll() を各レベルに按分し、最終レベルで
+    // 正確に maxroll() へ到達させる。非強制時は較正済み per-level ダイスを通常
+    // ロールして累積する (スケール保存)。
+    const auto max_total = this->hit_dice.maxroll();
+    auto total = 0;
+    for (auto i = 0; i < effective_level; i++) {
+        if (force_max) {
+            this->hp_table[i] = max_total * (i + 1) / effective_level;
+        } else {
+            total += per_level_die.roll();
+            this->hp_table[i] = total;
+        }
+    }
+
+    return this->hp_table[effective_level - 1];
+}
+
 void CreatureEntity::set_max_hp(int full_max_hp)
 {
     this->max_maxhp = full_max_hp;

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -292,6 +292,20 @@ public:
     void roll_hp_table();
 
     /*!
+     * @brief 敵モンスターの最大HPをレベル別HPテーブル経由で算出する (スケール保存)
+     * @param force_max 各レベルのロールを最大値で固定するか (FORCE_MAXHP 用)
+     * @return 実効レベルにおける基礎最大HP (hp_table[level-1] 相当)
+     * @details モンスター種族の全HPダイス (hit_dice) の期待値を実効レベル
+     *          (monrace.level/2) に均等配分する per-level ダイス (1d s) を導き、
+     *          1 レベルずつ累積して hp_table[] を埋める。s を較正することで累積HPの
+     *          期待値が従来の単発ロール (hit_dice.roll()) と一致し、分散のみ低下する
+     *          (より安定したHP)。プレイヤー用 roll_hp_table() の前方加重 (Lv1 maxroll
+     *          + 3 ロール) は敵HPのスケールを膨らませるため用いない。呼出側で事前に
+     *          hit_dice にモンスター種族のダイスを設定しておくこと。
+     */
+    int roll_monster_hp_table(bool force_max);
+
+    /*!
      * @brief クリーチャーの速度を取得
      * @return 速度値
      */


### PR DESCRIPTION
「敵モンスター最大HPのテーブル式への段階移行」の第1段として、敵モンスターの
基礎最大HPを単発ロール (hit_dice.roll()) からレベル別HPテーブル経由の累積式へ 切り替える。バランス不変 (期待値保存) を満たすよう較正する。

新メソッド CreatureEntity::roll_monster_hp_table(force_max):
- モンスター種族の hit_dice (全HPの単発ロールスケール) の期待値 num*(sides+1)/2 を実効レベル L (=get_level()=monrace.level/2, [1,PY_MAX_LEVEL] クランプ) に均等配分する per-level ダイス 1d s (s = round(num*(sides+1)/L) - 1, 最低 1d1) を導出。
- L レベル分を累積して hp_table[0..L-1] を埋め、hp_table[L-1] を返す。
- 累積HPの期待値は従来の単発ロールと一致 (スケール保存)、分散のみ低下し安定化。
- プレイヤー用 roll_hp_table() の前方加重 (Lv1 maxroll + 3 ロール) は敵HPの スケールを膨張させるため用いない (整数演算で較正、<cmath> 非依存)。

place_monster_one:
- 前コミットで全NPCに振っていた roll_hp_table() (前方加重) の呼出を roll_monster_hp_table() に置換し、戻り値を max_maxhp の基礎値に採用。
- サイズ補正・CON補正・状態補正・nightmare倍化・MONSTER_MAXHPクランプ・ calc_min_max_hp下限は従来通り後段で適用 (一切変更なし)。

検証 (実データ約2,300種, 最小HP下限込みの全パイプライン Monte-Carlo):
new/old 最終HP比 平均1.00 / 中央値1.00 / 99.4%が±10%以内 / 1.3倍超ゼロ。 極端に低HPな特殊モンスターも従来同様 calc_min_max_hp(level+1) で切り上げられ不変。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved enemy monster HP generation to use a calibrated, per-level cumulative HP table that preserves overall scaling.
  * Updated monster placement to use the new HP calculation, including proper handling for maximum-HP mode when enabled.

* **Documentation**
  * Added detailed notes on the level-based HP table approach for monsters, including how it differs from player HP rolling and how later HP modifiers still apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->