### PR TITLE
refactor: MP フィールド csp/msp を current_mp/max_mp に命名統一（提案6）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ CreatureEntity  (基底クラス)  src/system/creature-entity.h
 
 - 座標: `x`, `y`, `oldpx`, `oldpy`
 - HP: `hp`, `maxhp`, `max_maxhp`, `hp_frac`
-- MP: `csp`, `msp`, `csp_frac`
+- MP: `current_mp`, `max_mp`, `current_mp_frac` (旧 `csp` / `msp` / `csp_frac`、提案 6 で改名)
 - 能力値: `stat_cur[]`, `stat_max[]`, `stat_use[]` 等
 - スキル: `skill_dis`, `skill_dev`, `skill_sav` 等
 - タイムドエフェクト: `invuln`, `hero`, `oppose_fire` 等多数
@@ -949,9 +949,10 @@ bakabakaband 側と上流側でよくある構造的差異を以下のルール�
 | `creature.age = X` / `creature.ht = X` / `creature.wt = X` / `creature.prestige = X` 書込 | `creature.set_age(X)` / `set_ht(X)` / `set_wt(X)` / `set_prestige(X)`、加算は `add_age(d)` / `add_prestige(d)`、`prestige /= N` は `divide_prestige(N)` (提案 24) |
 | `creature.inven_cnt` / `creature.equip_cnt` フィールド | **提案 25 でフィールド廃止。** `creature.get_inven_cnt()` / `creature.get_equip_cnt()` を呼ぶ。インベントリ変更時の cnt 同期は不要 (inventory[] から自動計算) |
 | `creature.ambush_flag = X` / `creature.food = X` / `creature.town_num = X` / `creature.level = X` 書込 | `creature.set_ambush_flag(X)` / `set_food(X)` / `set_town_num(X)` / `set_level(X)` (提案 26) |
-| `creature.max_plv = X` / `creature.msp = X` 書込 | `creature.set_max_plv(X)` / `creature.set_msp(X)` (提案 27) |
+| `creature.max_plv = X` / `creature.msp = X` 書込 | `creature.set_max_plv(X)` / `creature.set_max_mp(X)` (提案 27、msp は提案 6 で `max_mp` に改名) |
 | `creature.exp = X` / `creature.max_exp = X` / `creature.max_max_exp = X` 書込 | `creature.set_exp(X)` / `set_max_exp(X)` / `set_max_max_exp(X)` (提案 27) |
-| `creature.au [+\-/]= X` / `creature.csp [+\-]= X` の compound assignment | `creature.set_au(X)` / `add_au(X)` / `sub_au(X)` / `divide_au(X)`、`set_csp(X)` / `add_csp(X)` / `sub_csp(X)` (提案 27b)。約 110 箇所の `+=` / `-=` を移行済み |
+| `creature.au [+\-/]= X` / `creature.csp [+\-]= X` の compound assignment | `creature.set_au(X)` / `add_au(X)` / `sub_au(X)` / `divide_au(X)`、`set_current_mp(X)` / `add_current_mp(X)` / `sub_current_mp(X)` (提案 27b。csp は提案 6 で `current_mp` に改名)。約 110 箇所の `+=` / `-=` を移行済み |
+| `creature.csp` / `creature.msp` / `creature.csp_frac` 読取り (上流の MP フィールド) | `creature.get_current_mp()` / `creature.get_max_mp()` / `current_mp_frac` (提案 6 でフィールドを `current_mp` / `max_mp` / `current_mp_frac` に改名。get/set/add/sub も `*_current_mp` / `*_max_mp` 系へ。**上流マージ時は `csp`→`current_mp`、`msp`→`max_mp` の置換が必要**) |
 | `creature.num_blow[hand]` / `creature.num_fire` / `creature.to_m_chance` / `creature.cur_lite` 読取り | `creature.get_num_blow(hand)` / `get_num_fire()` / `get_to_m_chance()` / `get_cur_lite()` (提案 39) |
 | `creature.num_blow[hand] = X` / `num_fire = X` 等の書込 | `creature.set_num_blow(hand, X)` / `set_num_fire(X)` / `set_to_m_chance(X)` / `set_cur_lite(X)` (提案 39) |
 | `creature.cumber_armor` / `cumber_glove` 読取り | `creature.is_cumber_armor()` / `is_cumber_glove()` (提案 39) |

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -22,7 +22,7 @@ Phase 1-8 完了後に残存している統合作業項目を整理したもの�
 | [3](#提案-3-残存する-playertypeget_instance-多用箇所の削減--完了) | `PlayerType::get_instance()` 多用箇所の削減 | ✅ 完了 | グローバルアクセスの削減 |
 | [4](#提案-4-未統合の状態チェック関数の仮想化--完了) | 未統合の状態チェック関数の仮想化 | ✅ 完了 | has_resist_X 等の自由関数 |
 | [5](#提案-5-timedeffects-オブジェクトとの二重管理解消--完了) | TimedEffects 二重管理解消 | ✅ 完了 | timed_effects_map 統一 |
-| [6](#提案-6-フィールド名の命名統一) | フィールド名の命名統一 | 🚧 | csp/msp → current_mp/max_mp 等 (大規模 diff、後回し) |
+| [6](#提案-6-フィールド名の命名統一--完了-mp-系) | フィールド名の命名統一 (MP 系) | ✅ 完了 | csp/msp → current_mp/max_mp (403 箇所改名) |
 | [7](#提案-7-モンスター可視判定-ml-の-virtual-アクセサ化--完了) | モンスター可視判定 (`ml`) の virtual 化 | ✅ 完了 | is_visible_on_map() |
 | [8](#提案-8-hpmp-自然回復計算の-virtual-hook-化--完了) | HP/MP 自然回復計算の virtual hook 化 | ✅ 完了 | get_base_natural_regen_amount() |
 | [9](#提案-9-monsterprofile-フィールド-virtual-アクセサ化--一部完了) | MonsterProfile read-side virtual | ✅ 一部完了 | get_alliance_idx / get_smart_flags 等 |
@@ -425,7 +425,7 @@ TimedEffects 優先の特殊分岐を持っていた。一方モンスターは 
 
 ---
 
-## 提案 6: フィールド名の命名統一
+## 提案 6: フィールド名の命名統一 ✅ 完了 (MP 系)
 
 ### 背景
 
@@ -433,19 +433,39 @@ TimedEffects 優先の特殊分岐を持っていた。一方モンスターは 
 命名を引きずっているものがある。統合が進んだ今、汎用的な名前に
 改名することで可読性が向上する。
 
-### 候補
+### 完了内容 (MP 系、提案 6 第1弾)
+
+`csp` / `msp` (Angband 由来の current/max spell points) を MP 概念に
+合わせて改名。全体識別子 `\b...\b` アンカーの一括スクリプトで実施し、
+`mspell` 等の部分一致衝突を回避。**403 箇所 / 65 ファイル** を置換、
+フルビルド (g++ -O3 -Werror) と clang-format-18 で検証済み。
+
+| 旧名称 | 新名称 |
+|---|---|
+| `csp` (フィールド) | `current_mp` |
+| `msp` (フィールド) | `max_mp` |
+| `csp_frac` | `current_mp_frac` |
+| `get_csp` / `set_csp` / `add_csp` / `sub_csp` | `get_current_mp` / `set_current_mp` / `add_current_mp` / `sub_current_mp` |
+| `add_csp_with_frac` / `sub_csp_with_frac` | `add_current_mp_with_frac` / `sub_current_mp_with_frac` |
+| `get_msp` / `set_msp` | `get_max_mp` / `set_max_mp` |
+| ローカル `max_csp` / `old_csp` / `baseline_msp` | `max_current_mp` / `old_current_mp` / `baseline_max_mp` |
+
+**上流マージへの影響**: フィールド自体は提案 27b で private 化済みのため、
+上流の `creature->csp` アクセスは元々変換が必要だった。本改名で変換先が
+`get_current_mp()` 等に変わるのみ (CLAUDE.md のマッピング表に追記済み)。
+
+### 残候補 (未着手)
 
 | 現名称 | 候補名 | 備考 |
 |---|---|---|
-| `csp` / `msp` | `current_mp` / `max_mp` | モンスターが MP 使用する設計拡張時に有効 |
-| `exp` / `max_exp` / `max_max_exp` | そのままクリーチャー共通で | モンスター側も経験値概念を将来運用 |
-| `hp_frac` / `csp_frac` | `hp_fraction` / `mp_fraction` | 可読性のみ |
+| `exp` / `max_exp` / `max_max_exp` | そのままクリーチャー共通で | 改名せず維持 |
+| `hp_frac` | `hp_fraction` | 可読性のみ。MP 系と対称にするなら別途検討 |
 
-### 注意
+### 注意 (今後の改名作業)
 
 改名 PR は diff が巨大化し、変愚マージ時の衝突を増やす。
-**提案 1-5 が全て完了してから着手する**のが安全。
-改名時は一括 sed 実行 + ビルド確認を自動化したスクリプトを用意すること。
+改名時は全体識別子 `\b...\b` アンカーの一括スクリプト + ビルド確認を
+用いること (素朴な部分一致 sed は `mspell`↔`msp` 等を破壊する)。
 
 ---
 

--- a/src/action/racial-execution.cpp
+++ b/src/action/racial-execution.cpp
@@ -122,7 +122,7 @@ racial_level_check_result check_racial_level(CreatureEntity &creature, rpi_type 
     const PLAYER_LEVEL min_level = rpi_ptr->min_level;
     int difficulty = rpi_ptr->fail;
     rpi_ptr->racial_cost = rpi_ptr->cost;
-    const int use_hp = creature.get_csp() < rpi_ptr->racial_cost ? rpi_ptr->racial_cost - creature.get_csp() : 0;
+    const int use_hp = creature.get_current_mp() < rpi_ptr->racial_cost ? rpi_ptr->racial_cost - creature.get_current_mp() : 0;
 
     PlayerEnergy energy(creature);
     if (creature.get_level() < min_level) {

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -477,7 +477,7 @@ static bool display_auto_roller_result(CreatureEntity &creature, bool prev, char
         rfu.set_flags(flags);
         update_creature(creature);
         creature.hp = creature.maxhp;
-        creature.set_csp(creature.get_msp());
+        creature.set_current_mp(creature.get_max_mp());
         (void)display_player(creature, mode);
         term_gotoxy(2, 23);
         const char b1 = '[';

--- a/src/birth/monster-birth.cpp
+++ b/src/birth/monster-birth.cpp
@@ -808,7 +808,7 @@ bool player_birth_as_monster(CreatureEntity &creature)
     RedrawingFlagsUpdater::get_instance().set_flags(flags);
     update_creature(creature);
     creature.hp = creature.maxhp;
-    creature.set_csp(creature.get_msp());
+    creature.set_current_mp(creature.get_max_mp());
 
     init_turn(creature);
     init_dungeon_quests(creature);

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -74,7 +74,7 @@ bool ask_quick_start(CreatureEntity &creature)
     RedrawingFlagsUpdater::get_instance().set_flags(flags);
     update_creature(creature);
     creature.hp = creature.maxhp;
-    creature.set_csp(creature.get_msp());
+    creature.set_current_mp(creature.get_max_mp());
     process_player_name(creature);
     return true;
 }

--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -384,8 +384,8 @@ int calculate_blue_magic_failure_probability(CreatureEntity &creature, const mon
 
     chance -= 3 * (adj_mag_stat[creature.get_stat_index(A_INT)] - 1);
     chance = mod_spell_chance_1(creature, chance);
-    if (need_mana > creature.get_csp()) {
-        chance += 5 * (need_mana - creature.get_csp());
+    if (need_mana > creature.get_current_mp()) {
+        chance += 5 * (need_mana - creature.get_current_mp());
     }
 
     PERCENTAGE minfail = adj_mag_fail[creature.get_stat_index(A_INT)];

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -329,7 +329,7 @@ void do_cmd_hissatsu(CreatureEntity &creature)
     const auto &spell = PlayerRealm::get_spell_info(RealmType::HISSATSU, n);
 
     /* Verify "dangerous" spells */
-    if (spell.smana > creature.get_csp()) {
+    if (spell.smana > creature.get_current_mp()) {
         if (flush_failure) {
             flush();
         }
@@ -347,9 +347,9 @@ void do_cmd_hissatsu(CreatureEntity &creature)
 
     creature.plus_incident_tree("USE_HISSATSU", 1);
     PlayerEnergy(creature).set_player_turn_energy(100);
-    creature.sub_csp(spell.smana);
-    if (creature.get_csp() < 0) {
-        creature.set_csp(0);
+    creature.sub_current_mp(spell.smana);
+    if (creature.get_current_mp() < 0) {
+        creature.set_current_mp(0);
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -63,7 +63,7 @@ struct cm_type {
     PERCENTAGE chance; //!< 失敗率
     PERCENTAGE minfail; //!< 最低失敗率
     PLAYER_LEVEL plev; //!< 取得レベル
-    int old_csp; //!< 行使前のMP
+    int old_current_mp; //!< 行使前のMP
     mind_type spell; //!< 職業技能の基本設定構造体
     bool cast; //!< 行使の成否
     int mana_cost; //!< 最終算出消費MP
@@ -79,7 +79,7 @@ static cm_type *initialize_cm_type(CreatureEntity &creature, cm_type *cm_ptr)
     cm_ptr->b = 0;
     cm_ptr->minfail = 0;
     cm_ptr->plev = creature.get_level();
-    cm_ptr->old_csp = creature.get_csp();
+    cm_ptr->old_current_mp = creature.get_current_mp();
     cm_ptr->on_mirror = false;
     return cm_ptr;
 }
@@ -157,7 +157,7 @@ static bool check_mind_hp_mp_sufficiency(CreatureEntity &creature, cm_type *cm_p
         return true;
     }
 
-    if (cm_ptr->mana_cost <= creature.get_csp()) {
+    if (cm_ptr->mana_cost <= creature.get_current_mp()) {
         return true;
     }
 
@@ -178,8 +178,8 @@ static void decide_mind_chance(CreatureEntity &creature, cm_type *cm_ptr)
     cm_ptr->chance -= 3 * (cm_ptr->plev - cm_ptr->spell.min_lev);
     cm_ptr->chance += creature.get_to_m_chance();
     cm_ptr->chance -= 3 * (adj_mag_stat[creature.get_stat_index(mp_ptr->spell_stat)] - 1);
-    if ((cm_ptr->mana_cost > creature.get_csp()) && (cm_ptr->use_mind != MindKindType::BERSERKER) && (cm_ptr->use_mind != MindKindType::NINJUTSU)) {
-        cm_ptr->chance += 5 * (cm_ptr->mana_cost - creature.get_csp());
+    if ((cm_ptr->mana_cost > creature.get_current_mp()) && (cm_ptr->use_mind != MindKindType::BERSERKER) && (cm_ptr->use_mind != MindKindType::NINJUTSU)) {
+        cm_ptr->chance += 5 * (cm_ptr->mana_cost - creature.get_current_mp());
     }
 
     cm_ptr->minfail = adj_mag_fail[creature.get_stat_index(mp_ptr->spell_stat)];
@@ -238,7 +238,7 @@ static void check_mind_mindcrafter(CreatureEntity &creature, cm_type *cm_ptr)
     msg_format(_("%sの力が制御できない氾流となって解放された！", "Your mind unleashes its power in an uncontrollable storm!"), cm_ptr->mind_explanation);
     project(creature, PROJECT_WHO_UNCTRL_POWER, 2 + cm_ptr->plev / 10, creature.y, creature.x, cm_ptr->plev * 2, AttributeType::MANA,
         PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM);
-    creature.set_csp(std::max(0, creature.get_csp() - cm_ptr->plev * std::max(1, cm_ptr->plev / 10)));
+    creature.set_current_mp(std::max(0, creature.get_current_mp() - cm_ptr->plev * std::max(1, cm_ptr->plev / 10)));
 }
 
 static void check_mind_mirror_master(CreatureEntity &creature, cm_type *cm_ptr)
@@ -266,7 +266,7 @@ static void check_mind_mirror_master(CreatureEntity &creature, cm_type *cm_ptr)
     msg_format(_("%sの力が制御できない氾流となって解放された！", "Your mind unleashes its power in an uncontrollable storm!"), cm_ptr->mind_explanation);
     project(creature, PROJECT_WHO_UNCTRL_POWER, 2 + cm_ptr->plev / 10, creature.y, creature.x, cm_ptr->plev * 2, AttributeType::MANA,
         PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM);
-    creature.set_csp(std::max(0, creature.get_csp() - cm_ptr->plev * std::max(1, cm_ptr->plev / 10)));
+    creature.set_current_mp(std::max(0, creature.get_current_mp() - cm_ptr->plev * std::max(1, cm_ptr->plev / 10)));
 }
 
 static void check_mind_class(CreatureEntity &creature, cm_type *cm_ptr)
@@ -349,12 +349,12 @@ static bool judge_mind_chance(CreatureEntity &creature, cm_type *cm_ptr)
 
 static void mind_reflection(CreatureEntity &creature, cm_type *cm_ptr)
 {
-    int oops = cm_ptr->mana_cost - cm_ptr->old_csp;
-    if ((creature.get_csp() - cm_ptr->mana_cost) < 0) {
-        creature.csp_frac = 0;
+    int oops = cm_ptr->mana_cost - cm_ptr->old_current_mp;
+    if ((creature.get_current_mp() - cm_ptr->mana_cost) < 0) {
+        creature.current_mp_frac = 0;
     }
 
-    creature.set_csp(std::max(0, creature.get_csp() - cm_ptr->mana_cost));
+    creature.set_current_mp(std::max(0, creature.get_current_mp() - cm_ptr->mana_cost));
     msg_print(_(format("%sを集中しすぎて気を失ってしまった！", cm_ptr->mind_explanation), "You faint from the effort!"));
     (void)BadStatusSetter(creature).mod_paralysis(randnum1<short>(5 * oops + 1));
     if (one_in_(2)) {
@@ -374,19 +374,19 @@ static void process_hard_concentration(CreatureEntity &creature, cm_type *cm_ptr
         return;
     }
 
-    if (cm_ptr->mana_cost > cm_ptr->old_csp) {
+    if (cm_ptr->mana_cost > cm_ptr->old_current_mp) {
         mind_reflection(creature, cm_ptr);
         return;
     }
 
-    creature.sub_csp(cm_ptr->mana_cost);
-    if (creature.get_csp() < 0) {
-        creature.set_csp(0);
+    creature.sub_current_mp(cm_ptr->mana_cost);
+    if (creature.get_current_mp() < 0) {
+        creature.set_current_mp(0);
     }
 
     if ((cm_ptr->use_mind == MindKindType::MINDCRAFTER) && (cm_ptr->n == 13)) {
-        creature.set_csp(0);
-        creature.csp_frac = 0;
+        creature.set_current_mp(0);
+        creature.current_mp_frac = 0;
     }
 }
 

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -447,11 +447,11 @@ static bool racial_power_reduce_mana(CreatureEntity &creature, rc_type *rc_ptr)
 
     int actual_racial_cost = racial_cost / 2 + randint1(racial_cost / 2);
 
-    if (creature.get_csp() >= actual_racial_cost) {
-        creature.sub_csp(actual_racial_cost);
+    if (creature.get_current_mp() >= actual_racial_cost) {
+        creature.sub_current_mp(actual_racial_cost);
     } else {
-        actual_racial_cost -= creature.get_csp();
-        creature.set_csp(0);
+        actual_racial_cost -= creature.get_current_mp();
+        creature.set_current_mp(0);
         take_hit(creature, DAMAGE_USELIFE, actual_racial_cost, _("過度の集中", "concentrating too hard"));
     }
 

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -1008,7 +1008,7 @@ bool do_cmd_cast(CreatureEntity &creature)
     need_mana = mod_need_mana(creature, spell.smana, spell_id, use_realm);
 
     /* Verify "dangerous" spells */
-    if (need_mana > creature.get_csp()) {
+    if (need_mana > creature.get_current_mp()) {
         if (flush_failure) {
             flush();
         }
@@ -1263,9 +1263,9 @@ bool do_cmd_cast(CreatureEntity &creature)
     PlayerEnergy(creature).set_player_turn_energy(100);
 
     /* Sufficient mana */
-    if (need_mana <= creature.get_csp()) {
+    if (need_mana <= creature.get_current_mp()) {
         /* Use some mana */
-        creature.sub_csp(need_mana);
+        creature.sub_current_mp(need_mana);
     } else {
         over_exerted = true;
     }
@@ -1275,8 +1275,8 @@ bool do_cmd_cast(CreatureEntity &creature)
     /* Over-exert the player */
     if (over_exerted) {
         int oops = need_mana;
-        creature.set_csp(0);
-        creature.csp_frac = 0;
+        creature.set_current_mp(0);
+        creature.current_mp_frac = 0;
         msg_print(_("精神を集中しすぎて気を失ってしまった！", "You faint from the effort!"));
         (void)BadStatusSetter(creature).mod_paralysis(randnum1<short>(5 * oops + 1));
         switch (use_realm) {

--- a/src/cmd-building/cmd-inn.cpp
+++ b/src/cmd-building/cmd-inn.cpp
@@ -117,7 +117,7 @@ static void back_to_health(CreatureEntity &creature)
     (void)bss.set_confusion(0);
     creature.set_timed_effect(CreatureTimedEffect::STUN, 0);
     creature.hp = creature.maxhp;
-    creature.set_csp(creature.get_msp());
+    creature.set_current_mp(creature.get_max_mp());
 }
 
 /*!

--- a/src/cmd-io/cmd-text-command.cpp
+++ b/src/cmd-io/cmd-text-command.cpp
@@ -195,8 +195,8 @@ static std::vector<TextCommand> get_text_commands()
 #endif
 
                 // 少しの体力消費
-                if (creature.get_csp() > 1) {
-                    creature.sub_csp(1);
+                if (creature.get_current_mp() > 1) {
+                    creature.sub_current_mp(1);
                     auto &rfu = RedrawingFlagsUpdater::get_instance();
                     rfu.set_flag(MainWindowRedrawingFlag::MP);
                 }

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -252,10 +252,10 @@ static bool exe_eat_corpse_type_object(CreatureEntity &creature, ItemEntity *o_p
     }
 
     if (monrace.meat_feed_flags.has(MonsterFeedType::DRAIN_MANA)) {
-        creature.sub_csp(30);
-        if (creature.get_csp() < 0) {
-            creature.set_csp(0);
-            creature.csp_frac = 0;
+        creature.sub_current_mp(30);
+        if (creature.get_current_mp() < 0) {
+            creature.set_current_mp(0);
+            creature.current_mp_frac = 0;
         }
     }
 

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -124,7 +124,7 @@ static AttributeFlags shot_attribute(CreatureEntity &creature, ItemEntity *bow_p
         }
     }
 
-    if ((flags.has(TR_FORCE_WEAPON)) && (creature.get_csp() > (creature.get_msp() / 30))) {
+    if ((flags.has(TR_FORCE_WEAPON)) && (creature.get_current_mp() > (creature.get_max_mp() / 30))) {
         attribute_flags.set(AttributeType::MANA);
     }
 
@@ -464,8 +464,8 @@ static MULTIPLY calc_shot_damage_with_slay(
             }
         }
 
-        if ((flags.has(TR_FORCE_WEAPON)) && (creature.get_csp() > (creature.get_msp() / 30))) {
-            creature.sub_csp((1 + (creature.get_msp() / 30)));
+        if ((flags.has(TR_FORCE_WEAPON)) && (creature.get_current_mp() > (creature.get_max_mp() / 30))) {
+            creature.sub_current_mp((1 + (creature.get_max_mp() / 30)));
             RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);
             mult = mult * 5 / 2;
         }
@@ -1290,7 +1290,7 @@ uint32_t calc_expect_dice(
     // 理力
     bool is_force = !CreatureClass(creature).equals(PlayerClassType::SAMURAI);
     is_force &= flags.has(TR_FORCE_WEAPON);
-    is_force &= creature.get_csp() > (o_ptr->damage_dice.maxroll() / 5);
+    is_force &= creature.get_current_mp() > (o_ptr->damage_dice.maxroll() / 5);
 
     dam = calc_slaydam(dam, 1, 1, is_force);
     dam = calc_expect_crit(creature, o_ptr->weight, o_ptr->to_h, dam, to_h, false, impact);

--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -210,8 +210,8 @@ int calc_attack_damage_with_slay(CreatureEntity &creature, ItemEntity *o_ptr, in
             mult = mult_hissatsu(creature, mult, flags, target, mode);
         }
 
-        if (!pc.equals(PlayerClassType::SAMURAI) && (flags.has(TR_FORCE_WEAPON)) && (creature.get_csp() > (o_ptr->damage_dice.maxroll() / 5))) {
-            creature.sub_csp((1 + (o_ptr->damage_dice.maxroll() / 5)));
+        if (!pc.equals(PlayerClassType::SAMURAI) && (flags.has(TR_FORCE_WEAPON)) && (creature.get_current_mp() > (o_ptr->damage_dice.maxroll() / 5))) {
+            creature.sub_current_mp((1 + (o_ptr->damage_dice.maxroll() / 5)));
             RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);
             mult = mult * 3 / 2 + 20;
         }
@@ -308,7 +308,7 @@ AttributeFlags melee_attribute(CreatureEntity &creature, ItemEntity *o_ptr, comb
         }
     }
 
-    if ((flags.has(TR_FORCE_WEAPON)) && (creature.get_csp() > (o_ptr->damage_dice.maxroll() / 5))) {
+    if ((flags.has(TR_FORCE_WEAPON)) && (creature.get_current_mp() > (o_ptr->damage_dice.maxroll() / 5))) {
         attribute_flags.set(AttributeType::MANA);
     }
 

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -156,7 +156,7 @@ void process_player(CreatureEntity &creature)
 
     if (creature.get_resting() < 0) {
         if (creature.get_resting() == COMMAND_ARG_REST_FULL_HEALING) {
-            if ((creature.hp == creature.maxhp) && (creature.get_csp() >= creature.get_msp())) {
+            if ((creature.hp == creature.maxhp) && (creature.get_current_mp() >= creature.get_max_mp())) {
                 set_action(creature, ACTION_NONE);
             }
         } else if (creature.get_resting() == COMMAND_ARG_REST_UNTIL_DONE) {
@@ -234,24 +234,24 @@ void process_player(CreatureEntity &creature)
 
     if (creature.get_action() == ACTION_LEARN) {
         int32_t cost = 0L;
-        uint32_t cost_frac = (creature.get_msp() + 30L) * 256L;
+        uint32_t cost_frac = (creature.get_max_mp() + 30L) * 256L;
         s64b_lshift(&cost, &cost_frac, 16);
-        if (s64b_cmp(creature.get_csp(), creature.csp_frac, cost, cost_frac) < 0) {
-            creature.set_csp(0);
-            creature.csp_frac = 0;
+        if (s64b_cmp(creature.get_current_mp(), creature.current_mp_frac, cost, cost_frac) < 0) {
+            creature.set_current_mp(0);
+            creature.current_mp_frac = 0;
             set_action(creature, ACTION_NONE);
         } else {
-            creature.sub_csp_with_frac(cost, cost_frac);
+            creature.sub_current_mp_with_frac(cost, cost_frac);
         }
 
         rfu.set_flag(MainWindowRedrawingFlag::MP);
     }
 
     if (CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU)) {
-        if (creature.get_csp() < 3) {
+        if (creature.get_current_mp() < 3) {
             set_action(creature, ACTION_NONE);
         } else {
-            creature.sub_csp(2);
+            creature.sub_current_mp(2);
             rfu.set_flag(MainWindowRedrawingFlag::MP);
         }
     }

--- a/src/core/stuff-handler.cpp
+++ b/src/core/stuff-handler.cpp
@@ -76,8 +76,8 @@ bool update_player()
 
 bool redraw_player(CreatureEntity &creature)
 {
-    if (creature.get_csp() > creature.get_msp()) {
-        creature.set_csp(creature.get_msp());
+    if (creature.get_current_mp() > creature.get_max_mp()) {
+        creature.set_current_mp(creature.get_max_mp());
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -257,9 +257,9 @@ static void effect_monster_psi_drain_resist(CreatureEntity &creature, EffectMons
     }
 
     msg_print(_("超能力パワーを吸いとられた！", "Your psychic energy is drained!"));
-    creature.sub_csp(Dice::roll(5, em_ptr->dam) / 2);
-    if (creature.get_csp() < 0) {
-        creature.set_csp(0);
+    creature.sub_current_mp(Dice::roll(5, em_ptr->dam) / 2);
+    if (creature.get_current_mp() < 0) {
+        creature.set_current_mp(0);
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
@@ -281,8 +281,8 @@ static void effect_monster_psi_drain_change_power(CreatureEntity &creature, Effe
     concptr msg = _("あなたは%sの苦痛を%sに変換した！", (em_ptr->seen ? "You convert %s's pain into %s!" : "You convert %ss pain into %s!"));
     msg_format(msg, em_ptr->m_name, str);
 
-    b = std::min(creature.get_msp(), creature.get_csp() + b);
-    creature.set_csp(b);
+    b = std::min(creature.get_max_mp(), creature.get_current_mp() + b);
+    creature.set_current_mp(b);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MP);
     rfu.set_flag(SubWindowRedrawingFlag::SPELL);

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -22,7 +22,7 @@ void effect_player_drain_mana(CreatureEntity &creature, EffectPlayerType *ep_ptr
         return;
     }
 
-    if (creature.get_csp() == 0) {
+    if (creature.get_current_mp() == 0) {
         ep_ptr->dam = 0;
         return;
     }
@@ -33,12 +33,12 @@ void effect_player_drain_mana(CreatureEntity &creature, EffectPlayerType *ep_ptr
         msg_print(_("精神エネルギーを吸い取られてしまった！", "Your psychic energy is drained!"));
     }
 
-    if (ep_ptr->dam >= creature.get_csp()) {
-        ep_ptr->dam = creature.get_csp();
-        creature.set_csp(0);
-        creature.csp_frac = 0;
+    if (ep_ptr->dam >= creature.get_current_mp()) {
+        ep_ptr->dam = creature.get_current_mp();
+        creature.set_current_mp(0);
+        creature.current_mp_frac = 0;
     } else {
-        creature.sub_csp(ep_ptr->dam);
+        creature.sub_current_mp(ep_ptr->dam);
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
@@ -93,10 +93,10 @@ void effect_player_mind_blast(CreatureEntity &creature, EffectPlayerType *ep_ptr
         (void)bss.mod_hallucination(randint0(250) + 150);
     }
 
-    creature.sub_csp(50);
-    if (creature.get_csp() < 0) {
-        creature.set_csp(0);
-        creature.csp_frac = 0;
+    creature.sub_current_mp(50);
+    if (creature.get_current_mp() < 0) {
+        creature.set_current_mp(0);
+        creature.current_mp_frac = 0;
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);
@@ -112,10 +112,10 @@ void effect_player_brain_smash(CreatureEntity &creature, EffectPlayerType *ep_pt
 
     if (!check_multishadow(creature)) {
         msg_print(_("霊的エネルギーで精神が攻撃された。", "Your mind is blasted by psionic energy."));
-        creature.sub_csp(100);
-        if (creature.get_csp() < 0) {
-            creature.set_csp(0);
-            creature.csp_frac = 0;
+        creature.sub_current_mp(100);
+        if (creature.get_current_mp() < 0) {
+            creature.set_current_mp(0);
+            creature.current_mp_frac = 0;
         }
 
         RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -414,7 +414,7 @@ void process_player_hp_mp(CreatureEntity &creature)
         regenmagic(creature, regen_amount);
     }
 
-    if ((creature.get_csp() == 0) && (creature.csp_frac == 0)) {
+    if ((creature.get_current_mp() == 0) && (creature.current_mp_frac == 0)) {
         while (upkeep_factor > 100) {
             msg_print(_("こんなに多くのペットを制御できない！", "Too many pets to control at once!"));
             msg_erase();

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -156,49 +156,49 @@ void regenhp(CreatureEntity &creature, int percent)
  */
 void regenmana(CreatureEntity &creature, MANA_POINT upkeep_factor, MANA_POINT regen_amount)
 {
-    MANA_POINT old_csp = creature.get_csp();
+    MANA_POINT old_current_mp = creature.get_current_mp();
     int32_t regen_rate = regen_amount * 100 - upkeep_factor * PY_REGEN_NORMAL;
 
     /*
      * Excess mana will decay 32 times faster than normal
      * regeneration rate.
      */
-    if (creature.get_csp() > creature.get_msp()) {
+    if (creature.get_current_mp() > creature.get_max_mp()) {
         int32_t decay = 0;
-        uint32_t decay_frac = (creature.get_msp() * 32 * PY_REGEN_NORMAL + PY_REGEN_MNBASE);
+        uint32_t decay_frac = (creature.get_max_mp() * 32 * PY_REGEN_NORMAL + PY_REGEN_MNBASE);
         s64b_lshift(&decay, &decay_frac, 16);
-        creature.sub_csp_with_frac(decay, decay_frac);
-        if (creature.get_csp() < creature.get_msp()) {
-            creature.set_csp(creature.get_msp());
-            creature.csp_frac = 0;
+        creature.sub_current_mp_with_frac(decay, decay_frac);
+        if (creature.get_current_mp() < creature.get_max_mp()) {
+            creature.set_current_mp(creature.get_max_mp());
+            creature.current_mp_frac = 0;
         }
     }
 
     /* Regenerating mana (unless the creature has excess mana) */
     else if (regen_rate > 0) {
         MANA_POINT new_mana = 0;
-        uint32_t new_mana_frac = (creature.get_msp() * regen_rate / 100 + PY_REGEN_MNBASE);
+        uint32_t new_mana_frac = (creature.get_max_mp() * regen_rate / 100 + PY_REGEN_MNBASE);
         s64b_lshift(&new_mana, &new_mana_frac, 16);
-        creature.add_csp_with_frac(new_mana, new_mana_frac);
-        if (creature.get_csp() >= creature.get_msp()) {
-            creature.set_csp(creature.get_msp());
-            creature.csp_frac = 0;
+        creature.add_current_mp_with_frac(new_mana, new_mana_frac);
+        if (creature.get_current_mp() >= creature.get_max_mp()) {
+            creature.set_current_mp(creature.get_max_mp());
+            creature.current_mp_frac = 0;
         }
     }
 
     /* Reduce mana (even when the creature has excess mana) */
     if (regen_rate < 0) {
         int32_t reduce_mana = 0;
-        uint32_t reduce_mana_frac = (creature.get_msp() * (-1) * regen_rate / 100 + PY_REGEN_MNBASE);
+        uint32_t reduce_mana_frac = (creature.get_max_mp() * (-1) * regen_rate / 100 + PY_REGEN_MNBASE);
         s64b_lshift(&reduce_mana, &reduce_mana_frac, 16);
-        creature.sub_csp_with_frac(reduce_mana, reduce_mana_frac);
-        if (creature.get_csp() < 0) {
-            creature.set_csp(0);
-            creature.csp_frac = 0;
+        creature.sub_current_mp_with_frac(reduce_mana, reduce_mana_frac);
+        if (creature.get_current_mp() < 0) {
+            creature.set_current_mp(0);
+            creature.current_mp_frac = 0;
         }
     }
 
-    if (old_csp != creature.get_csp()) {
+    if (old_current_mp != creature.get_current_mp()) {
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         rfu.set_flag(MainWindowRedrawingFlag::MP);
         static constexpr auto flags = {
@@ -287,7 +287,7 @@ void regenerate_monsters(CreatureEntity &creature)
         if (monster.hp < monster.maxhp) {
             regenhp(monster, regen_amount);
         }
-        if (monster.get_csp() < monster.get_msp()) {
+        if (monster.get_current_mp() < monster.get_max_mp()) {
             regenmana(monster, 0, regen_amount);
         }
 

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -433,17 +433,17 @@ static void curse_drain_hp(CreatureEntity &creature)
 
 static void curse_drain_mp(CreatureEntity &creature)
 {
-    if ((creature.get_cursed_flags().has_not(CurseTraitType::DRAIN_MANA)) || (creature.get_csp() == 0) || !one_in_(666)) {
+    if ((creature.get_cursed_flags().has_not(CurseTraitType::DRAIN_MANA)) || (creature.get_current_mp() == 0) || !one_in_(666)) {
         return;
     }
 
     const auto *item_ptr = choose_cursed_obj_name(creature, CurseTraitType::DRAIN_MANA);
     const auto item_name = describe_flavor(creature, *item_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     msg_format(_("%sはあなたの魔力を吸収した！", "Your %s drains mana from you!"), item_name.data());
-    creature.sub_csp(std::min<short>(creature.get_level(), 50));
-    if (creature.get_csp() < 0) {
-        creature.set_csp(0);
-        creature.csp_frac = 0;
+    creature.sub_current_mp(std::min<short>(creature.get_level(), 50));
+    if (creature.get_current_mp() < 0) {
+        creature.set_current_mp(0);
+        creature.current_mp_frac = 0;
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);

--- a/src/io-dump/player-status-dump-json.cpp
+++ b/src/io-dump/player-status-dump-json.cpp
@@ -121,8 +121,8 @@ static void add_status_to_json(nlohmann::json &j, CreatureEntity &creature)
 {
     j["status"]["hitpoints"] = creature.hp;
     j["status"]["max_hitpoints"] = creature.maxhp;
-    j["status"]["mana"] = creature.get_csp();
-    j["status"]["max_mana"] = creature.get_msp();
+    j["status"]["mana"] = creature.get_current_mp();
+    j["status"]["max_mana"] = creature.get_max_mp();
     j["status"]["armor_class"] = creature.ac;
     j["status"]["display_armor_class"] = creature.get_dis_ac();
 

--- a/src/load/creature-common-loader.cpp
+++ b/src/load/creature-common-loader.cpp
@@ -66,9 +66,9 @@ void rd_creature_common(CreatureEntity &creature)
     creature.set_level(rd_s16b());
     creature.set_age(rd_s16b());
     creature.hp_frac = rd_u32b();
-    creature.set_msp(rd_s32b());
-    creature.set_csp(rd_s32b());
-    creature.csp_frac = rd_u32b();
+    creature.set_max_mp(rd_s32b());
+    creature.set_current_mp(rd_s32b());
+    creature.current_mp_frac = rd_u32b();
     creature.set_max_exp(rd_u32b());
     creature.set_max_max_exp(rd_u32b());
     creature.exp_frac = rd_u32b();

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -348,11 +348,11 @@ static void rd_hp(CreatureEntity &creature)
  */
 static void rd_mana(CreatureEntity &creature)
 {
-    // msp / csp / csp_frac は v52 以降 rd_creature_common() で読込済み
+    // max_mp / current_mp / current_mp_frac は v52 以降 rd_creature_common() で読込済み
     if (loading_savefile_version_is_older_than(52)) {
-        creature.set_msp(rd_s32b());
-        creature.set_csp(rd_s32b());
-        creature.csp_frac = rd_u32b();
+        creature.set_max_mp(rd_s32b());
+        creature.set_current_mp(rd_s32b());
+        creature.current_mp_frac = rd_u32b();
     }
 }
 

--- a/src/main-godot/godot-player-status.cpp
+++ b/src/main-godot/godot-player-status.cpp
@@ -46,8 +46,8 @@ void player_status_push(const PlayerType *player_ptr)
 
     snap.chp = player_ptr->get_current_hp();
     snap.mhp = player_ptr->get_max_hp();
-    snap.csp = static_cast<int>(player_ptr->get_csp());
-    snap.msp = player_ptr->get_msp();
+    snap.current_mp = static_cast<int>(player_ptr->get_current_mp());
+    snap.max_mp = player_ptr->get_max_mp();
 
     snap.gold = static_cast<long>(player_ptr->get_au());
     snap.exp = static_cast<long>(player_ptr->get_exp());

--- a/src/main-godot/godot-player-status.h
+++ b/src/main-godot/godot-player-status.h
@@ -33,8 +33,8 @@ struct GodotPlayerStatusSnapshot {
     // --- HP / SP ---
     int chp{ 0 };
     int mhp{ 0 };
-    int csp{ 0 };
-    int msp{ 0 };
+    int current_mp{ 0 };
+    int max_mp{ 0 };
 
     // --- 所持金・経験値 ---
     long gold{ 0 };

--- a/src/main-godot/hengband-gdextension.cpp
+++ b/src/main-godot/hengband-gdextension.cpp
@@ -146,8 +146,8 @@ static godot::Dictionary snapshot_to_dict(const GodotPlayerStatusSnapshot &s)
     godot::Dictionary d;
     d["hp"] = s.chp;
     d["max_hp"] = s.mhp;
-    d["sp"] = s.csp;
-    d["max_sp"] = s.msp;
+    d["sp"] = s.current_mp;
+    d["max_sp"] = s.max_mp;
     d["level"] = s.level;
     d["dun_level"] = s.dun_level;
     d["gold"] = static_cast<int64_t>(s.gold);

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -106,7 +106,7 @@ static void compare_weapon_aux(CreatureEntity &creature, ItemEntity *o_ptr, int 
         show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("切れ味:", "Vorpal:"), TERM_L_RED);
     }
 
-    if (!CreatureClass(creature).equals(PlayerClassType::SAMURAI) && flags.has(TR_FORCE_WEAPON) && (creature.get_csp() > (o_ptr->damage_dice.maxroll() / 5))) {
+    if (!CreatureClass(creature).equals(PlayerClassType::SAMURAI) && flags.has(TR_FORCE_WEAPON) && (creature.get_current_mp() > (o_ptr->damage_dice.maxroll() / 5))) {
         force = true;
 
         mindam = calc_expect_dice(creature, mindice, 1, 1, force, o_ptr->weight, o_ptr->to_h, creature.get_to_h(0), dokubari, impact, vorpal_mult, vorpal_div);

--- a/src/mind/mind-blue-mage.cpp
+++ b/src/mind/mind-blue-mage.cpp
@@ -41,7 +41,7 @@ bool do_cmd_cast_learned(CreatureEntity &creature)
 
     const auto &spell = monster_powers.at(*selected_spell);
     const auto need_mana = mod_need_mana(creature, spell.smana, 0, RealmType::NONE);
-    if (need_mana > creature.get_csp()) {
+    if (need_mana > creature.get_current_mp()) {
         msg_print(_("ＭＰが足りません。", "You do not have enough mana to use this power."));
         if (!over_exert) {
             return false;
@@ -71,12 +71,12 @@ bool do_cmd_cast_learned(CreatureEntity &creature)
         }
     }
 
-    if (need_mana <= creature.get_csp()) {
-        creature.sub_csp(need_mana);
+    if (need_mana <= creature.get_current_mp()) {
+        creature.sub_current_mp(need_mana);
     } else {
         int oops = need_mana;
-        creature.set_csp(0);
-        creature.csp_frac = 0;
+        creature.set_current_mp(0);
+        creature.current_mp_frac = 0;
         msg_print(_("精神を集中しすぎて気を失ってしまった！", "You faint from the effort!"));
         (void)BadStatusSetter(creature).mod_paralysis(randnum1<short>(5 * oops + 1));
         chg_virtue(creature, Virtue::KNOWLEDGE, -10);

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -837,7 +837,7 @@ bool get_element_power(CreatureEntity &creature, SPELL_IDX *sn, bool only_browse
  */
 static bool check_element_mp_sufficiency(CreatureEntity &creature, int mana_cost)
 {
-    if (mana_cost <= creature.get_csp()) {
+    if (mana_cost <= creature.get_current_mp()) {
         return true;
     }
 
@@ -876,7 +876,7 @@ static bool try_cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx
         const auto element = get_element_types(creature.element_realm)[0];
         constexpr auto flags = PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM;
         project(creature, PROJECT_WHO_UNCTRL_POWER, 2 + plev / 10, creature.y, creature.x, plev * 2, element, flags);
-        creature.set_csp(std::max(0, creature.get_csp() - creature.get_msp() * 10 / (20 + randint1(10))));
+        creature.set_current_mp(std::max(0, creature.get_current_mp() - creature.get_max_mp() * 10 / (20 + randint1(10))));
 
         PlayerEnergy(creature).set_player_turn_energy(100);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
@@ -915,12 +915,12 @@ void do_cmd_element(CreatureEntity &creature)
         return;
     }
 
-    if (mana_cost <= creature.get_csp()) {
-        creature.sub_csp(mana_cost);
+    if (mana_cost <= creature.get_current_mp()) {
+        creature.sub_current_mp(mana_cost);
     } else {
         int oops = mana_cost;
-        creature.set_csp(0);
-        creature.csp_frac = 0;
+        creature.set_current_mp(0);
+        creature.current_mp_frac = 0;
         msg_print(_("精神を集中しすぎて気を失ってしまった！", "You faint from the effort!"));
         (void)BadStatusSetter(creature).mod_paralysis(randnum1<short>(5 * oops + 1));
         chg_virtue(creature, Virtue::KNOWLEDGE, -10);
@@ -995,7 +995,7 @@ void display_element_spell_list(CreatureEntity &creature, int y, int x)
 
         constexpr auto fmt = "  %c) %-30s%2d %4d %3d%%%s";
         const auto info_str = format(fmt, I2A(i), name.data(), spell.min_lev, mana_cost, chance, comment.data());
-        const auto color = mana_cost > creature.get_csp() ? TERM_ORANGE : TERM_WHITE;
+        const auto color = mana_cost > creature.get_current_mp() ? TERM_ORANGE : TERM_WHITE;
         c_prt(color, info_str, y + i + 1, x);
     }
     prt("", y + i + 1, x);

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -83,10 +83,10 @@ bool clear_mind(CreatureEntity &creature)
 
     msg_print(_("少し頭がハッキリした。", "You feel your head clear a little."));
 
-    creature.add_csp((3 + creature.get_level() / 20));
-    if (creature.get_csp() >= creature.get_msp()) {
-        creature.set_csp(creature.get_msp());
-        creature.csp_frac = 0;
+    creature.add_current_mp((3 + creature.get_level() / 20));
+    if (creature.get_current_mp() >= creature.get_max_mp()) {
+        creature.set_current_mp(creature.get_max_mp());
+        creature.current_mp_frac = 0;
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);

--- a/src/mind/mind-info.cpp
+++ b/src/mind/mind-info.cpp
@@ -35,7 +35,7 @@ static std::string switch_mind_mindcrafter(CreatureEntity &creature, const PLAYE
     case 12:
         return format(" %sd%d+%d", KWD_DAM, plev * 3, plev * 3);
     case 13:
-        return format(_(" 行動:%ld回", " %ld acts."), (long int)(creature.get_csp() + 100 - creature.energy_need - 50) / 100);
+        return format(_(" 行動:%ld回", " %ld acts."), (long int)(creature.get_current_mp() + 100 - creature.energy_need - 50) / 100);
     default:
         return std::string();
     }

--- a/src/mind/mind-mage.cpp
+++ b/src/mind/mind-mage.cpp
@@ -48,7 +48,7 @@ bool eat_magic(CreatureEntity &creature, int power)
             if (item->timeout > (item->number - 1) * base_pval) {
                 msg_print(_("充填中のロッドから魔力を吸収することはできません。", "You can't absorb energy from a discharged rod."));
             } else {
-                creature.add_csp(item_level);
+                creature.add_current_mp(item_level);
                 item->timeout += base_pval;
             }
         }
@@ -62,7 +62,7 @@ bool eat_magic(CreatureEntity &creature, int power)
             is_eating_successful = false;
         } else {
             if (item->pval > 0) {
-                creature.add_csp(item_level / 2);
+                creature.add_current_mp(item_level / 2);
                 item->pval--;
 
                 if ((tval == ItemKindType::STAFF) && (i_idx >= 0) && (item->number > 1)) {

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -290,8 +290,8 @@ void MindPowerGetter::calculate_mind_chance(bool has_weapon_main, bool has_weapo
     this->chance -= 3 * (this->creature_ptr->get_level() - this->spell->min_lev);
     this->chance -= 3 * (adj_mag_stat[this->creature_ptr->get_stat_index(mp_ptr->spell_stat)] - 1);
     calculate_ki_chance(has_weapon_main, has_weapon_sub);
-    if ((this->use_mind != MindKindType::BERSERKER) && (this->use_mind != MindKindType::NINJUTSU) && (this->mana_cost > this->creature_ptr->get_csp())) {
-        this->chance += 5 * (this->mana_cost - this->creature_ptr->get_csp());
+    if ((this->use_mind != MindKindType::BERSERKER) && (this->use_mind != MindKindType::NINJUTSU) && (this->mana_cost > this->creature_ptr->get_current_mp())) {
+        this->chance += 5 * (this->mana_cost - this->creature_ptr->get_current_mp());
     }
 
     this->chance += this->creature_ptr->get_to_m_chance();

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -339,7 +339,7 @@ MULTIPLY mult_hissatsu(CreatureEntity &creature, MULTIPLY mult, const TrFlags &f
 
 void concentration(CreatureEntity &creature)
 {
-    int max_csp = std::max(creature.get_msp() * 4, creature.get_level() * 5 + 5);
+    int max_current_mp = std::max(creature.get_max_mp() * 4, creature.get_level() * 5 + 5);
 
     if (total_friends) {
         msg_print(_("今はペットを操ることに集中していないと。", "Your pets demand all of your attention."));
@@ -353,10 +353,10 @@ void concentration(CreatureEntity &creature)
 
     msg_print(_("精神を集中して気合いを溜めた。", "You concentrate to charge your power."));
 
-    creature.add_csp(creature.get_msp() / 2);
-    if (creature.get_csp() >= max_csp) {
-        creature.set_csp(max_csp);
-        creature.csp_frac = 0;
+    creature.add_current_mp(creature.get_max_mp() / 2);
+    if (creature.get_current_mp() >= max_current_mp) {
+        creature.set_current_mp(max_current_mp);
+        creature.current_mp_frac = 0;
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);
@@ -519,12 +519,12 @@ void mineuchi(CreatureEntity &creature, player_attack_type *pa_ptr)
 void musou_counterattack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
     const auto is_musou = CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU);
-    if ((!creature.counter && !is_musou) || !monap_ptr->alive || creature.is_dead() || !monap_ptr->m_ptr->is_visible_on_map() || (creature.get_csp() <= 7)) {
+    if ((!creature.counter && !is_musou) || !monap_ptr->alive || creature.is_dead() || !monap_ptr->m_ptr->is_visible_on_map() || (creature.get_current_mp() <= 7)) {
         return;
     }
 
     const auto m_target_name = monster_desc(creature, *monap_ptr->m_ptr, 0);
-    creature.sub_csp(7);
+    creature.sub_current_mp(7);
     msg_format(_("%s^に反撃した！", "You counterattacked %s!"), m_target_name.data());
     do_cmd_attack(creature, monap_ptr->m_ptr->y, monap_ptr->m_ptr->x, HISSATSU_COUNTER);
     monap_ptr->fear = false;

--- a/src/mind/mind-warrior-mage.cpp
+++ b/src/mind/mind-warrior-mage.cpp
@@ -20,10 +20,10 @@ bool comvert_hp_to_mp(CreatureEntity &creature)
         return true;
     }
 
-    creature.add_csp(gain_sp);
-    if (creature.get_csp() > creature.get_msp()) {
-        creature.set_csp(creature.get_msp());
-        creature.csp_frac = 0;
+    creature.add_current_mp(gain_sp);
+    if (creature.get_current_mp() > creature.get_max_mp()) {
+        creature.set_current_mp(creature.get_max_mp());
+        creature.current_mp_frac = 0;
     }
 
     rfu.set_flags(flags);
@@ -32,8 +32,8 @@ bool comvert_hp_to_mp(CreatureEntity &creature)
 
 bool comvert_mp_to_hp(CreatureEntity &creature)
 {
-    if (creature.get_csp() >= creature.get_level() / 5) {
-        creature.sub_csp(creature.get_level() / 5);
+    if (creature.get_current_mp() >= creature.get_level() / 5) {
+        creature.sub_current_mp(creature.get_level() / 5);
         hp_player(creature, creature.get_level());
     } else {
         msg_print(_("変換に失敗した。", "You failed to convert."));

--- a/src/mind/monster-ability-caster.cpp
+++ b/src/mind/monster-ability-caster.cpp
@@ -81,7 +81,7 @@ bool do_cmd_use_monster_ability(CreatureEntity &creature)
     const auto selected_ability = *choice;
     const auto &power = monster_powers.at(selected_ability);
     const auto need_mana = mod_need_mana(creature, power.smana, 0, RealmType::NONE);
-    if (need_mana > creature.get_csp()) {
+    if (need_mana > creature.get_current_mp()) {
         msg_print(_("ＭＰが足りません。", "You do not have enough mana to use this power."));
         if (!over_exert) {
             return false;
@@ -110,12 +110,12 @@ bool do_cmd_use_monster_ability(CreatureEntity &creature)
         }
     }
 
-    if (need_mana <= creature.get_csp()) {
-        creature.sub_csp(need_mana);
+    if (need_mana <= creature.get_current_mp()) {
+        creature.sub_current_mp(need_mana);
     } else {
         const int oops = need_mana;
-        creature.set_csp(0);
-        creature.csp_frac = 0;
+        creature.set_current_mp(0);
+        creature.current_mp_frac = 0;
         msg_print(_("精神を集中しすぎて気を失ってしまった！", "You faint from the effort!"));
         (void)BadStatusSetter(creature).mod_paralysis(randnum1<short>(5 * oops + 1));
         chg_virtue(creature, Virtue::KNOWLEDGE, -10);

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -304,10 +304,10 @@ void process_drain_mana(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr
     }
 
     monap_ptr->do_cut = 0;
-    creature.sub_csp(monap_ptr->damage);
-    if (creature.get_csp() < 0) {
-        creature.set_csp(0);
-        creature.csp_frac = 0;
+    creature.sub_current_mp(monap_ptr->damage);
+    if (creature.get_current_mp() < 0) {
+        creature.set_current_mp(0);
+        creature.current_mp_frac = 0;
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -226,7 +226,7 @@ public:
             room -= 2;
         }
 
-        if (room >= (8 * (this->creature_ptr->hp + this->creature_ptr->get_csp())) / (this->creature_ptr->maxhp + this->creature_ptr->get_msp())) {
+        if (room >= (8 * (this->creature_ptr->hp + this->creature_ptr->get_current_mp())) / (this->creature_ptr->maxhp + this->creature_ptr->get_max_mp())) {
             return tl::nullopt;
         }
 

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -476,8 +476,8 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     // 最大MPを算出して満タンで開始する。プレイヤーと同じ calc_creature_mana()
     // (レベル・INT ベースの基礎MP) を用いる。これにより regenerate_monsters() の
     // 自然回復 (regenmana) が機能し、種族固有能力の行使にMPを使える。
-    m_ptr->set_msp(calc_creature_mana(*m_ptr));
-    m_ptr->set_csp(m_ptr->get_msp());
+    m_ptr->set_max_mp(calc_creature_mana(*m_ptr));
+    m_ptr->set_current_mp(m_ptr->get_max_mp());
 
     m_ptr->set_visible_on_map(false);
     if (any_bits(mode, PM_FORCE_PET)) {

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -783,7 +783,7 @@ void update_smart_learn(CreatureEntity &creature, MONSTER_IDX m_idx, int what)
 
         break;
     case DRS_MANA:
-        if (!creature.get_msp()) {
+        if (!creature.get_max_mp()) {
             monster.add_smart_flag(MonsterSmartLearnType::IMM_MANA);
         }
 

--- a/src/mspell/high-resistance-checker.cpp
+++ b/src/mspell/high-resistance-checker.cpp
@@ -62,7 +62,7 @@ void add_cheat_remove_flags_others(CreatureEntity &creature, msr_type *msr_ptr)
         msr_ptr->smart_flags.set(MonsterSmartLearnType::IMM_FREE);
     }
 
-    if (!creature.get_msp()) {
+    if (!creature.get_max_mp()) {
         msr_ptr->smart_flags.set(MonsterSmartLearnType::IMM_MANA);
     }
 }

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -98,7 +98,7 @@ static bool check_mspell_non_stupid(CreatureEntity &creature, msa_type *msa_ptr)
         return true;
     }
 
-    if (!creature.get_csp()) {
+    if (!creature.get_current_mp()) {
         msa_ptr->ability_flags.reset(MonsterAbilityType::DRAIN_MANA);
     }
 

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -497,26 +497,26 @@ void process_world_aux_mutation(CreatureEntity &creature)
     if (creature.get_mutations().has(PlayerMutationType::SP_TO_HP) && one_in_(2000)) {
         MANA_POINT wounds = (MANA_POINT)(creature.maxhp - creature.hp);
         if (wounds > 0) {
-            int healing = creature.get_csp();
+            int healing = creature.get_current_mp();
             if (healing > wounds) {
                 healing = wounds;
             }
 
             hp_player(creature, healing);
-            creature.sub_csp(healing);
+            creature.sub_current_mp(healing);
             RedrawingFlagsUpdater::get_instance().set_flags(flags);
         }
     }
 
     if (creature.get_mutations().has(PlayerMutationType::HP_TO_SP) && !creature.has_anti_magic() && one_in_(4000)) {
-        int wounds = (int)(creature.get_msp() - creature.get_csp());
+        int wounds = (int)(creature.get_max_mp() - creature.get_current_mp());
         if (wounds > 0) {
             int healing = creature.hp;
             if (healing > wounds) {
                 healing = wounds;
             }
 
-            creature.add_csp(healing);
+            creature.add_current_mp(healing);
             RedrawingFlagsUpdater::get_instance().set_flags(flags);
             take_hit(creature, DAMAGE_LOSELIFE, healing, _("頭に昇った血", "blood rushing to the head"));
         }

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -144,7 +144,7 @@ static void attack_dispel(CreatureEntity &creature, player_attack_type *pa_ptr)
     dispel_monster_status(creature, pa_ptr->m_idx);
 
     auto sp = Dice::roll(dd, 8);
-    creature.set_csp(std::min(creature.get_msp(), creature.get_csp() + sp));
+    creature.set_current_mp(std::min(creature.get_max_mp(), creature.get_current_mp() + sp));
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);
 }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -652,9 +652,9 @@ static void update_num_of_spells(CreatureEntity &creature)
 int calc_creature_mana(CreatureEntity &creature)
 {
     const auto stat_index = creature.get_stat_index(A_INT);
-    const int msp = adj_mag_mana[stat_index] * (creature.get_level() + 3) / 4;
+    const int max_mp = adj_mag_mana[stat_index] * (creature.get_level() + 3) / 4;
     const int floor_value = std::max(static_cast<int>(creature.get_level()), 1);
-    return std::max(msp, floor_value);
+    return std::max(max_mp, floor_value);
 }
 
 static int calc_innate_baseline_mana(CreatureEntity &creature)
@@ -664,15 +664,15 @@ static int calc_innate_baseline_mana(CreatureEntity &creature)
 
 static void update_max_mana(CreatureEntity &creature)
 {
-    const auto baseline_msp = calc_innate_baseline_mana(creature);
+    const auto baseline_max_mp = calc_innate_baseline_mana(creature);
     if ((mp_ptr->spell_book == ItemKindType::NONE) && mp_ptr->spell_first == SPELL_FIRST_NO_SPELL) {
         // 無魔法職でも常に基礎 MP を持たせる (種族固有能力の行使等に使用)。
-        if (creature.get_msp() != baseline_msp) {
-            if (creature.get_csp() > baseline_msp) {
-                creature.set_csp(baseline_msp);
-                creature.csp_frac = 0;
+        if (creature.get_max_mp() != baseline_max_mp) {
+            if (creature.get_current_mp() > baseline_max_mp) {
+                creature.set_current_mp(baseline_max_mp);
+                creature.current_mp_frac = 0;
             }
-            creature.set_msp(baseline_msp);
+            creature.set_max_mp(baseline_max_mp);
             RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);
         }
         return;
@@ -688,7 +688,7 @@ static void update_max_mana(CreatureEntity &creature)
         levels = creature.get_level();
     } else {
         if (mp_ptr->spell_first > creature.get_level()) {
-            creature.set_msp(baseline_msp);
+            creature.set_max_mp(baseline_max_mp);
             RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);
             return;
         }
@@ -696,28 +696,28 @@ static void update_max_mana(CreatureEntity &creature)
         levels = (creature.get_level() - mp_ptr->spell_first) + 1;
     }
 
-    int msp;
+    int max_mp;
     if (pc.equals(PlayerClassType::SAMURAI)) {
-        msp = (adj_mag_mana[creature.get_stat_index(mp_ptr->spell_stat)] + 10) * 2;
-        if (msp) {
-            msp += (msp * creature.get_race_info()->r_adj[mp_ptr->spell_stat] / 20);
+        max_mp = (adj_mag_mana[creature.get_stat_index(mp_ptr->spell_stat)] + 10) * 2;
+        if (max_mp) {
+            max_mp += (max_mp * creature.get_race_info()->r_adj[mp_ptr->spell_stat] / 20);
         }
     } else {
-        msp = adj_mag_mana[creature.get_stat_index(mp_ptr->spell_stat)] * (levels + 3) / 4;
-        if (msp) {
-            msp++;
+        max_mp = adj_mag_mana[creature.get_stat_index(mp_ptr->spell_stat)] * (levels + 3) / 4;
+        if (max_mp) {
+            max_mp++;
         }
-        if (msp) {
-            msp += (msp * creature.get_race_info()->r_adj[mp_ptr->spell_stat] / 20);
+        if (max_mp) {
+            max_mp += (max_mp * creature.get_race_info()->r_adj[mp_ptr->spell_stat] / 20);
         }
-        if (msp && (creature.ppersonality == PERSONALITY_MUNCHKIN)) {
-            msp += msp / 2;
+        if (max_mp && (creature.ppersonality == PERSONALITY_MUNCHKIN)) {
+            max_mp += max_mp / 2;
         }
-        if (msp && pc.equals(PlayerClassType::HIGH_MAGE)) {
-            msp += msp / 4;
+        if (max_mp && pc.equals(PlayerClassType::HIGH_MAGE)) {
+            max_mp += max_mp / 4;
         }
-        if (msp && pc.equals(PlayerClassType::SORCERER)) {
-            msp += msp * (25 + creature.get_level()) / 100;
+        if (max_mp && pc.equals(PlayerClassType::SORCERER)) {
+            max_mp += max_mp * (25 + creature.get_level()) / 100;
         }
     }
 
@@ -733,7 +733,7 @@ static void update_max_mana(CreatureEntity &creature)
         should_mp_decrease &= flags.has_not(TR_DEX) || (o_ptr->pval <= 0);
         if (should_mp_decrease) {
             creature.set_cumber_glove(true);
-            msp = (3 * msp) / 4;
+            max_mp = (3 * max_mp) / 4;
         }
     }
 
@@ -835,7 +835,7 @@ static void update_max_mana(CreatureEntity &creature)
         case PlayerClassType::HIGH_MAGE:
         case PlayerClassType::BLUE_MAGE:
         case PlayerClassType::ELEMENTALIST: {
-            msp -= msp * (cur_wgt - max_wgt) / 600;
+            max_mp -= max_mp * (cur_wgt - max_wgt) / 600;
             break;
         }
         case PlayerClassType::PRIEST:
@@ -845,24 +845,24 @@ static void update_max_mana(CreatureEntity &creature)
         case PlayerClassType::FORCETRAINER:
         case PlayerClassType::TOURIST:
         case PlayerClassType::MIRROR_MASTER: {
-            msp -= msp * (cur_wgt - max_wgt) / 800;
+            max_mp -= max_mp * (cur_wgt - max_wgt) / 800;
             break;
         }
         case PlayerClassType::SORCERER: {
-            msp -= msp * (cur_wgt - max_wgt) / 900;
+            max_mp -= max_mp * (cur_wgt - max_wgt) / 900;
             break;
         }
         case PlayerClassType::ROGUE:
         case PlayerClassType::RANGER:
         case PlayerClassType::MONK:
         case PlayerClassType::RED_MAGE: {
-            msp -= msp * (cur_wgt - max_wgt) / 1000;
+            max_mp -= max_mp * (cur_wgt - max_wgt) / 1000;
             break;
         }
         case PlayerClassType::PALADIN:
         case PlayerClassType::CHAOS_WARRIOR:
         case PlayerClassType::WARRIOR_MAGE: {
-            msp -= msp * (cur_wgt - max_wgt) / 1200;
+            max_mp -= max_mp * (cur_wgt - max_wgt) / 1200;
             break;
         }
         case PlayerClassType::SAMURAI: {
@@ -870,28 +870,28 @@ static void update_max_mana(CreatureEntity &creature)
             break;
         }
         default: {
-            msp -= msp * (cur_wgt - max_wgt) / 800;
+            max_mp -= max_mp * (cur_wgt - max_wgt) / 800;
             break;
         }
         }
     }
 
-    if (msp < baseline_msp) {
-        msp = baseline_msp;
+    if (max_mp < baseline_max_mp) {
+        max_mp = baseline_max_mp;
     }
 
-    if (creature.get_msp() != msp) {
-        if ((creature.get_csp() >= msp) && !pc.equals(PlayerClassType::SAMURAI)) {
-            creature.set_csp(msp);
-            creature.csp_frac = 0;
+    if (creature.get_max_mp() != max_mp) {
+        if ((creature.get_current_mp() >= max_mp) && !pc.equals(PlayerClassType::SAMURAI)) {
+            creature.set_current_mp(max_mp);
+            creature.current_mp_frac = 0;
         }
 
 #ifdef JP
-        if (creature.has_level_up_message() && (msp > creature.get_msp())) {
-            msg_format("最大マジック・ポイントが %d 増加した！", (msp - creature.get_msp()));
+        if (creature.has_level_up_message() && (max_mp > creature.get_max_mp())) {
+            msg_format("最大マジック・ポイントが %d 増加した！", (max_mp - creature.get_max_mp()));
         }
 #endif
-        creature.set_msp(msp);
+        creature.set_max_mp(max_mp);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         rfu.set_flag(MainWindowRedrawingFlag::MP);
         static constexpr auto flags = {

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -577,12 +577,12 @@ tl::optional<std::string> do_hex_spell(CreatureEntity &creature, spell_hex_type 
                 return "";
             }
 
-            creature.add_csp((creature.get_level() / 5) + randint1(creature.get_level() / 5));
+            creature.add_current_mp((creature.get_level() / 5) + randint1(creature.get_level() / 5));
             if (item->get_flags().has(TR_TY_CURSE) || item->curse_flags.has(CurseTraitType::TY_CURSE)) {
-                creature.add_csp(randint1(5));
+                creature.add_current_mp(randint1(5));
             }
-            if (creature.get_csp() > creature.get_msp()) {
-                creature.set_csp(creature.get_msp());
+            if (creature.get_current_mp() > creature.get_max_mp()) {
+                creature.set_current_mp(creature.get_max_mp());
             }
 
             if (item->curse_flags.has(CurseTraitType::PERMA_CURSE)) {

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -614,10 +614,10 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
                 }
                 if (is_new) {
                     /* Reserve needed mana point */
-                    creature.sub_csp(spell.smana);
+                    creature.sub_current_mp(spell.smana);
                     is_new = false;
                 } else {
-                    creature.sub_csp(mana_cost_per_monster);
+                    creature.sub_current_mp(mana_cost_per_monster);
                 }
 
                 if (!mdeath) {
@@ -627,14 +627,14 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
 
                 RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);
                 handle_stuff(creature);
-            } while (creature.get_csp() > mana_cost_per_monster);
+            } while (creature.get_current_mp() > mana_cost_per_monster);
 
             if (is_new) {
                 return tl::nullopt;
             }
 
             /* Restore reserved mana */
-            creature.add_csp(spell.smana);
+            creature.add_current_mp(spell.smana);
         }
         break;
 

--- a/src/save/creature-common-writer.cpp
+++ b/src/save/creature-common-writer.cpp
@@ -55,9 +55,9 @@ void wr_creature_common(const CreatureEntity &creature)
     wr_s16b(static_cast<int16_t>(creature.get_level()));
     wr_s16b(creature.get_age());
     wr_u32b(creature.hp_frac);
-    wr_s32b(creature.get_msp());
-    wr_s32b(creature.get_csp());
-    wr_u32b(creature.csp_frac);
+    wr_s32b(creature.get_max_mp());
+    wr_s32b(creature.get_current_mp());
+    wr_u32b(creature.current_mp_frac);
     wr_u32b(creature.get_max_exp());
     wr_u32b(creature.get_max_max_exp());
     wr_u32b(creature.exp_frac);

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -149,8 +149,8 @@ void wr_player(CreatureEntity &creature)
     wr_s16b((int16_t)creature.oldpy);
 
     wr_s16b(0);
-    // maxhp / hp / dealt_damage / hp_frac / msp / csp / csp_frac は
-    // wr_creature_common() で保存済み (hp_frac/msp/csp/csp_frac は v52 拡張)
+    // maxhp / hp / dealt_damage / hp_frac / max_mp / current_mp / current_mp_frac は
+    // wr_creature_common() で保存済み (hp_frac/max_mp/current_mp/current_mp_frac は v52 拡張)
     wr_s16b(creature.get_max_plv());
 
     const auto &dungeon_records = DungeonRecords::get_instance();

--- a/src/specific-object/death-scythe.cpp
+++ b/src/specific-object/death-scythe.cpp
@@ -110,8 +110,8 @@ static void compensate_death_scythe_reflection_magnification(CreatureEntity &cre
         *magnification = 25;
     }
 
-    if (!CreatureClass(creature).equals(PlayerClassType::SAMURAI) && (death_scythe_flags.has(TR_FORCE_WEAPON)) && (creature.get_csp() > (creature.get_msp() / 30))) {
-        creature.sub_csp((1 + (creature.get_msp() / 30)));
+    if (!CreatureClass(creature).equals(PlayerClassType::SAMURAI) && (death_scythe_flags.has(TR_FORCE_WEAPON)) && (creature.get_current_mp() > (creature.get_max_mp() / 30))) {
+        creature.sub_current_mp((1 + (creature.get_max_mp() / 30)));
         RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);
         *magnification = *magnification * 3 / 2 + 20;
     }

--- a/src/specific-object/stone-of-lore.cpp
+++ b/src/specific-object/stone-of-lore.cpp
@@ -49,20 +49,20 @@ bool StoneOfLore::perilous_secrets()
 
 void StoneOfLore::consume_mp()
 {
-    if (this->creature_ptr->get_msp() <= 0) {
+    if (this->creature_ptr->get_max_mp() <= 0) {
         return;
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (this->creature_ptr->get_csp() >= 20) {
-        this->creature_ptr->sub_csp(20);
+    if (this->creature_ptr->get_current_mp() >= 20) {
+        this->creature_ptr->sub_current_mp(20);
         rfu.set_flag(MainWindowRedrawingFlag::MP);
         return;
     }
 
-    auto oops = 20 - this->creature_ptr->get_csp();
-    this->creature_ptr->set_csp(0);
-    this->creature_ptr->csp_frac = 0;
+    auto oops = 20 - this->creature_ptr->get_current_mp();
+    this->creature_ptr->set_current_mp(0);
+    this->creature_ptr->current_mp_frac = 0;
     msg_print(_("石を制御できない！", "You are too weak to control the stone!"));
     BadStatusSetter bss(*this->creature_ptr);
     (void)bss.mod_paralysis(randnum1<short>(5 * oops + 1));

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -155,10 +155,10 @@ bool SpellsMirrorMaster::mirror_concentration()
     }
 
     msg_print(_("少し頭がハッキリした。", "You feel your head clear a little."));
-    this->creature_ptr->add_csp(5 + this->creature_ptr->get_level() * this->creature_ptr->get_level() / 100);
-    if (this->creature_ptr->get_csp() >= this->creature_ptr->get_msp()) {
-        this->creature_ptr->set_csp(this->creature_ptr->get_msp());
-        this->creature_ptr->csp_frac = 0;
+    this->creature_ptr->add_current_mp(5 + this->creature_ptr->get_level() * this->creature_ptr->get_level() / 100);
+    if (this->creature_ptr->get_current_mp() >= this->creature_ptr->get_max_mp()) {
+        this->creature_ptr->set_current_mp(this->creature_ptr->get_max_mp());
+        this->creature_ptr->current_mp_frac = 0;
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -217,13 +217,13 @@ bool SpellHex::process_mana_cost(const bool need_restart)
     s64b_div(&need_mana, &need_mana_frac, 0, 3); /* Divide by 3 */
     need_mana += this->get_casting_num() - 1;
 
-    auto enough_mana = s64b_cmp(this->creature.get_csp(), this->creature.csp_frac, need_mana, need_mana_frac) >= 0;
+    auto enough_mana = s64b_cmp(this->creature.get_current_mp(), this->creature.current_mp_frac, need_mana, need_mana_frac) >= 0;
     if (!enough_mana) {
         this->stop_all_spells();
         return false;
     }
 
-    this->creature.sub_csp_with_frac(need_mana, need_mana_frac);
+    this->creature.sub_current_mp_with_frac(need_mana, need_mana_frac);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MP);
     if (!need_restart) {

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -48,12 +48,12 @@ void check_music(CreatureEntity &creature)
     uint32_t need_mana_frac = 0;
 
     s64b_rshift(&need_mana, &need_mana_frac, 1);
-    if (s64b_cmp(creature.get_csp(), creature.csp_frac, need_mana, need_mana_frac) < 0) {
+    if (s64b_cmp(creature.get_current_mp(), creature.current_mp_frac, need_mana, need_mana_frac) < 0) {
         stop_singing(creature);
         return;
     }
 
-    creature.sub_csp_with_frac(need_mana, need_mana_frac);
+    creature.sub_current_mp_with_frac(need_mana, need_mana_frac);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MP);
     if (interupting_song_effect != 0) {

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -133,8 +133,8 @@ PERCENTAGE spell_chance(CreatureEntity &creature, SPELL_IDX spell_id, RealmType 
     }
 
     MANA_POINT need_mana = mod_need_mana(creature, spell.smana, spell_id, use_realm);
-    if (need_mana > creature.get_csp()) {
-        chance += 5 * (need_mana - creature.get_csp());
+    if (need_mana > creature.get_current_mp()) {
+        chance += 5 * (need_mana - creature.get_current_mp());
     }
 
     CreatureClass pc(creature);

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -211,7 +211,7 @@ bool time_walk(CreatureEntity &creature)
     //	msg_print(_("「『ザ・ワールド』！時は止まった！」", "You yell 'The World! Time has stopped!'"));
     msg_erase();
 
-    creature.energy_need -= 1000 + (100 + creature.get_csp() - 50) * TURNS_PER_TICK / 10;
+    creature.energy_need -= 1000 + (100 + creature.get_current_mp() - 50) * TURNS_PER_TICK / 10;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
@@ -506,12 +506,12 @@ bool restore_mana(CreatureEntity &creature, bool magic_eater)
         return true;
     }
 
-    if (creature.get_csp() >= creature.get_msp()) {
+    if (creature.get_current_mp() >= creature.get_max_mp()) {
         return false;
     }
 
-    creature.set_csp(creature.get_msp());
-    creature.csp_frac = 0;
+    creature.set_current_mp(creature.get_max_mp());
+    creature.current_mp_frac = 0;
     msg_print(_("頭がハッキリとした。", "You feel your head clear."));
     rfu.set_flag(MainWindowRedrawingFlag::MP);
     static constexpr auto flags_swrf = {

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -89,7 +89,7 @@ bool CreatureEntity::try_set_position(const Pos2D &pos)
 bool CreatureEntity::is_fully_healthy() const
 {
     auto is_healthy = this->hp == this->maxhp;
-    is_healthy &= this->csp >= this->msp;
+    is_healthy &= this->current_mp >= this->max_mp;
     is_healthy &= !this->is_blind();
     is_healthy &= !this->is_confused();
     is_healthy &= !this->is_poisoned();
@@ -770,14 +770,14 @@ void CreatureEntity::init_extended_inventory()
     }
 }
 
-void CreatureEntity::add_csp_with_frac(int delta, uint32_t delta_frac)
+void CreatureEntity::add_current_mp_with_frac(int delta, uint32_t delta_frac)
 {
-    s64b_add(&this->csp, &this->csp_frac, delta, delta_frac);
+    s64b_add(&this->current_mp, &this->current_mp_frac, delta, delta_frac);
 }
 
-void CreatureEntity::sub_csp_with_frac(int delta, uint32_t delta_frac)
+void CreatureEntity::sub_current_mp_with_frac(int delta, uint32_t delta_frac)
 {
-    s64b_sub(&this->csp, &this->csp_frac, delta, delta_frac);
+    s64b_sub(&this->current_mp, &this->current_mp_frac, delta, delta_frac);
 }
 
 void CreatureEntity::add_exp_with_frac(EXP delta, uint32_t delta_frac)

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -2087,10 +2087,10 @@ public:
         this->max_plv = value;
     }
 
-    /*! @brief 最大 MP (msp) を設定する (提案 27) */
-    virtual void set_msp(int value)
+    /*! @brief 最大 MP (max_mp) を設定する (提案 27) */
+    virtual void set_max_mp(int value)
     {
-        this->msp = value;
+        this->max_mp = value;
     }
 
     /*! @brief 現在の経験値を設定する (提案 27) */
@@ -2138,28 +2138,28 @@ public:
     }
 
     /*! @brief 現在の MP を設定する (提案 27b) */
-    virtual void set_csp(int value)
+    virtual void set_current_mp(int value)
     {
-        this->csp = value;
+        this->current_mp = value;
     }
 
     /*! @brief 現在の MP を加算する (提案 27b) */
-    virtual void add_csp(int delta)
+    virtual void add_current_mp(int delta)
     {
-        this->csp += delta;
+        this->current_mp += delta;
     }
 
     /*! @brief 現在の MP を減算する (提案 27b) */
-    virtual void sub_csp(int delta)
+    virtual void sub_current_mp(int delta)
     {
-        this->csp -= delta;
+        this->current_mp -= delta;
     }
 
     /*! @brief 64bit ペア演算で現在 MP を加算する (提案 32b) */
-    virtual void add_csp_with_frac(int delta, uint32_t delta_frac);
+    virtual void add_current_mp_with_frac(int delta, uint32_t delta_frac);
 
     /*! @brief 64bit ペア演算で現在 MP を減算する (提案 32b) */
-    virtual void sub_csp_with_frac(int delta, uint32_t delta_frac);
+    virtual void sub_current_mp_with_frac(int delta, uint32_t delta_frac);
 
     /*! @brief 64bit ペア演算で経験値を加算する (提案 32b) */
     virtual void add_exp_with_frac(EXP delta, uint32_t delta_frac);
@@ -2171,9 +2171,9 @@ public:
     }
 
     /*! @brief 現在の MP を取得する (提案 31) */
-    virtual int get_csp() const
+    virtual int get_current_mp() const
     {
-        return this->csp;
+        return this->current_mp;
     }
 
     /*! @brief 滋養度を取得する (提案 31) */
@@ -2218,10 +2218,10 @@ public:
         return this->max_plv;
     }
 
-    /*! @brief 最大 MP (msp) を取得する (提案 31) */
-    virtual int get_msp() const
+    /*! @brief 最大 MP (max_mp) を取得する (提案 31) */
+    virtual int get_max_mp() const
     {
-        return this->msp;
+        return this->max_mp;
     }
 
     /*! @brief 現在の経験値を取得する (提案 31) */
@@ -3978,13 +3978,13 @@ public:
     POSITION x{}; /*!< 現在のX座標 / Current location (X) */
 
     // MP関連
-    // [提案 32b] private 化済。get_msp()/set_msp()/get_csp()/set_csp()/add_csp()/sub_csp() 等経由。
+    // [提案 32b] private 化済。get_max_mp()/set_max_mp()/get_current_mp()/set_current_mp()/add_current_mp()/sub_current_mp() 等経由。
 private:
-    MANA_POINT msp{}; /*!< 最大MP / Max mana pts */
-    MANA_POINT csp{}; /*!< 現在MP / Current mana pts */
+    MANA_POINT max_mp{}; /*!< 最大MP / Max mana pts */
+    MANA_POINT current_mp{}; /*!< 現在MP / Current mana pts */
 
 public:
-    uint32_t csp_frac{}; /*!< MP小数部 / Current mana frac (times 2^16) */
+    uint32_t current_mp_frac{}; /*!< MP小数部 / Current mana frac (times 2^16) */
 
     // HP関連
     int hp{}; /*!< 現在のHP / Current Hit points */

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -309,16 +309,16 @@ static void display_playtime_in_game(CreatureEntity &creature)
         display_player_one_line(ENTRY_HP, format("%4d/%4d", creature.hp, creature.maxhp), TERM_RED);
     }
 
-    // SP は常に表示する。msp <= 0 のクリーチャー（多くのモンスター等）は
-    // 生成時に msp/csp とも 0 で初期化済みのため 0/0 と表示する。
-    if (creature.get_msp() <= 0) {
-        display_player_one_line(ENTRY_SP, format("%4d/%4d", creature.get_csp(), creature.get_msp()), TERM_SLATE);
-    } else if (creature.get_csp() >= creature.get_msp()) {
-        display_player_one_line(ENTRY_SP, format("%4d/%4d", creature.get_csp(), creature.get_msp()), TERM_L_GREEN);
-    } else if (creature.get_csp() > (creature.get_msp() * mana_warn) / 10) {
-        display_player_one_line(ENTRY_SP, format("%4d/%4d", creature.get_csp(), creature.get_msp()), TERM_YELLOW);
+    // SP は常に表示する。max_mp <= 0 のクリーチャー（多くのモンスター等）は
+    // 生成時に max_mp/current_mp とも 0 で初期化済みのため 0/0 と表示する。
+    if (creature.get_max_mp() <= 0) {
+        display_player_one_line(ENTRY_SP, format("%4d/%4d", creature.get_current_mp(), creature.get_max_mp()), TERM_SLATE);
+    } else if (creature.get_current_mp() >= creature.get_max_mp()) {
+        display_player_one_line(ENTRY_SP, format("%4d/%4d", creature.get_current_mp(), creature.get_max_mp()), TERM_L_GREEN);
+    } else if (creature.get_current_mp() > (creature.get_max_mp() * mana_warn) / 10) {
+        display_player_one_line(ENTRY_SP, format("%4d/%4d", creature.get_current_mp(), creature.get_max_mp()), TERM_YELLOW);
     } else {
-        display_player_one_line(ENTRY_SP, format("%4d/%4d", creature.get_csp(), creature.get_msp()), TERM_RED);
+        display_player_one_line(ENTRY_SP, format("%4d/%4d", creature.get_current_mp(), creature.get_max_mp()), TERM_RED);
     }
 }
 

--- a/src/view/display-player-misc-info.cpp
+++ b/src/view/display-player-misc-info.cpp
@@ -76,5 +76,5 @@ void display_player_misc_info(CreatureEntity &creature)
 
     c_put_str(TERM_L_BLUE, format("%d", (int)creature.get_level()), 6, 9);
     c_put_str(TERM_L_BLUE, format("%d/%d", (int)creature.hp, (int)creature.maxhp), 7, 9);
-    c_put_str(TERM_L_BLUE, format("%d/%d", (int)creature.get_csp(), (int)creature.get_msp()), 8, 9);
+    c_put_str(TERM_L_BLUE, format("%d/%d", (int)creature.get_current_mp(), (int)creature.get_max_mp()), 8, 9);
 }

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -318,14 +318,14 @@ static int calculate_mp_regen_rate(CreatureEntity &creature)
     // マイナスの場合は回復しない（減少する）
     if (regen_rate < 0) {
         // 減少量を計算 (表示上はマイナス表示)
-        int64_t mp_decay_per_10turn = ((int64_t)creature.get_msp() * (-regen_rate) / 100 + PY_REGEN_MNBASE) >> 16;
+        int64_t mp_decay_per_10turn = ((int64_t)creature.get_max_mp() * (-regen_rate) / 100 + PY_REGEN_MNBASE) >> 16;
         int64_t mp_per_turn_x100 = (mp_decay_per_10turn * 100) / 10;
         int64_t mp_per_100turn = -(mp_per_turn_x100 * 100); // 100ターン分（マイナス）
         return static_cast<int>(mp_per_100turn);
     }
 
     // 実際の回復量を計算
-    int64_t mp_per_10turn = ((int64_t)creature.get_msp() * regen_rate / 100 + PY_REGEN_MNBASE) >> 16;
+    int64_t mp_per_10turn = ((int64_t)creature.get_max_mp() * regen_rate / 100 + PY_REGEN_MNBASE) >> 16;
     int64_t mp_per_turn_x100 = (mp_per_10turn * 100) / 10; // 100倍して小数5桁表示用
     int64_t mp_per_100turn = mp_per_turn_x100 * 100; // 100ターン分
 

--- a/src/window/display-sub-window-spells.cpp
+++ b/src/window/display-sub-window-spells.cpp
@@ -98,8 +98,8 @@ static void display_spell_list(CreatureEntity &creature)
             chance -= 3 * (creature.get_level() - spell.min_lev);
             chance -= 3 * (adj_mag_stat[creature.get_stat_index(mp_ptr->spell_stat)] - 1);
             if (!use_hp) {
-                if (spell.mana_cost > creature.get_csp()) {
-                    chance += 5 * (spell.mana_cost - creature.get_csp());
+                if (spell.mana_cost > creature.get_current_mp()) {
+                    chance += 5 * (spell.mana_cost - creature.get_current_mp());
                     a = TERM_ORANGE;
                 }
             } else {

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -787,8 +787,8 @@ static void display_spell_list(CreatureEntity &creature)
             chance -= 3 * (creature.get_level() - spell.min_lev);
             chance -= 3 * (adj_mag_stat[creature.get_stat_index(mp_ptr->spell_stat)] - 1);
             if (!use_hp) {
-                if (spell.mana_cost > creature.get_csp()) {
-                    chance += 5 * (spell.mana_cost - creature.get_csp());
+                if (spell.mana_cost > creature.get_current_mp()) {
+                    chance += 5 * (spell.mana_cost - creature.get_current_mp());
                     a = TERM_ORANGE;
                 }
             } else {

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -154,8 +154,8 @@ void print_hp(CreatureEntity &creature)
 /*!
  * @brief MPを表示する / Prints max/cur spell points
  * @param creature クリーチャーへの参照
- * @details プレイヤー職業や msp の値に関わらず常に表示する。
- * モンスターは生成時に msp/csp とも 0 で初期化されるため 0/0 と表示される。
+ * @details プレイヤー職業や max_mp の値に関わらず常に表示する。
+ * モンスターは生成時に max_mp/current_mp とも 0 で初期化されるため 0/0 と表示される。
  */
 void print_sp(CreatureEntity &creature)
 {
@@ -163,22 +163,22 @@ void print_sp(CreatureEntity &creature)
     byte color;
 
     put_str(_("MP", "SP"), ROW_CURSP, COL_CURSP);
-    sprintf(tmp, "%4ld", (long int)creature.get_csp());
-    if (creature.get_msp() <= 0) {
+    sprintf(tmp, "%4ld", (long int)creature.get_current_mp());
+    if (creature.get_max_mp() <= 0) {
         color = TERM_SLATE;
-    } else if (creature.get_csp() >= creature.get_msp()) {
+    } else if (creature.get_current_mp() >= creature.get_max_mp()) {
         color = TERM_L_GREEN;
-    } else if (creature.get_csp() > (creature.get_msp() * mana_warn) / 10) {
+    } else if (creature.get_current_mp() > (creature.get_max_mp() * mana_warn) / 10) {
         color = TERM_YELLOW;
     } else {
         color = TERM_RED;
     }
 
-    c_put_str(color, format("%4d", creature.get_csp()), ROW_CURSP, COL_CURSP + 3);
+    c_put_str(color, format("%4d", creature.get_current_mp()), ROW_CURSP, COL_CURSP + 3);
     put_str("/", ROW_CURSP, COL_CURSP + 7);
-    sprintf(tmp, "%4ld", (long int)creature.get_msp());
-    color = (creature.get_msp() <= 0) ? TERM_SLATE : TERM_L_GREEN;
-    c_put_str(color, format("%4d", creature.get_msp()), ROW_CURSP, COL_CURSP + 8);
+    sprintf(tmp, "%4ld", (long int)creature.get_max_mp());
+    color = (creature.get_max_mp() <= 0) ? TERM_SLATE : TERM_L_GREEN;
+    c_put_str(color, format("%4d", creature.get_max_mp()), ROW_CURSP, COL_CURSP + 8);
 }
 
 /*!


### PR DESCRIPTION
CreatureEntity 統合リファクタリング 提案 6 (フィールド名の命名統一) 第1弾。
Angband 由来の csp/msp (current/max spell points) を MP 概念に合わせて改名し、 プレイヤー時代の命名を汎用化する。

全体識別子 \b...\b アンカーの一括スクリプトで実施し、mspell 等の部分一致
衝突を回避 (素朴な msp→max_mp の sed は mspell を破壊するため)。
403 箇所 / 65 ファイルを置換。

改名対応:
- csp → current_mp / msp → max_mp / csp_frac → current_mp_frac
- get_csp/set_csp/add_csp/sub_csp → *_current_mp 系
- add_csp_with_frac/sub_csp_with_frac → *_current_mp_with_frac
- get_msp/set_msp → *_max_mp 系
- ローカル max_csp/old_csp/baseline_msp → *_current_mp / baseline_max_mp

上流マージへの影響: フィールドは提案 27b で private 化済みのため上流の
creature->csp アクセスは元々変換が必要で、変換先が get_current_mp() 等に 変わるのみ (CLAUDE.md マッピング表に追記)。

CLAUDE.md / docs/creature-entity-refactoring-roadmap.md も更新。 フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証済み。