### PR TITLE
refactor: alliance の isAnnihilated 全滅判定を共通ヘルパへ集約（提案E11・dedup）

### DIFF
--- a/src/alliance/alliance-angartha.cpp
+++ b/src/alliance/alliance-angartha.cpp
@@ -21,5 +21,5 @@ int AllianceAngartha::calcImpressionPoint([[maybe_unused]] const CreatureEntity 
 bool AllianceAngartha::isAnnihilated()
 {
     // 万色の『サルマン』が存在しない場合、アンガルサは壊滅する
-    return MonraceList::get_instance().get_monrace(MonraceId::SARUMAN).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::SARUMAN });
 }

--- a/src/alliance/alliance-anor-londo.cpp
+++ b/src/alliance/alliance-anor-londo.cpp
@@ -42,6 +42,5 @@ void AllianceAnorLondo::panishment([[maybe_unused]] CreatureEntity &creature)
  */
 bool AllianceAnorLondo::isAnnihilated()
 {
-    const auto &monrace_list = MonraceList::get_instance();
-    return monrace_list.get_monrace(MonraceId::GWYN).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::GWYN });
 }

--- a/src/alliance/alliance-aryan-family.cpp
+++ b/src/alliance/alliance-aryan-family.cpp
@@ -46,5 +46,5 @@ int AllianceAryanFamily::calcImpressionPoint(const CreatureEntity &creature) con
 bool AllianceAryanFamily::isAnnihilated()
 {
     // アーリアン・ファミリーのボス『ビッグ・アイ』が存在しない場合、アーリアンファミリーは壊滅する
-    return MonraceList::get_instance().get_monrace(MonraceId::BIG_EYE).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::BIG_EYE });
 }

--- a/src/alliance/alliance-basam-empire.cpp
+++ b/src/alliance/alliance-basam-empire.cpp
@@ -21,5 +21,5 @@ int AllianceBasamEmpire::calcImpressionPoint(const CreatureEntity &creature) con
 bool AllianceBasamEmpire::isAnnihilated()
 {
     // 『オゴレス王』が存在しない場合、バサム帝国は壊滅する
-    return MonraceList::get_instance().get_monrace(MonraceId::OGRES_KING).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::OGRES_KING });
 }

--- a/src/alliance/alliance-binzyou-buddhism.cpp
+++ b/src/alliance/alliance-binzyou-buddhism.cpp
@@ -22,5 +22,5 @@ int AllianceBinzyouBuddhism::calcImpressionPoint([[maybe_unused]] const Creature
 
 bool AllianceBinzyouBuddhism::isAnnihilated()
 {
-    return MonraceList::get_instance().get_monrace(MonraceId::BINZYOU_MUR).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::BINZYOU_MUR });
 }

--- a/src/alliance/alliance-boletaria.cpp
+++ b/src/alliance/alliance-boletaria.cpp
@@ -44,5 +44,5 @@ void AllianceBoletaria::panishment([[maybe_unused]] CreatureEntity &creature)
 bool AllianceBoletaria::isAnnihilated()
 {
     // 老王『オーラント』が存在しない場合、ボーレタリアは壊滅する
-    return MonraceList::get_instance().get_monrace(MonraceId::OLD_KING_ALLANT).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::OLD_KING_ALLANT });
 }

--- a/src/alliance/alliance-diabolique.cpp
+++ b/src/alliance/alliance-diabolique.cpp
@@ -51,22 +51,7 @@ int AllianceDiabolique::calcImpressionPoint(const CreatureEntity &creature) cons
 
 bool AllianceDiabolique::isAnnihilated()
 {
-    if (MonraceList::get_instance().get_monrace(MonraceId::DIABOLIQUE_GOLDO).mob_num != 0) {
-        return false;
-    }
-    if (MonraceList::get_instance().get_monrace(MonraceId::DIABOLIQUE_KAENOH).mob_num != 0) {
-        return false;
-    }
-    if (MonraceList::get_instance().get_monrace(MonraceId::DIABOLIQUE_AZURITE).mob_num != 0) {
-        return false;
-    }
-    if (MonraceList::get_instance().get_monrace(MonraceId::DIABOLIQUE_FATRAS).mob_num != 0) {
-        return false;
-    }
-    if (MonraceList::get_instance().get_monrace(MonraceId::DIABOLIQUE_PENGZU).mob_num != 0) {
-        return false;
-    }
-    return true;
+    return all_monraces_extinct({ MonraceId::DIABOLIQUE_GOLDO, MonraceId::DIABOLIQUE_KAENOH, MonraceId::DIABOLIQUE_AZURITE, MonraceId::DIABOLIQUE_FATRAS, MonraceId::DIABOLIQUE_PENGZU });
 }
 
 void AllianceDiabolique::panishment(CreatureEntity &creature)

--- a/src/alliance/alliance-dokachans.cpp
+++ b/src/alliance/alliance-dokachans.cpp
@@ -23,5 +23,5 @@ int AllianceDokachans::calcImpressionPoint([[maybe_unused]] const CreatureEntity
 
 bool AllianceDokachans::isAnnihilated()
 {
-    return MonraceList::get_instance().get_monrace(MonraceId::DOKACHAN).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::DOKACHAN });
 }

--- a/src/alliance/alliance-fangfamily.cpp
+++ b/src/alliance/alliance-fangfamily.cpp
@@ -29,7 +29,7 @@ int AllianceFangFamily::calcImpressionPoint(const CreatureEntity &creature) cons
 
 bool AllianceFangFamily::isAnnihilated()
 {
-    return MonraceList::get_instance().get_monrace(MonraceId::KING_FANG_FAMILY).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::KING_FANG_FAMILY });
 }
 
 void AllianceFangFamily::panishment(CreatureEntity &creature)

--- a/src/alliance/alliance-feanor-noldor.cpp
+++ b/src/alliance/alliance-feanor-noldor.cpp
@@ -39,5 +39,5 @@ void AllianceFeanorNoldor::panishment([[maybe_unused]] CreatureEntity &creature)
 bool AllianceFeanorNoldor::isAnnihilated()
 {
     // 憤怒の上級王『フェアノール』が存在しない場合、フェアノール統ノルドールは壊滅する
-    return MonraceList::get_instance().get_monrace(MonraceId::FEANOR).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::FEANOR });
 }

--- a/src/alliance/alliance-fingolfin-noldor.cpp
+++ b/src/alliance/alliance-fingolfin-noldor.cpp
@@ -40,5 +40,5 @@ void AllianceFingolfinNoldor::panishment([[maybe_unused]] CreatureEntity &creatu
 bool AllianceFingolfinNoldor::isAnnihilated()
 {
     // 聡明の上級王『フィンゴルフィン』が存在しない場合、フィンゴルフィン統ノルドールは壊滅する
-    return MonraceList::get_instance().get_monrace(MonraceId::FINGOLFIN).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::FINGOLFIN });
 }

--- a/src/alliance/alliance-gaichi.cpp
+++ b/src/alliance/alliance-gaichi.cpp
@@ -24,5 +24,5 @@ int AllianceGaichi::calcImpressionPoint([[maybe_unused]] const CreatureEntity &c
  */
 bool AllianceGaichi::isAnnihilated()
 {
-    return MonraceList::get_instance().get_monrace(MonraceId::BIO_CORE).mob_num == 0 && MonraceList::get_instance().get_monrace(MonraceId::GAICHI_MOA).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::BIO_CORE, MonraceId::GAICHI_MOA });
 }

--- a/src/alliance/alliance-ge-orlic.cpp
+++ b/src/alliance/alliance-ge-orlic.cpp
@@ -21,5 +21,5 @@ int AllianceGEOrlic::calcImpressionPoint([[maybe_unused]] const CreatureEntity &
 bool AllianceGEOrlic::isAnnihilated()
 {
     // 銀河皇帝『カル・ダームIII世』が存在しない場合、オーリック朝銀河帝国は壊滅する
-    return MonraceList::get_instance().get_monrace(MonraceId::CALDARM).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::CALDARM });
 }

--- a/src/alliance/alliance-golan.cpp
+++ b/src/alliance/alliance-golan.cpp
@@ -26,5 +26,5 @@ int AllianceGOLAN::calcImpressionPoint([[maybe_unused]] const CreatureEntity &cr
 bool AllianceGOLAN::isAnnihilated()
 {
     // 総帥『カーネル』が存在しない場合、GOLANは壊滅する
-    return MonraceList::get_instance().get_monrace(MonraceId::GOLAN_COLONEL).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::GOLAN_COLONEL });
 }

--- a/src/alliance/alliance-ide.cpp
+++ b/src/alliance/alliance-ide.cpp
@@ -44,5 +44,5 @@ void AllianceIde::panishment([[maybe_unused]] CreatureEntity &creature)
  */
 bool AllianceIde::isAnnihilated()
 {
-    return MonraceList::get_instance().get_monrace(MonraceId::IDE).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::IDE });
 }

--- a/src/alliance/alliance-jural.cpp
+++ b/src/alliance/alliance-jural.cpp
@@ -33,7 +33,7 @@ int AllianceJural::calcImpressionPoint(const CreatureEntity &creature) const
 
 bool AllianceJural::isAnnihilated()
 {
-    return MonraceList::get_instance().get_monrace(MonraceId::JURAL_WITCHKING).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::JURAL_WITCHKING });
 }
 
 void AllianceJural::panishment(CreatureEntity &creature)

--- a/src/alliance/alliance-kenohgun.cpp
+++ b/src/alliance/alliance-kenohgun.cpp
@@ -24,5 +24,5 @@ int AllianceKenohgun::calcImpressionPoint(const CreatureEntity &creature) const
 
 bool AllianceKenohgun::isAnnihilated()
 {
-    return MonraceList::get_instance().get_monrace(MonraceId::RAOU).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::RAOU });
 }

--- a/src/alliance/alliance-ketholdeth.cpp
+++ b/src/alliance/alliance-ketholdeth.cpp
@@ -11,5 +11,5 @@ int AllianceKetholdeth::calcImpressionPoint([[maybe_unused]] const CreatureEntit
 
 bool AllianceKetholdeth::isAnnihilated()
 {
-    return MonraceList::get_instance().get_monrace(MonraceId::PRINCESS_KETHOLDETH).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::PRINCESS_KETHOLDETH });
 }

--- a/src/alliance/alliance-khorne.cpp
+++ b/src/alliance/alliance-khorne.cpp
@@ -48,8 +48,7 @@ int AllianceKhorne::calcImpressionPoint(const CreatureEntity &creature) const
 
 bool AllianceKhorne::isAnnihilated()
 {
-    const auto &monrace_list = MonraceList::get_instance();
-    return monrace_list.get_monrace(MonraceId::KHORNE).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::KHORNE });
 }
 
 void AllianceKhorne::panishment(CreatureEntity &creature)

--- a/src/alliance/alliance-king.cpp
+++ b/src/alliance/alliance-king.cpp
@@ -27,5 +27,5 @@ int AllianceKING::calcImpressionPoint([[maybe_unused]] const CreatureEntity &cre
 
 bool AllianceKING::isAnnihilated()
 {
-    return MonraceList::get_instance().get_monrace(MonraceId::KING_SHIN).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::KING_SHIN });
 }

--- a/src/alliance/alliance-kogan-ryu.cpp
+++ b/src/alliance/alliance-kogan-ryu.cpp
@@ -20,5 +20,5 @@ int AllianceKoganRyu::calcImpressionPoint(const CreatureEntity &creature) const
 bool AllianceKoganRyu::isAnnihilated()
 {
     // 濃尾無双『岩本虎眼』が存在しない場合、虎眼流は壊滅する
-    return MonraceList::get_instance().get_monrace(MonraceId::IWAMOTO_KOGAN).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::IWAMOTO_KOGAN });
 }

--- a/src/alliance/alliance-legendofsavior.cpp
+++ b/src/alliance/alliance-legendofsavior.cpp
@@ -26,7 +26,7 @@ int AllianceLegendOfSavior::calcImpressionPoint([[maybe_unused]] const CreatureE
 
 bool AllianceLegendOfSavior::isAnnihilated()
 {
-    return MonraceList::get_instance().get_monrace(MonraceId::KENSHIROU).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::KENSHIROU });
 }
 
 void AllianceLegendOfSavior::panishment(CreatureEntity &creature)

--- a/src/alliance/alliance-meldor.cpp
+++ b/src/alliance/alliance-meldor.cpp
@@ -14,6 +14,5 @@ int AllianceMeldor::calcImpressionPoint([[maybe_unused]] const CreatureEntity &c
 
 bool AllianceMeldor::isAnnihilated()
 {
-    const auto &monrace_list = MonraceList::get_instance();
-    return monrace_list.get_monrace(MonraceId::ANNATAR).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::ANNATAR });
 }

--- a/src/alliance/alliance-nibelung.cpp
+++ b/src/alliance/alliance-nibelung.cpp
@@ -252,5 +252,5 @@ void AllianceNibelung::panishment([[maybe_unused]] CreatureEntity &creature)
 bool AllianceNibelung::isAnnihilated()
 {
     // ニーベルング族の王『アルベリヒ』が存在しない場合、ニーベルングの王国は壊滅する
-    return MonraceList::get_instance().get_monrace(MonraceId::ALBERICH).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::ALBERICH });
 }

--- a/src/alliance/alliance-numenor.cpp
+++ b/src/alliance/alliance-numenor.cpp
@@ -30,5 +30,5 @@ int AllianceNumenor::calcImpressionPoint([[maybe_unused]] const CreatureEntity &
 bool AllianceNumenor::isAnnihilated()
 {
     // 黄金王『アル=ファラゾン』が存在しない場合、ヌメノールは壊滅する
-    return MonraceList::get_instance().get_monrace(MonraceId::AR_PHARAZON).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::AR_PHARAZON });
 }

--- a/src/alliance/alliance-shittodan.cpp
+++ b/src/alliance/alliance-shittodan.cpp
@@ -22,7 +22,7 @@ int AllianceShittoDan::calcImpressionPoint([[maybe_unused]] const CreatureEntity
 
 bool AllianceShittoDan::isAnnihilated()
 {
-    return MonraceList::get_instance().get_monrace(MonraceId::SHITTO_MASK).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::SHITTO_MASK });
 }
 
 void AllianceShittoDan::panishment(CreatureEntity &creature)

--- a/src/alliance/alliance-silvan-elf.cpp
+++ b/src/alliance/alliance-silvan-elf.cpp
@@ -33,6 +33,5 @@ void AllianceSilvanElf::panishment(CreatureEntity &creature)
 bool AllianceSilvanElf::isAnnihilated()
 {
     // 森エルフの王『スランドゥイル』と緑葉の『レゴラス』が両方とも存在しない場合、シルヴァンエルフは壊滅する
-    const auto &monrace_list = MonraceList::get_instance();
-    return monrace_list.get_monrace(MonraceId::THRANDUIL).mob_num == 0 && monrace_list.get_monrace(MonraceId::LEGOLAS).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::THRANDUIL, MonraceId::LEGOLAS });
 }

--- a/src/alliance/alliance-suren.cpp
+++ b/src/alliance/alliance-suren.cpp
@@ -31,5 +31,5 @@ int AllianceSuren::calcImpressionPoint([[maybe_unused]] const CreatureEntity &cr
 
 bool AllianceSuren::isAnnihilated()
 {
-    return MonraceList::get_instance().get_monrace(MonraceId::SUREN).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::SUREN });
 }

--- a/src/alliance/alliance-tophamhatt.cpp
+++ b/src/alliance/alliance-tophamhatt.cpp
@@ -27,5 +27,5 @@ int AllianceTophamHatt::calcImpressionPoint(const CreatureEntity &creature) cons
 
 bool AllianceTophamHatt::isAnnihilated()
 {
-    return MonraceList::get_instance().get_monrace(MonraceId::TOPHAMHATT_ENGINEER).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::TOPHAMHATT_ENGINEER });
 }

--- a/src/alliance/alliance-triothepunch.cpp
+++ b/src/alliance/alliance-triothepunch.cpp
@@ -35,6 +35,5 @@ int AllianceTrioThePunch::calcImpressionPoint(const CreatureEntity &creature) co
 bool AllianceTrioThePunch::isAnnihilated()
 {
     // 全てのメンバーが倒されている場合、トリオ・ザ・パンチは壊滅する
-    const auto &monrace_list = MonraceList::get_instance();
-    return monrace_list.get_monrace(MonraceId::KAMAKURAKUN).mob_num == 0 && monrace_list.get_monrace(MonraceId::SANTOS).mob_num == 0 && monrace_list.get_monrace(MonraceId::ROSESABU).mob_num == 0 && monrace_list.get_monrace(MonraceId::MASTER_CHEN).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::KAMAKURAKUN, MonraceId::SANTOS, MonraceId::ROSESABU, MonraceId::MASTER_CHEN });
 }

--- a/src/alliance/alliance-ungoliant.cpp
+++ b/src/alliance/alliance-ungoliant.cpp
@@ -31,6 +31,5 @@ int AllianceUngoliant::calcImpressionPoint(const CreatureEntity &creature) const
 bool AllianceUngoliant::isAnnihilated()
 {
     // 光なき闇の大蜘蛛『ウンゴリアント』と闇の蜘蛛『シェロブ』が両方とも存在しない場合、ウンゴリアント一族は壊滅する
-    const auto &monrace_list = MonraceList::get_instance();
-    return monrace_list.get_monrace(MonraceId::UNGOLIANT).mob_num == 0 && monrace_list.get_monrace(MonraceId::SHELOB).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::UNGOLIANT, MonraceId::SHELOB });
 }

--- a/src/alliance/alliance-utumno.cpp
+++ b/src/alliance/alliance-utumno.cpp
@@ -26,5 +26,5 @@ int AllianceUtumno::calcImpressionPoint(const CreatureEntity &creature) const
 bool AllianceUtumno::isAnnihilated()
 {
     // 冥王『メルコール』が存在しない場合、ウトゥムノは壊滅する
-    return MonraceList::get_instance().get_monrace(MonraceId::MORGOTH).mob_num == 0;
+    return all_monraces_extinct({ MonraceId::MORGOTH });
 }

--- a/src/alliance/alliance.cpp
+++ b/src/alliance/alliance.cpp
@@ -226,6 +226,18 @@ bool Alliance::isAnnihilated()
     return false;
 }
 
+bool Alliance::all_monraces_extinct(std::initializer_list<MonraceId> monrace_ids)
+{
+    const auto &monraces = MonraceList::get_instance();
+    for (const auto monrace_id : monrace_ids) {
+        if (monraces.get_monrace(monrace_id).mob_num != 0) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 bool Alliance::isFriendly([[maybe_unused]] const CreatureEntity &creature) const
 {
     return false;

--- a/src/alliance/alliance.h
+++ b/src/alliance/alliance.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "system/angband.h"
 #include "util/flag-group.h"
+#include <initializer_list>
 #include <map>
 #include <string>
 #include <vector>
@@ -138,6 +139,8 @@ public:
 protected:
     static int calcPlayerPower(const CreatureEntity &creature, const int bias, const int base_level);
     static int calcIronmanHostilityPenalty();
+    //! 指定した全モンレースが絶滅 (mob_num == 0) しているかを返す (isAnnihilated の定型集約)
+    static bool all_monraces_extinct(std::initializer_list<MonraceId> monrace_ids);
 };
 
 // 分離されたアライアンスクラスのインクルード


### PR DESCRIPTION
72 個の Alliance サブクラスのうち 32 個が isAnnihilated() を「定義モンスターが 全て絶滅 (mob_num == 0) したら壊滅」という同型ロジックで実装していたため、基底
Alliance に共通ヘルパ all_monraces_extinct(std::initializer_list<MonraceId>) を新設し、 各 isAnnihilated を 1 行の宣言的呼出へ集約。

- 単体判定 27 個: return all_monraces_extinct({ MonraceId::X });
- 複数 AND 判定 5 個 (diabolique/gaichi/silvan-elf/triothepunch/ungoliant): return all_monraces_extinct({ MonraceId::A, MonraceId::B, ... }); (diabolique は 5 連 if の逐次判定を 1 行へ)

各陣営の「定義モンスター」は引数リストで明示され可読性を維持。MonraceList の
get_instance/get_monrace/mob_num 定型と AND ロジックを 1 箇所に集約。

除外: 判定がコメントアウト済みで実体が return false の 3 個 (hafu/slaanesh/tzeentch。 TODO 状態) と、calcPlayerPower 等を含む複雑・カスタム実装は対象外 (挙動保存)。

挙動完全不変。フルビルド (g++ -O3 -Werror, BUILD_EXIT=0) / clang-format-18 で検証済。