### PR TITLE
merge: SpellReader のクラス化（hengband#5475 相当）

### DIFF
--- a/src/info-reader/spell-reader.cpp
+++ b/src/info-reader/spell-reader.cpp
@@ -7,19 +7,46 @@
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 
+SpellReader::SpellReader(const nlohmann::json &realm_data, SpellInfoList &spell_info_list)
+    : realm_data(realm_data)
+    , spell_info_list(spell_info_list)
+{
+}
+
+/*!
+ * @brief 呪文情報(SpellDefinitions)のパース関数
+ * @return エラーコード
+ */
+int SpellReader::read() const
+{
+    error_idx++; //!< @note 呪文領域は数値IDを持たないため、エラー表示用に要素の順序を用いる
+
+    RealmType realm_id;
+    if (auto err = this->set_realm(realm_id)) {
+        msg_format(_("領域名読込失敗。ID: '%d'。", "Failed to load realm name. ID: '%d'."), error_idx);
+        return err;
+    }
+
+    if (auto err = this->set_book_data(realm_id)) {
+        msg_format(_("呪文詳細読込失敗。ID: '%d'。", "Failed to load spell data. ID: '%d'."), error_idx);
+        return err;
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
 /*!
  * @brief JSON Objectから呪文領域IDを取得する
- * @param spell_data 情報の格納されたJSON Object
  * @param realm 呪文領域
  * @return エラーコード
  */
-static errr set_realm(const nlohmann::json &spell_data, RealmType &realm)
+int SpellReader::set_realm(RealmType &realm) const
 {
-    if (spell_data.is_null()) {
+    if (this->realm_data.is_null()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
-    const auto &realmname_obj = spell_data["name"];
+    const auto &realmname_obj = get_json_value(this->realm_data, "name");
     if (!realmname_obj.is_string()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
@@ -35,91 +62,66 @@ static errr set_realm(const nlohmann::json &spell_data, RealmType &realm)
 /*!
  * @brief JSON Objectから各呪文の詳細を取得する
  * @param spell_data 情報の格納されたJSON Object
- * @param spell_info_list 呪文情報リスト
  * @param realm 領域ID
  * @return エラーコード
  */
-static errr set_spell_data(const nlohmann::json &spell_data, SpellInfoList &spell_info_list, RealmType realm)
+int SpellReader::set_spell_data(const nlohmann::json &spell_data, RealmType realm) const
 {
     if (spell_data.is_null()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
     int spell_id;
-    if (auto err = info_set_integer(spell_data["spell_id"], spell_id, true, Range(0, 31))) {
+    if (auto err = info_set_integer(get_json_value(spell_data, "spell_id"), spell_id, true, Range(0, 31))) {
         msg_format(_("呪文ID読込失敗。ID: '%d'。", "Failed to load spell ID. ID: '%d'."), error_idx);
         return err;
     }
     auto info = SpellInfo();
     info.idx = static_cast<short>(spell_id);
 
-    const auto &tag_obj = spell_data["spell_tag"];
+    const auto &tag_obj = get_json_value(spell_data, "spell_tag");
     if (!tag_obj.is_string()) {
         msg_format(_("呪文タグ読込失敗。ID: '%d'。", "Failed to load spell tag. ID: '%d'."), error_idx);
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
     info.tag = tag_obj.get<std::string>();
 
-    if (auto err = info_set_string(spell_data["name"], info.name, true)) {
+    if (auto err = info_set_string(get_json_value(spell_data, "name"), info.name, true)) {
         msg_format(_("呪文名読込失敗。ID: '%d'。", "Failed to load spell name. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_string(spell_data["description"], info.description, true)) {
+    if (auto err = info_set_string(get_json_value(spell_data, "description"), info.description, true)) {
         msg_format(_("呪文説明読込失敗。ID: '%d'。", "Failed to load spell description. ID: '%d'."), error_idx);
         return err;
     }
-    spell_info_list.set_spell_info(realm, spell_id, std::move(info));
+    this->spell_info_list.set_spell_info(realm, spell_id, std::move(info));
 
     return PARSE_ERROR_NONE;
 }
 
 /*!
  * @brief JSON Objectから各呪文の詳細を呪文書単位で取得する
- * @param spell_data 情報の格納されたJSON Object
- * @param spell_info_list 呪文情報リスト
  * @param realm 領域ID
  * @return エラーコード
  */
-static errr set_book_data(const nlohmann::json &spell_data, SpellInfoList &spell_info_list, RealmType realm)
+int SpellReader::set_book_data(RealmType realm) const
 {
-    auto &book_obj = spell_data["books"];
+    const auto &book_obj = get_json_value(this->realm_data, "books");
     if (book_obj.is_null()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
     for (const auto &book : book_obj) {
-        const auto &spells_obj = book["spells"];
+        const auto &spells_obj = get_json_value(book, "spells");
         if (spells_obj.is_null()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
         for (const auto &spell : spells_obj) {
-            if (auto err = set_spell_data(spell, spell_info_list, realm)) {
+            if (auto err = this->set_spell_data(spell, realm)) {
                 return err;
             }
         }
     }
-    return PARSE_ERROR_NONE;
-}
-
-/*!
- * @brief 職業魔法情報(ClassMagicDefinitions)のパース関数
- * @param buf テキスト列
- * @param spell_info_list パースした結果を格納する領域
- * @return エラーコード
- */
-errr parse_spell_info(nlohmann::json &spell_data, SpellInfoList &spell_info_list)
-{
-    RealmType realm_id;
-    if (auto err = set_realm(spell_data, realm_id)) {
-        msg_format(_("領域名読込失敗。ID: '%d'。", "Failed to load realm name. ID: '%d'."), error_idx);
-        return err;
-    }
-
-    if (auto err = set_book_data(spell_data, spell_info_list, realm_id)) {
-        msg_format(_("呪文詳細読込失敗。ID: '%d'。", "Failed to load spell data. ID: '%d'."), error_idx);
-        return err;
-    }
-
     return PARSE_ERROR_NONE;
 }

--- a/src/info-reader/spell-reader.h
+++ b/src/info-reader/spell-reader.h
@@ -1,8 +1,26 @@
 #pragma once
 
-#include "system/angband.h"
 #include <nlohmann/json.hpp>
 
+enum class RealmType;
 class SpellInfoList;
 
-errr parse_spell_info(nlohmann::json &spell_data, SpellInfoList &spell_info_list);
+class SpellReader {
+public:
+    SpellReader(const nlohmann::json &realm_data, SpellInfoList &spell_info_list);
+    SpellReader(nlohmann::json &&, SpellInfoList &) = delete;
+    SpellReader(const SpellReader &) = delete;
+    SpellReader(SpellReader &&) = delete;
+    SpellReader &operator=(const SpellReader &) = delete;
+    SpellReader &operator=(SpellReader &&) = delete;
+
+    int read() const;
+
+private:
+    int set_realm(RealmType &realm) const;
+    int set_spell_data(const nlohmann::json &spell_data, RealmType realm) const;
+    int set_book_data(RealmType realm) const;
+
+    const nlohmann::json &realm_data;
+    SpellInfoList &spell_info_list;
+};

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -265,7 +265,7 @@ void init_spell_info()
     auto &spell_info_list = SpellInfoList::get_instance();
     spell_info_list.initialize();
     auto parser = [&spell_info_list](nlohmann::json &spell_data) {
-        return parse_spell_info(spell_data, spell_info_list);
+        return SpellReader(spell_data, spell_info_list).read();
     };
     init_json("SpellDefinitions.jsonc", "realms", DefinitionHashDataType::SPELLS, spell_info_list, parser);
 }


### PR DESCRIPTION
変愚蛮怒 PR #5475 の内容をマージ。呪文情報(SpellDefinitions)のパーサを自由関数 parse_spell_info + static set_realm/set_spell_data/set_book_data から SpellReader クラス (read() + 3 private メソッド) へ再構成。realm_data(JSON) と spell_info_list を member に保持する。

- info-initializer.cpp は lambda 経由で SpellReader(spell_data, spell_info_list).read()。
- 各 JSON アクセスを get_json_value(...) 経由に安全化 (上流に追従)。
- read() 先頭に error_idx++ を追加 (呪文領域は数値IDを持たないためエラー表示用に 要素順序を用いる、上流と同一)。エラーメッセージ表示のみに影響しパース結果は不変。

bakabakaband の spell-reader は上流と構造がほぼ同一で CreatureEntity 変換等は不要。 フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。

上流コミット: e353605cf (hengband/develop, PR #5475)。