### PR TITLE
refactor: charm/control セービングスロー共通実装を統合（提案D5）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3386,7 +3386,7 @@ A/B と違い挙動が変わるため、対象範囲と数値はメンテナ判�
 | D2 | 回復・状態治療関数の is_player ガード除去 + メッセージ seam | 同化中核 | 中〜大 | 高 | 計画 |
 | D3 | 統一クリーチャーテレポートプリミティブ | primitive | 中 | 中 | 計画 |
 | D4 | 属性ダメージ分類器（immune/resist/vuln）の共通化 | primitive | 中 | 中 | 計画 |
-| D5 | 小規模統合（charm/control セーヴ統合・時限効果満了エンベロープ） | 純粋refactor | 小 | 低〜中 | 計画 |
+| D5 | 小規模統合（charm/control セーヴ統合ほか） | 純粋refactor | 小 | 低〜中 | ✅ 完了（charm/control。他2件は精査の上見送り） |
 | D6 | `CreatureEntity` インスタンス化可能化（PlayerType dummy 撤廃） | 構造 | 中 | 中 | 計画 |
 | D7 | モンスターの cut/poison DoT（per-turn 未発火のギャップ） | 機能(C隣接) | 中 | 中 | 計画 |
 
@@ -3467,19 +3467,24 @@ lore/note/二次効果（do_polymorph 等）は型別のまま**残す（完全�
 
 ---
 
-## 提案 D5: 小規模統合
+## 提案 D5: 小規模統合 ✅ 完了（charm/control。他2件は見送り）
 
-- **`common_saving_throw_charm`(spells-diceroll.cpp:20) / `common_saving_throw_control`(:60)**:
-  ~90% 同一（`NO_CONF` 早期 return の有無のみ差）。単一ファイル内の trivial dedup。
-- **時限効果満了エンベロープ**: player `reduce_magic_effects_timeout` と monster
-  `process_monsters_timed_effect_aux` は「減算→満了検出→視認時メッセージ」の**外枠が
-  共通**（共有 6 効果 ACCEL/DECEL/STUN/CONFUSION/FEAR/INVULN）。回復量・文言は型別のため、
-  回復量コールバック + メッセージを取る `CreatureEntity` ヘルパに外枠のみ抽出可能
-  （B1 が setter+mproc を統一した続きの、per-turn 側の小整理）。
-- **モンスター対モンスターの属性オーラ** を `fire_dam/cold_dam/elec_dam` 経由に
-  寄せる（`process_aura_damage` の形）。
+**完了: `common_saving_throw_charm` / `common_saving_throw_control` 統合**
+(spells-diceroll.cpp)。~90% 同一（`NO_CONF` 早期 return の有無のみ差）だったため、
+`check_no_conf` フラグを取る file-local `common_saving_throw_impl()` に共通実装を集約し、
+両公開関数は薄い委譲へ。公開 API・挙動（charm の `resistance_flags.set(NO_CONF)`
+という既存の細部含む）は完全保存。フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。
 
-**工数:** 小。**価値:** 低〜中。
+**精査の上で見送った 2 件:**
+- **時限効果満了エンベロープ**: 「減算→満了検出→視認時メッセージ」の外枠が共通に
+  見えたが、実際は **player 側は満了メッセージを setter 内 (notice フラグ) に畳み込み、
+  monster 側は明示的に出す**構造差があり、共通エンベロープ抽出には一方の再構成が要る。
+  per-turn ホットパスへの侵襲・薄い共有ゆえリスク＞価値で現状維持。
+- **モンスター対モンスター属性オーラの `fire_dam/cold_dam/elec_dam` 再利用**: これらは
+  内部で `take_hit()`（プレイヤー死亡経路）を呼ぶ**プレイヤー専用**関数で、モンスター
+  被害者には使えないと判明。再利用不成立で見送り。
+
+**工数:** 小（実施分）。**価値:** 低〜中。
 
 ---
 

--- a/src/spell/spells-diceroll.cpp
+++ b/src/spell/spells-diceroll.cpp
@@ -12,12 +12,14 @@
 #include "system/monrace/monrace-definition.h"
 
 /*!
- * @brief モンスター魅了用セービングスロー共通部(汎用系)
- * @param pow 魅了パワー
- * @param m_ptr 対象モンスター
- * @return 魅了に抵抗したらTRUE
+ * @brief モンスター魅了/服従用セービングスロー共通実装 (提案D5)
+ * @param pow 魅了・服従パワー
+ * @param target 対象クリーチャー
+ * @param check_no_conf NO_CONF (混乱耐性) で無条件抵抗させるか (魅了=true / 服従=false)
+ * @return 抵抗したらTRUE
+ * @details charm/control で NO_CONF チェックの有無以外は完全に同一だったため統合。
  */
-bool common_saving_throw_charm(CreatureEntity &creature, int pow, const CreatureEntity &target)
+static bool common_saving_throw_impl(CreatureEntity &creature, int pow, const CreatureEntity &target, bool check_no_conf)
 {
     auto &monrace = target.get_monrace();
 
@@ -33,7 +35,7 @@ bool common_saving_throw_charm(CreatureEntity &creature, int pow, const Creature
         return true;
     }
 
-    if (monrace.resistance_flags.has(MonsterResistanceType::NO_CONF)) {
+    if (check_no_conf && monrace.resistance_flags.has(MonsterResistanceType::NO_CONF)) {
         if (is_original_ap_and_seen(creature, target)) {
             monrace.resistance_flags.set(MonsterResistanceType::NO_CONF);
         }
@@ -52,36 +54,25 @@ bool common_saving_throw_charm(CreatureEntity &creature, int pow, const Creature
 }
 
 /*!
+ * @brief モンスター魅了用セービングスロー共通部(汎用系)
+ * @param pow 魅了パワー
+ * @param target 対象モンスター
+ * @return 魅了に抵抗したらTRUE
+ */
+bool common_saving_throw_charm(CreatureEntity &creature, int pow, const CreatureEntity &target)
+{
+    return common_saving_throw_impl(creature, pow, target, true);
+}
+
+/*!
  * @brief モンスター服従用セービングスロー共通部(部族依存系)
  * @param pow 服従パワー
- * @param m_ptr 対象モンスター
+ * @param target 対象モンスター
  * @return 服従に抵抗したらTRUE
  */
 bool common_saving_throw_control(CreatureEntity &creature, int pow, const CreatureEntity &target)
 {
-    auto &monrace = target.get_monrace();
-
-    if (creature.get_floor()->inside_arena) {
-        return true;
-    }
-
-    /* Memorize a flag */
-    if (monrace.resistance_flags.has(MonsterResistanceType::RESIST_ALL)) {
-        if (is_original_ap_and_seen(creature, target)) {
-            monrace.r_resistance_flags.set(MonsterResistanceType::RESIST_ALL);
-        }
-        return true;
-    }
-
-    if (monrace.misc_flags.has(MonsterMiscType::QUESTOR) || target.is_nopet()) {
-        return true;
-    }
-
-    pow += adj_chr_chm[creature.get_stat_index(A_CHR)] - 1;
-    if (monrace.kind_flags.has(MonsterKindType::UNIQUE) || (monrace.population_flags.has(MonsterPopulationType::NAZGUL))) {
-        pow = pow * 2 / 3;
-    }
-    return (monrace.level > randint1((pow - 10) < 1 ? 1 : (pow - 10)) + 5);
+    return common_saving_throw_impl(creature, pow, target, false);
 }
 
 /*!


### PR DESCRIPTION
common_saving_throw_charm / common_saving_throw_control は NO_CONF チェックの有無 以外 ~90% 同一だったため、check_no_conf フラグを取る file-local
common_saving_throw_impl() に共通実装を集約。両公開関数は薄い委譲へ。公開 API と 挙動（charm の resistance_flags.set(NO_CONF) という既存の細部含む）は完全保存。

D5 の他 2 件は精査の上で見送り:
- 時限効果満了エンベロープ: player は満了メッセージを setter 内(notice)に畳み込み、 monster は明示出力する構造差があり共通抽出に一方の再構成が要る。per-turn ホット パス侵襲でリスク>価値のため現状維持。
- モンスター対モンスター属性オーラの fire/cold/elec_dam 再利用: これらは take_hit() (プレイヤー死亡経路)を呼ぶプレイヤー専用関数で monster 被害者に使えず不成立。

フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証。