### PR TITLE
refactor: モンスター属性ハンドラの部分耐性ブロックを共通ヘルパへ集約（提案D4第2弾）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3686,8 +3686,28 @@ monster ハンドラの直接 monrace 読取り（装備を含まない）とは
 acid/elec/fire/cold/pois/stungun の 6 ハンドラを移行（**monrace 読取り・思い出記録の
 意味論は維持、挙動完全不変**）。フルビルド (g++ -O3 -Werror) / clang-format-18 検証済。
 
-**残（第2弾以降）:** 他属性（高位元素・nether/chaos 等）の同型ブロックも同ヘルパへ
-横展開可能（同じく挙動不変）。プレイヤー計算式との真の統合は上記バランス判断が前提。
+### ✅ 第2弾 完了（部分耐性ヘルパの新設＋immune/hurt 横展開）
+
+**部分耐性ヘルパ `apply_monster_element_resist()` の新設:** 複数ハンドラに **byte 一致**で
+重複していた部分耐性ブロック（`note "resists."`・ダメージ `*3/(1d6+6)`・思い出フラグ記録）を
+file-local ヘルパへ集約。**byte 一致で移行できた 4 ハンドラ**（plasma / force / inertia /
+time）を移行。挙動完全不変（monrace 読取り・思い出記録のセマンティクス維持）。
+
+- **除外（byte 不一致のため見送り）:** gravity / meteor は note 文が `" resists!"`（感嘆符）で
+  異なり、gravity は途中に `do_dist = 0` の追加文があるため対象外。water は immune 兄弟枝と
+  思い出記録を共有する構造差、C1第3弾の二次属性（nether/chaos/shards/sound/conf/disen/
+  nexus）は race 耐性 OR-in の `native_resist` ガードで思い出記録条件が異なるため対象外。
+  hell_fire/holy_fire は `r_kind_flags`（`r_resistance_flags` でない）を記録するため別系統。
+
+**immune/hurt ヘルパの横展開:** 第1弾で 6 ハンドラに入れた `apply_monster_element_immune()` /
+`apply_monster_element_hurt()` を、残りの byte 一致サイトへ展開: icee_bolt の IMMUNE_COLD /
+HURT_COLD、dirt の IMMUNE_POISON（計 3 サイト）。
+
+合計 7 サイトの重複を集約。フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。
+
+**残（第3弾以降）:** プレイヤー計算式との真の統合は上記バランス判断（装備耐性を monster に
+反映する変更）が前提のため引き続き別提案。残る部分耐性ブロックは note 文・付随処理が
+個別に異なるため、無理な共通化はせず現状維持。
 
 ---
 

--- a/src/effect/effect-monster-resist-hurt.cpp
+++ b/src/effect/effect-monster-resist-hurt.cpp
@@ -52,6 +52,22 @@ void apply_monster_race_resistance(EffectMonster *em_ptr)
     em_ptr->note = _("には耐性がある。", " resists.");
     em_ptr->dam = (em_ptr->dam + 2) / 3;
 }
+
+/*!
+ * @brief モンスターが属性に (monrace 固有の) 部分耐性を持つ場合の共通処理 (提案D4第2弾)
+ * @details 「耐性がある」メッセージ・ダメージ *3/(1d6+6)・思い出フラグ記録を集約。
+ *          複数ハンドラ (plasma / force / inertia / time 等) に byte 一致で重複していた
+ *          部分耐性ブロックの統合 (挙動不変、monrace フラグ読取・思い出記録のセマンティクスは維持)。
+ */
+void apply_monster_element_resist(CreatureEntity &creature, EffectMonster *em_ptr, MonsterResistanceType resist_flag)
+{
+    em_ptr->note = _("には耐性がある。", " resists.");
+    em_ptr->dam *= 3;
+    em_ptr->dam /= randint1(6) + 6;
+    if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
+        em_ptr->monrace->r_resistance_flags.set(resist_flag);
+    }
+}
 }
 
 /*!
@@ -250,13 +266,7 @@ ProcessResult effect_monster_plasma(CreatureEntity &creature, EffectMonster *em_
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    em_ptr->note = _("には耐性がある。", " resists.");
-    em_ptr->dam *= 3;
-    em_ptr->dam /= randint1(6) + 6;
-    if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_PLASMA);
-    }
-
+    apply_monster_element_resist(creature, em_ptr, MonsterResistanceType::RESIST_PLASMA);
     return ProcessResult::PROCESS_CONTINUE;
 }
 
@@ -498,13 +508,7 @@ ProcessResult effect_monster_force(CreatureEntity &creature, EffectMonster *em_p
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    em_ptr->note = _("には耐性がある。", " resists.");
-    em_ptr->dam *= 3;
-    em_ptr->dam /= randint1(6) + 6;
-    if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_FORCE);
-    }
-
+    apply_monster_element_resist(creature, em_ptr, MonsterResistanceType::RESIST_FORCE);
     return ProcessResult::PROCESS_CONTINUE;
 }
 
@@ -516,13 +520,7 @@ ProcessResult effect_monster_inertial(CreatureEntity &creature, EffectMonster *e
     }
 
     if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_INERTIA)) {
-        em_ptr->note = _("には耐性がある。", " resists.");
-        em_ptr->dam *= 3;
-        em_ptr->dam /= randint1(6) + 6;
-        if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_INERTIA);
-        }
-
+        apply_monster_element_resist(creature, em_ptr, MonsterResistanceType::RESIST_INERTIA);
         return ProcessResult::PROCESS_CONTINUE;
     }
 
@@ -551,13 +549,7 @@ ProcessResult effect_monster_time(CreatureEntity &creature, EffectMonster *em_pt
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    em_ptr->note = _("には耐性がある。", " resists.");
-    em_ptr->dam *= 3;
-    em_ptr->dam /= randint1(6) + 6;
-    if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_TIME);
-    }
-
+    apply_monster_element_resist(creature, em_ptr, MonsterResistanceType::RESIST_TIME);
     return ProcessResult::PROCESS_CONTINUE;
 }
 
@@ -679,17 +671,9 @@ ProcessResult effect_monster_icee_bolt(CreatureEntity &creature, EffectMonster *
     }
 
     if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::IMMUNE_COLD)) {
-        em_ptr->note = _("にはかなり耐性がある！", " resists a lot.");
-        em_ptr->dam /= 9;
-        if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::IMMUNE_COLD);
-        }
+        apply_monster_element_immune(creature, em_ptr, MonsterResistanceType::IMMUNE_COLD);
     } else if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::HURT_COLD)) {
-        em_ptr->note = _("はひどい痛手をうけた。", " is hit hard.");
-        em_ptr->dam *= 2;
-        if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::HURT_COLD);
-        }
+        apply_monster_element_hurt(creature, em_ptr, MonsterResistanceType::HURT_COLD);
     } else if (target_race_resists_element(em_ptr, TR_RES_COLD)) {
         // [提案C1第7弾] 冷気ダメージも種族の冷気耐性で軽減 (effect_monster_cold と同水準)。
         apply_monster_race_resistance(em_ptr);
@@ -834,11 +818,7 @@ ProcessResult effect_monster_dirt(CreatureEntity &creature, EffectMonster *em_pt
 
     // 毒完全耐性があるモンスターは大幅に軽減
     if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::IMMUNE_POISON)) {
-        em_ptr->note = _("にはかなり耐性がある！", " resists a lot.");
-        em_ptr->dam /= 9;
-        if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::IMMUNE_POISON);
-        }
+        apply_monster_element_immune(creature, em_ptr, MonsterResistanceType::IMMUNE_POISON);
         return ProcessResult::PROCESS_CONTINUE;
     }
 


### PR DESCRIPTION
複数の属性ダメージハンドラに byte 一致で重複していた部分耐性処理を file-local
ヘルパへ集約し、重複を解消（挙動完全不変・純粋 refactor）。

- 部分耐性ヘルパ apply_monster_element_resist() を新設（note "resists."・ ダメージ *3/(1d6+6)・思い出フラグ記録）。byte 一致の 4 ハンドラ (plasma / force / inertia / time) を移行。
- 第1弾の apply_monster_element_immune() / apply_monster_element_hurt() を残りの byte 一致サイトへ横展開（icee_bolt の IMMUNE_COLD / HURT_COLD、dirt の IMMUNE_POISON）。

除外: gravity / meteor は note 文が異なり (" resists!")、gravity は付随処理 (do_dist=0) あり。water は immune 兄弟枝と思い出記録を共有。C1第3弾の二次属性は native_resist ガードで思い出記録条件が異なる。hell_fire/holy_fire は r_kind_flags 記録で別系統。いずれも byte 不一致のため無理な共通化はせず現状維持。

monrace 読取り・思い出記録のセマンティクスは維持し既存挙動は不変。
フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。