### PR TITLE
feat: モンスターの能力値(WIS)を状態異常セーヴへ opt-in 反映（提案C2第3弾・セーヴ）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -766,7 +766,16 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
   `applies_stat_combat_bonus` の個体につき `adj_dex_ta` テーブルの DEX 補正（`adj-128`）を
   加算（負値 0 下限）。get_ac() は攻撃側の命中判定で被対象の AC として参照されるため、
   高 DEX 個体は被弾しにくくなる（命中と対の守勢反映）。
-- **未反映:** 能力値→セーヴ、射撃・魔法命中への反映等は次段（都度 opt-in・段階導入）。
+- **セーヴィングスローへの拡大（同フラグ）:** `CreatureEntity::get_save_stat_bonus()` が
+  同じ `applies_stat_combat_bonus` の個体につき `adj_wis_sav` テーブルの WIS 補正
+  （**直接加算値・`-128` オフセット無し**、`stat_value_to_table_index` で索引）を返し、
+  状態異常のセーヴ判定（`effect-monster-oldies.cpp` の poly / slow / sleep / conf /
+  stasis / stun 各ハンドラの `monrace.level > randint1(...)` 比較）の実効レベルへ加算する。
+  モンスターのセーヴはプレイヤーの `skill_sav` ではなくレベル基準判定で行われるため、
+  WIS 補正を実効レベルに上乗せする形で反映する。高 WIS 個体は魔法睡眠・混乱・変身等の
+  状態異常に抵抗しやすくなる。**注:** `adj_wis_sav` は他の adj テーブル（STR/DEX 系は
+  中心 128）と異なり **0-19 の直接加算テーブル**なので `-128` しない。
+- **未反映:** 射撃・魔法命中への能力値反映等は次段（都度 opt-in・段階導入）。
 - スキーマに `applies_stat_combat_bonus` を登録済。
 
 ### モンスターの MP 消費詠唱 (`consumes_mp`) — 提案 C4

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3272,12 +3272,23 @@ AC へ拡大。`CreatureEntity::get_ac()` のモンスター分岐で、プレ�
 （`mam_ptr->ac = t_ptr->get_ac()`）で参照されるため、高 DEX の被対象個体は被弾しにくく
 なる。命中（攻撃側）と対になる守勢反映。既定 OFF のためバランス不変。
 
-**能力値戦闘反映のまとめ（`applies_stat_combat_bonus`）:** STR→近接ダメージ・
-STR/DEX→近接命中・DEX→AC を 1 フラグで一括制御。プレイヤーの近接戦闘の主要な
-能力値補正を opt-in でモンスターに反映する形が揃った。
+**第3弾の続き ✅ 完了（WIS → セーヴィングスロー）:** 同じ `applies_stat_combat_bonus`
+フラグの被覆をセーヴへ拡大。`CreatureEntity::get_save_stat_bonus()` が、プレイヤーと同じ
+`adj_wis_sav` テーブル（`stat_value_to_table_index` で索引）の WIS 補正を返す。**注意:**
+`adj_wis_sav` は STR/DEX 系（中心 128）と異なり **0-19 の直接加算テーブル**なので
+`-128` しない。モンスターのセーヴはプレイヤーの `skill_sav`（モンスターでは未計算≈0）
+ではなく**レベル基準判定**（`monrace.level > randint1(...)`）で行われるため、本 WIS 補正を
+**実効レベルへ加算**する形で反映する。適用先は `effect-monster-oldies.cpp` の状態異常
+セーヴ 6 ハンドラ（old_poly / old_slow / old_sleep / old_conf / stasis / stun）。高 WIS
+個体は魔法睡眠・混乱・変身・減速・拘束・朦朧に抵抗しやすくなる。既定 OFF のため
+バランス不変。フルビルドで検証済。
 
-**次段候補（未着手）:** 能力値→セーヴ（`get_skill_save` への DEX/WIS 等の反映）、
-射撃・魔法命中への能力値反映等。都度 opt-in で段階導入する。
+**能力値戦闘反映のまとめ（`applies_stat_combat_bonus`）:** STR→近接ダメージ・
+STR/DEX→近接命中・DEX→AC・WIS→状態異常セーヴを 1 フラグで一括制御。プレイヤーの
+近接戦闘とセーヴの主要な能力値補正を opt-in でモンスターに反映する形が揃った。
+
+**次段候補（未着手）:** 射撃・魔法命中への能力値反映、能力値→他系統セーヴ
+（呪文抵抗・恐怖等のレベル基準判定以外の経路）等。都度 opt-in で段階導入する。
 
 **デザイン判断メモ:** player weapon_exp/skill_exp は innate blow のモンスターに
 概念が合わないため、モンスターの熟練度は「戦闘経験＝レベル成長」で表現した。武器を

--- a/src/effect/effect-monster-oldies.cpp
+++ b/src/effect/effect-monster-oldies.cpp
@@ -27,7 +27,8 @@ ProcessResult effect_monster_old_poly(EffectMonster *em_ptr)
 
     bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
     has_resistance |= em_ptr->monrace->misc_flags.has(MonsterMiscType::QUESTOR);
-    has_resistance |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
+    has_resistance |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(std::max(1, em_ptr->dam - 10)) + 10);
 
     if (has_resistance) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
@@ -212,7 +213,8 @@ ProcessResult effect_monster_old_slow(CreatureEntity &creature, EffectMonster *e
     }
 
     bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
-    has_resistance |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
+    has_resistance |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(std::max(1, em_ptr->dam - 10)) + 10);
 
     /* Powerful monsters can resist */
     if (has_resistance) {
@@ -244,7 +246,8 @@ ProcessResult effect_monster_old_sleep(CreatureEntity &creature, EffectMonster *
     has_resistance |= em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_SLEEP);
     // [提案C1第5弾] 付与種族が自由行動 (TR_FREE_ACT) を持てば魔法睡眠を無効化 (opt-in・既定OFF)
     has_resistance |= target_race_resists_element(em_ptr, TR_FREE_ACT);
-    has_resistance |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
+    has_resistance |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(std::max(1, em_ptr->dam - 10)) + 10);
 
     if (has_resistance) {
         if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_SLEEP)) {
@@ -278,7 +281,8 @@ ProcessResult effect_monster_old_conf(CreatureEntity &creature, EffectMonster *e
 
     bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
     has_resistance |= em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF);
-    has_resistance |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
+    has_resistance |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(std::max(1, em_ptr->dam - 10)) + 10);
     if (has_resistance) {
         if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
             if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
@@ -303,7 +307,8 @@ ProcessResult effect_monster_stasis(EffectMonster *em_ptr, bool to_evil)
 
     int stasis_damage = (em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10);
     bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
-    has_resistance |= em_ptr->monrace->level > randint1(stasis_damage) + 10;
+    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
+    has_resistance |= (em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(stasis_damage) + 10;
     // [提案C1第5弾] 付与種族が自由行動 (TR_FREE_ACT) を持てば拘束(stasis)を無効化 (opt-in・既定OFF)
     has_resistance |= target_race_resists_element(em_ptr, TR_FREE_ACT);
     if (to_evil) {
@@ -331,7 +336,8 @@ ProcessResult effect_monster_stun(EffectMonster *em_ptr)
     em_ptr->do_stun = Dice::roll((em_ptr->caster_lev / 20) + 3, (em_ptr->dam)) + 1;
 
     bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
-    has_resistance |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
+    has_resistance |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(std::max(1, em_ptr->dam - 10)) + 10);
     if (has_resistance) {
         em_ptr->do_stun = 0;
         em_ptr->note = _("には効果がなかった。", " is unaffected.");

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -1942,6 +1942,21 @@ int CreatureEntity::get_melee_stat_hit_bonus() const
     return (static_cast<int>(adj_str_th[str_index]) - 128) + (static_cast<int>(adj_dex_th[dex_index]) - 128);
 }
 
+int CreatureEntity::get_save_stat_bonus() const
+{
+    if (!this->has_monster_profile()) {
+        return 0;
+    }
+
+    if (!this->get_monrace().applies_stat_combat_bonus) {
+        return 0;
+    }
+
+    // adj_wis_sav は直接加算テーブル (0-19, -128 オフセット無し)。
+    const auto index = stat_value_to_table_index(this->get_stat_use(A_WIS));
+    return static_cast<int>(adj_wis_sav[index]);
+}
+
 /*!
  * @brief 表示用の称号を取得する (提案 E5, 基底 = モンスター既定)
  * @details モンスターは称号を持たないため "なし" を返す。プレイヤーは

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -601,6 +601,16 @@ public:
     int get_melee_stat_hit_bonus() const;
 
     /*!
+     * @brief モンスターの能力値(WIS)によるセーヴィングスロー補正を返す (提案C2第3弾・セーヴ)
+     * @details applies_stat_combat_bonus が立つモンスターのみ、プレイヤーと同じ
+     * adj_wis_sav テーブル (stat_value_to_table_index で索引) で WIS に応じた
+     * セーヴ補正 (直接加算値・-128 オフセット無し) を返す。レベル基準の
+     * 状態異常セーヴ判定 (monrace.level > randint1(...)) の実効レベルに加算する。
+     * 既定 false / プレイヤーでは 0 を返すため既定バランス不変。
+     */
+    int get_save_stat_bonus() const;
+
+    /*!
      * @brief クリーチャーがプレイヤーかどうかを判定
      * @return プレイヤーならtrue、モンスターならfalse
      * @details デフォルトはfalse（モンスター）。PlayerTypeのみtrueを返す。


### PR DESCRIPTION
applies_stat_combat_bonus フラグの被覆をセーヴィングスローへ拡大。
CreatureEntity::get_save_stat_bonus() を新設し、adj_wis_sav テーブル (直接加算値・-128 オフセット無し、stat_value_to_table_index で索引) で WIS 補正を返す。モンスターのセーヴは skill_sav (未計算≈0) ではなく
レベル基準判定 (monrace.level > randint1(...)) で行われるため、本 WIS 補正を実効レベルへ加算する形で反映する。

適用先は effect-monster-oldies.cpp の状態異常セーヴ 6 ハンドラ
(old_poly / old_slow / old_sleep / old_conf / stasis / stun)。高 WIS 個体は 魔法睡眠・混乱・変身・減速・拘束・朦朧に抵抗しやすくなる。

既定 false / プレイヤーでは 0 を返すため既定バランス不変。CLAUDE.md /
roadmap 整備。フルビルドで検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monsters with applicable ability-based combat bonuses now receive Wisdom-based modifiers to saving throws.
  * Improved resistance checks for slow, sleep, confusion, stasis, stun, and similar status effects.
  * Existing behavior remains unchanged for players and monsters without the applicable setting.

* **Documentation**
  * Updated combat-stat documentation to describe Wisdom’s effect on saving throws and clarify remaining limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->