### PR TITLE
feat: モンスター突然変異の per-turn 処理を接続（提案C5-3 発火）

### DIFF
--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -96,6 +96,20 @@ void WorldTurnProcessor::process_world()
     reduce_lite_life(this->creature);
     process_terrain_effects(this->creature);
     process_world_aux_mutation(this->creature);
+
+    // [提案 C5-3] 突然変異を持つモンスターの per-turn 処理。プレイヤーと同一の
+    // 10 ゲームターン周期 (process_world 全体が TURNS_PER_TICK でゲートされる) のため、
+    // process_monster_mutation 内の発動確率はプレイヤー版とそのまま整合する。
+    // 大多数のモンスターは突然変異を持たず none() 判定で即スキップされる。
+    auto &floor_mut = *this->creature.get_floor();
+    for (MONSTER_IDX m_idx = 1; m_idx < floor_mut.m_max; m_idx++) {
+        auto &monster = floor_mut.m_list[m_idx];
+        if (!monster.is_valid() || monster.get_mutations().none()) {
+            continue;
+        }
+        process_monster_mutation(this->creature, monster);
+    }
+
     process_world_aux_sudden_attack(this->creature);
     process_alliance_recovery(this->creature);
     execute_cursed_items_effect(this->creature);


### PR DESCRIPTION
C5 の第3段。process_world() のプレイヤー突然変異処理直後に、突然変異を持つ
モンスターを走査して process_monster_mutation() を呼ぶループを追加。これで C5-1 で JSON 付与した突然変異が実際に発火する。

- process_world 全体が TURNS_PER_TICK(10ゲームターン)でゲートされるため、 プレイヤーと同一周期。発動確率(one_in_(3000)等)がプレイヤー版とそのまま整合
- 大多数のモンスターは突然変異を持たず none() 即スキップで perf 影響は軽微
- プレイヤー経路は不変（既定バランスは opt-in 個体以外すべて不変）

C5 完了: JSON "mutations" を指定した個体のみ、curated な能動突然変異
(BERS_RAGE/COWARDICE/RTELEPORT/SPEED_FLUX)がモンスター安全に発火する。

フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証。