### PR TITLE
feat: モンスターに付与した種族の属性耐性を被ダメージへ opt-in 反映（提案C1第2弾）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -626,11 +626,39 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
 - 指定時はモンスター生成 (`place_monster_one`) 内で
   `CreatureEntity::assign_fixed_player_race_and_class()` が `prace`/`pclass` に付与する
   (chameleon 判定後の実効 monrace を参照)。
-- **現状は効果未反映**（フィールド付与のみ。種族耐性・職業特典等の戦闘効果は
-  反映しない）。効果反映は将来の C トラック提案でメンテナのバランス判断のもと
-  段階導入する方針。
+- **第1弾は効果未反映**（フィールド付与のみ。種族耐性・職業特典等の戦闘効果は
+  反映しない）。効果反映は C トラックのバランス判断のもと段階導入する方針。
 - スキーマ `schema/MonraceDefinitions.schema.json` に `player_race`/`player_class`
   を登録済（CI の JSON 検証を通す）。
+
+### モンスターの種族属性耐性の反映 (`applies_player_race_resistances`) — 提案 C1第2弾
+
+`MonraceDefinition` に `bool applies_player_race_resistances`
+(`src/system/monrace/monrace-definition.h`) を持ち、JSON
+`lib/edit/MonraceDefinitions.jsonc` で「付与された `player_race`（C1）の属性耐性を
+被ダメージへ反映する」を有効化できる。C1 第1弾（種族付与・効果なし）に対し、
+**耐性という最初の戦闘効果**を JSON オプトイン方式（既定 `false`=無効でバランス不変）で
+導入したもの。
+
+```jsonc
+"player_race": "HIGH_ELF",
+"applies_player_race_resistances": true
+```
+
+- **反映対象:** 基本 5 属性（火 `TR_RES_FIRE` / 冷 `TR_RES_COLD` / 電 `TR_RES_ELEC` /
+  酸 `TR_RES_ACID` / 毒 `TR_RES_POIS`）。付与種族の `CreatureRace::tr_flags()` に
+  当該耐性があれば、`effect-monster-resist-hurt.cpp` の各属性ハンドラで
+  被ダメージを**約 1/3 に軽減**（プレイヤーの部分耐性と同水準）。
+- **配線箇所:** `target_race_resists_element(em_ptr, tr_type)` /
+  `apply_monster_race_resistance(em_ptr)`（`effect-monster-resist-hurt.cpp` の
+  匿名 namespace）。免疫 (`IMMUNE_*`) が優先、弱点 (`HURT_*`) とは排他
+  (`else if`)。毒は D7 の DoT 蓄積 (`dam/2`) より前に軽減を適用するため継続毒も減る。
+- **安全性:** `prace == NONE` は `false` を返すため、耐性反映は「有効な種族を持つ
+  個体」に限定され OOB 等は起きない。既定 `false` のため誰にも反映されず
+  **既定バランス完全不変**。
+- **未反映:** 職業特典・種族の非耐性特典（ESP・赤外線視等）は対象外（将来段階）。
+  軽減率（現状 1/3）はハンドラの `apply_monster_race_resistance` で調整可能。
+- スキーマに `applies_player_race_resistances` を登録済。
 
 ### モンスターの能力値成長 (`grows_stats`) — 提案 C2
 

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3029,7 +3029,7 @@ JSON で明示付与**する形で導入する。これにより:
 | 番号 | 提案 | 基盤 | 工数 | 価値 | 主なデザイン判断 |
 |---|---|---|---|---|---|
 | C0 | 成長状態の savefile 完全永続化 (`hp_table`) | ほぼ完了 | 小 | 小 | バージョン bump 要否 |
-| C1 | 種族・職業の顕在化（`prace`/`pclass` 付与） | ✅ cache 有 | 中 | 高 | ✅ 完了（第1弾: JSON付与・効果なし） |
+| C1 | 種族・職業の顕在化（`prace`/`pclass` 付与） | ✅ cache 有 | 中 | 高 | ✅ 第1弾（JSON付与）+第2弾（種族耐性opt-in反映）完了 |
 | C2 | 能力成長の拡張（stat / 熟練度） | ✅ 成長機構 | 中 | 中 | ✅ stat 成長完了（opt-in）／熟練度は次段 |
 | C3 | ESP のモンスター付与 | 🔴 新規 AI 要 | 中〜大 | 中 | ESP をモンスター AI にどう効かせるか（新規設計） |
 | C4 | MP 消費詠唱 | 🟡 pool 有 | 中 | 中 | ✅ 完了（opt-in・レベル比例コスト） |
@@ -3081,8 +3081,25 @@ monrace を参照）が `prace`/`pclass` に付与する。**効果は未反映*
   （オプトインのためメンテナが個体選定）。
 - フルビルド (g++ -O3 -Werror -Wall -Wextra) / clang-format-18 / validate_json.py で検証済。
 
-**第2弾以降（未着手）:** 種族耐性・職業特典等の**戦闘効果の反映**。メンテナの
-バランス判断のもと、対象個体・反映範囲を決めて段階導入する。
+**第2弾 ✅ 完了（種族耐性の opt-in 反映）:**
+`MonraceDefinition::applies_player_race_resistances`（bool, 既定 false）を追加。
+付与された `player_race`（C1第1弾）が基本 5 属性（火/冷/電/酸/毒）の耐性
+（`TR_RES_*`）を持つ個体は、`effect-monster-resist-hurt.cpp` の各属性ハンドラで
+被ダメージを約 1/3 に軽減する（プレイヤー部分耐性と同水準）。
+
+- 配線: 匿名 namespace の `target_race_resists_element()` /
+  `apply_monster_race_resistance()`。免疫優先・弱点排他（`else if`）、毒は D7 の
+  DoT 蓄積前に軽減。`prace == NONE` は false（OOB 回避）。
+- **既定 false のため誰にも反映されず既定バランス不変。** 軽減率はハンドラ定数で調整可。
+- 実コード調査で判明した重要事実: 耐性クエリ経路（`common_cause_flags`）は元々
+  `is_player()` ガード無しで monster prace を読むが、**モンスター被ダメージ経路は
+  monrace フラグを直接読む**ため prace 付与だけでは戦闘に反映されなかった。本第2弾は
+  その被ダメージ経路へ種族耐性を opt-in で明示配線したもの。
+- reader（`info_set_bool`）／schema／CLAUDE.md 整備。フルビルド（g++ -O3 -Werror）／
+  validate_json.py で検証済。
+
+**第3弾以降（未着手）:** 職業特典・種族の非耐性特典（ESP・赤外線視・stat 補正等）の
+反映。メンテナのバランス判断のもと段階導入する。
 
 ---
 

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -197,6 +197,10 @@
                         "type": "boolean",
                         "description": "毒攻撃で継続毒(POISON DoT)を受けるか (提案D7)。既定false=オプトイン。trueの個体のみ毒攻撃後に継続ダメージを受ける。"
                     },
+                    "applies_player_race_resistances": {
+                        "type": "boolean",
+                        "description": "付与された player_race の属性耐性(火/冷/電/酸/毒)を被ダメージへ反映するか (提案C1第2弾)。既定false=オプトイン。trueかつ有効なplayer_raceを持つ個体のみ、種族耐性がある属性の被ダメージが約1/3に軽減される。"
+                    },
                     "odds_correction_ratio": {
                         "type": "integer",
                         "description": "闘技場オッズ補正値。1/100を使用、100で等倍200で2倍",

--- a/src/effect/effect-monster-resist-hurt.cpp
+++ b/src/effect/effect-monster-resist-hurt.cpp
@@ -5,6 +5,9 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
+#include "object-enchant/tr-types.h"
+#include "player-base/player-race.h"
+#include "player-info/race-types.h"
 #include "system/creature-entity.h"
 #include "system/creature-timed-effect-types.h"
 #include "system/enums/monrace/monrace-id.h"
@@ -41,6 +44,33 @@ void apply_monster_element_hurt(CreatureEntity &creature, EffectMonster *em_ptr,
         em_ptr->monrace->r_resistance_flags.set(hurt_flag);
     }
 }
+
+/*!
+ * @brief 対象モンスターが付与された player_race 由来の属性耐性を持つか (提案C1第2弾)
+ * @details opt-in フラグ applies_player_race_resistances が立ち、かつ有効な player_race
+ *          を持つ個体のみ、その種族の tr_flags に指定耐性があれば true。既定 OFF の
+ *          ため誰にも反映されずバランス不変。prace==NONE は安全に false を返す。
+ */
+bool target_race_resists_element(EffectMonster *em_ptr, tr_type res_flag)
+{
+    if (!em_ptr->monrace->applies_player_race_resistances) {
+        return false;
+    }
+    if (em_ptr->m_ptr->get_prace() == PlayerRaceType::NONE) {
+        return false;
+    }
+    return CreatureRace(em_ptr->m_ptr).tr_flags().has(res_flag);
+}
+
+/*!
+ * @brief player_race 由来の属性耐性による被ダメージ軽減 (提案C1第2弾)
+ * @details プレイヤーの部分耐性と同様、被ダメージを約 1/3 に軽減する。
+ */
+void apply_monster_race_resistance(EffectMonster *em_ptr)
+{
+    em_ptr->note = _("には耐性がある。", " resists.");
+    em_ptr->dam = (em_ptr->dam + 2) / 3;
+}
 }
 
 /*!
@@ -65,6 +95,8 @@ ProcessResult effect_monster_acid(CreatureEntity &creature, EffectMonster *em_pt
 
     if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::IMMUNE_ACID)) {
         apply_monster_element_immune(creature, em_ptr, MonsterResistanceType::IMMUNE_ACID);
+    } else if (target_race_resists_element(em_ptr, TR_RES_ACID)) {
+        apply_monster_race_resistance(em_ptr);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -78,6 +110,8 @@ ProcessResult effect_monster_elec(CreatureEntity &creature, EffectMonster *em_pt
 
     if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::IMMUNE_ELEC)) {
         apply_monster_element_immune(creature, em_ptr, MonsterResistanceType::IMMUNE_ELEC);
+    } else if (target_race_resists_element(em_ptr, TR_RES_ELEC)) {
+        apply_monster_race_resistance(em_ptr);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -96,6 +130,8 @@ ProcessResult effect_monster_fire(CreatureEntity &creature, EffectMonster *em_pt
 
     if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::HURT_FIRE)) {
         apply_monster_element_hurt(creature, em_ptr, MonsterResistanceType::HURT_FIRE);
+    } else if (target_race_resists_element(em_ptr, TR_RES_FIRE)) {
+        apply_monster_race_resistance(em_ptr);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -114,6 +150,8 @@ ProcessResult effect_monster_cold(CreatureEntity &creature, EffectMonster *em_pt
 
     if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::HURT_COLD)) {
         apply_monster_element_hurt(creature, em_ptr, MonsterResistanceType::HURT_COLD);
+    } else if (target_race_resists_element(em_ptr, TR_RES_COLD)) {
+        apply_monster_race_resistance(em_ptr);
     }
 
     return ProcessResult::PROCESS_CONTINUE;
@@ -128,6 +166,12 @@ ProcessResult effect_monster_pois(CreatureEntity &creature, EffectMonster *em_pt
     if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::IMMUNE_POISON)) {
         apply_monster_element_immune(creature, em_ptr, MonsterResistanceType::IMMUNE_POISON);
         return ProcessResult::PROCESS_CONTINUE;
+    }
+
+    // [提案C1第2弾] player_race 由来の毒耐性を反映 (opt-in・既定OFF)。
+    // dam 軽減を D7 の DoT 蓄積 (dam/2) より前に行うことで継続毒も軽減される。
+    if (target_race_resists_element(em_ptr, TR_RES_POIS)) {
+        apply_monster_race_resistance(em_ptr);
     }
 
     // [提案D7] suffers_poison_dot が立つ個体は毒攻撃で継続毒 (POISON DoT) を蓄積する。

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -1556,6 +1556,11 @@ errr RaceReader::read()
         msg_format(_("モンスター継続毒フラグ読込失敗。ID: '%d'。", "Failed to load monster suffers_poison_dot. ID: '%d'."), error_idx);
         return err;
     }
+    err = info_set_bool(mon_data["applies_player_race_resistances"], monrace.applies_player_race_resistances, false);
+    if (err) {
+        msg_format(_("モンスター種族耐性反映フラグ読込失敗。ID: '%d'。", "Failed to load monster applies_player_race_resistances. ID: '%d'."), error_idx);
+        return err;
+    }
     err = info_set_integer(mon_data["odds_correction_ratio"], monrace.arena_ratio, false, Range(1, 9999));
     if (err) {
         msg_format(_("モンスター賭け倍率読込失敗。ID: '%d'。", "Failed to load monster odds for arena. ID: '%d'."), error_idx);

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -138,6 +138,7 @@ public:
     EnumClassFlagGroup<PlayerMutationType> mutations{}; //!< 生成時に付与する突然変異 (提案C5。空=なし=オプトイン)
     RealmType realm_abilities = RealmType::NONE; //!< 詠唱能力を付与する魔法領域 (提案C6。NONE=なし=オプトイン。詠唱時に realm 由来の MonsterAbilityType を追加)
     bool suffers_poison_dot = false; //!< 毒攻撃で継続毒(POISON DoT)を受けるか (提案D7。既定false=オプトイン。既定バランス不変)
+    bool applies_player_race_resistances = false; //!< 付与された player_race の属性耐性を被ダメージへ反映するか (提案C1第2弾。既定false=オプトイン。既定バランス不変)
     EnumClassFlagGroup<MonsterFeedType> meat_feed_flags;
     EnumClassFlagGroup<MonsterAbilityType> ability_flags; //!< 能力フラグ(魔法/ブレス) / Ability Flags
     EnumClassFlagGroup<MonsterAuraType> aura_flags; //!< オーラフラグ / Aura Flags


### PR DESCRIPTION
C1第1弾（player_race 付与・効果なし）に対し、耐性という最初の戦闘効果を JSON
オプトイン（既定OFF・バランス不変）で導入。MonraceDefinition::applies_player_race_resistances （bool, 既定false）を追加し、付与種族が基本5属性(火/冷/電/酸/毒)の TR_RES_* を持つ 個体は effect-monster-resist-hurt.cpp の各ハンドラで被ダメージを約1/3に軽減する。

- 配線: 匿名 namespace の target_race_resists_element() / apply_monster_race_resistance()。 免疫優先・弱点排他(else if)、毒は D7 の DoT 蓄積前に軽減を適用。
- 安全性: prace==NONE は false を返し OOB を回避。既定 false のため誰にも反映されず 既定バランス完全不変。
- 調査で判明: モンスター被ダメージ経路は monrace フラグを直接読むため prace 付与だけ では戦闘に反映されず、本第2弾でその経路へ種族耐性を opt-in 明示配線した。
- reader / schema / CLAUDE.md / roadmap 整備。フルビルド(g++ -O3 -Werror) / validate_json.py で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Monster definitions can now optionally apply configured player-race resistances to incoming damage.
  - Fire, cold, lightning, acid, and poison damage may be reduced to approximately one-third when the corresponding resistance applies.
  - Immunities take priority, while weaknesses do not override the resistance behavior.
  - Poison resistance is applied before ongoing poison damage is accumulated.

- **Documentation**
  - Updated configuration guidance and the creature refactoring roadmap to document this feature and its opt-in behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->