### PR TITLE
feat: モンスターの魔法領域詠唱を JSON でオプトイン可能に（提案C6 案A）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -707,6 +707,35 @@ C トラック第 4 弾で、**JSON オプトイン方式**（既定=なし=バ�
 - **未対応の変異は付与しても per-turn では発火しない**（上記 4 種以外）。受動変異
   （耐性・ESP 等）の反映は将来拡張。スキーマに `mutations` を登録済。
 
+### モンスターの魔法領域詠唱 (`realm_abilities`) — 提案 C6
+
+`MonraceDefinition` に `RealmType realm_abilities`
+(`src/system/monrace/monrace-definition.h`) を持ち、JSON
+`lib/edit/MonraceDefinitions.jsonc` で個別モンスターに魔法領域由来の詠唱能力を
+付与できる。C トラック第 5 弾で、**JSON オプトイン方式**（既定 `NONE`=無効で
+バランス不変）。
+
+```jsonc
+"realm_abilities": "CHAOS"
+```
+
+指定可能なトークンは `r_info_realm`（`RealmType` の enum 名。LIFE / SORCERY /
+NATURE / CHAOS / DEATH / TRUMP / ARCANE / CRAFT / DAEMON / CRUSADE / MUSIC /
+HISSATSU / HEX）を参照。
+
+- **橋渡し方式（メンテナ選択: 案A realm→ability マッピング）:** プレイヤーの
+  `exe_spell()` は `get_aim_dir` 等の UI プロンプトを直呼びしヘッドレス不可のため、
+  realm 呪文を対応する `MonsterAbilityType` に写像し、**既存 mspell 経路**
+  （自動ターゲット・MP消費(C4)・耐性・smart AI）で詠唱させる。
+- **非破壊・race-level 尊重:** モンスター能力は race 単位 (`monrace.ability_flags`)
+  で mspell に読まれるため、恒久的に monrace を書き換えず、詠唱文脈
+  (`msa_type` 構築時) の `ability_flags` にのみ realm 由来能力を **OR-in** する
+  (`src/mspell/mspell-attack-util.cpp` の `add_realm_granted_abilities()`)。
+- 写像表は保守的な初期セット（10 魔法領域。MUSIC/HISSATSU/HEX は未マッピング）で、
+  バランス調整・拡張はこの表で行う。
+- 実際に撃たせるには当該 monrace に `freq_spell > 0`（詠唱頻度）が必要。
+- 既定 `NONE` のため実データ・既定バランスは不変。スキーマに `realm_abilities` を登録済。
+
 ### モンスターのレベル別HPダイス指定 (`hit_point_per_level`)
 
 `MonraceDefinition` に `Dice hit_dice_per_level`

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3034,7 +3034,7 @@ JSON で明示付与**する形で導入する。これにより:
 | C3 | ESP のモンスター付与 | 🔴 新規 AI 要 | 中〜大 | 中 | ESP をモンスター AI にどう効かせるか（新規設計） |
 | C4 | MP 消費詠唱 | 🟡 pool 有 | 中 | 中 | ✅ 完了（opt-in・レベル比例コスト） |
 | C5 | 突然変異のモンスター運用 | 🟡 処理汎用 | 中 | 中 | ✅ 完了（3段: 付与→専用処理→発火） |
-| C6 | 魔法領域詠唱のモンスター運用 | 🔴 別系統 | 大 | 中〜高 | realm↔ability マッピング設計 |
+| C6 | 魔法領域詠唱のモンスター運用 | 🔴 別系統 | 大 | 中〜高 | ✅ 完了（案A: realm→ability・opt-in） |
 | C7 | class_specific_data の限定運用 | 🔴 | 中 | 低〜中 | 対象クラス(青魔/侍/忍者/僧)の選定 |
 | C8 | 徳・空腹の運用 | 🔴 UI 束縛 | 大 | 低 | **見送り**（UI/物語依存） |
 
@@ -3270,10 +3270,28 @@ per-turn 変異処理ループの新設（性能・正当性）、(b) 副作用�
   `ability_flags` へ付与。以降は通常の mspell が撃つ。
 - realm→ability の写像表は保守的な小集合から開始（各 realm 数個）。メンテナが拡張。
 
-**要相談（着手前）:** 橋渡し方式（A/B/C）と、realm→ability 写像の初期範囲。
-本提案は設計フェーズで、方式確定後に段階実装する。
+### ✅ 完了（案 A: realm→ability マッピング、メンテナ選択）
 
-**工数:** 中（案 A）。**価値:** 中〜高。**リスク:** 低（案 A、mspell 再利用）。
+**完了内容:** `MonraceDefinition::realm_abilities`（`RealmType`、既定 `NONE`）を追加。
+JSON `"realm_abilities": "CHAOS"` を指定した個体は、詠唱時（`msa_type` 構築時）に
+その realm 由来の `MonsterAbilityType` 群が `ability_flags` へ **OR-in** され、以降は
+**既存 mspell 経路（自動ターゲット・MP消費(C4)・耐性・smart AI）がそのまま撃つ**。
+
+- **race-level を尊重した非破壊設計:** モンスター能力は race 単位
+  (`monrace.ability_flags`) で mspell に読まれるため、恒久的に monrace を書き換えず、
+  **詠唱文脈の `msa_type.ability_flags` にのみ OR-in**（他所の lore/spoiler は不変）。
+  JSON パース順にも非依存。
+- realm→ability 写像は `mspell-attack-util.cpp` の file-local
+  `add_realm_granted_abilities()` に保守的な初期セットで実装（LIFE/SORCERY/NATURE/
+  CHAOS/DEATH/TRUMP/ARCANE/CRAFT/DAEMON/CRUSADE の 10 realm。MUSIC/HISSATSU/HEX は
+  技術領域のため現状未マッピング）。バランス調整・拡張はこの表で行う。
+- realm トークン表 `r_info_realm`（13 realm）/ reader `set_mon_realm_abilities` /
+  schema を整備。
+- **既定 `NONE` のため実データ・既定バランスは不変。** 実際に撃たせるには当該
+  monrace に `freq_spell > 0` が要る（メンテナのデータ設定）。
+- フルビルド (g++ -O3 -Werror) / clang-format-18 / validate_json.py で検証済。
+
+**将来拡張余地:** 写像表の精緻化、realm2 の併用、realm レベル依存の能力段階化。
 
 ---
 

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -189,6 +189,10 @@
                             "type": "string"
                         }
                     },
+                    "realm_abilities": {
+                        "type": "string",
+                        "description": "詠唱能力を付与する魔法領域 (提案C6)。トークンは r_info_realm を参照。指定するとその realm 由来の MonsterAbilityType が詠唱時に追加される。既定=なし=オプトイン。"
+                    },
                     "odds_correction_ratio": {
                         "type": "integer",
                         "description": "闘技場オッズ補正値。1/100を使用、100で等倍200で2倍",

--- a/src/info-reader/race-info-tokens-table.cpp
+++ b/src/info-reader/race-info-tokens-table.cpp
@@ -1045,3 +1045,22 @@ const std::unordered_map<std::string_view, PlayerMutationType> r_info_mutation =
     { "DESTROYED_ASSHOLE", PlayerMutationType::DESTROYED_ASSHOLE },
     { "LOST_HEAD", PlayerMutationType::LOST_HEAD },
 };
+
+/*!
+ * @brief 魔法領域トークン (提案 C6: モンスターへの realm 由来能力付与用)
+ */
+const std::unordered_map<std::string_view, RealmType> r_info_realm = {
+    { "LIFE", RealmType::LIFE },
+    { "SORCERY", RealmType::SORCERY },
+    { "NATURE", RealmType::NATURE },
+    { "CHAOS", RealmType::CHAOS },
+    { "DEATH", RealmType::DEATH },
+    { "TRUMP", RealmType::TRUMP },
+    { "ARCANE", RealmType::ARCANE },
+    { "CRAFT", RealmType::CRAFT },
+    { "DAEMON", RealmType::DAEMON },
+    { "CRUSADE", RealmType::CRUSADE },
+    { "MUSIC", RealmType::MUSIC },
+    { "HISSATSU", RealmType::HISSATSU },
+    { "HEX", RealmType::HEX },
+};

--- a/src/info-reader/race-info-tokens-table.h
+++ b/src/info-reader/race-info-tokens-table.h
@@ -22,6 +22,7 @@
 #include "player-info/class-types.h"
 #include "player-info/race-types.h"
 #include "player/player-personality-types.h"
+#include "realm/realm-types.h"
 #include "system/angband.h"
 #include "system/monrace/body-structure-types.h"
 #include "system/monrace/extended-slot.h"
@@ -77,3 +78,4 @@ extern const std::unordered_map<std::string_view, CreatureMaterialType> r_info_m
 extern const std::unordered_map<std::string_view, PlayerRaceType> r_info_player_race;
 extern const std::unordered_map<std::string_view, PlayerClassType> r_info_player_class;
 extern const std::unordered_map<std::string_view, PlayerMutationType> r_info_mutation;
+extern const std::unordered_map<std::string_view, RealmType> r_info_realm;

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -383,6 +383,32 @@ errr RaceReader::set_mon_player_class(const nlohmann::json &class_data, MonraceD
 }
 
 /*!
+ * @brief JSON Objectからモンスターの詠唱魔法領域を設定する (提案C6)
+ * @param realm_data 魔法領域情報の格納されたJSON Object (文字列)
+ * @param monrace 保管先のモンスター種族構造体
+ * @return エラーコード
+ * @details 未指定 (null) なら RealmType::NONE のまま。指定時は詠唱 (mspell) 実行時に
+ *          その realm 由来の MonsterAbilityType 群が能力に追加される (効果反映)。
+ *          トークンは r_info_realm を参照。
+ */
+errr RaceReader::set_mon_realm_abilities(const nlohmann::json &realm_data, MonraceDefinition &monrace)
+{
+    if (realm_data.is_null()) {
+        return PARSE_ERROR_NONE;
+    }
+    if (!realm_data.is_string()) {
+        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    }
+
+    uint32_t realm;
+    if (!info_grab_one_const(realm, r_info_realm, realm_data.get<std::string>())) {
+        return PARSE_ERROR_INVALID_FLAG;
+    }
+    monrace.realm_abilities = static_cast<RealmType>(realm);
+    return PARSE_ERROR_NONE;
+}
+
+/*!
  * @brief JSON Objectからモンスターに付与する突然変異をセットする (提案C5)
  * @param mutations_data 突然変異情報の格納されたJSON Array (文字列の配列)
  * @param monrace 保管先のモンスター種族構造体
@@ -1518,6 +1544,11 @@ errr RaceReader::read()
     err = set_mon_mutations(mon_data["mutations"], monrace);
     if (err) {
         msg_format(_("モンスター突然変異読込失敗。ID: '%d'。", "Failed to load monster mutations. ID: '%d'."), error_idx);
+        return err;
+    }
+    err = set_mon_realm_abilities(mon_data["realm_abilities"], monrace);
+    if (err) {
+        msg_format(_("モンスター魔法領域読込失敗。ID: '%d'。", "Failed to load monster realm_abilities. ID: '%d'."), error_idx);
         return err;
     }
     err = info_set_integer(mon_data["odds_correction_ratio"], monrace.arena_ratio, false, Range(1, 9999));

--- a/src/info-reader/race-reader.h
+++ b/src/info-reader/race-reader.h
@@ -31,6 +31,7 @@ private:
     errr set_mon_player_race(const nlohmann::json &race_data, MonraceDefinition &monrace);
     errr set_mon_player_class(const nlohmann::json &class_data, MonraceDefinition &monrace);
     errr set_mon_mutations(const nlohmann::json &mutations_data, MonraceDefinition &monrace);
+    errr set_mon_realm_abilities(const nlohmann::json &realm_data, MonraceDefinition &monrace);
     errr set_mon_materials(const nlohmann::json &materials_data, MonraceDefinition &monrace);
     errr set_mon_body_structure(const nlohmann::json &body_data, MonraceDefinition &monrace);
     errr set_mon_extended_slots(const nlohmann::json &slots_data, MonraceDefinition &monrace);

--- a/src/mspell/mspell-attack-util.cpp
+++ b/src/mspell/mspell-attack-util.cpp
@@ -1,7 +1,58 @@
 #include "mspell/mspell-attack-util.h"
+#include "monster-race/race-ability-flags.h"
+#include "realm/realm-types.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
+
+namespace {
+/*!
+ * @brief 魔法領域に対応する MonsterAbilityType 群を詠唱能力へ加える (提案C6)
+ * @details realm_abilities が指定されたモンスターの詠唱時に、その realm 由来の
+ *          モンスター能力を ability_flags に OR-in する。既存 mspell 経路
+ *          (自動ターゲット・MP消費(C4)・耐性・AI) をそのまま利用する。
+ *          写像は保守的な初期セット。バランス調整・拡張はこの表で行う。
+ *          MUSIC / HISSATSU / HEX / NONE は現状未マッピング。
+ */
+void add_realm_granted_abilities(EnumClassFlagGroup<MonsterAbilityType> &flags, RealmType realm)
+{
+    using Ma = MonsterAbilityType;
+    switch (realm) {
+    case RealmType::LIFE:
+        flags.set({ Ma::HEAL, Ma::CAUSE_2, Ma::CAUSE_3 });
+        break;
+    case RealmType::SORCERY:
+        flags.set({ Ma::SLOW, Ma::CONF, Ma::SCARE, Ma::BLINK, Ma::TELE_AWAY });
+        break;
+    case RealmType::NATURE:
+        flags.set({ Ma::BA_ELEC, Ma::BA_COLD, Ma::BO_FIRE });
+        break;
+    case RealmType::CHAOS:
+        flags.set({ Ma::BA_CHAO, Ma::BA_FIRE, Ma::BR_CHAO, Ma::CONF });
+        break;
+    case RealmType::DEATH:
+        flags.set({ Ma::CAUSE_3, Ma::CAUSE_4, Ma::BO_NETH, Ma::BA_NETH, Ma::DRAIN_MANA });
+        break;
+    case RealmType::TRUMP:
+        flags.set({ Ma::BLINK, Ma::TPORT, Ma::TELE_TO, Ma::S_MONSTER, Ma::S_KIN });
+        break;
+    case RealmType::ARCANE:
+        flags.set({ Ma::BO_MANA, Ma::BA_MANA, Ma::MIND_BLAST });
+        break;
+    case RealmType::CRAFT:
+        flags.set({ Ma::HASTE, Ma::HEAL });
+        break;
+    case RealmType::DAEMON:
+        flags.set({ Ma::BA_FIRE, Ma::BR_FIRE, Ma::BA_NETH, Ma::S_DEMON });
+        break;
+    case RealmType::CRUSADE:
+        flags.set({ Ma::BA_LITE, Ma::CAUSE_3, Ma::SCARE });
+        break;
+    default:
+        break;
+    }
+}
+}
 
 msa_type::msa_type(CreatureEntity &creature, MONSTER_IDX m_idx)
     : m_idx(m_idx)
@@ -14,6 +65,12 @@ msa_type::msa_type(CreatureEntity &creature, MONSTER_IDX m_idx)
     this->monrace = this->m_ptr->get_monrace_shared();
     this->no_inate = !evaluate_percent(this->monrace->freq_spell * 2);
     this->ability_flags = this->monrace->ability_flags;
+
+    // [提案 C6] realm_abilities が指定された個体は、その魔法領域由来の
+    // モンスター能力を詠唱能力へ加える (恒久的に monrace は変えず、詠唱文脈のみ)。
+    if (this->monrace->realm_abilities != RealmType::NONE) {
+        add_realm_granted_abilities(this->ability_flags, this->monrace->realm_abilities);
+    }
 }
 
 Pos2D msa_type::get_position() const

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -25,6 +25,7 @@
 #include "player-info/class-types.h"
 #include "player-info/race-types.h"
 #include "player/player-personality-types.h"
+#include "realm/realm-types.h"
 #include "system/angband.h"
 #include "system/material-type-definition.h"
 #include "system/monrace/body-structure-types.h"
@@ -135,6 +136,7 @@ public:
     bool grows_stats = false; //!< レベルアップ時に能力値も成長させるか (提案C2。既定false=オプトイン。既定バランス不変)
     bool consumes_mp = false; //!< 呪文詠唱時に MP を消費するか (提案C4。既定false=オプトイン。既定バランス不変)
     EnumClassFlagGroup<PlayerMutationType> mutations{}; //!< 生成時に付与する突然変異 (提案C5。空=なし=オプトイン)
+    RealmType realm_abilities = RealmType::NONE; //!< 詠唱能力を付与する魔法領域 (提案C6。NONE=なし=オプトイン。詠唱時に realm 由来の MonsterAbilityType を追加)
     EnumClassFlagGroup<MonsterFeedType> meat_feed_flags;
     EnumClassFlagGroup<MonsterAbilityType> ability_flags; //!< 能力フラグ(魔法/ブレス) / Ability Flags
     EnumClassFlagGroup<MonsterAuraType> aura_flags; //!< オーラフラグ / Aura Flags


### PR DESCRIPTION
C トラック第5弾。メンテナ選択の「案A: realm→ability マッピング」で実装。

設計: exe_spell の realm 詠唱は get_aim_dir 等 UI プロンプト直呼びでヘッドレス不可と 判明したため、realm 呪文を対応する MonsterAbilityType に写像し既存 mspell 経路 （自動ターゲット・MP消費(C4)・耐性・smart AI）で撃たせる。

- MonraceDefinition に realm_abilities (RealmType, 既定 NONE) を追加
- JSON "realm_abilities": "CHAOS" で個体に魔法領域を指定
- 非破壊設計: 能力は race 単位で mspell に読まれるため monrace は恒久変更せず、 詠唱文脈(msa_type 構築時)の ability_flags にのみ realm 由来能力を OR-in
- 写像表 add_realm_granted_abilities() を保守的な初期セット(10領域)で実装
- realm トークン表 r_info_realm(13) / reader set_mon_realm_abilities / schema 整備

既定 NONE のため実データ・既定バランス不変。実詠唱には freq_spell>0 が必要。
写像表の精緻化・realm2 併用は将来拡張。

フルビルド (g++ -O3 -Werror -Wall -Wextra) / clang-format-18 / validate_json.py で検証。