### PR TITLE
refactor: メッセージ seam notify_self 導入 + 回復6関数の is_player ガード除去（提案D2 第1弾）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3383,7 +3383,7 @@ A/B と違い挙動が変わるため、対象範囲と数値はメンテナ判�
 | 番号 | 提案 | 種別 | 工数 | 価値 | 状態 |
 |---|---|---|---|---|---|
 | D1 | セービングスロー述語 `does_save_against()` 統一 | 純粋refactor | 小 | 中 | ✅ 完了 |
-| D2 | 回復・状態治療関数の is_player ガード除去 + メッセージ seam | 同化中核 | 中〜大 | 高 | 計画 |
+| D2 | 回復・状態治療関数の is_player ガード除去 + メッセージ seam | 同化中核 | 中〜大 | 高 | ✅ 第1弾完了（seam + 回復6関数） |
 | D3 | 統一クリーチャーテレポートプリミティブ | primitive | 中 | 中 | 計画 |
 | D4 | 属性ダメージ分類器（immune/resist/vuln）の共通化 | primitive | 中 | 中 | 計画 |
 | D5 | 小規模統合（charm/control セーヴ統合ほか） | 純粋refactor | 小 | 低〜中 | ✅ 完了（charm/control。他2件は精査の上見送り） |
@@ -3410,7 +3410,36 @@ effect-monster-charm / mspell-status / mspell-floor / effect-player-resist-hurt�
 
 ---
 
-## 提案 D2: 回復・状態治療関数の is_player ガード除去 + メッセージ seam（同化の中核）
+## 提案 D2: 回復・状態治療関数の is_player ガード除去 + メッセージ seam（同化の中核） ✅ 第1弾完了
+
+### ✅ 第1弾 完了内容（メッセージ seam + 回復6関数）
+
+**メッセージ seam の導入:** `CreatureEntity::notify_self(std::string_view)` を新設。
+プレイヤーなら `msg_print()`、それ以外 (モンスター) では無表示。状態異常/バフ setter
+群の 2 人称メッセージ（`bad-status-setter.cpp` 26 + `buff-setter.cpp` 18 = **44 箇所**）を
+`msg_print(...)` → `creature.notify_self(...)` へ機械置換。**プレイヤーでは
+`notify_self ≡ msg_print` のため挙動完全不変**（現行の setter 呼出は全てプレイヤー）。
+
+**回復6関数のガード除去:** `heroism` / `berserk` / `cure_light_wounds` /
+`cure_serious_wounds` / `cure_critical_wounds` / `true_healing` の
+`if (!creature.is_player()) return false;` を撤去。本体は既に creature-general
+プリミティブ（`hp_player` / `BadStatusSetter::set_*` / `set_hero` 等）のみで、
+メッセージは seam でプレイヤーのみ表示されるため、**モンスターにも安全に適用可能**に
+なった。現状これらを monster に渡す呼出は無いため既存挙動は不変（enabling 変更）。
+
+- フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。
+
+### 第2弾以降（残）
+
+- 残る回復・治療系（`restore_all_status:527` / `status_shuffle:693` / `life_stream`
+  tail）のガード除去（`do_res_stat` 等は既に creature-general）。
+- `notify_self` を**モンスター視認時の 3 人称文**へ拡張（現状はモンスター無表示）。
+- setter 群の残るプレイヤー専用テール（stance / spell 停止 / redraw）は no-op で
+  モンスター無害だが、必要なら虚拟化で整理。
+- これにより「モンスターの回復・状態治療」を実際に使う機能（C トラックの回復
+  モンスター等）への足場が完成する。
+
+### 参考: 当初の設計メモ
 
 **現状:** `src/spell/spells-status.cpp` の回復・治療関数は**本体が 100% creature-general
 プリミティブ**（`hp_player` / `BadStatusSetter::set_*` / `mod_cut` 等、すべて既に

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -295,10 +295,8 @@ bool life_stream(CreatureEntity &creature, bool message, bool virtue_change)
 
 bool heroism(CreatureEntity &creature, int base)
 {
-    if (!creature.is_player()) {
-        return false;
-    }
-
+    // [提案D2] メッセージは setter 内の notify_self seam でプレイヤーのみ表示される。
+    // モンスターにも安全に適用できるため is_player ガードを撤去。
     auto ident = false;
     if (BadStatusSetter(creature).set_fear(0)) {
         ident = true;
@@ -317,10 +315,7 @@ bool heroism(CreatureEntity &creature, int base)
 
 bool berserk(CreatureEntity &creature, int base)
 {
-    if (!creature.is_player()) {
-        return false;
-    }
-
+    // [提案D2] is_player ガード撤去 (メッセージは notify_self seam でプレイヤーのみ)。
     auto ident = false;
     if (BadStatusSetter(creature).set_fear(0)) {
         ident = true;
@@ -339,10 +334,7 @@ bool berserk(CreatureEntity &creature, int base)
 
 bool cure_light_wounds(CreatureEntity &creature, int pow)
 {
-    if (!creature.is_player()) {
-        return false;
-    }
-
+    // [提案D2] is_player ガード撤去 (メッセージは notify_self seam でプレイヤーのみ)。
     auto ident = false;
     if (hp_player(creature, pow)) {
         ident = true;
@@ -366,10 +358,7 @@ bool cure_light_wounds(CreatureEntity &creature, int pow)
 
 bool cure_serious_wounds(CreatureEntity &creature, int pow)
 {
-    if (!creature.is_player()) {
-        return false;
-    }
-
+    // [提案D2] is_player ガード撤去 (メッセージは notify_self seam でプレイヤーのみ)。
     auto ident = false;
     if (hp_player(creature, pow)) {
         ident = true;
@@ -397,10 +386,7 @@ bool cure_serious_wounds(CreatureEntity &creature, int pow)
 
 bool cure_critical_wounds(CreatureEntity &creature, int pow)
 {
-    if (!creature.is_player()) {
-        return false;
-    }
-
+    // [提案D2] is_player ガード撤去 (メッセージは notify_self seam でプレイヤーのみ)。
     auto ident = false;
     if (hp_player(creature, pow)) {
         ident = true;
@@ -436,10 +422,7 @@ bool cure_critical_wounds(CreatureEntity &creature, int pow)
 
 bool true_healing(CreatureEntity &creature, int pow)
 {
-    if (!creature.is_player()) {
-        return false;
-    }
-
+    // [提案D2] is_player ガード撤去 (メッセージは notify_self seam でプレイヤーのみ)。
     auto ident = false;
     if (hp_player(creature, pow)) {
         ident = true;

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -53,9 +53,9 @@ bool BadStatusSetter::set_blindness(const TIME_EFFECT tmp_v)
     if (v > 0) {
         if (!is_blind) {
             if (pr.equals(PlayerRaceType::ANDROID)) {
-                msg_print(_("センサーをやられた！", "The sensor broke!"));
+                this->creature.notify_self(_("センサーをやられた！", "The sensor broke!"));
             } else {
-                msg_print(_("目が見えなくなってしまった！", "You are blind!"));
+                this->creature.notify_self(_("目が見えなくなってしまった！", "You are blind!"));
             }
 
             notice = true;
@@ -64,9 +64,9 @@ bool BadStatusSetter::set_blindness(const TIME_EFFECT tmp_v)
     } else {
         if (is_blind) {
             if (pr.equals(PlayerRaceType::ANDROID)) {
-                msg_print(_("センサーが復旧した。", "The sensor has been restored."));
+                this->creature.notify_self(_("センサーが復旧した。", "The sensor has been restored."));
             } else {
-                msg_print(_("やっと目が見えるようになった。", "You can see again."));
+                this->creature.notify_self(_("やっと目が見えるようになった。", "You can see again."));
             }
 
             notice = true;
@@ -125,22 +125,22 @@ bool BadStatusSetter::set_confusion(const TIME_EFFECT tmp_v)
     const auto is_confused = this->creature.is_confused();
     if (v > 0) {
         if (!is_confused) {
-            msg_print(_("あなたは混乱した！", "You are confused!"));
+            this->creature.notify_self(_("あなたは混乱した！", "You are confused!"));
             if (this->creature.get_action() == ACTION_LEARN) {
-                msg_print(_("学習が続けられない！", "You cannot continue learning!"));
+                this->creature.notify_self(_("学習が続けられない！", "You cannot continue learning!"));
                 auto bluemage_data = CreatureClass(this->creature).get_specific_data<bluemage_data_type>();
                 bluemage_data->new_magic_learned = false;
                 rfu.set_flag(MainWindowRedrawingFlag::ACTION);
                 this->creature.set_action(ACTION_NONE);
             }
             if (this->creature.get_action() == ACTION_MONK_STANCE) {
-                msg_print(_("構えがとけた。", "You lose your stance."));
+                this->creature.notify_self(_("構えがとけた。", "You lose your stance."));
                 CreatureClass(this->creature).set_monk_stance(MonkStanceType::NONE);
                 rfu.set_flag(StatusRecalculatingFlag::BONUS);
                 rfu.set_flag(MainWindowRedrawingFlag::ACTION);
                 this->creature.set_action(ACTION_NONE);
             } else if (this->creature.get_action() == ACTION_SAMURAI_STANCE) {
-                msg_print(_("型が崩れた。", "You lose your stance."));
+                this->creature.notify_self(_("型が崩れた。", "You lose your stance."));
                 CreatureClass(this->creature).lose_balance();
             }
 
@@ -158,7 +158,7 @@ bool BadStatusSetter::set_confusion(const TIME_EFFECT tmp_v)
         }
     } else {
         if (is_confused) {
-            msg_print(_("やっと混乱がおさまった。", "You feel less confused now."));
+            this->creature.notify_self(_("やっと混乱がおさまった。", "You feel less confused now."));
             this->creature.remove_special_attack(ATTACK_SUIKEN);
             notice = true;
         }
@@ -199,12 +199,12 @@ bool BadStatusSetter::set_poison(const TIME_EFFECT tmp_v)
     const auto is_poisoned = this->creature.is_poisoned();
     if (v > 0) {
         if (!is_poisoned) {
-            msg_print(_("毒に侵されてしまった！", "You are poisoned!"));
+            this->creature.notify_self(_("毒に侵されてしまった！", "You are poisoned!"));
             notice = true;
         }
     } else {
         if (is_poisoned) {
-            msg_print(_("やっと毒の痛みがなくなった。", "You are no longer poisoned."));
+            this->creature.notify_self(_("やっと毒の痛みがなくなった。", "You are no longer poisoned."));
             notice = true;
         }
     }
@@ -244,9 +244,9 @@ bool BadStatusSetter::set_fear(const TIME_EFFECT tmp_v)
     const auto is_fearful = this->creature.is_fearful();
     if (v > 0) {
         if (!is_fearful) {
-            msg_print(_("何もかも恐くなってきた！", "You are terrified!"));
+            this->creature.notify_self(_("何もかも恐くなってきた！", "You are terrified!"));
             if (CreatureClass(this->creature).lose_balance()) {
-                msg_print(_("型が崩れた。", "You lose your stance."));
+                this->creature.notify_self(_("型が崩れた。", "You lose your stance."));
             }
 
             notice = true;
@@ -255,7 +255,7 @@ bool BadStatusSetter::set_fear(const TIME_EFFECT tmp_v)
         }
     } else {
         if (is_fearful) {
-            msg_print(_("やっと恐怖を振り払った。", "You feel bolder now."));
+            this->creature.notify_self(_("やっと恐怖を振り払った。", "You feel bolder now."));
             notice = true;
         }
     }
@@ -295,7 +295,7 @@ bool BadStatusSetter::set_paralysis(const TIME_EFFECT tmp_v)
     const auto is_paralyzed = this->creature.is_paralyzed();
     if (v > 0) {
         if (!is_paralyzed) {
-            msg_print(_("体が麻痺してしまった！", "You are paralyzed!"));
+            this->creature.notify_self(_("体が麻痺してしまった！", "You are paralyzed!"));
             reset_concentration(this->creature, true);
 
             SpellHex spell_hex(this->creature);
@@ -308,7 +308,7 @@ bool BadStatusSetter::set_paralysis(const TIME_EFFECT tmp_v)
         }
     } else {
         if (is_paralyzed) {
-            msg_print(_("やっと動けるようになった。", "You can move again."));
+            this->creature.notify_self(_("やっと動けるようになった。", "You can move again."));
             notice = true;
         }
     }
@@ -355,7 +355,7 @@ bool BadStatusSetter::hallucination(const TIME_EFFECT tmp_v)
     if (v > 0) {
         set_tsuyoshi(this->creature, 0, true);
         if (!is_hallucinated) {
-            msg_print(_("ワーオ！何もかも虹色に見える！", "Oh, wow! Everything looks so cosmic now!"));
+            this->creature.notify_self(_("ワーオ！何もかも虹色に見える！", "Oh, wow! Everything looks so cosmic now!"));
             reset_concentration(this->creature, true);
 
             this->creature.set_counter(false);
@@ -363,7 +363,7 @@ bool BadStatusSetter::hallucination(const TIME_EFFECT tmp_v)
         }
     } else {
         if (is_hallucinated) {
-            msg_print(_("やっとはっきりと物が見えるようになった。", "You can see clearly again."));
+            this->creature.notify_self(_("やっとはっきりと物が見えるようになった。", "You can see clearly again."));
             notice = true;
         }
     }
@@ -421,12 +421,12 @@ bool BadStatusSetter::set_deceleration(const TIME_EFFECT tmp_v, bool do_dec)
                 return false;
             }
         } else if (!is_slow) {
-            msg_print(_("体の動きが遅くなってしまった！", "You feel yourself moving slower!"));
+            this->creature.notify_self(_("体の動きが遅くなってしまった！", "You feel yourself moving slower!"));
             notice = true;
         }
     } else {
         if (is_slow) {
-            msg_print(_("動きの遅さがなくなったようだ。", "You feel yourself speed up."));
+            this->creature.notify_self(_("動きの遅さがなくなったようだ。", "You feel yourself speed up."));
             notice = true;
         }
     }
@@ -550,10 +550,10 @@ bool BadStatusSetter::process_stun_effect(const short v)
 void BadStatusSetter::process_stun_status(const PlayerStunRank new_rank, const short v)
 {
     auto stun_mes = PlayerStun::get_stun_mes(new_rank);
-    msg_print(stun_mes);
+    this->creature.notify_self(stun_mes);
     this->decrease_int_wis(v);
     if (CreatureClass(this->creature).lose_balance()) {
-        msg_print(_("型が崩れた。", "You lose your stance."));
+        this->creature.notify_self(_("型が崩れた。", "You lose your stance."));
     }
 
     reset_concentration(this->creature, true);
@@ -570,7 +570,7 @@ void BadStatusSetter::clear_head()
         return;
     }
 
-    msg_print(_("やっと朦朧状態から回復した。", "You are no longer stunned."));
+    this->creature.notify_self(_("やっと朦朧状態から回復した。", "You are no longer stunned."));
     if (disturb_state) {
         disturb(this->creature, false, false);
     }
@@ -585,7 +585,7 @@ void BadStatusSetter::decrease_int_wis(const short v)
         return;
     }
 
-    msg_print(_("割れるような頭痛がする。", "A vicious blow hits your head."));
+    this->creature.notify_self(_("割れるような頭痛がする。", "A vicious blow hits your head."));
     auto rand = randint0(5);
     switch (rand) {
     case 0:
@@ -637,7 +637,7 @@ bool BadStatusSetter::process_cut_effect(const short v)
 void BadStatusSetter::decrease_charisma(const PlayerCutRank new_rank, const short v)
 {
     auto cut_mes = PlayerCut::get_cut_mes(new_rank);
-    msg_print(cut_mes);
+    this->creature.notify_self(cut_mes);
     if (v <= randint1(1000) && !one_in_(16)) {
         return;
     }
@@ -646,7 +646,7 @@ void BadStatusSetter::decrease_charisma(const PlayerCutRank new_rank, const shor
         return;
     }
 
-    msg_print(_("ひどい傷跡が残ってしまった。", "You have been horribly scarred."));
+    this->creature.notify_self(_("ひどい傷跡が残ってしまった。", "You have been horribly scarred."));
     do_dec_stat(this->creature, A_CHR);
 }
 

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -136,7 +136,7 @@ bool set_acceleration(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
                 return false;
             }
         } else if (!is_fast && !creature.get_timed_effect(CreatureTimedEffect::LIGHTSPEED)) {
-            msg_print(_("素早く動けるようになった！", "You feel yourself moving much faster!"));
+            creature.notify_self(_("素早く動けるようになった！", "You feel yourself moving much faster!"));
             notice = true;
             chg_virtue(creature, Virtue::PATIENCE, -1);
             chg_virtue(creature, Virtue::DILIGENCE, 1);
@@ -146,7 +146,7 @@ bool set_acceleration(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
             auto is_singing = music_singing(creature, MUSIC_SPEED);
             is_singing |= music_singing(creature, MUSIC_SHERO);
             if (!is_singing) {
-                msg_print(_("動きの素早さがなくなったようだ。", "You feel yourself slow down."));
+                creature.notify_self(_("動きの素早さがなくなったようだ。", "You feel yourself slow down."));
                 sound(SoundKind::BUFF_EXPIRE);
                 notice = true;
             }
@@ -193,12 +193,12 @@ bool set_shield(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
                 return false;
             }
         } else if (!creature.get_timed_effect(CreatureTimedEffect::SHIELD)) {
-            msg_print(_("肌が石になった。", "Your skin turns to stone."));
+            creature.notify_self(_("肌が石になった。", "Your skin turns to stone."));
             notice = true;
         }
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::SHIELD)) {
-            msg_print(_("肌が元に戻った。", "Your skin returns to normal."));
+            creature.notify_self(_("肌が元に戻った。", "Your skin returns to normal."));
             sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
@@ -242,12 +242,12 @@ bool set_magicdef(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
                 return false;
             }
         } else if (!creature.get_timed_effect(CreatureTimedEffect::MAGICDEF)) {
-            msg_print(_("魔法の防御力が増したような気がする。", "You feel more resistant to magic."));
+            creature.notify_self(_("魔法の防御力が増したような気がする。", "You feel more resistant to magic."));
             notice = true;
         }
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::MAGICDEF)) {
-            msg_print(_("魔法の防御力が元に戻った。", "You feel less resistant to magic."));
+            creature.notify_self(_("魔法の防御力が元に戻った。", "You feel less resistant to magic."));
             sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
@@ -291,12 +291,12 @@ bool set_blessed(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
                 return false;
             }
         } else if (!creature.is_blessed()) {
-            msg_print(_("高潔な気分になった！", "You feel righteous!"));
+            creature.notify_self(_("高潔な気分になった！", "You feel righteous!"));
             notice = true;
         }
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::BLESSED) && !music_singing(creature, MUSIC_BLESS)) {
-            msg_print(_("高潔な気分が消え失せた。", "The prayer has expired."));
+            creature.notify_self(_("高潔な気分が消え失せた。", "The prayer has expired."));
             sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
@@ -340,12 +340,12 @@ bool set_hero(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
                 return false;
             }
         } else if (!creature.is_hero()) {
-            msg_print(_("ヒーローになった気がする！", "You feel like a hero!"));
+            creature.notify_self(_("ヒーローになった気がする！", "You feel like a hero!"));
             notice = true;
         }
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::HERO) && !music_singing(creature, MUSIC_HERO) && !music_singing(creature, MUSIC_SHERO)) {
-            msg_print(_("ヒーローの気分が消え失せた。", "The heroism wears off."));
+            creature.notify_self(_("ヒーローの気分が消え失せた。", "The heroism wears off."));
             sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
@@ -394,7 +394,7 @@ bool set_mimic(CreatureEntity &creature, TIME_EFFECT v, MimicKindType mimic_race
                 return false;
             }
         } else if ((!creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC)) || (creature.get_mimic_form() != mimic_race_idx)) {
-            msg_print(_("自分の体が変わってゆくのを感じた。", "You feel that your body changes."));
+            creature.notify_self(_("自分の体が変わってゆくのを感じた。", "You feel that your body changes."));
             creature.set_mimic_form(mimic_race_idx);
             notice = true;
         }
@@ -402,7 +402,7 @@ bool set_mimic(CreatureEntity &creature, TIME_EFFECT v, MimicKindType mimic_race
 
     else {
         if (creature.get_timed_effect(CreatureTimedEffect::TIM_MIMIC)) {
-            msg_print(_("変身が解けた。", "You are no longer transformed."));
+            creature.notify_self(_("変身が解けた。", "You are no longer transformed."));
             sound(SoundKind::BUFF_EXPIRE);
             if (creature.get_mimic_form() == MimicKindType::DEMON) {
                 set_oppose_fire(creature, 0, true);
@@ -464,13 +464,13 @@ bool set_berserk(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
                 return false;
             }
         } else if (!creature.get_timed_effect(CreatureTimedEffect::BERSERK)) {
-            msg_print(_("殺戮マシーンになった気がする！", "You feel like a killing machine!"));
+            creature.notify_self(_("殺戮マシーンになった気がする！", "You feel like a killing machine!"));
             notice = true;
         }
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::BERSERK)) {
             sound(SoundKind::BUFF_EXPIRE);
-            msg_print(_("野蛮な気持ちが消え失せた。", "You feel less berserk."));
+            creature.notify_self(_("野蛮な気持ちが消え失せた。", "You feel less berserk."));
             notice = true;
         }
     }
@@ -522,7 +522,7 @@ bool set_wraith_form(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
                 return false;
             }
         } else if (!creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
-            msg_print(_("物質界を離れて幽鬼のような存在になった！", "You leave the physical world and turn into a wraith-being!"));
+            creature.notify_self(_("物質界を離れて幽鬼のような存在になった！", "You leave the physical world and turn into a wraith-being!"));
             notice = true;
             chg_virtue(creature, Virtue::UNLIFE, 3);
             chg_virtue(creature, Virtue::HONOUR, -2);
@@ -534,7 +534,7 @@ bool set_wraith_form(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::WRAITH_FORM)) {
-            msg_print(_("不透明になった感じがする。", "You feel opaque."));
+            creature.notify_self(_("不透明になった感じがする。", "You feel opaque."));
             sound(SoundKind::BUFF_EXPIRE);
             notice = true;
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
@@ -580,14 +580,14 @@ bool set_tsuyoshi(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
                 return false;
             }
         } else if (!creature.get_timed_effect(CreatureTimedEffect::TSUYOSHI)) {
-            msg_print(_("「オクレ兄さん！」", "Brother OKURE!"));
+            creature.notify_self(_("「オクレ兄さん！」", "Brother OKURE!"));
             notice = true;
             chg_virtue(creature, Virtue::VITALITY, 2);
         }
     } else {
         if (creature.get_timed_effect(CreatureTimedEffect::TSUYOSHI)) {
             sound(SoundKind::BUFF_EXPIRE);
-            msg_print(_("肉体が急速にしぼんでいった。", "Your body has quickly shriveled."));
+            creature.notify_self(_("肉体が急速にしぼんでいった。", "Your body has quickly shriveled."));
 
             (void)dec_stat(creature, A_CON, 20, true);
             (void)dec_stat(creature, A_STR, 20, true);

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -58,6 +58,7 @@
 #include "tracking/lore-tracker.h"
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
+#include "view/display-messages.h"
 #include "world/world.h"
 #include <algorithm>
 #include <range/v3/algorithm.hpp>
@@ -143,6 +144,13 @@ void CreatureEntity::consume_energy_by_speed(int speed_value)
 bool CreatureEntity::does_save_against(int power) const
 {
     return randint0(100 + power / 2) < this->get_skill_save();
+}
+
+void CreatureEntity::notify_self(std::string_view message) const
+{
+    if (this->is_player()) {
+        msg_print(message);
+    }
 }
 
 void CreatureEntity::plus_incident(INCIDENT incidentID, int num)

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -952,6 +952,17 @@ public:
     tl::optional<std::string> get_pain_message(std::string_view monster_name, int damage) const;
 
     /*!
+     * @brief クリーチャー自身に関する状態メッセージを表示する (提案D2 メッセージ seam)
+     * @param message 2 人称の状態メッセージ (プレイヤー視点文)
+     * @details プレイヤーなら `msg_print()` で表示、それ以外 (モンスター) では表示しない。
+     *          状態異常/バフ setter 群の 2 人称メッセージをこの seam に載せ替えることで、
+     *          プレイヤー挙動を完全保存しつつ、それらの setter をモンスターにも安全に
+     *          適用できるようにする (モンスターは 2 人称文を出さない)。将来モンスター
+     *          視認時の 3 人称文へ拡張する余地を残す。定義は creature-entity.cpp。
+     */
+    void notify_self(std::string_view message) const;
+
+    /*!
      * @brief カメレオンの変身を元に戻す。
      * @details r_idx と ap_r_idx を実種族IDにリセットする。
      */


### PR DESCRIPTION
D トラック"同化"の中核。既に creature-general な回復・状態治療関数群をモンスターへ 開くため、2人称メッセージをプレイヤー限定表示にする seam を導入。

- CreatureEntity::notify_self(string_view) を新設（player: msg_print / else: 無表示）
- bad-status-setter(26) + buff-setter(18) の計44箇所を msg_print → notify_self へ 機械置換。player では notify_self ≡ msg_print のため挙動完全不変（現行 setter 呼出は 全てプレイヤー、monster は set_monster_* 経由で別系統）
- 回復6関数（heroism/berserk/cure_light/serious/critical_wounds/true_healing）の is_player ガードを撤去。本体は creature-general プリミティブのみで、メッセージは seam でプレイヤーのみ表示されるためモンスターにも安全。現状 monster 呼出は無く 既存挙動は不変（enabling 変更）

残（第2弾）: restore_all_status/status_shuffle/life_stream のガード除去、 notify_self のモンスター視認時3人称文への拡張。

フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added creature-specific status messages that still show for players but stay silent for monsters.
  * Healing and buff effects can now apply to non-player creatures more safely.

* **Bug Fixes**
  * Improved status updates for effects like fear, poison, paralysis, blindness, confusion, stun, and timed buffs.
  * Recovery and healing now continue correctly without being blocked by player-only checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->