### PR TITLE
refactor: print_title の is_player 分岐を CreatureEntity::get_title() vir…

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3622,7 +3622,7 @@ virtual 化・処理の同化・機能付与** がほぼ出揃った。E トラ�
 | E2 | `const_cast<PlayerType&>` 排除（CreatureClass const ビューコンストラクタ） | const 衛生 | 小 | 中 | ✅ 完了 |
 | E3 | シリアライズ共通ブロック拡張（`prace`/`pclass`） | 重複解消 | 中 | 中 | ✅ 完了（version 54 bump） |
 | E4 | インライン accessor 本体（約 480 個）の .cpp 移設 | ビルド衛生 | 大（機械的） | 中 | 計画（小刻みコミット） |
-| E5 | `is_player()` 自由関数分岐（約 101 箇所）の virtual 化 | 同化 | 大 | 中 | 計画（サイト別判断） |
+| E5 | `is_player()` 自由関数分岐の virtual 化 | 同化 | 大 | 中 | ✅ 第1弾完了（`get_title()`。残候補は少数・据え置き） |
 
 ---
 
@@ -3728,16 +3728,43 @@ accessor が約 480 個。**692 TU がこのヘッダに fan-out** するため�
 
 ---
 
-## 提案 E5: `is_player()` 自由関数分岐（約 101 箇所）の virtual 化
+## 提案 E5: `is_player()` 自由関数分岐の virtual 化 ✅ 第1弾完了
 
-**現状:** 提案 35 でヘッダ内の機械的冗長ガードは掃除済だが、自由関数側には
-`if (creature.is_player()) { ... } else { ... }` の**真の振る舞い分岐が約 101 箇所**残る。
-これらは型契約ではなく実際にプレイヤー/モンスターで処理が分かれる本丸。
+**全サイト調査結論（75 個の `CreatureEntity::is_player()` 実サイトを分類）:**
+生 grep 約 93 件のうち `EffectMonster::is_player()` / `EffectPlayerType::is_player()`
+（別ラッパクラス）・ヘッダ宣言・コメントを除いた **75 個が実サイト**。内訳:
 
-**修正案:** サイトごとに「プレイヤー/モンスターで意味が対称化できるか」を判断し、
-対称化できるものは `CreatureEntity` virtual に押し込む（B トラック D2 と同じ同化手法）。
-機械的一括は不可でサイト別判断が要るため工数大・価値中。同化トラック（B/D）の
-継続として、個別に価値の高いサイトから拾う運用が現実的。
+- **バケット A（virtual 化可能）: 4 個のみ。** `if (is_player()) {...} else {...}` の
+  両枝が同じ論理値を型別に算出する真の対称分岐。
+- **バケット B（型契約ガード）: 69 個。** `if (!is_player()) return;` 等の早期 return /
+  プレイヤー専用副作用ガード。提案 35 の結論通り、これらは型契約であり削減対象外。
+- **バケット C（本質的発散）: 2 個。** 描画サブシステム dispatch 等、小 virtual に
+  畳めない大規模型別処理。
+
+→ **E5 は提案 35 時点で既にほぼ枯渇しており、機械的 virtual 化余地は 4 サイトのみ。**
+
+**第1弾 完了内容（A2: `get_title()`）:**
+- `print_title()`（`main-window-left-frame.cpp`）の `is_player()` 4 分岐（None /
+  wizard / winner / 職業別称号）を `CreatureEntity::get_title()` virtual に集約。
+  基底（モンスター）は "なし"、`PlayerType::get_title()` override が
+  wizard / winner / 職業・レベル別称号を返す。呼出側は
+  `print_field(creature.get_title(), ...)` に簡素化。
+- 称号は「クリーチャーの表示属性」でありモンスターに既定値を持たせる形は
+  CLAUDE.md のプレイヤー属性共通化方針（`get_pclass()` 等と同じ）に合致。
+- フルビルド（g++ -O3 -Werror）で検証済。
+
+**据え置いた A 候補（3 個、理由付き）:**
+- **A1 `cmd-draw.cpp:174`（ステータス画面プロンプト文字列）:** UI キーヒント文字列の
+  選択。UI 層の局所三項が適切で、`CreatureEntity` に UI 文字列を持たせる価値は低い。
+- **A3 `main-window-left-frame.cpp:83`（exp 表示値）:** プレイヤー枝に android /
+  `exp_need` の残余分岐があり、単純 getter に畳めない。
+- **A4 `melee-util.cpp:18`（近接イベント知覚フィールド）:** 複数フィールド（see_m /
+  see_t / do_silly_attack）を設定するため単一 virtual に畳めない。
+
+**結論:** E5 の機械的 virtual 化は `get_title()` で実質完了。残る 69 ガードは型契約、
+2 サイトは本質的発散、3 A 候補は上記理由で据え置き。今後の「モンスターにも
+振る舞いを持たせる」拡張はガード除去＋モンスター実装（C/D トラックの機能作業）で
+個別に扱う方針。
 
 ---
 

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -1888,6 +1888,16 @@ PLAYER_LEVEL CreatureEntity::get_level() const
 }
 
 /*!
+ * @brief 表示用の称号を取得する (提案 E5, 基底 = モンスター既定)
+ * @details モンスターは称号を持たないため "なし" を返す。プレイヤーは
+ * PlayerType::get_title() override が wizard / winner / 職業別称号を返す。
+ */
+std::string CreatureEntity::get_title() const
+{
+    return _("なし", "None");
+}
+
+/*!
  * @brief モンスターの個体加速を設定する / Get initial monster speed
  * @param force_fixed_speed 速度を固定にする(個体差を適用しない)か否か
  */

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -542,6 +542,14 @@ public:
     }
 
     /*!
+     * @brief 表示用の称号を取得する (提案 E5)
+     * @details プレイヤーは wizard / winner 状態や職業・レベル別称号を返す。
+     * モンスターは既定で "なし" を返す (将来モンスター固有の称号運用の余地)。
+     * 本体は creature-entity.cpp (基底) / player-type-definition.cpp (override) に定義。
+     */
+    virtual std::string get_title() const;
+
+    /*!
      * @brief 第 1 魔法領域 enum を取得する (提案 1/2)
      * @details モンスターは init_monster_profile() で RealmType::NONE に
      * 初期化されており、魔法領域効果は発動しない (NONE ガード前提)。

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -1,5 +1,9 @@
 #include "system/player-type-definition.h"
+#include "locale/language-switcher.h"
+#include "player-info/class-info.h"
 #include "system/creature-entity.h"
+#include "world/world.h"
+#include <algorithm>
 
 /*!
  * @brief プレイヤー構造体実体 / Static player info record
@@ -42,4 +46,25 @@ bool PlayerType::is_player() const
 void PlayerType::wipe()
 {
     *this = {};
+}
+
+/*!
+ * @brief 表示用の称号を取得する (提案 E5, プレイヤー override)
+ * @details wizard モード / 勝利者状態を最優先し、通常時は職業・レベル別称号を返す。
+ * 旧 print_title() の is_player() 分岐をここへ集約 (基底は "なし" を返す)。
+ */
+std::string PlayerType::get_title() const
+{
+    const auto &world = AngbandWorld::get_instance();
+    if (world.wizard) {
+        return _("［ウィザード］", "[=-WIZARD-=]");
+    }
+
+    if (world.total_winner) {
+        return world.is_player_true_winner() ? _("*真・勝利者*", "*TRUEWINNER*") : _("***勝利者***", "***WINNER***");
+    }
+
+    const auto &titles = player_titles.at(this->get_pclass());
+    const auto title_index = std::min(static_cast<size_t>((this->get_level() - 1) / 5), titles.size() - 1);
+    return titles.at(title_index);
 }

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -23,6 +23,8 @@ public:
 
     void wipe() override;
 
+    std::string get_title() const override;
+
     /*!
      * @brief プレイヤー唯一のインスタンスを取得する
      * @return プレイヤーインスタンスへの参照

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -36,25 +36,9 @@ struct condition_layout_info {
  */
 void print_title(CreatureEntity &creature)
 {
-    std::string p;
-    const auto &world = AngbandWorld::get_instance();
-    if (!creature.is_player()) {
-        p = _("なし", "None");
-    } else if (world.wizard) {
-        p = _("［ウィザード］", "[=-WIZARD-=]");
-    } else if (world.total_winner) {
-        if (world.is_player_true_winner()) {
-            p = _("*真・勝利者*", "*TRUEWINNER*");
-        } else {
-            p = _("***勝利者***", "***WINNER***");
-        }
-    } else {
-        const auto &titles = player_titles.at(creature.get_pclass());
-        const auto title_index = std::min(static_cast<size_t>((creature.get_level() - 1) / 5), titles.size() - 1);
-        p = titles.at(title_index);
-    }
-
-    print_field(p, ROW_TITLE, COL_TITLE);
+    // 称号算出は CreatureEntity::get_title() virtual に集約 (提案 E5)。
+    // プレイヤーは wizard / winner / 職業別称号、モンスターは "なし"。
+    print_field(creature.get_title(), ROW_TITLE, COL_TITLE);
 }
 
 /*!


### PR DESCRIPTION
…tual に集約（提案E5第1弾）

print_title() (main-window-left-frame.cpp) の is_player() 4 分岐（None / wizard / winner / 職業別称号）を CreatureEntity::get_title() virtual へ集約。基底（モンスター）は "なし" を返し、PlayerType::get_title() override が wizard / winner / 職業・レベル別称号を 返す。呼出側は print_field(creature.get_title(), ...) に簡素化。

称号は「クリーチャーの表示属性」でありモンスターに既定値を持たせる形は CLAUDE.md の
プレイヤー属性共通化方針（get_pclass() 等と同じ）に合致。

あわせて roadmap に E5 全サイト調査結論を記載（75 実サイト = A:4/B:69/C:2。機械的 virtual 化余地は 4 サイトのみで E5 は提案 35 時点でほぼ枯渇。A2=get_title を実装、 A1/A3/A4 は理由付きで据え置き）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic title display for characters, including class- and level-based titles.
  * Wizard, winner, and true-winner titles are now shown with the appropriate localized wording.
  * Monsters display a default “None” title.

* **Documentation**
  * Updated the creature entity refactoring roadmap to reflect the completed first phase and remaining work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->