### PR TITLE
feat: モンスターの種族再生(TR_REGEN)を自然回復倍化へ opt-in 反映（提案C1第10弾）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -690,6 +690,15 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
   ため対象外」としていたが誤りで、本弾で訂正・実装）。種族由来 resist では思い出フラグを
   記録しない（`native_resist` ガード）。WATER_ELEM/UNMAKER の完全耐性分岐は monrace 固有
   ID 判定のため race-monster には非該当（部分軽減側になる）。
+- **反映対象（第10弾: 再生）:** 再生 `TR_REGEN`。**別フラグ
+  `applies_player_race_regeneration`（既定 `false`=オプトイン）**（属性耐性・反射とは別軸の
+  常時発動特典のため独立フラグ）。`has_regen_flag()` のモンスター分岐（native REGENERATE
+  判定）へ `|| has_race_granted_regeneration()` を OR-in。付与種族が `TR_REGEN` を持てば
+  monrace の `REGENERATE` と同様に自然回復量が 2 倍になる（`compute_regen_amount` の
+  `has_regen_flag()` 分岐）。**10 のプレイヤー種族が `TR_REGEN` を付与**。反射・再生の
+  述語は共通の private ヘルパ `race_grants_tr_flag(tr_type)`（has_monster_profile ＋
+  prace!=NONE ＋ `CreatureRace(this).tr_flags().has(flag)`）に集約し、有効化フラグの判定は
+  各公開メソッド側で行う。
 - **共通述語の配置:** `target_race_resists_element(EffectMonster*, tr_type)` は
   `effect-monster-util.{h,cpp}` に配置（属性ダメージ／状態異常の両 TU から使う共通述語）。
   ダメージ軽減 `apply_monster_race_resistance(em_ptr)`（基本 5 属性用の 1/3 軽減）は

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3184,6 +3184,15 @@ const_cast（`tr_flags()` は read-only）。reader/schema/CLAUDE.md 整備、�
 記録は固有耐性時のみ）。**実データ検証で 14 のプレイヤー種族が `TR_RES_WATER` を付与**する
 ことが判明し、下記「対象外」の記述（water を含む）が誤りだったため訂正・実装した。
 
+**第10弾 ✅ 完了（再生）:** `TR_REGEN` を `has_regen_flag()` のモンスター分岐（native
+`REGENERATE` 判定）へ `|| has_race_granted_regeneration()` で OR-in。付与種族が再生を持てば
+自然回復量が 2 倍（`compute_regen_amount`）。属性耐性・反射とは別軸の常時発動特典のため
+**独立フラグ `applies_player_race_regeneration`**（既定 false）。反射・再生の述語は共通の
+private ヘルパ `race_grants_tr_flag(tr_type)` に集約。**10 のプレイヤー種族が付与**。
+race-perk 集計により、残る未反映特典は AI 要（ESP/see_invis/telepathy）・モンスターに無意味
+（sustain/hold_exp/slow_digest）・常時発動バフでバランス判断要（speed）に整理され、
+clean-hook の耐性/防御特典反映は一通り完了。
+
 **未反映（意図的）:** 職業特典・種族の非耐性特典（ESP・赤外線視）はモンスター AI 索敵の
 新規実装が要る（C3 と同課題）ため大。time/gravity/plasma 系は player 種族が
 該当耐性を持たないため対象外（water は第9弾で反映済み）。

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -205,6 +205,10 @@
                         "type": "boolean",
                         "description": "付与された player_race の反射(TR_REFLECT)をボルト反射へ反映するか (提案C1第8弾)。既定false=オプトイン。trueかつ有効なplayer_raceを持つ個体のみ、種族が反射を持てばモンスターのREFLECTINGと同様にボルトを反射する。"
                     },
+                    "applies_player_race_regeneration": {
+                        "type": "boolean",
+                        "description": "付与された player_race の再生(TR_REGEN)を自然回復倍化へ反映するか (提案C1第10弾)。既定false=オプトイン。trueかつ有効なplayer_raceを持つ個体のみ、種族が再生を持てばモンスターのREGENERATEと同様に自然回復量が2倍になる。"
+                    },
                     "grows_melee_proficiency": {
                         "type": "boolean",
                         "description": "レベルアップで得た戦闘習熟を近接命中へ反映するか (提案C2第2弾)。既定false=オプトイン。trueの個体は、生成時レベルを超えて成長した分だけ近接攻撃の命中判定が向上する。"

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -1566,6 +1566,11 @@ errr RaceReader::read()
         msg_format(_("モンスター種族反射反映フラグ読込失敗。ID: '%d'。", "Failed to load monster applies_player_race_reflection. ID: '%d'."), error_idx);
         return err;
     }
+    err = info_set_bool(mon_data["applies_player_race_regeneration"], monrace.applies_player_race_regeneration, false);
+    if (err) {
+        msg_format(_("モンスター種族再生反映フラグ読込失敗。ID: '%d'。", "Failed to load monster applies_player_race_regeneration. ID: '%d'."), error_idx);
+        return err;
+    }
     err = info_set_bool(mon_data["grows_melee_proficiency"], monrace.grows_melee_proficiency, false);
     if (err) {
         msg_format(_("モンスター戦闘習熟フラグ読込失敗。ID: '%d'。", "Failed to load monster grows_melee_proficiency. ID: '%d'."), error_idx);

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -2350,20 +2350,30 @@ BIT_FLAGS CreatureEntity::has_reflect()
     return ::has_reflect(*this);
 }
 
-bool CreatureEntity::has_race_granted_reflection() const
+bool CreatureEntity::race_grants_tr_flag(tr_type tr_flag) const
 {
-    // [提案C1第8弾] 付与種族の反射をボルト反射へ反映 (opt-in・既定OFF・モンスター専用)
-    if (!this->has_monster_profile()) {
-        return false;
-    }
-    if (!this->get_monrace().applies_player_race_reflection) {
+    // 付与された player_race が指定 tr_flag を持つか (opt-in 特典反映の共通述語・モンスター専用)。
+    // 有効化フラグ (applies_player_race_*) の判定は呼出側が行う。
+    if (this->is_player()) {
         return false;
     }
     if (this->get_prace() == PlayerRaceType::NONE) {
         return false;
     }
 
-    return CreatureRace(const_cast<CreatureEntity *>(this)).tr_flags().has(TR_REFLECT);
+    return CreatureRace(const_cast<CreatureEntity *>(this)).tr_flags().has(tr_flag);
+}
+
+bool CreatureEntity::has_race_granted_reflection() const
+{
+    // [提案C1第8弾] 付与種族の反射をボルト反射へ反映 (opt-in・既定OFF・モンスター専用)
+    return this->race_grants_tr_flag(TR_REFLECT) && this->get_monrace().applies_player_race_reflection;
+}
+
+bool CreatureEntity::has_race_granted_regeneration() const
+{
+    // [提案C1第10弾] 付与種族の再生を自然回復倍化へ反映 (opt-in・既定OFF・モンスター専用)
+    return this->race_grants_tr_flag(TR_REGEN) && this->get_monrace().applies_player_race_regeneration;
 }
 bool CreatureEntity::has_two_handed_weapons()
 {
@@ -2434,7 +2444,8 @@ bool CreatureEntity::has_levitation() const
 bool CreatureEntity::has_regen_flag() const
 {
     if (this->has_monster_profile()) {
-        return this->get_monrace().misc_flags.has(MonsterMiscType::REGENERATE);
+        // [提案C1第10弾] 付与種族の再生 (TR_REGEN) も native REGENERATE と同様に自然回復を倍化 (opt-in・既定OFF)。
+        return this->get_monrace().misc_flags.has(MonsterMiscType::REGENERATE) || this->has_race_granted_regeneration();
     }
     return this->regenerate != 0;
 }

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -55,6 +55,7 @@ enum class PlayerSkillKindType;
 enum class RaceBlowMethodType;
 enum class RealmType;
 enum class Virtue : short;
+enum tr_type : int;
 
 enum class INCIDENT {
     WALK = 0,
@@ -2219,6 +2220,8 @@ public:
     virtual BIT_FLAGS has_reflect();
     //! 付与された player_race 由来の反射 (TR_REFLECT) を持つか (提案C1第8弾。opt-in・既定OFF・モンスター専用)
     bool has_race_granted_reflection() const;
+    //! 付与された player_race 由来の再生 (TR_REGEN) を持つか (提案C1第10弾。opt-in・既定OFF・モンスター専用)
+    bool has_race_granted_regeneration() const;
     virtual bool has_two_handed_weapons();
     virtual BIT_FLAGS has_sh_fire();
     virtual BIT_FLAGS has_sh_elec();
@@ -3344,6 +3347,8 @@ protected:
     FloorType *current_floor_ptr{}; /*!< 現在所属しているフロアへのポインタ / Current floor pointer */
 
 private:
+    //! 付与された player_race が指定 tr_flag を持つか (opt-in 特典反映の共通述語・モンスター専用)
+    bool race_grants_tr_flag(tr_type tr_flag) const;
     std::string build_damage_description() const;
     std::string build_attitude_description() const;
     tl::optional<bool> order_pet_named(const CreatureEntity &other) const;

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -140,6 +140,7 @@ public:
     bool suffers_poison_dot = false; //!< 毒攻撃で継続毒(POISON DoT)を受けるか (提案D7。既定false=オプトイン。既定バランス不変)
     bool applies_player_race_resistances = false; //!< 付与された player_race の属性耐性を被ダメージへ反映するか (提案C1第2弾。既定false=オプトイン。既定バランス不変)
     bool applies_player_race_reflection = false; //!< 付与された player_race の反射(TR_REFLECT)をボルト反射へ反映するか (提案C1第8弾。既定false=オプトイン。既定バランス不変)
+    bool applies_player_race_regeneration = false; //!< 付与された player_race の再生(TR_REGEN)を自然回復倍化へ反映するか (提案C1第10弾。既定false=オプトイン。既定バランス不変)
     bool grows_melee_proficiency = false; //!< レベルアップで得た戦闘習熟を近接命中へ反映するか (提案C2第2弾。既定false=オプトイン。既定バランス不変)
     bool applies_stat_combat_bonus = false; //!< 能力値(STR)を近接ダメージへ反映するか (提案C2第3弾。既定false=オプトイン。既定バランス不変)
     EnumClassFlagGroup<MonsterFeedType> meat_feed_flags;


### PR DESCRIPTION
付与された player_race が再生(TR_REGEN)を持つ場合、has_regen_flag() のモンスター分岐 (native REGENERATE 判定) へ || has_race_granted_regeneration() を OR-in し、自然回復量を 2 倍にする(compute_regen_amount)。常時発動特典のため独立フラグ
applies_player_race_regeneration (既定 false=オプトイン) で制御。

- 実データ検証で 10 のプレイヤー種族が TR_REGEN を付与。
- 反射(C1第8弾)・再生の述語を共通 private ヘルパ race_grants_tr_flag(tr_type) に集約 (has_monster_profile ＋ prace!=NONE ＋ CreatureRace(this).tr_flags().has(flag))。 有効化フラグ(applies_player_race_*)の判定は各公開メソッド側。

race-perk 集計の結果、clean-hook の耐性/防御特典反映は一通り完了 (残りは AI 要=ESP/ see_invis、モンスターに無意味=sustain/hold_exp/slow_digest、バランス判断要=speed)。

既定 false・プレイヤーでは反映されないため既定バランス不変。CLAUDE.md / roadmap 整備。 フルビルド (g++ -O3 -Werror, BUILD_EXIT=0) / clang-format-18 / validate_json 8/8 で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional regeneration effects based on a monster’s configured player race.
  * Eligible monsters can now gain increased natural recovery through the new regeneration setting.
  * Added schema support for configuring this behavior, disabled by default.

* **Documentation**
  * Documented the regeneration behavior, affected races, configuration, and remaining considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->