### PR TITLE
merge: 不正値で実行時不具合を起こすデータをJSON Schemaで弾く（hengband#5476 相当・部分）

### DIFF
--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -267,9 +267,9 @@
                     "blows": {
                         "type": "array",
                         "description": "物理攻撃",
+                        "maxItems": 4,
                         "items": {
                             "type": "object",
-                            "maxItems": 4,
                             "additionalProperties": false,
                             "required": [
                                 "method",
@@ -328,7 +328,7 @@
                             "probability": {
                                 "type": "string",
                                 "description": "能力使用確率",
-                                "pattern": "1_IN_[1-9][0-9]*"
+                                "pattern": "^1_IN_([1-9][0-9]?|100)$"
                             },
                             "shoot": {
                                 "type": "string",


### PR DESCRIPTION
変愚蛮怒 PR #5476 の内容をマージ。CIで強制される JSON Schema validation を厳格化し、 reader 側に到達すると不具合を起こす値を事前に排除する。

適用 (MonraceDefinitions.schema.json):
- skill.probability の分母を 1〜100 に制限 (pattern を ^1_IN_([1-9][0-9]?|100)$ へ)。 1_IN_0 のゼロ除算・1_IN_256 等の byte narrowing 由来ゼロ除算・巨大値 std::stoi 例外を排除。
- blows の maxItems:4 を items サブスキーマ (no-op だった) から配列レベルへ移動。 打撃5個以上のデータが通過し set_mon_blows で blows[] 範囲外書込(UB)する不具合を排除。

適用前検証 (pyjson5 で全 2300+ 種を走査):
- 最大 blow 数 = 4 (5個以上なし) のため maxItems:4 で既存データは全て通過。
- skill.probability の分母は最大 15 (>100 なし) のため tightening でも全て通過。
- validate_json.py 8/8 成功で既存データが新制約を満たすことを確認。

DungeonDefinitions の tile.rate は bakabakaband では既に maximum:100 (上流の 32767 より 厳格) で保護済みのため対象外 (作業不要)。room_rates.rate は bakabakaband 独自フィールドで 上流 PR 対象外。

上流コミット: bdf85182a (hengband/develop)。