### PR TITLE
refactor: BIT_FLAGS 2個・scalar 3個を private 化（提案A-1第2弾）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -2639,10 +2639,30 @@ virtual アクセサを整備:
   読取は `is_X()` に機械置換。
 - フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証済み。
 
-### 残作業 (A-1 続き / A-2 / A-3)
+### 提案 A-1 第2弾 ✅ 完了
 
-- **A-1 続き**: BIT_FLAGS (`easy_2weapon` / `down_saving`)、scalar
-  (`mutant_regenerate_mod` / `learned_spells` / `add_spells`) の private 化
+提案 51 (第1弾, bool 5 個) に続き、BIT_FLAGS 2 個と scalar 3 個を private 化:
+
+| フィールド | 型 | 用途 |
+|---|---|---|
+| `easy_2weapon` | BIT_FLAGS | 二刀流ペナルティ軽減 (手別ビット) |
+| `down_saving` | BIT_FLAGS | 劣化セーヴィングスロー |
+| `mutant_regenerate_mod` | PERCENTAGE | ミュータント体質の自然回復補正(%) |
+| `learned_spells` | int16_t | 習得済み呪文数 |
+| `add_spells` | int16_t | 追加習得可能呪文数 |
+
+- 10 個の virtual アクセサ (`get_X()` / `set_X()`) を整備し、12 ファイル
+  約 22 アクセスサイトを migration。
+- 読取は `get_X()`、書込は `set_X()`、`++` (learned_spells / add_spells) は
+  `set_X(get_X() + 1)` に展開。`PlayerType::apply_creature_specific_regen_modifier`
+  の `this->mutant_regenerate_mod` も `this->get_mutant_regenerate_mod()` に変換。
+- 既存の `has_down_saving()` / `has_easy2_weapon()` は装備集計を計算する別物
+  (キャッシュ値の格納先がこのフィールド)。フィールド getter は `get_down_saving()`
+  / `get_easy_2weapon()` と命名して衝突回避。
+- フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証済み。
+
+### 残作業 (A-2 / A-3)
+
 - **A-2**: `energy_need` (compound 多) / `knowledge` (BIT_FLAGS) /
   `element_realm` (getter 既存)
 - **A-3**: 配列/vector (`hp_table[]` / `extra_blows[]` / `extended_inventory`)、

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -83,10 +83,10 @@ void player_wipe_without_name(CreatureEntity &creature)
     pss.realm1().initialize();
     pss.realm2().initialize();
 
-    creature.learned_spells = 0;
-    creature.add_spells = 0;
+    creature.set_learned_spells(0);
+    creature.set_add_spells(0);
     creature.knowledge = 0;
-    creature.mutant_regenerate_mod = 100;
+    creature.set_mutant_regenerate_mod(100);
 
     cheat_peek = false;
     cheat_hear = false;

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -880,7 +880,7 @@ void do_cmd_study(CreatureEntity &creature)
     sound(SoundKind::STUDY);
 
     /* One less spell available */
-    creature.learned_spells++;
+    creature.set_learned_spells(creature.get_learned_spells() + 1);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(StatusRecalculatingFlag::SPELLS);

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -109,7 +109,7 @@ int PlayerType::apply_state_regen_modifier(int amount) const
 
 int PlayerType::apply_creature_specific_regen_modifier(int amount) const
 {
-    return (amount * this->mutant_regenerate_mod) / 100;
+    return (amount * this->get_mutant_regenerate_mod()) / 100;
 }
 
 /*!

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -163,8 +163,8 @@ static void load_spells(CreatureEntity &creature)
     creature.set_spell_worked_flags(1, rd_u32b());
     creature.set_spell_forgotten_flags(0, rd_u32b());
     creature.set_spell_forgotten_flags(1, rd_u32b());
-    creature.learned_spells = rd_s16b();
-    creature.add_spells = rd_s16b();
+    creature.set_learned_spells(rd_s16b());
+    creature.set_add_spells(rd_s16b());
 }
 
 static errr verify_checksum()
@@ -232,7 +232,7 @@ static errr exe_reading_savefile(CreatureEntity &creature)
 
     load_spells(creature);
     if (CreatureClass(creature).equals(PlayerClassType::MINDCRAFTER)) {
-        creature.add_spells = 0;
+        creature.set_add_spells(0);
     }
 
     auto load_inventory_result = load_inventory(creature);

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -569,7 +569,7 @@ static void rd_player_status(CreatureEntity &creature)
         creature.set_timed_effect(CreatureTimedEffect::TSUYOSHI, rd_s16b());
     }
     rd_timed_effects(creature);
-    creature.mutant_regenerate_mod = calc_mutant_regenerate_mod(creature);
+    creature.set_mutant_regenerate_mod(calc_mutant_regenerate_mod(creature));
 
     if (!loading_savefile_version_is_older_than(6)) {
         int32_t num = rd_s32b();

--- a/src/mutation/mutation-investor-remover.cpp
+++ b/src/mutation/mutation-investor-remover.cpp
@@ -256,7 +256,7 @@ bool gain_mutation(CreatureEntity &creature, MUTATION_IDX choose_mut)
         }
     }
 
-    creature.mutant_regenerate_mod = calc_mutant_regenerate_mod(creature);
+    creature.set_mutant_regenerate_mod(calc_mutant_regenerate_mod(creature));
     RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(creature);
     return true;
@@ -304,7 +304,7 @@ bool lose_mutation(CreatureEntity &creature, MUTATION_IDX choose_mut)
 
     RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(creature);
-    creature.mutant_regenerate_mod = calc_mutant_regenerate_mod(creature);
+    creature.set_mutant_regenerate_mod(calc_mutant_regenerate_mod(creature));
     return true;
 }
 
@@ -316,6 +316,6 @@ void lose_all_mutations(CreatureEntity &creature)
         creature.clear_mutations();
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
         handle_stuff(creature);
-        creature.mutant_regenerate_mod = calc_mutant_regenerate_mod(creature);
+        creature.set_mutant_regenerate_mod(calc_mutant_regenerate_mod(creature));
     }
 }

--- a/src/object-use/read/scroll-read-executor.cpp
+++ b/src/object-use/read/scroll-read-executor.cpp
@@ -357,7 +357,7 @@ bool ScrollReadExecutor::read()
             break;
         }
 
-        this->creature.add_spells++;
+        this->creature.set_add_spells(this->creature.get_add_spells() + 1);
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::SPELLS);
         this->ident = true;
         break;

--- a/src/player-attack/blood-sucking-processor.cpp
+++ b/src/player-attack/blood-sucking-processor.cpp
@@ -159,7 +159,7 @@ static void drain_result(CreatureEntity &creature, player_attack_type *pa_ptr, b
         *drain_msg = false;
     }
 
-    drain_heal = (drain_heal * creature.mutant_regenerate_mod) / 100;
+    drain_heal = (drain_heal * creature.get_mutant_regenerate_mod()) / 100;
     hp_player(creature, drain_heal);
 }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -269,8 +269,8 @@ static void update_bonuses(CreatureEntity &creature)
     creature.set_esp_unique(has_esp_unique(creature));
     creature.set_telepathy(has_esp_telepathy(creature));
     creature.set_bless_blade(has_bless_blade(creature));
-    creature.easy_2weapon = creature.has_easy2_weapon();
-    creature.down_saving = creature.has_down_saving();
+    creature.set_easy_2weapon(creature.has_easy2_weapon());
+    creature.set_down_saving(creature.has_down_saving());
     creature.set_yoiyami(creature.has_no_ac());
     creature.set_mighty_throw(has_mighty_throw(creature));
     creature.set_dec_mana(has_dec_mana(creature));
@@ -496,7 +496,7 @@ static void update_num_of_spells(CreatureEntity &creature)
         }
     }
 
-    creature.new_spells = num_allowed + creature.add_spells + num_forgotten - creature.learned_spells;
+    creature.new_spells = num_allowed + creature.get_add_spells() + num_forgotten - creature.get_learned_spells();
 
     for (auto it = creature.spell_order_learned.crbegin(); it != creature.spell_order_learned.crend(); ++it) {
         const auto is_realm1 = *it < 32;
@@ -1152,7 +1152,7 @@ static ACTION_SKILL_POWER calc_saving_throw(CreatureEntity &creature)
         pow = 95 + creature.get_level();
     }
 
-    if (creature.down_saving) {
+    if (creature.get_down_saving()) {
         pow /= 2;
     }
 
@@ -1861,7 +1861,7 @@ int16_t calc_double_weapon_penalty(CreatureEntity &creature, INVENTORY_IDX slot)
         }
 
         for (uint i = FLAG_CAUSE_INVEN_MAIN_HAND; i < FLAG_CAUSE_MAX; i <<= 1) {
-            if (penalty > 0 && any_bits(creature.easy_2weapon, i)) {
+            if (penalty > 0 && any_bits(creature.get_easy_2weapon(), i)) {
                 penalty /= 2;
             }
         }

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -200,8 +200,8 @@ static bool wr_savefile_new(CreatureEntity &creature)
     wr_u32b(creature.get_spell_worked_flags(1));
     wr_u32b(creature.get_spell_forgotten_flags(0));
     wr_u32b(creature.get_spell_forgotten_flags(1));
-    wr_s16b(creature.learned_spells);
-    wr_s16b(creature.add_spells);
+    wr_s16b(creature.get_learned_spells());
+    wr_s16b(creature.get_add_spells());
     for (auto i = 0; i < 64; i++) {
         const auto spell_id = (i < std::ssize(creature.spell_order_learned)) ? creature.spell_order_learned[i] : 255;
         wr_byte(static_cast<byte>(spell_id));

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -2087,6 +2087,36 @@ public:
         this->max_plv = value;
     }
 
+    /*! @brief ミュータント体質による自然回復補正(%)を設定する (A-1) */
+    virtual void set_mutant_regenerate_mod(PERCENTAGE value)
+    {
+        this->mutant_regenerate_mod = value;
+    }
+
+    /*! @brief 習得済み呪文数を設定する (A-1) */
+    virtual void set_learned_spells(int16_t value)
+    {
+        this->learned_spells = value;
+    }
+
+    /*! @brief 追加習得可能呪文数を設定する (A-1) */
+    virtual void set_add_spells(int16_t value)
+    {
+        this->add_spells = value;
+    }
+
+    /*! @brief 二刀流ペナルティ軽減フラグを設定する (A-1) */
+    virtual void set_easy_2weapon(BIT_FLAGS value)
+    {
+        this->easy_2weapon = value;
+    }
+
+    /*! @brief 劣化セーヴィングスローフラグを設定する (A-1) */
+    virtual void set_down_saving(BIT_FLAGS value)
+    {
+        this->down_saving = value;
+    }
+
     /*! @brief 最大 MP (max_mp) を設定する (提案 27) */
     virtual void set_max_mp(int value)
     {
@@ -2216,6 +2246,36 @@ public:
     virtual int16_t get_max_plv() const
     {
         return this->max_plv;
+    }
+
+    /*! @brief ミュータント体質による自然回復補正(%)を取得する (A-1) */
+    virtual PERCENTAGE get_mutant_regenerate_mod() const
+    {
+        return this->mutant_regenerate_mod;
+    }
+
+    /*! @brief 習得済み呪文数を取得する (A-1) */
+    virtual int16_t get_learned_spells() const
+    {
+        return this->learned_spells;
+    }
+
+    /*! @brief 追加習得可能呪文数を取得する (A-1) */
+    virtual int16_t get_add_spells() const
+    {
+        return this->add_spells;
+    }
+
+    /*! @brief 二刀流ペナルティ軽減フラグを取得する (A-1) */
+    virtual BIT_FLAGS get_easy_2weapon() const
+    {
+        return this->easy_2weapon;
+    }
+
+    /*! @brief 劣化セーヴィングスローフラグを取得する (A-1) */
+    virtual BIT_FLAGS get_down_saving() const
+    {
+        return this->down_saving;
     }
 
     /*! @brief 最大 MP (max_mp) を取得する (提案 31) */
@@ -4237,16 +4297,19 @@ public:
 
     std::map<INCIDENT, int32_t> incident{}; /*!< これまでに行った出来事カウント（従来型、enumベース） */
 
+    // [A-1] private 化済。get_mutant_regenerate_mod() / set_mutant_regenerate_mod() 経由。
+private:
     PERCENTAGE mutant_regenerate_mod{};
 
     // [提案 32] private 化済。get_max_plv() / set_max_plv() 経由。
-private:
     int16_t max_plv{}; /* Max Player Level */
 
-public:
+    // [A-1] private 化済。get_learned_spells() / set_learned_spells() /
+    // get_add_spells() / set_add_spells() 経由。
     int16_t learned_spells{};
     int16_t add_spells{};
 
+public:
     uint32_t count{};
 
     // [提案 43] timewalk / resting は private 化済。
@@ -4474,11 +4537,11 @@ public:
 private:
     BIT_FLAGS yoiyami{};
 
-public:
+    // [A-1] private 化済。get_easy_2weapon() / set_easy_2weapon() /
+    // get_down_saving() / set_down_saving() 経由。
     BIT_FLAGS easy_2weapon{};
     BIT_FLAGS down_saving{};
 
-private:
     bool sutemi{};
 
 public:

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -642,7 +642,7 @@ void wiz_reset_class(CreatureEntity &creature)
     PlayerSpellStatus pss(creature);
     pss.realm1().initialize();
     pss.realm2().initialize();
-    creature.learned_spells = 0;
+    creature.set_learned_spells(0);
     change_birth_flags();
     handle_stuff(creature);
 }
@@ -668,7 +668,7 @@ void wiz_reset_realms(CreatureEntity &creature)
     PlayerSpellStatus pss(creature);
     pss.realm1().initialize();
     pss.realm2().initialize();
-    creature.learned_spells = 0;
+    creature.set_learned_spells(0);
     change_birth_flags();
     handle_stuff(creature);
 }


### PR DESCRIPTION
easy_2weapon / down_saving (BIT_FLAGS)、mutant_regenerate_mod (PERCENTAGE)、 learned_spells / add_spells (int16_t) を CreatureEntity の private へ移し、 get_X() / set_X() の virtual アクセサ 10 個を整備。12 ファイル約 22 サイトの read/write を migration（++ は set_X(get_X()+1) へ展開）。

has_down_saving() / has_easy2_weapon() は装備集計を計算する別物のため、 フィールド getter は get_down_saving() / get_easy_2weapon() と命名して衝突回避。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when tracking learned and added spells across gameplay, saving/loading, and class reset flows.
  * Updated spell-related status calculations so bonuses and spell counts stay in sync more reliably.
  * Fixed mutation-related regeneration and drain effects to use the latest character state.
* **Refactor**
  * Moved several character stats to cleaner internal access patterns, helping keep future updates more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->