### PR TITLE
feat: モンスターの能力値(STR)を近接ダメージへ opt-in 反映（提案C2第3弾）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -737,6 +737,30 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
 - **安全性:** プレイヤー・未成長・フラグ OFF では 0 を返すため**既定バランス不変**。
 - スキーマに `grows_melee_proficiency` を登録済。
 
+### モンスターの能力値の戦闘反映＝STR→近接ダメージ (`applies_stat_combat_bonus`) — 提案 C2第3弾
+
+`MonraceDefinition` に `bool applies_stat_combat_bonus`
+(`src/system/monrace/monrace-definition.h`) を持ち、JSON
+`lib/edit/MonraceDefinitions.jsonc` で「能力値(STR)を近接ダメージへ反映」を
+有効化できる。C2 の「能力値を戦闘へ反映」拡張の第1弾で、**JSON オプトイン方式**
+（既定 `false`=無効でバランス不変）。
+
+```jsonc
+"applies_stat_combat_bonus": true
+```
+
+- **効果:** `CreatureEntity::get_melee_stat_damage_bonus()` が、フラグ ON の個体につき
+  プレイヤーと同じ `adj_str_td` テーブル（monster の内部×10 stat を
+  `stat_value_to_table_index()` で索引化）で STR 補正 `adj-128` を返し、近接ダメージへ
+  加算する。両経路（monster-vs-monster / monster-vs-player）の `damage_dice.roll()`
+  直後に加算し、負値は 0 下限クランプ（explode 時は据え置き）。
+- **能力値スケールの扱い:** モンスター stat は内部×10（30-400）だが、CON→HP 補正
+  （`calc_max_hp_con_bonus`）と同じ `stat_value_to_table_index()` で adj テーブル索引に
+  変換するため、プレイヤー用 adj テーブルをそのまま流用できる。
+- **安全性:** プレイヤー・フラグ OFF では 0 を返すため**既定バランス不変**。
+- **未反映:** STR/DEX→命中、DEX→AC、能力値→セーヴ等は次段（都度 opt-in・段階導入）。
+- スキーマに `applies_stat_combat_bonus` を登録済。
+
 ### モンスターの MP 消費詠唱 (`consumes_mp`) — 提案 C4
 
 `MonraceDefinition` に `bool consumes_mp`

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3030,7 +3030,7 @@ JSON で明示付与**する形で導入する。これにより:
 |---|---|---|---|---|---|
 | C0 | 成長状態の savefile 完全永続化 (`hp_table`) | ほぼ完了 | 小 | 小 | バージョン bump 要否 |
 | C1 | 種族・職業の顕在化（`prace`/`pclass` 付与） | ✅ cache 有 | 中 | 高 | ✅ 1(付与)/2(基本5)/3(二次7)/4(恐怖)/5(自由行動)/6(光闇)/7(複合攻撃) 完了 |
-| C2 | 能力成長の拡張（stat / 熟練度） | ✅ 成長機構 | 中 | 中 | ✅ stat成長(opt-in)+熟練度=近接命中(opt-in) 完了／能力値の戦闘広範反映は次段 |
+| C2 | 能力成長の拡張（stat / 熟練度） | ✅ 成長機構 | 中 | 中 | ✅ stat成長/熟練度=近接命中/STR→近接ダメージ(全opt-in) 完了／命中・AC・セーヴ反映は次段 |
 | C3 | ESP のモンスター付与 | 🔴 新規 AI 要 | 中〜大 | 中 | ESP をモンスター AI にどう効かせるか（新規設計） |
 | C4 | MP 消費詠唱 | 🟡 pool 有 | 中 | 中 | ✅ 完了（opt-in・レベル比例コスト） |
 | C5 | 突然変異のモンスター運用 | 🟡 処理汎用 | 中 | 中 | ✅ 完了（3段: 付与→専用処理→発火） |
@@ -3244,8 +3244,22 @@ melee-util / monster-attack-player 全経路で確認）。よって「player we
   CLAUDE.md 整備。既定 OFF のため実データ・既定バランス不変。フルビルド／
   validate_json で検証済。
 
-- **能力値のゲーム効果拡張**: 成長した stat を戦闘（命中・ダメージ・セーヴ等）へ
-  広く反映する（未着手）。メンテナのバランス判断のもと段階導入。
+### 第3弾 ✅ 完了（能力値の戦闘反映＝STR→近接ダメージ、第1弾）
+
+能力値を戦闘へ反映する拡張の第1弾として、**STR を近接ダメージへ opt-in 反映**。
+
+- `MonraceDefinition::applies_stat_combat_bonus`（bool・既定 false）を追加。
+- `CreatureEntity::get_melee_stat_damage_bonus()` を新設。フラグ ON の個体のみ、
+  プレイヤーと同じ `adj_str_td` テーブル（`stat_value_to_table_index` で monster の
+  内部×10 stat を索引化）で STR 補正 `adj-128` を返す。プレイヤー・フラグ OFF では 0。
+- 近接ダメージの両経路（monster-vs-monster `monster-attack-monster.cpp`、
+  monster-vs-player `monster-attack-player.cpp`）の `damage_dice.roll()` 直後に加算し、
+  負値を 0 下限クランプ（explode 時は据え置き）。
+- 既定 OFF のため実データ・既定バランス不変。reader/schema/CLAUDE.md 整備。
+  フルビルド／validate_json で検証済。
+
+**次段候補（未着手）:** STR/DEX → 近接命中、DEX → AC、能力値 → セーヴ等への拡張。
+バランス感度が高いため adj テーブルベースで段階導入し、都度 opt-in フラグで制御する。
 
 **デザイン判断メモ:** player weapon_exp/skill_exp は innate blow のモンスターに
 概念が合わないため、モンスターの熟練度は「戦闘経験＝レベル成長」で表現した。武器を

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -205,6 +205,10 @@
                         "type": "boolean",
                         "description": "レベルアップで得た戦闘習熟を近接命中へ反映するか (提案C2第2弾)。既定false=オプトイン。trueの個体は、生成時レベルを超えて成長した分だけ近接攻撃の命中判定が向上する。"
                     },
+                    "applies_stat_combat_bonus": {
+                        "type": "boolean",
+                        "description": "能力値(STR)を近接ダメージへ反映するか (提案C2第3弾)。既定false=オプトイン。trueの個体は、プレイヤーと同じ adj_str_td テーブルで STR に応じた近接ダメージ補正を受ける。"
+                    },
                     "odds_correction_ratio": {
                         "type": "integer",
                         "description": "闘技場オッズ補正値。1/100を使用、100で等倍200で2倍",

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -1566,6 +1566,11 @@ errr RaceReader::read()
         msg_format(_("モンスター戦闘習熟フラグ読込失敗。ID: '%d'。", "Failed to load monster grows_melee_proficiency. ID: '%d'."), error_idx);
         return err;
     }
+    err = info_set_bool(mon_data["applies_stat_combat_bonus"], monrace.applies_stat_combat_bonus, false);
+    if (err) {
+        msg_format(_("モンスター能力値戦闘反映フラグ読込失敗。ID: '%d'。", "Failed to load monster applies_stat_combat_bonus. ID: '%d'."), error_idx);
+        return err;
+    }
     err = info_set_integer(mon_data["odds_correction_ratio"], monrace.arena_ratio, false, Range(1, 9999));
     if (err) {
         msg_format(_("モンスター賭け倍率読込失敗。ID: '%d'。", "Failed to load monster odds for arena. ID: '%d'."), error_idx);

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -278,6 +278,12 @@ static void process_melee(CreatureEntity &creature, mam_type *mam_ptr)
     mam_ptr->obvious = true;
     mam_ptr->damage = mam_ptr->damage_dice.roll();
 
+    // [提案C2第3弾] 能力値(STR)を近接ダメージへ反映 (applies_stat_combat_bonus・既定OFF)。
+    mam_ptr->damage += mam_ptr->m_ptr->get_melee_stat_damage_bonus();
+    if (mam_ptr->damage < 0) {
+        mam_ptr->damage = 0;
+    }
+
     // 武器を装備している場合、プレイヤーと共通の calc_attack_damage_with_slay() で
     // スレイ・ブランド効果を反映したダメージを加算する。
     if (!mam_ptr->explode && (mam_ptr->weapon_slot_for_blow >= 0)) {

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -279,6 +279,14 @@ bool MonsterAttackPlayer::process_monster_attack_hit()
         this->damage = 0;
     }
 
+    // [提案C2第3弾] 能力値(STR)を近接ダメージへ反映 (applies_stat_combat_bonus・既定OFF)。
+    if (!this->explode) {
+        this->damage += this->m_ptr->get_melee_stat_damage_bonus();
+        if (this->damage < 0) {
+            this->damage = 0;
+        }
+    }
+
     // [フェーズ B-2b / 二刀流対応] 装備武器によるダメージボーナス
     // weapon_slot_for_blow は process_monster_blows() で設定され、
     // 物理打撃 (HIT/PUNCH/SLASH/STING) かつ武器装備時のみ有効

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -1903,6 +1903,20 @@ int CreatureEntity::get_melee_proficiency_bonus() const
     return grown > 0 ? grown : 0;
 }
 
+int CreatureEntity::get_melee_stat_damage_bonus() const
+{
+    if (!this->has_monster_profile()) {
+        return 0;
+    }
+
+    if (!this->get_monrace().applies_stat_combat_bonus) {
+        return 0;
+    }
+
+    const auto index = stat_value_to_table_index(this->get_stat_use(A_STR));
+    return static_cast<int>(adj_str_td[index]) - 128;
+}
+
 /*!
  * @brief 表示用の称号を取得する (提案 E5, 基底 = モンスター既定)
  * @details モンスターは称号を持たないため "なし" を返す。プレイヤーは

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -583,6 +583,15 @@ public:
     int get_melee_proficiency_bonus() const;
 
     /*!
+     * @brief モンスターの能力値(STR)による近接ダメージ補正を返す (提案C2第3弾)
+     * @details applies_stat_combat_bonus が立つモンスターのみ、プレイヤーと同じ
+     * adj_str_td テーブル (stat_value_to_table_index で索引) で STR に応じた
+     * 近接ダメージ補正 (adj-128) を返す。既定 false / プレイヤーでは 0 を返す
+     * ため既定バランス不変。
+     */
+    int get_melee_stat_damage_bonus() const;
+
+    /*!
      * @brief クリーチャーがプレイヤーかどうかを判定
      * @return プレイヤーならtrue、モンスターならfalse
      * @details デフォルトはfalse（モンスター）。PlayerTypeのみtrueを返す。

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -140,6 +140,7 @@ public:
     bool suffers_poison_dot = false; //!< 毒攻撃で継続毒(POISON DoT)を受けるか (提案D7。既定false=オプトイン。既定バランス不変)
     bool applies_player_race_resistances = false; //!< 付与された player_race の属性耐性を被ダメージへ反映するか (提案C1第2弾。既定false=オプトイン。既定バランス不変)
     bool grows_melee_proficiency = false; //!< レベルアップで得た戦闘習熟を近接命中へ反映するか (提案C2第2弾。既定false=オプトイン。既定バランス不変)
+    bool applies_stat_combat_bonus = false; //!< 能力値(STR)を近接ダメージへ反映するか (提案C2第3弾。既定false=オプトイン。既定バランス不変)
     EnumClassFlagGroup<MonsterFeedType> meat_feed_flags;
     EnumClassFlagGroup<MonsterAbilityType> ability_flags; //!< 能力フラグ(魔法/ブレス) / Ability Flags
     EnumClassFlagGroup<MonsterAuraType> aura_flags; //!< オーラフラグ / Aura Flags


### PR DESCRIPTION
C2「能力値を戦闘へ反映」拡張の第1弾。STR を近接ダメージへ opt-in 反映する。

- MonraceDefinition::applies_stat_combat_bonus (bool・既定false) を追加。
- CreatureEntity::get_melee_stat_damage_bonus(): フラグONの個体のみ、プレイヤーと 同じ adj_str_td テーブル (monster の内部×10 stat を stat_value_to_table_index で 索引化) で STR 補正(adj-128) を返す。プレイヤー/OFF では 0。
- 近接ダメージの両経路(monster-attack-monster / monster-attack-player)の damage_dice.roll() 直後に加算、負値は 0 下限クランプ(explode時は据え置き)。
- 能力値スケール: monster stat は内部×10 だが CON→HP と同じ stat_value_to_table_index で adj テーブル索引へ変換しプレイヤー用テーブルを流用。

既定OFFのため実データ・既定バランス不変。reader/schema/CLAUDE.md/roadmap 整備。 フルビルド(g++ -O3 -Werror)/validate_json で検証済。次段: 命中/AC/セーヴ反映。