### PR TITLE
feat: モンスターの戦闘習熟(レベル成長)を近接命中へ opt-in 反映（提案C2第2弾）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -711,6 +711,32 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
   能力値を戦闘へ広く反映する拡張は将来提案で段階導入する。
 - スキーマに `grows_stats` を登録済。
 
+### モンスターの戦闘習熟＝近接命中補正 (`grows_melee_proficiency`) — 提案 C2第2弾
+
+`MonraceDefinition` に `bool grows_melee_proficiency`
+(`src/system/monrace/monrace-definition.h`) を持ち、JSON
+`lib/edit/MonraceDefinitions.jsonc` で「レベル成長で得た戦闘習熟を近接命中へ反映」を
+有効化できる。C2第1弾（stat 成長）に続くモンスター成長の拡張で、**JSON オプトイン方式**
+（既定 `false`=無効でバランス不変）。
+
+```jsonc
+"grows_melee_proficiency": true
+```
+
+- **背景（重要）:** プレイヤーの `weapon_exp`（武器熟練度）は**モンスターの innate
+  blow には適用されない**（モンスター近接は `power = mbe_info[effect].power`・
+  `rlev = monrace.level` 固定で weapon_exp を参照しない）。よってモンスターの「熟練度」は
+  **撃破によるレベル成長（第4段）**で表現する。
+- **効果:** `CreatureEntity::get_melee_proficiency_bonus()` が、フラグ ON の個体につき
+  生成時基準 `monrace.level/2` を超えて成長した分（`get_level() - monrace.level/2`、
+  0 下限）を返し、近接命中判定の `rlev` に加算する。両経路（monster-vs-monster =
+  `melee-util.cpp`、monster-vs-player = `monster-attack-player.cpp`）に配線。命中式は
+  B3 共通化済の `check_hit_from_monster_to_*` をそのまま利用。
+- 現状 `rlev` は `monrace.level` 固定で、モンスターがレベルアップしても命中が向上
+  しないギャップを埋める。満成長で `rlev` は最大 `1.5×monrace.level`（有界）。
+- **安全性:** プレイヤー・未成長・フラグ OFF では 0 を返すため**既定バランス不変**。
+- スキーマに `grows_melee_proficiency` を登録済。
+
 ### モンスターの MP 消費詠唱 (`consumes_mp`) — 提案 C4
 
 `MonraceDefinition` に `bool consumes_mp`

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3219,14 +3219,38 @@ monrace を参照）が `prace`/`pclass` に付与する。**効果は未反映*
   本提案は成長機構・データ経路の確立が主眼で、効果の深化は下記次段以降。
 - フルビルド (g++ -O3 -Werror -Wall -Wextra) / clang-format-18 / validate_json.py で検証済。
 
-### 第2弾以降（未着手）
+### 第2弾 ✅ 完了（戦闘習熟＝近接命中補正、モンスター適合形）
 
-- **熟練度成長**: 攻撃・詠唱で `weapon_exp`/`skill_exp` を蓄積し命中/ダメージへ反映
-  （命中式は B3 で共通化済のため差込口は明確）。別途 growth-on-use フックが要る。
+**着手前の実コード検証（重要）:** プレイヤーの `weapon_exp`（武器熟練度）は
+**モンスターの innate blow（RaceBlow）には適用されない**ことを確認した。モンスター
+近接は `power = mbe_info[effect].power`（固定表）・`rlev = monrace.level`（固定の種族
+レベル）で命中判定され、`weapon_exp` を一切参照しない（monster-attack-monster /
+melee-util / monster-attack-player 全経路で確認）。よって「player weapon_exp の反映」
+は**そのままでは実装不可**。
+
+**モンスター適合形で実装:** モンスターの「戦闘習熟」は**撃破による経験値でのレベル
+成長（第4段）**に相当するため、それを近接命中へ反映する形とした。現状 `rlev` は
+`monrace.level`（固定）で、モンスターがレベルアップしても**命中は向上しない**という
+ギャップを埋める。
+
+- `MonraceDefinition::grows_melee_proficiency`（bool・既定 false）を追加。
+- `CreatureEntity::get_melee_proficiency_bonus()` を新設。フラグ ON の個体のみ、
+  生成時基準 `monrace.level/2` を超えて成長した分（`get_level() - monrace.level/2`、
+  0 下限）を返す。プレイヤー・未成長・フラグ OFF では 0（バランス不変）。
+- 近接命中の両経路（monster-vs-monster `melee-util.cpp`、monster-vs-player
+  `monster-attack-player.cpp`）の `rlev` へ本ボーナスを加算。命中式（B3 共通化済の
+  `check_hit_from_monster_to_*`）はそのまま利用。
+- 満成長で `rlev` は最大 `monrace.level → 1.5×monrace.level`（有界）。reader/schema/
+  CLAUDE.md 整備。既定 OFF のため実データ・既定バランス不変。フルビルド／
+  validate_json で検証済。
+
 - **能力値のゲーム効果拡張**: 成長した stat を戦闘（命中・ダメージ・セーヴ等）へ
-  広く反映する。メンテナのバランス判断のもと段階導入。
+  広く反映する（未着手）。メンテナのバランス判断のもと段階導入。
 
-**デザイン判断（残）:** 熟練度をモンスター戦闘にどう効かせるか、能力値効果の反映範囲。
+**デザイン判断メモ:** player weapon_exp/skill_exp は innate blow のモンスターに
+概念が合わないため、モンスターの熟練度は「戦闘経験＝レベル成長」で表現した。武器を
+装備するモンスター（提案12）への weapon_exp 反映は、モンスター攻撃が innate blow
+主体のため対象外（将来、装備武器で殴るモンスターを実装する場合の拡張余地）。
 
 ---
 

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -201,6 +201,10 @@
                         "type": "boolean",
                         "description": "付与された player_race の属性耐性(火/冷/電/酸/毒)を被ダメージへ反映するか (提案C1第2弾)。既定false=オプトイン。trueかつ有効なplayer_raceを持つ個体のみ、種族耐性がある属性の被ダメージが約1/3に軽減される。"
                     },
+                    "grows_melee_proficiency": {
+                        "type": "boolean",
+                        "description": "レベルアップで得た戦闘習熟を近接命中へ反映するか (提案C2第2弾)。既定false=オプトイン。trueの個体は、生成時レベルを超えて成長した分だけ近接攻撃の命中判定が向上する。"
+                    },
                     "odds_correction_ratio": {
                         "type": "integer",
                         "description": "闘技場オッズ補正値。1/100を使用、100で等倍200で2倍",

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -1561,6 +1561,11 @@ errr RaceReader::read()
         msg_format(_("モンスター種族耐性反映フラグ読込失敗。ID: '%d'。", "Failed to load monster applies_player_race_resistances. ID: '%d'."), error_idx);
         return err;
     }
+    err = info_set_bool(mon_data["grows_melee_proficiency"], monrace.grows_melee_proficiency, false);
+    if (err) {
+        msg_format(_("モンスター戦闘習熟フラグ読込失敗。ID: '%d'。", "Failed to load monster grows_melee_proficiency. ID: '%d'."), error_idx);
+        return err;
+    }
     err = info_set_integer(mon_data["odds_correction_ratio"], monrace.arena_ratio, false, Range(1, 9999));
     if (err) {
         msg_format(_("モンスター賭け倍率読込失敗。ID: '%d'。", "Failed to load monster odds for arena. ID: '%d'."), error_idx);

--- a/src/melee/melee-util.cpp
+++ b/src/melee/melee-util.cpp
@@ -32,7 +32,8 @@ mam_type *initialize_mam_type(CreatureEntity &creature, mam_type *mam_ptr, MONST
 
     const auto &monrace = mam_ptr->m_ptr->get_monrace();
     mam_ptr->ac = static_cast<ARMOUR_CLASS>(mam_ptr->t_ptr->get_ac());
-    mam_ptr->rlev = ((monrace.level >= 1) ? monrace.level : 1);
+    // [提案C2第2弾] 戦闘習熟(レベル成長分)を近接命中へ加算 (grows_melee_proficiency・既定OFF)。
+    mam_ptr->rlev = ((monrace.level >= 1) ? monrace.level : 1) + mam_ptr->m_ptr->get_melee_proficiency_bonus();
     mam_ptr->blinked = false;
     mam_ptr->power = 0;
     mam_ptr->obvious = false;

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -88,7 +88,8 @@ void MonsterAttackPlayer::make_attack_normal()
     }
 
     const auto &monrace = this->m_ptr->get_monrace();
-    this->rlev = ((monrace.level >= 1) ? monrace.level : 1);
+    // [提案C2第2弾] 戦闘習熟(レベル成長分)を近接命中へ加算 (grows_melee_proficiency・既定OFF)。
+    this->rlev = ((monrace.level >= 1) ? monrace.level : 1) + this->m_ptr->get_melee_proficiency_bonus();
     angband_strcpy(this->m_name, monster_desc(creature, *this->m_ptr, 0), sizeof(this->m_name));
     angband_strcpy(this->ddesc, monster_desc(creature, *this->m_ptr, MD_WRONGDOER_NAME), sizeof(this->ddesc));
     if (CreatureClass(creature).samurai_stance_is(SamuraiStanceType::IAI)) {

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -1887,6 +1887,22 @@ PLAYER_LEVEL CreatureEntity::get_level() const
     return this->level;
 }
 
+int CreatureEntity::get_melee_proficiency_bonus() const
+{
+    if (!this->has_monster_profile()) {
+        return 0;
+    }
+
+    const auto &monrace = this->get_monrace();
+    if (!monrace.grows_melee_proficiency) {
+        return 0;
+    }
+
+    const auto base_level = monrace.level / 2;
+    const auto grown = static_cast<int>(this->get_level()) - base_level;
+    return grown > 0 ? grown : 0;
+}
+
 /*!
  * @brief 表示用の称号を取得する (提案 E5, 基底 = モンスター既定)
  * @details モンスターは称号を持たないため "なし" を返す。プレイヤーは

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -575,6 +575,14 @@ public:
     virtual PLAYER_LEVEL get_level() const;
 
     /*!
+     * @brief モンスターの戦闘習熟による近接命中補正を返す (提案C2第2弾)
+     * @details grows_melee_proficiency が立つモンスターのみ、生成時の基準レベル
+     * (monrace.level/2) を超えて成長した分を近接命中判定の rlev へ加算する補正として返す。
+     * 既定 false / 未成長 / プレイヤーでは 0 を返すため既定バランス不変。
+     */
+    int get_melee_proficiency_bonus() const;
+
+    /*!
      * @brief クリーチャーがプレイヤーかどうかを判定
      * @return プレイヤーならtrue、モンスターならfalse
      * @details デフォルトはfalse（モンスター）。PlayerTypeのみtrueを返す。

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -139,6 +139,7 @@ public:
     RealmType realm_abilities = RealmType::NONE; //!< 詠唱能力を付与する魔法領域 (提案C6。NONE=なし=オプトイン。詠唱時に realm 由来の MonsterAbilityType を追加)
     bool suffers_poison_dot = false; //!< 毒攻撃で継続毒(POISON DoT)を受けるか (提案D7。既定false=オプトイン。既定バランス不変)
     bool applies_player_race_resistances = false; //!< 付与された player_race の属性耐性を被ダメージへ反映するか (提案C1第2弾。既定false=オプトイン。既定バランス不変)
+    bool grows_melee_proficiency = false; //!< レベルアップで得た戦闘習熟を近接命中へ反映するか (提案C2第2弾。既定false=オプトイン。既定バランス不変)
     EnumClassFlagGroup<MonsterFeedType> meat_feed_flags;
     EnumClassFlagGroup<MonsterAbilityType> ability_flags; //!< 能力フラグ(魔法/ブレス) / Ability Flags
     EnumClassFlagGroup<MonsterAuraType> aura_flags; //!< オーラフラグ / Aura Flags


### PR DESCRIPTION
着手前検証: プレイヤーの weapon_exp は モンスターの innate blow には適用されない (モンスター近接は power=mbe_info[effect].power・rlev=monrace.level 固定で weapon_exp を参照しない)。よってモンスターの「熟練度」は撃破によるレベル成長(第4段)で表現する。

- MonraceDefinition::grows_melee_proficiency (bool・既定false) を追加。
- CreatureEntity::get_melee_proficiency_bonus(): フラグONの個体につき生成時基準 (monrace.level/2)を超えて成長した分を返す(0下限)。プレイヤー/未成長/OFFでは0。
- 近接命中の両経路(melee-util / monster-attack-player)の rlev へ本ボーナスを加算。 命中式は B3 共通化済の check_hit_from_monster_to_* をそのまま利用。
- 現状 rlev=monrace.level 固定でレベルアップしても命中が向上しないギャップを解消。 満成長で rlev 最大 1.5×monrace.level(有界)。

既定OFFのため実データ・既定バランス不変。reader/schema/CLAUDE.md/roadmap 整備。 フルビルド(g++ -O3 -Werror)/validate_json で検証済。