### PR TITLE
refactor: モンスターのレベル基準セーヴ式を共通述語へ集約（DRY・挙動不変）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3297,6 +3297,17 @@ WIS 補正を統一適用し、「WIS がモンスターのセーヴを助ける
   能力値→命中の拡大は近接に限る（エンジン仕様）。
 既定 OFF のためバランス不変。フルビルドで検証済。
 
+**WIS→セーヴのレベル判定を述語へ集約（DRY 続き ✅ 完了）:** WIS 補正を注入した
+レベル基準セーヴ式 `(monrace.level + WIS) > randint1(max(1, difficulty-10)) + 10` が
+約 10 サイトに散在していたため、共通述語 `monster_saves_status_by_level(em_ptr, difficulty)`
+（`effect-monster-util.{h,cpp}`）へ集約。`difficulty` は通常 `em_ptr->dam`、術者レベル基準の
+効果（mind_blast / brain_smash）は `caster_lev` を渡す。移行サイト: oldies の poly / slow /
+sleep / conf / stun / stasis（6）、evil の turn undead / turn evil / turn all（3）、spirit の
+mind_blast / brain_smash（2）。`randint1` の消費は 1 回のみ・呼出側の短絡評価も保存され
+**挙動完全不変**。WIS 補正の注入点が 1 箇所に一元化され、将来のセーヴ調整が容易になった。
+stasis の未使用化した `stasis_damage` ローカルも削除。（psi は `randint1(3*dam)` で式が
+異なるため対象外・インライン維持、charm/control は `common_saving_throw_impl` に別途集約済）。
+
 **能力値戦闘反映のまとめ（`applies_stat_combat_bonus`）:** STR→近接ダメージ・
 STR/DEX→近接命中・DEX→AC・WIS→状態異常セーヴを 1 フラグで一括制御。プレイヤーの
 近接戦闘とセーヴの主要な能力値補正を opt-in でモンスターに反映する形が揃った。

--- a/src/effect/effect-monster-evil.cpp
+++ b/src/effect/effect-monster-evil.cpp
@@ -111,8 +111,7 @@ ProcessResult effect_monster_turn_undead(CreatureEntity &creature, EffectMonster
     }
 
     em_ptr->do_fear = Dice::roll(3, (em_ptr->dam / 2)) + 1;
-    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
-    if ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10) {
+    if (monster_saves_status_by_level(em_ptr, em_ptr->dam)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         em_ptr->do_fear = 0;
@@ -139,8 +138,7 @@ ProcessResult effect_monster_turn_evil(CreatureEntity &creature, EffectMonster *
     }
 
     em_ptr->do_fear = Dice::roll(3, (em_ptr->dam / 2)) + 1;
-    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
-    if ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10) {
+    if (monster_saves_status_by_level(em_ptr, em_ptr->dam)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         em_ptr->do_fear = 0;
@@ -157,10 +155,9 @@ ProcessResult effect_monster_turn_all(EffectMonster *em_ptr)
     }
 
     em_ptr->do_fear = Dice::roll(3, (em_ptr->dam / 2)) + 1;
-    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
     if (em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE) ||
         em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_FEAR) ||
-        ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10)) {
+        monster_saves_status_by_level(em_ptr, em_ptr->dam)) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
         em_ptr->do_fear = 0;

--- a/src/effect/effect-monster-oldies.cpp
+++ b/src/effect/effect-monster-oldies.cpp
@@ -27,8 +27,7 @@ ProcessResult effect_monster_old_poly(EffectMonster *em_ptr)
 
     bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
     has_resistance |= em_ptr->monrace->misc_flags.has(MonsterMiscType::QUESTOR);
-    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
-    has_resistance |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    has_resistance |= monster_saves_status_by_level(em_ptr, em_ptr->dam);
 
     if (has_resistance) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
@@ -213,8 +212,7 @@ ProcessResult effect_monster_old_slow(CreatureEntity &creature, EffectMonster *e
     }
 
     bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
-    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
-    has_resistance |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    has_resistance |= monster_saves_status_by_level(em_ptr, em_ptr->dam);
 
     /* Powerful monsters can resist */
     if (has_resistance) {
@@ -246,8 +244,7 @@ ProcessResult effect_monster_old_sleep(CreatureEntity &creature, EffectMonster *
     has_resistance |= em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_SLEEP);
     // [提案C1第5弾] 付与種族が自由行動 (TR_FREE_ACT) を持てば魔法睡眠を無効化 (opt-in・既定OFF)
     has_resistance |= target_race_resists_element(em_ptr, TR_FREE_ACT);
-    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
-    has_resistance |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    has_resistance |= monster_saves_status_by_level(em_ptr, em_ptr->dam);
 
     if (has_resistance) {
         if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_SLEEP)) {
@@ -281,8 +278,7 @@ ProcessResult effect_monster_old_conf(CreatureEntity &creature, EffectMonster *e
 
     bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
     has_resistance |= em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF);
-    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
-    has_resistance |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    has_resistance |= monster_saves_status_by_level(em_ptr, em_ptr->dam);
     if (has_resistance) {
         if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
             if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
@@ -305,10 +301,8 @@ ProcessResult effect_monster_stasis(EffectMonster *em_ptr, bool to_evil)
         em_ptr->obvious = true;
     }
 
-    int stasis_damage = std::max(1, em_ptr->dam - 10);
     bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
-    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
-    has_resistance |= (em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(stasis_damage) + 10;
+    has_resistance |= monster_saves_status_by_level(em_ptr, em_ptr->dam);
     // [提案C1第5弾] 付与種族が自由行動 (TR_FREE_ACT) を持てば拘束(stasis)を無効化 (opt-in・既定OFF)
     has_resistance |= target_race_resists_element(em_ptr, TR_FREE_ACT);
     if (to_evil) {
@@ -336,8 +330,7 @@ ProcessResult effect_monster_stun(EffectMonster *em_ptr)
     em_ptr->do_stun = Dice::roll((em_ptr->caster_lev / 20) + 3, (em_ptr->dam)) + 1;
 
     bool has_resistance = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
-    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
-    has_resistance |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    has_resistance |= monster_saves_status_by_level(em_ptr, em_ptr->dam);
     if (has_resistance) {
         em_ptr->do_stun = 0;
         em_ptr->note = _("には効果がなかった。", " is unaffected.");

--- a/src/effect/effect-monster-spirit.cpp
+++ b/src/effect/effect-monster-spirit.cpp
@@ -71,8 +71,7 @@ ProcessResult effect_monster_mind_blast(CreatureEntity &creature, EffectMonster 
 
     bool has_immute = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
     has_immute |= em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF);
-    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
-    has_immute |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(std::max(1, em_ptr->caster_lev - 10)) + 10);
+    has_immute |= monster_saves_status_by_level(em_ptr, em_ptr->caster_lev);
 
     if (has_immute) {
         if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF)) {
@@ -120,8 +119,7 @@ ProcessResult effect_monster_brain_smash(CreatureEntity &creature, EffectMonster
 
     bool has_immute = em_ptr->monrace->kind_flags.has(MonsterKindType::UNIQUE);
     has_immute |= em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF);
-    // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
-    has_immute |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(std::max(1, em_ptr->caster_lev - 10)) + 10);
+    has_immute |= monster_saves_status_by_level(em_ptr, em_ptr->caster_lev);
 
     if (has_immute) {
         if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_CONF)) {

--- a/src/effect/effect-monster-util.cpp
+++ b/src/effect/effect-monster-util.cpp
@@ -19,6 +19,8 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
+#include "term/z-rand.h"
+#include <algorithm>
 
 /*!
  * @brief EffectMonster構造体のコンストラクタ
@@ -79,4 +81,10 @@ bool target_race_resists_element(EffectMonster *em_ptr, tr_type res_flag)
         return false;
     }
     return CreatureRace(em_ptr->m_ptr).tr_flags().has(res_flag);
+}
+
+bool monster_saves_status_by_level(EffectMonster *em_ptr, int difficulty)
+{
+    const auto effective_level = em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus();
+    return effective_level > randint1(std::max(1, difficulty - 10)) + 10;
 }

--- a/src/effect/effect-monster-util.h
+++ b/src/effect/effect-monster-util.h
@@ -65,3 +65,15 @@ enum tr_type : int;
  *          属性ダメージ (effect-monster-resist-hurt) と状態異常 (fear 等) の両方から使う共通述語。
  */
 bool target_race_resists_element(EffectMonster *em_ptr, tr_type res_flag);
+
+/*!
+ * @brief 状態異常/精神攻撃に対するモンスターのレベル基準セーヴ判定 (提案D4/C2第3弾セーヴ)
+ * @param difficulty セーヴ難易度の基準値 (通常は em_ptr->dam。術者レベル基準の効果は caster_lev)
+ * @return 抵抗に成功したら true
+ * @details 実効レベル (monrace.level + WIS セーヴ補正) が randint1(max(1, difficulty-10)) + 10 を
+ *          上回れば抵抗成功。oldies (poly/slow/sleep/conf/stun/stasis)・evil (turn 系)・
+ *          spirit (mind_blast/brain_smash) に散在していた同一式を集約し、WIS 補正
+ *          (applies_stat_combat_bonus、既定 OFF) の注入点を一元化する。randint1 の消費は
+ *          1 回のみで、呼出側の短絡評価 (`UNIQUE || ...` 等) も保存される。
+ */
+bool monster_saves_status_by_level(EffectMonster *em_ptr, int difficulty);


### PR DESCRIPTION
WIS セーヴ補正を注入したレベル基準セーヴ式
(monrace.level + WIS) > randint1(max(1, difficulty-10)) + 10 が約10サイトに 散在していたため、共通述語 monster_saves_status_by_level(em_ptr, difficulty) (effect-monster-util.{h,cpp}) へ集約。difficulty は通常 em_ptr->dam、 術者レベル基準の効果 (mind_blast / brain_smash) は caster_lev を渡す。

移行サイト:
- oldies: poly / slow / sleep / conf / stun / stasis (6)
- evil: turn undead / turn evil / turn all (3)
- spirit: mind_blast / brain_smash (2)

randint1 の消費は 1 回のみ・呼出側の短絡評価も保存され挙動完全不変。WIS 補正の
注入点が 1 箇所に一元化され将来のセーヴ調整が容易になった。未使用化した stasis_damage ローカルも削除。psi は randint1(3*dam) で式が異なるため対象外 (インライン維持)、 charm/control は common_saving_throw_impl に別途集約済。

フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。