### PR TITLE
refactor: MonsterSpellResult の learnable 生成定型を make_learnable() へ集約（提…

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3840,6 +3840,28 @@ virtual 化・処理の同化・機能付与** がほぼ出揃った。E トラ�
 | E4 | インライン accessor 本体（481 個）の .cpp 移設 | ビルド衛生 | 大（機械的） | 中 | ✅ 完了（3 batch・ヘッダ約32%削減） |
 | E5 | `is_player()` 自由関数分岐の virtual 化 | 同化 | 大 | 中 | ✅ 第1弾完了（`get_title()`。残候補は少数・据え置き） |
 | E6 | 一時ステータス setter 末尾の共通後処理集約（`notice_bonus_status_change()`） | 重複解消 | 小 | 中 | ✅ 完了（18 サイト・byte 一致） |
+| E7 | `MonsterSpellResult` の learnable 生成定型集約（`make_learnable()`） | 重複解消 | 小 | 中 | ✅ 完了（36 サイト・byte 一致） |
+
+---
+
+## 提案 E7: `MonsterSpellResult::make_learnable()` による learnable 生成の集約 ✅ 完了
+
+**現状（実コード検証済）:** モンスター呪文ハンドラが末尾で
+`auto res = MonsterSpellResult::make_valid([dam]); res.learnable = 〈式〉; return res;`
+という 3〜4 行の定型を多数重複していた（learnable 式は `target_type == MONSTER_TO_PLAYER`
+または `proj_res.affected_player`）。
+
+**実施:** `MonsterSpellResult` に静的ファクトリ
+`make_learnable(bool learnable, int dam = 0)` を追加し、上記定型を 1 行
+`return MonsterSpellResult::make_learnable(〈式〉[, dam]);` へ置換。**byte 一致の 36 サイト**
+（`mspell-summon.cpp` 30 / `mspell-status.cpp` 3 / `mspell-attack/abstract-mspell.cpp` 1 /
+`mspell-attack/mspell-breath.cpp` 1 / `mspell-attack/mspell-curse.cpp` 1）を移行。
+
+**対象外:** `res` を生成後にさらに加工・条件分岐してから返す関数（`mspell-dispel.cpp` /
+`mspell-floor.cpp` / `assign-monster-spell.cpp` 等、`res.learnable = false` を後段で
+条件的に上書きする箇所）は末尾定型でないため据え置き。
+
+挙動完全不変（同値のファクトリ抽出）。フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。
 
 ---
 

--- a/src/mspell/mspell-attack/abstract-mspell.cpp
+++ b/src/mspell/mspell-attack/abstract-mspell.cpp
@@ -40,8 +40,5 @@ MonsterSpellResult AbstractMSpellAttack::shoot(POSITION y, POSITION x)
         this->data.drs.execute(*this->creature_ptr, this->m_idx);
     }
 
-    auto res = MonsterSpellResult::make_valid(dam);
-    res.learnable = proj_res.affected_player;
-
-    return res;
+    return MonsterSpellResult::make_learnable(proj_res.affected_player, dam);
 }

--- a/src/mspell/mspell-attack/mspell-breath.cpp
+++ b/src/mspell/mspell-attack/mspell-breath.cpp
@@ -164,8 +164,5 @@ MonsterSpellResult spell_RF4_BREATH(CreatureEntity &creature, MonsterAbilityType
         data->drs.execute(creature, m_idx);
     }
 
-    auto res = MonsterSpellResult::make_valid(dam);
-    res.learnable = proj_res.affected_player;
-
-    return res;
+    return MonsterSpellResult::make_learnable(proj_res.affected_player, dam);
 }

--- a/src/mspell/mspell-attack/mspell-curse.cpp
+++ b/src/mspell/mspell-attack/mspell-curse.cpp
@@ -84,8 +84,5 @@ MonsterSpellResult spell_RF5_CAUSE(CreatureEntity &creature, MonsterAbilityType 
 
     pointed(creature, y, x, m_idx, curse_list.at(ms_type).type, dam, target_type);
 
-    auto res = MonsterSpellResult::make_valid(dam);
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER, dam);
 }

--- a/src/mspell/mspell-result.h
+++ b/src/mspell/mspell-result.h
@@ -20,6 +20,14 @@ public:
         return MonsterSpellResult(true, dam);
     }
 
+    //! valid かつ learnable を指定して生成する (res.learnable = ... の定型を集約)
+    static MonsterSpellResult make_learnable(bool learnable, int dam = 0)
+    {
+        MonsterSpellResult res(true, dam);
+        res.learnable = learnable;
+        return res;
+    }
+
     static MonsterSpellResult make_invalid()
     {
         return MonsterSpellResult(false);

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -152,10 +152,7 @@ MonsterSpellResult spell_RF5_DRAIN_MANA(CreatureEntity &creature, POSITION y, PO
         update_smart_learn(creature, m_idx, DRS_MANA);
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = proj_res.affected_player;
-
-    return res;
+    return MonsterSpellResult::make_learnable(proj_res.affected_player);
 }
 
 /*!
@@ -190,10 +187,7 @@ MonsterSpellResult spell_RF5_MIND_BLAST(CreatureEntity &creature, POSITION y, PO
     const auto dam = monspell_damage(creature, MonsterAbilityType::MIND_BLAST, m_idx, DAM_ROLL);
     const auto proj_res = pointed(creature, y, x, m_idx, AttributeType::MIND_BLAST, dam, target_type);
 
-    auto res = MonsterSpellResult::make_valid(dam);
-    res.learnable = proj_res.affected_player;
-
-    return res;
+    return MonsterSpellResult::make_learnable(proj_res.affected_player, dam);
 }
 
 /*!
@@ -228,10 +222,7 @@ MonsterSpellResult spell_RF5_BRAIN_SMASH(CreatureEntity &creature, POSITION y, P
     const auto dam = monspell_damage(creature, MonsterAbilityType::BRAIN_SMASH, m_idx, DAM_ROLL);
     const auto proj_res = pointed(creature, y, x, m_idx, AttributeType::BRAIN_SMASH, dam, target_type);
 
-    auto res = MonsterSpellResult::make_valid(dam);
-    res.learnable = proj_res.affected_player;
-
-    return res;
+    return MonsterSpellResult::make_learnable(proj_res.affected_player, dam);
 }
 
 /*!

--- a/src/mspell/mspell-summon.cpp
+++ b/src/mspell/mspell-summon.cpp
@@ -244,10 +244,7 @@ MonsterSpellResult spell_RF6_S_KIN(CreatureEntity &creature, POSITION y, POSITIO
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -292,10 +289,7 @@ MonsterSpellResult spell_RF6_S_CYBER(CreatureEntity &creature, POSITION y, POSIT
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -343,10 +337,7 @@ MonsterSpellResult spell_RF6_S_MONSTER(CreatureEntity &creature, POSITION y, POS
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -394,10 +385,7 @@ MonsterSpellResult spell_RF6_S_MONSTERS(CreatureEntity &creature, POSITION y, PO
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -439,10 +427,7 @@ MonsterSpellResult spell_RF6_S_ANT(CreatureEntity &creature, POSITION y, POSITIO
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -484,10 +469,7 @@ MonsterSpellResult spell_RF6_S_SPIDER(CreatureEntity &creature, POSITION y, POSI
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -529,10 +511,7 @@ MonsterSpellResult spell_RF6_S_HOUND(CreatureEntity &creature, POSITION y, POSIT
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -574,10 +553,7 @@ MonsterSpellResult spell_RF6_S_HYDRA(CreatureEntity &creature, POSITION y, POSIT
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -619,10 +595,7 @@ MonsterSpellResult spell_RF6_S_FAIRY(CreatureEntity &creature, POSITION y, POSIT
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -664,10 +637,7 @@ MonsterSpellResult spell_RF6_S_APE(CreatureEntity &creature, POSITION y, POSITIO
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -709,10 +679,7 @@ MonsterSpellResult spell_RF6_S_BIRD(CreatureEntity &creature, POSITION y, POSITI
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -767,10 +734,7 @@ MonsterSpellResult spell_RF6_S_ANGEL(CreatureEntity &creature, POSITION y, POSIT
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -812,10 +776,7 @@ MonsterSpellResult spell_RF6_S_DEMON(CreatureEntity &creature, POSITION y, POSIT
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -857,10 +818,7 @@ MonsterSpellResult spell_RF6_S_UNDEAD(CreatureEntity &creature, POSITION y, POSI
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -906,10 +864,7 @@ MonsterSpellResult spell_RF6_S_DRAGON(CreatureEntity &creature, POSITION y, POSI
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -964,10 +919,7 @@ MonsterSpellResult spell_RF6_S_HI_UNDEAD(CreatureEntity &creature, POSITION y, P
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -1016,10 +968,7 @@ MonsterSpellResult spell_RF6_S_HI_DRAGON(CreatureEntity &creature, POSITION y, P
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -1062,10 +1011,7 @@ MonsterSpellResult spell_RF6_S_AMBERITES(CreatureEntity &creature, POSITION y, P
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -1108,10 +1054,7 @@ MonsterSpellResult spell_RF6_S_CHOASIANS(CreatureEntity &creature, POSITION y, P
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -1172,10 +1115,7 @@ MonsterSpellResult spell_RF6_S_UNIQUE(CreatureEntity &creature, POSITION y, POSI
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -1218,10 +1158,7 @@ MonsterSpellResult spell_RF6_S_DEAD_UNIQUE(CreatureEntity &creature, POSITION y,
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 /*!
  * @brief RF6_S_NASTYの処理。汚いモンスターの召喚。 /
@@ -1259,10 +1196,7 @@ MonsterSpellResult spell_RF6_S_NASTY(CreatureEntity &creature, POSITION y, POSIT
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -1302,10 +1236,7 @@ MonsterSpellResult spell_RF6_S_GOLEM(CreatureEntity &creature, POSITION y, POSIT
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -1344,10 +1275,7 @@ MonsterSpellResult spell_RF6_S_CATS(CreatureEntity &creature, POSITION y, POSITI
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -1387,10 +1315,7 @@ MonsterSpellResult spell_RF6_S_PERVERTS(CreatureEntity &creature, POSITION y, PO
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -1430,10 +1355,7 @@ MonsterSpellResult spell_RF6_S_PUYO(CreatureEntity &creature, POSITION y, POSITI
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 /*!
  * @brief RF6_S_HOMOの処理。ホモ召喚。 /
@@ -1478,10 +1400,7 @@ MonsterSpellResult spell_RF6_S_HOMO(CreatureEntity &creature, POSITION y, POSITI
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 /*!
  * @brief RF6_S_WALLの処理。壁一体召喚。 /
@@ -1522,10 +1441,7 @@ MonsterSpellResult spell_RF6_S_WALL(CreatureEntity &creature, POSITION y, POSITI
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -1567,10 +1483,7 @@ MonsterSpellResult spell_RF6_S_INSECT(CreatureEntity &creature, POSITION y, POSI
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }
 
 /*!
@@ -1611,8 +1524,5 @@ MonsterSpellResult spell_RF6_S_ELDRAZI(CreatureEntity &creature, POSITION y, POS
         floor.monster_noise = true;
     }
 
-    auto res = MonsterSpellResult::make_valid();
-    res.learnable = target_type == MONSTER_TO_PLAYER;
-
-    return res;
+    return MonsterSpellResult::make_learnable(target_type == MONSTER_TO_PLAYER);
 }


### PR DESCRIPTION
…案E7・dedup）

モンスター呪文ハンドラ末尾の定型
auto res = MonsterSpellResult::make_valid([dam]); res.learnable = 〈式〉; return res; (learnable 式は target_type == MONSTER_TO_PLAYER または proj_res.affected_player) が 多数重複していたため、静的ファクトリ make_learnable(bool learnable, int dam = 0) を 追加し 1 行へ集約。

byte 一致の 36 サイトを移行:
- mspell-summon.cpp (30)
- mspell-status.cpp (3)
- mspell-attack/abstract-mspell.cpp (1)
- mspell-attack/mspell-breath.cpp (1)
- mspell-attack/mspell-curse.cpp (1)

対象外: res を生成後に加工・条件分岐してから返す関数 (mspell-dispel /
mspell-floor / assign-monster-spell 等) は末尾定型でないため据え置き。

挙動完全不変 (同値のファクトリ抽出)。フルビルド (g++ -O3 -Werror) /
clang-format-18 で検証済。