### PR TITLE
refactor: 一時ステータスsetter末尾の共通後処理を共通関数へ集約（提案E6・dedup）

### DIFF
--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
@@ -737,6 +737,7 @@
     <ClCompile Include="..\..\src\status\element-resistance.cpp" />
     <ClCompile Include="..\..\src\status\shape-changer.cpp" />
     <ClCompile Include="..\..\src\status\sight-setter.cpp" />
+    <ClCompile Include="..\..\src\status\status-change-notice.cpp" />
     <ClCompile Include="..\..\src\status\experience.cpp" />
     <ClCompile Include="..\..\src\status\temporary-resistance.cpp" />
     <ClCompile Include="..\..\src\stdafx.cpp">
@@ -1670,6 +1671,7 @@
     <ClInclude Include="..\..\src\status\element-resistance.h" />
     <ClInclude Include="..\..\src\status\shape-changer.h" />
     <ClInclude Include="..\..\src\status\sight-setter.h" />
+    <ClInclude Include="..\..\src\status\status-change-notice.h" />
     <ClInclude Include="..\..\src\status\experience.h" />
     <ClInclude Include="..\..\src\status\temporary-resistance.h" />
     <ClInclude Include="..\..\src\stdafx.h" />

--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
@@ -1316,6 +1316,9 @@
     <ClCompile Include="..\..\src\status\sight-setter.cpp">
       <Filter>status</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\status\status-change-notice.cpp">
+      <Filter>status</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\status\buff-setter.cpp">
       <Filter>status</Filter>
     </ClCompile>
@@ -4358,6 +4361,9 @@
       <Filter>player</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\status\sight-setter.h">
+      <Filter>status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\status\status-change-notice.h">
       <Filter>status</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\status\buff-setter.h">

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3839,6 +3839,45 @@ virtual 化・処理の同化・機能付与** がほぼ出揃った。E トラ�
 | E3 | シリアライズ共通ブロック拡張（`prace`/`pclass`） | 重複解消 | 中 | 中 | ✅ 完了（version 54 bump） |
 | E4 | インライン accessor 本体（481 個）の .cpp 移設 | ビルド衛生 | 大（機械的） | 中 | ✅ 完了（3 batch・ヘッダ約32%削減） |
 | E5 | `is_player()` 自由関数分岐の virtual 化 | 同化 | 大 | 中 | ✅ 第1弾完了（`get_title()`。残候補は少数・据え置き） |
+| E6 | 一時ステータス setter 末尾の共通後処理集約（`notice_bonus_status_change()`） | 重複解消 | 小 | 中 | ✅ 完了（18 サイト・byte 一致） |
+
+---
+
+## 提案 E6: 一時ステータス setter 末尾の共通後処理集約 ✅ 完了
+
+**現状（実コード検証済）:** 多数の一時ステータス setter（`set_tim_*` / `set_*` 系）が
+末尾に **byte 一致**の共通後処理を重複して持っていた:
+
+```cpp
+auto &rfu = RedrawingFlagsUpdater::get_instance();
+rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
+if (!notice) {
+    return false;
+}
+if (disturb_state || Travel::get_instance().is_ongoing()) {
+    disturb(creature, false, true);
+}
+rfu.set_flag(StatusRecalculatingFlag::BONUS);
+handle_stuff(creature);
+return true;
+```
+
+**実施:** 新規 file-local でない共通関数
+`notice_bonus_status_change(CreatureEntity &, bool notice)`
+（`src/status/status-change-notice.{h,cpp}`）へ集約。**byte 一致の 18 サイト**
+（`status/temporary-resistance.cpp` 6 / `status/body-improvement.cpp` 4 /
+`status/buff-setter.cpp` 3 / `mind/mind-mirror-master.cpp` 2 /
+`mind/mind-magic-resistance.cpp` 1 / `racial/racial-kutar.cpp` 1 /
+`spell-realm/spells-song.cpp` 1）を `return notice_bonus_status_change(creature, notice);`
+へ置換。各末尾で **約 13 行 → 1 行**（計 200 行超の重複を解消）。
+
+**対象外（byte 不一致のため据え置き）:** `MainWindowRedrawingFlag::BASIC` を使う
+`shape-changer.cpp`、`StatusRecalculatingFlag::MONSTER_STATUSES` を `set_flags` で
+複数指定する `sight-setter.cpp`、および `rfu` を末尾以前で宣言・別フラグ設定する
+一部関数（recalc フラグや再描画対象が異なるため共通化すると挙動が変わる）。
+
+Makefile.am / VisualStudio プロジェクト（`.vcxproj` / `.filters`）に新ファイルを登録。
+挙動完全不変（純粋な suffix 抽出）。フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。
 
 ---
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1325,6 +1325,7 @@ hengband_SOURCES = \
 	status/experience.cpp status/experience.h \
 	status/shape-changer.cpp status/shape-changer.h \
 	status/sight-setter.cpp status/sight-setter.h \
+	status/status-change-notice.cpp status/status-change-notice.h \
 	status/temporary-resistance.cpp status/temporary-resistance.h \
 	\
 	store/home.cpp store/home.h \

--- a/src/mind/mind-magic-resistance.cpp
+++ b/src/mind/mind-magic-resistance.cpp
@@ -5,6 +5,7 @@
 #include "game-option/disturbance-options.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
+#include "status/status-change-notice.h"
 #include "system/creature-entity.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
@@ -44,17 +45,5 @@ bool set_resist_magic(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::RESIST_MAGIC, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -38,6 +38,7 @@
 #include "status/body-improvement.h"
 #include "status/buff-setter.h"
 #include "status/sight-setter.h"
+#include "status/status-change-notice.h"
 #include "system/angband-system.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
@@ -279,19 +280,7 @@ bool set_multishadow(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::MULTISHADOW, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }
 
 /*!
@@ -328,19 +317,7 @@ bool set_dustrobe(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::DUSTROBE, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }
 
 /*!

--- a/src/racial/racial-kutar.cpp
+++ b/src/racial/racial-kutar.cpp
@@ -5,6 +5,7 @@
 #include "game-option/disturbance-options.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
+#include "status/status-change-notice.h"
 #include "system/creature-entity.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
@@ -43,17 +44,5 @@ bool set_leveling(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::TSUBURERU, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -16,6 +16,7 @@
 #include "spell/spells-execution.h"
 #include "spell/technic-info-table.h"
 #include "status/action-setter.h"
+#include "status/status-change-notice.h"
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/redrawing-flags-updater.h"
@@ -118,19 +119,7 @@ bool set_tim_stealth(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::TIM_STEALTH, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }
 
 /*!

--- a/src/status/body-improvement.cpp
+++ b/src/status/body-improvement.cpp
@@ -10,6 +10,7 @@
 #include "main/sound-of-music.h"
 #include "realm/realm-song-numbers.h"
 #include "spell-realm/spells-song.h"
+#include "status/status-change-notice.h"
 #include "system/creature-entity.h"
 #include "system/creature-timed-effect-types.h"
 #include "system/redrawing-flags-updater.h"
@@ -178,19 +179,7 @@ bool set_tim_regen(CreatureEntity &creature, short v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::TIM_REGEN, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }
 
 /*!
@@ -227,19 +216,7 @@ bool set_tim_reflect(CreatureEntity &creature, short v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::TIM_REFLECT, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }
 
 /*!
@@ -276,19 +253,7 @@ bool set_pass_wall(CreatureEntity &creature, short v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::TIM_PASS_WALL, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }
 
 /*!
@@ -374,17 +339,5 @@ bool set_tim_exorcism(CreatureEntity &creature, short v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::TIM_EXORCISM, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -18,6 +18,7 @@
 #include "status/base-status.h"
 #include "status/buff-setter.h"
 #include "status/element-resistance.h"
+#include "status/status-change-notice.h"
 #include "system/creature-entity.h"
 #include "system/creature-timed-effect-types.h"
 #include "system/redrawing-flags-updater.h"
@@ -205,19 +206,7 @@ bool set_shield(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::SHIELD, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }
 
 /*!
@@ -254,19 +243,7 @@ bool set_magicdef(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::MAGICDEF, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }
 
 /*!
@@ -303,19 +280,7 @@ bool set_blessed(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::BLESSED, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }
 
 /*!

--- a/src/status/status-change-notice.cpp
+++ b/src/status/status-change-notice.cpp
@@ -1,0 +1,24 @@
+#include "status/status-change-notice.h"
+#include "action/travel-execution.h"
+#include "core/disturbance.h"
+#include "core/stuff-handler.h"
+#include "game-option/disturbance-options.h"
+#include "system/creature-entity.h"
+#include "system/redrawing-flags-updater.h"
+
+bool notice_bonus_status_change(CreatureEntity &creature, bool notice)
+{
+    auto &rfu = RedrawingFlagsUpdater::get_instance();
+    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
+    if (!notice) {
+        return false;
+    }
+
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(creature, false, true);
+    }
+
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
+    handle_stuff(creature);
+    return true;
+}

--- a/src/status/status-change-notice.h
+++ b/src/status/status-change-notice.h
@@ -1,0 +1,14 @@
+#pragma once
+
+class CreatureEntity;
+
+/*!
+ * @brief 一時ステータス setter 末尾の共通後処理 (再描画 → 視認可能な変化なら disturb/再計算/handle_stuff)
+ * @param creature 対象クリーチャーへの参照
+ * @param notice 観測可能な変化があったか (false なら再描画のみ行い false を返す)
+ * @return notice が true のとき true、false のとき false
+ * @details 多数の一時ステータス setter に byte 一致で重複していた末尾
+ *          (TIMED_EFFECT 再描画 → notice なしなら return false → disturb →
+ *          BONUS 再計算 → handle_stuff → return true) を集約した共通処理。挙動不変。
+ */
+bool notice_bonus_status_change(CreatureEntity &creature, bool notice);

--- a/src/status/temporary-resistance.cpp
+++ b/src/status/temporary-resistance.cpp
@@ -5,6 +5,7 @@
 #include "game-option/disturbance-options.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
+#include "status/status-change-notice.h"
 #include "system/creature-entity.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
@@ -43,19 +44,7 @@ bool set_tim_levitation(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::TIM_LEVITATION, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }
 
 bool set_ultimate_res(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
@@ -86,19 +75,7 @@ bool set_ultimate_res(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::ULTIMATE_RESISTANCE, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }
 
 bool set_tim_res_nether(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
@@ -131,19 +108,7 @@ bool set_tim_res_nether(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::TIM_RES_NETHER, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }
 
 bool set_tim_res_lite(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
@@ -173,19 +138,7 @@ bool set_tim_res_lite(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::TIM_RES_LITE, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }
 
 bool set_tim_res_dark(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
@@ -215,19 +168,7 @@ bool set_tim_res_dark(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::TIM_RES_DARK, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }
 
 bool set_tim_res_fear(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
@@ -295,19 +236,7 @@ bool set_tim_res_time(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)
     }
 
     creature.set_timed_effect(CreatureTimedEffect::TIM_RES_TIME, v);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (!notice) {
-        return false;
-    }
-
-    if (disturb_state || Travel::get_instance().is_ongoing()) {
-        disturb(creature, false, true);
-    }
-
-    rfu.set_flag(StatusRecalculatingFlag::BONUS);
-    handle_stuff(creature);
-    return true;
+    return notice_bonus_status_change(creature, notice);
 }
 
 bool set_tim_imm_dark(CreatureEntity &creature, TIME_EFFECT v, bool do_dec)


### PR DESCRIPTION
多数の一時ステータス setter が末尾に byte 一致の共通後処理
(TIMED_EFFECT 再描画 → notice なしなら return false → disturb → BONUS 再計算 → handle_stuff → return true) を重複して持っていたため、 共通関数 notice_bonus_status_change() (src/status/status-change-notice.{h,cpp}) へ集約。

byte 一致の 18 サイトを 1 行へ置換 (各末尾 約13行→1行、計200行超の重複解消):
- status/temporary-resistance.cpp (6)
- status/body-improvement.cpp (4)
- status/buff-setter.cpp (3)
- mind/mind-mirror-master.cpp (2)
- mind/mind-magic-resistance.cpp (1)
- racial/racial-kutar.cpp (1)
- spell-realm/spells-song.cpp (1)

対象外: BASIC 再描画の shape-changer、MONSTER_STATUSES を set_flags する sight-setter、rfu を末尾以前で宣言・別フラグ設定する一部関数 (byte 不一致)。

Makefile.am / VisualStudio プロジェクトに新ファイルを登録。挙動完全不変
(純粋な suffix 抽出)。フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。