### PR TITLE
refactor: 残り public bool フィールド5個を private 化（提案51 / A-1第1弾）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -70,6 +70,7 @@ Phase 1-8 完了後に残存している統合作業項目を整理したもの�
 | [48](#提案-48-追加の小規模フィールドの-private-化--完了) | 追加の小規模フィールドまとめ | ✅ 完了 | **+6 = 141 個** (tval_ammo / dtrap / autopick_autoregister / recall_dungeon / enchant_energy_need / energy_use) |
 | [49](#提案-49-モンスター時限効果付与プリミティブの集約-b1-第1段--完了) | モンスター時限効果付与プリミティブ集約 (B1 第1段) | ✅ 完了 | FloorType::set_monster_timed_effect、7 setter 集約 |
 | [50](#提案-50-set_timed_effect-への-mproc-保守統合-b1-後続段--完了-要実機smoke-test) | set_timed_effect への mproc 保守統合 (B1 後続段) | ✅ 完了 (要実機smoke-test) | get_self_m_idx、mproc を set_timed_effect に内包 |
+| [51](#提案-51-残り-public-bool-フィールドの-private-化-a-1-第1弾--完了) | 残り public bool フィールドの private 化 (A-1 第1弾) | ✅ 完了 | counter / select_ring_slot / no_flowed / hack_mutation / invoking_midnight_curse |
 
 **累計 private 化フィールド数 (主要マイルストーン):**
 - 提案 29 (3 個) → 32 (10 個) → 32b (37 個) → 33 (72 個) → 34 (77 個) →
@@ -2608,6 +2609,48 @@ virtual では中身が分離した 2 経路になり価値が薄い。さらに
   再描画」のみの薄いラッパとなった。将来これらを `CreatureEntity` の
   状態異常付与 API (例: `inflict_*`) へ寄せる余地がある (ただしプレイヤーの
   豊富な副作用とは別経路のまま)。
+
+---
+
+## 提案 51: 残り public bool フィールドの private 化 (A-1 第1弾) ✅ 完了
+
+### 背景
+
+提案 24-48 で 141+ フィールドを private 化したが、未カプセル化の public
+フィールドがまだ残存している (棚卸し結果: 単純スカラ/bool 約 10、energy_need /
+knowledge / element_realm、配列/vector 系、汎用名 count 等)。本提案はその
+うち最も安全な「単純 bool 5 個」を private 化する第1弾。
+
+### 完了内容
+
+以下 5 個の public bool フィールドを private 化し、`is_X()` / `set_X()`
+virtual アクセサを整備:
+
+| フィールド | 用途 |
+|---|---|
+| `counter` | 侍カウンター攻撃の構え |
+| `select_ring_slot` | 指輪スロット選択中フラグ (UI 一時) |
+| `no_flowed` | モンスター流れ込み AI 抑制フラグ |
+| `hack_mutation` | 誕生時の突然変異強制フラグ |
+| `invoking_midnight_curse` | 深夜の呪い発動中フラグ |
+
+- 16 ファイル / 32 アクセスサイト (書込 21・読取 11) を migration。
+  bool 書込は全て `= true`/`= false` のため `set_X(true/false)` に、
+  読取は `is_X()` に機械置換。
+- フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証済み。
+
+### 残作業 (A-1 続き / A-2 / A-3)
+
+- **A-1 続き**: BIT_FLAGS (`easy_2weapon` / `down_saving`)、scalar
+  (`mutant_regenerate_mod` / `learned_spells` / `add_spells`) の private 化
+- **A-2**: `energy_need` (compound 多) / `knowledge` (BIT_FLAGS) /
+  `element_realm` (getter 既存)
+- **A-3**: 配列/vector (`hp_table[]` / `extra_blows[]` / `extended_inventory`)、
+  汎用名 `count` (要精査) / `class_specific_data`
+
+**留意**: これらは player 固有・低 churn のフィールドで機能的影響はなく、
+カプセル化の完全性のための作業。`creature-entity.h` 変更は上流マージ衝突を
+増やすため、効果と費用を勘案して進めること。
 
 ---
 

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -182,9 +182,9 @@ void player_birth(CreatureEntity &creature, std::optional<QuestId> initial_quest
 
     WildernessGrids::get_instance().initialize_seeds();
     if (CreatureRace(&creature).equals(PlayerRaceType::BEASTMAN)) {
-        creature.hack_mutation = true;
+        creature.set_hack_mutation(true);
     } else {
-        creature.hack_mutation = false;
+        creature.set_hack_mutation(false);
     }
 
     if (g_window_flags[1].none()) {

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -224,15 +224,15 @@ void do_cmd_wield(CreatureEntity &creature)
         }
 
         constexpr auto s = _("おっと。", "Oops.");
-        creature.select_ring_slot = true;
+        creature.set_select_ring_slot(true);
         const auto &[item_replace, slot_replace] = choose_item(creature, q, s, (USE_EQUIP | IGNORE_BOTHHAND_SLOT));
         if (!item_replace) {
-            creature.select_ring_slot = false;
+            creature.set_select_ring_slot(false);
             return;
         }
 
         slot = slot_replace;
-        creature.select_ring_slot = false;
+        creature.set_select_ring_slot(false);
         break;
     }
     default:

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -100,7 +100,7 @@
 
 static void restore_windows(CreatureEntity &creature)
 {
-    creature.hack_mutation = false;
+    creature.set_hack_mutation(false);
     AngbandWorld::get_instance().character_icky_depth = 1;
     term_activate(angband_terms[0]);
     angband_terms[0]->resize_hook = resize_map;

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -108,17 +108,17 @@ bool continuous_action_running(CreatureEntity &creature)
  */
 void process_player(CreatureEntity &creature)
 {
-    if (creature.hack_mutation) {
+    if (creature.is_hack_mutation()) {
         msg_print(_("何か変わった気がする！", "You feel different!"));
         (void)gain_mutation(creature, 0);
-        creature.hack_mutation = false;
+        creature.set_hack_mutation(false);
     }
 
-    if (creature.invoking_midnight_curse) {
+    if (creature.is_invoking_midnight_curse()) {
         int count = 0;
         mark_monsters_present(creature);
         activate_ty_curse(creature, false, &count);
-        creature.invoking_midnight_curse = false;
+        creature.set_invoking_midnight_curse(false);
     }
 
     const auto &system = AngbandSystem::get_instance();
@@ -260,7 +260,7 @@ void process_player(CreatureEntity &creature)
     while (creature.energy_need <= 0) {
         rfu.set_flag(SubWindowRedrawingFlag::PLAYER);
         creature.set_sutemi(false);
-        creature.counter = false;
+        creature.set_counter(false);
         creature.set_now_damaged(false);
 
         update_monsters(creature, false);

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -201,8 +201,8 @@ static void test_equipment_floor(CreatureEntity &creature, FloorItemSelection *f
     }
 
     for (const auto i_idx : INVEN_WIELDING_SLOTS) {
-        if (creature.select_ring_slot ? is_ring_slot(i_idx)
-                                      : item_tester.okay(creature.inventory[i_idx].get()) || (fis_ptr->mode & USE_FULL)) {
+        if (creature.is_select_ring_slot() ? is_ring_slot(i_idx)
+                                           : item_tester.okay(creature.inventory[i_idx].get()) || (fis_ptr->mode & USE_FULL)) {
             fis_ptr->max_equip++;
         }
     }

--- a/src/inventory/inventory-util.cpp
+++ b/src/inventory/inventory-util.cpp
@@ -140,7 +140,7 @@ bool get_item_okay(CreatureEntity &creature, OBJECT_IDX i, const ItemTester &ite
         return false;
     }
 
-    if (creature.select_ring_slot) {
+    if (creature.is_select_ring_slot()) {
         return is_ring_slot(i);
     }
 
@@ -198,7 +198,7 @@ INVENTORY_IDX label_to_equipment(CreatureEntity &creature, int c)
         return -1;
     }
 
-    if (creature.select_ring_slot) {
+    if (creature.is_select_ring_slot()) {
         return is_ring_slot(i) ? i : -1;
     }
 

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -519,7 +519,7 @@ void mineuchi(CreatureEntity &creature, player_attack_type *pa_ptr)
 void musou_counterattack(CreatureEntity &creature, MonsterAttackPlayer *monap_ptr)
 {
     const auto is_musou = CreatureClass(creature).samurai_stance_is(SamuraiStanceType::MUSOU);
-    if ((!creature.counter && !is_musou) || !monap_ptr->alive || creature.is_dead() || !monap_ptr->m_ptr->is_visible_on_map() || (creature.get_current_mp() <= 7)) {
+    if ((!creature.is_counter() && !is_musou) || !monap_ptr->alive || creature.is_dead() || !monap_ptr->m_ptr->is_visible_on_map() || (creature.get_current_mp() <= 7)) {
         return;
     }
 

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -975,7 +975,7 @@ void process_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
      *  Forward movements failed, but now received LOS attack!
      *  Try to flow by smell.
      */
-    if (creature.no_flowed && count > 2 && monster.get_target_position().y) {
+    if (creature.is_no_flowed() && count > 2 && monster.get_target_position().y) {
         monster.reset_constant_flag(MonsterConstantFlagType::NOFLOW);
     }
 
@@ -1671,7 +1671,7 @@ void sweep_monster_process(CreatureEntity &creature)
 
         process_monster(creature, m_idx);
         monster.reset_target();
-        if (creature.no_flowed && one_in_(3)) {
+        if (creature.is_no_flowed() && one_in_(3)) {
             monster.set_constant_flag(MonsterConstantFlagType::NOFLOW);
         }
 
@@ -1691,7 +1691,7 @@ bool decide_process_continue(CreatureEntity &creature, CreatureEntity &monster)
 {
     const auto &monrace = monster.get_monrace();
 
-    if (!creature.no_flowed) {
+    if (!creature.is_no_flowed()) {
         monster.reset_constant_flag(MonsterConstantFlagType::NOFLOW);
     }
 

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -755,16 +755,16 @@ void check_no_flowed(CreatureEntity &creature)
     ItemEntity *o_ptr;
     bool has_sw = false, has_kabe = false;
 
-    creature.no_flowed = false;
+    creature.set_no_flowed(false);
 
     if (has_pass_wall(creature) && !has_kill_wall(creature)) {
-        creature.no_flowed = true;
+        creature.set_no_flowed(true);
         return;
     }
 
     PlayerRealm pr(creature);
     if (!pr.realm1().is_available()) {
-        creature.no_flowed = false;
+        creature.set_no_flowed(false);
         return;
     }
 
@@ -794,14 +794,14 @@ void check_no_flowed(CreatureEntity &creature)
     if (has_sw && (pr.realm1().equals(RealmType::NATURE) || pr.realm2().equals(RealmType::NATURE) || pc.equals(PlayerClassType::SORCERER))) {
         const auto &spell = PlayerRealm::get_spell_info(RealmType::NATURE, SPELL_SW);
         if (creature.get_level() >= spell.slevel) {
-            creature.no_flowed = true;
+            creature.set_no_flowed(true);
         }
     }
 
     if (has_kabe && (pr.realm1().equals(RealmType::CRAFT) || pr.realm2().equals(RealmType::CRAFT) || pc.equals(PlayerClassType::SORCERER))) {
         const auto &spell = PlayerRealm::get_spell_info(RealmType::CRAFT, SPELL_WALL);
         if (creature.get_level() >= spell.slevel) {
-            creature.no_flowed = true;
+            creature.set_no_flowed(true);
         }
     }
 }

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -157,7 +157,7 @@ tl::optional<std::string> do_hissatsu_spell(CreatureEntity &creature, SPELL_IDX 
                 return tl::nullopt;
             }
             msg_print(_("相手の攻撃に対して身構えた。", "You prepare to counterattack."));
-            creature.counter = true;
+            creature.set_counter(true);
         }
         break;
 

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -153,7 +153,7 @@ bool BadStatusSetter::set_confusion(const TIME_EFFECT tmp_v)
             }
 
             notice = true;
-            this->creature.counter = false;
+            this->creature.set_counter(false);
             chg_virtue(this->creature, Virtue::HARMONY, -1);
         }
     } else {
@@ -250,7 +250,7 @@ bool BadStatusSetter::set_fear(const TIME_EFFECT tmp_v)
             }
 
             notice = true;
-            this->creature.counter = false;
+            this->creature.set_counter(false);
             chg_virtue(this->creature, Virtue::VALOUR, -1);
         }
     } else {
@@ -303,7 +303,7 @@ bool BadStatusSetter::set_paralysis(const TIME_EFFECT tmp_v)
                 (void)spell_hex.stop_all_spells();
             }
 
-            this->creature.counter = false;
+            this->creature.set_counter(false);
             notice = true;
         }
     } else {
@@ -358,7 +358,7 @@ bool BadStatusSetter::hallucination(const TIME_EFFECT tmp_v)
             msg_print(_("ワーオ！何もかも虹色に見える！", "Oh, wow! Everything looks so cosmic now!"));
             reset_concentration(this->creature, true);
 
-            this->creature.counter = false;
+            this->creature.set_counter(false);
             notice = true;
         }
     } else {

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -90,7 +90,7 @@ void reset_tim_flags(CreatureEntity &creature)
 
     // 非 CreatureTimedEffect のリセット
     creature.set_sutemi(false);
-    creature.counter = false;
+    creature.set_counter(false);
     creature.set_special_attack_flags(0L);
     creature.set_special_defense_flags(0L);
 

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -4089,7 +4089,19 @@ private:
 
 public:
     // 装備・能力関連フラグ / Equipment and ability flags
+private:
     bool hack_mutation{};
+
+public:
+    // [提案 51] hack_mutation を private 化。is_hack_mutation() / set_hack_mutation() 経由。
+    bool is_hack_mutation() const
+    {
+        return this->hack_mutation;
+    }
+    void set_hack_mutation(bool value)
+    {
+        this->hack_mutation = value;
+    }
 
     // [提案 43] is_fired (フィールド名 fired にリネーム) / level_up_message は
     // private 化済。is_fired() / set_is_fired() / has_level_up_message() /
@@ -4131,7 +4143,19 @@ private:
     BIT_FLAGS see_nocto{}; /* Noctovision */
 
 public:
+private:
     bool invoking_midnight_curse{};
+
+public:
+    // [提案 51] invoking_midnight_curse を private 化。is_invoking_midnight_curse() / set_invoking_midnight_curse() 経由。
+    bool is_invoking_midnight_curse() const
+    {
+        return this->invoking_midnight_curse;
+    }
+    void set_invoking_midnight_curse(bool value)
+    {
+        this->invoking_midnight_curse = value;
+    }
 
     // インシデント記録（ツリー構造）
     std::map<std::string, int32_t> incident_tree{}; /*!< ツリー構造ID（例: "root/attack/critical"）で記録するインシデントカウント */
@@ -4374,7 +4398,19 @@ private:
 public:
     /*** Temporary fields ***/
 
+private:
     bool select_ring_slot{};
+
+public:
+    // [提案 51] select_ring_slot を private 化。is_select_ring_slot() / set_select_ring_slot() 経由。
+    bool is_select_ring_slot() const
+    {
+        return this->select_ring_slot;
+    }
+    void set_select_ring_slot(bool value)
+    {
+        this->select_ring_slot = value;
+    }
 
     // [提案 43] playing / leaving / monk_notify_aux / teleport_town は private 化済。
     // is_playing() / set_playing() / is_leaving() / set_leaving() /
@@ -4446,7 +4482,19 @@ private:
     bool sutemi{};
 
 public:
+private:
     bool counter{};
+
+public:
+    // [提案 51] counter を private 化。is_counter() / set_counter() 経由。
+    bool is_counter() const
+    {
+        return this->counter;
+    }
+    void set_counter(bool value)
+    {
+        this->counter = value;
+    }
 
 private:
     DIRECTION fishing_dir{};
@@ -4470,7 +4518,19 @@ private:
 public:
     Dice damage_dice_bonus[2]{}; /* Extra damage dice num/sides */
 
+private:
     bool no_flowed{};
+
+public:
+    // [提案 51] no_flowed を private 化。is_no_flowed() / set_no_flowed() 経由。
+    bool is_no_flowed() const
+    {
+        return this->no_flowed;
+    }
+    void set_no_flowed(bool value)
+    {
+        this->no_flowed = value;
+    }
 
 private:
     // [提案 48] private 化済。get_tval_ammo() / set_tval_ammo() 経由。

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -319,7 +319,7 @@ static void display_equipment(CreatureEntity &creature, const ItemTester &item_t
         }
 
         const auto &item = *creature.inventory[i_idx];
-        auto do_disp = creature.select_ring_slot ? is_ring_slot(i_idx) : item_tester.okay(&item);
+        auto do_disp = creature.is_select_ring_slot() ? is_ring_slot(i_idx) : item_tester.okay(&item);
         std::string tmp_val = "   ";
 
         if (do_disp) {

--- a/src/window/main-window-equipments.cpp
+++ b/src/window/main-window-equipments.cpp
@@ -44,7 +44,7 @@ COMMAND_CODE show_equipment(CreatureEntity &creature, int target_item, BIT_FLAGS
     k = 0;
     for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         const auto &item = *creature.inventory[i_idx];
-        auto only_slot = !(creature.select_ring_slot ? is_ring_slot(i_idx) : (item_tester.okay(&item) || any_bits(mode, USE_FULL)));
+        auto only_slot = !(creature.is_select_ring_slot() ? is_ring_slot(i_idx) : (item_tester.okay(&item) || any_bits(mode, USE_FULL)));
         auto is_any_hand = (i_idx == INVEN_MAIN_HAND) && can_attack_with_sub_hand(creature);
         is_any_hand |= (i_idx == INVEN_SUB_HAND) && can_attack_with_main_hand(creature);
         auto is_two_handed = is_any_hand && creature.has_two_handed_weapons();

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -370,5 +370,5 @@ void WorldTurnProcessor::ring_nightmare_bell(int prev_min)
         PlayerEnergy(this->creature).set_player_turn_energy(100);
     }
 
-    this->creature.invoking_midnight_curse = true;
+    this->creature.set_invoking_midnight_curse(true);
 }


### PR DESCRIPTION
CreatureEntity 統合リファクタリング 提案 51。提案 24-48 で 141+ フィールドを private 化したが未カプセル化の public フィールドが残存していたため、最も
安全な単純 bool 5 個を private 化する第1弾。

- counter（侍カウンター構え）/ select_ring_slot（指輪スロット選択中）/ no_flowed（流れ込み AI 抑制）/ hack_mutation（誕生時変異強制）/ invoking_midnight_curse（深夜呪い発動中）を private 化し、 is_X() / set_X() virtual アクセサを整備。
- 16 ファイル / 32 サイト（書込 21・読取 11）を migration。bool 書込は 全て true/false のため set_X(true/false)、読取は is_X() へ機械置換。

フルビルド（g++ -O3 -Werror -Wall -Wextra）と clang-format-18 で検証済み。 ロードマップに提案 51 と A-1 続き / A-2 / A-3 の残棚卸しを記録。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the creature entity refactoring roadmap to reflect completed encapsulation of remaining creature boolean flags and list upcoming follow-up items.
* **Refactor**
  * Encapsulated multiple creature state flags behind accessor/mutator methods and updated gameplay/equipment/status logic to use the new API.
  * Ensured consistent handling for hack mutation, midnight curse, ring-slot selection, counter/can-counter state, and NOFLOW-related state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->