### PR TITLE
merge: フロア連結性チェックが生成成功時に判定されない不具合を修正（hengband#5484 相当）

### DIFF
--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -654,7 +654,7 @@ void generate_floor(CreatureEntity &creature)
         // 狂戦士でのプレイに支障をきたしうるので再生成する。
         // 地上、荒野マップ、クエストでは連結性判定は行わない。
         // TODO: 本来はダンジョン生成アルゴリズム自身で連結性を保証するのが理想ではある。
-        const auto check_conn = why && floor.is_underground() && !floor.is_in_quest();
+        const auto check_conn = !why && floor.is_underground() && !floor.is_in_quest();
         if (check_conn && !floor_is_connected(floor, is_permanent_blocker)) {
             // 一定回数試しても連結にならないなら諦める。
             if (num >= 1000) {


### PR DESCRIPTION
変愚蛮怒 PR #5484 の内容をマージ。ダンジョン内フロアの連結性判定
(孤立領域の検出→再生成) は本来「生成が他要因で成功した時」に走るべきだが、
条件が why (再生成理由あり=失敗時) になっており、成功時に判定されず孤立領域が
そのまま残る不具合があった。条件を !why に修正し、生成成功時に連結性を判定する。

上流コミット: d50ef6f39 (hengband/develop)
bakabakaband 側は該当行の文脈が上流と同一のため、CreatureEntity 変換等は不要で 1 文字修正 (why → !why) をそのまま適用。フルビルド (g++ -O3 -Werror) で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dungeon floor generation by correctly validating floor connectivity before accepting a generated floor.
  * Reduced the chance of disconnected underground, non-quest floors being generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->