### PR TITLE
feat: モンスターの能力値(WIS)セーヴ反映を精神/状態異常セーヴ全体へ統一（提案C2第3弾・セーヴ続き）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -769,12 +769,20 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
 - **セーヴィングスローへの拡大（同フラグ）:** `CreatureEntity::get_save_stat_bonus()` が
   同じ `applies_stat_combat_bonus` の個体につき `adj_wis_sav` テーブルの WIS 補正
   （**直接加算値・`-128` オフセット無し**、`stat_value_to_table_index` で索引）を返し、
-  状態異常のセーヴ判定（`effect-monster-oldies.cpp` の poly / slow / sleep / conf /
-  stasis / stun 各ハンドラの `monrace.level > randint1(...)` 比較）の実効レベルへ加算する。
-  モンスターのセーヴはプレイヤーの `skill_sav` ではなくレベル基準判定で行われるため、
-  WIS 補正を実効レベルに上乗せする形で反映する。高 WIS 個体は魔法睡眠・混乱・変身等の
-  状態異常に抵抗しやすくなる。**注:** `adj_wis_sav` は他の adj テーブル（STR/DEX 系は
-  中心 128）と異なり **0-19 の直接加算テーブル**なので `-128` しない。
+  状態異常・精神攻撃のセーヴ判定（`monrace.level > randint1(...)` 比較）の実効レベルへ
+  加算する。モンスターのセーヴはプレイヤーの `skill_sav` ではなくレベル基準判定で
+  行われるため、WIS 補正を実効レベルに上乗せする形で反映する。高 WIS 個体は魔法睡眠・
+  混乱・変身・恐怖・精神攻撃・魅了/服従等に抵抗しやすくなる。**注:** `adj_wis_sav` は
+  他の adj テーブル（STR/DEX 系は中心 128）と異なり **0-19 の直接加算テーブル**なので
+  `-128` しない。**適用先（レベル基準セーヴを一括反映）:**
+  - `effect-monster-oldies.cpp`: poly / slow / sleep / conf / stasis / stun
+  - `spells-diceroll.cpp` の `common_saving_throw_impl`: 魅了/服従系 6 呼出
+    (charm / control undead/demon/animal / charm living / domination) を DRY に一括反映
+  - `effect-monster-psi.cpp`: psi 攻撃耐性
+  - `effect-monster-spirit.cpp`: mind_blast / brain_smash（精神攻撃）
+  - `effect-monster-evil.cpp`: turn undead / turn evil / turn all（恐怖セーヴ）
+  - **除外:** teleport 耐性（`effect-monster-evil.cpp` の RESIST_TELEPORT 判定）は
+    精神/状態異常セーヴではないため対象外。
 - **未反映:** 射撃・魔法命中への能力値反映等は次段（都度 opt-in・段階導入）。
 - スキーマに `applies_stat_combat_bonus` を登録済。
 

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3283,6 +3283,20 @@ AC へ拡大。`CreatureEntity::get_ac()` のモンスター分岐で、プレ�
 個体は魔法睡眠・混乱・変身・減速・拘束・朦朧に抵抗しやすくなる。既定 OFF のため
 バランス不変。フルビルドで検証済。
 
+**WIS→セーヴの一括適用（続き ✅ 完了）:** oldies 6 ハンドラに続き、コードベース全体の
+レベル基準モンスターセーヴ（`monrace.level > randint1(...)`）のうち**精神/状態異常系**へ
+WIS 補正を統一適用し、「WIS がモンスターのセーヴを助ける」を一貫させた。
+- `spells-diceroll.cpp` の `common_saving_throw_impl`（魅了/服従の DRY 共通実装。
+  charm / control undead/demon/animal / charm living / domination の 6 呼出を 1 箇所で反映）
+- `effect-monster-psi.cpp`（psi 攻撃耐性）
+- `effect-monster-spirit.cpp`（mind_blast / brain_smash＝精神攻撃）
+- `effect-monster-evil.cpp`（turn undead / turn evil / turn all＝恐怖セーヴ）
+- **除外:** `effect-monster-evil.cpp` の RESIST_TELEPORT 判定（`level > randint1(100)`）は
+  テレポート耐性であり精神/状態異常セーヴではないため対象外。射撃・魔法命中は
+  **モンスター経路が auto-hit（`check_hit` 不使用・`project` で必中）** のため反映先が無く、
+  能力値→命中の拡大は近接に限る（エンジン仕様）。
+既定 OFF のためバランス不変。フルビルドで検証済。
+
 **能力値戦闘反映のまとめ（`applies_stat_combat_bonus`）:** STR→近接ダメージ・
 STR/DEX→近接命中・DEX→AC・WIS→状態異常セーヴを 1 フラグで一括制御。プレイヤーの
 近接戦闘とセーヴの主要な能力値補正を opt-in でモンスターに反映する形が揃った。

--- a/src/effect/effect-monster-evil.cpp
+++ b/src/effect/effect-monster-evil.cpp
@@ -111,7 +111,8 @@ ProcessResult effect_monster_turn_undead(CreatureEntity &creature, EffectMonster
     }
 
     em_ptr->do_fear = Dice::roll(3, (em_ptr->dam / 2)) + 1;
-    if (em_ptr->monrace->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10) {
+    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
+    if ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         em_ptr->do_fear = 0;
@@ -138,7 +139,8 @@ ProcessResult effect_monster_turn_evil(CreatureEntity &creature, EffectMonster *
     }
 
     em_ptr->do_fear = Dice::roll(3, (em_ptr->dam / 2)) + 1;
-    if (em_ptr->monrace->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10) {
+    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
+    if ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         em_ptr->do_fear = 0;
@@ -155,9 +157,10 @@ ProcessResult effect_monster_turn_all(EffectMonster *em_ptr)
     }
 
     em_ptr->do_fear = Dice::roll(3, (em_ptr->dam / 2)) + 1;
+    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
     if (em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE) ||
         em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_FEAR) ||
-        (em_ptr->monrace->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10)) {
+        ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         em_ptr->do_fear = 0;

--- a/src/effect/effect-monster-oldies.cpp
+++ b/src/effect/effect-monster-oldies.cpp
@@ -305,7 +305,7 @@ ProcessResult effect_monster_stasis(EffectMonster *em_ptr, bool to_evil)
         em_ptr->obvious = true;
     }
 
-    int stasis_damage = (em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10);
+    int stasis_damage = std::max(1, em_ptr->dam - 10);
     bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
     // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
     has_resistance |= (em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(stasis_damage) + 10;

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -55,7 +55,8 @@ static bool resisted_psi_because_weird_mind_or_powerful(EffectMonster *em_ptr)
     bool has_resistance = em_ptr->monrace->behavior_flags.has(MonsterBehaviorType::STUPID);
     has_resistance |= em_ptr->monrace->misc_flags.has(MonsterMiscType::WEIRD_MIND);
     has_resistance |= em_ptr->monrace->kind_flags.has(MonsterKindType::ANIMAL);
-    has_resistance |= (em_ptr->monrace->level > randint1(3 * em_ptr->dam));
+    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
+    has_resistance |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(3 * em_ptr->dam));
     if (!has_resistance) {
         return false;
     }

--- a/src/effect/effect-monster-spirit.cpp
+++ b/src/effect/effect-monster-spirit.cpp
@@ -71,7 +71,8 @@ ProcessResult effect_monster_mind_blast(CreatureEntity &creature, EffectMonster 
 
     bool has_immute = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
     has_immute |= em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF);
-    has_immute |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->caster_lev - 10)) + 10);
+    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
+    has_immute |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(std::max(1, em_ptr->caster_lev - 10)) + 10);
 
     if (has_immute) {
         if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
@@ -119,7 +120,8 @@ ProcessResult effect_monster_brain_smash(CreatureEntity &creature, EffectMonster
 
     bool has_immute = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
     has_immute |= em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF);
-    has_immute |= (em_ptr->monrace->level > randint1(std::max(1, em_ptr->caster_lev - 10)) + 10);
+    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
+    has_immute |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(std::max(1, em_ptr->caster_lev - 10)) + 10);
 
     if (has_immute) {
         if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF)) {

--- a/src/spell/spells-diceroll.cpp
+++ b/src/spell/spells-diceroll.cpp
@@ -50,7 +50,8 @@ static bool common_saving_throw_impl(CreatureEntity &creature, int pow, const Cr
     if (monrace.kind_flags.has(MonsterKindType::UNIQUE) || (monrace.population_flags.has(MonsterPopulationType::NAZGUL))) {
         pow = pow * 2 / 3;
     }
-    return (monrace.level > randint1((pow - 10) < 1 ? 1 : (pow - 10)) + 5);
+    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の対象は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
+    return ((monrace.level + target.get_save_stat_bonus()) > randint1((pow - 10) < 1 ? 1 : (pow - 10)) + 5);
 }
 
 /*!


### PR DESCRIPTION
前コミットで oldies 6 ハンドラに入れた WIS→セーヴ反映を、コードベース全体の
レベル基準モンスターセーヴ (monrace.level > randint1(...)) のうち精神/状態異常系へ 統一適用し、「WIS がモンスターのセーヴを助ける」を一貫させた。

適用先:
- spells-diceroll.cpp の common_saving_throw_impl (魅了/服従の DRY 共通実装。 charm / control undead/demon/animal / charm living / domination の 6 呼出を一括反映)
- effect-monster-psi.cpp (psi 攻撃耐性)
- effect-monster-spirit.cpp (mind_blast / brain_smash＝精神攻撃)
- effect-monster-evil.cpp (turn undead / turn evil / turn all＝恐怖セーヴ)

除外: effect-monster-evil.cpp の RESIST_TELEPORT 判定はテレポート耐性であり 精神/状態異常セーヴではないため対象外。射撃・魔法命中はモンスター経路が
auto-hit (check_hit 不使用・project で必中) のため能力値→命中は近接に限る。

いずれも applies_stat_combat_bonus (既定 false)・プレイヤーでは get_save_stat_bonus() が 0 を返すため既定バランス不変。CLAUDE.md / roadmap 整備。フルビルドで検証済。