### PR TITLE
refactor: アイテム関連サブウィンドウ再描画の定型を集約（提案E10・dedup）

### DIFF
--- a/src/mind/mind-mindcrafter.cpp
+++ b/src/mind/mind-mindcrafter.cpp
@@ -87,14 +87,7 @@ bool psychometry(CreatureEntity &creature)
         StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
-    static constexpr auto flags_swrf = {
-        SubWindowRedrawingFlag::INVENTORY,
-        SubWindowRedrawingFlag::EQUIPMENT,
-        SubWindowRedrawingFlag::PLAYER,
-        SubWindowRedrawingFlag::FLOOR_ITEMS,
-        SubWindowRedrawingFlag::FOUND_ITEMS,
-    };
-    rfu.set_flags(flags_swrf);
+    rfu.set_item_related_sub_window_flags();
 
     bool okay = false;
     switch (item->bi_key.tval()) {

--- a/src/object-use/use-execution.cpp
+++ b/src/object-use/use-execution.cpp
@@ -121,14 +121,7 @@ void ObjectUseEntity::execute()
         gain_exp(creature, (item_level + (creature.get_level() >> 1)) / creature.get_level());
     }
 
-    static constexpr auto flags_swrf = {
-        SubWindowRedrawingFlag::INVENTORY,
-        SubWindowRedrawingFlag::EQUIPMENT,
-        SubWindowRedrawingFlag::PLAYER,
-        SubWindowRedrawingFlag::FLOOR_ITEMS,
-        SubWindowRedrawingFlag::FOUND_ITEMS,
-    };
-    rfu.set_flags(flags_swrf);
+    rfu.set_item_related_sub_window_flags();
     rfu.set_flags(flags_srf);
     if (!use_charge) {
         return;

--- a/src/object-use/zaprod-execution.cpp
+++ b/src/object-use/zaprod-execution.cpp
@@ -144,14 +144,7 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX i_idx)
         gain_exp(creature, (item_level + (creature.get_level() >> 1)) / creature.get_level());
     }
 
-    static constexpr auto flags_swrf = {
-        SubWindowRedrawingFlag::INVENTORY,
-        SubWindowRedrawingFlag::EQUIPMENT,
-        SubWindowRedrawingFlag::PLAYER,
-        SubWindowRedrawingFlag::FLOOR_ITEMS,
-        SubWindowRedrawingFlag::FOUND_ITEMS,
-    };
-    rfu.set_flags(flags_swrf);
+    rfu.set_item_related_sub_window_flags();
 }
 
 bool ObjectZapRodEntity::check_can_zap()

--- a/src/object-use/zapwand-execution.cpp
+++ b/src/object-use/zapwand-execution.cpp
@@ -123,14 +123,7 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX i_idx)
         gain_exp(this->creature, (item_level + (this->creature.get_level() >> 1)) / this->creature.get_level());
     }
 
-    static constexpr auto flags_swrf = {
-        SubWindowRedrawingFlag::INVENTORY,
-        SubWindowRedrawingFlag::EQUIPMENT,
-        SubWindowRedrawingFlag::PLAYER,
-        SubWindowRedrawingFlag::FLOOR_ITEMS,
-        SubWindowRedrawingFlag::FOUND_ITEMS,
-    };
-    rfu.set_flags(flags_swrf);
+    rfu.set_item_related_sub_window_flags();
     rfu.set_flags(flags_srf);
     item->pval--;
     if (i_idx >= 0) {

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -77,14 +77,7 @@ bool identify_item(CreatureEntity &creature, ItemEntity *o_ptr)
         StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
-    static constexpr auto flags_swrf = {
-        SubWindowRedrawingFlag::INVENTORY,
-        SubWindowRedrawingFlag::EQUIPMENT,
-        SubWindowRedrawingFlag::PLAYER,
-        SubWindowRedrawingFlag::FLOOR_ITEMS,
-        SubWindowRedrawingFlag::FOUND_ITEMS,
-    };
-    rfu.set_flags(flags_swrf);
+    rfu.set_item_related_sub_window_flags();
     record_item_name = known_item_name;
     record_turn = AngbandWorld::get_instance().game_turn;
 

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -450,14 +450,7 @@ bool enchant_equipment(ItemEntity &item, int n, int eflag)
         StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
-    static constexpr auto flags_swrf = {
-        SubWindowRedrawingFlag::INVENTORY,
-        SubWindowRedrawingFlag::EQUIPMENT,
-        SubWindowRedrawingFlag::PLAYER,
-        SubWindowRedrawingFlag::FLOOR_ITEMS,
-        SubWindowRedrawingFlag::FOUND_ITEMS,
-    };
-    rfu.set_flags(flags_swrf);
+    rfu.set_item_related_sub_window_flags();
     return true;
 }
 

--- a/src/status/base-status.cpp
+++ b/src/status/base-status.cpp
@@ -335,14 +335,7 @@ bool lose_all_info(CreatureEntity &creature)
         StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
-    static constexpr auto flags_swrf = {
-        SubWindowRedrawingFlag::INVENTORY,
-        SubWindowRedrawingFlag::EQUIPMENT,
-        SubWindowRedrawingFlag::PLAYER,
-        SubWindowRedrawingFlag::FLOOR_ITEMS,
-        SubWindowRedrawingFlag::FOUND_ITEMS,
-    };
-    rfu.set_flags(flags_swrf);
+    rfu.set_item_related_sub_window_flags();
     wiz_dark(creature);
     return true;
 }

--- a/src/system/redrawing-flags-updater.cpp
+++ b/src/system/redrawing-flags-updater.cpp
@@ -83,6 +83,18 @@ void RedrawingFlagsUpdater::set_flags(const EnumClassFlagGroup<StatusRecalculati
     this->status_flags.set(flags);
 }
 
+void RedrawingFlagsUpdater::set_item_related_sub_window_flags()
+{
+    static constexpr auto flags = {
+        SubWindowRedrawingFlag::INVENTORY,
+        SubWindowRedrawingFlag::EQUIPMENT,
+        SubWindowRedrawingFlag::PLAYER,
+        SubWindowRedrawingFlag::FLOOR_ITEMS,
+        SubWindowRedrawingFlag::FOUND_ITEMS,
+    };
+    this->sub_window_flags.set(flags);
+}
+
 void RedrawingFlagsUpdater::reset_flag(MainWindowRedrawingFlag flag)
 {
     this->main_window_flags.reset(flag);

--- a/src/system/redrawing-flags-updater.h
+++ b/src/system/redrawing-flags-updater.h
@@ -101,6 +101,9 @@ public:
     void set_flags(const EnumClassFlagGroup<SubWindowRedrawingFlag> &flags);
     void set_flags(const EnumClassFlagGroup<StatusRecalculatingFlag> &flags);
 
+    //! アイテム関連サブウィンドウ (INVENTORY/EQUIPMENT/PLAYER/FLOOR_ITEMS/FOUND_ITEMS) の再描画をまとめてセットする
+    void set_item_related_sub_window_flags();
+
     void reset_flag(MainWindowRedrawingFlag flag);
     void reset_flag(SubWindowRedrawingFlag flag);
     void reset_flag(StatusRecalculatingFlag flag);


### PR DESCRIPTION
7 ファイルに byte 一致で重複していたアイテム関連サブウィンドウ再描画の定型
  static constexpr auto flags_swrf = {
      SubWindowRedrawingFlag::INVENTORY, EQUIPMENT, PLAYER, FLOOR_ITEMS, FOUND_ITEMS,
  };
  rfu.set_flags(flags_swrf);
を RedrawingFlagsUpdater::set_item_related_sub_window_flags() へ集約。呼出側は 既存の rfu 参照をそのまま使うため未使用変数化を回避。

移行 7 サイト:
- object-use/zaprod-execution.cpp / zapwand-execution.cpp / use-execution.cpp
- spell/spells-object.cpp / spell-kind/spells-perception.cpp
- mind/mind-mindcrafter.cpp / status/base-status.cpp

flags 集合が異なる他バリアント (4/6 フラグ・SPELL 付き等) は各サイト固有のため対象外。 挙動完全不変。フルビルド (g++ -O3 -Werror, BUILD_EXIT=0) / clang-format-18 で検証済。