### PR TITLE
merge: オプション画面をウィンドウ中央に表示（hengband#3081 相当 / #3051）

### DIFF
--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -425,6 +425,8 @@ void extract_option_vars(void)
  */
 void do_cmd_options(CreatureEntity &creature)
 {
+    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
+
     char k;
     int skey;
     TERM_LEN i, y = 0;


### PR DESCRIPTION
変愚蛮怒 PR #3081「オプション画面をウィンドウ中央に表示する」を
bakabakaband に適応してマージ。do_cmd_options() 冒頭に
TermCenteredOffsetSetter を導入し、ターミナルが既定サイズ
(MAIN_TERM_MIN_COLS x MAIN_TERM_MIN_ROWS) より大きい場合に オプション画面を中央寄せで表示する。

同 PR のもう一方の対象 (cmd-autopick.cpp の TermCenteredOffsetSetter 導入) は bakabakaband 側で既に適用済みのため、本コミットは
未適用だった cmd-gameoption.cpp 側のみを補完する。

TermCenteredOffsetSetter は term/screen-processor.h 経由で既に 可視（cmd-autopick.cpp と同経路）のため追加 include は不要。
フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the options screen’s terminal positioning so it stays centered and better aligned when opened, especially in smaller window sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->