### PR TITLE
refactor: 光/闇属性の部分耐性ブロックを file-local ヘルパへ集約（提案D4第2弾・仕上げ）

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3721,8 +3721,14 @@ race 耐性 (opt-in) の OR-in を入れた二次属性ハンドラは、思い�
 sound（軽減が `*2` で異なる）・confusion（live `resistance_flags.set(NO_CONF)` を記録する
 quirk）・nether（immune 兄弟枝と思い出記録を共有）は byte 不一致のため対象外。
 
-合計 11 サイト（第1弾からの通算では immune/hurt 9 + resist 4 + resist_native 4）の重複を
-集約。フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。
+**光/闇ハンドラの専用ヘルパ `apply_monster_lite_dark_resist()`（別ファイル）:** lite / dark は
+軽減率が `*2/(1d6+6)`・メッセージが `" resists!"` で resist-hurt の helper 群とは異なるが、
+両者間では byte 一致。`effect-monster-lite-dark.cpp` に file-local ヘルパを新設し lite（第1分岐）/
+dark の 2 サイトを集約（native_resist 条件も維持、挙動不変）。
+
+合計 13 サイト（immune/hurt 9 + resist 4 + resist_native 4 + lite/dark 2、※ helper 定義除く）の
+重複を集約。effect-monster の属性耐性ハンドラの byte 一致重複はこれで概ね解消。フルビルド
+(g++ -O3 -Werror) / clang-format-18 で検証済。
 
 **残（第3弾以降）:** プレイヤー計算式との真の統合は上記バランス判断（装備耐性を monster に
 反映する変更）が前提のため引き続き別提案。残る部分耐性ブロックは note 文・付随処理が

--- a/src/effect/effect-monster-lite-dark.cpp
+++ b/src/effect/effect-monster-lite-dark.cpp
@@ -5,6 +5,27 @@
 #include "object-enchant/tr-types.h"
 #include "system/creature-entity.h"
 #include "system/monrace/monrace-definition.h"
+#include "term/z-rand.h"
+
+namespace {
+/*!
+ * @brief 光/闇属性の部分耐性の共通処理 (提案D4第2弾)
+ * @param native_resist monrace 固有耐性フラグを持つか (思い出記録は固有耐性時のみ)
+ * @details 「耐性がある！」メッセージ・ダメージ *2/(1d6+6)・思い出記録 (native_resist 時) を
+ *          集約。lite (第1分岐) と dark で byte 一致だったブロックを統合。挙動不変。
+ *          resist-hurt の `apply_monster_element_resist_native` とは軽減率 (*2 vs *3)・
+ *          メッセージ (" resists!" vs " resists.") が異なるため別ヘルパ。
+ */
+void apply_monster_lite_dark_resist(CreatureEntity &creature, EffectMonster *em_ptr, MonsterResistanceType resist_flag, bool native_resist)
+{
+    em_ptr->note = _("には耐性がある！", " resists!");
+    em_ptr->dam *= 2;
+    em_ptr->dam /= (randint1(6) + 6);
+    if (native_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
+        em_ptr->monrace->r_resistance_flags.set(resist_flag);
+    }
+}
+}
 
 ProcessResult effect_monster_lite_weak(CreatureEntity &creature, EffectMonster *em_ptr)
 {
@@ -41,12 +62,7 @@ ProcessResult effect_monster_lite(CreatureEntity &creature, EffectMonster *em_pt
     // 光耐性は光弱点 (HURT_LITE) より優先 (else if で弱点経路を回避)。
     const auto native_lite_resist = em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_LITE);
     if (native_lite_resist || target_race_resists_element(em_ptr, TR_RES_LITE)) {
-        em_ptr->note = _("には耐性がある！", " resists!");
-        em_ptr->dam *= 2;
-        em_ptr->dam /= (randint1(6) + 6);
-        if (native_lite_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-            em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_LITE);
-        }
+        apply_monster_lite_dark_resist(creature, em_ptr, MonsterResistanceType::RESIST_LITE, native_lite_resist);
     } else if (em_ptr->monrace->resistance_flags.has(MonsterResistanceType::HURT_LITE)) {
         if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
             em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::HURT_LITE);
@@ -72,12 +88,6 @@ ProcessResult effect_monster_dark(CreatureEntity &creature, EffectMonster *em_pt
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    em_ptr->note = _("には耐性がある！", " resists!");
-    em_ptr->dam *= 2;
-    em_ptr->dam /= (randint1(6) + 6);
-    if (native_dark_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
-        em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_DARK);
-    }
-
+    apply_monster_lite_dark_resist(creature, em_ptr, MonsterResistanceType::RESIST_DARK, native_dark_resist);
     return ProcessResult::PROCESS_CONTINUE;
 }


### PR DESCRIPTION
lite / dark は軽減率が *2/(1d6+6)・メッセージが " resists!" で resist-hurt の helper 群とは異なるが、両者間では byte 一致。effect-monster-lite-dark.cpp に file-local ヘルパ apply_monster_lite_dark_resist() を新設し、lite (第1分岐) / dark の 2 サイトを集約。native_resist 条件 (思い出記録は固有耐性時のみ) も維持し挙動不変。

これで effect-monster の属性耐性ハンドラの byte 一致重複は概ね解消。
フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。