### PR TITLE
merge: MessageReader のクラス化（hengband#5474 相当）

### DIFF
--- a/src/info-reader/message-reader.cpp
+++ b/src/info-reader/message-reader.cpp
@@ -14,6 +14,25 @@
 #include "view/display-messages.h"
 #include <string>
 
+MessageReader::MessageReader(const nlohmann::json &message_data)
+    : message_data(message_data)
+{
+}
+
+/*!
+ * @brief モンスターメッセージ情報(JSON Object)のパース関数
+ * @return エラーコード
+ */
+int MessageReader::read() const
+{
+    if (auto err = this->set_mon_message()) {
+        msg_format(_("モンスターメッセージ読込失敗。", "Failed to load monster message."));
+        return err;
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
 /*!
  * @brief JSON Objectからid群をセットする
  * @param id_list_data id群情報の格納されたJSON Object
@@ -44,13 +63,14 @@ static errr set_id_list(const nlohmann::json &id_list_data, std::vector<int> &id
  * @param message_data メッセージ情報の格納されたJSON Object
  * @return エラーコード
  */
-static errr set_mon_message(const nlohmann::json &group_data)
+int MessageReader::set_mon_message() const
 {
+    const auto &group_data = this->message_data;
     const auto message_iter = group_data.find("message");
     if (message_iter == group_data.end() || !message_iter->is_array()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
-    const auto &message_data = message_iter.value();
+    const auto &message_array = message_iter.value();
     auto id_list = std::vector<int>();
 
     const auto id_list_iter = group_data.find("id_list");
@@ -62,21 +82,22 @@ static errr set_mon_message(const nlohmann::json &group_data)
             return id_err;
         }
     } else {
-        if (!group_data["name"].is_string()) {
+        const auto &name_obj = get_json_value(group_data, "name");
+        if (!name_obj.is_string()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
-        const auto group_name = group_data["name"].get<std::string>();
+        const auto group_name = name_obj.get<std::string>();
         if (group_name != "DEFAULT") {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
     }
 
-    if (!message_data.is_array()) {
+    if (!message_array.is_array()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
-    for (const auto &message : message_data) {
+    for (const auto &message : message_array) {
         const auto action_iter = message.find("action");
         if (action_iter == message.end() || !action_iter->is_string()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
@@ -157,22 +178,5 @@ static errr set_mon_message(const nlohmann::json &group_data)
             }
         }
     }
-    return PARSE_ERROR_NONE;
-}
-
-/*!
- * @brief モンスターメッセージ情報(JSON Object)のパース関数
- * @param mon_data モンスターメッセージの格納されたJSON Object
- * @return エラーコード
- */
-errr parse_monster_messages_info(nlohmann::json &message_data)
-{
-    errr err;
-    err = set_mon_message(message_data);
-    if (err) {
-        msg_format(_("モンスターメッセージ読込失敗。", "Failed to load monster message."));
-        return err;
-    }
-
     return PARSE_ERROR_NONE;
 }

--- a/src/info-reader/message-reader.h
+++ b/src/info-reader/message-reader.h
@@ -1,7 +1,20 @@
 #pragma once
 
-#include "system/angband.h"
 #include <nlohmann/json.hpp>
-#include <string_view>
 
-errr parse_monster_messages_info(nlohmann::json &element);
+class MessageReader {
+public:
+    explicit MessageReader(const nlohmann::json &message_data);
+    MessageReader(nlohmann::json &&) = delete;
+    MessageReader(const MessageReader &) = delete;
+    MessageReader(MessageReader &&) = delete;
+    MessageReader &operator=(const MessageReader &) = delete;
+    MessageReader &operator=(MessageReader &&) = delete;
+
+    int read() const;
+
+private:
+    int set_mon_message() const;
+
+    const nlohmann::json &message_data;
+};

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -243,7 +243,10 @@ void init_monrace_definitions()
  */
 void init_monster_message_definitions()
 {
-    init_json("MonsterMessages.jsonc", "groups", DefinitionHashDataType::MONSTER_MESSAGES, MonraceMessageList::get_instance(), parse_monster_messages_info);
+    auto parser = [](nlohmann::json &message_data) {
+        return MessageReader(message_data).read();
+    };
+    init_json("MonsterMessages.jsonc", "groups", DefinitionHashDataType::MONSTER_MESSAGES, MonraceMessageList::get_instance(), parser);
 }
 
 /*!


### PR DESCRIPTION
変愚蛮怒 PR #5474 の内容をマージ。モンスターメッセージのパーサを自由関数
parse_monster_messages_info + static set_mon_message から MessageReader クラス (read() + private set_mon_message()) へ再構成。JSON Object を member に保持する。

- info-initializer.cpp は lambda 経由で MessageReader(message_data).read() を呼ぶ。
- name アクセスを group_data["name"] から get_json_value(group_data, "name") へ (上流の安全化に追従、bakabakaband にも get_json_value は既存)。
- 内部ローカル message_data を member 名衝突回避のため message_array にリネーム。

bakabakaband の message-reader は上流と構造がほぼ同一で、CreatureEntity 変換等は 不要だった。フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。

上流コミット: 67780c6c9 (hengband/develop, PR #5474)。