### PR TITLE
fix: hp_player の回復メッセージを notify_self seam でゲート（Dトラック D2 同化の穴を修正）

### DIFF
--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -469,14 +469,15 @@ bool hp_player(CreatureEntity &creature, int num)
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         rfu.set_flag(MainWindowRedrawingFlag::HP);
         rfu.set_flag(SubWindowRedrawingFlag::PLAYER);
+        // [提案D2] 2 人称回復メッセージは notify_self seam でプレイヤーのみ表示 (モンスター回復時は無音)。
         if (num < 5) {
-            msg_print(_("少し気分が良くなった。", "You feel a little better."));
+            creature.notify_self(_("少し気分が良くなった。", "You feel a little better."));
         } else if (num < 15) {
-            msg_print(_("気分が良くなった。", "You feel better."));
+            creature.notify_self(_("気分が良くなった。", "You feel better."));
         } else if (num < 35) {
-            msg_print(_("とても気分が良くなった。", "You feel much better."));
+            creature.notify_self(_("とても気分が良くなった。", "You feel much better."));
         } else {
-            msg_print(_("ひじょうに気分が良くなった。", "You feel very good."));
+            creature.notify_self(_("ひじょうに気分が良くなった。", "You feel very good."));
         }
 
         return true;


### PR DESCRIPTION
D2 (回復・状態治療関数の is_player ガード除去) で cure_light_wounds / true_healing / heroism / berserk 等は「本体が 100% creature-general プリミティブ」を前提に monster へ 開放されたが、共有プリミティブ hp_player() だけが 2 人称回復メッセージ
(「気分が良くなった」/ "You feel better") を **notify_self を経由せず無条件 msg_print** していた。このためモンスターを hp_player 経由で回復させると、モンスターの回復で
プレイヤー宛メッセージが誤表示される潜在ギャップがあった (現状 monster 呼出は無いため
実害は未発生だが D2 の「creature-general」前提が未達だった)。

4 つの回復メッセージを creature.notify_self() へ載せ替え、プレイヤー呼出では従来通り 表示・モンスター呼出では無音に統一。buff-setter / bad-status-setter (raw msg_print ゼロ)・ do_res_stat (is_player ガード済) と同水準の seam ゲートに揃え、D2 healing 経路の message seam を完全化した。プレイヤー挙動は不変。

フルビルド (g++ -O3 -Werror, BUILD_EXIT=0) / clang-format-18 で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery notifications now appear directly to the affected player instead of being added to the shared message log.
  * Improved recovery messaging so monster healing remains handled appropriately without creating confusing player-facing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->