### PR TITLE
feat: 種族属性耐性の opt-in 反映を二次属性7種へ拡大（提案C1第3弾）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -645,14 +645,24 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
 "applies_player_race_resistances": true
 ```
 
-- **反映対象:** 基本 5 属性（火 `TR_RES_FIRE` / 冷 `TR_RES_COLD` / 電 `TR_RES_ELEC` /
-  酸 `TR_RES_ACID` / 毒 `TR_RES_POIS`）。付与種族の `CreatureRace::tr_flags()` に
-  当該耐性があれば、`effect-monster-resist-hurt.cpp` の各属性ハンドラで
-  被ダメージを**約 1/3 に軽減**（プレイヤーの部分耐性と同水準）。
+- **反映対象（第2弾: 基本 5 属性）:** 火 `TR_RES_FIRE` / 冷 `TR_RES_COLD` /
+  電 `TR_RES_ELEC` / 酸 `TR_RES_ACID` / 毒 `TR_RES_POIS`。付与種族の
+  `CreatureRace::tr_flags()` に当該耐性があれば、`effect-monster-resist-hurt.cpp` の
+  各属性ハンドラで被ダメージを**約 1/3 に軽減**（プレイヤーの部分耐性と同水準）。
+- **反映対象（第3弾: 二次属性 7 種）:** 地獄 `TR_RES_NETHER` / 混沌 `TR_RES_CHAOS` /
+  破片 `TR_RES_SHARDS` / 轟音 `TR_RES_SOUND` / 混乱 `TR_RES_CONF` /
+  劣化 `TR_RES_DISEN` / 因果 `TR_RES_NEXUS`。各ハンドラの**ネイティブ耐性経路へ
+  OR-in** する形で反映（種族耐性でネイティブと同じ軽減・副作用抑止を発火）。
+  轟音は `do_stun`、混乱は `do_conf`、混沌は polymorph/混乱の**状態異常も抑止**する。
+  種族由来耐性では monrace ネイティブ耐性の思い出フラグ (`r_resistance_flags`) を
+  記録しない（`native_resist` ガード）。付随攻撃（rocket/icee/void/abyss 等の
+  複合・特殊ロジック）は対象外（将来拡張余地）。
 - **配線箇所:** `target_race_resists_element(em_ptr, tr_type)` /
-  `apply_monster_race_resistance(em_ptr)`（`effect-monster-resist-hurt.cpp` の
-  匿名 namespace）。免疫 (`IMMUNE_*`) が優先、弱点 (`HURT_*`) とは排他
-  (`else if`)。毒は D7 の DoT 蓄積 (`dam/2`) より前に軽減を適用するため継続毒も減る。
+  `apply_monster_race_resistance(em_ptr)`（基本 5 属性用の 1/3 軽減）（
+  `effect-monster-resist-hurt.cpp` の匿名 namespace）。基本属性は免疫 (`IMMUNE_*`)
+  優先・弱点 (`HURT_*`) と排他 (`else if`)。毒は D7 の DoT 蓄積 (`dam/2`) より前に
+  軽減を適用するため継続毒も減る。二次属性は各ハンドラのネイティブ resist 条件へ
+  `|| target_race_resists_element(...)` を OR-in。
 - **安全性:** `prace == NONE` は `false` を返すため、耐性反映は「有効な種族を持つ
   個体」に限定され OOB 等は起きない。既定 `false` のため誰にも反映されず
   **既定バランス完全不変**。

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3029,7 +3029,7 @@ JSON で明示付与**する形で導入する。これにより:
 | 番号 | 提案 | 基盤 | 工数 | 価値 | 主なデザイン判断 |
 |---|---|---|---|---|---|
 | C0 | 成長状態の savefile 完全永続化 (`hp_table`) | ほぼ完了 | 小 | 小 | バージョン bump 要否 |
-| C1 | 種族・職業の顕在化（`prace`/`pclass` 付与） | ✅ cache 有 | 中 | 高 | ✅ 第1弾（JSON付与）+第2弾（種族耐性opt-in反映）完了 |
+| C1 | 種族・職業の顕在化（`prace`/`pclass` 付与） | ✅ cache 有 | 中 | 高 | ✅ 第1弾(付与)+第2弾(基本5属性耐性)+第3弾(二次7属性耐性) 完了 |
 | C2 | 能力成長の拡張（stat / 熟練度） | ✅ 成長機構 | 中 | 中 | ✅ stat 成長完了（opt-in）／熟練度は次段 |
 | C3 | ESP のモンスター付与 | 🔴 新規 AI 要 | 中〜大 | 中 | ESP をモンスター AI にどう効かせるか（新規設計） |
 | C4 | MP 消費詠唱 | 🟡 pool 有 | 中 | 中 | ✅ 完了（opt-in・レベル比例コスト） |
@@ -3098,8 +3098,24 @@ monrace を参照）が `prace`/`pclass` に付与する。**効果は未反映*
 - reader（`info_set_bool`）／schema／CLAUDE.md 整備。フルビルド（g++ -O3 -Werror）／
   validate_json.py で検証済。
 
-**第3弾以降（未着手）:** 職業特典・種族の非耐性特典（ESP・赤外線視・stat 補正等）の
-反映。メンテナのバランス判断のもと段階導入する。
+**第3弾 ✅ 完了（二次属性への耐性反映拡大）:**
+第2弾（基本 5 属性）と同じ opt-in フラグ `applies_player_race_resistances` の被覆を
+**二次属性 7 種**（地獄 `TR_RES_NETHER` / 混沌 `TR_RES_CHAOS` / 破片 `TR_RES_SHARDS` /
+轟音 `TR_RES_SOUND` / 混乱 `TR_RES_CONF` / 劣化 `TR_RES_DISEN` / 因果 `TR_RES_NEXUS`）へ
+拡大。
+
+- 各ハンドラのネイティブ resist 条件へ `|| target_race_resists_element(em_ptr, TR_RES_X)`
+  を **OR-in** し、種族耐性でネイティブと同じ軽減・**副作用抑止**（轟音の `do_stun`・
+  混乱の `do_conf`・混沌の polymorph/混乱）を発火させる。
+- 種族由来 resist では monrace ネイティブ耐性の思い出フラグを記録しない
+  （`native_resist` ローカルでガード）。
+- フラグ被覆拡大のみで新フラグは追加せず、**既定 false のまま＝バランス不変**。
+  複合/特殊攻撃（rocket/icee_bolt/void/abyss）は多属性・特殊ロジックのため対象外。
+- フルビルド（g++ -O3 -Werror）で検証済。
+
+**第4弾以降（未着手）:** 職業特典・種族の非耐性特典（ESP・赤外線視・stat 補正等）の
+反映。ESP/赤外線視はモンスター AI 索敵の新規実装が要る（C3 と同課題）ため大。
+メンテナのバランス判断のもと段階導入する。
 
 ---
 

--- a/src/effect/effect-monster-resist-hurt.cpp
+++ b/src/effect/effect-monster-resist-hurt.cpp
@@ -281,7 +281,8 @@ ProcessResult effect_monster_plasma(CreatureEntity &creature, EffectMonster *em_
 
 static bool effect_monster_nether_resist(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_NETHER)) {
+    const auto native_resist = em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_NETHER);
+    if (!native_resist && !target_race_resists_element(em_ptr, TR_RES_NETHER)) {
         return false;
     }
 
@@ -297,7 +298,7 @@ static bool effect_monster_nether_resist(CreatureEntity &creature, EffectMonster
         em_ptr->dam /= randint1(6) + 6;
     }
 
-    if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
+    if (native_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
         em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_NETHER);
     }
 
@@ -355,11 +356,12 @@ ProcessResult effect_monster_chaos(CreatureEntity &creature, EffectMonster *em_p
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_CHAOS)) {
+    const auto native_chaos_resist = em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_CHAOS);
+    if (native_chaos_resist || target_race_resists_element(em_ptr, TR_RES_CHAOS)) {
         em_ptr->note = _("には耐性がある。", " resists.");
         em_ptr->dam *= 3;
         em_ptr->dam /= randint1(6) + 6;
-        if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
+        if (native_chaos_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
             em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_CHAOS);
         }
     } else if (em_ptr->monrace->kind_flags.has(MonsterKindType::DEMON) && one_in_(3)) {
@@ -383,14 +385,15 @@ ProcessResult effect_monster_shards(CreatureEntity &creature, EffectMonster *em_
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_SHARDS)) {
+    const auto native_resist = em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_SHARDS);
+    if (!native_resist && !target_race_resists_element(em_ptr, TR_RES_SHARDS)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     em_ptr->note = _("には耐性がある。", " resists.");
     em_ptr->dam *= 3;
     em_ptr->dam /= randint1(6) + 6;
-    if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
+    if (native_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
         em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_SHARDS);
     }
 
@@ -422,7 +425,8 @@ ProcessResult effect_monster_sound(CreatureEntity &creature, EffectMonster *em_p
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_SOUND)) {
+    const auto native_resist = em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_SOUND);
+    if (!native_resist && !target_race_resists_element(em_ptr, TR_RES_SOUND)) {
         em_ptr->do_stun = (10 + randint1(15) + em_ptr->r) / (em_ptr->r + 1);
         return ProcessResult::PROCESS_CONTINUE;
     }
@@ -430,7 +434,7 @@ ProcessResult effect_monster_sound(CreatureEntity &creature, EffectMonster *em_p
     em_ptr->note = _("には耐性がある。", " resists.");
     em_ptr->dam *= 2;
     em_ptr->dam /= randint1(6) + 6;
-    if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
+    if (native_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
         em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_SOUND);
     }
 
@@ -443,7 +447,8 @@ ProcessResult effect_monster_confusion(CreatureEntity &creature, EffectMonster *
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::NO_CONF)) {
+    const auto native_resist = em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF);
+    if (!native_resist && !target_race_resists_element(em_ptr, TR_RES_CONF)) {
         em_ptr->do_conf = (10 + randint1(15) + em_ptr->r) / (em_ptr->r + 1);
         return ProcessResult::PROCESS_CONTINUE;
     }
@@ -451,7 +456,7 @@ ProcessResult effect_monster_confusion(CreatureEntity &creature, EffectMonster *
     em_ptr->note = _("には耐性がある。", " resists.");
     em_ptr->dam *= 3;
     em_ptr->dam /= randint1(6) + 6;
-    if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
+    if (native_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
         em_ptr->monrace->resistance_flags.set(MonsterResistanceType::NO_CONF);
     }
 
@@ -464,14 +469,15 @@ ProcessResult effect_monster_disenchant(CreatureEntity &creature, EffectMonster 
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_DISENCHANT)) {
+    const auto native_resist = em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_DISENCHANT);
+    if (!native_resist && !target_race_resists_element(em_ptr, TR_RES_DISEN)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     em_ptr->note = _("には耐性がある。", " resists.");
     em_ptr->dam *= 3;
     em_ptr->dam /= randint1(6) + 6;
-    if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
+    if (native_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
         em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_DISENCHANT);
     }
 
@@ -484,14 +490,15 @@ ProcessResult effect_monster_nexus(CreatureEntity &creature, EffectMonster *em_p
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_NEXUS)) {
+    const auto native_resist = em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_NEXUS);
+    if (!native_resist && !target_race_resists_element(em_ptr, TR_RES_NEXUS)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
     em_ptr->note = _("には耐性がある。", " resists.");
     em_ptr->dam *= 3;
     em_ptr->dam /= randint1(6) + 6;
-    if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
+    if (native_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
         em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_NEXUS);
     }
 


### PR DESCRIPTION
C1第2弾（基本5属性）と同じ opt-in フラグ applies_player_race_resistances の被覆を 二次属性7種（地獄/混沌/破片/轟音/混乱/劣化/因果）へ拡大。各ハンドラのネイティブ
resist 条件へ || target_race_resists_element(em_ptr, TR_RES_X) を OR-in し、種族耐性で ネイティブと同じ軽減・副作用抑止（轟音のdo_stun・混乱のdo_conf・混沌のpolymorph/ 混乱）を発火させる。

- 種族由来 resist では monrace ネイティブ耐性の思い出フラグを記録しない (native_resist ローカルでガード)。
- フラグ被覆拡大のみで新フラグ追加なし。既定 false のままバランス不変。
- 複合/特殊攻撃(rocket/icee_bolt/void/abyss)は多属性・特殊ロジックのため対象外。
- CLAUDE.md / roadmap 整備。フルビルド(g++ -O3 -Werror)で検証済。