### PR TITLE
docs: roadmap E トラック索引に E11 (alliance isAnnihilated 集約) を追記

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3844,6 +3844,7 @@ virtual 化・処理の同化・機能付与** がほぼ出揃った。E トラ�
 | E8 | コマンド反復回数セット定型集約（`set_command_repeat_from_arg()`） | 重複解消 | 小 | 中 | ✅ 完了（9 サイト・byte 一致） |
 | E9 | 進路上モンスター打撃定型集約（`attack_monster_in_the_way()`） | 重複解消 | 小 | 低〜中 | ✅ 完了（5 サイト・byte 一致） |
 | E10 | アイテム関連サブウィンドウ再描画定型集約（`set_item_related_sub_window_flags()`） | 重複解消 | 小 | 低〜中 | ✅ 完了（7 サイト・byte 一致） |
+| E11 | alliance の `isAnnihilated` 全滅判定を共通ヘルパへ集約（`all_monraces_extinct()`） | 重複解消 | 中 | 中 | ✅ 完了（32 サブクラス・同型ロジック） |
 
 ---
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added completed proposal E11 to the creature entity refactoring roadmap.
  * Documented consolidating alliance-wide annihilation checks into a shared helper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->