### PR TITLE
feat: モンスターの能力値(STR/DEX)を近接命中へ opt-in 反映（提案C2第3弾・命中）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -758,7 +758,11 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
   （`calc_max_hp_con_bonus`）と同じ `stat_value_to_table_index()` で adj テーブル索引に
   変換するため、プレイヤー用 adj テーブルをそのまま流用できる。
 - **安全性:** プレイヤー・フラグ OFF では 0 を返すため**既定バランス不変**。
-- **未反映:** STR/DEX→命中、DEX→AC、能力値→セーヴ等は次段（都度 opt-in・段階導入）。
+- **近接命中への拡大（同フラグ）:** `get_melee_stat_hit_bonus()` が同じ
+  `applies_stat_combat_bonus` フラグの個体につき `adj_str_th` / `adj_dex_th` で STR/DEX の
+  命中補正（各 `adj-128` の和）を返し、両経路の命中判定 `power` へ加算する。ダメージ
+  （STR）と命中（STR/DEX）を 1 フラグで一括制御。
+- **未反映:** DEX→AC、能力値→セーヴ等は次段（都度 opt-in・段階導入）。
 - スキーマに `applies_stat_combat_bonus` を登録済。
 
 ### モンスターの MP 消費詠唱 (`consumes_mp`) — 提案 C4

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3258,8 +3258,16 @@ melee-util / monster-attack-player 全経路で確認）。よって「player we
 - 既定 OFF のため実データ・既定バランス不変。reader/schema/CLAUDE.md 整備。
   フルビルド／validate_json で検証済。
 
-**次段候補（未着手）:** STR/DEX → 近接命中、DEX → AC、能力値 → セーヴ等への拡張。
-バランス感度が高いため adj テーブルベースで段階導入し、都度 opt-in フラグで制御する。
+**第3弾の続き ✅ 完了（STR/DEX → 近接命中）:** 同じ `applies_stat_combat_bonus` フラグの
+被覆を命中へ拡大。`CreatureEntity::get_melee_stat_hit_bonus()` が、プレイヤーと同じ
+`adj_str_th` / `adj_dex_th` テーブル（`stat_value_to_table_index` で索引）で STR/DEX の
+命中補正（各 `adj-128` の和）を返す。近接命中の両経路の `power`（`check_hit_from_monster_
+to_*` の accuracy 入力）へ加算。ダメージ（STR）と同じフラグで一括制御（新フラグなし）。
+既定 OFF のためバランス不変。フルビルドで検証済。
+
+**次段候補（未着手）:** DEX → AC、能力値 → セーヴ等への拡張。バランス感度が高いため
+adj テーブルベースで段階導入し、`applies_stat_combat_bonus` の被覆をさらに広げるか
+別フラグにするかは反映範囲の粒度次第で判断する。
 
 **デザイン判断メモ:** player weapon_exp/skill_exp は innate blow のモンスターに
 概念が合わないため、モンスターの熟練度は「戦闘経験＝レベル成長」で表現した。武器を

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -265,7 +265,9 @@ static void process_monster_attack_effect(CreatureEntity &creature, mam_type *ma
 static void process_melee(CreatureEntity &creature, mam_type *mam_ptr)
 {
     const auto remaining_stun = mam_ptr->m_ptr->get_remaining_stun();
-    if (mam_ptr->effect != RaceBlowEffectType::NONE && !check_hit_from_monster_to_monster(mam_ptr->power, mam_ptr->rlev, mam_ptr->ac, remaining_stun)) {
+    // [提案C2第3弾] 能力値(STR/DEX)を近接命中へ反映 (applies_stat_combat_bonus・既定OFF)。
+    const auto hit_power = mam_ptr->power + mam_ptr->m_ptr->get_melee_stat_hit_bonus();
+    if (mam_ptr->effect != RaceBlowEffectType::NONE && !check_hit_from_monster_to_monster(hit_power, mam_ptr->rlev, mam_ptr->ac, remaining_stun)) {
         describe_monster_missed_monster(*creature.get_floor(), mam_ptr);
         return;
     }

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -187,6 +187,8 @@ bool MonsterAttackPlayer::process_monster_blows()
             if (this->weapon_slot_for_blow >= 0) {
                 power += this->m_ptr->inventory[this->weapon_slot_for_blow]->to_h;
             }
+            // [提案C2第3弾] 能力値(STR/DEX)を近接命中へ反映 (applies_stat_combat_bonus・既定OFF)。
+            power += this->m_ptr->get_melee_stat_hit_bonus();
             hit = check_hit_from_monster_to_player(creature, power, this->rlev, this->m_ptr->get_remaining_stun());
         }
 

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -1917,6 +1917,21 @@ int CreatureEntity::get_melee_stat_damage_bonus() const
     return static_cast<int>(adj_str_td[index]) - 128;
 }
 
+int CreatureEntity::get_melee_stat_hit_bonus() const
+{
+    if (!this->has_monster_profile()) {
+        return 0;
+    }
+
+    if (!this->get_monrace().applies_stat_combat_bonus) {
+        return 0;
+    }
+
+    const auto str_index = stat_value_to_table_index(this->get_stat_use(A_STR));
+    const auto dex_index = stat_value_to_table_index(this->get_stat_use(A_DEX));
+    return (static_cast<int>(adj_str_th[str_index]) - 128) + (static_cast<int>(adj_dex_th[dex_index]) - 128);
+}
+
 /*!
  * @brief 表示用の称号を取得する (提案 E5, 基底 = モンスター既定)
  * @details モンスターは称号を持たないため "なし" を返す。プレイヤーは

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -592,6 +592,15 @@ public:
     int get_melee_stat_damage_bonus() const;
 
     /*!
+     * @brief モンスターの能力値(STR/DEX)による近接命中補正を返す (提案C2第3弾)
+     * @details applies_stat_combat_bonus が立つモンスターのみ、プレイヤーと同じ
+     * adj_str_th / adj_dex_th テーブル (stat_value_to_table_index で索引) で
+     * STR/DEX に応じた近接命中補正 (各 adj-128 の和) を返す。既定 false /
+     * プレイヤーでは 0 を返すため既定バランス不変。
+     */
+    int get_melee_stat_hit_bonus() const;
+
+    /*!
      * @brief クリーチャーがプレイヤーかどうかを判定
      * @return プレイヤーならtrue、モンスターならfalse
      * @details デフォルトはfalse（モンスター）。PlayerTypeのみtrueを返す。


### PR DESCRIPTION
STR→近接ダメージに続き、同じ applies_stat_combat_bonus フラグの被覆を近接命中へ拡大。

- CreatureEntity::get_melee_stat_hit_bonus(): フラグONの個体のみ、プレイヤーと同じ adj_str_th / adj_dex_th テーブル (stat_value_to_table_index で索引) で STR/DEX の 命中補正(各 adj-128 の和)を返す。プレイヤー/OFF では 0。
- 近接命中の両経路(monster-attack-monster / monster-attack-player)の power (check_hit_from_monster_to_* の accuracy 入力)へ加算。
- ダメージ(STR)と命中(STR/DEX)を 1 フラグで一括制御(新フラグなし)。

既定OFFのため実データ・既定バランス不変。CLAUDE.md/roadmap 整備。
フルビルド(g++ -O3 -Werror)で検証済。次段: DEX→AC、能力値→セーヴ。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Monster melee attacks now receive hit bonuses based on the attacker’s Strength and Dexterity.
  - These bonuses are applied when monsters attack players and during monster-versus-monster combat.
  - Monsters configured to use stat-based combat bonuses benefit automatically, while other creatures remain unchanged.

- **Documentation**
  - Updated combat documentation to reflect the expanded Strength/Dexterity melee accuracy support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->