### PR TITLE
feat: モンスターの能力値(DEX)を AC へ opt-in 反映（提案C2第3弾・AC）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -762,7 +762,11 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
   `applies_stat_combat_bonus` フラグの個体につき `adj_str_th` / `adj_dex_th` で STR/DEX の
   命中補正（各 `adj-128` の和）を返し、両経路の命中判定 `power` へ加算する。ダメージ
   （STR）と命中（STR/DEX）を 1 フラグで一括制御。
-- **未反映:** DEX→AC、能力値→セーヴ等は次段（都度 opt-in・段階導入）。
+- **AC への拡大（同フラグ）:** `CreatureEntity::get_ac()` のモンスター分岐で、同じ
+  `applies_stat_combat_bonus` の個体につき `adj_dex_ta` テーブルの DEX 補正（`adj-128`）を
+  加算（負値 0 下限）。get_ac() は攻撃側の命中判定で被対象の AC として参照されるため、
+  高 DEX 個体は被弾しにくくなる（命中と対の守勢反映）。
+- **未反映:** 能力値→セーヴ、射撃・魔法命中への反映等は次段（都度 opt-in・段階導入）。
 - スキーマに `applies_stat_combat_bonus` を登録済。
 
 ### モンスターの MP 消費詠唱 (`consumes_mp`) — 提案 C4

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3265,9 +3265,19 @@ melee-util / monster-attack-player 全経路で確認）。よって「player we
 to_*` の accuracy 入力）へ加算。ダメージ（STR）と同じフラグで一括制御（新フラグなし）。
 既定 OFF のためバランス不変。フルビルドで検証済。
 
-**次段候補（未着手）:** DEX → AC、能力値 → セーヴ等への拡張。バランス感度が高いため
-adj テーブルベースで段階導入し、`applies_stat_combat_bonus` の被覆をさらに広げるか
-別フラグにするかは反映範囲の粒度次第で判断する。
+**第3弾の続き ✅ 完了（DEX → AC）:** 同じ `applies_stat_combat_bonus` フラグの被覆を
+AC へ拡大。`CreatureEntity::get_ac()` のモンスター分岐で、プレイヤーと同じ
+`adj_dex_ta` テーブル（`stat_value_to_table_index` で索引）の DEX 補正（`adj-128`）を
+`total_ac` へ加算し、負値は 0 下限クランプ。get_ac() は攻撃側の命中判定
+（`mam_ptr->ac = t_ptr->get_ac()`）で参照されるため、高 DEX の被対象個体は被弾しにくく
+なる。命中（攻撃側）と対になる守勢反映。既定 OFF のためバランス不変。
+
+**能力値戦闘反映のまとめ（`applies_stat_combat_bonus`）:** STR→近接ダメージ・
+STR/DEX→近接命中・DEX→AC を 1 フラグで一括制御。プレイヤーの近接戦闘の主要な
+能力値補正を opt-in でモンスターに反映する形が揃った。
+
+**次段候補（未着手）:** 能力値→セーヴ（`get_skill_save` への DEX/WIS 等の反映）、
+射撃・魔法命中への能力値反映等。都度 opt-in で段階導入する。
 
 **デザイン判断メモ:** player weapon_exp/skill_exp は innate blow のモンスターに
 概念が合わないため、モンスターの熟練度は「戦闘経験＝レベル成長」で表現した。武器を

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -1705,6 +1705,16 @@ int CreatureEntity::get_ac() const
             }
             total_ac += item_ptr->ac + item_ptr->to_a;
         }
+
+        // [提案C2第3弾] 能力値(DEX)を AC へ反映 (applies_stat_combat_bonus・既定OFF)。
+        // プレイヤーと同じ adj_dex_ta テーブルで DEX 補正を加算し、負値は 0 下限。
+        if (this->get_monrace().applies_stat_combat_bonus) {
+            const auto dex_index = stat_value_to_table_index(this->get_stat_use(A_DEX));
+            total_ac += static_cast<int>(adj_dex_ta[dex_index]) - 128;
+            if (total_ac < 0) {
+                total_ac = 0;
+            }
+        }
     }
 
     return total_ac;


### PR DESCRIPTION
STR→ダメージ・STR/DEX→命中に続き、同じ applies_stat_combat_bonus フラグの被覆を AC へ拡大。

- CreatureEntity::get_ac() のモンスター分岐で、フラグONの個体につきプレイヤーと 同じ adj_dex_ta テーブル (stat_value_to_table_index で索引) の DEX 補正(adj-128)を total_ac へ加算、負値は 0 下限クランプ。
- get_ac() は攻撃側の命中判定(mam_ptr->ac = t_ptr->get_ac())で被対象 AC として 参照されるため、高 DEX 個体は被弾しにくくなる(命中と対の守勢反映)。

能力値戦闘反映(STR→ダメージ / STR/DEX→命中 / DEX→AC)を 1 フラグで一括制御。 既定OFFのため実データ・既定バランス不変。CLAUDE.md/roadmap 整備。
フルビルド(g++ -O3 -Werror)で検証済。次段: 能力値→セーヴ等。