### PR TITLE
feat: 敵モンスター最大HPテーブル式 第3段(レベルアップHP成長機構, groundwork)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,8 +533,21 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
     面数 `Y` を維持する都合上、高 `Y`・低 `X` の個体 (例: `3d800` のドラゴン) は
     HP が膨張する** (全 2,300 種中 152 体が 1.5 倍超、最大 8 倍)。これらの
     アンバランス個体は `"hit_point_per_level"` で手動調節する方針。
-  - **今後の段**: モンスターのレベルアップに伴う HP 成長 (`hp_table[]` を生成時
-    より上の添字へ伸ばす) 等。
+  - **第 3 段 (完了, groundwork)**: モンスターのレベルアップに伴う HP 成長機構。
+    `grow_hp_table_to_level(new_level)` が `hp_table[]` を生成時の添字より上へ
+    (旧レベル→新レベルまで) per-level ダイスで累積し、基礎HP増分と CON 補正増分を
+    現在の最大HPに**加算**する (生成時 1 回限りのサイズ補正乱数倍率は成長分には
+    乗じない加算的成長)。per-level ダイスは `make_monster_per_level_die()` に共通化し、
+    既定値の較正レベルを種族本来のレベル (`monrace.level/2`) で固定して反復成長でも
+    ダイスが変動しないようにした。`set_level()` で実効レベルも更新する。
+    **実際のレベルアップ発火は wizard デバッグコマンド `L`
+    (`wiz_level_up_target_monster`) のみ**で、通常プレイのゲームバランスは不変。
+    あわせて進化 (`monster_gain_exp`) 時の最大HP再計算も `roll_monster_hp_table()`
+    のテーブル式に統一した (従来は単発ロールのままだった整合性修正)。
+    モンスターの `hp_table[]` 自体は savefile 非保存だが、成長後の `max_maxhp` /
+    `level` は creature-common で保存されるため成長結果は永続する。
+  - **今後の段**: exp 蓄積等を契機とする実ゲームでのレベルアップ発火
+    (バランス設計を伴う) や、モンスター `hp_table[]` の savefile 保存等。
 
 ### `psex` の SEX_NONE
 

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -392,7 +392,10 @@ void monster_gain_exp(CreatureEntity &creature, MONSTER_IDX m_idx, MonraceId mon
     monster.set_ap_r_idx(monster.get_r_idx());
 
     const auto &new_monrace = monster.get_monrace(); //!< @details 進化後の種族.
-    monster.max_maxhp = new_monrace.misc_flags.has(MonsterMiscType::FORCE_MAXHP) ? new_monrace.hit_dice.maxroll() : new_monrace.hit_dice.roll();
+    // 進化後の最大HPも生成時 (place_monster_one) と同じテーブル式で算出する。
+    // hit_dice を進化後種族のものに揃えてから roll_monster_hp_table() を呼ぶ。
+    monster.hit_dice = new_monrace.hit_dice;
+    monster.max_maxhp = monster.roll_monster_hp_table(new_monrace.misc_flags.has(MonsterMiscType::FORCE_MAXHP));
     if (ironman_nightmare) {
         const auto hp = monster.max_maxhp * 2;
         monster.max_maxhp = std::min(MONSTER_MAXHP, hp);

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -2257,23 +2257,36 @@ void CreatureEntity::roll_hp_table()
     }
 }
 
+/*!
+ * @brief 敵モンスターのレベル別HPテーブル用 per-level ダイス (1レベルあたりHPダイス) を求める
+ * @param creature 対象クリーチャー (モンスター)
+ * @return per-level ダイス
+ * @details JSON (MonraceDefinition::hit_dice_per_level) に明示指定があればそれを優先する
+ *          (アンバランスな個体の手動調節用)。未指定時は既定値を hit_dice (旧 XdY) から
+ *          算出する: 面数は旧 Y を維持し、ダイス数を期待値保存で較正する。
+ *            E[n d Y] * L = n*(Y+1)/2 * L が旧単発ロール期待値 X*(Y+1)/2 と
+ *            一致するよう n = round(X / L)。最低でも 1dY を保証する。
+ *          較正に用いる L は種族本来のレベル (monrace.level/2) で固定し、生成後の動的な
+ *          レベルアップ (grow_hp_table_to_level) でも成長ダイスが変動しないようにする。
+ */
+static Dice make_monster_per_level_die(CreatureEntity &creature)
+{
+    auto per_level_die = creature.get_monrace().hit_dice_per_level;
+    if (!per_level_die.is_valid()) {
+        const auto natural_level = std::clamp<int>(creature.get_monrace().level / 2, 1, PY_MAX_LEVEL);
+        const auto num = std::max(1, (creature.hit_dice.num + natural_level / 2) / natural_level);
+        per_level_die = Dice(num, creature.hit_dice.sides);
+    }
+
+    return per_level_die;
+}
+
 int CreatureEntity::roll_monster_hp_table(bool force_max)
 {
     // 実効レベル (敵モンスターは get_level() = monrace.level/2)。hp_table[] の
     // 添字に収めるため [1, PY_MAX_LEVEL] にクランプする。
     const auto effective_level = std::clamp<int>(this->get_level(), 1, PY_MAX_LEVEL);
-
-    // per-level ダイス (1レベルあたりHPダイス) を決定する。
-    // JSON (MonraceDefinition::hit_dice_per_level) に明示指定があればそれを優先する
-    // (アンバランスな個体の手動調節用)。未指定時は既定値を hit_dice (旧 XdY) から
-    // 算出する: 面数は旧 Y を維持し、ダイス数を期待値保存で較正する。
-    //   E[n d Y] * level = n*(Y+1)/2 * level が旧単発ロール期待値 X*(Y+1)/2 と
-    //   一致するよう n = round(X / level)。最低でも 1dY を保証する。
-    auto per_level_die = this->get_monrace().hit_dice_per_level;
-    if (!per_level_die.is_valid()) {
-        const auto num = std::max(1, (this->hit_dice.num + effective_level / 2) / effective_level);
-        per_level_die = Dice(num, this->hit_dice.sides);
-    }
+    const auto per_level_die = make_monster_per_level_die(*this);
 
     // FORCE_MAXHP は「種族 hit_dice の最大値 (maxroll() = num*sides)」を基礎HPと
     // する従来契約 (monster-status / monster-damage / lore 表示が前提) を維持する。
@@ -2293,6 +2306,41 @@ int CreatureEntity::roll_monster_hp_table(bool force_max)
     }
 
     return this->hp_table[effective_level - 1];
+}
+
+void CreatureEntity::grow_hp_table_to_level(int new_level)
+{
+    // 本メソッドは敵モンスター専用 (プレイヤー / モンスター運用は roll_hp_table() と
+    // 通常のレベルアップ経路で HP を成長させる)。
+    if (!this->has_monster_profile()) {
+        return;
+    }
+
+    const auto old_level = std::clamp<int>(this->get_level(), 1, PY_MAX_LEVEL);
+    const auto target_level = std::clamp(new_level, 1, PY_MAX_LEVEL);
+    if (target_level <= old_level) {
+        return;
+    }
+
+    // 生成時と同じ per-level ダイスで hp_table を「生成時より上の添字へ」伸ばす。
+    const auto per_level_die = make_monster_per_level_die(*this);
+    const auto old_base = this->hp_table[old_level - 1];
+    for (auto i = old_level; i < target_level; i++) {
+        this->hp_table[i] = this->hp_table[i - 1] + per_level_die.roll();
+    }
+    const auto base_growth = this->hp_table[target_level - 1] - old_base;
+
+    // CON 補正はレベル依存 (calc_max_hp_con_bonus が get_level() を参照) のため、
+    // レベル確定の前後で差分を取って成長分に加える。
+    const auto old_con_bonus = this->calc_max_hp_con_bonus();
+    this->set_level(static_cast<int16_t>(target_level));
+    const auto con_growth = this->calc_max_hp_con_bonus() - old_con_bonus;
+
+    // 既存の最大HP (生成時のサイズ補正・状態補正等を含む) に基礎成長分と CON 補正
+    // 差分を加算する。サイズ補正は生成時 1 回限りの乱数倍率のため成長分には
+    // 乗じない (現在の最大HPは保ったまま上積みする加算的成長)。
+    const auto grown = this->get_max_maxhp() + base_growth + con_growth;
+    this->set_max_hp(std::clamp(grown, this->calc_min_max_hp(), MONSTER_MAXHP));
 }
 
 void CreatureEntity::set_max_hp(int full_max_hp)

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -306,6 +306,16 @@ public:
     int roll_monster_hp_table(bool force_max);
 
     /*!
+     * @brief 敵モンスターのレベルアップに伴い hp_table[] を上の添字へ伸ばし最大HPを成長させる
+     * @param new_level 成長後の実効レベル ([1, PY_MAX_LEVEL] にクランプ)
+     * @details 生成時と同じ per-level ダイスで hp_table を旧レベルから new_level まで累積し、
+     *          基礎HPの増分と CON 補正の増分を現在の最大HPに加算する (加算的成長)。
+     *          set_level() で実効レベルも更新する。new_level が現レベル以下なら何もしない。
+     *          モンスター専用 (プレイヤーは通常のレベルアップ経路で成長する)。
+     */
+    void grow_hp_table_to_level(int new_level);
+
+    /*!
      * @brief クリーチャーの速度を取得
      * @return 速度値
      */

--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -67,6 +67,7 @@ constexpr std::array debug_menu_table = {
     std::make_tuple('i', _("鑑定", "Idenfity")),
     std::make_tuple('I', _("アイテム設定コマンドメニュー", "Modify item configurations")),
     std::make_tuple('j', _("指定ダンジョン階にワープ", "Jump to floor depth of target dungeon")),
+    std::make_tuple('L', _("対象モンスターをレベルアップ(HP成長)", "Level up target monster (grow HP)")),
     std::make_tuple('k', _("指定ダメージ・半径0の指定属性のボールを自分に放つ", "Fire a zero ball to self")),
     std::make_tuple('m', _("魔法の地図", "Magic mapping")),
     std::make_tuple('M', _("突然変異コマンドメニュー", "Mutation debug commands")),
@@ -207,6 +208,9 @@ bool exe_cmd_debug(CreatureEntity &creature, char cmd)
         return true;
     case 'k':
         wiz_kill_target(creature, 0, (AttributeType)command_arg, true);
+        return true;
+    case 'L':
+        wiz_level_up_target_monster(creature);
         return true;
     case 'm':
         map_area(creature, DETECT_RAD_ALL * 3);

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -34,6 +34,7 @@
 #include "monster-floor/monster-remover.h"
 #include "monster/monster-describer.h"
 #include "monster/monster-description-types.h"
+#include "monster/monster-update.h"
 #include "object-enchant/item-apply-magic.h"
 #include "object-enchant/item-magic-applier.h"
 #include "perception/object-perception.h"
@@ -72,6 +73,8 @@
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "target/grid-selector.h"
+#include "target/target-setter.h"
+#include "target/target-types.h"
 #include "util/angband-files.h"
 #include "util/candidate-selector.h"
 #include "util/dice.h"
@@ -812,6 +815,42 @@ void wiz_zap_floor_monsters(CreatureEntity &creature)
 
         delete_monster_idx(creature, i);
     }
+}
+
+/*!
+ * @brief 対象モンスターを指定レベルまでレベルアップさせ最大HPを成長させる (デバッグ用)
+ * @param creature プレイヤーへの参照
+ * @details レベル別HPテーブルを上の添字へ伸ばすモンスターHP成長機構
+ *          (CreatureEntity::grow_hp_table_to_level) を検証するためのコマンド。
+ *          通常プレイのゲームバランスには影響しない (本コマンド経由でのみ発火する)。
+ */
+void wiz_level_up_target_monster(CreatureEntity &creature)
+{
+    const auto pos = target_set(creature, TARGET_KILL).get_position();
+    if (!pos) {
+        return;
+    }
+
+    auto &floor = *creature.get_floor();
+    const auto &grid = floor.get_grid(*pos);
+    if (!grid.has_monster()) {
+        msg_print(_("そこにはモンスターはいない。", "There is no monster there."));
+        return;
+    }
+
+    auto &monster = floor.get_monster(grid.m_idx);
+    const auto m_name = monster_desc(creature, monster, 0);
+    const auto input_level = input_integer(_("レベル", "Level"), monster.get_level() + 1, PY_MAX_LEVEL, monster.get_level() + 1);
+    if (!input_level.has_value()) {
+        return;
+    }
+
+    const auto old_maxhp = monster.get_max_maxhp();
+    monster.grow_hp_table_to_level(*input_level);
+    update_monster(creature, grid.m_idx, false);
+    RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::HEALTH);
+    msg_format(_("%s^をレベル%dに成長させた (最大HP %d→%d)。", "%s^ grew to level %d (max HP %d -> %d)."),
+        m_name.data(), monster.get_level(), old_maxhp, monster.get_max_maxhp());
 }
 
 /* @brief 死を欺く仕様(馬鹿馬鹿蛮怒独自実装) */

--- a/src/wizard/wizard-special-process.h
+++ b/src/wizard/wizard-special-process.h
@@ -17,4 +17,5 @@ void wiz_dump_options();
 void wiz_dump_current_floor(CreatureEntity &creature);
 void wiz_zap_surrounding_monsters(CreatureEntity &creature);
 void wiz_zap_floor_monsters(CreatureEntity &creature);
+void wiz_level_up_target_monster(CreatureEntity &creature);
 void cheat_death(CreatureEntity &creature, bool no_penalty);


### PR DESCRIPTION
「敵モンスター最大HPのテーブル式移行」の第3段。モンスターのレベルアップに
伴うHP成長機構を groundwork として実装する (通常プレイのバランスは不変)。

CreatureEntity::grow_hp_table_to_level(new_level):
- hp_table[] を生成時の添字より上へ (旧レベル→新レベル) per-level ダイスで累積。
- 基礎HP増分と CON 補正増分を現在の最大HPに加算 (加算的成長)。生成時1回限りの サイズ補正乱数倍率は成長分には乗じない。
- set_level() で実効レベルも更新。new_level が現レベル以下なら何もしない。
- モンスター専用 (プレイヤーは通常のレベルアップ経路で成長)。

per-level ダイス導出を make_monster_per_level_die() に共通化:
- roll_monster_hp_table() と grow_hp_table_to_level() で共有。
- 既定値の較正レベルを種族本来のレベル (monrace.level/2) で固定し、反復成長でも 成長ダイスが変動しないようにした。

進化時HPのテーブル式統一 (整合性修正):
- monster_gain_exp() の進化後 max_maxhp 算出を単発ロールから roll_monster_hp_table() に統一 (生成時 place_monster_one と同経路)。

wizard デバッグコマンド 'L' (wiz_level_up_target_monster):
- 対象モンスターを指定レベルまで成長させ HP 成長を検証する。
- 実ゲームのレベルアップ発火は本コマンド経由のみ (バランス不変)。

savefile: モンスター hp_table[] は非保存だが、成長後の max_maxhp / level は creature-common で保存されるため成長結果は永続する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a debug command (**L**) that lets you select a monster, choose a target level, and apply HP growth accordingly.

* **Bug Fixes**
  * Improved evolved monsters’ maximum HP calculation so results remain consistent with the game’s HP-table growth behavior.
  * Level-up HP-table growth now follows the same rolling rules used for initial generation, keeping base and CON-related gains aligned.

* **Documentation**
  * Updated notes describing the HP-table “stage transitions,” including the revised handling for “Stage 3” and “future stages.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->