### PR TITLE
feat: モンスターの継続毒(poison DoT)を JSON でオプトイン可能に（提案D7）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -736,6 +736,30 @@ HISSATSU / HEX）を参照。
 - 実際に撃たせるには当該 monrace に `freq_spell > 0`（詠唱頻度）が必要。
 - 既定 `NONE` のため実データ・既定バランスは不変。スキーマに `realm_abilities` を登録済。
 
+### モンスターの継続毒 (`suffers_poison_dot`) — 提案 D7
+
+`MonraceDefinition` に `bool suffers_poison_dot`
+(`src/system/monrace/monrace-definition.h`) を持ち、JSON
+`lib/edit/MonraceDefinitions.jsonc` で個別モンスターが毒攻撃で継続毒 (POISON DoT) を
+受けるようにできる。D トラック（処理同化）で判明した「モンスターは POISON を持てても
+per-turn で発火しない（切り傷・毒の inflict 経路が無い）」ギャップを、**JSON オプトイン
+方式**（既定 `false`=無効でバランス不変）の小機能として埋めたもの。
+
+```jsonc
+"suffers_poison_dot": true
+```
+
+- **inflict:** `effect_monster_pois`（`src/effect/effect-monster-resist-hurt.cpp`）で、
+  毒免疫でなく `suffers_poison_dot` が立つ個体は毒攻撃を受けると `POISON` タイマーを
+  `max(1, dam/2)` 蓄積する。
+- **tick:** `process_world()`（`TURNS_PER_TICK`=10 ゲームターン周期、プレイヤーの毒 DoT
+  と同一）で `POISON>0` のモンスターに 1/ターンの毒ダメージを `MonsterDamageProcessor`
+  (`AttributeType::POIS`) で与え、`POISON` を 1 減らす。無敵中はスキップ。死亡時は
+  ドロップ・経験値も正規経路で処理。
+- 既定 OFF のため誰にも POISON が蓄積せず**既定バランス不変**。蓄積量 (`dam/2`)・
+  tick 量 (1) で調整可能。cut DoT は近接由来で inflict 経路が別のため今回は poison のみ。
+- スキーマに `suffers_poison_dot` を登録済。
+
 ### モンスターのレベル別HPダイス指定 (`hit_point_per_level`)
 
 `MonraceDefinition` に `Dice hit_dice_per_level`

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3388,7 +3388,7 @@ A/B と違い挙動が変わるため、対象範囲と数値はメンテナ判�
 | D4 | 属性ダメージ分類器（immune/resist/vuln）の共通化 | primitive | 中 | 中 | ✅ 第1弾完了（monster側 immune/hurt 共通化） |
 | D5 | 小規模統合（charm/control セーヴ統合ほか） | 純粋refactor | 小 | 低〜中 | ✅ 完了（charm/control。他2件は精査の上見送り） |
 | D6 | spoiler/lore の PlayerType dummy 軽量化（※前提訂正） | 構造 | 小 | 低 | 計画（低優先・前提誤り訂正済） |
-| D7 | モンスターの cut/poison DoT（per-turn 未発火のギャップ） | 機能(C隣接) | 中 | 中 | 計画 |
+| D7 | モンスターの poison DoT（opt-in 機能） | 機能(C隣接) | 中 | 中 | ✅ 完了（poison、opt-in・既定OFF） |
 
 ---
 
@@ -3561,13 +3561,26 @@ virtual へ hoist し `const_cast<PlayerType&>` を排除、は独立の小整�
 
 ## 提案 D7: モンスターの cut/poison DoT（per-turn ギャップ）
 
-**現状:** cut/poison の毎ターンダメージ・自然減少は**プレイヤー専用**
-(`hp-mp-processor.cpp:124-135` / `magic-effects-timeout-reducer.cpp:235-252`)。
-CUT/POISON は `MONSTER_TIMED_EFFECT_LIST` に無いため、モンスターは値を持てても
-**発火しない**（切り傷・毒を与えても無害）。これは重複ではなく**ギャップ**で、
-統一とは「モンスター per-turn 経路に CUT/POISON tick を追加する」機能実装
-（C トラック隣接、opt-in 検討）。**工数:** 中。**価値:** 中（状態異常のモンスター
-運用が意味を持つ）。
+### ✅ 完了（poison DoT、opt-in・既定OFF）
+
+**着手前検証:** cut/poison の毎ターン処理はプレイヤー専用で、モンスターに
+**positive な cut/poison を与える経路が存在しない**（monster-processor は 0 セットのみ、
+BadStatusSetter は実質プレイヤー専用）。よって tick だけ足しても dead code。
+→ **重複解消ではなく「inflict＋tick」の小機能**として、C トラック方針の
+**JSON オプトイン・既定OFF**で実装。
+
+**完了内容（poison に限定）:**
+- `MonraceDefinition::suffers_poison_dot`（bool、既定 false）+ reader + schema。
+- **inflict:** `effect_monster_pois`（D4 で整理済）で、免疫でなく `suffers_poison_dot`
+  が立つ個体は毒攻撃で `POISON` を `max(1, dam/2)` 蓄積（`MAX_SHORT` クランプ）。
+- **tick:** `process_world()`（10 ゲームターン周期、プレイヤー毒 DoT と同一）で
+  `POISON>0` のモンスターに 1/ターンの毒ダメージを `MonsterDamageProcessor`
+  (`AttributeType::POIS`) で与え、`POISON` を 1 減らす。無敵中はスキップ。死亡時は
+  ドロップ・経験値含め正規経路で処理。
+- **既定 OFF のため誰にも POISON が蓄積せず、既定バランス完全不変。** 蓄積量
+  (`dam/2`) と tick 量 (1) で調整可能。cut DoT は近接由来で inflict 経路が別のため
+  今回は poison のみ（将来同様に opt-in 拡張可）。
+- フルビルド (g++ -O3 -Werror) / clang-format-18 / validate_json.py で検証済。
 
 ---
 

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -193,6 +193,10 @@
                         "type": "string",
                         "description": "詠唱能力を付与する魔法領域 (提案C6)。トークンは r_info_realm を参照。指定するとその realm 由来の MonsterAbilityType が詠唱時に追加される。既定=なし=オプトイン。"
                     },
+                    "suffers_poison_dot": {
+                        "type": "boolean",
+                        "description": "毒攻撃で継続毒(POISON DoT)を受けるか (提案D7)。既定false=オプトイン。trueの個体のみ毒攻撃後に継続ダメージを受ける。"
+                    },
                     "odds_correction_ratio": {
                         "type": "integer",
                         "description": "闘技場オッズ補正値。1/100を使用、100で等倍200で2倍",

--- a/src/effect/effect-monster-resist-hurt.cpp
+++ b/src/effect/effect-monster-resist-hurt.cpp
@@ -6,10 +6,12 @@
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
 #include "system/creature-entity.h"
+#include "system/creature-timed-effect-types.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
 #include "util/bit-flags-calculator.h"
+#include <algorithm>
 
 namespace {
 /*!
@@ -125,6 +127,15 @@ ProcessResult effect_monster_pois(CreatureEntity &creature, EffectMonster *em_pt
 
     if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::IMMUNE_POISON)) {
         apply_monster_element_immune(creature, em_ptr, MonsterResistanceType::IMMUNE_POISON);
+        return ProcessResult::PROCESS_CONTINUE;
+    }
+
+    // [提案D7] suffers_poison_dot が立つ個体は毒攻撃で継続毒 (POISON DoT) を蓄積する。
+    // 既定OFFのためバランス不変。蓄積量はダメージの半分で有界 (毎ターン 1 ずつ処理される)。
+    if (em_ptr->monrace->suffers_poison_dot && (em_ptr->dam > 0)) {
+        const auto added = std::max(1, em_ptr->dam / 2);
+        const auto current = em_ptr->m_ptr->get_timed_effect(CreatureTimedEffect::POISON);
+        em_ptr->m_ptr->set_timed_effect(CreatureTimedEffect::POISON, static_cast<short>(std::min<int>(MAX_SHORT, current + added)));
     }
 
     return ProcessResult::PROCESS_CONTINUE;

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -1551,6 +1551,11 @@ errr RaceReader::read()
         msg_format(_("モンスター魔法領域読込失敗。ID: '%d'。", "Failed to load monster realm_abilities. ID: '%d'."), error_idx);
         return err;
     }
+    err = info_set_bool(mon_data["suffers_poison_dot"], monrace.suffers_poison_dot, false);
+    if (err) {
+        msg_format(_("モンスター継続毒フラグ読込失敗。ID: '%d'。", "Failed to load monster suffers_poison_dot. ID: '%d'."), error_idx);
+        return err;
+    }
     err = info_set_integer(mon_data["odds_correction_ratio"], monrace.arena_ratio, false, Range(1, 9999));
     if (err) {
         msg_format(_("モンスター賭け倍率読込失敗。ID: '%d'。", "Failed to load monster odds for arena. ID: '%d'."), error_idx);

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -137,6 +137,7 @@ public:
     bool consumes_mp = false; //!< 呪文詠唱時に MP を消費するか (提案C4。既定false=オプトイン。既定バランス不変)
     EnumClassFlagGroup<PlayerMutationType> mutations{}; //!< 生成時に付与する突然変異 (提案C5。空=なし=オプトイン)
     RealmType realm_abilities = RealmType::NONE; //!< 詠唱能力を付与する魔法領域 (提案C6。NONE=なし=オプトイン。詠唱時に realm 由来の MonsterAbilityType を追加)
+    bool suffers_poison_dot = false; //!< 毒攻撃で継続毒(POISON DoT)を受けるか (提案D7。既定false=オプトイン。既定バランス不変)
     EnumClassFlagGroup<MonsterFeedType> meat_feed_flags;
     EnumClassFlagGroup<MonsterAbilityType> ability_flags; //!< 能力フラグ(魔法/ブレス) / Ability Flags
     EnumClassFlagGroup<MonsterAuraType> aura_flags; //!< オーラフラグ / Aura Flags

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -3,6 +3,7 @@
 #include "core/disturbance.h"
 #include "core/magic-effects-timeout-reducer.h"
 #include "dungeon/quest.h"
+#include "effect/attribute-types.h"
 #include "floor/floor-events.h"
 #include "floor/floor-mode-changer.h"
 #include "floor/wild.h"
@@ -18,6 +19,7 @@
 #include "market/bounty.h"
 #include "monster-floor/monster-generator.h"
 #include "monster-floor/monster-summon.h"
+#include "monster/monster-damage.h"
 #include "monster/monster-describer.h"
 #include "monster/monster-status.h"
 #include "monster/monster-timed-effects.h"
@@ -32,6 +34,7 @@
 #include "system/angband-system.h"
 #include "system/building-type-definition.h"
 #include "system/creature-entity.h"
+#include "system/creature-timed-effect-types.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/enums/dungeon/dungeon-id.h"
 #include "system/floor/floor-info.h"
@@ -108,6 +111,23 @@ void WorldTurnProcessor::process_world()
             continue;
         }
         process_monster_mutation(this->creature, monster);
+    }
+
+    // [提案 D7] 継続毒 (POISON) を受けたモンスターの毎ターン毒ダメージ。プレイヤーの
+    // 毒 DoT (process_player_hp_mp、1/ターン) と同一周期・同一量。POISON は
+    // suffers_poison_dot 個体にしか蓄積しないため、既定では誰にも発火しない。
+    for (MONSTER_IDX m_idx = 1; m_idx < floor_mut.m_max; m_idx++) {
+        auto &monster = floor_mut.m_list[m_idx];
+        if (!monster.is_valid() || (monster.get_timed_effect(CreatureTimedEffect::POISON) <= 0) || monster.is_invulnerable()) {
+            continue;
+        }
+        auto fear = false;
+        MonsterDamageProcessor mdp(this->creature, m_idx, 1, &fear, AttributeType::POIS);
+        if (mdp.mon_take_hit(_("は毒で倒れた。", " dies from poison."))) {
+            continue; // 死亡済 (monster は削除されている)
+        }
+        const auto poison = monster.get_timed_effect(CreatureTimedEffect::POISON);
+        monster.set_timed_effect(CreatureTimedEffect::POISON, static_cast<short>(poison - 1));
     }
 
     process_world_aux_sudden_attack(this->creature);


### PR DESCRIPTION
D トラックで判明した「モンスターは POISON を持てても per-turn で発火せず、positive な 毒を与える経路も無い」ギャップを、C トラック方針の JSON オプトイン・既定OFFで埋める
小機能として実装（dead code を避け、inflict＋tick を揃える）。

- MonraceDefinition に suffers_poison_dot (bool, 既定 false) + reader + schema
- inflict: effect_monster_pois で、免疫でなく suffers_poison_dot が立つ個体は毒攻撃で POISON を max(1, dam/2) 蓄積（MAX_SHORT クランプ）
- tick: process_world()（10ゲームターン周期・プレイヤー毒DoTと同一）で POISON>0 の モンスターに 1/ターンの毒ダメージを MonsterDamageProcessor(POIS) で与え POISON を 1 減らす。無敵中スキップ、死亡は正規経路でドロップ/経験値処理
- 既定 OFF のため誰にも POISON が蓄積せず既定バランス不変。cut DoT は inflict 経路が 別（近接由来）のため今回は poison のみ

フルビルド (g++ -O3 -Werror -Wall -Wextra) / clang-format-18 / validate_json.py で検証。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional continuous poison damage for selected monsters.
  * Monsters can now be configured to take ongoing poison damage after being hit by poison attacks.

* **Bug Fixes**
  * Poison damage now ticks over time and decreases gradually.
  * Monsters that are invulnerable are skipped, and defeated monsters continue through the normal drop/experience flow.

* **Documentation**
  * Updated design notes and schema details to reflect the new monster setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->