### PR TITLE
refactor: energy_need / element_realm / knowledge を private 化（提案A-2）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -2661,10 +2661,32 @@ virtual アクセサを整備:
   / `get_easy_2weapon()` と命名して衝突回避。
 - フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証済み。
 
-### 残作業 (A-2 / A-3)
+### 提案 A-2 ✅ 完了
 
-- **A-2**: `energy_need` (compound 多) / `knowledge` (BIT_FLAGS) /
-  `element_realm` (getter 既存)
+3 フィールド (`energy_need` / `element_realm` / `knowledge`) を private 化:
+
+| フィールド | 型 | アクセサ |
+|---|---|---|
+| `energy_need` | ACTION_ENERGY | `get_energy_need()` / `set_energy_need()` (既存) + 新規 `add_energy_need()` / `sub_energy_need()` |
+| `element_realm` | ElementRealmType | `get_element_realm()` / `set_element_realm()` (既存) |
+| `knowledge` | BIT_FLAGS8 | 新規 `has_knowledge()` / `add_knowledge()` / `remove_knowledge()` / `get_knowledge()` / `set_knowledge()` |
+
+- `energy_need`: get/set は既存だったが約 38 サイトが compound assignment
+  (`+=` / `-=`) や直接読取りでフィールドに触れていた。`add_energy_need()` /
+  `sub_energy_need()` を新設し、`+=`→`add_`、`-=`→`sub_`、`=`→`set_`、
+  読取り→`get_` に regex 一括変換 (`creature` / `monster` / `m_ptr` の
+  `.` / `->` 両アクセス)。プレイヤー・モンスター共用フィールドのため
+  両系統の access site を含む。
+- `element_realm`: get/set 既存。約 25 read + 5 write を migration。
+  CreatureEntity 内部 (`creature-entity.cpp`) の `this->element_realm` 代入は
+  private 内アクセスのため残置。
+- `knowledge`: 自己分析知識フラグ (KNOW_STAT / KNOW_HPRATE)。`& FLAG`→
+  `has_knowledge(FLAG)`、`|= FLAG`→`add_knowledge(FLAG)`、`&= ~FLAG`→
+  `remove_knowledge(FLAG)`、`= 0`/load→`set_knowledge()`、save→`get_knowledge()`。
+- フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証済み。
+
+### 残作業 (A-3)
+
 - **A-3**: 配列/vector (`hp_table[]` / `extra_blows[]` / `extended_inventory`)、
   汎用名 `count` (要精査) / `class_specific_data`
 

--- a/src/birth/birth-select-realm.cpp
+++ b/src/birth/birth-select-realm.cpp
@@ -293,10 +293,10 @@ bool get_player_realms(CreatureEntity &creature)
         if (!realm) {
             return false;
         }
-        creature.element_realm = *realm;
+        creature.set_element_realm(*realm);
 
         put_str(_("魔法        :", "Magic       :"), 6, 1);
-        c_put_str(TERM_L_BLUE, get_element_title(creature.element_realm), 6, 15);
+        c_put_str(TERM_L_BLUE, get_element_title(creature.get_element_realm()), 6, 15);
         return true;
     }
 

--- a/src/birth/birth-stat.cpp
+++ b/src/birth/birth-stat.cpp
@@ -226,6 +226,6 @@ void get_max_stats(CreatureEntity &creature)
         }
     }
 
-    creature.knowledge &= ~(KNOW_STAT);
+    creature.remove_knowledge(KNOW_STAT);
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::ABILITY_SCORE);
 }

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -83,8 +83,8 @@ static void write_birth_diary(CreatureEntity &creature)
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_realm);
     }
 
-    if (creature.element_realm != ElementRealmType::NONE) {
-        const auto mes_element = format(_("%s元素系統に%sを選択した。", "%schose %s system."), indent, get_element_title(creature.element_realm).data());
+    if (creature.get_element_realm() != ElementRealmType::NONE) {
+        const auto mes_element = format(_("%s元素系統に%sを選択した。", "%schose %s system."), indent, get_element_title(creature.get_element_realm()).data());
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_element);
     }
 

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -85,7 +85,7 @@ void player_wipe_without_name(CreatureEntity &creature)
 
     creature.set_learned_spells(0);
     creature.set_add_spells(0);
-    creature.knowledge = 0;
+    creature.set_knowledge(0);
     creature.set_mutant_regenerate_mod(100);
 
     cheat_peek = false;

--- a/src/birth/monster-birth.cpp
+++ b/src/birth/monster-birth.cpp
@@ -73,7 +73,7 @@ void setup_default_player_attributes(CreatureEntity &creature)
     // ここではポインタ初期化のための既定値を入れておく。
     creature.ppersonality = PERSONALITY_ORDINARY;
     creature.set_patron(0);
-    creature.element_realm = ElementRealmType::NONE;
+    creature.set_element_realm(ElementRealmType::NONE);
 
     sp_ptr = &sex_info[creature.psex];
     creature.race = &race_info[enum2i(creature.prace)];

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -91,7 +91,7 @@ void save_prev_data(CreatureEntity &creature, birther *birther_ptr)
     birther_ptr->ppersonality = creature.ppersonality;
 
     if (CreatureClass(creature).equals(PlayerClassType::ELEMENTALIST)) {
-        birther_ptr->realm1 = static_cast<int16_t>(creature.element_realm);
+        birther_ptr->realm1 = static_cast<int16_t>(creature.get_element_realm());
         birther_ptr->realm2 = 0;
     } else {
         PlayerRealm pr(creature);
@@ -142,7 +142,7 @@ void load_prev_data(CreatureEntity &creature, bool swap)
     PlayerRealm pr(creature);
     pr.reset();
     if (CreatureClass(creature).equals(PlayerClassType::ELEMENTALIST)) {
-        creature.element_realm = i2enum<ElementRealmType>(previous_char.realm1);
+        creature.set_element_realm(i2enum<ElementRealmType>(previous_char.realm1));
     } else {
         const auto realm1 = i2enum<RealmType>(previous_char.realm1);
         const auto realm2 = i2enum<RealmType>(previous_char.realm2);

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -331,7 +331,7 @@ static void init_riding_pet(CreatureEntity &creature, bool new_game)
     monster.max_maxhp = monster.maxhp;
     monster.hp = monrace.hit_dice.floored_expected_value();
     monster.set_dealt_damage(0);
-    monster.energy_need = ENERGY_NEED() + ENERGY_NEED();
+    monster.set_energy_need(ENERGY_NEED() + ENERGY_NEED());
 }
 
 static void decide_arena_death(CreatureEntity &creature)

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -137,11 +137,11 @@ void process_player(CreatureEntity &creature)
         WorldTurnProcessor(creature).print_world_collapse();
         WorldTurnProcessor(creature).print_cheat_position();
 
-    } else if (!(load && creature.energy_need <= 0)) {
-        creature.energy_need -= speed_to_energy(static_cast<byte>(creature.get_speed()));
+    } else if (!(load && creature.get_energy_need() <= 0)) {
+        creature.sub_energy_need(speed_to_energy(static_cast<byte>(creature.get_speed())));
     }
 
-    if (creature.energy_need > 0) {
+    if (creature.get_energy_need() > 0) {
         return;
     }
     if (!command_rep) {
@@ -257,7 +257,7 @@ void process_player(CreatureEntity &creature)
     }
 
     /*** Handle actual user input ***/
-    while (creature.energy_need <= 0) {
+    while (creature.get_energy_need() <= 0) {
         rfu.set_flag(SubWindowRedrawingFlag::PLAYER);
         creature.set_sutemi(false);
         creature.set_counter(false);
@@ -330,9 +330,9 @@ void process_player(CreatureEntity &creature)
         pack_overflow(creature);
         if (creature.get_energy_use()) {
             if (creature.is_timewalking() || creature.get_energy_use() > 400) {
-                creature.energy_need += creature.get_energy_use() * TURNS_PER_TICK / 10;
+                creature.add_energy_need(creature.get_energy_use() * TURNS_PER_TICK / 10);
             } else {
-                creature.energy_need += (int16_t)((int32_t)creature.get_energy_use() * ENERGY_NEED() / 100L);
+                creature.add_energy_need((int16_t)((int32_t)creature.get_energy_use() * ENERGY_NEED() / 100L));
             }
 
             if (creature.is_hallucinated()) {
@@ -398,7 +398,7 @@ void process_player(CreatureEntity &creature)
                 rfu.set_flag(MainWindowRedrawingFlag::ACTION);
             }
 
-            if (creature.is_timewalking() && (creature.energy_need > -1000)) {
+            if (creature.is_timewalking() && (creature.get_energy_need() > -1000)) {
                 rfu.set_flag(MainWindowRedrawingFlag::MAP);
                 rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
                 static constexpr auto flags_swrf = {
@@ -409,7 +409,7 @@ void process_player(CreatureEntity &creature)
                 msg_print(_("「時は動きだす…」", "You feel time flowing around you once more."));
                 msg_erase();
                 creature.set_timewalking(false);
-                creature.energy_need = ENERGY_NEED();
+                creature.set_energy_need(ENERGY_NEED());
 
                 handle_stuff(creature);
             }

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -165,7 +165,7 @@ void process_dungeon(CreatureEntity &creature, bool load_game)
     const auto is_watching = AngbandSystem::get_instance().is_phase_out();
     if (is_watching) {
         if (load_game) {
-            creature.energy_need = 0;
+            creature.set_energy_need(0);
             auto &melee_arena = MeleeArena::get_instance();
             melee_arena.update_gladiators(creature);
         } else {
@@ -207,8 +207,8 @@ void process_dungeon(CreatureEntity &creature, bool load_game)
     floor.monster_level = floor.base_level;
     floor.object_level = floor.base_level;
     world.is_loading_now = true;
-    if (creature.energy_need > 0 && !is_watching && (floor.is_underground() || floor.is_leaving_dungeon() || floor.inside_arena)) {
-        creature.energy_need = 0;
+    if (creature.get_energy_need() > 0 && !is_watching && (floor.is_underground() || floor.is_leaving_dungeon() || floor.inside_arena)) {
+        creature.set_energy_need(0);
     }
 
     floor.leave_dungeon(false);

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -501,7 +501,7 @@ void jump_floor(CreatureEntity &creature, DungeonId dun_idx, DEPTH depth)
     msg_print_wizard(creature, 2, format(mes, to.data()));
     floor.quest_number = QuestId::NONE;
     PlayerEnergy(creature).reset_player_turn();
-    creature.energy_need = 0;
+    creature.set_energy_need(0);
     fcms->set(FloorChangeMode::FIRST_FLOOR);
     creature.set_leaving(true);
 }

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -851,7 +851,7 @@ bool change_wild_mode(CreatureEntity &creature, bool encount)
     auto &wilderness = WildernessGrids::get_instance();
     if (world.is_wild_mode()) {
         wilderness.set_player_position(creature.get_position());
-        creature.energy_need = 0;
+        creature.set_energy_need(0);
         world.set_wild_mode(false);
         creature.set_leaving(true);
         return true;

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -447,14 +447,14 @@ static void dump_aux_virtues(CreatureEntity &creature, FILE *fff)
     fmt::println(fff, _("\n\n  [自分に関する情報]\n", "\n\n  [HP-rate & Max stat & Virtues]\n"));
 
 #ifdef JP
-    if (creature.knowledge & KNOW_HPRATE) {
+    if (creature.has_knowledge(KNOW_HPRATE)) {
         fmt::println(fff, "現在の体力ランク : {}/100\n", creature.calc_life_rating());
     } else {
         fmt::println(fff, "現在の体力ランク : ???\n");
     }
     fmt::println(fff, "能力の最大値");
 #else
-    if (creature.knowledge & KNOW_HPRATE) {
+    if (creature.has_knowledge(KNOW_HPRATE)) {
         fmt::println(fff, "Your current Life Rating is {}/100.\n", creature.calc_life_rating());
     } else {
         fmt::println(fff, "Your current Life Rating is ???.\n");
@@ -462,7 +462,7 @@ static void dump_aux_virtues(CreatureEntity &creature, FILE *fff)
     fmt::println(fff, "Limits of maximum stats");
 #endif
     for (auto v_nr = 0; v_nr < A_MAX; v_nr++) {
-        if ((creature.knowledge & KNOW_STAT) || creature.get_stat_max(v_nr) == creature.get_stat_max_max(v_nr)) {
+        if ((creature.has_knowledge(KNOW_STAT)) || creature.get_stat_max(v_nr) == creature.get_stat_max_max(v_nr)) {
             fmt::println(fff, "{} 18/{}", stat_names[v_nr], creature.get_stat_max_max(v_nr) - 18);
         } else {
             fmt::println(fff, "{} ???", stat_names[v_nr]);

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -241,7 +241,7 @@ bool report_score(CreatureEntity &creature)
     personality_desc.append(_((*creature.get_personality_info()).no ? "の" : "", " "));
 
     PlayerRealm pr(creature);
-    const auto &realm1_name = CreatureClass(creature).equals(PlayerClassType::ELEMENTALIST) ? get_element_title(creature.element_realm) : pr.realm1().get_name().string();
+    const auto &realm1_name = CreatureClass(creature).equals(PlayerClassType::ELEMENTALIST) ? get_element_title(creature.get_element_realm()) : pr.realm1().get_name().string();
     score_ss << fmt::format("name: {}\n", creature.name)
              << fmt::format("version: {}\n", AngbandSystem::get_instance().build_version_expression(VersionExpression::FULL))
              << fmt::format("score: {}\n", calc_score(creature))

--- a/src/knowledge/knowledge-self.cpp
+++ b/src/knowledge/knowledge-self.cpp
@@ -161,7 +161,7 @@ void do_cmd_knowledge_stat(CreatureEntity &creature)
     fprintf(fff, _("合計のプレイ時間 : %d:%02d:%02d\n", "  Total play Time is %d:%02d:%02d\n"), all_time / (60 * 60), (all_time / 60) % 60, all_time % 60);
     fputs("\n", fff);
 
-    if (creature.knowledge & KNOW_HPRATE) {
+    if (creature.has_knowledge(KNOW_HPRATE)) {
         fprintf(fff, _("現在の体力ランク : %d/100\n\n", "Your current Life Rating is %d/100.\n\n"), creature.calc_life_rating());
     } else {
         fprintf(fff, _("現在の体力ランク : ???\n\n", "Your current Life Rating is ???.\n\n"));
@@ -169,7 +169,7 @@ void do_cmd_knowledge_stat(CreatureEntity &creature)
 
     fprintf(fff, _("能力の最大値\n\n", "Limits of maximum stats\n\n"));
     for (int v_nr = 0; v_nr < A_MAX; v_nr++) {
-        if ((creature.knowledge & KNOW_STAT) || creature.get_stat_max(v_nr) == creature.get_stat_max_max(v_nr)) {
+        if ((creature.has_knowledge(KNOW_STAT)) || creature.get_stat_max(v_nr) == creature.get_stat_max_max(v_nr)) {
             fprintf(fff, "%s 18/%d\n", stat_names[v_nr], creature.get_stat_max_max(v_nr) - 18);
         } else {
             fprintf(fff, "%s ???\n", stat_names[v_nr]);

--- a/src/load/creature-common-loader.cpp
+++ b/src/load/creature-common-loader.cpp
@@ -23,7 +23,7 @@ void rd_creature_common(CreatureEntity &creature)
     creature.set_dealt_damage(static_cast<int>(rd_u32b()));
 
     creature.speed = rd_s16b();
-    creature.energy_need = rd_s16b();
+    creature.set_energy_need(rd_s16b());
     creature.ac = rd_s16b();
 
     creature.set_exp(rd_u32b());

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -133,7 +133,7 @@ static void load_player_world(CreatureEntity &creature)
     rd_global_configurations(creature);
     rd_extra(creature);
 
-    if (creature.energy_need < -999) {
+    if (creature.get_energy_need() < -999) {
         creature.set_timewalking(true);
     }
 

--- a/src/load/old/monster-loader-savefile50.cpp
+++ b/src/load/old/monster-loader-savefile50.cpp
@@ -65,7 +65,7 @@ void MonsterLoader50::rd_monster_legacy(CreatureEntity &monster)
     monster.set_sub_align(any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN) ? rd_byte() : 0);
     monster.set_timed_effect(CreatureTimedEffect::SLEEP_OR_PARALYSIS, any_bits(flags, SaveDataMonsterFlagType::SLEEP) ? rd_s16b() : 0);
     monster.speed = rd_byte();
-    monster.energy_need = rd_s16b();
+    monster.set_energy_need(rd_s16b());
     if (loading_savefile_version_is_older_than(38)) {
         MonraceDefinition *r_ptr = &MonraceList::get_instance().get_monrace(monster.get_r_idx());
         monster.ac = r_ptr->ac;

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -42,7 +42,7 @@ static void rd_realms(CreatureEntity &creature)
     pr.reset();
 
     if (CreatureClass(creature).equals(PlayerClassType::ELEMENTALIST)) {
-        creature.element_realm = i2enum<ElementRealmType>(rd_byte());
+        creature.set_element_realm(i2enum<ElementRealmType>(rd_byte()));
         (void)rd_byte();
         return;
     }
@@ -381,7 +381,7 @@ static void rd_energy(CreatureEntity &creature)
 {
     // energy_need は v51 以降 rd_creature_common() で読込済み
     if (loading_savefile_version_is_older_than(51)) {
-        creature.energy_need = rd_s16b();
+        creature.set_energy_need(rd_s16b());
     }
     creature.set_enchant_energy_need(rd_s16b());
 }
@@ -598,7 +598,7 @@ void rd_player_info(CreatureEntity &creature)
     rd_special_attack(creature);
     rd_special_action(creature);
     rd_special_defense(creature);
-    creature.knowledge = rd_byte();
+    creature.set_knowledge(rd_byte());
     rd_autopick(creature);
     rd_action(creature);
 }

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -313,7 +313,7 @@ AttributeType get_element_type(ElementRealmType realm, int n)
  */
 static AttributeType get_element_spells_type(CreatureEntity &creature, int n)
 {
-    const auto &realm = element_types.at(creature.element_realm);
+    const auto &realm = element_types.at(creature.get_element_realm());
     const auto t = realm.type.at(n);
     if (realm.extra.find(t) != realm.extra.end()) {
         if (evaluate_percent(creature.get_level() * 2)) {
@@ -352,7 +352,7 @@ const std::string &get_element_name(ElementRealmType realm, int n)
  */
 static std::string get_element_tip(CreatureEntity &creature, int spell_idx)
 {
-    auto realm = creature.element_realm;
+    auto realm = creature.get_element_realm();
     auto spell = i2enum<ElementSpells>(spell_idx);
     auto elem = element_powers.at(spell).elem;
     return format(element_tips.at(spell).data(), element_types.at(realm).name[elem].data());
@@ -873,7 +873,7 @@ static bool try_cast_element_spell(CreatureEntity &creature, SPELL_IDX spell_idx
     if (randint1(100) < chance / 2) {
         int plev = creature.get_level();
         msg_print(_("元素の力が制御できない氾流となって解放された！", "The elemental power surges from you in an uncontrollable torrent!"));
-        const auto element = get_element_types(creature.element_realm)[0];
+        const auto element = get_element_types(creature.get_element_realm())[0];
         constexpr auto flags = PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM;
         project(creature, PROJECT_WHO_UNCTRL_POWER, 2 + plev / 10, creature.y, creature.x, plev * 2, element, flags);
         creature.set_current_mp(std::max(0, creature.get_current_mp() - creature.get_max_mp() * 10 / (20 + randint1(10))));
@@ -987,7 +987,7 @@ void display_element_spell_list(CreatureEntity &creature, int y, int x)
         }
 
         const auto elem = get_elemental_elem(creature, i);
-        const auto name = format(spell.name, get_element_name(creature.element_realm, elem).data());
+        const auto name = format(spell.name, get_element_name(creature.get_element_realm(), elem).data());
 
         const auto mana_cost = decide_element_mana_cost(creature, spell);
         const auto chance = decide_element_chance(creature, spell);
@@ -1065,7 +1065,7 @@ static bool is_elemental_genocide_effective(const MonraceDefinition &monrace, At
  */
 ProcessResult effect_monster_elemental_genocide(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    const auto &name = get_element_name(creature.element_realm, 0);
+    const auto &name = get_element_name(creature.get_element_realm(), 0);
     if (em_ptr->seen_msg) {
         msg_format(_("%sが%sを包み込んだ。", "The %s surrounds %s."), name.data(), em_ptr->m_name);
     }
@@ -1074,7 +1074,7 @@ ProcessResult effect_monster_elemental_genocide(CreatureEntity &creature, Effect
         em_ptr->obvious = true;
     }
 
-    const auto type = get_element_type(creature.element_realm, 0);
+    const auto type = get_element_type(creature.get_element_realm(), 0);
     const auto is_effective = is_elemental_genocide_effective(*em_ptr->monrace, type);
     if (!is_effective) {
         if (em_ptr->seen_msg) {
@@ -1112,7 +1112,7 @@ bool has_element_resist(CreatureEntity &creature, ElementRealmType realm, PLAYER
         return false;
     }
 
-    return (creature.element_realm == realm) && (creature.get_level() >= lev);
+    return (creature.get_element_realm() == realm) && (creature.get_level() >= lev);
 }
 
 /*!
@@ -1293,7 +1293,7 @@ void switch_element_racial(CreatureEntity &creature, rc_type *rc_ptr)
 {
     auto plev = creature.get_level();
     rpi_type rpi;
-    switch (creature.element_realm) {
+    switch (creature.get_element_realm()) {
     case ElementRealmType::FIRE:
         rpi = rpi_type(_("ライト・エリア", "Light area"));
         rpi.text = _("光源が照らしている範囲か部屋全体を永久に明るくする。", "Lights up nearby area and the inside of a room permanently.");
@@ -1474,7 +1474,7 @@ bool switch_element_execution(CreatureEntity &creature)
 {
     PLAYER_LEVEL plev = creature.get_level();
 
-    switch (creature.element_realm) {
+    switch (creature.get_element_realm()) {
     case ElementRealmType::FIRE:
         (void)lite_area(creature, Dice::roll(2, plev / 2), plev / 10);
         return true;

--- a/src/mind/mind-info.cpp
+++ b/src/mind/mind-info.cpp
@@ -35,7 +35,7 @@ static std::string switch_mind_mindcrafter(CreatureEntity &creature, const PLAYE
     case 12:
         return format(" %sd%d+%d", KWD_DAM, plev * 3, plev * 3);
     case 13:
-        return format(_(" 行動:%ld回", " %ld acts."), (long int)(creature.get_current_mp() + 100 - creature.energy_need - 50) / 100);
+        return format(_(" 行動:%ld回", " %ld acts."), (long int)(creature.get_current_mp() + 100 - creature.get_energy_need() - 50) / 100);
     default:
         return std::string();
     }

--- a/src/mind/mind-mindcrafter.cpp
+++ b/src/mind/mind-mindcrafter.cpp
@@ -280,7 +280,7 @@ bool cast_mindcrafter_spell(CreatureEntity &creature, MindMindcrafterType spell)
 
         dam = Dice::roll(plev / 2, 6);
         if (fire_ball(creature, AttributeType::PSI_DRAIN, dir, dam, 0)) {
-            creature.energy_need += randnum1<short>(150);
+            creature.add_energy_need(randnum1<short>(150));
         }
 
         break;

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -460,14 +460,14 @@ bool process_monster_movement(CreatureEntity &creature, turn_flags *turn_flags_p
         can_recover_energy &= monrace.feature_flags.has_not(MonsterFeatureType::CAN_FLY);
         can_recover_energy &= monrace.wilderness_flags.has_not(MonsterWildernessType::WILD_WOOD);
         if (can_recover_energy) {
-            monster.energy_need += ENERGY_NEED();
+            monster.add_energy_need(ENERGY_NEED());
         }
 
         // SLOW地形での減速処理（飛行モンスターは影響を受けない）
         auto is_slowed_by_terrain = terrain.flags.has(TerrainCharacteristics::SLOW);
         is_slowed_by_terrain &= monrace.feature_flags.has_not(MonsterFeatureType::CAN_FLY);
         if (is_slowed_by_terrain) {
-            monster.energy_need += ENERGY_NEED() / 2;
+            monster.add_energy_need(ENERGY_NEED() / 2);
         }
 
         if (!update_riding_monster(creature, turn_flags_ptr, m_idx, pos.y, pos.x, pos_neighbor.y, pos_neighbor.x)) {

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -620,9 +620,9 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     }
 
     if (!ironman_nightmare) {
-        m_ptr->energy_need = ENERGY_NEED() - randnum0<short>(100);
+        m_ptr->set_energy_need(ENERGY_NEED() - randnum0<short>(100));
     } else {
-        m_ptr->energy_need = ENERGY_NEED() - randnum0<short>(100) * 2;
+        m_ptr->set_energy_need(ENERGY_NEED() - randnum0<short>(100) * 2);
     }
 
     if (!ironman_nightmare) {

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -1607,12 +1607,12 @@ void sweep_monster_process(CreatureEntity &creature)
         }
 
         byte speed = monster.is_riding() ? creature.get_speed() : monster.get_temporary_speed();
-        monster.energy_need -= speed_to_energy(speed);
-        if (monster.energy_need > 0) {
+        monster.sub_energy_need(speed_to_energy(speed));
+        if (monster.get_energy_need() > 0) {
             continue;
         }
 
-        monster.energy_need += ENERGY_NEED();
+        monster.add_energy_need(ENERGY_NEED());
         auto m_name = monster_desc(creature, monster, 0);
 
         if (monster.get_death_count() > 0) {

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -198,7 +198,7 @@ bool set_monster_invulner(FloorType &floor, MONSTER_IDX m_idx, int v, bool energ
 
     // 無敵が解除された (notice かつ v<=0) 場合、行動ターン消費のオプション処理。
     if (notice && (v <= 0) && energy_need && !AngbandWorld::get_instance().is_wild_mode()) {
-        monster.energy_need += ENERGY_NEED();
+        monster.add_energy_need(ENERGY_NEED());
     }
 
     if (!notice) {

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -119,7 +119,7 @@ static void dispel_player(CreatureEntity &creature)
             SubWindowRedrawingFlag::DUNGEON,
         };
         rfu.set_flags(flags_swrf);
-        creature.energy_need += ENERGY_NEED();
+        creature.add_energy_need(ENERGY_NEED());
     }
 }
 

--- a/src/racial/racial-draconian.cpp
+++ b/src/racial/racial-draconian.cpp
@@ -84,8 +84,8 @@ static tl::optional<std::pair<AttributeType, std::string>> decide_breath_kind(Cr
 
         return std::pair(AttributeType::SOUND, _("轟音", "sound"));
     case PlayerClassType::ELEMENTALIST: {
-        const auto type = get_element_type(creature.element_realm, 0);
-        const std::string name(get_element_name(creature.element_realm, 0));
+        const auto type = get_element_type(creature.get_element_realm(), 0);
+        const std::string name(get_element_name(creature.get_element_realm(), 0));
         return std::pair(type, name);
     }
     default:

--- a/src/save/creature-common-writer.cpp
+++ b/src/save/creature-common-writer.cpp
@@ -25,7 +25,7 @@ void wr_creature_common(const CreatureEntity &creature)
     wr_u32b(static_cast<uint32_t>(creature.get_dealt_damage()));
 
     wr_s16b(static_cast<int16_t>(creature.speed));
-    wr_s16b(static_cast<int16_t>(creature.energy_need));
+    wr_s16b(static_cast<int16_t>(creature.get_energy_need()));
     wr_s16b(static_cast<int16_t>(creature.ac));
 
     wr_u32b(creature.get_exp());

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -33,7 +33,7 @@ static void wr_relams(CreatureEntity &creature)
 {
     PlayerRealm pr(creature);
     if (CreatureClass(creature).equals(PlayerClassType::ELEMENTALIST)) {
-        wr_byte((byte)creature.element_realm);
+        wr_byte((byte)creature.get_element_realm());
     } else {
         wr_byte((byte)pr.realm1().to_enum());
     }
@@ -227,7 +227,7 @@ void wr_player(CreatureEntity &creature)
     // ELE_ATTACK / ELE_IMMUNE は wr_creature_common() の全時限効果ダンプに集約済み
     wr_u32b(creature.get_special_attack_flags());
     wr_u32b(creature.get_special_defense_flags());
-    wr_byte(creature.knowledge);
+    wr_byte(creature.get_knowledge());
     wr_bool(creature.is_autopick_autoregister());
     wr_byte(0);
     wr_byte((byte)creature.get_action());

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -211,7 +211,7 @@ bool time_walk(CreatureEntity &creature)
     //	msg_print(_("「『ザ・ワールド』！時は止まった！」", "You yell 'The World! Time has stopped!'"));
     msg_erase();
 
-    creature.energy_need -= 1000 + (100 + creature.get_current_mp() - 50) * TURNS_PER_TICK / 10;
+    creature.sub_energy_need(1000 + (100 + creature.get_current_mp() - 50) * TURNS_PER_TICK / 10);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
@@ -238,7 +238,7 @@ void roll_hitdice(CreatureEntity &creature, spell_operation options)
     // hp_table[] のロールはプレイヤー・モンスター共通の処理に集約。
     creature.roll_hp_table();
 
-    creature.knowledge &= ~(KNOW_HPRATE);
+    creature.remove_knowledge(KNOW_HPRATE);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(StatusRecalculatingFlag::HP);
@@ -254,7 +254,7 @@ void roll_hitdice(CreatureEntity &creature, spell_operation options)
 
     if (options & SPOP_DEBUG) {
         msg_format(_("現在の体力ランクは %d/100 です。", "Your life rate is %d/100 now."), creature.calc_life_rating());
-        creature.knowledge |= KNOW_HPRATE;
+        creature.add_knowledge(KNOW_HPRATE);
         return;
     }
 

--- a/src/status/body-improvement.cpp
+++ b/src/status/body-improvement.cpp
@@ -124,7 +124,7 @@ bool set_invuln(CreatureEntity &creature, short v, bool do_dec)
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
             rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
             rfu.set_flags(flags_swrf);
-            creature.energy_need += ENERGY_NEED();
+            creature.add_energy_need(ENERGY_NEED());
         }
     }
 

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -626,6 +626,18 @@ public:
         this->energy_need = energy;
     }
 
+    /*! @brief 次の行動までに必要なエネルギーを加算する (A-2) */
+    virtual void add_energy_need(ACTION_ENERGY delta)
+    {
+        this->energy_need += delta;
+    }
+
+    /*! @brief 次の行動までに必要なエネルギーを減算する (A-2) */
+    virtual void sub_energy_need(ACTION_ENERGY delta)
+    {
+        this->energy_need -= delta;
+    }
+
     /*!
      * @brief クリーチャーのレベルを取得
      * @return レベル値。個体レベルが設定されていればそれを返し、未設定なら種族レベルの半分を返す。
@@ -2276,6 +2288,36 @@ public:
     virtual BIT_FLAGS get_down_saving() const
     {
         return this->down_saving;
+    }
+
+    /*! @brief 自己分析で得た知識フラグを保持しているか (A-2) */
+    virtual bool has_knowledge(BIT_FLAGS8 flag) const
+    {
+        return (this->knowledge & flag) != 0;
+    }
+
+    /*! @brief 自己分析で得た知識フラグを追加する (A-2) */
+    virtual void add_knowledge(BIT_FLAGS8 flag)
+    {
+        this->knowledge |= flag;
+    }
+
+    /*! @brief 自己分析で得た知識フラグを除去する (A-2) */
+    virtual void remove_knowledge(BIT_FLAGS8 flag)
+    {
+        this->knowledge &= ~flag;
+    }
+
+    /*! @brief 自己分析で得た知識フラグ全体を取得する (A-2, savefile 用) */
+    virtual BIT_FLAGS8 get_knowledge() const
+    {
+        return this->knowledge;
+    }
+
+    /*! @brief 自己分析で得た知識フラグ全体を設定する (A-2, savefile 用) */
+    virtual void set_knowledge(BIT_FLAGS8 value)
+    {
+        this->knowledge = value;
     }
 
     /*! @brief 最大 MP (max_mp) を取得する (提案 31) */
@@ -4076,10 +4118,13 @@ private:
     // [提案 44] private 化済。get_patron()/set_patron() 経由。
     int16_t patron{}; /*!< カオスパトロンのID / Chaos patron ID */
 
-public:
     // エネルギー関連
+    // [A-2] private 化済。get_energy_need() / set_energy_need() /
+    // add_energy_need() / sub_energy_need() 経由。
+private:
     ACTION_ENERGY energy_need{}; /*!< 次の行動までに必要なエネルギー / Energy needed for next move */
 
+public:
     // 速度関連
     int speed{}; /*!< クリーチャーの速度 / Creature speed */
 
@@ -4287,8 +4332,12 @@ public:
 
     RealmType realm1{}; /* First magic realm */
     RealmType realm2{}; /* Second magic realm */
+
+    // [A-2] private 化済。get_element_realm() / set_element_realm() 経由。
+private:
     ElementRealmType element_realm{}; //!< 元素使い領域
 
+public:
     Dice hit_dice{}; /* Hit dice */
     uint16_t expfact{}; /* Experience factor
                          * Note: was byte, causing overflow for Amberite
@@ -4429,8 +4478,12 @@ private:
 public:
 #define KNOW_STAT 0x01
 #define KNOW_HPRATE 0x02
+    // [A-2] private 化済。has_knowledge() / add_knowledge() / remove_knowledge() /
+    // get_knowledge() / set_knowledge() 経由。
+private:
     BIT_FLAGS8 knowledge{}; /* Knowledge about yourself */
 
+public:
     // [提案 42] old_race1/2 / old_realm は private 化済。
     // get_old_race_flags1/2() / set_old_race_flags1/2() / get_old_realm() / set_old_realm() 経由。
 private:

--- a/src/view/display-self-info.cpp
+++ b/src/view/display-self-info.cpp
@@ -15,7 +15,7 @@
 
 void display_life_rating(CreatureEntity &creature, self_info_type *self_ptr)
 {
-    creature.knowledge |= KNOW_STAT | KNOW_HPRATE;
+    creature.add_knowledge(KNOW_STAT | KNOW_HPRATE);
     auto info = format(_("現在の体力ランク : %d/100", "Your current Life Rating is %d/100."), creature.calc_life_rating());
     self_ptr->info_list.push_back(std::move(info));
     self_ptr->info_list.emplace_back("");

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -638,7 +638,7 @@ void wiz_reset_class(CreatureEntity &creature)
     if (realm1 != RealmType::NONE) {
         pr.set(realm1, realm2);
     }
-    creature.element_realm = element_realm;
+    creature.set_element_realm(element_realm);
     PlayerSpellStatus pss(creature);
     pss.realm1().initialize();
     pss.realm2().initialize();
@@ -664,7 +664,7 @@ void wiz_reset_realms(CreatureEntity &creature)
     if (realm1 != RealmType::NONE) {
         pr.set(realm1, realm2);
     }
-    creature.element_realm = element_realm;
+    creature.set_element_realm(element_realm);
     PlayerSpellStatus pss(creature);
     pss.realm1().initialize();
     pss.realm2().initialize();

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -197,7 +197,7 @@ void WorldTurnProcessor::process_monster_arena()
     if (m_idxs.empty()) {
         msg_print(_("相打ちに終わりました。", "Nothing survived."));
         msg_erase();
-        this->creature.energy_need = 0;
+        this->creature.set_energy_need(0);
         auto &melee_arena = MeleeArena::get_instance();
         melee_arena.update_gladiators(this->creature);
         return;
@@ -229,7 +229,7 @@ void WorldTurnProcessor::process_monster_arena_winner(int win_m_idx)
     }
 
     msg_erase();
-    this->creature.energy_need = 0;
+    this->creature.set_energy_need(0);
     melee_arena.update_gladiators(this->creature);
 }
 
@@ -243,7 +243,7 @@ void WorldTurnProcessor::process_monster_arena_draw()
     msg_print(_("申し訳ありませんが、この勝負は引き分けとさせていただきます。", "Sorry, but this battle ended in a draw."));
     this->creature.add_au(MeleeArena::get_instance().get_payback(true));
     msg_erase();
-    this->creature.energy_need = 0;
+    this->creature.set_energy_need(0);
     auto &melee_arena = MeleeArena::get_instance();
     melee_arena.update_gladiators(this->creature);
 }


### PR DESCRIPTION
energy_need (ACTION_ENERGY)・element_realm (ElementRealmType)・knowledge (BIT_FLAGS8) を CreatureEntity の private へ移動。

- energy_need: 既存 get/set に add_energy_need() / sub_energy_need() を新設し、 約38サイトの compound assignment (+= / -=) と直接読取りを virtual 経由に統一 （creature / monster / m_ptr の . / -> 両アクセスを regex 一括変換）。
- element_realm: 既存 get/set 経由に約30サイトを migration。
- knowledge: has_knowledge() / add_knowledge() / remove_knowledge() / get_knowledge() / set_knowledge() を新設し12サイトを migration。

フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency for element realm, energy requirement, and knowledge across character creation, save/load, and in-game screens.
  * Updated status/info outputs so life-rating and learned-stat visibility reflect the correct knowledge states.
  * Fixed energy accounting and reset behaviors across key gameplay flows (turn handling, timewalking, battles, movement, and special modes).
* **Refactor**
  * Centralized state updates through accessor-based energy and knowledge operations, without changing user-facing controls or save format layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->