### PR TITLE
merge: MagicReaderのクラス化（hengband#5463 相当）

### DIFF
--- a/src/info-reader/magic-reader.cpp
+++ b/src/info-reader/magic-reader.cpp
@@ -69,19 +69,77 @@ const std::unordered_map<std::string_view, PlayerClassType> class_list = {
 };
 }
 
+MagicReader::MagicReader(const nlohmann::json &class_data)
+    : class_data(class_data)
+{
+}
+
+/*!
+ * @brief 職業魔法情報(ClassMagicDefinitions)のパース関数
+ * @return エラーコード
+ */
+int MagicReader::read() const
+{
+    if (!this->class_data.is_object()) {
+        return PARSE_ERROR_INVALID_TYPE;
+    }
+
+    int class_id;
+    if (auto err = this->set_class_id(class_id)) {
+        msg_format(_("職業ID読込失敗。ID: '%d'。", "Failed to load class id. ID: '%d'."), error_idx);
+        return err;
+    }
+
+    if (class_id < error_idx) {
+        return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
+    }
+    error_idx = class_id;
+    player_magic &magics_info = class_magics_info[class_id];
+
+    if (auto err = this->set_spell_type(magics_info)) {
+        msg_format(_("呪文タイプ読込失敗。ID: '%d'。", "Failed to load spell type. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = this->set_magic_status(magics_info)) {
+        msg_format(_("呪文行使に使用する能力値読込失敗。ID: '%d'。", "Failed to load magic status. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_bool(get_json_value(this->class_data, "has_glove_mp_penalty"), magics_info.has_glove_mp_penalty, true)) {
+        msg_format(_("籠手によるMPペナルティ読込失敗。ID: '%d'。", "Failed to load glove_mp_penalty. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_bool(get_json_value(this->class_data, "has_magic_fail_rate_cap"), magics_info.has_magic_fail_rate_cap, true)) {
+        msg_format(_("最低呪文失率情報読込失敗。ID: '%d'。", "Failed to load magic_fail_rate_cap. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_bool(get_json_value(this->class_data, "is_spell_trainable"), magics_info.is_spell_trainable, true)) {
+        msg_format(_("呪文訓練可能性読込失敗。ID: '%d'。", "Failed to load spell_trainability. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_integer(get_json_value(this->class_data, "first_spell_level"), magics_info.spell_first, true, Range(0, 99))) {
+        msg_format(_("呪文行使開始レベル読込失敗。ID: '%d'。", "Failed to load spell-first level. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_integer(get_json_value(this->class_data, "armour_weight_limit"), magics_info.spell_weight, true, Range(0, 999))) {
+        msg_format(_("MP重量制限値読込失敗。ID: '%d'。", "Failed to load spell-weight value. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = this->set_realm_data(magics_info)) {
+        msg_format(_("呪文データ読込失敗。ID: '%d'。", "Failed to load spell data. ID: '%d'."), error_idx);
+        return err;
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
 /*!
  * @brief JSON Objectから職業IDを取得する
- * @param class_data 情報の格納されたJSON Object
  * @param class_id 職業ID
  * @return エラーコード
  */
-static errr set_class_id(const nlohmann::json &class_data, int &class_id)
+int MagicReader::set_class_id(int &class_id) const
 {
-    if (class_data.is_null()) {
-        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-    }
-
-    const auto &classname_obj = class_data["name"];
+    const auto &classname_obj = get_json_value(this->class_data, "name");
     if (!classname_obj.is_string()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
@@ -96,17 +154,12 @@ static errr set_class_id(const nlohmann::json &class_data, int &class_id)
 
 /*!
  * @brief JSON Objectから職業で使用する呪文タイプを取得する
- * @param class_data 情報の格納されたJSON Object
  * @param magics_info 保存先の魔法情報構造体
  * @return エラーコード
  */
-static errr set_spell_type(const nlohmann::json &class_data, player_magic &magics_info)
+int MagicReader::set_spell_type(player_magic &magics_info) const
 {
-    if (class_data.is_null()) {
-        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-    }
-
-    const auto &spell_book = class_data["spell_type"];
+    const auto &spell_book = get_json_value(this->class_data, "spell_type");
     if (!spell_book.is_string()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
@@ -121,17 +174,12 @@ static errr set_spell_type(const nlohmann::json &class_data, player_magic &magic
 
 /*!
  * @brief JSON Objectから職業で呪文行使に使用する能力値を取得する
- * @param class_data 情報の格納されたJSON Object
  * @param magics_info 保存先の魔法情報構造体
  * @return エラーコード
  */
-static errr set_magic_status(const nlohmann::json &class_data, player_magic &magics_info)
+int MagicReader::set_magic_status(player_magic &magics_info) const
 {
-    if (class_data.is_null()) {
-        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-    }
-
-    const auto &magic_status = class_data["magic_status"];
+    const auto &magic_status = get_json_value(this->class_data, "magic_status");
     if (!magic_status.is_string()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
@@ -146,13 +194,14 @@ static errr set_magic_status(const nlohmann::json &class_data, player_magic &mag
 
 /*!
  * @brief JSON Objectから各呪文の詳細を取得する
- * @param class_data 情報の格納されたJSON Object
+ * @param spell_data 各呪文情報の格納されたJSON Object
  * @param magics_info 保存先の魔法情報構造体
+ * @param realm 呪文の領域
  * @return エラーコード
  */
-static errr set_spell_data(const nlohmann::json &spell_data, player_magic &magics_info, RealmType realm)
+int MagicReader::set_spell_data(const nlohmann::json &spell_data, player_magic &magics_info, RealmType realm) const
 {
-    const auto &spell_tag_obj = spell_data["spell_tag"];
+    const auto &spell_tag_obj = get_json_value(spell_data, "spell_tag");
     if (!spell_tag_obj.is_string()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
@@ -162,19 +211,19 @@ static errr set_spell_data(const nlohmann::json &spell_data, player_magic &magic
     }
     auto &info = magics_info.info[enum2i(realm)][*spell_id];
 
-    if (auto err = info_set_integer(spell_data["learn_level"], info.slevel, true, Range(0, 99))) {
+    if (auto err = info_set_integer(get_json_value(spell_data, "learn_level"), info.slevel, true, Range(0, 99))) {
         msg_format(_("呪文学習レベル読込失敗。ID: '%d'。", "Failed to load spell learn_level. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(spell_data["mana_cost"], info.smana, true, Range(0, 999))) {
+    if (auto err = info_set_integer(get_json_value(spell_data, "mana_cost"), info.smana, true, Range(0, 999))) {
         msg_format(_("呪文コスト読込失敗。ID: '%d'。", "Failed to load spell mana_cost. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(spell_data["difficulty"], info.sfail, true, Range(0, 999))) {
+    if (auto err = info_set_integer(get_json_value(spell_data, "difficulty"), info.sfail, true, Range(0, 999))) {
         msg_format(_("呪文難易度読込失敗。ID: '%d'。", "Failed to load spell difficulty. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(spell_data["first_cast_exp_rate"], info.sexp, true, Range(0, 999))) {
+    if (auto err = info_set_integer(get_json_value(spell_data, "first_cast_exp_rate"), info.sexp, true, Range(0, 999))) {
         msg_format(_("呪文詠唱ボーナスEXP読込失敗。ID: '%d'。", "Failed to load spell first_cast_exp_rate. ID: '%d'."), error_idx);
         return err;
     }
@@ -184,18 +233,21 @@ static errr set_spell_data(const nlohmann::json &spell_data, player_magic &magic
 
 /*!
  * @brief JSON Objectから職業毎に定義された各呪文の詳細を取得する
- * @param class_data 情報の格納されたJSON Object
  * @param magics_info 保存先の魔法情報構造体
  * @return エラーコード
  */
-static errr set_realm_data(const nlohmann::json &class_data, player_magic &magics_info)
+int MagicReader::set_realm_data(player_magic &magics_info) const
 {
-    if (class_data.is_null()) {
+    const auto &realms_data = get_json_value(this->class_data, "realms");
+    if (realms_data.is_null()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
+    if (!realms_data.is_array()) {
+        return PARSE_ERROR_INVALID_TYPE;
+    }
 
-    for (const auto &realm : class_data["realms"]) {
-        const auto &realm_name_obj = realm["name"];
+    for (const auto &realm : realms_data) {
+        const auto &realm_name_obj = get_json_value(realm, "name");
         if (!realm_name_obj.is_string()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
@@ -206,72 +258,20 @@ static errr set_realm_data(const nlohmann::json &class_data, player_magic &magic
         }
 
         const auto realm_id = realm_name->second;
-        const auto &spells_info_obj = realm["spells_info"];
+        const auto &spells_info_obj = get_json_value(realm, "spells_info");
         if (spells_info_obj.is_null()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
+        if (!spells_info_obj.is_array()) {
+            return PARSE_ERROR_INVALID_TYPE;
+        }
 
         for (const auto &spell : spells_info_obj) {
-            if (auto err = set_spell_data(spell, magics_info, realm_id)) {
+            if (auto err = this->set_spell_data(spell, magics_info, realm_id)) {
                 msg_format(_("呪文データ読込失敗。ID: '%d'。", "Failed to load spell data. ID: '%d'."), error_idx);
                 return err;
             }
         }
-    }
-
-    return PARSE_ERROR_NONE;
-}
-
-/*!
- * @brief 職業魔法情報(ClassMagicDefinitions)のパース関数
- * @param buf テキスト列
- * @return エラーコード
- */
-errr parse_class_magics_info(nlohmann::json &class_data)
-{
-    int class_id;
-    if (auto err = set_class_id(class_data, class_id)) {
-        msg_format(_("職業ID読込失敗。ID: '%d'。", "Failed to load class id. ID: '%d'."), error_idx);
-        return err;
-    }
-
-    if (class_id < error_idx) {
-        return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
-    }
-    error_idx = class_id;
-    player_magic &magics_info = class_magics_info[class_id];
-
-    if (auto err = set_spell_type(class_data, magics_info)) {
-        msg_format(_("呪文タイプ読込失敗。ID: '%d'。", "Failed to load spell type. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = set_magic_status(class_data, magics_info)) {
-        msg_format(_("呪文行使に使用する能力値読込失敗。ID: '%d'。", "Failed to load magic status. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_bool(class_data["has_glove_mp_penalty"], magics_info.has_glove_mp_penalty, true)) {
-        msg_format(_("籠手によるMPペナルティ読込失敗。ID: '%d'。", "Failed to load glove_mp_penalty. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_bool(class_data["has_magic_fail_rate_cap"], magics_info.has_magic_fail_rate_cap, true)) {
-        msg_format(_("最低呪文失率情報読込失敗。ID: '%d'。", "Failed to load magic_fail_rate_cap. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_bool(class_data["is_spell_trainable"], magics_info.is_spell_trainable, true)) {
-        msg_format(_("呪文訓練可能性読込失敗。ID: '%d'。", "Failed to load spell_trainability. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_integer(class_data["first_spell_level"], magics_info.spell_first, true, Range(0, 99))) {
-        msg_format(_("呪文行使開始レベル読込失敗。ID: '%d'。", "Failed to load spell-first level. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_integer(class_data["armour_weight_limit"], magics_info.spell_weight, true, Range(0, 999))) {
-        msg_format(_("MP重量制限値読込失敗。ID: '%d'。", "Failed to load spell-weight value. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = set_realm_data(class_data, magics_info)) {
-        msg_format(_("呪文データ読込失敗。ID: '%d'。", "Failed to load spell data. ID: '%d'."), error_idx);
-        return err;
     }
 
     return PARSE_ERROR_NONE;

--- a/src/info-reader/magic-reader.h
+++ b/src/info-reader/magic-reader.h
@@ -1,7 +1,27 @@
 #pragma once
 
-#include "system/angband.h"
 #include <nlohmann/json.hpp>
-#include <string_view>
 
-errr parse_class_magics_info(nlohmann::json &class_data);
+enum class RealmType;
+struct player_magic;
+
+class MagicReader {
+public:
+    explicit MagicReader(const nlohmann::json &class_data);
+    MagicReader(nlohmann::json &&) = delete;
+    MagicReader(const MagicReader &) = delete;
+    MagicReader(MagicReader &&) = delete;
+    MagicReader &operator=(const MagicReader &) = delete;
+    MagicReader &operator=(MagicReader &&) = delete;
+
+    int read() const;
+
+private:
+    int set_class_id(int &class_id) const;
+    int set_spell_type(player_magic &magics_info) const;
+    int set_magic_status(player_magic &magics_info) const;
+    int set_spell_data(const nlohmann::json &spell_data, player_magic &magics_info, RealmType realm) const;
+    int set_realm_data(player_magic &magics_info) const;
+
+    const nlohmann::json &class_data;
+};

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -184,7 +184,10 @@ void init_baseitems_info()
 void init_class_magics_info()
 {
     class_magics_info.assign(PLAYER_CLASS_TYPE_MAX, {});
-    init_json("ClassMagicDefinitions.jsonc", "classes", DefinitionHashDataType::CLASS_MAGICS, class_magics_info, parse_class_magics_info);
+    auto parser = [](nlohmann::json &class_data) {
+        return MagicReader(class_data).read();
+    };
+    init_json("ClassMagicDefinitions.jsonc", "classes", DefinitionHashDataType::CLASS_MAGICS, class_magics_info, parser);
 }
 
 /*!


### PR DESCRIPTION
変愚蛮怒 PR #5463 の内容を bakabakaband 構造に適応してマージ。
自由関数 parse_class_magics_info を MagicReader クラス（read() + private setter 群）に変換し、既存の BaseitemReader と同じ規約・
get_json_value() 防御的アクセスに統一した。

- src/info-reader/magic-reader.{h,cpp}: クラス化
- src/main/info-initializer.cpp: 呼び出しを MagicReader(class_data).read() のラムダ形式に変更

info-reader はプレイヤー型に依存しないため CreatureEntity 由来の
型変換は不要。フルビルド（g++ -O3 -Werror -Wall -Wextra）と
clang-format-18 で検証済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how class magic data is loaded and validated, making parsing more consistent and robust.
  * Added stronger checks for missing or invalid magic data so malformed entries are handled more safely.
  * Streamlined the initialization flow for class magic definitions without changing the visible behavior of valid data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->