### PR TITLE
fix: make dist の壊れた配布マニフェストを修復し全スキーマを同梱（hengband#5361 相当 / #8298）

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,45 +3,19 @@
 AUTOMAKE_OPTIONS = foreign
 
 visual_studio_files = \
-	Bakabakaband/Bakabakaband.sln \
-	Bakabakaband/Bakabakaband/curl/include/curl/curl.h \
-	Bakabakaband/Bakabakaband/curl/include/curl/curlver.h \
-	Bakabakaband/Bakabakaband/curl/include/curl/easy.h \
-	Bakabakaband/Bakabakaband/curl/include/curl/header.h \
-	Bakabakaband/Bakabakaband/curl/include/curl/mprintf.h \
-	Bakabakaband/Bakabakaband/curl/include/curl/multi.h \
-	Bakabakaband/Bakabakaband/curl/include/curl/options.h \
-	Bakabakaband/Bakabakaband/curl/include/curl/stdcheaders.h \
-	Bakabakaband/Bakabakaband/curl/include/curl/system.h \
-	Bakabakaband/Bakabakaband/curl/include/curl/typecheck-gcc.h \
-	Bakabakaband/Bakabakaband/curl/include/curl/urlapi.h \
-	Bakabakaband/Bakabakaband/curl/include/curl/websockets.h \
-	Bakabakaband/Bakabakaband/curl/lib/libcurl_a.lib \
-	Bakabakaband/Bakabakaband/Bakabakaband.vcxproj \
-	Bakabakaband/Bakabakaband/Bakabakaband.vcxproj.filters \
-	Bakabakaband/Bakabakaband/packages.config
-
-visual_studio_libcurl_files = \
-	VisualStudio/Hengband/libcurl/include/curl/curl.h \
-	VisualStudio/Hengband/libcurl/include/curl/curlver.h \
-	VisualStudio/Hengband/libcurl/include/curl/easy.h \
-	VisualStudio/Hengband/libcurl/include/curl/header.h \
-	VisualStudio/Hengband/libcurl/include/curl/mprintf.h \
-	VisualStudio/Hengband/libcurl/include/curl/multi.h \
-	VisualStudio/Hengband/libcurl/include/curl/options.h \
-	VisualStudio/Hengband/libcurl/include/curl/stdcheaders.h \
-	VisualStudio/Hengband/libcurl/include/curl/system.h \
-	VisualStudio/Hengband/libcurl/include/curl/typecheck-gcc.h \
-	VisualStudio/Hengband/libcurl/include/curl/urlapi.h \
-	VisualStudio/Hengband/libcurl/include/curl/websockets.h \
-	VisualStudio/Hengband/libcurl/lib/libcurl_a.lib \
-	VisualStudio/Hengband/libcurl/lib/libcurl_a_debug.lib
+	VisualStudio/Bakabakaband.sln \
+	VisualStudio/Bakabakaband/Bakabakaband.vcxproj \
+	VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters \
+	VisualStudio/Bakabakaband/packages.config \
+	VisualStudio/Hengband/Hengband.vcxproj \
+	VisualStudio/Hengband/Hengband.vcxproj.filters
 
 schema_files = \
 	schema/ArtifactDefinitions.schema.json \
 	schema/BaseitemDefinitions.schema.json \
 	schema/ClassMagicDefinitions.schema.json \
-	schema/CreaturePartyDefinitions.schema.json \
+	schema/CreatureParty.schema.json \
+	schema/DungeonDefinitions.schema.json \
 	schema/MonraceDefinitions.schema.json \
 	schema/MonsterMessages.schema.json \
 	schema/SpellDefinitions.schema.json
@@ -56,7 +30,6 @@ EXTRA_DIST = \
 	THIRD-PARTY-NOTICES.txt \
 	hengband.spec \
 	$(visual_studio_files) \
-	$(visual_studio_libcurl_files) \
 	$(schema_files)
 
 SUBDIRS = src lib

--- a/lib/file/Makefile.am
+++ b/lib/file/Makefile.am
@@ -5,13 +5,13 @@ AUTOMAKE_OPTIONS = foreign
 angband_files = \
 	a_cursed_j.txt a_high_j.txt a_low_j.txt a_med_j.txt \
 	aname_j.txt chainswd_j.txt dead_j.txt \
-	death_j.txt elvish_j.txt error_j.txt news_j.txt \
+	death_j.txt elvish_j.txt news_j.txt \
 	rumors_j.txt seppuku_j.txt silly_j.txt timefun_j.txt \
 	timenorm_j.txt w_cursed_j.txt w_high_j.txt w_low_j.txt \
 	w_med_j.txt \
 	a_cursed.txt a_high.txt a_low.txt a_med.txt \
 	chainswd.txt dead.txt \
-	death.txt elvish.txt error.txt news.txt \
+	death.txt elvish.txt news.txt \
 	rumors.txt seppuku.txt silly.txt sname.txt timefun.txt \
 	timenorm.txt w_cursed.txt w_high.txt w_low.txt\
 	w_med.txt

--- a/lib/file/books/Makefile.am
+++ b/lib/file/books/Makefile.am
@@ -2,13 +2,16 @@
 
 angband_files = \
 	book-000_en.txt book-000_jp.txt \
-	book-001_en.txt book-001_jp.txt \
-	book-002_en.txt book-002_jp.txt \
-	book-003_en.txt book-003_jp.txt \
-	book-004_en.txt book-004_jp.txt \
+	book-001_jp.txt \
+	book-002_jp.txt \
+	book-003_jp.txt \
+	book-004_jp.txt \
 	book-005_en.txt book-005_jp.txt \
 	book-006_en.txt book-006_jp.txt \
-	book-007_en.txt book-007_jp.txt
+	book-007_en.txt book-007_jp.txt \
+	book-008_en.txt book-008_jp.txt \
+	book-009_en.txt book-009_jp.txt \
+	book-010_en.txt book-010_jp.txt
 
 EXTRA_DIST = \
 	$(angband_files)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -73,7 +73,7 @@ hengband_SOURCES = \
 	alliance/alliance-fingolfin-noldor.cpp alliance/alliance-fingolfin-noldor.h \
 	alliance/alliance-frieza-clan.cpp alliance/alliance-frieza-clan.h \
 	alliance/alliance-sexy-commando-club.cpp alliance/alliance-sexy-commando-club.h \
-	alliance/alliance-slaanesh.cpp alliance/alliance-sllanesh.h \
+	alliance/alliance-slaanesh.cpp alliance/alliance-slaanesh.h \
 	alliance/alliance-nurgle.cpp alliance/alliance-nurgle.h \
 	alliance/alliance-nanman.cpp alliance/alliance-nanman.h \
 	alliance/alliance-nanto-orthodox.cpp alliance/alliance-nanto-orthodox.h \
@@ -97,7 +97,7 @@ hengband_SOURCES = \
 	alliance/alliance-valinor.cpp alliance/alliance-valinor.h \
 	alliance/alliance-yeek-kingdom.cpp alliance/alliance-yeek-kingdom.h \
 	\
-	artifact/artifact-info.cpp artifact/artifact-info.h \
+	artifact/artifact-info.cpp \
 	artifact/fixed-art-generator.cpp artifact/fixed-art-generator.h \
 	artifact/fixed-art-types.h \
 	artifact/random-art-activation.cpp artifact/random-art-activation.h \
@@ -1533,12 +1533,12 @@ hengband_SOURCES = \
 	world/world.cpp world/world.h \
 	world/world-alliance-processor.cpp world/world-alliance-processor.h \
 	world/world-collapsion.cpp world/world-collapsion.h \
-	world/world-object.cpp world/world-object.h \
+	world/world-object.cpp \
 	world/world-movement-processor.cpp world/world-movement-processor.h \
 	world/world-turn-processor.cpp world/world-turn-processor.h
 
 EXTRA_hengband_SOURCES = \
-	angband.ico angband.rc ang_eng.rc ang_jp.rc maid-x11.cpp main-win.cpp \
+	bakabakaband.ico angband.rc ang_eng.rc ang_jp.rc maid-x11.cpp main-win.cpp \
 	main-win/commandline-win.cpp main-win/commandline-win.h \
 	main-win/graphics-win.cpp main-win/graphics-win.h \
 	main-win/main-win-bg.cpp main-win/main-win-bg.h \


### PR DESCRIPTION
変愚蛮怒 PR #5361「schema を make dist に含める」の意図を bakabakaband に 適応。bakabakaband 側では schema_files の不整合に加え make dist 自体が 複数の stale 参照で全面的に壊れていたため、配布マニフェストを実ファイルに
合わせて全面修復した。

スキーマ (本題, #8298):
- Makefile.am の schema_files を実在ファイルに一致させた:
  - 誤記 CreaturePartyDefinitions.schema.json → CreatureParty.schema.json
  - 欠落していた DungeonDefinitions.schema.json を追加 （bakabakaband に TerrainDefinitions.schema.json は存在しないため除外）

make dist を阻害していた stale 参照の修復:
- Makefile.am: visual_studio_files を実在の VisualStudio/ 配下 6 ファイルに 修正（旧 Bakabakaband/... パスは全て不在）。実体の無い visual_studio_libcurl_files ブロックを削除。
- src/Makefile.am: 不在ファイル参照を修正
  - alliance/alliance-sllanesh.h → alliance-slaanesh.h（誤記）
  - artifact/artifact-info.h / world/world-object.h（不在）を除去
  - angband.ico → bakabakaband.ico（リネーム追従、.rc は対応済）
- lib/file/Makefile.am: 不在の error.txt / error_j.txt 参照を除去
- lib/file/books/Makefile.am: 不在の英語版 book-001..004_en を除去、 実在する book-008..010 (en/jp) を追加
- lib/save/delete.me: 空ディレクトリ配布用プレースホルダを追加（上流同様）

検証: ./bootstrap → ./configure → make dist が成功し、生成 tarball に schema/*.schema.json 全 8 件が含まれることを確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled distribution files for the build and release package.
  * Adjusted included Visual Studio project assets and schema files.
  * Refined distributed text assets, including Japanese/English book files and other library text files.
  * Corrected a source filename reference and updated packaged resources, including the app icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->