### PR TITLE
refactor: 能力値回復系のガード除去 + base-status メッセージ gate（提案D2 第2弾）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3383,7 +3383,7 @@ A/B と違い挙動が変わるため、対象範囲と数値はメンテナ判�
 | 番号 | 提案 | 種別 | 工数 | 価値 | 状態 |
 |---|---|---|---|---|---|
 | D1 | セービングスロー述語 `does_save_against()` 統一 | 純粋refactor | 小 | 中 | ✅ 完了 |
-| D2 | 回復・状態治療関数の is_player ガード除去 + メッセージ seam | 同化中核 | 中〜大 | 高 | ✅ 第1弾完了（seam + 回復6関数） |
+| D2 | 回復・状態治療関数の is_player ガード除去 + メッセージ seam | 同化中核 | 中〜大 | 高 | ✅ 完了（回復・治療9関数＋能力値回復） |
 | D3 | 統一クリーチャーテレポートプリミティブ | primitive | 中 | 中 | 計画 |
 | D4 | 属性ダメージ分類器（immune/resist/vuln）の共通化 | primitive | 中 | 中 | 計画 |
 | D5 | 小規模統合（charm/control セーヴ統合ほか） | 純粋refactor | 小 | 低〜中 | ✅ 完了（charm/control。他2件は精査の上見送り） |
@@ -3429,13 +3429,22 @@ effect-monster-charm / mspell-status / mspell-floor / effect-player-resist-hurt�
 
 - フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。
 
-### 第2弾以降（残）
+### ✅ 第2弾 完了内容（能力値回復系 + life_stream）
 
-- 残る回復・治療系（`restore_all_status:527` / `status_shuffle:693` / `life_stream`
-  tail）のガード除去（`do_res_stat` 等は既に creature-general）。
+- `restore_all_status` / `status_shuffle` / `life_stream` tail の `is_player` ガードを撤去。
+- `base-status.cpp` の能力値メッセージ（`do_dec_stat` / `do_res_stat` / `do_inc_stat`
+  の `msg_format` 4 箇所）を `if (creature.is_player())` でガード（可変長メッセージのため
+  string_view seam ではなく inline gate、挙動はプレイヤー保存）。`status_shuffle` は
+  メッセージ無しの純粋能力値入替のためガード除去のみ。`life_stream` 冒頭の
+  `msg_print` は `notify_self` へ載せ替え。
+- フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。**回復・状態治療系 9 関数
+  ＋能力値回復がモンスターに安全に適用可能**になった（現状 monster 呼出は無く挙動不変）。
+
+### 第3弾以降（残）
+
 - `notify_self` を**モンスター視認時の 3 人称文**へ拡張（現状はモンスター無表示）。
 - setter 群の残るプレイヤー専用テール（stance / spell 停止 / redraw）は no-op で
-  モンスター無害だが、必要なら虚拟化で整理。
+  モンスター無害だが、必要なら virtual 化で整理。
 - これにより「モンスターの回復・状態治療」を実際に使う機能（C トラックの回復
   モンスター等）への足場が完成する。
 

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -269,14 +269,13 @@ bool life_stream(CreatureEntity &creature, bool message, bool virtue_change)
     }
 
     if (message) {
-        msg_print(_("体中に生命力が満ちあふれてきた！", "You feel life flow through your body!"));
+        creature.notify_self(_("体中に生命力が満ちあふれてきた！", "You feel life flow through your body!"));
     }
 
     restore_level(creature);
-    if (!creature.is_player()) {
-        return true;
-    }
 
+    // [提案D2] 以降の治療系は setter/do_res_stat 側でメッセージがプレイヤー限定に
+    // なるため、モンスターにも安全。ガード撤去。
     BadStatusSetter bss(creature);
     (void)bss.set_poison(0);
     (void)bss.set_blindness(0);
@@ -507,10 +506,7 @@ bool restore_mana(CreatureEntity &creature, bool magic_eater)
 
 bool restore_all_status(CreatureEntity &creature)
 {
-    if (!creature.is_player()) {
-        return false;
-    }
-
+    // [提案D2] メッセージは do_res_stat 側でプレイヤーのみ表示されるためガード撤去。
     bool ident = false;
     if (do_res_stat(creature, A_STR)) {
         ident = true;
@@ -673,10 +669,7 @@ void apply_nexus(const CreatureEntity &attacker, CreatureEntity &creature)
  */
 void status_shuffle(CreatureEntity &creature)
 {
-    if (!creature.is_player()) {
-        return;
-    }
-
+    // [提案D2] メッセージ無しの純粋な能力値入替のためモンスターにも安全。ガード撤去。
     /* Pick a pair of stats */
     int i = randint0(A_MAX);
     int j;

--- a/src/status/base-status.cpp
+++ b/src/status/base-status.cpp
@@ -244,12 +244,17 @@ bool do_dec_stat(CreatureEntity &creature, int stat)
     }
 
     if (sust && (!ironman_nightmare || randint0(13))) {
-        msg_format(_("%sなった気がしたが、すぐに元に戻った。", "You feel %s for a moment, but the feeling passes."), desc_stat_neg[stat]);
+        // [提案D2] 2人称メッセージはプレイヤーのみ (モンスターも安全に呼べるように)
+        if (creature.is_player()) {
+            msg_format(_("%sなった気がしたが、すぐに元に戻った。", "You feel %s for a moment, but the feeling passes."), desc_stat_neg[stat]);
+        }
         return true;
     }
 
     if (dec_stat(creature, stat, 10, (ironman_nightmare && !randint0(13)))) {
-        msg_format(_("ひどく%sなった気がする。", "You feel %s."), desc_stat_neg[stat]);
+        if (creature.is_player()) {
+            msg_format(_("ひどく%sなった気がする。", "You feel %s."), desc_stat_neg[stat]);
+        }
         return true;
     }
 
@@ -262,7 +267,9 @@ bool do_dec_stat(CreatureEntity &creature, int stat)
 bool do_res_stat(CreatureEntity &creature, int stat)
 {
     if (res_stat(creature, stat)) {
-        msg_format(_("元通りに%sなった気がする。", "You feel %s."), desc_stat_pos[stat]);
+        if (creature.is_player()) {
+            msg_format(_("元通りに%sなった気がする。", "You feel %s."), desc_stat_pos[stat]);
+        }
         return true;
     }
 
@@ -286,12 +293,16 @@ bool do_inc_stat(CreatureEntity &creature, int stat)
             chg_virtue(creature, Virtue::VITALITY, 1);
         }
 
-        msg_format(_("ワーオ！とても%sなった！", "Wow! You feel %s!"), desc_stat_pos[stat]);
+        if (creature.is_player()) {
+            msg_format(_("ワーオ！とても%sなった！", "Wow! You feel %s!"), desc_stat_pos[stat]);
+        }
         return true;
     }
 
     if (res) {
-        msg_format(_("元通りに%sなった気がする。", "You feel %s."), desc_stat_pos[stat]);
+        if (creature.is_player()) {
+            msg_format(_("元通りに%sなった気がする。", "You feel %s."), desc_stat_pos[stat]);
+        }
         return true;
     }
 


### PR DESCRIPTION
D2 第1弾（seam + 回復6関数）に続き、残る回復・治療系のモンスター安全化を完了。

- restore_all_status / status_shuffle / life_stream tail の is_player ガードを撤去
- base-status.cpp の能力値メッセージ（do_dec_stat / do_res_stat / do_inc_stat の msg_format 4箇所）を if (creature.is_player()) で gate（可変長のため string_view seam でなく inline gate、return true は外側に残しプレイヤー挙動保存）
- status_shuffle はメッセージ無しの純粋能力値入替のためガード除去のみ
- life_stream 冒頭の msg_print は notify_self へ載せ替え

これで回復・状態治療系9関数＋能力値回復がモンスターに安全に適用可能に。現状
monster 呼出は無く挙動不変（enabling 変更）。

フルビルド (g++ -O3 -Werror -Wall -Wextra) と clang-format-18 で検証。