### PR TITLE
refactor: CreatureEntity::extended_inventory を private 化（提案52・フィールドカプ…

### DIFF
--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -63,13 +63,10 @@ void wield_all(CreatureEntity &creature)
         // インデックスでアクセスすると vector subscript out of range で落ちる。
         if (slot >= INVEN_EXTENDED_BASE) {
             const auto ext_idx = static_cast<size_t>(slot - INVEN_EXTENDED_BASE);
-            if (ext_idx >= creature.extended_inventory.size()) {
+            if (ext_idx >= creature.get_extended_inventory_size()) {
                 continue;
             }
-            if (!creature.extended_inventory[ext_idx]) {
-                creature.extended_inventory[ext_idx] = std::make_shared<ItemEntity>();
-            }
-            auto &ext_slot_item = *creature.extended_inventory[ext_idx];
+            auto &ext_slot_item = creature.ensure_extended_item(ext_idx);
             if (ext_slot_item.is_valid()) {
                 continue;
             }

--- a/src/load/old/monster-loader-savefile50.cpp
+++ b/src/load/old/monster-loader-savefile50.cpp
@@ -242,16 +242,13 @@ void MonsterLoader50::rd_monster_legacy(CreatureEntity &monster)
                 if (n == 0xFFFF) {
                     break;
                 }
-                if (n >= monster.extended_inventory.size()) {
+                if (n >= monster.get_extended_inventory_size()) {
                     // 範囲外: ダミー読込で savefile を進める
                     auto dummy = std::make_shared<ItemEntity>();
                     item_loader->rd_item(dummy.get());
                     continue;
                 }
-                if (!monster.extended_inventory[n]) {
-                    monster.extended_inventory[n] = std::make_shared<ItemEntity>();
-                }
-                item_loader->rd_item(monster.extended_inventory[n].get());
+                item_loader->rd_item(&monster.ensure_extended_item(n));
             }
         }
     }
@@ -351,15 +348,12 @@ void MonsterLoader50::rd_monster_v50(CreatureEntity &monster)
             if (n == 0xFFFF) {
                 break;
             }
-            if (n >= monster.extended_inventory.size()) {
+            if (n >= monster.get_extended_inventory_size()) {
                 auto dummy = std::make_shared<ItemEntity>();
                 item_loader->rd_item(dummy.get());
                 continue;
             }
-            if (!monster.extended_inventory[n]) {
-                monster.extended_inventory[n] = std::make_shared<ItemEntity>();
-            }
-            item_loader->rd_item(monster.extended_inventory[n].get());
+            item_loader->rd_item(&monster.ensure_extended_item(n));
         }
     }
 }

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -169,8 +169,8 @@ static void monster_pickup_object(CreatureEntity &creature, turn_flags *turn_fla
         // [Phase 2.5] 拡張装備スロットへの装備メッセージ
         if (acquired_slot >= INVEN_EXTENDED_BASE && player_can_see_bold(creature, ny, nx)) {
             const auto ext_idx = static_cast<size_t>(acquired_slot - INVEN_EXTENDED_BASE);
-            if (ext_idx < monster.extended_inventory.size() && monster.extended_inventory[ext_idx]) {
-                const auto eq_name = describe_flavor(creature, *monster.extended_inventory[ext_idx], 0);
+            if (ext_idx < monster.get_extended_inventory_size() && monster.get_extended_item(ext_idx)) {
+                const auto eq_name = describe_flavor(creature, *monster.get_extended_item(ext_idx), 0);
                 const auto slot_name = get_extended_slot_name(monster.get_extended_slot_type(ext_idx));
                 msg_format(_("%s^は%sに%sを装着した。", "%s^ attaches %s to its %s."),
                     m_name.data(),

--- a/src/object/object-info.cpp
+++ b/src/object/object-info.cpp
@@ -63,7 +63,7 @@ short find_extended_slot(CreatureEntity &creature, ItemKindType tval)
         if (!accepts) {
             continue;
         }
-        if (i >= creature.extended_inventory.size() || !creature.extended_inventory[i] || !creature.extended_inventory[i]->is_valid()) {
+        if (i >= creature.get_extended_inventory_size() || !creature.get_extended_item(i) || !creature.get_extended_item(i)->is_valid()) {
             return static_cast<short>(INVEN_EXTENDED_BASE + i);
         }
     }

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -132,7 +132,7 @@ BIT_FLAGS check_equipment_flags(CreatureEntity &creature, tr_type tr_flag)
     }
 
     // [Phase 2.6] 拡張装備スロット (モンスターのみ) も集計対象に含める
-    for (const auto &item_ptr : creature.extended_inventory) {
+    for (const auto &item_ptr : creature.get_extended_inventory()) {
         if (!item_ptr || !item_ptr->is_valid()) {
             continue;
         }

--- a/src/save/monster-writer.cpp
+++ b/src/save/monster-writer.cpp
@@ -53,8 +53,8 @@ void MonsterWriter::write_to_savedata() const
     wr_u16b(0xFFFF);
 
     // 拡張装備スロット (同形式)
-    for (size_t i = 0; i < this->monster.extended_inventory.size(); i++) {
-        const auto &item = this->monster.extended_inventory[i];
+    for (size_t i = 0; i < this->monster.get_extended_inventory_size(); i++) {
+        const auto &item = this->monster.get_extended_item(i);
         if (!item || !item->is_valid()) {
             continue;
         }

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -814,6 +814,30 @@ void CreatureEntity::init_extended_inventory()
     }
 }
 
+size_t CreatureEntity::get_extended_inventory_size() const
+{
+    return this->extended_inventory.size();
+}
+
+const std::shared_ptr<ItemEntity> &CreatureEntity::get_extended_item(size_t idx) const
+{
+    return this->extended_inventory[idx];
+}
+
+const std::vector<std::shared_ptr<ItemEntity>> &CreatureEntity::get_extended_inventory() const
+{
+    return this->extended_inventory;
+}
+
+ItemEntity &CreatureEntity::ensure_extended_item(size_t idx)
+{
+    if (!this->extended_inventory[idx]) {
+        this->extended_inventory[idx] = std::make_shared<ItemEntity>();
+    }
+
+    return *this->extended_inventory[idx];
+}
+
 void CreatureEntity::add_current_mp_with_frac(int delta, uint32_t delta_frac)
 {
     s64b_add(&this->current_mp, &this->current_mp_frac, delta, delta_frac);

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -1527,6 +1527,27 @@ public:
      */
     void init_extended_inventory();
 
+    /*! @brief 拡張インベントリのスロット数を返す */
+    size_t get_extended_inventory_size() const;
+
+    /*!
+     * @brief 拡張インベントリの指定スロットのアイテム (nullable) を返す (読取り用)
+     * @param idx スロットインデックス (呼出側で範囲確認すること)
+     */
+    const std::shared_ptr<ItemEntity> &get_extended_item(size_t idx) const;
+
+    /*!
+     * @brief 拡張インベントリ全体を読取り専用参照で返す (走査用)
+     */
+    const std::vector<std::shared_ptr<ItemEntity>> &get_extended_inventory() const;
+
+    /*!
+     * @brief 拡張インベントリの指定スロットのアイテムを確保して返す (生成/ロード用)
+     * @param idx スロットインデックス (呼出側で範囲確認すること)
+     * @details スロットが空 (nullptr) の場合は空の ItemEntity を生成して格納し、その参照を返す。
+     */
+    ItemEntity &ensure_extended_item(size_t idx);
+
     /*! @brief 年齢を設定する (提案 24) */
     virtual void set_age(int16_t value);
 
@@ -2754,11 +2775,9 @@ public:
     // 所持品数 inven_cnt / 装備品数 equip_cnt は提案 25 で inventory[] から自動計算する
     // get_inven_cnt() / get_equip_cnt() に置換済み。
 
-    // [Phase 2] 拡張装備スロット (尾の指輪、第二の首など、種族固有部位)。
-    // body_structure の get_extended_slots() で定義されるスロットに対応し、
-    // インデックス順に格納される。プレイヤーは HUMANOID で空。
-    // モンスター生成時に init_extended_inventory() で初期化。
-    std::vector<std::shared_ptr<ItemEntity>> extended_inventory{};
+    // [Phase 2] 拡張装備スロット (尾の指輪、第二の首など、種族固有部位) は
+    // private 化し、get_extended_inventory_size() / get_extended_item() /
+    // ensure_extended_item() / get_extended_inventory() 経由でアクセスする。
 
     // 座標関連
     POSITION oldpy{}; /*!< 前回のY座標 / Previous location (Y) */
@@ -3327,4 +3346,11 @@ private:
     std::string build_attitude_description() const;
     tl::optional<bool> order_pet_named(const CreatureEntity &other) const;
     tl::optional<bool> order_pet_hp(const CreatureEntity &other) const;
+
+    // [Phase 2] 拡張装備スロット (尾の指輪、第二の首など、種族固有部位)。
+    // body_structure の get_extended_slots() で定義されるスロットに対応し、
+    // インデックス順に格納される。プレイヤーは HUMANOID で空。
+    // モンスター生成時に init_extended_inventory() で初期化。アクセスは
+    // get_extended_inventory_size() / get_extended_item() / ensure_extended_item() 経由。
+    std::vector<std::shared_ptr<ItemEntity>> extended_inventory{};
 };

--- a/src/view/display-player-inventory-page.cpp
+++ b/src/view/display-player-inventory-page.cpp
@@ -58,10 +58,10 @@ void display_equipment_section(CreatureEntity &creature)
         const auto name = get_extended_slot_name(slot_type);
         const auto label = format("%-12s :", name.empty() ? "" : name.data());
         c_put_str(TERM_WHITE, label, row, EQUIPMENT_COL);
-        if (i >= creature.extended_inventory.size() || !creature.extended_inventory[i] || !creature.extended_inventory[i]->is_valid()) {
+        if (i >= creature.get_extended_inventory_size() || !creature.get_extended_item(i) || !creature.get_extended_item(i)->is_valid()) {
             c_put_str(TERM_L_DARK, _("(なし)", "(empty)"), row, EQUIPMENT_COL + 14);
         } else {
-            const auto desc = describe_flavor(creature, *creature.extended_inventory[i], OD_OMIT_PREFIX | OD_NAME_AND_ENCHANT);
+            const auto desc = describe_flavor(creature, *creature.get_extended_item(i), OD_OMIT_PREFIX | OD_NAME_AND_ENCHANT);
             c_put_str(TERM_L_GREEN, desc.substr(0, 24), row, EQUIPMENT_COL + 14);
         }
         ++row;


### PR DESCRIPTION
…セル化）

フィールドカプセル化キャンペーンで唯一 public 残置だった拡張装備スロット
extended_inventory (std::vector<std::shared_ptr<ItemEntity>>) を private 化し、 アクセサ経由に統一。

新設アクセサ:
- get_extended_inventory_size(): スロット数
- get_extended_item(idx): 読取り (nullable shared_ptr const 参照)
- get_extended_inventory(): 走査用の read-only const 参照
- ensure_extended_item(idx): 生成/ロード用 (空なら make_shared して ItemEntity& を返す)

外部アクセス 9 サイトを移行 (object-info / display-player-inventory-page / monster-object / player-status-flags / monster-writer の読取り・走査、 monster-loader-savefile50 ×2・inventory-initializer の生成イディオムを ensure_extended_item() へ)。init_extended_inventory() は既存メソッドのため変更なし。 内部アクセスは creature-entity.cpp のみに閉じた。

挙動完全不変。フルビルド (g++ -O3 -Werror, BUILD_EXIT=0) / clang-format-18 で検証済。