### PR TITLE
feat: 種族の自由行動(TR_FREE_ACT)を睡眠/拘束耐性として opt-in 反映（提案C1第5弾）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -661,6 +661,11 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
   中央ゲート `effect_damage_piles_fear`（`effect-monster.cpp`）の `do_fear→恐怖` 変換を
   種族恐怖耐性で無効化（`NO_FEAR` と同経路に OR-in）。ダメージ属性でない状態異常
   耐性を反映した最初の例。
+- **反映対象（第5弾: 自由行動＝睡眠/拘束耐性）:** 自由行動 `TR_FREE_ACT`（耐麻痺）。
+  プレイヤーの麻痺免疫に相当するモンスター状態異常＝魔法睡眠 `effect_monster_old_sleep`
+  と拘束 `effect_monster_stasis`（`effect-monster-oldies.cpp`）の `has_resistance` 集約へ
+  `NO_SLEEP`・UNIQUE・レベルセーヴと同列に OR-in（抵抗時は「効果がなかった」表示）。
+  psi 睡眠・円月の特殊睡眠は据え置き（主要ハンドラのみ方針）。
 - **共通述語の配置:** `target_race_resists_element(EffectMonster*, tr_type)` は
   `effect-monster-util.{h,cpp}` に配置（属性ダメージ／状態異常の両 TU から使う共通述語）。
   ダメージ軽減 `apply_monster_race_resistance(em_ptr)`（基本 5 属性用の 1/3 軽減）は

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3029,7 +3029,7 @@ JSON で明示付与**する形で導入する。これにより:
 | 番号 | 提案 | 基盤 | 工数 | 価値 | 主なデザイン判断 |
 |---|---|---|---|---|---|
 | C0 | 成長状態の savefile 完全永続化 (`hp_table`) | ほぼ完了 | 小 | 小 | バージョン bump 要否 |
-| C1 | 種族・職業の顕在化（`prace`/`pclass` 付与） | ✅ cache 有 | 中 | 高 | ✅ 1(付与)/2(基本5耐性)/3(二次7耐性)/4(恐怖耐性) 完了 |
+| C1 | 種族・職業の顕在化（`prace`/`pclass` 付与） | ✅ cache 有 | 中 | 高 | ✅ 1(付与)/2(基本5)/3(二次7)/4(恐怖)/5(自由行動) 完了 |
 | C2 | 能力成長の拡張（stat / 熟練度） | ✅ 成長機構 | 中 | 中 | ✅ stat 成長完了（opt-in）／熟練度は次段 |
 | C3 | ESP のモンスター付与 | 🔴 新規 AI 要 | 中〜大 | 中 | ESP をモンスター AI にどう効かせるか（新規設計） |
 | C4 | MP 消費詠唱 | 🟡 pool 有 | 中 | 中 | ✅ 完了（opt-in・レベル比例コスト） |
@@ -3125,9 +3125,22 @@ monrace を参照）が `prace`/`pclass` に付与する。**効果は未反映*
 - 同じ opt-in フラグ `applies_player_race_resistances` を使用（新フラグなし）。
   既定 false のままバランス不変。フルビルド（g++ -O3 -Werror）で検証済。
 
-**第5弾以降（未着手）:** 職業特典・種族の非耐性特典（ESP・赤外線視・stat 補正等）。
-ESP/赤外線視はモンスター AI 索敵の新規実装が要る（C3 と同課題）ため大。
-麻痺耐性（`TR_FREE_ACT`）等の追加状態異常も同パターンで拡張可能。メンテナの
+**第5弾 ✅ 完了（自由行動＝睡眠/拘束耐性の反映）:**
+種族の自由行動 `TR_FREE_ACT`（耐麻痺）を反映。プレイヤーの麻痺免疫に相当する
+モンスター状態異常＝魔法睡眠・拘束(stasis)を無効化。
+
+- **配線:** `effect_monster_old_sleep`（GF_OLD_SLEEP）と `effect_monster_stasis`
+  （STASIS/STASIS_EVIL）の `has_resistance` 集約へ
+  `|= target_race_resists_element(em_ptr, TR_FREE_ACT)` を OR-in。ネイティブ `NO_SLEEP`・
+  UNIQUE・レベルセーヴと同列に扱い、抵抗時は正しく「効果がなかった」メッセージを表示。
+- 同じ opt-in フラグ `applies_player_race_resistances` を使用（新フラグなし）。
+  既定 false のままバランス不変。フルビルド（g++ -O3 -Werror）で検証済。
+- **対象外（niche）:** psi 攻撃由来の睡眠（`effect-monster-psi.cpp`）・円月
+  (`effect_monster_engetsu`) の特殊睡眠は据え置き（第3弾の rocket/void 等と同じ
+  「主要ハンドラのみ」方針）。
+
+**第6弾以降（未着手）:** 職業特典・種族の非耐性特典（ESP・赤外線視・stat 補正等）。
+ESP/赤外線視はモンスター AI 索敵の新規実装が要る（C3 と同課題）ため大。メンテナの
 バランス判断のもと段階導入する。
 
 ---

--- a/src/effect/effect-monster-oldies.cpp
+++ b/src/effect/effect-monster-oldies.cpp
@@ -6,6 +6,7 @@
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
 #include "monster/monster-util.h"
+#include "object-enchant/tr-types.h"
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "system/floor/floor-info.h"
@@ -241,6 +242,8 @@ ProcessResult effect_monster_old_sleep(CreatureEntity &creature, EffectMonster *
 
     bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
     has_resistance |= em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_SLEEP);
+    // [提案C1第5弾] 付与種族が自由行動 (TR_FREE_ACT) を持てば魔法睡眠を無効化 (opt-in・既定OFF)
+    has_resistance |= target_race_resists_element(em_ptr, TR_FREE_ACT);
     has_resistance |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
 
     if (has_resistance) {
@@ -301,6 +304,8 @@ ProcessResult effect_monster_stasis(EffectMonster *em_ptr, bool to_evil)
     int stasis_damage = (em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10);
     bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
     has_resistance |= em_ptr->monrace->level > randint1(stasis_damage) + 10;
+    // [提案C1第5弾] 付与種族が自由行動 (TR_FREE_ACT) を持てば拘束(stasis)を無効化 (opt-in・既定OFF)
+    has_resistance |= target_race_resists_element(em_ptr, TR_FREE_ACT);
     if (to_evil) {
         has_resistance |= em_ptr->monrace->kind_flags.has_not(MonsterKindType::EVIL);
     }


### PR DESCRIPTION
種族の自由行動 TR_FREE_ACT（耐麻痺）を反映。プレイヤーの麻痺免疫に相当する
モンスター状態異常＝魔法睡眠(effect_monster_old_sleep)と拘束(effect_monster_stasis)を 無効化する。両ハンドラの has_resistance 集約へ
|= target_race_resists_element(em_ptr, TR_FREE_ACT) を OR-in し、NO_SLEEP・UNIQUE・ レベルセーヴと同列に扱う（抵抗時は正しく「効果がなかった」メッセージ表示）。

- 同じ opt-in フラグ applies_player_race_resistances を使用（新フラグなし）。 既定 false のままバランス不変。
- 対象外(niche): psi 攻撃睡眠・円月の特殊睡眠は据え置き（主要ハンドラのみ方針）。
- CLAUDE.md / roadmap 整備。フルビルド(g++ -O3 -Werror)で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monsters with the Free Action racial trait now resist magical sleep and restraint effects.
  * Resisted effects are handled as unaffected, with no damage applied.

* **Documentation**
  * Updated monster resistance documentation and the refactoring roadmap to reflect Free Action resistance support.
  * Psychic sleep and special sleep effects remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->