### PR TITLE
refactor: 部屋の床敷き詰め二重ループを fill_room_floor() へ集約（提案E12・dedup）

### DIFF
--- a/src/room/rooms-normal.cpp
+++ b/src/room/rooms-normal.cpp
@@ -14,6 +14,28 @@
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 
+namespace {
+/*!
+ * @brief 矩形領域 [y1,y2]×[x1,x2] を部屋の床で敷き詰める (部屋生成の定型集約)
+ * @param should_brighten 部屋を明るくする場合 true (CAVE_GLOW を付与)
+ * @details rooms-normal 内で 6 箇所重複していた「床設置 + CAVE_ROOM + 任意の CAVE_GLOW」の
+ *          二重ループを集約したもの。挙動不変。
+ */
+void fill_room_floor(CreatureEntity &creature, FloorType &floor, POSITION y1, POSITION y2, POSITION x1, POSITION x2, bool should_brighten)
+{
+    for (auto y = y1; y <= y2; y++) {
+        for (auto x = x1; x <= x2; x++) {
+            auto &grid = floor.get_grid({ y, x });
+            place_grid(creature, grid, GB_FLOOR);
+            grid.info |= (CAVE_ROOM);
+            if (should_brighten) {
+                grid.info |= (CAVE_GLOW);
+            }
+        }
+    }
+}
+}
+
 /*!
  * @brief タイプ1の部屋…通常可変長方形の部屋を生成する
  * @param creature クリーチャーへの参照
@@ -52,16 +74,7 @@ bool build_type1(CreatureEntity &creature, DungeonData *dd_ptr)
     const auto right = center->x + (width - 1) / 2;
 
     /* Place a full floor under the room */
-    for (auto y = top - 1; y <= bottom + 1; y++) {
-        for (auto x = left - 1; x <= right + 1; x++) {
-            auto &grid = floor.get_grid({ y, x });
-            place_grid(creature, grid, GB_FLOOR);
-            grid.info |= (CAVE_ROOM);
-            if (should_brighten) {
-                grid.info |= (CAVE_GLOW);
-            }
-        }
-    }
+    fill_room_floor(creature, floor, top - 1, bottom + 1, left - 1, right + 1, should_brighten);
 
     /* Walls around the room */
     for (auto y = top - 1; y <= bottom + 1; y++) {
@@ -195,28 +208,10 @@ bool build_type2(CreatureEntity &creature, DungeonData *dd_ptr)
     auto x2b = center->x + randint1(10);
 
     /* Place a full floor for room "a" */
-    for (auto y = y1a - 1; y <= y2a + 1; y++) {
-        for (auto x = x1a - 1; x <= x2a + 1; x++) {
-            auto &grid = floor.get_grid({ y, x });
-            place_grid(creature, grid, GB_FLOOR);
-            grid.info |= (CAVE_ROOM);
-            if (should_brighten) {
-                grid.info |= (CAVE_GLOW);
-            }
-        }
-    }
+    fill_room_floor(creature, floor, y1a - 1, y2a + 1, x1a - 1, x2a + 1, should_brighten);
 
     /* Place a full floor for room "b" */
-    for (auto y = y1b - 1; y <= y2b + 1; y++) {
-        for (auto x = x1b - 1; x <= x2b + 1; x++) {
-            auto &grid = floor.get_grid({ y, x });
-            place_grid(creature, grid, GB_FLOOR);
-            grid.info |= (CAVE_ROOM);
-            if (should_brighten) {
-                grid.info |= (CAVE_GLOW);
-            }
-        }
-    }
+    fill_room_floor(creature, floor, y1b - 1, y2b + 1, x1b - 1, x2b + 1, should_brighten);
 
     /* Place the walls around room "a" */
     for (auto y = y1a - 1; y <= y2a + 1; y++) {
@@ -303,28 +298,10 @@ bool build_type3(CreatureEntity &creature, DungeonData *dd_ptr)
     auto x2b = center->x + dx;
 
     /* Place a full floor for room "a" */
-    for (auto y = y1a - 1; y <= y2a + 1; y++) {
-        for (auto x = x1a - 1; x <= x2a + 1; x++) {
-            auto &grid = floor.get_grid({ y, x });
-            place_grid(creature, grid, GB_FLOOR);
-            grid.info |= (CAVE_ROOM);
-            if (should_brighten) {
-                grid.info |= (CAVE_GLOW);
-            }
-        }
-    }
+    fill_room_floor(creature, floor, y1a - 1, y2a + 1, x1a - 1, x2a + 1, should_brighten);
 
     /* Place a full floor for room "b" */
-    for (auto y = y1b - 1; y <= y2b + 1; y++) {
-        for (auto x = x1b - 1; x <= x2b + 1; x++) {
-            auto &grid = floor.get_grid({ y, x });
-            place_grid(creature, grid, GB_FLOOR);
-            grid.info |= (CAVE_ROOM);
-            if (should_brighten) {
-                grid.info |= (CAVE_GLOW);
-            }
-        }
-    }
+    fill_room_floor(creature, floor, y1b - 1, y2b + 1, x1b - 1, x2b + 1, should_brighten);
 
     /* Place the walls around room "a" */
     for (auto y = y1a - 1; y <= y2a + 1; y++) {
@@ -495,16 +472,7 @@ bool build_type4(CreatureEntity &creature, DungeonData *dd_ptr)
     const auto x2_outer = center->x + 11;
 
     /* Place a full floor under the room */
-    for (auto y = y1_outer - 1; y <= y2_outer + 1; y++) {
-        for (auto x = x1_outer - 1; x <= x2_outer + 1; x++) {
-            auto &grid = floor.get_grid({ y, x });
-            place_grid(creature, grid, GB_FLOOR);
-            grid.info |= (CAVE_ROOM);
-            if (should_brighten) {
-                grid.info |= (CAVE_GLOW);
-            }
-        }
-    }
+    fill_room_floor(creature, floor, y1_outer - 1, y2_outer + 1, x1_outer - 1, x2_outer + 1, should_brighten);
 
     /* Outer Walls */
     for (auto y = y1_outer - 1; y <= y2_outer + 1; y++) {


### PR DESCRIPTION
rooms-normal.cpp 内に 6 箇所 byte 一致で重複していた「矩形領域を部屋の床で 敷き詰める」二重ループ (place_grid GB_FLOOR + CAVE_ROOM 付与 + 任意の CAVE_GLOW) を file-local ヘルパ fill_room_floor(creature, floor, y1, y2, x1, x2, should_brighten) へ集約。

各 build_type1/2/... の呼出は矩形境界を引数で渡す 1 行へ (計 6 サイト、
約 8 行×6 → 1 行×6)。挙動完全不変。

フルビルド (g++ -O3 -Werror, BUILD_EXIT=0) / clang-format-18 で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined room generation logic for standard room layouts.
  * Preserved existing floor placement, room marking, and lighting behavior across room types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->