### PR TITLE
merge: CAVE_ICKY を CAVE_NO_TELEPORT_DEST にリネーム（hengband#5485 相当）

### DIFF
--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -140,7 +140,7 @@ static void recursive_river(FloorType &floor, const Pos2D &pos_start, const Pos2
                     }
 
                     /* Hack -- don't teleport here */
-                    grid.info |= CAVE_ICKY;
+                    grid.info |= CAVE_NO_TELEPORT_DEST;
                 }
             }
 
@@ -380,7 +380,7 @@ void place_trees(CreatureEntity &creature, const Pos2D &pos)
             }
 
             auto &grid = floor.get_grid(pos_neighbor);
-            if (any_bits(grid.info, CAVE_ICKY) || !grid.o_idx_list.empty()) {
+            if (any_bits(grid.info, CAVE_NO_TELEPORT_DEST) || !grid.o_idx_list.empty()) {
                 continue;
             }
 

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -565,7 +565,7 @@ void lite_spot(CreatureEntity &creature, const Pos2D &pos)
  * and should be illuminated by "lite room" and "darkness" spells.
  *
  *
- * A grid may be marked as "CAVE_ICKY" which means it is part of a "vault",
+ * A grid may be marked as "CAVE_NO_TELEPORT_DEST" which means it is part of a "vault",
  * and should be unavailable for "teleportation" destinations.
  *
  *

--- a/src/info-reader/general-parser.h
+++ b/src/info-reader/general-parser.h
@@ -20,7 +20,7 @@ struct dungeon_grid {
     EgoType ego; /* Ego-Item */
     FixedArtifactId artifact; /* Artifact */
     IDX trap; /* Trap */
-    BIT_FLAGS cave_info; /* Flags for CAVE_MARK, CAVE_GLOW, CAVE_ICKY, CAVE_ROOM */
+    BIT_FLAGS cave_info; /* Flags for CAVE_MARK, CAVE_GLOW, CAVE_NO_TELEPORT_DEST, CAVE_ROOM */
     int16_t special; /* Reserved for special terrain info */
     int random; /* Number of the random effect */
     bool force_monster_place; /*!< モンスターの強制配置 */

--- a/src/room/cave-filler.cpp
+++ b/src/room/cave-filler.cpp
@@ -92,7 +92,7 @@ void generate_hmap(FloorType &floor, POSITION y0, POSITION x0, POSITION xsiz, PO
     for (POSITION i = 0; i <= xsize; i++) {
         for (POSITION j = 0; j <= ysize; j++) {
             floor.grid_array[(int)(fill_data.ymin + j)][(int)(fill_data.xmin + i)].feat = -1;
-            floor.grid_array[(int)(fill_data.ymin + j)][(int)(fill_data.xmin + i)].info &= ~(CAVE_ICKY);
+            floor.grid_array[(int)(fill_data.ymin + j)][(int)(fill_data.xmin + i)].info &= ~(CAVE_NO_TELEPORT_DEST);
         }
     }
 
@@ -180,11 +180,11 @@ static bool hack_isnt_wall(CreatureEntity &creature, POSITION y, POSITION x, int
     BIT_FLAGS info1, BIT_FLAGS info2, BIT_FLAGS info3)
 {
     auto &floor = *creature.get_floor();
-    if (floor.grid_array[y][x].info & CAVE_ICKY) {
+    if (floor.grid_array[y][x].info & CAVE_NO_TELEPORT_DEST) {
         return false;
     }
 
-    floor.grid_array[y][x].info |= (CAVE_ICKY);
+    floor.grid_array[y][x].info |= (CAVE_NO_TELEPORT_DEST);
     if (floor.grid_array[y][x].feat <= c1) {
         if (randint1(100) < 75) {
             floor.grid_array[y][x].feat = feat1;
@@ -244,12 +244,12 @@ static void cave_fill(CreatureEntity &creature, const Pos2D &initial_pos)
             const auto pos_to = pos + d.vec();
             auto &grid = floor.get_grid(pos_to);
             if (!floor.contains(pos_to, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
-                grid.info |= CAVE_ICKY;
+                grid.info |= CAVE_NO_TELEPORT_DEST;
                 continue;
             }
 
             if ((pos_to.x <= fill_data.xmin) || (pos_to.x >= fill_data.xmax) || (pos_to.y <= fill_data.ymin) || (pos_to.y >= fill_data.ymax)) {
-                grid.info |= CAVE_ICKY;
+                grid.info |= CAVE_NO_TELEPORT_DEST;
                 continue;
             }
 
@@ -285,7 +285,7 @@ bool generate_fracave(CreatureEntity &creature, POSITION y0, POSITION x0, POSITI
         for (POSITION x = 0; x <= xsize; ++x) {
             for (POSITION y = 0; y <= ysize; ++y) {
                 place_bold(creature, y0 + y - yhsize, x0 + x - xhsize, GB_EXTRA);
-                floor.grid_array[y0 + y - yhsize][x0 + x - xhsize].info &= ~(CAVE_ICKY | CAVE_ROOM);
+                floor.grid_array[y0 + y - yhsize][x0 + x - xhsize].info &= ~(CAVE_NO_TELEPORT_DEST | CAVE_ROOM);
             }
         }
 
@@ -319,8 +319,8 @@ bool generate_fracave(CreatureEntity &creature, POSITION y0, POSITION x0, POSITI
             place_bold(creature, y0 + ysize - yhsize, x0 + i - xhsize, GB_EXTRA);
         }
 
-        grid1.info &= ~(CAVE_ICKY);
-        grid2.info &= ~(CAVE_ICKY);
+        grid1.info &= ~(CAVE_NO_TELEPORT_DEST);
+        grid2.info &= ~(CAVE_NO_TELEPORT_DEST);
     }
 
     for (int i = 1; i < ysize; ++i) {
@@ -350,15 +350,15 @@ bool generate_fracave(CreatureEntity &creature, POSITION y0, POSITION x0, POSITI
             place_bold(creature, y0 + i - yhsize, x0 + xsize - xhsize, GB_EXTRA);
         }
 
-        grid1.info &= ~(CAVE_ICKY);
-        grid2.info &= ~(CAVE_ICKY);
+        grid1.info &= ~(CAVE_NO_TELEPORT_DEST);
+        grid2.info &= ~(CAVE_NO_TELEPORT_DEST);
     }
 
     for (POSITION x = 1; x < xsize; ++x) {
         for (POSITION y = 1; y < ysize; ++y) {
             auto &grid1 = floor.grid_array[y0 + y - yhsize][x0 + x - xhsize];
             if (grid1.is_floor() && grid1.is_icky()) {
-                grid1.info &= ~CAVE_ICKY;
+                grid1.info &= ~CAVE_NO_TELEPORT_DEST;
                 if (light) {
                     grid1.info |= (CAVE_GLOW);
                 }
@@ -372,7 +372,7 @@ bool generate_fracave(CreatureEntity &creature, POSITION y0, POSITION x0, POSITI
 
             auto &grid2 = floor.grid_array[y0 + y - yhsize][x0 + x - xhsize];
             if (grid2.is_outer() && grid2.is_icky()) {
-                grid2.info &= ~(CAVE_ICKY);
+                grid2.info &= ~(CAVE_NO_TELEPORT_DEST);
                 if (light) {
                     grid2.info |= (CAVE_GLOW);
                 }
@@ -388,7 +388,7 @@ bool generate_fracave(CreatureEntity &creature, POSITION y0, POSITION x0, POSITI
             }
 
             place_bold(creature, y0 + y - yhsize, x0 + x - xhsize, GB_EXTRA);
-            grid2.info &= ~(CAVE_ICKY | CAVE_ROOM);
+            grid2.info &= ~(CAVE_NO_TELEPORT_DEST | CAVE_ROOM);
         }
     }
 
@@ -468,7 +468,7 @@ bool generate_lake(CreatureEntity &creature, POSITION y0, POSITION x0, POSITION 
             for (auto y = 0; y <= ysize; ++y) {
                 const Pos2D pos(y0 + y - yhsize, x0 + x - xhsize);
                 place_bold(creature, pos.y, pos.x, GB_FLOOR);
-                floor.get_grid(pos).info &= ~(CAVE_ICKY);
+                floor.get_grid(pos).info &= ~(CAVE_NO_TELEPORT_DEST);
             }
         }
 
@@ -480,8 +480,8 @@ bool generate_lake(CreatureEntity &creature, POSITION y0, POSITION x0, POSITION 
         const Pos2DVec vec(ysize, 0);
         place_bold(creature, pos.y, pos.x, GB_EXTRA);
         place_bold(creature, (pos + vec).y, (pos + vec).x, GB_EXTRA);
-        floor.get_grid(pos).info &= ~(CAVE_ICKY);
-        floor.get_grid(pos + vec).info &= ~(CAVE_ICKY);
+        floor.get_grid(pos).info &= ~(CAVE_NO_TELEPORT_DEST);
+        floor.get_grid(pos + vec).info &= ~(CAVE_NO_TELEPORT_DEST);
     }
 
     for (auto i = 1; i < ysize; ++i) {
@@ -489,8 +489,8 @@ bool generate_lake(CreatureEntity &creature, POSITION y0, POSITION x0, POSITION 
         const Pos2DVec vec(0, xsize);
         place_bold(creature, pos.y, pos.x, GB_EXTRA);
         place_bold(creature, (pos + vec).y, (pos + vec).x, GB_EXTRA);
-        floor.get_grid(pos).info &= ~(CAVE_ICKY);
-        floor.get_grid(pos + vec).info &= ~(CAVE_ICKY);
+        floor.get_grid(pos).info &= ~(CAVE_NO_TELEPORT_DEST);
+        floor.get_grid(pos + vec).info &= ~(CAVE_NO_TELEPORT_DEST);
     }
 
     for (auto x = 1; x < xsize; ++x) {
@@ -501,7 +501,7 @@ bool generate_lake(CreatureEntity &creature, POSITION y0, POSITION x0, POSITION 
                 place_bold(creature, pos.y, pos.x, GB_EXTRA);
             }
 
-            grid.info &= ~(CAVE_ICKY | CAVE_ROOM);
+            grid.info &= ~(CAVE_NO_TELEPORT_DEST | CAVE_ROOM);
             if (floor.has_terrain_characteristics(pos, TerrainCharacteristics::LAVA)) {
                 if (floor.get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS)) {
                     grid.info |= CAVE_GLOW;

--- a/src/room/rooms-builder.cpp
+++ b/src/room/rooms-builder.cpp
@@ -168,16 +168,16 @@ void build_room(CreatureEntity &creature, POSITION x1, POSITION x2, POSITION y1,
     auto &floor = *creature.get_floor();
     for (int i = 0; i <= xsize; i++) {
         place_bold(creature, y1, x1 + i, GB_OUTER_NOPERM);
-        floor.grid_array[y1][x1 + i].info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.grid_array[y1][x1 + i].info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         place_bold(creature, y2, x1 + i, GB_OUTER_NOPERM);
-        floor.grid_array[y2][x1 + i].info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.grid_array[y2][x1 + i].info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
     }
 
     for (int i = 1; i < ysize; i++) {
         place_bold(creature, y1 + i, x1, GB_OUTER_NOPERM);
-        floor.grid_array[y1 + i][x1].info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.grid_array[y1 + i][x1].info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         place_bold(creature, y1 + i, x2, GB_OUTER_NOPERM);
-        floor.grid_array[y1 + i][x2].info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.grid_array[y1 + i][x2].info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
     }
 
     for (POSITION x = 1; x < xsize; x++) {
@@ -185,9 +185,9 @@ void build_room(CreatureEntity &creature, POSITION x1, POSITION x2, POSITION y1,
             auto &grid = floor.grid_array[y1 + y][x1 + x];
             if (grid.is_extra()) {
                 place_bold(creature, y1 + y, x1 + x, GB_FLOOR);
-                grid.info |= (CAVE_ROOM | CAVE_ICKY);
+                grid.info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
             } else {
-                grid.info |= (CAVE_ROOM | CAVE_ICKY);
+                grid.info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
             }
         }
     }

--- a/src/room/rooms-maze-vault.cpp
+++ b/src/room/rooms-maze-vault.cpp
@@ -113,7 +113,7 @@ void build_maze_vault(CreatureEntity &creature, const Pos2D &center, const Pos2D
             auto &grid = floor.get_grid({ y, x });
             grid.info |= CAVE_ROOM;
             if (is_vault) {
-                grid.info |= CAVE_ICKY;
+                grid.info |= CAVE_NO_TELEPORT_DEST;
             }
             if ((x == x1 - 1) || (x == x2 + 1) || (y == y1 - 1) || (y == y2 + 1)) {
                 place_grid(creature, grid, GB_OUTER);

--- a/src/room/rooms-nest.cpp
+++ b/src/room/rooms-nest.cpp
@@ -96,7 +96,7 @@ void generate_inner_room(CreatureEntity &creature, const Pos2D &center, Rect2D &
     });
 
     for (const auto &pos : inner_rectangle) {
-        floor.get_grid(pos).add_info(CAVE_ICKY);
+        floor.get_grid(pos).add_info(CAVE_NO_TELEPORT_DEST);
     }
 
     /* Place a secret door */

--- a/src/room/rooms-pit.cpp
+++ b/src/room/rooms-pit.cpp
@@ -148,7 +148,7 @@ void place_pit_inner(CreatureEntity &creature, const Pos2D &center)
 
     for (auto y = rectangle.top_left.y; y <= rectangle.bottom_right.y; y++) {
         for (auto x = rectangle.top_left.x; x <= rectangle.bottom_right.x; x++) {
-            floor.get_grid({ y, x }).add_info(CAVE_ICKY);
+            floor.get_grid({ y, x }).add_info(CAVE_NO_TELEPORT_DEST);
         }
     }
 
@@ -382,22 +382,22 @@ bool build_type13(CreatureEntity &creature, DungeonData *dd_ptr)
     for (auto x = rectangle.top_left.x + 3; x <= rectangle.bottom_right.x - 3; x++) {
         auto &grid_top = floor.get_grid({ center->y - 2, x });
         place_grid(creature, grid_top, GB_FLOOR);
-        grid_top.add_info(CAVE_ICKY);
+        grid_top.add_info(CAVE_NO_TELEPORT_DEST);
 
         auto &grid_bottom = floor.get_grid({ center->y + 2, x });
         place_grid(creature, grid_bottom, GB_FLOOR);
-        grid_bottom.add_info(CAVE_ICKY);
+        grid_bottom.add_info(CAVE_NO_TELEPORT_DEST);
     }
 
     /* Place the floor area 2 */
     for (auto x = rectangle.top_left.x + 5; x <= rectangle.bottom_right.x - 5; x++) {
         auto &grid_left = floor.get_grid({ center->y - 3, x });
         place_grid(creature, grid_left, GB_FLOOR);
-        grid_left.add_info(CAVE_ICKY);
+        grid_left.add_info(CAVE_NO_TELEPORT_DEST);
 
         auto &grid_right = floor.get_grid({ center->y + 3, x });
         place_grid(creature, grid_right, GB_FLOOR);
-        grid_right.add_info(CAVE_ICKY);
+        grid_right.add_info(CAVE_NO_TELEPORT_DEST);
     }
 
     /* Corridor */

--- a/src/room/rooms-special.cpp
+++ b/src/room/rooms-special.cpp
@@ -120,7 +120,7 @@ bool build_type15(CreatureEntity &creature, DungeonData *dd_ptr)
         /* Walls around the potion */
         for (const auto &d : Direction::directions_4()) {
             place_inner_perm_glass(creature, floor.get_grid(*center + d.vec() * 2));
-            floor.get_grid(*center + d.vec()).info |= CAVE_ICKY;
+            floor.get_grid(*center + d.vec()).info |= CAVE_NO_TELEPORT_DEST;
         }
 
         /* Glass door */
@@ -133,7 +133,7 @@ bool build_type15(CreatureEntity &creature, DungeonData *dd_ptr)
 
         /* Place a potion */
         place_object(creature, *center, AM_NO_FIXED_ART, kind_is_potion);
-        floor.get_grid(*center).info |= CAVE_ICKY;
+        floor.get_grid(*center).info |= CAVE_NO_TELEPORT_DEST;
     } break;
 
     case 2: /* 1 lite breather + random object */
@@ -168,7 +168,7 @@ bool build_type15(CreatureEntity &creature, DungeonData *dd_ptr)
 
         /* Place an object */
         place_object(creature, *center, AM_NO_FIXED_ART);
-        floor.get_grid(*center).info |= CAVE_ICKY;
+        floor.get_grid(*center).info |= CAVE_NO_TELEPORT_DEST;
     } break;
 
     case 3: /* 4 shards breathers + 2 potions */
@@ -210,7 +210,7 @@ bool build_type15(CreatureEntity &creature, DungeonData *dd_ptr)
 
         for (auto y = center->y - 2; y <= center->y + 2; y++) {
             for (auto x = center->x - 2; x <= center->x + 2; x++) {
-                floor.get_grid({ y, x }).info |= CAVE_ICKY;
+                floor.get_grid({ y, x }).info |= CAVE_NO_TELEPORT_DEST;
             }
         }
     } break;

--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -87,7 +87,7 @@ std::array<Pos2D, NUM_BUBBLES> create_bubbles_center(const Pos2DVec &vec)
 void set_boundaries(CreatureEntity &creature, const Pos2D &pos)
 {
     place_bold(creature, pos.y, pos.x, GB_OUTER_NOPERM);
-    creature.get_floor()->get_grid(pos).add_info(CAVE_ROOM | CAVE_ICKY);
+    creature.get_floor()->get_grid(pos).add_info(CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
 }
 }
 
@@ -149,7 +149,7 @@ static void build_bubble_vault(CreatureEntity &creature, const Pos2D &pos0, cons
             }
 
             /* clean up rest of flags */
-            floor.get_grid({ pos0.y - vec_half.y + y, pos0.x - vec_half.x + x }).add_info(CAVE_ROOM | CAVE_ICKY);
+            floor.get_grid({ pos0.y - vec_half.y + y, pos0.x - vec_half.x + x }).add_info(CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         }
     }
 
@@ -179,7 +179,7 @@ static void build_room_vault(CreatureEntity &creature, const Pos2D &center, cons
         for (auto y1 = 0; y1 < vec.y; y1++) {
             const Pos2D pos(center.y - vec_half.y + y1, x);
             place_bold(creature, pos.y, pos.x, GB_EXTRA);
-            floor.get_grid(pos).info &= (~CAVE_ICKY);
+            floor.get_grid(pos).info &= (~CAVE_NO_TELEPORT_DEST);
         }
     }
 
@@ -240,7 +240,7 @@ static void build_cave_vault(CreatureEntity &creature, const Pos2D &center, cons
     /* Set icky flag because is a vault */
     const Rect2D area(center, vec_half);
     for (const auto &pos : area) {
-        floor.get_grid(pos).info |= CAVE_ICKY;
+        floor.get_grid(pos).info |= CAVE_NO_TELEPORT_DEST;
     }
 
     /* Fill with monsters and treasure, low difficulty */
@@ -335,7 +335,7 @@ void build_vault(vault_type &vault, CreatureEntity &creature, POSITION yval, POS
             grid.mimic = 0;
 
             /* Part of a vault */
-            grid.info |= (CAVE_ROOM | CAVE_ICKY);
+            grid.info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
 
             if (vault.feature_list.find(*t) != vault.feature_list.end()) {
                 grid.set_terrain_id(vault.feature_list.find(*t)->second);
@@ -578,7 +578,7 @@ static void build_target_vault(CreatureEntity &creature, const Pos2D &center, co
             const Pos2D pos(y, x);
             auto &grid = floor.get_grid(pos);
             grid.info &= ~(CAVE_ROOM);
-            grid.info |= CAVE_ICKY;
+            grid.info |= CAVE_NO_TELEPORT_DEST;
 
             if (dist2(center.y, center.x, pos.y, pos.x, h1, h2, h3, h4) <= rad - 1) {
                 /* inside- so is floor */
@@ -708,7 +708,7 @@ static void build_elemental_vault(CreatureEntity &creature, const Pos2D &center,
     /* Set icky flag because is a vault */
     const Rect2D area(center, vec_half);
     for (const auto &pos : area) {
-        floor.get_grid(pos).info |= CAVE_ICKY;
+        floor.get_grid(pos).info |= CAVE_NO_TELEPORT_DEST;
     }
 
     /* make a few rooms in the vault */
@@ -747,7 +747,7 @@ static void build_mini_c_vault(CreatureEntity &creature, const Pos2D &center, co
             break;
         }
 
-        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         place_bold(creature, pos.y, pos.x, GB_OUTER_NOPERM);
     }
 
@@ -757,7 +757,7 @@ static void build_mini_c_vault(CreatureEntity &creature, const Pos2D &center, co
             break;
         }
 
-        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         place_bold(creature, pos.y, pos.x, GB_OUTER_NOPERM);
     }
 
@@ -767,7 +767,7 @@ static void build_mini_c_vault(CreatureEntity &creature, const Pos2D &center, co
             break;
         }
 
-        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         place_bold(creature, pos.y, pos.x, GB_OUTER_NOPERM);
     }
 
@@ -777,14 +777,14 @@ static void build_mini_c_vault(CreatureEntity &creature, const Pos2D &center, co
             break;
         }
 
-        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         place_bold(creature, pos.y, pos.x, GB_OUTER_NOPERM);
     }
 
     for (auto y = y1 - 1; y <= y2 + 1; y++) {
         for (auto x = x1 - 1; x <= x2 + 1; x++) {
             auto &grid = floor.get_grid({ y, x });
-            grid.info |= (CAVE_ROOM | CAVE_ICKY);
+            grid.info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
 
             /* Permanent walls */
             place_grid(creature, grid, GB_INNER_PERM);
@@ -846,7 +846,7 @@ static void build_castle_vault(CreatureEntity &creature, const Pos2D &center, co
     /* generate the room */
     auto &floor = *creature.get_floor();
     for (const auto &pos : area.resized(1)) {
-        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         /* Make everything a floor */
         place_bold(creature, pos.y, pos.x, GB_FLOOR);
     }

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -49,7 +49,7 @@ void reset_grid_info(FloorType &floor, std::span<const Pos2D> area)
 {
     for (const auto &pos : area) {
         auto &grid = floor.get_grid(pos);
-        grid.info &= ~(CAVE_ROOM | CAVE_ICKY | CAVE_UNSAFE);
+        grid.info &= ~(CAVE_ROOM | CAVE_NO_TELEPORT_DEST | CAVE_UNSAFE);
         grid.info &= ~(CAVE_GLOW | CAVE_MARK | CAVE_KNOWN);
     }
 }

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -281,7 +281,7 @@ bool destroy_area(CreatureEntity &creature, const POSITION y1, const POSITION x1
             auto &grid = floor.get_grid(pos);
 
             /* Lose room and vault */
-            grid.info &= ~(CAVE_ROOM | CAVE_ICKY);
+            grid.info &= ~(CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
 
             /* Lose light and knowledge */
             grid.info &= ~(CAVE_MARK | CAVE_GLOW | CAVE_KNOWN);

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -97,7 +97,7 @@ static void erase_wall(FloorType &floor, const Pos2D &pos)
 {
     auto &grid = floor.get_grid(pos);
     const auto &terrain = grid.get_terrain(TerrainKind::MIMIC_RAW);
-    grid.info &= ~(CAVE_ROOM | CAVE_ICKY);
+    grid.info &= ~(CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
     if ((grid.mimic == 0) || terrain.flags.has_not(TerrainCharacteristics::CAN_DISINTEGRATE)) {
         return;
     }
@@ -139,7 +139,7 @@ bool vanish_dungeon(CreatureEntity &creature)
     for (const auto &pos : floor.get_area(FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
         auto &grid = floor.get_grid(pos);
         const auto &terrrain = grid.get_terrain();
-        grid.info &= ~(CAVE_ROOM | CAVE_ICKY);
+        grid.info &= ~(CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         const auto &monster = floor.get_monster(grid.m_idx);
         if (grid.has_monster() && monster.is_asleep()) {
             (void)set_monster_csleep(floor, grid.m_idx, 0);

--- a/src/system/grid-type-definition.cpp
+++ b/src/system/grid-type-definition.cpp
@@ -97,7 +97,7 @@ bool Grid::is_solid() const
 
 bool Grid::is_icky() const
 {
-    return any_bits(this->info, CAVE_ICKY);
+    return any_bits(this->info, CAVE_NO_TELEPORT_DEST);
 }
 
 bool Grid::is_lite() const

--- a/src/system/grid-type-definition.h
+++ b/src/system/grid-type-definition.h
@@ -12,7 +12,7 @@
  */
 #define CAVE_MARK 0x0001 /*!< 現在プレイヤーの記憶に収まっている / memorized feature */
 #define CAVE_GLOW 0x0002 /*!< マス自体が光源を持っている / self-illuminating */
-#define CAVE_ICKY 0x0004 /*!< 生成されたVaultの一部である / part of a vault */
+#define CAVE_NO_TELEPORT_DEST 0x0004 /*!< Vaultの一部でありテレポート等の移動先にできない / part of a vault; forbidden as a teleport destination */
 #define CAVE_ROOM 0x0008 /*!< 生成された部屋の一部である / part of a room */
 #define CAVE_LITE 0x0010 /*!< 現在光に照らされている / lite flag  */
 #define CAVE_VIEW 0x0020 /*!< 現在プレイヤーの視界に収まっている / view flag */


### PR DESCRIPTION
変愚蛮怒 PR #5485 の内容をマージ。フラグ CAVE_ICKY を意味を明確にした
CAVE_NO_TELEPORT_DEST へリネーム（Vault の一部でありテレポート等の移動先に できないグリッドを表す）。挙動変更のない純粋なシンボルリネーム。

bakabakaband 全 15 ファイル・59 箇所を機械的に置換し、#define のコメントも 上流に合わせて更新。フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。

上流コミット: 4032c1d82 (hengband/develop)。上流との命名同期により今後の マージ衝突を低減する。