### PR TITLE
merge: DungeonReader/RaceReaderのクラス化（hengband#5464/#5466 相当）

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -148430,15 +148430,7 @@
         "MINDFLAYER",
       ],
       "skill": {
-        "list": [
-          "BLIND",
-          "HOLD",
-          "SCARE",
-          "FORGET",
-          "DRAIN_MANA",
-          "MIND_BLAST",
-          "BRAIN_SMASH",
-        ],
+        "list": ["BLIND", "HOLD", "SCARE", "FORGET", "DRAIN_MANA", "MIND_BLAST", "BRAIN_SMASH"],
         "probability": "1_IN_5",
       },
     },

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -30,7 +30,7 @@
  * @param what 参照元の文字列
  * @return 見つけたらtrue
  */
-static bool grab_one_dungeon_flag(DungeonDefinition &dungeon, std::string_view what)
+bool DungeonReader::grab_one_dungeon_flag(DungeonDefinition &dungeon, std::string_view what)
 {
     if (EnumClassFlagGroup<DungeonFeatureType>::grab_one_flag(dungeon.flags, dungeon_flags, what)) {
         return true;
@@ -46,7 +46,7 @@ static bool grab_one_dungeon_flag(DungeonDefinition &dungeon, std::string_view w
  * @param what 参照元の文字列
  * @return 見つけたらtrue
  */
-static bool grab_one_basic_monster_flag(DungeonDefinition &dungeon, std::string_view what)
+bool DungeonReader::grab_one_basic_monster_flag(DungeonDefinition &dungeon, std::string_view what)
 {
     if (EnumClassFlagGroup<MonsterFeedType>::grab_one_flag(dungeon.mon_meat_feed_flags, r_info_meat_feed, what)) {
         return true;
@@ -108,7 +108,7 @@ static bool grab_one_basic_monster_flag(DungeonDefinition &dungeon, std::string_
  * @param what 参照元の文字列
  * @return 見つけたらtrue
  */
-static bool grab_one_spell_monster_flag(DungeonDefinition &dungeon, std::string_view what)
+bool DungeonReader::grab_one_spell_monster_flag(DungeonDefinition &dungeon, std::string_view what)
 {
     if (EnumClassFlagGroup<MonsterAbilityType>::grab_one_flag(dungeon.mon_ability_flags, r_info_ability_flags, what)) {
         return true;
@@ -141,7 +141,7 @@ static tl::optional<ProbabilityTable<short>> parse_terrain_probability(std::span
  * @param buf テキスト列
  * @return エラーコード
  */
-errr parse_dungeons_info(std::string_view buf)
+errr DungeonReader::parse_dungeons_info(std::string_view buf)
 {
     const auto &tokens = str_split(buf, ':', false);
     const auto &terrains = TerrainList::get_instance();
@@ -380,6 +380,10 @@ errr parse_dungeons_info(std::string_view buf)
 
     // M:Monster flags
     if (tokens[0] == "M") {
+        if (tokens.size() < 2) {
+            return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+        }
+
         if (tokens[1] == "X") {
             if (tokens.size() < 3) {
                 return PARSE_ERROR_TOO_FEW_ARGUMENTS;
@@ -392,10 +396,6 @@ errr parse_dungeons_info(std::string_view buf)
 
             dungeon->mon_sex = static_cast<MonsterSex>(sex);
             return 0;
-        }
-
-        if (tokens.size() < 2) {
-            return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
         const auto &flags = str_split(tokens[1], '|', true);
@@ -453,7 +453,7 @@ errr parse_dungeons_info(std::string_view buf)
 
     if (tokens[0] == "R") {
         int r_type, r_rate;
-        if (tokens.size() < 2) {
+        if (tokens.size() < 3) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
         info_set_value(r_type, tokens[1]);
@@ -548,7 +548,7 @@ static tl::optional<std::string> read_localized_name(const nlohmann::json &name_
  * @param desc_obj description オブジェクト (ja / en キーを含む)
  * @return エラーコード
  */
-static errr set_dungeon_description(DungeonDefinition &dungeon, const nlohmann::json &desc_obj)
+errr DungeonReader::set_dungeon_description(DungeonDefinition &dungeon, const nlohmann::json &desc_obj)
 {
 #ifdef JP
     if (!desc_obj.contains("ja")) {
@@ -579,7 +579,7 @@ static errr set_dungeon_description(DungeonDefinition &dungeon, const nlohmann::
 /*!
  * @brief generation オブジェクトを DungeonDefinition の生成パラメータに直接フィル
  */
-static errr set_dungeon_generation(DungeonDefinition &dungeon, const nlohmann::json &gen_obj)
+errr DungeonReader::set_dungeon_generation(DungeonDefinition &dungeon, const nlohmann::json &gen_obj)
 {
     if (!gen_obj.is_object()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
@@ -698,7 +698,7 @@ static tl::optional<ProbabilityTable<short>> build_probability_table_from_tiles(
 /*!
  * @brief floor オブジェクトを DungeonDefinition の床関連フィールドに直接フィル
  */
-static errr set_dungeon_floor(DungeonDefinition &dungeon, const nlohmann::json &floor_obj)
+errr DungeonReader::set_dungeon_floor(DungeonDefinition &dungeon, const nlohmann::json &floor_obj)
 {
     if (!floor_obj.is_object()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
@@ -718,7 +718,7 @@ static errr set_dungeon_floor(DungeonDefinition &dungeon, const nlohmann::json &
 /*!
  * @brief wall オブジェクトを DungeonDefinition の壁関連フィールドに直接フィル
  */
-static errr set_dungeon_wall(DungeonDefinition &dungeon, const nlohmann::json &wall_obj)
+errr DungeonReader::set_dungeon_wall(DungeonDefinition &dungeon, const nlohmann::json &wall_obj)
 {
     if (!wall_obj.is_object()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
@@ -791,7 +791,7 @@ static errr set_dungeon_wall(DungeonDefinition &dungeon, const nlohmann::json &w
  * @details `guardian` (MonraceId 整数) / `object` (BaseitemId 整数) / `artifact`
  *          (FixedArtifactId 整数) を受け取り、それぞれの整合性も検証する。
  */
-static errr set_dungeon_final_floor(DungeonDefinition &dungeon, const nlohmann::json &final_floor_obj)
+errr DungeonReader::set_dungeon_final_floor(DungeonDefinition &dungeon, const nlohmann::json &final_floor_obj)
 {
     if (final_floor_obj.is_null()) {
         return PARSE_ERROR_NONE;
@@ -839,10 +839,10 @@ static errr set_dungeon_final_floor(DungeonDefinition &dungeon, const nlohmann::
  * @brief JSON flags 配列、および MONSTER_RATE / TRAP_RATE 等のスカラ
  *        + FIXED_ROOM / ALLIANCE 等のサブ構造を DungeonDefinition に直接フィル
  */
-static errr set_dungeon_feature_flags(DungeonDefinition &dungeon, const nlohmann::json &dungeon_data)
+errr DungeonReader::set_dungeon_feature_flags(DungeonDefinition &dungeon, const nlohmann::json &dungeon_json)
 {
-    if (dungeon_data.contains("flags")) {
-        for (const auto &flag : dungeon_data["flags"]) {
+    if (dungeon_json.contains("flags")) {
+        for (const auto &flag : dungeon_json["flags"]) {
             const auto f = flag.get<std::string>();
             if (f.empty()) {
                 continue;
@@ -852,17 +852,17 @@ static errr set_dungeon_feature_flags(DungeonDefinition &dungeon, const nlohmann
             }
         }
     }
-    if (dungeon_data.contains("monster_rate")) {
-        dungeon.monster_rate = dungeon_data["monster_rate"].get<int>();
+    if (dungeon_json.contains("monster_rate")) {
+        dungeon.monster_rate = dungeon_json["monster_rate"].get<int>();
     }
-    if (dungeon_data.contains("trap_rate")) {
-        dungeon.trap_rate = dungeon_data["trap_rate"].get<int>();
+    if (dungeon_json.contains("trap_rate")) {
+        dungeon.trap_rate = dungeon_json["trap_rate"].get<int>();
     }
-    if (dungeon_data.contains("normal_monster_rate")) {
-        dungeon.normal_monster_rate = static_cast<PROB>(dungeon_data["normal_monster_rate"].get<int>());
+    if (dungeon_json.contains("normal_monster_rate")) {
+        dungeon.normal_monster_rate = static_cast<PROB>(dungeon_json["normal_monster_rate"].get<int>());
     }
-    if (dungeon_data.contains("alliance")) {
-        const auto alliance_tag = dungeon_data["alliance"].get<std::string>();
+    if (dungeon_json.contains("alliance")) {
+        const auto alliance_tag = dungeon_json["alliance"].get<std::string>();
         for (const auto &a : alliance_list) {
             if (a.second->tag == alliance_tag) {
                 dungeon.alliance_idx = static_cast<AllianceType>(a.second->id);
@@ -870,8 +870,8 @@ static errr set_dungeon_feature_flags(DungeonDefinition &dungeon, const nlohmann
             }
         }
     }
-    if (dungeon_data.contains("fixed_rooms")) {
-        for (const auto &fr : dungeon_data["fixed_rooms"]) {
+    if (dungeon_json.contains("fixed_rooms")) {
+        for (const auto &fr : dungeon_json["fixed_rooms"]) {
             const auto depth = fr.value("depth", 0);
             const auto id = fr.value("id", 0);
             const auto percentage = fr.value("percentage", 0);
@@ -885,7 +885,7 @@ static errr set_dungeon_feature_flags(DungeonDefinition &dungeon, const nlohmann
  * @brief monster_flags 配列を直接フィル
  *        フラグ文字列の他、`R_CHAR_X` (出現許可シンボル) / `X_FOO` (性別) を扱う
  */
-static errr set_dungeon_monster_flags(DungeonDefinition &dungeon, const nlohmann::json &flags_array)
+errr DungeonReader::set_dungeon_monster_flags(DungeonDefinition &dungeon, const nlohmann::json &flags_array)
 {
     for (const auto &flag_node : flags_array) {
         const auto f = flag_node.get<std::string>();
@@ -917,7 +917,7 @@ static errr set_dungeon_monster_flags(DungeonDefinition &dungeon, const nlohmann
  * @brief symbols 配列を直接フィル (出現許可モンスターシンボル)
  *        従来の `R_CHAR_xxx` 記法に代わる、可読性の高いシンボル配列形式。
  */
-static errr set_dungeon_monster_symbols(DungeonDefinition &dungeon, const nlohmann::json &symbols_array)
+errr DungeonReader::set_dungeon_monster_symbols(DungeonDefinition &dungeon, const nlohmann::json &symbols_array)
 {
     for (const auto &symbol_node : symbols_array) {
         const auto s = symbol_node.get<std::string>();
@@ -932,7 +932,7 @@ static errr set_dungeon_monster_symbols(DungeonDefinition &dungeon, const nlohma
 /*!
  * @brief monster_spells 配列を直接フィル
  */
-static errr set_dungeon_monster_spells(DungeonDefinition &dungeon, const nlohmann::json &flags_array)
+errr DungeonReader::set_dungeon_monster_spells(DungeonDefinition &dungeon, const nlohmann::json &flags_array)
 {
     for (const auto &flag_node : flags_array) {
         const auto f = flag_node.get<std::string>();
@@ -956,7 +956,7 @@ static errr set_dungeon_monster_spells(DungeonDefinition &dungeon, const nlohman
 /*!
  * @brief specific_items 配列を direct-fill (階層別アイテム生成ルール)
  */
-static errr set_dungeon_specific_items(DungeonDefinition &dungeon, const nlohmann::json &items_array)
+errr DungeonReader::set_dungeon_specific_items(DungeonDefinition &dungeon, const nlohmann::json &items_array)
 {
     for (const auto &item : items_array) {
         const auto floor_level = item.value("floor", 0);
@@ -972,7 +972,7 @@ static errr set_dungeon_specific_items(DungeonDefinition &dungeon, const nlohman
 /*!
  * @brief specific_vaults 配列を direct-fill (階層別 Vault 指定)
  */
-static errr set_dungeon_specific_vaults(DungeonDefinition &dungeon, const nlohmann::json &vaults_array)
+errr DungeonReader::set_dungeon_specific_vaults(DungeonDefinition &dungeon, const nlohmann::json &vaults_array)
 {
     for (const auto &v : vaults_array) {
         const auto floor_level = v.value("floor", 0);
@@ -985,7 +985,7 @@ static errr set_dungeon_specific_vaults(DungeonDefinition &dungeon, const nlohma
 /*!
  * @brief room_rates 配列を direct-fill (部屋種別ごとの生成率)
  */
-static errr set_dungeon_room_rates(DungeonDefinition &dungeon, const nlohmann::json &rates_array)
+errr DungeonReader::set_dungeon_room_rates(DungeonDefinition &dungeon, const nlohmann::json &rates_array)
 {
     for (const auto &r : rates_array) {
         const auto type = r.value("type", 0);
@@ -998,7 +998,7 @@ static errr set_dungeon_room_rates(DungeonDefinition &dungeon, const nlohmann::j
 /*!
  * @brief position オブジェクトから wilderness 位置を初期化
  */
-static void set_dungeon_position(DungeonDefinition &dungeon, const nlohmann::json &pos_obj)
+void DungeonReader::set_dungeon_position(DungeonDefinition &dungeon, const nlohmann::json &pos_obj)
 {
     const auto y = pos_obj.value("y", 0);
     const auto x = pos_obj.value("x", 0);
@@ -1011,7 +1011,12 @@ static void set_dungeon_position(DungeonDefinition &dungeon, const nlohmann::jso
  *          (旧 token-emit 方式は提案 38 で廃止)。version 1 (lines 配列) は
  *          legacy `parse_dungeons_info()` トークンパーサを使う互換パスで継続。
  */
-errr parse_dungeons_info_json(nlohmann::json &dungeon_data)
+DungeonReader::DungeonReader(nlohmann::json &dungeon_data)
+    : dungeon_data(dungeon_data)
+{
+}
+
+errr DungeonReader::read()
 {
     // version 1 (wrapped-line) 互換パス
     if (dungeon_data.contains("lines") && dungeon_data["lines"].is_array()) {
@@ -1032,7 +1037,7 @@ errr parse_dungeons_info_json(nlohmann::json &dungeon_data)
     }
 
     // version 2 (structured) パス - direct fill 方式
-    if (!dungeon_data.contains("id")) {
+    if (!dungeon_data.contains("id") || !dungeon_data["id"].is_number_integer()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
     const auto id = dungeon_data["id"].get<int>();
@@ -1044,13 +1049,14 @@ errr parse_dungeons_info_json(nlohmann::json &dungeon_data)
     DungeonDefinition dungeon;
 
     // name (必須)
-    if (dungeon_data.contains("name")) {
-        auto name = read_localized_name(dungeon_data["name"]);
-        if (!name) {
-            return PARSE_ERROR_INVALID_FLAG;
-        }
-        dungeon.name = std::move(*name);
+    if (!dungeon_data.contains("name")) {
+        return PARSE_ERROR_INVALID_FLAG;
     }
+    auto name = read_localized_name(dungeon_data["name"]);
+    if (!name || name->empty()) {
+        return PARSE_ERROR_INVALID_FLAG;
+    }
+    dungeon.name = std::move(*name);
 
     // tag
     if (dungeon_data.contains("tag")) {

--- a/src/info-reader/dungeon-reader.h
+++ b/src/info-reader/dungeon-reader.h
@@ -4,5 +4,37 @@
 #include <nlohmann/json.hpp>
 #include <string_view>
 
-errr parse_dungeons_info(std::string_view buf);
-errr parse_dungeons_info_json(nlohmann::json &dungeon_data);
+class DungeonDefinition;
+
+class DungeonReader {
+public:
+    explicit DungeonReader(nlohmann::json &dungeon_data);
+    DungeonReader(nlohmann::json &&) = delete;
+    DungeonReader(const DungeonReader &) = delete;
+    DungeonReader(DungeonReader &&) = delete;
+    DungeonReader &operator=(const DungeonReader &) = delete;
+    DungeonReader &operator=(DungeonReader &&) = delete;
+
+    errr read();
+
+private:
+    bool grab_one_dungeon_flag(DungeonDefinition &dungeon, std::string_view what);
+    bool grab_one_basic_monster_flag(DungeonDefinition &dungeon, std::string_view what);
+    bool grab_one_spell_monster_flag(DungeonDefinition &dungeon, std::string_view what);
+    errr parse_dungeons_info(std::string_view buf);
+    errr set_dungeon_description(DungeonDefinition &dungeon, const nlohmann::json &desc_obj);
+    errr set_dungeon_generation(DungeonDefinition &dungeon, const nlohmann::json &gen_obj);
+    errr set_dungeon_floor(DungeonDefinition &dungeon, const nlohmann::json &floor_obj);
+    errr set_dungeon_wall(DungeonDefinition &dungeon, const nlohmann::json &wall_obj);
+    errr set_dungeon_final_floor(DungeonDefinition &dungeon, const nlohmann::json &final_floor_obj);
+    errr set_dungeon_feature_flags(DungeonDefinition &dungeon, const nlohmann::json &dungeon_json);
+    errr set_dungeon_monster_flags(DungeonDefinition &dungeon, const nlohmann::json &flags_array);
+    errr set_dungeon_monster_symbols(DungeonDefinition &dungeon, const nlohmann::json &symbols_array);
+    errr set_dungeon_monster_spells(DungeonDefinition &dungeon, const nlohmann::json &flags_array);
+    errr set_dungeon_specific_items(DungeonDefinition &dungeon, const nlohmann::json &items_array);
+    errr set_dungeon_specific_vaults(DungeonDefinition &dungeon, const nlohmann::json &vaults_array);
+    errr set_dungeon_room_rates(DungeonDefinition &dungeon, const nlohmann::json &rates_array);
+    void set_dungeon_position(DungeonDefinition &dungeon, const nlohmann::json &pos_obj);
+
+    nlohmann::json &dungeon_data;
+};

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -24,7 +24,7 @@
  * @param what 参照元の文字列ポインタ
  * @return 見つけたらtrue
  */
-static bool grab_one_basic_flag(MonraceDefinition &monrace, std::string_view what)
+bool RaceReader::grab_one_basic_flag(MonraceDefinition &monrace, std::string_view what)
 {
     if (EnumClassFlagGroup<MonsterFeedType>::grab_one_flag(monrace.meat_feed_flags, r_info_meat_feed, what)) {
         return true;
@@ -84,7 +84,7 @@ static bool grab_one_basic_flag(MonraceDefinition &monrace, std::string_view wha
     if (EnumClassFlagGroup<MonsterMiscType>::grab_one_flag(monrace.misc_flags, r_info_misc_flags, what)) {
         return true;
     }
-    msg_format(_("モンスターフラグ読込失敗'%d'。", "Failed to load monster flag data.'%d'."), what);
+    msg_format(_("モンスターフラグ読込失敗'%s'。", "Failed to load monster flag data.'%s'."), what.data());
     return false;
 }
 
@@ -95,7 +95,7 @@ static bool grab_one_basic_flag(MonraceDefinition &monrace, std::string_view wha
  * @param what 参照元の文字列ポインタ
  * @return 見つけたらtrue
  */
-static bool grab_one_spell_flag(MonraceDefinition &monrace, std::string_view what)
+bool RaceReader::grab_one_spell_flag(MonraceDefinition &monrace, std::string_view what)
 {
     if (EnumClassFlagGroup<MonsterAbilityType>::grab_one_flag(monrace.ability_flags, r_info_ability_flags, what)) {
         return true;
@@ -111,7 +111,7 @@ static bool grab_one_spell_flag(MonraceDefinition &monrace, std::string_view wha
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_name(const nlohmann::json &name_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_name(const nlohmann::json &name_data, MonraceDefinition &monrace)
 {
     if (name_data.is_null()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
@@ -152,7 +152,7 @@ static errr set_mon_name(const nlohmann::json &name_data, MonraceDefinition &mon
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_symbol(const nlohmann::json &symbol_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_symbol(const nlohmann::json &symbol_data, MonraceDefinition &monrace)
 {
     if (symbol_data.is_null()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
@@ -186,7 +186,7 @@ static errr set_mon_symbol(const nlohmann::json &symbol_data, MonraceDefinition 
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_speed(const nlohmann::json &speed_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_speed(const nlohmann::json &speed_data, MonraceDefinition &monrace)
 {
     int speed;
     if (auto err = info_set_integer(speed_data, speed, true, Range(-50, 99))) {
@@ -206,7 +206,7 @@ static errr set_mon_speed(const nlohmann::json &speed_data, MonraceDefinition &m
  * 各値は表示単位 (1 = 内部 10 単位 = +1.0) で記述する。
  * 指定されていないキーは tl::nullopt のままとなり、生成時に補正されない。
  */
-static errr set_mon_stat_modifiers(const nlohmann::json &stat_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_stat_modifiers(const nlohmann::json &stat_data, MonraceDefinition &monrace)
 {
     if (stat_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -246,7 +246,7 @@ static errr set_mon_stat_modifiers(const nlohmann::json &stat_data, MonraceDefin
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_evolve(nlohmann::json &evolve_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_evolve(nlohmann::json &evolve_data, MonraceDefinition &monrace)
 {
     if (evolve_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -268,7 +268,7 @@ static errr set_mon_evolve(nlohmann::json &evolve_data, MonraceDefinition &monra
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_transform(nlohmann::json &transform_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_transform(nlohmann::json &transform_data, MonraceDefinition &monrace)
 {
     if (transform_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -290,7 +290,7 @@ static errr set_mon_transform(nlohmann::json &transform_data, MonraceDefinition 
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_sex(const nlohmann::json &sex_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_sex(const nlohmann::json &sex_data, MonraceDefinition &monrace)
 {
     if (sex_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -315,7 +315,7 @@ static errr set_mon_sex(const nlohmann::json &sex_data, MonraceDefinition &monra
  * @details 未指定 (null) の場合は PERSONALITY_NONE のまま (生成時ランダム)。
  *          指定された場合はその性格が常に適用される。
  */
-static errr set_mon_personality(const nlohmann::json &personality_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_personality(const nlohmann::json &personality_data, MonraceDefinition &monrace)
 {
     if (personality_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -340,7 +340,7 @@ static errr set_mon_personality(const nlohmann::json &personality_data, MonraceD
  * @details "materials": [ "IRON", "GOLD" ] のように材質トークンの配列で指定する。
  *          未指定 (null) の場合は材質なし。複数指定でき、能力値修正と AC 修正が累積する。
  */
-static errr set_mon_materials(const nlohmann::json &materials_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_materials(const nlohmann::json &materials_data, MonraceDefinition &monrace)
 {
     if (materials_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -375,7 +375,7 @@ static errr set_mon_materials(const nlohmann::json &materials_data, MonraceDefin
  * 未指定の場合はデフォルトの HUMANOID が維持される。
  * 詳細は docs/monster-body-structure-equipment-slots.md 参照。
  */
-static errr set_mon_body_structure(const nlohmann::json &body_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_body_structure(const nlohmann::json &body_data, MonraceDefinition &monrace)
 {
     if (body_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -402,7 +402,7 @@ static errr set_mon_body_structure(const nlohmann::json &body_data, MonraceDefin
  * 指定があれば body_structure のデフォルト拡張スロットを上書き。
  * 空配列または未指定の場合は body_structure 既定値を使用。
  */
-static errr set_mon_extended_slots(const nlohmann::json &slots_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_extended_slots(const nlohmann::json &slots_data, MonraceDefinition &monrace)
 {
     if (slots_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -432,7 +432,7 @@ static errr set_mon_extended_slots(const nlohmann::json &slots_data, MonraceDefi
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_artifacts(nlohmann::json &artifact_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_artifacts(nlohmann::json &artifact_data, MonraceDefinition &monrace)
 {
     if (artifact_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -462,7 +462,7 @@ static errr set_mon_artifacts(nlohmann::json &artifact_data, MonraceDefinition &
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_escorts(nlohmann::json &escort_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_escorts(nlohmann::json &escort_data, MonraceDefinition &monrace)
 {
     if (escort_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -493,7 +493,7 @@ static errr set_mon_escorts(nlohmann::json &escort_data, MonraceDefinition &monr
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_blows(nlohmann::json &blow_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_blows(nlohmann::json &blow_data, MonraceDefinition &monrace)
 {
     if (blow_data.is_null()) {
         monrace.behavior_flags.set(MonsterBehaviorType::NEVER_BLOW);
@@ -539,7 +539,7 @@ static errr set_mon_blows(nlohmann::json &blow_data, MonraceDefinition &monrace)
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_flags(const nlohmann::json &flag_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_flags(const nlohmann::json &flag_data, MonraceDefinition &monrace)
 {
     if (flag_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -811,7 +811,7 @@ static errr set_mon_flags(const nlohmann::json &flag_data, MonraceDefinition &mo
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_skills(const nlohmann::json &skill_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_skills(const nlohmann::json &skill_data, MonraceDefinition &monrace)
 {
     if (skill_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -866,14 +866,18 @@ static errr set_mon_skills(const nlohmann::json &skill_data, MonraceDefinition &
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_alliance(const nlohmann::json &alliance_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_alliance(const nlohmann::json &alliance_data, MonraceDefinition &monrace)
 {
     if (alliance_data.is_null()) {
         return PARSE_ERROR_NONE;
     }
+    if (!alliance_data.is_string()) {
+        return PARSE_ERROR_INVALID_FLAG;
+    }
 
+    const auto alliance_tag = alliance_data.get<std::string>();
     for (auto a : alliance_list) {
-        if (a.second->tag == alliance_data.get<std::string>()) {
+        if (a.second->tag == alliance_tag) {
             monrace.alliance_idx = static_cast<AllianceType>(a.second->id);
             return PARSE_ERROR_NONE;
         }
@@ -887,7 +891,7 @@ static errr set_mon_alliance(const nlohmann::json &alliance_data, MonraceDefinit
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_final_summons(const nlohmann::json &summon_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_final_summons(const nlohmann::json &summon_data, MonraceDefinition &monrace)
 {
     if (summon_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -927,7 +931,7 @@ static errr set_mon_final_summons(const nlohmann::json &summon_data, MonraceDefi
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_message(const nlohmann::json &message_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_message(const nlohmann::json &message_data, MonraceDefinition &monrace)
 {
     if (message_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -976,7 +980,7 @@ static errr set_mon_message(const nlohmann::json &message_data, MonraceDefinitio
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_terrain_feature(const nlohmann::json &terrain_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_terrain_feature(const nlohmann::json &terrain_data, MonraceDefinition &monrace)
 {
     if (terrain_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -1032,7 +1036,7 @@ static errr set_mon_terrain_feature(const nlohmann::json &terrain_data, MonraceD
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_spawn_creature(const nlohmann::json &spawn_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_spawn_creature(const nlohmann::json &spawn_data, MonraceDefinition &monrace)
 {
     if (spawn_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -1088,7 +1092,7 @@ static errr set_mon_spawn_creature(const nlohmann::json &spawn_data, MonraceDefi
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_spawn_item(const nlohmann::json &spawn_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_spawn_item(const nlohmann::json &spawn_data, MonraceDefinition &monrace)
 {
     if (spawn_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -1144,7 +1148,7 @@ static errr set_mon_spawn_item(const nlohmann::json &spawn_data, MonraceDefiniti
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_drop_kinds(const nlohmann::json &drop_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_drop_kinds(const nlohmann::json &drop_data, MonraceDefinition &monrace)
 {
     if (drop_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -1227,7 +1231,7 @@ static errr set_mon_drop_kinds(const nlohmann::json &drop_data, MonraceDefinitio
  * @param monrace 保管先のモンスター種族構造体
  * @return エラーコード
  */
-static errr set_mon_dead_spawns(const nlohmann::json &dead_spawn_data, MonraceDefinition &monrace)
+errr RaceReader::set_mon_dead_spawns(const nlohmann::json &dead_spawn_data, MonraceDefinition &monrace)
 {
     if (dead_spawn_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -1304,8 +1308,15 @@ static errr set_mon_dead_spawns(const nlohmann::json &dead_spawn_data, MonraceDe
  * @param mon_data モンスターデータの格納されたJSON Object
  * @return エラーコード
  */
-errr parse_monraces_info(nlohmann::json &mon_data)
+RaceReader::RaceReader(nlohmann::json &monrace_data)
+    : monrace_data(monrace_data)
 {
+}
+
+errr RaceReader::read()
+{
+    auto &mon_data = this->monrace_data;
+
     if (!mon_data["id"].is_number_integer()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
@@ -1479,6 +1490,7 @@ errr parse_monraces_info(nlohmann::json &mon_data)
     err = set_mon_alliance(mon_data["alliance"], monrace);
     if (err) {
         msg_format(_("モンスターアライアンス情報読込失敗。ID: '%d'。", "Failed to load monster alliance: '%d'."), error_idx);
+        return err;
     }
     err = set_mon_message(mon_data["message"], monrace);
     if (err) {

--- a/src/info-reader/race-reader.h
+++ b/src/info-reader/race-reader.h
@@ -4,4 +4,46 @@
 #include <nlohmann/json.hpp>
 #include <string_view>
 
-errr parse_monraces_info(nlohmann::json &element);
+class MonraceDefinition;
+
+class RaceReader {
+public:
+    explicit RaceReader(nlohmann::json &monrace_data);
+    RaceReader(nlohmann::json &&) = delete;
+    RaceReader(const RaceReader &) = delete;
+    RaceReader(RaceReader &&) = delete;
+    RaceReader &operator=(const RaceReader &) = delete;
+    RaceReader &operator=(RaceReader &&) = delete;
+
+    errr read();
+
+private:
+    bool grab_one_basic_flag(MonraceDefinition &monrace, std::string_view what);
+    bool grab_one_spell_flag(MonraceDefinition &monrace, std::string_view what);
+    errr set_mon_name(const nlohmann::json &name_data, MonraceDefinition &monrace);
+    errr set_mon_symbol(const nlohmann::json &symbol_data, MonraceDefinition &monrace);
+    errr set_mon_speed(const nlohmann::json &speed_data, MonraceDefinition &monrace);
+    errr set_mon_stat_modifiers(const nlohmann::json &stat_data, MonraceDefinition &monrace);
+    errr set_mon_evolve(nlohmann::json &evolve_data, MonraceDefinition &monrace);
+    errr set_mon_transform(nlohmann::json &transform_data, MonraceDefinition &monrace);
+    errr set_mon_sex(const nlohmann::json &sex_data, MonraceDefinition &monrace);
+    errr set_mon_personality(const nlohmann::json &personality_data, MonraceDefinition &monrace);
+    errr set_mon_materials(const nlohmann::json &materials_data, MonraceDefinition &monrace);
+    errr set_mon_body_structure(const nlohmann::json &body_data, MonraceDefinition &monrace);
+    errr set_mon_extended_slots(const nlohmann::json &slots_data, MonraceDefinition &monrace);
+    errr set_mon_artifacts(nlohmann::json &artifact_data, MonraceDefinition &monrace);
+    errr set_mon_escorts(nlohmann::json &escort_data, MonraceDefinition &monrace);
+    errr set_mon_blows(nlohmann::json &blow_data, MonraceDefinition &monrace);
+    errr set_mon_flags(const nlohmann::json &flag_data, MonraceDefinition &monrace);
+    errr set_mon_skills(const nlohmann::json &skill_data, MonraceDefinition &monrace);
+    errr set_mon_alliance(const nlohmann::json &alliance_data, MonraceDefinition &monrace);
+    errr set_mon_final_summons(const nlohmann::json &summon_data, MonraceDefinition &monrace);
+    errr set_mon_message(const nlohmann::json &message_data, MonraceDefinition &monrace);
+    errr set_mon_terrain_feature(const nlohmann::json &terrain_data, MonraceDefinition &monrace);
+    errr set_mon_spawn_creature(const nlohmann::json &spawn_data, MonraceDefinition &monrace);
+    errr set_mon_spawn_item(const nlohmann::json &spawn_data, MonraceDefinition &monrace);
+    errr set_mon_drop_kinds(const nlohmann::json &drop_data, MonraceDefinition &monrace);
+    errr set_mon_dead_spawns(const nlohmann::json &dead_spawn_data, MonraceDefinition &monrace);
+
+    nlohmann::json &monrace_data;
+};

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -204,7 +204,10 @@ void init_class_skills_info()
 void init_dungeons_info()
 {
     auto &dungeons = DungeonList::get_instance();
-    init_json("DungeonDefinitions.jsonc", "dungeons", DefinitionHashDataType::DUNGEONS, dungeons, parse_dungeons_info_json, [&dungeons] { dungeons.retouch(); });
+    auto parser = [](nlohmann::json &dungeon_data) {
+        return DungeonReader(dungeon_data).read();
+    };
+    init_json("DungeonDefinitions.jsonc", "dungeons", DefinitionHashDataType::DUNGEONS, dungeons, parser, [&dungeons] { dungeons.retouch(); });
 }
 
 /*!
@@ -229,7 +232,10 @@ void init_terrains_info()
  */
 void init_monrace_definitions()
 {
-    init_json("MonraceDefinitions.jsonc", "monsters", DefinitionHashDataType::MONRACES, MonraceList::get_instance(), parse_monraces_info);
+    auto parser = [](nlohmann::json &monrace_data) {
+        return RaceReader(monrace_data).read();
+    };
+    init_json("MonraceDefinitions.jsonc", "monsters", DefinitionHashDataType::MONRACES, MonraceList::get_instance(), parser);
 }
 
 /*!


### PR DESCRIPTION
変愚蛮怒 PR #5464 (DungeonReader) / #5466 (RaceReader) のリーダー クラス化パターンを bakabakaband 構造に適応してマージ。

bakabakaband 側の dungeon-reader / race-reader は上流から大きく乖離 （race は stat_modifiers / personality / transform / materials / body_structure / extended_slots / alliance / terrain_feature / spawn_creature / spawn_item / drop_kinds / dead_spawns 等の独自 setter、 dungeon はレガシー token パーサ parse_dungeons_info の併存と独自の direct-fill ヘルパ群）しているため上流コードのコピーは不可。よって
上流のクラス化「パターン」のみを適用し、既存の解析ロジックは挙動を
完全保持した。

- src/info-reader/race-reader.{h,cpp}: 自由関数 parse_monraces_info + 26 個の static ヘルパを RaceReader クラス（read() + private メソッド群） に変換。
- src/info-reader/dungeon-reader.{h,cpp}: parse_dungeons_info_json + 16 個の static ヘルパ + レガシー token パーサ parse_dungeons_info を DungeonReader クラスに変換。tl::optional<...> を返す純ヘルパ 3 個 (parse_terrain_probability / read_localized_name / build_probability_table_from_tiles) はヘッダ依存を避けるため file-local static のまま残置。
- src/main/info-initializer.cpp: 呼び出しを BaseitemReader/MagicReader と 同じ DungeonReader(data).read() / RaceReader(data).read() ラムダ形式に 統一。

既存ヘルパが非 const の nlohmann::json& を取り mutating operator[] を 使うため、上流の const + get_json_value 形ではなく挙動保持を優先して
非 const のままクラス化した。info-reader はプレイヤー型に依存しないため
CreatureEntity 由来の型変換は不要。フルビルド
（g++ -O3 -Werror -Wall -Wextra）と clang-format-18 で検証済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated dungeon and monster data loading to use dedicated reader objects with a single read step for each dataset.
  * Improved parsing/validation during dungeon and monster import, including stricter ID handling and more reliable dungeon name extraction.
  * Updated startup initialization to route dungeon and monster loading through the new reader-based flow.
* **Bug Fixes**
  * Enhanced handling of invalid alliance data in monster definitions to return clearer parse errors.
* **Chores**
  * Reformatted an editor skill list in the JSON configuration without changing its contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->