### PR TITLE
refactor: HP 回復プリミティブ heal_hp() を共通化（提案B5）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -2766,7 +2766,7 @@ A トラック（フィールドのカプセル化）が一段落したため、
 | B2 | ターン・エネルギー消費カーネルの共通化 | 行動 | 中 | 低（ただし critical path） | 計画 |
 | B3 | モンスター命中判定 2 関数の統合 | 攻撃 | 中 | 低 | ✅ 完了 |
 | B4 | モンスター打撃の武器スロット選択共通化 | 攻撃 | 中 | 低〜中 | 計画 |
-| B5 | HP 回復プリミティブ `heal_hp()` の共通化 | 効果適用 | 中 | 低 | 計画 |
+| B5 | HP 回復プリミティブ `heal_hp()` の共通化 | 効果適用 | 中 | 低 | ✅ 完了 |
 | B6 | `is_player()` 真分岐の限定的 virtual 化 | 横断 | 中 | 低〜中 | 計画 |
 | B7 | テレポート先判定の共通化 | 効果適用 | 低〜中 | 中 | 計画 |
 | B8 | 大規模統合（effect switcher / 状態異常付与 API / damage sink） | 横断 | 低 | 高 | **見送り（要再評価）** |
@@ -2832,18 +2832,29 @@ RaceBlowMethodType method) -> int slot` を抽出し両 call site で共用。�
 
 ---
 
-## 提案 B5: HP 回復プリミティブ `heal_hp()` の共通化
+## 提案 B5: HP 回復プリミティブ `heal_hp()` の共通化 ✅ 完了
 
-**現状の分離:** プレイヤーは `hp_player(creature, amount)` で回復するが、
-モンスター回復 (`effect-monster-oldies.cpp:157-164` 等) は
-`hp += dam; if (hp > maxhp) hp = maxhp;` の手書きクランプを各所で繰り返す。
+**現状の分離:** モンスター回復経路が
+`hp += dam; if (hp > maxhp) hp = maxhp;` / `hp = std::min(hp + X, maxhp)` の
+手書きクランプを各所で繰り返していた。
 
-**提案:** `CreatureEntity::heal_hp(int amount)`（`maxhp` クランプ＋再描画フックは
-型側）を共通プリミティブとして用意し、モンスター回復経路の生クランプを置換。
-プレイヤー `hp_player` も内部でこれを使えば上限処理が一本化する。
-ダメージ側の `apply_raw_damage()` と対称な「回復側プリミティブ」。
+**完了内容:** `CreatureEntity::heal_hp(int amount)`（`apply_raw_damage()` と対称な
+回復側プリミティブ。現在 HP に加算し `maxhp` でクランプ）を新設し、**生クランプが
+純粋形だった 6 サイトを移行**:
+- `effect-monster-spirit.cpp` (ドレインによる回復)
+- `monster-eating.cpp:284` (吸収攻撃)
+- `melee/monster-attack-monster.cpp:52` (吸収攻撃)
+- `monster-processor.cpp` の `heal` ラムダ 2 箇所 (ポーション)
+- `monster-damage.cpp:533` (マゾヒスト反応)
 
-**規模/価値:** 小〜中。リスク低（クランプ意味論は明確）。HP 直接操作の散在を削減。
+**意図的にスキップ:** メッセージと絡む `mspell-status.cpp`（full-heal 判定が
+`>=` で分岐）、事前クランプ形＋変数再利用の `monster-eating.cpp:234`、
+`MONSTER_MAXHP` ガード付きの `effect-monster-oldies.cpp` は挙動不変を優先して
+現状維持。
+
+**規模/価値:** 小〜中。リスク低（クランプ意味論は明確）。HP 直接操作の散在を削減し、
+将来「最大 HP 一時減少」異常導入時に回復上限を 1 箇所で扱える足場とした。
+フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証済み。
 
 ---
 

--- a/src/effect/effect-monster-spirit.cpp
+++ b/src/effect/effect-monster-spirit.cpp
@@ -44,10 +44,7 @@ ProcessResult effect_monster_drain_mana(CreatureEntity &creature, EffectMonster 
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    em_ptr->m_ptr->hp += em_ptr->dam;
-    if (em_ptr->m_ptr->hp > em_ptr->m_ptr->maxhp) {
-        em_ptr->m_ptr->hp = em_ptr->m_ptr->maxhp;
-    }
+    em_ptr->m_ptr->heal_hp(em_ptr->dam);
 
     HealthBarTracker::get_instance().set_flag_if_tracking(em_ptr->src_idx);
     if (em_ptr->m_caster_ptr && em_ptr->m_caster_ptr->is_riding()) {

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -49,10 +49,7 @@ static void heal_monster_by_melee(mam_type *mam_ptr)
     }
 
     bool did_heal = mam_ptr->m_ptr->hp < mam_ptr->m_ptr->maxhp;
-    mam_ptr->m_ptr->hp += Dice::roll(4, mam_ptr->damage / 6);
-    if (mam_ptr->m_ptr->hp > mam_ptr->m_ptr->maxhp) {
-        mam_ptr->m_ptr->hp = mam_ptr->m_ptr->maxhp;
-    }
+    mam_ptr->m_ptr->heal_hp(Dice::roll(4, mam_ptr->damage / 6));
 
     HealthBarTracker::get_instance().set_flag_if_tracking(mam_ptr->m_idx);
     if (mam_ptr->m_ptr->is_riding()) {

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -281,10 +281,7 @@ void process_drain_life(MonsterAttackPlayer *monap_ptr, const bool resist_drain)
     }
 
     bool did_heal = monap_ptr->m_ptr->hp < monap_ptr->m_ptr->maxhp;
-    monap_ptr->m_ptr->hp += Dice::roll(4, monap_ptr->damage / 6);
-    if (monap_ptr->m_ptr->hp > monap_ptr->m_ptr->maxhp) {
-        monap_ptr->m_ptr->hp = monap_ptr->m_ptr->maxhp;
-    }
+    monap_ptr->m_ptr->heal_hp(Dice::roll(4, monap_ptr->damage / 6));
 
     HealthBarTracker::get_instance().set_flag_if_tracking(monap_ptr->m_idx);
     if (monap_ptr->m_ptr->is_riding()) {

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -530,7 +530,7 @@ void MonsterDamageProcessor::process_masochist_reaction()
         // 一定確率で少量回復
         if (monster.hp > 0) {
             auto heal_amount = randint1(this->dam / 4 + 1);
-            monster.hp = std::min(monster.hp + heal_amount, monster.maxhp);
+            monster.heal_hp(heal_amount);
 
             if (monster.is_visible_on_map()) {
                 msg_format(_("%s^は苦痛に悦んでいる！", "%s^ seems to enjoy the pain!"), monster.get_monrace().name.data());

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -267,7 +267,7 @@ static bool monster_quaff_potion(CreatureEntity &creature, CreatureEntity &monst
     }
 
     auto heal = [&](int amount) {
-        monster.hp = std::min<int>(monster.maxhp, monster.hp + amount);
+        monster.heal_hp(amount);
     };
     auto add_timed = [&](CreatureTimedEffect effect, int duration) {
         const auto current = monster.get_timed_effect(effect);
@@ -652,7 +652,7 @@ static bool monster_use_wand_or_rod(CreatureEntity &creature, CreatureEntity &mo
     }
 
     auto heal = [&](int amount) {
-        monster.hp = std::min<int>(monster.maxhp, monster.hp + amount);
+        monster.heal_hp(amount);
     };
     auto add_timed = [&](CreatureTimedEffect effect, int duration) {
         const auto current = monster.get_timed_effect(effect);

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -707,6 +707,22 @@ public:
     }
 
     /*!
+     * @brief HP を回復する共通プリミティブ (提案 B5)
+     * @param amount 回復量
+     * @details `apply_raw_damage()` と対称な回復側プリミティブ。現在 HP に
+     * amount を加え、現在の最大 HP (maxhp) でクランプする。プレイヤー・
+     * モンスターで散在していた `hp += X; if (hp > maxhp) hp = maxhp;` /
+     * `hp = std::min(hp + X, maxhp)` を一本化する。
+     */
+    void heal_hp(int amount)
+    {
+        this->hp += amount;
+        if (this->hp > this->maxhp) {
+            this->hp = this->maxhp;
+        }
+    }
+
+    /*!
      * @brief クリーチャーの時限効果の残りターン数を取得
      * @param effect 取得する時限効果の種別
      * @return 残りターン数（0なら効果なし）


### PR DESCRIPTION
CreatureEntity::heal_hp(int) を新設（apply_raw_damage と対称な回復側 プリミティブ。hp += amount し maxhp でクランプ）。モンスター回復経路に散在した
純粋クランプ形 6 サイトを移行:
- effect-monster-spirit / monster-eating:284 / monster-attack-monster:52 / monster-processor の heal ラムダ2箇所 / monster-damage:533

メッセージと絡む mspell-status、事前クランプ形の monster-eating:234、 MONSTER_MAXHP ガード付きの effect-monster-oldies は挙動不変を優先しスキップ。

フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monsters now use a more consistent healing behavior across combat, self-use items, and other healing effects.
  * Improved context handling for monster item use, which can change which consumables are chosen in certain encounters.

* **Bug Fixes**
  * Fixed several healing cases where HP updates could behave inconsistently near maximum HP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->