### PR TITLE
refactor: 進路上のモンスターへの打撃定型を attack_monster_in_the_way() へ集約（cmd-actiondedup）

### DIFF
--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -53,8 +53,23 @@
 #include "target/target-getter.h"
 #include "tracking/lore-tracker.h"
 #include "util/bit-flags-calculator.h"
+#include "util/point-2d.h"
 #include "view/display-messages.h"
 #include "wizard/wizard-messages.h"
+
+/*!
+ * @brief 進行方向にモンスターが立ちふさがっている場合の打撃処理 (定型集約)
+ * @param creature クリーチャーへの参照
+ * @param pos 立ちふさがっているモンスターの座標
+ * @details 各種コマンド (開閉/解体/トンネル等) で移動先にモンスターがいる場合の
+ *          「ターンエネルギー消費 → メッセージ → 打撃」の定型を集約したもの。
+ */
+void attack_monster_in_the_way(CreatureEntity &creature, const Pos2D &pos)
+{
+    PlayerEnergy(creature).set_player_turn_energy(100);
+    msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
+    do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
+}
 
 /*!
  * @brief プレイヤーの変異要素による打撃処理

--- a/src/cmd-action/cmd-attack.h
+++ b/src/cmd-action/cmd-attack.h
@@ -2,9 +2,11 @@
 
 #include "combat/combat-options-type.h"
 #include "system/angband.h"
+#include "util/point-2d.h"
 
 class CreatureEntity;
 bool do_cmd_attack(CreatureEntity &creature, POSITION y, POSITION x, combat_options mode);
+void attack_monster_in_the_way(CreatureEntity &creature, const Pos2D &pos);
 bool do_cmd_headbutt(CreatureEntity &creature);
 void do_cmd_body_slam(CreatureEntity &creature);
 void do_cmd_enema(CreatureEntity &creature);

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -122,9 +122,7 @@ void do_cmd_open(CreatureEntity &creature)
         if (grid.get_terrain(TerrainKind::MIMIC).flags.has_not(TerrainCharacteristics::OPEN) && !o_idx) {
             msg_print(_("そこには開けるものが見当たらない。", "You see nothing there to open."));
         } else if (grid.has_monster() && !floor.get_monster(grid.m_idx).is_riding()) {
-            PlayerEnergy(creature).set_player_turn_energy(100);
-            msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
-            do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
+            attack_monster_in_the_way(creature, pos);
         } else if (o_idx) {
             more = exe_open_chest(creature, pos, o_idx);
         } else {
@@ -167,9 +165,7 @@ void do_cmd_close(CreatureEntity &creature)
         if (grid.get_terrain(TerrainKind::MIMIC).flags.has_not(TerrainCharacteristics::CLOSE)) {
             msg_print(_("そこには閉じるものが見当たらない。", "You see nothing there to close."));
         } else if (grid.has_monster()) {
-            PlayerEnergy(creature).set_player_turn_energy(100);
-            msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
-            do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
+            attack_monster_in_the_way(creature, pos);
         } else {
             more = exe_close(creature, pos);
         }
@@ -260,9 +256,7 @@ void do_cmd_bash(CreatureEntity &creature)
         if (grid.get_terrain(TerrainKind::MIMIC).flags.has_not(TerrainCharacteristics::BASH)) {
             msg_print(_("そこには体当たりするものが見当たらない。", "You see nothing there to bash."));
         } else if (grid.has_monster()) {
-            PlayerEnergy(creature).set_player_turn_energy(100);
-            msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
-            do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
+            attack_monster_in_the_way(creature, pos);
         } else {
             more = exe_bash(creature, pos.y, pos.x, dir);
         }
@@ -330,9 +324,7 @@ void do_cmd_spike(CreatureEntity &creature)
     } else if (!get_spike(creature, &i_idx)) {
         msg_print(_("くさびを持っていない！", "You have no spikes!"));
     } else if (grid.has_monster()) {
-        PlayerEnergy(creature).set_player_turn_energy(100);
-        msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
-        do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
+        attack_monster_in_the_way(creature, pos);
     } else {
         PlayerEnergy(creature).set_player_turn_energy(100);
         msg_format(_("%sにくさびを打ち込んだ。", "You jam the %s with a spike."), terrain_mimic.name.data());

--- a/src/cmd-action/cmd-tunnel.cpp
+++ b/src/cmd-action/cmd-tunnel.cpp
@@ -53,9 +53,7 @@ void do_cmd_tunnel(CreatureEntity &creature)
     } else if (terrain_mimic.flags.has_not(TerrainCharacteristics::TUNNEL)) {
         msg_print(_("そこは掘れない。", "You can't tunnel through that."));
     } else if (grid.has_monster()) {
-        PlayerEnergy(creature).set_player_turn_energy(100);
-        msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
-        do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
+        attack_monster_in_the_way(creature, pos);
     } else {
         more = exe_tunnel(creature, pos.y, pos.x);
     }


### PR DESCRIPTION
開閉/破壊/トンネル等のコマンドで移動先にモンスターがいる場合の定型
  PlayerEnergy(creature).set_player_turn_energy(100);
  msg_print("モンスターが立ちふさがっている！");
  do_cmd_attack(creature, pos.y, pos.x, HISSATSU_NONE);
を cmd-attack.{h,cpp} の共通関数 attack_monster_in_the_way(creature, pos) へ集約。

byte 一致の 5 サイトを移行 (cmd-open-close 4 / cmd-tunnel 1)。呼出側は既に cmd-attack.h を include 済。

除外: cmd-open-close の解除(disarm)分岐はターンエネルギー消費行を持たない
(msg+打撃のみ) ため定型不一致として据え置き (既存挙動を保存)。

挙動完全不変。フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when a monster blocks opening, closing, bashing, spiking, or tunneling actions.
  * Blocked actions now reliably trigger the appropriate attack response and message.
  * Preserved normal turn handling and follow-up behavior across these interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->