### PR TITLE
feat: モンスターの種族水耐性(TR_RES_WATER)を opt-in 反映（提案C1第9弾）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -682,6 +682,14 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
   は `CreatureEntity` のメソッド（`applies_player_race_reflection` ガード＋`prace!=NONE`＋
   `CreatureRace(this).tr_flags().has(TR_REFLECT)`）。ダメージ属性でも状態異常でもない
   防御特典を反映した最初の例。
+- **反映対象（第9弾: 水耐性）:** 水 `TR_RES_WATER`。`effect_monster_water`
+  （`effect-monster-resist-hurt.cpp`）のネイティブ `RESIST_WATER` 判定へ
+  `native_resist` パターンで OR-in（`!native_resist && !target_race_resists_element(...)`
+  なら早期 return、成立時は `dam*3/(1d6+6)` の部分軽減）。**14 のプレイヤー種族が
+  `TR_RES_WATER` を付与する**（当初 roadmap は「水系は player 種族が該当耐性を持たない
+  ため対象外」としていたが誤りで、本弾で訂正・実装）。種族由来 resist では思い出フラグを
+  記録しない（`native_resist` ガード）。WATER_ELEM/UNMAKER の完全耐性分岐は monrace 固有
+  ID 判定のため race-monster には非該当（部分軽減側になる）。
 - **共通述語の配置:** `target_race_resists_element(EffectMonster*, tr_type)` は
   `effect-monster-util.{h,cpp}` に配置（属性ダメージ／状態異常の両 TU から使う共通述語）。
   ダメージ軽減 `apply_monster_race_resistance(em_ptr)`（基本 5 属性用の 1/3 軽減）は

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3179,9 +3179,14 @@ const_cast（`tr_flags()` は read-only）。reader/schema/CLAUDE.md 整備、�
 **主要な属性耐性・状態異常防御・防御特典はほぼ全て**モンスターへ opt-in 反映済み（基本5属性・
 二次7属性・光/闇・恐怖・自由行動＝睡眠/拘束、複合攻撃 rocket/icee、及び反射）。
 
+**第9弾 ✅ 完了（水耐性）:** `TR_RES_WATER` を `effect_monster_water` のネイティブ
+`RESIST_WATER` 判定へ `native_resist` パターンで OR-in（部分軽減 `dam*3/(1d6+6)`、思い出
+記録は固有耐性時のみ）。**実データ検証で 14 のプレイヤー種族が `TR_RES_WATER` を付与**する
+ことが判明し、下記「対象外」の記述（water を含む）が誤りだったため訂正・実装した。
+
 **未反映（意図的）:** 職業特典・種族の非耐性特典（ESP・赤外線視）はモンスター AI 索敵の
-新規実装が要る（C3 と同課題）ため大。time/gravity/water/plasma 系は player 種族が
-該当耐性を持たないため対象外。
+新規実装が要る（C3 と同課題）ため大。time/gravity/plasma 系は player 種族が
+該当耐性を持たないため対象外（water は第9弾で反映済み）。
 
 **（訂正）能力値の戦闘反映は C2 第3弾で解決済み:** かつて「stat 補正はプレイヤー
 (percentile 3-18)とモンスター(内部 ×10・線形 30-400)でスケールが異なり反映不可」と

--- a/src/effect/effect-monster-resist-hurt.cpp
+++ b/src/effect/effect-monster-resist-hurt.cpp
@@ -334,7 +334,9 @@ ProcessResult effect_monster_water(CreatureEntity &creature, EffectMonster *em_p
         em_ptr->obvious = true;
     }
 
-    if (em_ptr->monrace->resistance_flags.has_not(MonsterResistanceType::RESIST_WATER)) {
+    // [提案C1第9弾] 付与種族の水耐性 (TR_RES_WATER) を native と同経路で反映 (opt-in・既定OFF)。
+    const auto native_resist = em_ptr->monrace->resistance_flags.has(MonsterResistanceType::RESIST_WATER);
+    if (!native_resist && !target_race_resists_element(em_ptr, TR_RES_WATER)) {
         return ProcessResult::PROCESS_CONTINUE;
     }
 
@@ -347,7 +349,8 @@ ProcessResult effect_monster_water(CreatureEntity &creature, EffectMonster *em_p
         em_ptr->dam /= randint1(6) + 6;
     }
 
-    if (is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
+    // 種族由来 resist では monrace ネイティブ耐性の思い出フラグを記録しない (native_resist ガード)。
+    if (native_resist && is_original_ap_and_seen(creature, *em_ptr->m_ptr)) {
         em_ptr->monrace->r_resistance_flags.set(MonsterResistanceType::RESIST_WATER);
     }
 


### PR DESCRIPTION
付与された player_race が水耐性(TR_RES_WATER)を持つ場合、effect_monster_water の ネイティブ RESIST_WATER 判定へ native_resist パターンで OR-in し、水属性の被ダメージを 部分軽減(dam*3/(1d6+6))する。既存フラグ applies_player_race_resistances で制御(既定OFF)。

- 実データ検証で 14 のプレイヤー種族が TR_RES_WATER を付与することが判明。roadmap が 「water 系は player 種族が該当耐性を持たないため対象外」としていたのは誤りで、 本弾で訂正・実装。
- native_resist ガードにより種族由来 resist では monrace ネイティブ耐性の思い出フラグを 記録しない(C1第3弾と同パターン)。WATER_ELEM/UNMAKER の完全耐性分岐は monrace 固有 ID 判定のため race-monster には非該当(部分軽減側)。

既定 false・プレイヤーでは反映されないため既定バランス不変。CLAUDE.md / roadmap 整備。 フルビルド (g++ -O3 -Werror, BUILD_EXIT=0) / clang-format-18 で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Water resistance granted by a character’s race is now applied correctly to incoming water-based effects.
  * Partial damage reduction is handled for both innate and race-derived water resistance.
  * Race-derived resistance no longer affects remembered innate resistance state.

* **Documentation**
  * Updated resistance coverage documentation to reflect that water resistance is now supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->