### PR TITLE
refactor: モンスター時限効果付与プリミティブを FloorType に集約（提案49 / B1第1段）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -68,6 +68,7 @@ Phase 1-8 完了後に残存している統合作業項目を整理したもの�
 | [46](#提案-46-esp--知覚系フラグの差分検出スナップショット化--完了) | ESP / 知覚系フラグの差分検出スナップショット化 | ✅ 完了 | PerceptionFlagsSnapshot、getter 15 個撤廃 |
 | [47](#提案-47-その他小規模フィールドの-private-化--完了) | その他小規模フィールドまとめ | ✅ 完了 | **+6 = 135 個** (dealt_damage / run_py/px / vanish_stairs_flag / suppress_multi_reward / tracking_bi_id、tval_xtra 削除) |
 | [48](#提案-48-追加の小規模フィールドの-private-化--完了) | 追加の小規模フィールドまとめ | ✅ 完了 | **+6 = 141 個** (tval_ammo / dtrap / autopick_autoregister / recall_dungeon / enchant_energy_need / energy_use) |
+| [49](#提案-49-モンスター時限効果付与プリミティブの集約-b1-第1段--完了) | モンスター時限効果付与プリミティブ集約 (B1 第1段) | ✅ 完了 | FloorType::set_monster_timed_effect、7 setter 集約 |
 
 **累計 private 化フィールド数 (主要マイルストーン):**
 - 提案 29 (3 個) → 32 (10 個) → 32b (37 個) → 33 (72 個) → 34 (77 個) →
@@ -2467,6 +2468,62 @@ virtual を追加し、PlayerEnergy はそれらを呼び出す形に切替え�
 - B-3: 装備フラグキャッシュ (性能必要時)
 
 各提案は独立した PR として進めること。
+
+---
+
+## 提案 49: モンスター時限効果付与プリミティブの集約 (B1 第1段) ✅ 完了
+
+### 背景 (B1「状態異常付与処理の統合」の調査結果)
+
+第2層 B1 として「状態異常付与ロジック (耐性判定＋メッセージ＋セット) を
+`creature.try_inflict_X()` 的な virtual に共通化」を狙ったが、調査の結果
+**プレイヤー経路と モンスター経路の共有ロジックは想定より小さい**ことが判明:
+
+- **プレイヤー** (`BadStatusSetter`): 値クランプ + 豊富な副作用 (行動中断 /
+  構え崩し / 徳変化 / 連携リセット等) + プレイヤー向けメッセージ + `set_timed_effect`。
+- **モンスター** (`set_monster_*`): 値クランプ + **mproc キュー保守**
+  (毎ターン処理対象への登録/解除、`m_idx` キー) + `set_timed_effect`。
+
+両者で真に共通なのは `set_timed_effect` のみ。モンスターは mproc という
+固有機構を、プレイヤーは固有副作用を持つため、単純な `try_inflict_X()`
+virtual では中身が分離した 2 経路になり価値が薄い。さらに統一 `set_timed_effect`
+(提案 5) は mproc を保守しないため、モンスターに直接呼ぶと効果が毎ターン
+処理されない**フットガン**が存在する (各 set_monster_* がこれを個別に吸収)。
+
+**真の統一 (set_timed_effect が mproc を自動保守) には、モンスターが自身の
+`m_idx` を知る仕組みが必要**で、これはモンスターデータ構造とホットパスに
+関わる別提案 (アーキテクチャ判断要) とする。
+
+### 完了内容 (B1 の安全な第 1 段)
+
+モンスター側の「時限効果付与 (mproc 保守込み)」をまず単一プリミティブへ集約:
+
+- `FloorType::set_monster_timed_effect(m_idx, mte, v, max_value)` を新設。
+  クランプ + mproc 保守 (付与時 add / 解除時 remove) + 値設定 + 変化有無
+  (notice) 返却を 1 箇所に集約。`is_X()` ≡ `get_timed_effect(X) > 0` の
+  等価性を確認の上で共通化したため挙動不変。
+- `set_monster_csleep` / `fast` / `slow` / `stunned` / `confused` /
+  `monfear` / `invulner` の 7 setter が、それぞれ複製していたコア
+  (クランプ + mproc + set) を本プリミティブへ委譲。各 setter 固有の
+  前段ガード (monfear の狂乱) と後段再描画は維持。
+- `stunned` / `confused` は 1 行に縮約。`invulner` の解除時エネルギー消費は
+  `notice && v<=0` で等価に再現。
+
+### 効果
+
+- モンスター時限効果付与の「mproc 保守を伴う正しい設定」が単一メソッドに
+  集約され、フットガン (mproc 保守漏れ) を構造的に防止
+- 7 setter 合計で重複コア (1 setter あたり ~10 行) を削減
+- 将来の真の player/monster 時限効果統一 (set_timed_effect への mproc 統合)
+  の足場が整備
+- フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証済み
+
+### 残作業 (B1 後続段 / 別提案)
+
+- **アーキテクチャ前提**: モンスター自身の `m_idx` 参照手段の導入
+  (これにより `CreatureEntity::set_timed_effect` がモンスターの mproc を
+  自動保守でき、player/monster の時限効果 API が真に一本化する)
+- 上記完了後、`creature.try_inflict_X()` 的な付与 API の共通化を再検討
 
 ---
 

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -69,27 +69,11 @@ void anger_monster(CreatureEntity &creature, CreatureEntity &target)
  */
 bool set_monster_csleep(FloorType &floor, MONSTER_IDX m_idx, int v)
 {
-    auto &monster = floor.get_monster(m_idx);
-    bool notice = false;
-    v = (v > 10000) ? 10000 : (v < 0) ? 0
-                                      : v;
-    if (v) {
-        if (!monster.is_asleep()) {
-            floor.add_mproc(m_idx, CreatureTimedEffect::SLEEP_OR_PARALYSIS);
-            notice = true;
-        }
-    } else {
-        if (monster.is_asleep()) {
-            floor.remove_mproc(m_idx, CreatureTimedEffect::SLEEP_OR_PARALYSIS);
-            notice = true;
-        }
-    }
-
-    monster.set_timed_effect(CreatureTimedEffect::SLEEP_OR_PARALYSIS, (int16_t)v);
-    if (!notice) {
+    if (!floor.set_monster_timed_effect(m_idx, CreatureTimedEffect::SLEEP_OR_PARALYSIS, v, 10000)) {
         return false;
     }
 
+    auto &monster = floor.get_monster(m_idx);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     if (monster.is_visible_on_map()) {
         HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
@@ -114,28 +98,11 @@ bool set_monster_csleep(FloorType &floor, MONSTER_IDX m_idx, int v)
  */
 bool set_monster_fast(FloorType &floor, MONSTER_IDX m_idx, int v)
 {
-    auto &monster = floor.get_monster(m_idx);
-    bool notice = false;
-    v = (v > 200) ? 200 : (v < 0) ? 0
-                                  : v;
-    if (v) {
-        if (!monster.is_accelerated()) {
-            floor.add_mproc(m_idx, CreatureTimedEffect::ACCELERATION);
-            notice = true;
-        }
-    } else {
-        if (monster.is_accelerated()) {
-            floor.remove_mproc(m_idx, CreatureTimedEffect::ACCELERATION);
-            notice = true;
-        }
-    }
-
-    monster.set_timed_effect(CreatureTimedEffect::ACCELERATION, (int16_t)v);
-    if (!notice) {
+    if (!floor.set_monster_timed_effect(m_idx, CreatureTimedEffect::ACCELERATION, v, 200)) {
         return false;
     }
 
-    if (monster.is_riding()) {
+    if (floor.get_monster(m_idx).is_riding()) {
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     }
 
@@ -151,28 +118,11 @@ bool set_monster_fast(FloorType &floor, MONSTER_IDX m_idx, int v)
  */
 bool set_monster_slow(FloorType &floor, MONSTER_IDX m_idx, int v)
 {
-    auto &monster = floor.get_monster(m_idx);
-    bool notice = false;
-    v = (v > 200) ? 200 : (v < 0) ? 0
-                                  : v;
-    if (v) {
-        if (!monster.is_decelerated()) {
-            floor.add_mproc(m_idx, CreatureTimedEffect::DECELERATION);
-            notice = true;
-        }
-    } else {
-        if (monster.is_decelerated()) {
-            floor.remove_mproc(m_idx, CreatureTimedEffect::DECELERATION);
-            notice = true;
-        }
-    }
-
-    monster.set_timed_effect(CreatureTimedEffect::DECELERATION, (int16_t)v);
-    if (!notice) {
+    if (!floor.set_monster_timed_effect(m_idx, CreatureTimedEffect::DECELERATION, v, 200)) {
         return false;
     }
 
-    if (monster.is_riding()) {
+    if (floor.get_monster(m_idx).is_riding()) {
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     }
 
@@ -188,24 +138,7 @@ bool set_monster_slow(FloorType &floor, MONSTER_IDX m_idx, int v)
  */
 bool set_monster_stunned(FloorType &floor, MONSTER_IDX m_idx, int v)
 {
-    auto &monster = floor.get_monster(m_idx);
-    bool notice = false;
-    v = (v > 200) ? 200 : (v < 0) ? 0
-                                  : v;
-    if (v) {
-        if (!monster.is_stunned()) {
-            floor.add_mproc(m_idx, CreatureTimedEffect::STUN);
-            notice = true;
-        }
-    } else {
-        if (monster.is_stunned()) {
-            floor.remove_mproc(m_idx, CreatureTimedEffect::STUN);
-            notice = true;
-        }
-    }
-
-    monster.set_timed_effect(CreatureTimedEffect::STUN, (int16_t)v);
-    return notice;
+    return floor.set_monster_timed_effect(m_idx, CreatureTimedEffect::STUN, v, 200);
 }
 
 /*!
@@ -217,24 +150,7 @@ bool set_monster_stunned(FloorType &floor, MONSTER_IDX m_idx, int v)
  */
 bool set_monster_confused(FloorType &floor, MONSTER_IDX m_idx, int v)
 {
-    auto &monster = floor.get_monster(m_idx);
-    bool notice = false;
-    v = (v > 200) ? 200 : (v < 0) ? 0
-                                  : v;
-    if (v) {
-        if (!monster.is_confused()) {
-            floor.add_mproc(m_idx, CreatureTimedEffect::CONFUSION);
-            notice = true;
-        }
-    } else {
-        if (monster.is_confused()) {
-            floor.remove_mproc(m_idx, CreatureTimedEffect::CONFUSION);
-            notice = true;
-        }
-    }
-
-    monster.set_timed_effect(CreatureTimedEffect::CONFUSION, (int16_t)v);
-    return notice;
+    return floor.set_monster_timed_effect(m_idx, CreatureTimedEffect::CONFUSION, v, 200);
 }
 
 /*!
@@ -247,30 +163,13 @@ bool set_monster_confused(FloorType &floor, MONSTER_IDX m_idx, int v)
 bool set_monster_monfear(FloorType &floor, MONSTER_IDX m_idx, int v)
 {
     auto &monster = floor.get_monster(m_idx);
-    bool notice = false;
 
     // 狂乱状態のモンスターは恐怖しない
     if (monster.is_frenzied() && v > 0) {
         return false;
     }
 
-    v = (v > 200) ? 200 : (v < 0) ? 0
-                                  : v;
-    if (v) {
-        if (!monster.is_fearful()) {
-            floor.add_mproc(m_idx, CreatureTimedEffect::FEAR);
-            notice = true;
-        }
-    } else {
-        if (monster.is_fearful()) {
-            floor.remove_mproc(m_idx, CreatureTimedEffect::FEAR);
-            notice = true;
-        }
-    }
-
-    monster.set_timed_effect(CreatureTimedEffect::FEAR, (int16_t)v);
-
-    if (!notice) {
+    if (!floor.set_monster_timed_effect(m_idx, CreatureTimedEffect::FEAR, v, 200)) {
         return false;
     }
 
@@ -295,25 +194,13 @@ bool set_monster_monfear(FloorType &floor, MONSTER_IDX m_idx, int v)
 bool set_monster_invulner(FloorType &floor, MONSTER_IDX m_idx, int v, bool energy_need)
 {
     auto &monster = floor.get_monster(m_idx);
-    bool notice = false;
-    v = (v > 200) ? 200 : (v < 0) ? 0
-                                  : v;
-    if (v) {
-        if (!monster.is_invulnerable()) {
-            floor.add_mproc(m_idx, CreatureTimedEffect::INVULNERABILITY);
-            notice = true;
-        }
-    } else {
-        if (monster.is_invulnerable()) {
-            floor.remove_mproc(m_idx, CreatureTimedEffect::INVULNERABILITY);
-            if (energy_need && !AngbandWorld::get_instance().is_wild_mode()) {
-                monster.energy_need += ENERGY_NEED();
-            }
-            notice = true;
-        }
+    const auto notice = floor.set_monster_timed_effect(m_idx, CreatureTimedEffect::INVULNERABILITY, v, 200);
+
+    // 無敵が解除された (notice かつ v<=0) 場合、行動ターン消費のオプション処理。
+    if (notice && (v <= 0) && energy_need && !AngbandWorld::get_instance().is_wild_mode()) {
+        monster.energy_need += ENERGY_NEED();
     }
 
-    monster.set_timed_effect(CreatureTimedEffect::INVULNERABILITY, (int16_t)v);
     if (!notice) {
         return false;
     }

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -610,6 +610,38 @@ void FloorType::remove_mproc(short m_idx, CreatureTimedEffect mte)
 }
 
 /*!
+ * @brief モンスターに時限効果を設定し、mproc キュー (時限効果処理リスト) を保守する
+ * @param m_idx 対象モンスターのインデックス
+ * @param mte 設定する時限効果
+ * @param v 効果値 (0 で解除)。[0, max_value] にクランプされる
+ * @param max_value 効果値の上限
+ * @return 効果の有無が変化した (新規付与または完全解除された) 場合 true
+ * @details モンスターの時限効果は mproc キューに登録されたものだけが毎ターン
+ *          処理されるため、効果値の設定と mproc 登録/解除は常に対で行う必要が
+ *          ある。本メソッドはこの不変条件 (クランプ + mproc 保守 + 値設定) を
+ *          1 箇所へ集約し、各 set_monster_* 系が個別に複製していたコア処理を
+ *          共通化する。
+ */
+bool FloorType::set_monster_timed_effect(short m_idx, CreatureTimedEffect mte, int v, int max_value)
+{
+    auto &monster = this->get_monster(m_idx);
+    v = (v < 0) ? 0 : ((v > max_value) ? max_value : v);
+    const auto had_effect = monster.get_timed_effect(mte) > 0;
+    const auto will_have_effect = v > 0;
+    auto notice = false;
+    if (will_have_effect && !had_effect) {
+        this->add_mproc(m_idx, mte);
+        notice = true;
+    } else if (!will_have_effect && had_effect) {
+        this->remove_mproc(m_idx, mte);
+        notice = true;
+    }
+
+    monster.set_timed_effect(mte, static_cast<int16_t>(v));
+    return notice;
+}
+
+/*!
  * @brief モンスター配列の空きを探す
  * @return 使われていないモンスターのフロア内インデックス
  */

--- a/src/system/floor/floor-info.h
+++ b/src/system/floor/floor-info.h
@@ -149,6 +149,7 @@ public:
     tl::optional<int> get_mproc_index(short m_idx, CreatureTimedEffect mte);
     void add_mproc(short m_idx, CreatureTimedEffect mte);
     void remove_mproc(short m_idx, CreatureTimedEffect mte);
+    bool set_monster_timed_effect(short m_idx, CreatureTimedEffect mte, int v, int max_value);
 
     CreatureEntity &get_monster(MONSTER_IDX m_idx);
     const CreatureEntity &get_monster(MONSTER_IDX m_idx) const;


### PR DESCRIPTION
CreatureEntity 統合リファクタリング B1「状態異常付与処理の統合」の第1段。

調査の結果、プレイヤー(BadStatusSetter)とモンスター(set_monster_*)の状態 異常付与は共有ロジックが小さく(真に共通なのは set_timed_effect のみ)、
モンスターは mproc キュー保守(m_idx キー)、プレイヤーは固有副作用を持つため
単純な try_inflict_X() virtual では価値が薄いと判明。真の統一には
モンスター自身の m_idx 参照手段(アーキテクチャ変更)が前提となるため別提案とし、
本コミットでは安全な第1段としてモンスター側の付与コアを集約する。

- src/system/floor/floor-info.{h,cpp}: FloorType::set_monster_timed_effect() を新設。クランプ + mproc 保守(付与時 add/解除時 remove)+ 値設定 + 変化 有無返却を集約。is_X() ≡ get_timed_effect(X) > 0 の等価性を確認の上で 共通化したため挙動不変。
- src/monster/monster-status-setter.cpp: set_monster_csleep/fast/slow/ stunned/confused/monfear/invulner の 7 setter が複製していたコアを 本プリミティブへ委譲。固有の前段ガード(monfear の狂乱)・後段再描画は維持。 invulner の解除時エネルギー消費は notice && v<=0 で等価に再現。
- docs/creature-entity-refactoring-roadmap.md: 提案 49 として記録、B1 の 調査結果と後続(m_idx 参照導入)を明記。

フルビルド(g++ -O3 -Werror -Wall -Wextra)と clang-format-18 で検証済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified way to apply monster timed effects, improving consistency across status changes.

* **Bug Fixes**
  * Simplified several monster status updates so effect changes are handled more reliably.
  * Preserved existing behavior for sleep, speed changes, fear, stun, confusion, and invulnerability, while keeping related updates intact.

* **Documentation**
  * Updated the refactoring roadmap to reflect the completed monster timed-effect consolidation and the remaining follow-up work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->