### PR TITLE
refactor: E12件数の注記を明確化し、通常部屋の床敷設ループをfill_room_floorへ集約

### DIFF
--- a/src/room/rooms-normal.cpp
+++ b/src/room/rooms-normal.cpp
@@ -234,18 +234,10 @@ bool build_type2(CreatureEntity &creature, DungeonData *dd_ptr)
     }
 
     /* Replace the floor for room "a" */
-    for (auto y = y1a; y <= y2a; y++) {
-        for (auto x = x1a; x <= x2a; x++) {
-            place_grid(creature, floor.get_grid({ y, x }), GB_FLOOR);
-        }
-    }
+    fill_room_floor(creature, floor, y1a, y2a, x1a, x2a, should_brighten);
 
     /* Replace the floor for room "b" */
-    for (auto y = y1b; y <= y2b; y++) {
-        for (auto x = x1b; x <= x2b; x++) {
-            place_grid(creature, floor.get_grid({ y, x }), GB_FLOOR);
-        }
-    }
+    fill_room_floor(creature, floor, y1b, y2b, x1b, x2b, should_brighten);
 
     return true;
 }
@@ -324,18 +316,10 @@ bool build_type3(CreatureEntity &creature, DungeonData *dd_ptr)
     }
 
     /* Replace the floor for room "a" */
-    for (auto y = y1a; y <= y2a; y++) {
-        for (auto x = x1a; x <= x2a; x++) {
-            place_grid(creature, floor.get_grid({ y, x }), GB_FLOOR);
-        }
-    }
+    fill_room_floor(creature, floor, y1a, y2a, x1a, x2a, should_brighten);
 
     /* Replace the floor for room "b" */
-    for (auto y = y1b; y <= y2b; y++) {
-        for (auto x = x1b; x <= x2b; x++) {
-            place_grid(creature, floor.get_grid({ y, x }), GB_FLOOR);
-        }
-    }
+    fill_room_floor(creature, floor, y1b, y2b, x1b, x2b, should_brighten);
 
     const Rect2D rect_inner(y1b, x1a, y2b, x2a);
     /* Special features (3/4) */


### PR DESCRIPTION
docsのE12記述を実コードに合わせて修正
rooms-normalの fill_room_floor( マッチ7件の内訳を明記
関数定義1件を除外し、呼び出し6件であることを注記
build_type2/build_type3 の内側床ループ重複を fill_room_floor 呼び出しに置換 既存の部屋境界・明るさ判定を維持し、CAVE_ROOM/CAVE_GLOW 付与経路を統一
重複nitpickは同一修正で解消（追加変更なし）