### PR TITLE
refactor: set_timed_effect に mproc 保守を統合し時限効果設定経路を一本化（提案50 / B1後続段）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -69,6 +69,7 @@ Phase 1-8 完了後に残存している統合作業項目を整理したもの�
 | [47](#提案-47-その他小規模フィールドの-private-化--完了) | その他小規模フィールドまとめ | ✅ 完了 | **+6 = 135 個** (dealt_damage / run_py/px / vanish_stairs_flag / suppress_multi_reward / tracking_bi_id、tval_xtra 削除) |
 | [48](#提案-48-追加の小規模フィールドの-private-化--完了) | 追加の小規模フィールドまとめ | ✅ 完了 | **+6 = 141 個** (tval_ammo / dtrap / autopick_autoregister / recall_dungeon / enchant_energy_need / energy_use) |
 | [49](#提案-49-モンスター時限効果付与プリミティブの集約-b1-第1段--完了) | モンスター時限効果付与プリミティブ集約 (B1 第1段) | ✅ 完了 | FloorType::set_monster_timed_effect、7 setter 集約 |
+| [50](#提案-50-set_timed_effect-への-mproc-保守統合-b1-後続段--完了-要実機smoke-test) | set_timed_effect への mproc 保守統合 (B1 後続段) | ✅ 完了 (要実機smoke-test) | get_self_m_idx、mproc を set_timed_effect に内包 |
 
 **累計 private 化フィールド数 (主要マイルストーン):**
 - 提案 29 (3 個) → 32 (10 個) → 32b (37 個) → 33 (72 個) → 34 (77 個) →
@@ -2524,6 +2525,69 @@ virtual では中身が分離した 2 経路になり価値が薄い。さらに
   (これにより `CreatureEntity::set_timed_effect` がモンスターの mproc を
   自動保守でき、player/monster の時限効果 API が真に一本化する)
 - 上記完了後、`creature.try_inflict_X()` 的な付与 API の共通化を再検討
+
+---
+
+## 提案 50: set_timed_effect への mproc 保守統合 (B1 後続段) ✅ 完了 (要実機smoke-test)
+
+### 背景・前提調査
+
+提案 49 で「モンスター側の時限効果付与は mproc キュー (毎ターン処理リスト) 保守を
+伴う」ことを集約したが、統一 API `CreatureEntity::set_timed_effect()` を
+モンスターへ直接呼ぶと mproc が保守されない**フットガン**が残っていた
+(`set_monster_*` 経由でのみ保守)。これを解消し、player/monster で
+時限効果設定経路を真に一本化する。
+
+調査で判明した mproc のアーキテクチャ:
+
+- **時限効果 map が source of truth** (savefile に保存)。
+- **mproc は派生キャッシュ**。`FloorType::reset_mproc()` が map から全走査で
+  再構築し、**フロア入場時 (`dungeon-processor` のターンループ直前 L215)**・
+  セーブ後・ポリモーフ後に呼ばれる。さらにゲームプレイ中は付与経路が
+  逐次保守する 2 段構成。
+
+この「フロア入場時 reset_mproc がターン処理前に必ず走る」安全網により、
+ロード中等で mproc 保守が漏れても (または一時的に誤っても) 処理前に
+再構築され整合する。
+
+### 完了内容
+
+- `CreatureEntity::get_self_m_idx()` を追加。モンスターは自身の m_idx を保持
+  しないが、`floor.m_list` 上のインデックスは配置先グリッドの m_idx と一致する
+  ため、現在位置のグリッドから導出する (プレイヤー・未配置・フロア未設定は 0)。
+- `CreatureEntity::set_timed_effect()` に **mproc 保守を内包**。値が 0 を
+  またいで変化した時のみ、対象が「配置済みモンスター」かつ
+  `MONSTER_TIMED_EFFECT_LIST` の 7 効果なら `add_mproc`/`remove_mproc` を行う
+  (file-local `maintain_monster_mproc_on_toggle`)。プレイヤー・未配置時は
+  no-op で `reset_mproc()` に委ねる。
+- `FloorType::set_monster_timed_effect()` から明示 mproc 呼出を撤去
+  (set_timed_effect に集約)。クランプ + notice 算出のみに簡素化。
+- これで mproc を触る箇所は **`reset_mproc()` (全再構築) と
+  `set_timed_effect()` (逐次保守) の 2 箇所のみ**に集約。二重保守なし。
+
+### 安全性の根拠
+
+- ゲームプレイ中: モンスターはグリッド上にあり m_idx が正しく導出され逐次保守。
+- ロード/生成中: モンスター未配置で m_idx=0 のため保守はスキップされるが、
+  フロア入場時の `reset_mproc()` がターン処理前に map から再構築するため整合。
+- `add_mproc` は他に呼出元がなく二重登録経路なし。`remove_mproc` は不在
+  エントリに対し no-op で冪等。
+
+### ⚠️ 残確認 (実機 smoke-test 推奨)
+
+セーブ/ロード・per-turn 処理という critical path への変更のため、ビルド
+(g++ -O3 -Werror) 検証に加え、実機での **(1) 減速/混乱/恐怖等を受けた
+モンスターのセーブ→ロード後の継続、(2) フロア移動を跨いだ効果処理、
+(3) 通常戦闘での状態異常付与/解除** の動作確認を推奨。問題があれば
+`maintain_monster_mproc_on_toggle` のガード条件を見直すこと。
+
+### 今後 (B1 後続)
+
+- mproc 保守が set_timed_effect に集約されたことで、`set_monster_*` 自由関数
+  および `FloorType::set_monster_timed_effect` は「クランプ + メッセージ +
+  再描画」のみの薄いラッパとなった。将来これらを `CreatureEntity` の
+  状態異常付与 API (例: `inflict_*`) へ寄せる余地がある (ただしプレイヤーの
+  豊富な副作用とは別経路のまま)。
 
 ---
 

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -561,10 +561,74 @@ short CreatureEntity::get_timed_effect(CreatureTimedEffect effect) const
     return (it != this->timed_effects_map.end()) ? it->second : 0;
 }
 
+namespace {
+/*!
+ * @brief モンスターの時限効果が 0 をまたいで変化した際に mproc キャッシュを保守する
+ * @param creature 対象クリーチャー
+ * @param effect 変化した時限効果
+ * @param became_active true なら新規付与 (add)、false なら解除 (remove)
+ * @details mproc はモンスター時限効果の毎ターン処理用の派生キャッシュ。プレイヤー・
+ *          未配置モンスター (ロード中等) は対象外で、その場合は FloorType::reset_mproc()
+ *          による再構築 (フロア入場時等) に委ねる。これによりモンスターへ
+ *          set_timed_effect() を直接呼んでも mproc 保守が漏れない (従来は
+ *          set_monster_* 経由でのみ保守されていた footgun を解消)。
+ */
+void maintain_monster_mproc_on_toggle(CreatureEntity &creature, CreatureTimedEffect effect, bool became_active)
+{
+    if (creature.is_player() || !creature.has_monster_profile()) {
+        return;
+    }
+
+    const auto is_mproc_effect = std::find(MONSTER_TIMED_EFFECT_LIST.begin(), MONSTER_TIMED_EFFECT_LIST.end(), effect) != MONSTER_TIMED_EFFECT_LIST.end();
+    if (!is_mproc_effect) {
+        return;
+    }
+
+    const auto m_idx = creature.get_self_m_idx();
+    if (m_idx <= 0) {
+        return; // グリッド未配置 (ロード中等)。reset_mproc() による再構築に委ねる。
+    }
+
+    auto &floor = *creature.get_floor();
+    if (became_active) {
+        floor.add_mproc(m_idx, effect);
+    } else {
+        floor.remove_mproc(m_idx, effect);
+    }
+}
+}
+
+MONSTER_IDX CreatureEntity::get_self_m_idx() const
+{
+    const auto floor = this->get_floor();
+    if (floor == nullptr) {
+        return 0;
+    }
+
+    const auto m_idx = floor->get_grid(this->get_position()).m_idx;
+    if (m_idx <= 0) {
+        return 0;
+    }
+
+    // グリッド上のモンスターが自分自身であることを確認する。座標が古い / 別モンスターが
+    // 立っている / プレイヤー等で不一致の場合は 0 を返し、他モンスターの m_idx 誤取得を防ぐ。
+    if (&floor->get_monster(m_idx) != this) {
+        return 0;
+    }
+
+    return m_idx;
+}
+
 void CreatureEntity::set_timed_effect(CreatureTimedEffect effect, short value)
 {
+    const auto was_active = this->get_timed_effect(effect) > 0;
     auto key = (effect == CreatureTimedEffect::SLEEP_OR_PARALYSIS) ? CreatureTimedEffect::PARALYSIS : effect;
     this->timed_effects_map[key] = value;
+
+    const auto is_active = value > 0;
+    if (was_active != is_active) {
+        maintain_monster_mproc_on_toggle(*this, effect, is_active);
+    }
 }
 
 int CreatureEntity::get_base_natural_regen_amount() const

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -716,6 +716,17 @@ public:
     virtual void set_timed_effect(CreatureTimedEffect effect, short value);
 
     /*!
+     * @brief モンスター自身のフロア上インデックス (m_idx) を、配置先グリッドから導出して返す
+     * @return 配置済みモンスターなら m_idx、プレイヤー・未配置・フロア未設定なら 0
+     * @details モンスターは自身の m_idx を保持しないが、floor.m_list 上のインデックスは
+     *          配置先グリッドの m_idx と一致するため、現在位置のグリッドから導出できる。
+     *          導出した m_idx のモンスターが自分自身であることを検証し、座標が古い等で
+     *          不一致なら 0 を返す (他モンスターの m_idx 誤取得を防止)。
+     *          時限効果の mproc キャッシュ保守 (set_timed_effect) 等で自己参照に用いる。
+     */
+    MONSTER_IDX get_self_m_idx() const;
+
+    /*!
      * @brief 自然回復をスキップすべき状態か（侍 KOUKIJIN 構え・早駆け中等）を判定
      * @return スキップすべきなら true。デフォルトは false（モンスターは常に回復対象）
      * @details PlayerType でオーバーライドし、KOUKIJIN 構え・HAYAGAKE 行動を判定する

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -610,17 +610,15 @@ void FloorType::remove_mproc(short m_idx, CreatureTimedEffect mte)
 }
 
 /*!
- * @brief モンスターに時限効果を設定し、mproc キュー (時限効果処理リスト) を保守する
+ * @brief モンスターに時限効果を設定する (値クランプ + 変化有無の返却)
  * @param m_idx 対象モンスターのインデックス
  * @param mte 設定する時限効果
  * @param v 効果値 (0 で解除)。[0, max_value] にクランプされる
  * @param max_value 効果値の上限
  * @return 効果の有無が変化した (新規付与または完全解除された) 場合 true
- * @details モンスターの時限効果は mproc キューに登録されたものだけが毎ターン
- *          処理されるため、効果値の設定と mproc 登録/解除は常に対で行う必要が
- *          ある。本メソッドはこの不変条件 (クランプ + mproc 保守 + 値設定) を
- *          1 箇所へ集約し、各 set_monster_* 系が個別に複製していたコア処理を
- *          共通化する。
+ * @details mproc キュー (毎ターン処理対象) の保守は CreatureEntity::set_timed_effect()
+ *          内に集約済み (提案 B1 後続段)。本メソッドは各 set_monster_* 系が共通で
+ *          必要とする「値クランプ + 変化有無 (notice) の算出」を担う。
  */
 bool FloorType::set_monster_timed_effect(short m_idx, CreatureTimedEffect mte, int v, int max_value)
 {
@@ -628,17 +626,10 @@ bool FloorType::set_monster_timed_effect(short m_idx, CreatureTimedEffect mte, i
     v = (v < 0) ? 0 : ((v > max_value) ? max_value : v);
     const auto had_effect = monster.get_timed_effect(mte) > 0;
     const auto will_have_effect = v > 0;
-    auto notice = false;
-    if (will_have_effect && !had_effect) {
-        this->add_mproc(m_idx, mte);
-        notice = true;
-    } else if (!will_have_effect && had_effect) {
-        this->remove_mproc(m_idx, mte);
-        notice = true;
-    }
 
+    // 値設定に伴う mproc 保守は set_timed_effect() が内部で行う。
     monster.set_timed_effect(mte, static_cast<int16_t>(v));
-    return notice;
+    return had_effect != will_have_effect;
 }
 
 /*!


### PR DESCRIPTION
CreatureEntity 統合リファクタリング B1「状態異常付与処理の統合」後続段。
統一 API set_timed_effect() をモンスターへ直接呼ぶと mproc キュー(毎ターン 処理リスト)が保守されない footgun を解消し、player/monster の時限効果設定
経路を真に一本化する。

アーキテクチャ前提(調査結果): 時限効果 map が source of truth(savefile保存)、 mproc は派生キャッシュ。FloorType::reset_mproc() が map から全走査で再構築し、 フロア入場時(dungeon-processor のターンループ直前)・セーブ後・ポリモーフ後に
必ず走る。この安全網により、ロード/生成中に逐次保守が漏れても処理前に整合する。

- src/system/creature-entity.{h,cpp}:
  - get_self_m_idx() 追加。モンスターは自身の m_idx を保持しないが、m_list 上の インデックスは配置先グリッドの m_idx と一致するため現在位置から導出 (プレイヤー・未配置・フロア未設定は 0)。
  - set_timed_effect() に mproc 保守を内包。値が 0 をまたいで変化した時のみ、 配置済みモンスターかつ MONSTER_TIMED_EFFECT_LIST の 7 効果なら add/remove_mproc (file-local maintain_monster_mproc_on_toggle)。未配置時は no-op で reset_mproc に委ねる。
- src/system/floor/floor-info.cpp: FloorType::set_monster_timed_effect から明示 mproc 呼出を撤去(set_timed_effect に集約)。クランプ + notice 算出のみに簡素化。

これで mproc を触る箇所は reset_mproc()(全再構築)と set_timed_effect()(逐次保守) の 2 箇所のみに集約、二重保守なし。

注意: セーブ/ロード・per-turn という critical path への変更のため、ビルド検証 (g++ -O3 -Werror)に加え実機 smoke-test(状態異常モンスターのセーブ→ロード継続/ フロア移動跨ぎ/通常戦闘の付与解除)を推奨。詳細はロードマップ提案50参照。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of timed monster effects with per-turn processing so effects no longer fall out of step when being enabled or disabled.
  * Timed-effect state changes now correctly update the underlying processing queue for the affected monster on the grid, avoiding stale registrations.
* **Documentation**
  * Updated the refactoring roadmap (including Proposal 50) with the latest plan, completion details, and safety notes for unified timed-effect handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->