### PR TITLE
refactor: モンスター打撃の武器スロット選択を共通化（提案B4）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -2765,7 +2765,7 @@ A トラック（フィールドのカプセル化）が一段落したため、
 | B1 | 時限効果付与＋mproc 保守の統合 (提案 49/50) | 状態異常 | — | — | ✅ 完了 |
 | B2 | ターン・エネルギー消費カーネルの共通化 | 行動 | 中→小 | 低（ただし critical path） | ✅ 完了（縮小） |
 | B3 | モンスター命中判定 2 関数の統合 | 攻撃 | 中 | 低 | ✅ 完了 |
-| B4 | モンスター打撃の武器スロット選択共通化 | 攻撃 | 中 | 低〜中 | 計画 |
+| B4 | モンスター打撃の武器スロット選択共通化 | 攻撃 | 中 | 低〜中 | ✅ 完了 |
 | B5 | HP 回復プリミティブ `heal_hp()` の共通化 | 効果適用 | 中 | 低 | ✅ 完了 |
 | B6 | `is_player()` 真分岐の限定的 virtual 化 | 横断 | 中 | 低〜中 | 計画 |
 | B7 | テレポート先判定の共通化 | 効果適用 | 低〜中 | 中 | 計画 |
@@ -2819,18 +2819,23 @@ clang-format-18 で検証済み。
 
 ---
 
-## 提案 B4: モンスター打撃の武器スロット選択共通化
+## 提案 B4: モンスター打撃の武器スロット選択共通化 ✅ 完了
 
 **現状の分離:** モンスター対プレイヤー (`monster-attack-player.cpp:176-198`) と
 モンスター対モンスター (`melee/monster-attack-monster.cpp:354-373`) が、打撃
 メソッド (HIT/PUNCH/SLASH/STING) に対する二刀流の blow-index 交互選択・単手選択・
-素手 (-1) のロジックを重複実装している。
+素手 (-1) のロジックを重複実装していた。
 
-**提案:** `select_monster_blow_weapon(CreatureEntity &attacker, int blow_index,
-RaceBlowMethodType method) -> int slot` を抽出し両 call site で共用。攻撃側は
-両経路とも `CreatureEntity`（モンスター）なので素直に共通化できる。
+**完了内容:** 攻撃側は両経路とも `CreatureEntity`（モンスター）なので、
+`CreatureEntity::select_melee_weapon_slot(int blow_index, RaceBlowMethodType
+method) const` メソッドに集約し、両 call site の switch ブロック (~20 行 ×2) を
+1 行呼出に置換。`RaceBlowMethodType` は creature-entity.h に前方宣言を追加し、
+定義は creature-entity.cpp（`monster-attack-table.h` を include）に置いた。
+**新規ファイルを作らず既存 TU（creature-entity）に収め、Makefile.am / VS
+プロジェクトの更新を回避**した。挙動不変。
 
-**規模/価値:** 中（重複 ~20 行 ×2）。リスク低〜中（攻撃ループ内のため要回帰確認）。
+**規模/価値:** 中。リスク低〜中（攻撃ループ内のため要回帰確認、ビルドで検証）。
+フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証済み。
 
 ---
 

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -345,29 +345,9 @@ static void repeat_melee(CreatureEntity &creature, mam_type *mam_ptr)
         mam_ptr->method = monrace.blows[ap_cnt].method;
         mam_ptr->damage_dice = monrace.blows[ap_cnt].damage_dice;
 
-        // 物理打撃 (HIT/PUNCH/SLASH/STING) かつ武器装備時は当該打撃で使う武器スロットを決める。
-        // 二刀流なら blow index で交互、片手のみならそちら、武器なしなら -1。
-        // (monster-attack-player.cpp の処理と揃える)
-        mam_ptr->weapon_slot_for_blow = -1;
-        switch (mam_ptr->method) {
-        case RaceBlowMethodType::HIT:
-        case RaceBlowMethodType::PUNCH:
-        case RaceBlowMethodType::SLASH:
-        case RaceBlowMethodType::STING: {
-            const bool main_valid = monster.inventory[INVEN_MAIN_HAND]->is_valid() && monster.inventory[INVEN_MAIN_HAND]->is_melee_weapon();
-            const bool sub_valid = monster.inventory[INVEN_SUB_HAND]->is_valid() && monster.inventory[INVEN_SUB_HAND]->is_melee_weapon();
-            if (main_valid && sub_valid) {
-                mam_ptr->weapon_slot_for_blow = (ap_cnt % 2 == 0) ? INVEN_MAIN_HAND : INVEN_SUB_HAND;
-            } else if (main_valid) {
-                mam_ptr->weapon_slot_for_blow = INVEN_MAIN_HAND;
-            } else if (sub_valid) {
-                mam_ptr->weapon_slot_for_blow = INVEN_SUB_HAND;
-            }
-            break;
-        }
-        default:
-            break;
-        }
+        // 物理打撃で使う武器スロットを決める (提案 B4)。
+        // CreatureEntity::select_melee_weapon_slot に集約。対プレイヤー経路と共用。
+        mam_ptr->weapon_slot_for_blow = monster.select_melee_weapon_slot(ap_cnt, mam_ptr->method);
 
         if (!monster.is_valid()) {
             break;

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -173,29 +173,9 @@ bool MonsterAttackPlayer::process_monster_blows()
         // フレーバーの打撃は必中扱い。それ以外は通常の命中判定を行う。
         this->ac = static_cast<ARMOUR_CLASS>(creature.get_ac());
 
-        // [フェーズ B-2 二刀流対応] HIT/PUNCH/SLASH/STING の物理打撃で、
-        // MAIN/SUB の双方が有効な武器なら blow index で交互に使用、
-        // 片方のみなら一貫してそちらを使用、武器なしなら slot < 0
-        this->weapon_slot_for_blow = -1;
-        switch (this->method) {
-        case RaceBlowMethodType::HIT:
-        case RaceBlowMethodType::PUNCH:
-        case RaceBlowMethodType::SLASH:
-        case RaceBlowMethodType::STING: {
-            const bool main_valid = this->m_ptr->inventory[INVEN_MAIN_HAND]->is_valid() && this->m_ptr->inventory[INVEN_MAIN_HAND]->is_melee_weapon();
-            const bool sub_valid = this->m_ptr->inventory[INVEN_SUB_HAND]->is_valid() && this->m_ptr->inventory[INVEN_SUB_HAND]->is_melee_weapon();
-            if (main_valid && sub_valid) {
-                this->weapon_slot_for_blow = (ap_cnt % 2 == 0) ? INVEN_MAIN_HAND : INVEN_SUB_HAND;
-            } else if (main_valid) {
-                this->weapon_slot_for_blow = INVEN_MAIN_HAND;
-            } else if (sub_valid) {
-                this->weapon_slot_for_blow = INVEN_SUB_HAND;
-            }
-            break;
-        }
-        default:
-            break;
-        }
+        // [フェーズ B-2 二刀流対応 / 提案 B4] 物理打撃で使う武器スロットを決定。
+        // (CreatureEntity::select_melee_weapon_slot に集約。対モンスター経路と共用)
+        this->weapon_slot_for_blow = this->m_ptr->select_melee_weapon_slot(ap_cnt, this->method);
 
         bool hit;
         if (this->effect == RaceBlowEffectType::FLAVOR) {

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -9,6 +9,7 @@
 #include "inventory/inventory-slot-types.h"
 #include "market/arena-entry.h"
 #include "mind/mind-elementalist.h"
+#include "monster-attack/monster-attack-table.h"
 #include "monster-race/race-brightness-flags.h"
 #include "monster-race/race-feature-flags.h"
 #include "monster-race/race-flags-resistance.h"
@@ -711,6 +712,31 @@ short CreatureEntity::get_equip_cnt() const
         }
     }
     return cnt;
+}
+
+short CreatureEntity::select_melee_weapon_slot(int blow_index, RaceBlowMethodType method) const
+{
+    switch (method) {
+    case RaceBlowMethodType::HIT:
+    case RaceBlowMethodType::PUNCH:
+    case RaceBlowMethodType::SLASH:
+    case RaceBlowMethodType::STING: {
+        const auto main_valid = this->inventory[INVEN_MAIN_HAND]->is_valid() && this->inventory[INVEN_MAIN_HAND]->is_melee_weapon();
+        const auto sub_valid = this->inventory[INVEN_SUB_HAND]->is_valid() && this->inventory[INVEN_SUB_HAND]->is_melee_weapon();
+        if (main_valid && sub_valid) {
+            return (blow_index % 2 == 0) ? INVEN_MAIN_HAND : INVEN_SUB_HAND;
+        }
+        if (main_valid) {
+            return INVEN_MAIN_HAND;
+        }
+        if (sub_valid) {
+            return INVEN_SUB_HAND;
+        }
+        return -1;
+    }
+    default:
+        return -1;
+    }
 }
 
 bool CreatureEntity::can_equip_to(int slot) const

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -52,6 +52,7 @@ enum class ExtendedSlotType : uint8_t;
 enum class MonraceId : int16_t;
 enum class MonsterAbilityType;
 enum class PlayerSkillKindType;
+enum class RaceBlowMethodType;
 enum class RealmType;
 enum class Virtue : short;
 
@@ -2018,6 +2019,17 @@ public:
      * @details inventory[INVEN_MAIN_HAND..INVEN_TOTAL) の有効アイテム数を返す。
      */
     short get_equip_cnt() const;
+
+    /*!
+     * @brief 近接打撃で使用する武器スロットを決定する (提案 B4)
+     * @param blow_index 打撃インデックス (二刀流時の交互使用判定に使用)
+     * @param method 打撃メソッド
+     * @return 使用する武器スロット (INVEN_MAIN_HAND / INVEN_SUB_HAND)、武器なしは -1
+     * @details HIT/PUNCH/SLASH/STING の物理打撃で MAIN/SUB の双方が有効な近接武器なら
+     *          blow index で交互、片方のみならそちら、武器なしなら -1。モンスター対
+     *          プレイヤー／モンスター対モンスターの両攻撃経路で共用する。
+     */
+    short select_melee_weapon_slot(int blow_index, RaceBlowMethodType method) const;
 
     /*!
      * @brief 指定スロットに装備可能か判定する (提案: モンスター体構造)


### PR DESCRIPTION
モンスター対プレイヤー / モンスター対モンスターで重複していた二刀流武器スロット
選択ロジック（HIT/PUNCH/SLASH/STING で MAIN/SUB 交互・単手・素手 -1）を CreatureEntity::select_melee_weapon_slot(blow_index, method) に集約し、両 call site の switch ブロックを 1 行呼出へ置換。

攻撃側が両経路とも CreatureEntity（モンスター）のためメソッド化が自然。
RaceBlowMethodType は前方宣言＋定義を creature-entity.cpp に置き、新規 TU を 作らず Makefile.am / VS プロジェクト更新を回避。挙動不変。

フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the creature/entity refactoring roadmap to mark one item as completed and reflect the finished implementation details.
* **Refactor**
  * Centralized melee weapon-slot selection for monster physical attacks into a shared code path.
  * Replaced duplicated selection logic in multiple attack flows with the shared behavior.
  * No gameplay behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->