### PR TITLE
feat: 種族の恐怖耐性を opt-in 反映し共通述語を util へ昇格（提案C1第4弾）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -657,11 +657,16 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
   種族由来耐性では monrace ネイティブ耐性の思い出フラグ (`r_resistance_flags`) を
   記録しない（`native_resist` ガード）。付随攻撃（rocket/icee/void/abyss 等の
   複合・特殊ロジック）は対象外（将来拡張余地）。
-- **配線箇所:** `target_race_resists_element(em_ptr, tr_type)` /
-  `apply_monster_race_resistance(em_ptr)`（基本 5 属性用の 1/3 軽減）（
-  `effect-monster-resist-hurt.cpp` の匿名 namespace）。基本属性は免疫 (`IMMUNE_*`)
+- **反映対象（第4弾: 状態異常耐性・恐怖）:** 恐怖 `TR_RES_FEAR`。全恐怖源が通る
+  中央ゲート `effect_damage_piles_fear`（`effect-monster.cpp`）の `do_fear→恐怖` 変換を
+  種族恐怖耐性で無効化（`NO_FEAR` と同経路に OR-in）。ダメージ属性でない状態異常
+  耐性を反映した最初の例。
+- **共通述語の配置:** `target_race_resists_element(EffectMonster*, tr_type)` は
+  `effect-monster-util.{h,cpp}` に配置（属性ダメージ／状態異常の両 TU から使う共通述語）。
+  ダメージ軽減 `apply_monster_race_resistance(em_ptr)`（基本 5 属性用の 1/3 軽減）は
+  `effect-monster-resist-hurt.cpp` の匿名 namespace。基本属性は免疫 (`IMMUNE_*`)
   優先・弱点 (`HURT_*`) と排他 (`else if`)。毒は D7 の DoT 蓄積 (`dam/2`) より前に
-  軽減を適用するため継続毒も減る。二次属性は各ハンドラのネイティブ resist 条件へ
+  軽減を適用するため継続毒も減る。二次属性・恐怖は各ネイティブ耐性条件へ
   `|| target_race_resists_element(...)` を OR-in。
 - **安全性:** `prace == NONE` は `false` を返すため、耐性反映は「有効な種族を持つ
   個体」に限定され OOB 等は起きない。既定 `false` のため誰にも反映されず

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3029,7 +3029,7 @@ JSON で明示付与**する形で導入する。これにより:
 | 番号 | 提案 | 基盤 | 工数 | 価値 | 主なデザイン判断 |
 |---|---|---|---|---|---|
 | C0 | 成長状態の savefile 完全永続化 (`hp_table`) | ほぼ完了 | 小 | 小 | バージョン bump 要否 |
-| C1 | 種族・職業の顕在化（`prace`/`pclass` 付与） | ✅ cache 有 | 中 | 高 | ✅ 第1弾(付与)+第2弾(基本5属性耐性)+第3弾(二次7属性耐性) 完了 |
+| C1 | 種族・職業の顕在化（`prace`/`pclass` 付与） | ✅ cache 有 | 中 | 高 | ✅ 1(付与)/2(基本5耐性)/3(二次7耐性)/4(恐怖耐性) 完了 |
 | C2 | 能力成長の拡張（stat / 熟練度） | ✅ 成長機構 | 中 | 中 | ✅ stat 成長完了（opt-in）／熟練度は次段 |
 | C3 | ESP のモンスター付与 | 🔴 新規 AI 要 | 中〜大 | 中 | ESP をモンスター AI にどう効かせるか（新規設計） |
 | C4 | MP 消費詠唱 | 🟡 pool 有 | 中 | 中 | ✅ 完了（opt-in・レベル比例コスト） |
@@ -3113,9 +3113,22 @@ monrace を参照）が `prace`/`pclass` に付与する。**効果は未反映*
   複合/特殊攻撃（rocket/icee_bolt/void/abyss）は多属性・特殊ロジックのため対象外。
 - フルビルド（g++ -O3 -Werror）で検証済。
 
-**第4弾以降（未着手）:** 職業特典・種族の非耐性特典（ESP・赤外線視・stat 補正等）の
-反映。ESP/赤外線視はモンスター AI 索敵の新規実装が要る（C3 と同課題）ため大。
-メンテナのバランス判断のもと段階導入する。
+**第4弾 ✅ 完了（状態異常耐性・恐怖の反映）:**
+種族の恐怖耐性 `TR_RES_FEAR` を反映。全恐怖源が通る中央ゲート
+`effect_damage_piles_fear`（`effect-monster.cpp`）の `do_fear→恐怖` 変換を、
+`NO_FEAR` と同経路へ `|| target_race_resists_element(em_ptr, TR_RES_FEAR)` を OR-in
+して無効化。ダメージ属性でない**状態異常耐性を反映した最初の例**。
+
+- 共通述語 `target_race_resists_element(EffectMonster*, tr_type)` を
+  `effect-monster-resist-hurt.cpp` の匿名 namespace から **`effect-monster-util.{h,cpp}`
+  へ昇格**（属性ダメージ／状態異常の両 TU から使う共通述語に）。
+- 同じ opt-in フラグ `applies_player_race_resistances` を使用（新フラグなし）。
+  既定 false のままバランス不変。フルビルド（g++ -O3 -Werror）で検証済。
+
+**第5弾以降（未着手）:** 職業特典・種族の非耐性特典（ESP・赤外線視・stat 補正等）。
+ESP/赤外線視はモンスター AI 索敵の新規実装が要る（C3 と同課題）ため大。
+麻痺耐性（`TR_FREE_ACT`）等の追加状態異常も同パターンで拡張可能。メンテナの
+バランス判断のもと段階導入する。
 
 ---
 

--- a/src/effect/effect-monster-resist-hurt.cpp
+++ b/src/effect/effect-monster-resist-hurt.cpp
@@ -6,8 +6,6 @@
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
 #include "object-enchant/tr-types.h"
-#include "player-base/player-race.h"
-#include "player-info/race-types.h"
 #include "system/creature-entity.h"
 #include "system/creature-timed-effect-types.h"
 #include "system/enums/monrace/monrace-id.h"
@@ -43,23 +41,6 @@ void apply_monster_element_hurt(CreatureEntity &creature, EffectMonster *em_ptr,
     if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
         em_ptr->monrace->r_resistance_flags.set(hurt_flag);
     }
-}
-
-/*!
- * @brief 対象モンスターが付与された player_race 由来の属性耐性を持つか (提案C1第2弾)
- * @details opt-in フラグ applies_player_race_resistances が立ち、かつ有効な player_race
- *          を持つ個体のみ、その種族の tr_flags に指定耐性があれば true。既定 OFF の
- *          ため誰にも反映されずバランス不変。prace==NONE は安全に false を返す。
- */
-bool target_race_resists_element(EffectMonster *em_ptr, tr_type res_flag)
-{
-    if (!em_ptr->monrace->applies_player_race_resistances) {
-        return false;
-    }
-    if (em_ptr->m_ptr->get_prace() == PlayerRaceType::NONE) {
-        return false;
-    }
-    return CreatureRace(em_ptr->m_ptr).tr_flags().has(res_flag);
 }
 
 /*!

--- a/src/effect/effect-monster-util.cpp
+++ b/src/effect/effect-monster-util.cpp
@@ -11,6 +11,9 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
 #include "monster/monster-util.h"
+#include "object-enchant/tr-types.h"
+#include "player-base/player-race.h"
+#include "player-info/race-types.h"
 #include "system/angband-system.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
@@ -65,4 +68,15 @@ bool EffectMonster::is_monster() const
 Pos2D EffectMonster::get_position() const
 {
     return { this->y, this->x };
+}
+
+bool target_race_resists_element(EffectMonster *em_ptr, tr_type res_flag)
+{
+    if (!em_ptr->monrace->applies_player_race_resistances) {
+        return false;
+    }
+    if (em_ptr->m_ptr->get_prace() == PlayerRaceType::NONE) {
+        return false;
+    }
+    return CreatureRace(em_ptr->m_ptr).tr_flags().has(res_flag);
 }

--- a/src/effect/effect-monster-util.h
+++ b/src/effect/effect-monster-util.h
@@ -54,3 +54,14 @@ public:
     bool is_monster() const;
     Pos2D get_position() const;
 };
+
+enum tr_type : int;
+
+/*!
+ * @brief 対象モンスターが付与された player_race 由来の属性耐性を持つか (提案C1第2弾/第3弾/第4弾)
+ * @details opt-in フラグ applies_player_race_resistances が立ち、かつ有効な player_race
+ *          を持つ個体のみ、その種族の tr_flags に指定耐性 (res_flag) があれば true。
+ *          既定 OFF のため誰にも反映されずバランス不変。prace==NONE は安全に false。
+ *          属性ダメージ (effect-monster-resist-hurt) と状態異常 (fear 等) の両方から使う共通述語。
+ */
+bool target_race_resists_element(EffectMonster *em_ptr, tr_type res_flag);

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -34,6 +34,7 @@
 #include "monster/monster-update.h"
 #include "monster/monster-util.h"
 #include "object-enchant/special-object-flags.h"
+#include "object-enchant/tr-types.h"
 #include "spell-kind/blood-curse.h"
 #include "spell-kind/spells-polymorph.h"
 #include "spell-kind/spells-teleport.h"
@@ -470,7 +471,9 @@ static void effect_damage_piles_confusion(CreatureEntity &creature, EffectMonste
  */
 static void effect_damage_piles_fear(CreatureEntity &creature, EffectMonster *em_ptr)
 {
-    if (em_ptr->do_fear == 0 || em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_FEAR)) {
+    // [提案C1第4弾] 付与種族が恐怖耐性 (TR_RES_FEAR) を持つ個体は恐怖を無効化する
+    // (applies_player_race_resistances opt-in・既定OFF)。全恐怖源が通る中央ゲート。
+    if (em_ptr->do_fear == 0 || em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_FEAR) || target_race_resists_element(em_ptr, TR_RES_FEAR)) {
         return;
     }
 


### PR DESCRIPTION
種族の恐怖耐性 TR_RES_FEAR を反映。全恐怖源が通る中央ゲート
effect_damage_piles_fear (effect-monster.cpp) の do_fear→恐怖 変換を、NO_FEAR と 同経路へ || target_race_resists_element(em_ptr, TR_RES_FEAR) を OR-in して無効化。 ダメージ属性でない状態異常耐性を反映した最初の例。

- 共通述語 target_race_resists_element(EffectMonster*, tr_type) を effect-monster-resist-hurt.cpp の匿名 namespace から effect-monster-util.{h,cpp} へ昇格（属性ダメージ／状態異常の両 TU から使う共通述語に）。
- 同じ opt-in フラグ applies_player_race_resistances を使用（新フラグなし）。 既定 false のままバランス不変。CLAUDE.md / roadmap 整備。 フルビルド(g++ -O3 -Werror)で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Player race-based fear resistance is now applied to incoming fear effects.
  * Targets with fear resistance are protected from fear regardless of the effect’s normal application value.

* **Bug Fixes**
  * Race-based resistance handling is now shared consistently across elemental damage and status effects.
  * Resistance is applied before poison damage-over-time accumulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->