### PR TITLE
refactor: 二次属性の種族耐性OR-in版部分耐性ブロックを共通ヘルパへ集約（提案D4第2弾続き）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3714,7 +3714,15 @@ time）を移行。挙動完全不変（monrace 読取り・思い出記録の�
 `apply_monster_element_hurt()` を、残りの byte 一致サイトへ展開: icee_bolt の IMMUNE_COLD /
 HURT_COLD、dirt の IMMUNE_POISON（計 3 サイト）。
 
-合計 7 サイトの重複を集約。フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。
+**種族耐性 OR-in 版ヘルパ `apply_monster_element_resist_native()` の新設:** C1第3弾で
+race 耐性 (opt-in) の OR-in を入れた二次属性ハンドラは、思い出記録を `native_resist`
+（monrace 固有耐性を持つか）で条件化した部分耐性ブロックを持つ。この byte 一致ブロックを
+専用ヘルパへ集約し、chaos（第1分岐）/ shards / disenchant / nexus の 4 サイトを移行。
+sound（軽減が `*2` で異なる）・confusion（live `resistance_flags.set(NO_CONF)` を記録する
+quirk）・nether（immune 兄弟枝と思い出記録を共有）は byte 不一致のため対象外。
+
+合計 11 サイト（第1弾からの通算では immune/hurt 9 + resist 4 + resist_native 4）の重複を
+集約。フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。
 
 **残（第3弾以降）:** プレイヤー計算式との真の統合は上記バランス判断（装備耐性を monster に
 反映する変更）が前提のため引き続き別提案。残る部分耐性ブロックは note 文・付随処理が

--- a/src/effect/effect-monster-resist-hurt.cpp
+++ b/src/effect/effect-monster-resist-hurt.cpp
@@ -54,19 +54,32 @@ void apply_monster_race_resistance(EffectMonster *em_ptr)
 }
 
 /*!
- * @brief モンスターが属性に (monrace 固有の) 部分耐性を持つ場合の共通処理 (提案D4第2弾)
- * @details 「耐性がある」メッセージ・ダメージ *3/(1d6+6)・思い出フラグ記録を集約。
- *          複数ハンドラ (plasma / force / inertia / time 等) に byte 一致で重複していた
- *          部分耐性ブロックの統合 (挙動不変、monrace フラグ読取・思い出記録のセマンティクスは維持)。
+ * @brief 種族耐性 (C1第3弾) OR-in 付き部分耐性の共通処理 (提案D4第2弾)
+ * @param native_resist monrace 固有耐性フラグを持つか (思い出記録は固有耐性時のみ)
+ * @details 「耐性がある」メッセージ・ダメージ *3/(1d6+6)・思い出フラグ記録を集約した
+ *          部分耐性の単一実装。native_resist が true の時のみ思い出 (r_resistance_flags) を
+ *          記録する。二次属性 (chaos / shards / disenchant / nexus) の byte 一致ブロックや、
+ *          native 固定の `apply_monster_element_resist` はいずれも本関数へ委譲する。挙動不変。
  */
-void apply_monster_element_resist(CreatureEntity &creature, EffectMonster *em_ptr, MonsterResistanceType resist_flag)
+void apply_monster_element_resist_native(CreatureEntity &creature, EffectMonster *em_ptr, MonsterResistanceType resist_flag, bool native_resist)
 {
     em_ptr->note = _("には耐性がある。", " resists.");
     em_ptr->dam *= 3;
     em_ptr->dam /= randint1(6) + 6;
-    if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
+    if (native_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
         em_ptr->monrace->r_resistance_flags.set(resist_flag);
     }
+}
+
+/*!
+ * @brief モンスターが属性に (monrace 固有の) 部分耐性を持つ場合の共通処理 (提案D4第2弾)
+ * @details 複数ハンドラ (plasma / force / inertia / time 等) に byte 一致で重複していた
+ *          部分耐性ブロックの統合。monrace 固有耐性のため native_resist=true 固定で
+ *          `apply_monster_element_resist_native` へ委譲する (挙動不変)。
+ */
+void apply_monster_element_resist(CreatureEntity &creature, EffectMonster *em_ptr, MonsterResistanceType resist_flag)
+{
+    apply_monster_element_resist_native(creature, em_ptr, resist_flag, true);
 }
 }
 
@@ -349,12 +362,7 @@ ProcessResult effect_monster_chaos(CreatureEntity &creature, EffectMonster *em_p
 
     const auto native_chaos_resist = em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_CHAOS);
     if (native_chaos_resist || target_race_resists_element(em_ptr, TR_RES_CHAOS)) {
-        em_ptr->note = _("には耐性がある。", " resists.");
-        em_ptr->dam *= 3;
-        em_ptr->dam /= randint1(6) + 6;
-        if (native_chaos_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_CHAOS);
-        }
+        apply_monster_element_resist_native(creature, em_ptr, MonsterResistanceType::RESIST_CHAOS, native_chaos_resist);
     } else if (em_ptr->monrace->kind_flags.has(MonsterKindType::DEMON) && one_in_(3)) {
         em_ptr->note = _("はいくらか耐性を示した。", " resists somewhat.");
         em_ptr->dam *= 3;
@@ -381,13 +389,7 @@ ProcessResult effect_monster_shards(CreatureEntity &creature, EffectMonster *em_
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    em_ptr->note = _("には耐性がある。", " resists.");
-    em_ptr->dam *= 3;
-    em_ptr->dam /= randint1(6) + 6;
-    if (native_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_SHARDS);
-    }
-
+    apply_monster_element_resist_native(creature, em_ptr, MonsterResistanceType::RESIST_SHARDS, native_resist);
     return ProcessResult::PROCESS_CONTINUE;
 }
 
@@ -466,13 +468,7 @@ ProcessResult effect_monster_disenchant(CreatureEntity &creature, EffectMonster 
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    em_ptr->note = _("には耐性がある。", " resists.");
-    em_ptr->dam *= 3;
-    em_ptr->dam /= randint1(6) + 6;
-    if (native_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_DISENCHANT);
-    }
-
+    apply_monster_element_resist_native(creature, em_ptr, MonsterResistanceType::RESIST_DISENCHANT, native_resist);
     return ProcessResult::PROCESS_CONTINUE;
 }
 
@@ -487,13 +483,7 @@ ProcessResult effect_monster_nexus(CreatureEntity &creature, EffectMonster *em_p
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    em_ptr->note = _("には耐性がある。", " resists.");
-    em_ptr->dam *= 3;
-    em_ptr->dam /= randint1(6) + 6;
-    if (native_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_NEXUS);
-    }
-
+    apply_monster_element_resist_native(creature, em_ptr, MonsterResistanceType::RESIST_NEXUS, native_resist);
     return ProcessResult::PROCESS_CONTINUE;
 }
 


### PR DESCRIPTION
C1第3弾で race 耐性 (opt-in) の OR-in を入れた二次属性ハンドラは、思い出記録を native_resist (monrace 固有耐性を持つか) で条件化した部分耐性ブロックを持つ。この byte 一致ブロックを専用ヘルパ apply_monster_element_resist_native() へ集約。

移行サイト: chaos (第1分岐) / shards / disenchant / nexus (4サイト)。

除外: sound (軽減が *2 で異なる)・confusion (live resistance_flags.set(NO_CONF) を 記録する quirk)・nether (immune 兄弟枝と思い出記録を共有) は byte 不一致のため対象外。

monrace 読取り・思い出記録のセマンティクス (native_resist 条件含む) は維持し挙動不変。 フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the creature resistance refactoring roadmap to reflect expanded coverage for shared partial-resistance handling.

* **Bug Fixes**
  * Standardized partial elemental resistance behavior across chaos, shards, disenchant, and nexus damage effects.
  * Improved consistency in resistance messaging and resistance tracking when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->