### PR TITLE
refactor: コマンド反復回数セットの定型を set_command_repeat_from_arg() へ集約（提案E8・dedup）

### DIFF
--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -387,11 +387,7 @@ void do_cmd_go_down(CreatureEntity &creature)
  */
 void do_cmd_walk(CreatureEntity &creature, bool pickup)
 {
-    if (command_arg) {
-        command_rep = command_arg - 1;
-        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::ACTION);
-        command_arg = 0;
-    }
+    set_command_repeat_from_arg();
 
     auto more = false;
     const auto is_wild_mode = AngbandWorld::get_instance().is_wild_mode();
@@ -469,11 +465,7 @@ void do_cmd_run(CreatureEntity &creature)
 void do_cmd_stay(CreatureEntity &creature, bool pickup)
 {
     uint32_t mpe_mode = MPE_STAYING | MPE_ENERGY_USE;
-    if (command_arg) {
-        command_rep = command_arg - 1;
-        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::ACTION);
-        command_arg = 0;
-    }
+    set_command_repeat_from_arg();
 
     PlayerEnergy(creature).set_player_turn_energy(100);
     if (pickup) {

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -113,11 +113,7 @@ void do_cmd_open(CreatureEntity &creature)
         }
     }
 
-    if (command_arg) {
-        command_rep = command_arg - 1;
-        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::ACTION);
-        command_arg = 0;
-    }
+    set_command_repeat_from_arg();
 
     if (const auto dir = get_rep_dir(creature, true)) {
         const auto pos = creature.get_neighbor(dir);
@@ -162,11 +158,7 @@ void do_cmd_close(CreatureEntity &creature)
         }
     }
 
-    if (command_arg) {
-        command_rep = command_arg - 1;
-        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::ACTION);
-        command_arg = 0;
-    }
+    set_command_repeat_from_arg();
 
     auto more = false;
     if (const auto dir = get_rep_dir(creature)) {
@@ -211,11 +203,7 @@ void do_cmd_disarm(CreatureEntity &creature)
         }
     }
 
-    if (command_arg) {
-        command_rep = command_arg - 1;
-        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::ACTION);
-        command_arg = 0;
-    }
+    set_command_repeat_from_arg();
 
     auto more = false;
     if (const auto dir = get_rep_dir(creature, true)) {
@@ -263,11 +251,7 @@ void do_cmd_bash(CreatureEntity &creature)
     }
 
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
-    if (command_arg) {
-        command_rep = command_arg - 1;
-        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::ACTION);
-        command_arg = 0;
-    }
+    set_command_repeat_from_arg();
 
     auto more = false;
     if (const auto dir = get_rep_dir(creature)) {

--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -48,11 +48,7 @@
  */
 void do_cmd_search(CreatureEntity &creature)
 {
-    if (command_arg) {
-        command_rep = command_arg - 1;
-        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::ACTION);
-        command_arg = 0;
-    }
+    set_command_repeat_from_arg();
 
     PlayerEnergy(creature).set_player_turn_energy(100);
     search(creature);
@@ -110,11 +106,7 @@ void do_cmd_alter(CreatureEntity &creature)
 {
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
-    if (command_arg) {
-        command_rep = command_arg - 1;
-        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::ACTION);
-        command_arg = 0;
-    }
+    set_command_repeat_from_arg();
 
     if (!exe_alter(creature)) {
         disturb(creature, false, false);

--- a/src/cmd-action/cmd-tunnel.cpp
+++ b/src/cmd-action/cmd-tunnel.cpp
@@ -36,11 +36,7 @@ void do_cmd_tunnel(CreatureEntity &creature)
 {
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
-    if (command_arg) {
-        command_rep = command_arg - 1;
-        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::ACTION);
-        command_arg = 0;
-    }
+    set_command_repeat_from_arg();
 
     const auto dir = get_rep_dir(creature);
     if (!dir) {

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -19,6 +19,7 @@
 #include "system/creature-entity.h"
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
+#include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h" //!< @todo 相互依存している、後で何とかする.
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
@@ -39,6 +40,15 @@ TERM_LEN command_gap = 999; /* アイテムの表示に使う (詳細未調査) 
 int16_t command_new; /* Command chaining from inven/equip view */
 
 static char request_command_buffer[256]{}; /*!< Special buffer to hold the action of the current keymap */
+
+void set_command_repeat_from_arg()
+{
+    if (command_arg) {
+        command_rep = command_arg - 1;
+        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::ACTION);
+        command_arg = 0;
+    }
+}
 
 InputKeyRequestor::InputKeyRequestor(CreatureEntity &creature, bool shopping)
     : creature_ptr(&creature)

--- a/src/io/input-key-requester.h
+++ b/src/io/input-key-requester.h
@@ -17,6 +17,14 @@ extern TERM_LEN command_gap;
 extern int16_t command_wrk;
 extern int16_t command_new;
 
+/*!
+ * @brief 数値プレフィックス (command_arg) からコマンド反復回数をセットする
+ * @details command_arg が指定されていれば command_rep = command_arg - 1 とし、
+ *          ACTION 再描画をセットして command_arg をクリアする。多数のコマンド
+ *          ハンドラ冒頭に byte 一致で重複していた定型を集約したもの。
+ */
+void set_command_repeat_from_arg();
+
 enum class KeymapMode;
 class CreatureEntity;
 class SpecialMenuContent;


### PR DESCRIPTION
cmd-action の多数のコマンドハンドラ冒頭に byte 一致で重複していた定型
  if (command_arg) {
      command_rep = command_arg - 1;
      RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::ACTION);
      command_arg = 0;
  }
を、command_arg/command_rep グローバルと同じ TU (io/input-key-requester.{h,cpp}) に共通関数 set_command_repeat_from_arg() を新設して集約。

byte 一致の 9 サイトを 1 行へ置換:
- cmd-action/cmd-open-close.cpp (4)
- cmd-action/cmd-move.cpp (2)
- cmd-action/cmd-others.cpp (2)
- cmd-action/cmd-tunnel.cpp (1)

呼出側は既に input-key-requester.h を include 済のため追加 include 不要。挙動完全不変。 フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when repeating movement, interaction, search, tunnel, and other commands.
  - Ensured command arguments are applied uniformly and the interface refreshes correctly during repeated actions.
- **Refactor**
  - Consolidated command-repeat handling to provide more predictable behavior across supported actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->