### PR TITLE
refactor: extra_blows[] / count / hp_table[] を private 化（提案A-3）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -2685,14 +2685,42 @@ virtual アクセサを整備:
   `remove_knowledge(FLAG)`、`= 0`/load→`set_knowledge()`、save→`get_knowledge()`。
 - フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証済み。
 
-### 残作業 (A-3)
+### 提案 A-3 ✅ 完了 (一部スコープ確定で残置)
 
-- **A-3**: 配列/vector (`hp_table[]` / `extra_blows[]` / `extended_inventory`)、
-  汎用名 `count` (要精査) / `class_specific_data`
+配列・汎用名フィールドのうち、スカラ／固定長配列の 3 個を private 化:
 
-**留意**: これらは player 固有・低 churn のフィールドで機能的影響はなく、
-カプセル化の完全性のための作業。`creature-entity.h` 変更は上流マージ衝突を
-増やすため、効果と費用を勘案して進めること。
+| フィールド | 型 | アクセサ |
+|---|---|---|
+| `extra_blows[2]` | int[2] | `get_extra_blows(hand)` / `set_extra_blows(hand, value)` / `add_extra_blows(hand, delta)` |
+| `count` | uint32_t | `get_count()` / `set_count()` |
+| `hp_table[PY_MAX_LEVEL]` | int[] | `get_hp_table(idx)` / `set_hp_table(idx, value)` |
+
+- `extra_blows`: 装備由来追加攻撃。`+=` は `add_extra_blows()`、`= ... = 0` は
+  2 文へ分解。7 サイト migration。
+- `count`: セーブ用カウンタ。`.count` の大多数は `std::map/set::count()` や
+  `ItemEntity::count` など別物のため、`creature.count` のみを慎重に抽出して 6 サイト
+  migration。`++creature.count` は `set_count(get_count()+1)` に展開。
+- `hp_table`: レベル別累積HPテーブル。CreatureEntity 内部 (`roll_hp_table()` /
+  `roll_monster_hp_table()` / `grow_hp_table_to_level()`) の `this->hp_table` 直接操作は
+  private 内アクセスで残置。外部の `creature.hp_table` 読書 9 サイトを migration
+  (`Birther::hp_table` / `previous_char.hp_table` は別構造体のため対象外、慎重に除外)。
+- フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証済み。
+
+**残置 (複合型、参照アクセサではカプセル化効果が薄いため見送り):**
+
+- `class_specific_data` (`ClassSpecificData` = std::variant): `std::visit` /
+  `std::get_if` / `std::holds_alternative` / 直接代入で使われ、可変参照を返す
+  アクセサでは実質的な保護にならない。かつ完全にプレイヤー専用データ。
+- `extended_inventory` (`std::vector<std::shared_ptr<ItemEntity>>`): `[i]` への
+  代入・`.size()`・range-for で多用され、これも可変参照アクセサでは保護が薄い。
+  プレイヤー／モンスター共用だが既に `init_extended_inventory()` /
+  `store_item()` 等の OO API で操作経路は整備済み。
+
+**留意**: A-1〜A-3 で CreatureEntity 直下のスカラ／固定長配列フィールドは
+ほぼ全て private 化が完了した。残るのは上記 2 個の複合型のみで、これらは
+参照アクセサ化の費用対効果が低いため現状維持とする。`creature-entity.h`
+変更は上流マージ衝突を増やすため、今後の追加カプセル化は効果と費用を
+勘案して判断する。
 
 ---
 

--- a/src/birth/birth-stat.cpp
+++ b/src/birth/birth-stat.cpp
@@ -191,7 +191,7 @@ void get_extra(CreatureEntity &creature, bool roll_hitdie)
         roll_hitdice(creature, SPOP_NO_UPDATE);
     }
 
-    creature.maxhp = creature.hp_table[0];
+    creature.maxhp = creature.get_hp_table(0);
 }
 
 /*!

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -111,7 +111,7 @@ void save_prev_data(CreatureEntity &creature, birther *birther_ptr)
     }
 
     for (int i = 0; i < PY_MAX_LEVEL; i++) {
-        birther_ptr->hp_table[i] = creature.hp_table[i];
+        birther_ptr->hp_table[i] = creature.get_hp_table(i);
     }
 
     birther_ptr->patron = creature.get_patron();
@@ -164,11 +164,11 @@ void load_prev_data(CreatureEntity &creature, bool swap)
     }
 
     for (int i = 0; i < PY_MAX_LEVEL; i++) {
-        creature.hp_table[i] = previous_char.hp_table[i];
+        creature.set_hp_table(i, previous_char.hp_table[i]);
     }
 
-    creature.maxhp = creature.hp_table[0];
-    creature.hp = creature.hp_table[0];
+    creature.maxhp = creature.get_hp_table(0);
+    creature.hp = creature.get_hp_table(0);
     creature.set_patron(previous_char.patron);
     creature.virtues = previous_char.virtues;
 

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -199,7 +199,7 @@ static void init_world_floor_info(CreatureEntity &creature, std::optional<QuestI
     system.set_seed_town(randint0(0x10000000));
     player_birth(creature, initial_quest_id);
     counts_write(creature, 2, 0);
-    creature.count = 0;
+    creature.set_count(0);
     load = false;
     determine_bounty_uniques(creature);
     determine_daily_bounty(creature);

--- a/src/load/extra-loader.cpp
+++ b/src/load/extra-loader.cpp
@@ -39,7 +39,7 @@ void rd_extra(CreatureEntity &creature)
     }
 
     TownRecords::get_instance().set_ids(visited_towns);
-    creature.count = rd_u32b();
+    creature.set_count(rd_u32b());
 
     // [モンスタープレイヤー] プレイヤーがモンスター化している場合の種族 ID を復元する。
     // セーブファイルバージョン 48 以降で保存される。旧データは PLAYER のまま。

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -149,7 +149,7 @@ static errr load_hp(CreatureEntity &creature)
     }
 
     for (auto i = 0; i < tmp16u; i++) {
-        creature.hp_table[i] = rd_s16b();
+        creature.set_hp_table(i, rd_s16b());
     }
 
     return 0;
@@ -468,13 +468,14 @@ bool load_savedata(CreatureEntity &creature, bool *new_game)
 
     world.character_loaded = true;
     auto tmp = counts_read(creature, 2);
-    if (tmp > creature.count) {
-        creature.count = tmp;
+    if (tmp > creature.get_count()) {
+        creature.set_count(tmp);
     }
 
     const auto play_time = world.play_time.elapsed_sec();
     if (counts_read(creature, 0) > play_time || counts_read(creature, 1) == play_time) {
-        counts_write(creature, 2, ++creature.count);
+        creature.set_count(creature.get_count() + 1);
+        counts_write(creature, 2, creature.get_count());
     }
 
     counts_write(creature, 1, play_time);

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -1219,7 +1219,8 @@ BIT_FLAGS has_earthquake(CreatureEntity &creature)
 void update_extra_blows(CreatureEntity &creature)
 {
     ItemEntity *o_ptr;
-    creature.extra_blows[0] = creature.extra_blows[1] = 0;
+    creature.set_extra_blows(0, 0);
+    creature.set_extra_blows(1, 0);
 
     const melee_type melee_type = player_melee_type(creature);
     const bool two_handed = (melee_type == MELEE_TYPE_WEAPON_TWOHAND || melee_type == MELEE_TYPE_BAREHAND_TWO);
@@ -1233,12 +1234,12 @@ void update_extra_blows(CreatureEntity &creature)
         const auto flags = o_ptr->get_flags();
         if (flags.has(TR_BLOWS)) {
             if ((i_idx == INVEN_MAIN_HAND || i_idx == INVEN_MAIN_RING) && !two_handed) {
-                creature.extra_blows[0] += o_ptr->pval;
+                creature.add_extra_blows(0, o_ptr->pval);
             } else if ((i_idx == INVEN_SUB_HAND || i_idx == INVEN_SUB_RING) && !two_handed) {
-                creature.extra_blows[1] += o_ptr->pval;
+                creature.add_extra_blows(1, o_ptr->pval);
             } else {
-                creature.extra_blows[0] += o_ptr->pval;
-                creature.extra_blows[1] += o_ptr->pval;
+                creature.add_extra_blows(0, o_ptr->pval);
+                creature.add_extra_blows(1, o_ptr->pval);
             }
         }
     }

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -383,7 +383,7 @@ static void update_bonuses(CreatureEntity &creature)
 static void update_max_hitpoints(CreatureEntity &creature)
 {
     int bonus = creature.calc_max_hp_con_bonus();
-    int mhp = creature.hp_table[creature.get_level() - 1];
+    int mhp = creature.get_hp_table(creature.get_level() - 1);
 
     CreatureClass pc(creature);
     auto is_sorcerer = pc.equals(PlayerClassType::SORCERER);
@@ -1467,7 +1467,7 @@ static int16_t calc_num_blow(CreatureEntity &creature, int i)
                 num_blow = (int16_t)num;
             }
 
-            num_blow += (int16_t)creature.extra_blows[i];
+            num_blow += (int16_t)creature.get_extra_blows(i);
             if (pc.equals(PlayerClassType::WARRIOR)) {
                 num_blow += (creature.get_level() / 40);
             } else if (pc.equals(PlayerClassType::BERSERKER)) {
@@ -1555,7 +1555,7 @@ static int16_t calc_num_blow(CreatureEntity &creature, int i)
             num_blow /= 2;
         }
 
-        num_blow += 1 + creature.extra_blows[0];
+        num_blow += 1 + creature.get_extra_blows(0);
     }
 
     return num_blow;

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -277,7 +277,7 @@ void wr_player(CreatureEntity &creature)
     }
 
     wr_s32b(visit_flags);
-    wr_u32b(creature.count);
+    wr_u32b(creature.get_count());
 
     // [モンスタープレイヤー] プレイヤーがモンスター化している場合の種族 ID を保存する。
     // 通常プレイヤーは PLAYER (= 0)。セーブファイルバージョン 48 以降。

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -191,7 +191,7 @@ static bool wr_savefile_new(CreatureEntity &creature)
     tmp16u = PY_MAX_LEVEL;
     wr_u16b(tmp16u);
     for (int i = 0; i < tmp16u; i++) {
-        wr_s16b((int16_t)creature.hp_table[i]);
+        wr_s16b((int16_t)creature.get_hp_table(i));
     }
 
     wr_u32b(creature.get_spell_learned_flags(0));

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -2506,6 +2506,41 @@ public:
     {
         this->num_blow[hand] = value;
     }
+    /*! @brief 装備由来の追加攻撃回数を取得する (A-3) */
+    virtual int get_extra_blows(int hand) const
+    {
+        return this->extra_blows[hand];
+    }
+    /*! @brief 装備由来の追加攻撃回数を設定する (A-3) */
+    virtual void set_extra_blows(int hand, int value)
+    {
+        this->extra_blows[hand] = value;
+    }
+    /*! @brief 装備由来の追加攻撃回数を加算する (A-3) */
+    virtual void add_extra_blows(int hand, int delta)
+    {
+        this->extra_blows[hand] += delta;
+    }
+    /*! @brief セーブ用カウンタを取得する (A-3) */
+    virtual uint32_t get_count() const
+    {
+        return this->count;
+    }
+    /*! @brief セーブ用カウンタを設定する (A-3) */
+    virtual void set_count(uint32_t value)
+    {
+        this->count = value;
+    }
+    /*! @brief レベル別累積HPテーブルの値を取得する (A-3) */
+    virtual int get_hp_table(int level_index) const
+    {
+        return this->hp_table[level_index];
+    }
+    /*! @brief レベル別累積HPテーブルの値を設定する (A-3) */
+    virtual void set_hp_table(int level_index, int value)
+    {
+        this->hp_table[level_index] = value;
+    }
     virtual int16_t get_num_fire() const
     {
         return this->num_fire;
@@ -4358,9 +4393,11 @@ private:
     int16_t learned_spells{};
     int16_t add_spells{};
 
-public:
+    // [A-3] private 化済。get_count() / set_count() 経由。
+private:
     uint32_t count{};
 
+public:
     // [提案 43] timewalk / resting は private 化済。
     // is_timewalking() / set_timewalking() / get_resting() / set_resting() 経由。
 private:
@@ -4465,7 +4502,12 @@ public:
     }
     std::vector<int> spell_order_learned{}; /* order spells learned */
 
+    // [A-3] private 化済。get_hp_table(level_index) / set_hp_table(level_index, value) 経由。
+    // CreatureEntity 内部の roll_hp_table() 等は this->hp_table を直接操作。
+private:
     int hp_table[PY_MAX_LEVEL]{};
+
+public:
     std::string last_message = ""; /* Last message on death or retirement */
     char history[4][60]{}; /* Textual "history" for the Player */
 
@@ -4565,9 +4607,12 @@ private:
     bool old_riding_ryoute{};
     bool old_monlite{};
 
-public:
+    // [A-3] private 化済。get_extra_blows(hand) / set_extra_blows(hand, value) /
+    // add_extra_blows(hand, delta) 経由。
+private:
     int extra_blows[2]{};
 
+public:
     // [提案 39] 装備派生キャッシュフラグは private 化済。
     // is_cumber_armor() / set_cumber_armor() / is_cumber_glove() / set_cumber_glove() /
     // is_heavy_wield(hand) / set_heavy_wield(hand, value) / is_icky_wield(hand) /


### PR DESCRIPTION
CreatureEntity 直下のスカラ・固定長配列フィールド 3 個を private 化:
- extra_blows[2]: get/set/add_extra_blows(hand,...) を新設、7 サイト migration
- count: get_count() / set_count() を新設、creature.count の 6 サイトのみ慎重に 抽出して migration（.count() メソッド呼出や ItemEntity::count とは区別）
- hp_table[]: get_hp_table(idx) / set_hp_table(idx, value) を新設、外部 9 サイト を migration（内部 roll/grow は this->hp_table 直接操作で残置、Birther の 同名フィールドは対象外）

複合型の class_specific_data (std::variant) と extended_inventory (vector) は 可変参照アクセサではカプセル化効果が薄いため残置（roadmap に判断を記録）。

フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved save/load handling for character stats so hit points, attack bonuses, and count-related values are restored more consistently.
  * Updated several stat calculations to use the latest player data during gameplay.
* **Documentation**
  * Refined the refactoring roadmap to mark completed work and clarify which areas remain intentionally unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->