### PR TITLE
refactor: 知覚系フラグの差分検出をスナップショット化し getter 15個を撤廃（提案46）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -65,7 +65,7 @@ Phase 1-8 完了後に残存している統合作業項目を整理したもの�
 | [43](#提案-43-行動状態フラグの-private-化--完了) | 行動状態フラグ private 化 | ✅ 完了 | **+14 = 129 個** (action / running / resting / leaving / playing 等) |
 | [44](#提案-44-突然変異呪い系フラグの-private-化--完了) | 突然変異/呪い系フラグ private 化 | ✅ 完了 | **+5 = 99 個** (muta / cursed / patron 等) |
 | [45](#提案-45-pet_t_m_idx--riding_t_m_idx-のターゲット保守ロジック集約--完了) | pet/riding ターゲット保守ロジック集約 | ✅ 完了 | reset/clear/remap_pet_riding_targets |
-| [46](#提案-46-esp--装備集計の差分検出を-update_creature-内-raw-access-に閉じる) | ESP / 装備集計の差分検出を内部に閉じる | 🚧 | get_X_flags() 公開撤廃検討 |
+| [46](#提案-46-esp--知覚系フラグの差分検出スナップショット化--完了) | ESP / 知覚系フラグの差分検出スナップショット化 | ✅ 完了 | PerceptionFlagsSnapshot、getter 15 個撤廃 |
 | [47](#提案-47-その他小規模フィールドの-private-化--完了) | その他小規模フィールドまとめ | ✅ 完了 | **+6 = 135 個** (dealt_damage / run_py/px / vanish_stairs_flag / suppress_multi_reward / tracking_bi_id、tval_xtra 削除) |
 | [48](#提案-48-追加の小規模フィールドの-private-化--完了) | 追加の小規模フィールドまとめ | ✅ 完了 | **+6 = 141 個** (tval_ammo / dtrap / autopick_autoregister / recall_dungeon / enchant_energy_need / energy_use) |
 
@@ -2165,11 +2165,46 @@ CreatureEntity 共通化」は**提案 40 で既に達成済み**。
 
 ---
 
-## 提案 46: ESP / 装備集計の差分検出を `update_creature()` 内 raw access に閉じる
+## 提案 46: ESP / 知覚系フラグの差分検出スナップショット化 ✅ 完了
 
-提案 33 で telepathy/esp_* は private 化済だが、`get_X_flags()` が
-差分検出キャッシュ用に依然外部公開。これを `update_creature()`
-内部完結に閉じる試み。
+### 背景
+
+提案 33 で telepathy / esp_* / see_inv / mighty_throw は private 化済だが、
+旧値スナップショット (差分検出キャッシュ) 用に 15 個の `get_X_flags()`
+BIT_FLAGS getter が外部公開されたまま残っていた。これらは
+`update_bonuses()` (player-status.cpp) の「再計算前に旧値退避 → 再計算 →
+新旧比較で再描画フラグ設定」という差分検出のためだけに使われており、
+内部表現 (raw BIT_FLAGS) を外部に漏らしていた。
+
+### 完了内容
+
+- `CreatureEntity` にネスト構造体 `PerceptionFlagsSnapshot` を追加
+  (15 フラグ: telepathy / esp 12 種 / see_inv / mighty_throw)。
+  差分判定ヘルパ 2 種を提供:
+  - `mighty_throw_differs_from(other)` … 強投擲変化 (→ インベントリ再描画)
+  - `monster_perception_differs_from(other)` … テレパシー/ESP/透明視認の
+    いずれか変化 (→ モンスター状態再計算)
+- スナップショット取得 `capture_perception_flags()` を追加
+  (private フィールドを内部で読むため、個別 getter は不要)
+- **個別 `get_X_flags()` 15 個を撤廃**
+  (impact / earthquake は player-attack の実ロジックで使うため残置)
+- `player-status.cpp::update_bonuses()` を書き換え:
+  - 旧 15 行の `BIT_FLAGS old_X = get_X_flags();` → `const auto
+    old_perception = creature.capture_perception_flags();`
+  - 旧 27 行の個別比較ブロック → スナップショット 2 メソッド比較
+
+### 効果
+
+- 内部表現を漏らす public getter 15 個を撤廃し、差分検出を
+  「スナップショット取得 + 比較」という呼出側の関心事に閉じた
+- update_bonuses() の差分検出が ~42 行 → ~10 行に簡素化
+- player-status.cpp の getter 呼出 30 箇所が 2 箇所に集約
+- フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証済み
+
+### 残置
+
+`get_impact_flags()` / `get_earthquake_flags()` は player-attack.cpp が
+FLAG_CAUSE_* ビットマスク (どちらの手由来か) を実判定に使うため公開維持。
 
 ---
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -246,21 +246,7 @@ static void update_bonuses(CreatureEntity &creature)
     ItemEntity *o_ptr;
 
     /* Save the old vision stuff */
-    BIT_FLAGS old_telepathy = creature.get_telepathy_flags();
-    BIT_FLAGS old_esp_animal = creature.get_esp_animal_flags();
-    BIT_FLAGS old_esp_undead = creature.get_esp_undead_flags();
-    BIT_FLAGS old_esp_demon = creature.get_esp_demon_flags();
-    BIT_FLAGS old_esp_orc = creature.get_esp_orc_flags();
-    BIT_FLAGS old_esp_troll = creature.get_esp_troll_flags();
-    BIT_FLAGS old_esp_giant = creature.get_esp_giant_flags();
-    BIT_FLAGS old_esp_dragon = creature.get_esp_dragon_flags();
-    BIT_FLAGS old_esp_human = creature.get_esp_human_flags();
-    BIT_FLAGS old_esp_evil = creature.get_esp_evil_flags();
-    BIT_FLAGS old_esp_good = creature.get_esp_good_flags();
-    BIT_FLAGS old_esp_nonliving = creature.get_esp_nonliving_flags();
-    BIT_FLAGS old_esp_unique = creature.get_esp_unique_flags();
-    BIT_FLAGS old_see_inv = creature.get_see_inv_flags();
-    BIT_FLAGS old_mighty_throw = creature.get_mighty_throw_flags();
+    const auto old_perception = creature.capture_perception_flags();
     int16_t old_speed = static_cast<int16_t>(creature.get_speed());
 
     ARMOUR_CLASS old_dis_ac = creature.get_dis_ac();
@@ -362,31 +348,12 @@ static void update_bonuses(CreatureEntity &creature)
     creature.set_dis_to_a(calc_to_ac(creature, false));
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (old_mighty_throw != creature.get_mighty_throw_flags()) {
+    const auto new_perception = creature.capture_perception_flags();
+    if (new_perception.mighty_throw_differs_from(old_perception)) {
         rfu.set_flag(SubWindowRedrawingFlag::INVENTORY);
     }
 
-    if (creature.get_telepathy_flags() != old_telepathy) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
-    }
-
-    auto is_esp_updated = creature.get_esp_animal_flags() != old_esp_animal;
-    is_esp_updated |= creature.get_esp_undead_flags() != old_esp_undead;
-    is_esp_updated |= creature.get_esp_demon_flags() != old_esp_demon;
-    is_esp_updated |= creature.get_esp_orc_flags() != old_esp_orc;
-    is_esp_updated |= creature.get_esp_troll_flags() != old_esp_troll;
-    is_esp_updated |= creature.get_esp_giant_flags() != old_esp_giant;
-    is_esp_updated |= creature.get_esp_dragon_flags() != old_esp_dragon;
-    is_esp_updated |= creature.get_esp_human_flags() != old_esp_human;
-    is_esp_updated |= creature.get_esp_evil_flags() != old_esp_evil;
-    is_esp_updated |= creature.get_esp_good_flags() != old_esp_good;
-    is_esp_updated |= creature.get_esp_nonliving_flags() != old_esp_nonliving;
-    is_esp_updated |= creature.get_esp_unique_flags() != old_esp_unique;
-    if (is_esp_updated) {
-        rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
-    }
-
-    if (creature.get_see_inv_flags() != old_see_inv) {
+    if (new_perception.monster_perception_differs_from(old_perception)) {
         rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     }
 

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -3418,66 +3418,64 @@ public:
         return this->earthquake;
     }
 
-    // 旧値スナップショット用 BIT_FLAGS getter (差分検出キャッシュ向け)。
-    virtual BIT_FLAGS get_telepathy_flags() const
+    // [提案 46] 知覚系フラグ (テレパシー / ESP 12 種 / 透明視認 / 強投擲) の
+    // 差分検出スナップショット。update_bonuses() の再計算前後で
+    // capture_perception_flags() を取得・比較することで、個別の BIT_FLAGS
+    // getter を外部公開せず、差分検出を呼出側の関心事に閉じる。
+    struct PerceptionFlagsSnapshot {
+        BIT_FLAGS telepathy{};
+        BIT_FLAGS esp_animal{};
+        BIT_FLAGS esp_nasty{};
+        BIT_FLAGS esp_homo{};
+        BIT_FLAGS esp_undead{};
+        BIT_FLAGS esp_demon{};
+        BIT_FLAGS esp_orc{};
+        BIT_FLAGS esp_troll{};
+        BIT_FLAGS esp_giant{};
+        BIT_FLAGS esp_dragon{};
+        BIT_FLAGS esp_human{};
+        BIT_FLAGS esp_evil{};
+        BIT_FLAGS esp_good{};
+        BIT_FLAGS esp_nonliving{};
+        BIT_FLAGS esp_unique{};
+        BIT_FLAGS see_inv{};
+        BIT_FLAGS mighty_throw{};
+
+        //!< 強投擲フラグが変化したか (変化時はインベントリ再描画が必要)。
+        bool mighty_throw_differs_from(const PerceptionFlagsSnapshot &other) const
+        {
+            return this->mighty_throw != other.mighty_throw;
+        }
+
+        //!< テレパシー / ESP / 透明視認のいずれかが変化したか
+        //!< (変化時はモンスター状態の再計算が必要)。
+        bool monster_perception_differs_from(const PerceptionFlagsSnapshot &other) const
+        {
+            return (this->telepathy != other.telepathy) || (this->esp_animal != other.esp_animal) || (this->esp_nasty != other.esp_nasty) || (this->esp_homo != other.esp_homo) || (this->esp_undead != other.esp_undead) || (this->esp_demon != other.esp_demon) || (this->esp_orc != other.esp_orc) || (this->esp_troll != other.esp_troll) || (this->esp_giant != other.esp_giant) || (this->esp_dragon != other.esp_dragon) || (this->esp_human != other.esp_human) || (this->esp_evil != other.esp_evil) || (this->esp_good != other.esp_good) || (this->esp_nonliving != other.esp_nonliving) || (this->esp_unique != other.esp_unique) || (this->see_inv != other.see_inv);
+        }
+    };
+
+    PerceptionFlagsSnapshot capture_perception_flags() const
     {
-        return this->telepathy;
-    }
-    virtual BIT_FLAGS get_esp_animal_flags() const
-    {
-        return this->esp_animal;
-    }
-    virtual BIT_FLAGS get_esp_undead_flags() const
-    {
-        return this->esp_undead;
-    }
-    virtual BIT_FLAGS get_esp_demon_flags() const
-    {
-        return this->esp_demon;
-    }
-    virtual BIT_FLAGS get_esp_orc_flags() const
-    {
-        return this->esp_orc;
-    }
-    virtual BIT_FLAGS get_esp_troll_flags() const
-    {
-        return this->esp_troll;
-    }
-    virtual BIT_FLAGS get_esp_giant_flags() const
-    {
-        return this->esp_giant;
-    }
-    virtual BIT_FLAGS get_esp_dragon_flags() const
-    {
-        return this->esp_dragon;
-    }
-    virtual BIT_FLAGS get_esp_human_flags() const
-    {
-        return this->esp_human;
-    }
-    virtual BIT_FLAGS get_esp_evil_flags() const
-    {
-        return this->esp_evil;
-    }
-    virtual BIT_FLAGS get_esp_good_flags() const
-    {
-        return this->esp_good;
-    }
-    virtual BIT_FLAGS get_esp_nonliving_flags() const
-    {
-        return this->esp_nonliving;
-    }
-    virtual BIT_FLAGS get_esp_unique_flags() const
-    {
-        return this->esp_unique;
-    }
-    virtual BIT_FLAGS get_see_inv_flags() const
-    {
-        return this->see_inv;
-    }
-    virtual BIT_FLAGS get_mighty_throw_flags() const
-    {
-        return this->mighty_throw;
+        return {
+            this->telepathy,
+            this->esp_animal,
+            this->esp_nasty,
+            this->esp_homo,
+            this->esp_undead,
+            this->esp_demon,
+            this->esp_orc,
+            this->esp_troll,
+            this->esp_giant,
+            this->esp_dragon,
+            this->esp_human,
+            this->esp_evil,
+            this->esp_good,
+            this->esp_nonliving,
+            this->esp_unique,
+            this->see_inv,
+            this->mighty_throw,
+        };
     }
 
     // 特殊攻撃 / 特殊防御フラグ。compound assignment が複数箇所にあるため


### PR DESCRIPTION
CreatureEntity 統合リファクタリング 提案 46。提案 33 で private 化した telepathy / esp_* / see_inv / mighty_throw について、差分検出キャッシュ用に 外部公開されていた 15 個の get_X_flags() BIT_FLAGS getter を撤廃。

これらは update_bonuses() (player-status.cpp) の「再計算前に旧値退避 → 再計算 → 新旧比較で再描画フラグ設定」のためだけに使われ、内部表現
(raw BIT_FLAGS) を外部へ漏らしていた。差分検出をスナップショット方式に
閉じ込めることで隠蔽する。

- src/system/creature-entity.h:
  - ネスト構造体 PerceptionFlagsSnapshot を追加 (15 フラグ + 差分判定 ヘルパ mighty_throw_differs_from / monster_perception_differs_from)
  - capture_perception_flags() を追加 (private フィールドを内部で読む)
  - 個別 get_X_flags() 15 個を撤廃 (impact / earthquake は player-attack の 実ロジックで使用するため残置)
- src/player/player-status.cpp: update_bonuses() の旧値退避 15 行と 比較ブロック 27 行を、スナップショット取得 + 2 メソッド比較に簡素化 (getter 呼出 30 箇所 → 2 箇所)
- docs/creature-entity-refactoring-roadmap.md: 提案 46 を完了に更新

フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of perception/ESP/telepathy changes so inventory redraws and monster status recalculations refresh more reliably when relevant traits are modified.
* **Refactor**
  * Consolidated perception change tracking into a single snapshot-based mechanism instead of comparing individual flag values.
* **Documentation**
  * Updated the perception-change handling roadmap to reflect the completed snapshot approach and simplified comparison flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->