### PR TITLE
feat: モンスターの種族反射(TR_REFLECT)をボルト反射へ opt-in 反映（提案C1第8弾）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -673,6 +673,15 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
 - **反映対象（第7弾: 複合攻撃＝カバレッジ完成）:** rocket は破片 `TR_RES_SHARDS`、
   icee_bolt は付随スタンを `TR_RES_SOUND`・冷気本体を `TR_RES_COLD`（1/3 軽減）で反映。
   第3弾で主要ハンドラのみ対象とした分の残りを埋めてカバレッジを完成。
+- **反映対象（第8弾: 反射＝ボルト反射）:** 反射 `TR_REFLECT`。**別フラグ
+  `applies_player_race_reflection`（既定 `false`=オプトイン）** で制御する（属性耐性の
+  `applies_player_race_resistances` とは別軸のため独立フラグ）。`effect-processor.cpp`
+  のボルト反射判定（`monrace.misc_flags.has(REFLECTING)`）へ
+  `|| monster.has_race_granted_reflection()` を OR-in。付与種族が `TR_REFLECT` を持てば
+  モンスターの `REFLECTING` と同様にボルトを反射する。述語 `has_race_granted_reflection()`
+  は `CreatureEntity` のメソッド（`applies_player_race_reflection` ガード＋`prace!=NONE`＋
+  `CreatureRace(this).tr_flags().has(TR_REFLECT)`）。ダメージ属性でも状態異常でもない
+  防御特典を反映した最初の例。
 - **共通述語の配置:** `target_race_resists_element(EffectMonster*, tr_type)` は
   `effect-monster-util.{h,cpp}` に配置（属性ダメージ／状態異常の両 TU から使う共通述語）。
   ダメージ軽減 `apply_monster_race_resistance(em_ptr)`（基本 5 属性用の 1/3 軽減）は

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3165,9 +3165,19 @@ monrace を参照）が `prace`/`pclass` に付与する。**効果は未反映*
   （`native_resist` ガード）。同じ opt-in フラグ `applies_player_race_resistances`
   を使用（新フラグなし）。既定 false のままバランス不変。フルビルドで検証済。
 
-**種族耐性反映トラックのまとめ（第2〜7弾で完了）:** プレイヤー種族が持つ
-**主要な属性耐性・状態異常防御はほぼ全て**モンスターへ opt-in 反映済み（基本5属性・
-二次7属性・光/闇・恐怖・自由行動＝睡眠/拘束、及び複合攻撃 rocket/icee）。
+**第8弾 ✅ 完了（反射＝ボルト反射）:** 反射 `TR_REFLECT` をモンスターのボルト反射へ
+opt-in 反映。属性耐性とは別軸の防御特典のため**独立フラグ
+`applies_player_race_reflection`（既定 false）** を新設。`effect-processor.cpp` の
+ボルト反射判定 `monrace.misc_flags.has(REFLECTING)` へ
+`|| monster.has_race_granted_reflection()` を OR-in。述語 `has_race_granted_reflection()`
+は `CreatureEntity` メソッド（`has_monster_profile` && フラグ && `prace!=NONE` &&
+`CreatureRace(this).tr_flags().has(TR_REFLECT)`）。const 呼出のため CreatureRace は
+const_cast（`tr_flags()` は read-only）。reader/schema/CLAUDE.md 整備、既定 false で
+バランス不変。フルビルド (BUILD_EXIT=0) / validate_json 8/8 で検証済。
+
+**種族特典反映トラックのまとめ（第2〜8弾で完了）:** プレイヤー種族が持つ
+**主要な属性耐性・状態異常防御・防御特典はほぼ全て**モンスターへ opt-in 反映済み（基本5属性・
+二次7属性・光/闇・恐怖・自由行動＝睡眠/拘束、複合攻撃 rocket/icee、及び反射）。
 
 **未反映（意図的）:** 職業特典・種族の非耐性特典（ESP・赤外線視）はモンスター AI 索敵の
 新規実装が要る（C3 と同課題）ため大。stat 補正はプレイヤー(percentile 3-18)と

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -201,6 +201,10 @@
                         "type": "boolean",
                         "description": "付与された player_race の属性耐性(火/冷/電/酸/毒)を被ダメージへ反映するか (提案C1第2弾)。既定false=オプトイン。trueかつ有効なplayer_raceを持つ個体のみ、種族耐性がある属性の被ダメージが約1/3に軽減される。"
                     },
+                    "applies_player_race_reflection": {
+                        "type": "boolean",
+                        "description": "付与された player_race の反射(TR_REFLECT)をボルト反射へ反映するか (提案C1第8弾)。既定false=オプトイン。trueかつ有効なplayer_raceを持つ個体のみ、種族が反射を持てばモンスターのREFLECTINGと同様にボルトを反射する。"
+                    },
                     "grows_melee_proficiency": {
                         "type": "boolean",
                         "description": "レベルアップで得た戦闘習熟を近接命中へ反映するか (提案C2第2弾)。既定false=オプトイン。trueの個体は、生成時レベルを超えて成長した分だけ近接攻撃の命中判定が向上する。"

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -272,7 +272,7 @@ ProjectResult project(CreatureEntity &creature, const MONSTER_IDX src_idx, POSIT
             if (positions.size() <= 1) {
                 const auto &monster = floor.get_monster(grid.m_idx);
                 auto &monrace = monster.get_monrace();
-                if ((flag & PROJECT_REFLECTABLE) && grid.m_idx && monrace.misc_flags.has(MonsterMiscType::REFLECTING) && (!monster.is_riding() || !(flag & PROJECT_PLAYER)) && (!src_idx || path_n > 1) && !one_in_(10)) {
+                if ((flag & PROJECT_REFLECTABLE) && grid.m_idx && (monrace.misc_flags.has(MonsterMiscType::REFLECTING) || monster.has_race_granted_reflection()) && (!monster.is_riding() || !(flag & PROJECT_PLAYER)) && (!src_idx || path_n > 1) && !one_in_(10)) {
 
                     Pos2D pos_reflection(0, 0);
                     auto max_attempts = 10;

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -1561,6 +1561,11 @@ errr RaceReader::read()
         msg_format(_("モンスター種族耐性反映フラグ読込失敗。ID: '%d'。", "Failed to load monster applies_player_race_resistances. ID: '%d'."), error_idx);
         return err;
     }
+    err = info_set_bool(mon_data["applies_player_race_reflection"], monrace.applies_player_race_reflection, false);
+    if (err) {
+        msg_format(_("モンスター種族反射反映フラグ読込失敗。ID: '%d'。", "Failed to load monster applies_player_race_reflection. ID: '%d'."), error_idx);
+        return err;
+    }
     err = info_set_bool(mon_data["grows_melee_proficiency"], monrace.grows_melee_proficiency, false);
     if (err) {
         msg_format(_("モンスター戦闘習熟フラグ読込失敗。ID: '%d'。", "Failed to load monster grows_melee_proficiency. ID: '%d'."), error_idx);

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -20,8 +20,10 @@
 #include "monster/monster-pain-describer.h"
 #include "monster/monster-timed-effects.h"
 #include "monster/monster-util.h"
+#include "object-enchant/tr-types.h"
 #include "object/object-info.h"
 #include "player-ability/player-ability-types.h"
+#include "player-base/player-race.h"
 #include "player-info/bard-data-type.h"
 #include "player-info/class-info.h"
 #include "player-info/class-types.h"
@@ -2346,6 +2348,22 @@ BIT_FLAGS CreatureEntity::has_reflect()
         return this->get_monrace().misc_flags.has(MonsterMiscType::REFLECTING) ? static_cast<BIT_FLAGS>(FLAG_CAUSE_RACE) : 0U;
     }
     return ::has_reflect(*this);
+}
+
+bool CreatureEntity::has_race_granted_reflection() const
+{
+    // [提案C1第8弾] 付与種族の反射をボルト反射へ反映 (opt-in・既定OFF・モンスター専用)
+    if (!this->has_monster_profile()) {
+        return false;
+    }
+    if (!this->get_monrace().applies_player_race_reflection) {
+        return false;
+    }
+    if (this->get_prace() == PlayerRaceType::NONE) {
+        return false;
+    }
+
+    return CreatureRace(const_cast<CreatureEntity *>(this)).tr_flags().has(TR_REFLECT);
 }
 bool CreatureEntity::has_two_handed_weapons()
 {

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -2217,6 +2217,8 @@ public:
     virtual bool has_pass_wall();
     virtual bool has_kill_wall();
     virtual BIT_FLAGS has_reflect();
+    //! 付与された player_race 由来の反射 (TR_REFLECT) を持つか (提案C1第8弾。opt-in・既定OFF・モンスター専用)
+    bool has_race_granted_reflection() const;
     virtual bool has_two_handed_weapons();
     virtual BIT_FLAGS has_sh_fire();
     virtual BIT_FLAGS has_sh_elec();

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -139,6 +139,7 @@ public:
     RealmType realm_abilities = RealmType::NONE; //!< 詠唱能力を付与する魔法領域 (提案C6。NONE=なし=オプトイン。詠唱時に realm 由来の MonsterAbilityType を追加)
     bool suffers_poison_dot = false; //!< 毒攻撃で継続毒(POISON DoT)を受けるか (提案D7。既定false=オプトイン。既定バランス不変)
     bool applies_player_race_resistances = false; //!< 付与された player_race の属性耐性を被ダメージへ反映するか (提案C1第2弾。既定false=オプトイン。既定バランス不変)
+    bool applies_player_race_reflection = false; //!< 付与された player_race の反射(TR_REFLECT)をボルト反射へ反映するか (提案C1第8弾。既定false=オプトイン。既定バランス不変)
     bool grows_melee_proficiency = false; //!< レベルアップで得た戦闘習熟を近接命中へ反映するか (提案C2第2弾。既定false=オプトイン。既定バランス不変)
     bool applies_stat_combat_bonus = false; //!< 能力値(STR)を近接ダメージへ反映するか (提案C2第3弾。既定false=オプトイン。既定バランス不変)
     EnumClassFlagGroup<MonsterFeedType> meat_feed_flags;


### PR DESCRIPTION
付与された player_race が反射(TR_REFLECT)を持つ場合、モンスターのボルト反射 (REFLECTING) と同様にボルトを反射できるようにした。属性耐性(C1第2弾)とは別軸の
防御特典のため、独立フラグ applies_player_race_reflection (既定 false=オプトイン) で制御。

- MonraceDefinition::applies_player_race_reflection を追加、reader / schema 整備。
- CreatureEntity::has_race_granted_reflection() を新設 (has_monster_profile && フラグ && prace!=NONE && CreatureRace(this).tr_flags().has(TR_REFLECT))。const 呼出 のため CreatureRace は const_cast (tr_flags() は read-only)。
- effect-processor.cpp のボルト反射判定へ || monster.has_race_granted_reflection() を OR-in。

ダメージ属性でも状態異常でもない防御特典を反映した最初の例。既定 false・プレイヤー
では false を返すため既定バランス不変。CLAUDE.md / roadmap 整備。
フルビルド (g++ -O3 -Werror, BUILD_EXIT=0) / clang-format-18 / validate_json 8/8 で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional monster support for reflecting bolts through assigned player-race traits.
  * Added a JSON setting to enable this reflection behavior per monster; it is disabled by default.
* **Documentation**
  * Documented the new reflection behavior and updated the implementation roadmap to include this feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->