### PR TITLE
feat: モンスターの種族加速(TR_SPEED)を生成時速度へ opt-in 反映（提案C1第11弾）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -699,6 +699,14 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
   述語は共通の private ヘルパ `race_grants_tr_flag(tr_type)`（has_monster_profile ＋
   prace!=NONE ＋ `CreatureRace(this).tr_flags().has(flag)`）に集約し、有効化フラグの判定は
   各公開メソッド側で行う。
+- **反映対象（第11弾: 加速）:** 加速 `TR_SPEED`。**別フラグ
+  `applies_player_race_speed`（既定 `false`=オプトイン）**。`place_monster_one` の生成時
+  速度設定（サイズ補正の後段）で `has_race_granted_speed()` が真なら保守的な固定
+  ボーナス **+3** を `speed` に加算。**注意:** プレイヤーの種族速度は `CreatureRace::speed()`
+  経由で**種族依存（KLACKON/SPRITE のみ level/10）かつ位置/レベル依存で動的**であり、
+  TR_SPEED フラグ自体は速度値を持たない（多くの動物種族は表示用）。モンスター速度は
+  静的な `speed` フィールドで動くため、動的反映は侵襲的すぎるとして**保守的な固定近似
+  (+3)** を採用（`one-monster-placer.cpp` の調整用 constexpr）。
 - **共通述語の配置:** `target_race_resists_element(EffectMonster*, tr_type)` は
   `effect-monster-util.{h,cpp}` に配置（属性ダメージ／状態異常の両 TU から使う共通述語）。
   ダメージ軽減 `apply_monster_race_resistance(em_ptr)`（基本 5 属性用の 1/3 軽減）は

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3190,8 +3190,15 @@ const_cast（`tr_flags()` は read-only）。reader/schema/CLAUDE.md 整備、�
 **独立フラグ `applies_player_race_regeneration`**（既定 false）。反射・再生の述語は共通の
 private ヘルパ `race_grants_tr_flag(tr_type)` に集約。**10 のプレイヤー種族が付与**。
 race-perk 集計により、残る未反映特典は AI 要（ESP/see_invis/telepathy）・モンスターに無意味
-（sustain/hold_exp/slow_digest）・常時発動バフでバランス判断要（speed）に整理され、
-clean-hook の耐性/防御特典反映は一通り完了。
+（sustain/hold_exp/slow_digest）に整理された。
+
+**第11弾 ✅ 完了（加速）:** `TR_SPEED` を生成時速度へ opt-in 反映。**独立フラグ
+`applies_player_race_speed`**（既定 false）。`place_monster_one` のサイズ補正後段で
+`has_race_granted_speed()` が真なら固定 +3 を `speed` に加算。**設計上の注意:** プレイヤーの
+種族速度は `CreatureRace::speed()` 経由で種族依存（KLACKON/SPRITE のみ level/10）かつ
+位置/レベル依存で動的であり、TR_SPEED フラグ自体は速度値を持たない（動物種族は表示用）。
+モンスター速度は静的 `speed` フィールドのため動的反映は侵襲的すぎるとし、**保守的な固定
+近似 (+3、調整用 constexpr)** を採用。これで clean-hook の耐性/防御/常時特典の反映を一通り完了。
 
 **未反映（意図的）:** 職業特典・種族の非耐性特典（ESP・赤外線視）はモンスター AI 索敵の
 新規実装が要る（C3 と同課題）ため大。time/gravity/plasma 系は player 種族が

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -209,6 +209,10 @@
                         "type": "boolean",
                         "description": "付与された player_race の再生(TR_REGEN)を自然回復倍化へ反映するか (提案C1第10弾)。既定false=オプトイン。trueかつ有効なplayer_raceを持つ個体のみ、種族が再生を持てばモンスターのREGENERATEと同様に自然回復量が2倍になる。"
                     },
+                    "applies_player_race_speed": {
+                        "type": "boolean",
+                        "description": "付与された player_race の加速(TR_SPEED)を生成時の速度へ反映するか (提案C1第11弾)。既定false=オプトイン。trueかつ種族が加速を持つ個体のみ、生成時に控えめな加速ボーナス(+3)を得る。プレイヤーの種族速度は種族依存・動的なため、モンスターには保守的な固定近似を用いる。"
+                    },
                     "grows_melee_proficiency": {
                         "type": "boolean",
                         "description": "レベルアップで得た戦闘習熟を近接命中へ反映するか (提案C2第2弾)。既定false=オプトイン。trueの個体は、生成時レベルを超えて成長した分だけ近接攻撃の命中判定が向上する。"

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -1571,6 +1571,11 @@ errr RaceReader::read()
         msg_format(_("モンスター種族再生反映フラグ読込失敗。ID: '%d'。", "Failed to load monster applies_player_race_regeneration. ID: '%d'."), error_idx);
         return err;
     }
+    err = info_set_bool(mon_data["applies_player_race_speed"], monrace.applies_player_race_speed, false);
+    if (err) {
+        msg_format(_("モンスター種族加速反映フラグ読込失敗。ID: '%d'。", "Failed to load monster applies_player_race_speed. ID: '%d'."), error_idx);
+        return err;
+    }
     err = info_set_bool(mon_data["grows_melee_proficiency"], monrace.grows_melee_proficiency, false);
     if (err) {
         msg_format(_("モンスター戦闘習熟フラグ読込失敗。ID: '%d'。", "Failed to load monster grows_melee_proficiency. ID: '%d'."), error_idx);

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -627,6 +627,14 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
         m_ptr->speed += randint1(3) + 2; // +2～+4の加速ボーナス
     }
 
+    // [提案C1第11弾] 付与種族の加速 (TR_SPEED) を生成時速度へ opt-in 反映 (既定OFF)。
+    // プレイヤーの種族速度は種族依存 (KLACKON/SPRITE のみ) かつ位置/レベル依存で動的なため、
+    // 静的な speed フィールドで動くモンスターには保守的な固定近似 (+3) を用いる。調整用定数。
+    if (m_ptr->has_race_granted_speed()) {
+        constexpr short race_granted_speed_bonus = 3;
+        m_ptr->speed += race_granted_speed_bonus;
+    }
+
     if (any_bits(mode, PM_HASTE)) {
         (void)set_monster_fast(floor, g_ptr->m_idx, 100);
     }

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -2375,6 +2375,12 @@ bool CreatureEntity::has_race_granted_regeneration() const
     // [提案C1第10弾] 付与種族の再生を自然回復倍化へ反映 (opt-in・既定OFF・モンスター専用)
     return this->race_grants_tr_flag(TR_REGEN) && this->get_monrace().applies_player_race_regeneration;
 }
+
+bool CreatureEntity::has_race_granted_speed() const
+{
+    // [提案C1第11弾] 付与種族の加速を生成時速度へ反映 (opt-in・既定OFF・モンスター専用)
+    return this->race_grants_tr_flag(TR_SPEED) && this->get_monrace().applies_player_race_speed;
+}
 bool CreatureEntity::has_two_handed_weapons()
 {
     if (this->has_monster_profile()) {

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -2222,6 +2222,8 @@ public:
     bool has_race_granted_reflection() const;
     //! 付与された player_race 由来の再生 (TR_REGEN) を持つか (提案C1第10弾。opt-in・既定OFF・モンスター専用)
     bool has_race_granted_regeneration() const;
+    //! 付与された player_race 由来の加速 (TR_SPEED) を持つか (提案C1第11弾。opt-in・既定OFF・モンスター専用)
+    bool has_race_granted_speed() const;
     virtual bool has_two_handed_weapons();
     virtual BIT_FLAGS has_sh_fire();
     virtual BIT_FLAGS has_sh_elec();

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -141,6 +141,7 @@ public:
     bool applies_player_race_resistances = false; //!< 付与された player_race の属性耐性を被ダメージへ反映するか (提案C1第2弾。既定false=オプトイン。既定バランス不変)
     bool applies_player_race_reflection = false; //!< 付与された player_race の反射(TR_REFLECT)をボルト反射へ反映するか (提案C1第8弾。既定false=オプトイン。既定バランス不変)
     bool applies_player_race_regeneration = false; //!< 付与された player_race の再生(TR_REGEN)を自然回復倍化へ反映するか (提案C1第10弾。既定false=オプトイン。既定バランス不変)
+    bool applies_player_race_speed = false; //!< 付与された player_race の加速(TR_SPEED)を生成時の速度へ反映するか (提案C1第11弾。既定false=オプトイン。既定バランス不変)
     bool grows_melee_proficiency = false; //!< レベルアップで得た戦闘習熟を近接命中へ反映するか (提案C2第2弾。既定false=オプトイン。既定バランス不変)
     bool applies_stat_combat_bonus = false; //!< 能力値(STR)を近接ダメージへ反映するか (提案C2第3弾。既定false=オプトイン。既定バランス不変)
     EnumClassFlagGroup<MonsterFeedType> meat_feed_flags;


### PR DESCRIPTION
付与された player_race が加速(TR_SPEED)を持つ場合、place_monster_one の生成時速度設定 (サイズ補正の後段) で保守的な固定ボーナス +3 を speed に加算する。独立フラグ
applies_player_race_speed (既定 false=オプトイン) で制御。

設計上の注意 (投機的でない固定近似を選んだ根拠):
- プレイヤーの種族速度は PlayerSpeed::race_bonus() = CreatureRace::speed() 経由で、 種族依存 (KLACKON/SPRITE のみ level/10) かつ位置(terrain)/レベル依存で毎ターン動的に 算出される。TR_SPEED フラグ自体は速度値を持たず、多くの動物種族では表示用。
- モンスター速度は静的な speed フィールド (生成時確定+時限効果) で動くため、 プレイヤーの動的算出をそのまま反映するのは侵襲的。よって保守的な固定近似 (+3、 one-monster-placer.cpp の調整用 constexpr) を採用。

述語 has_race_granted_speed() は共通ヘルパ race_grants_tr_flag(TR_SPEED) + 有効化フラグ。 既定 false・プレイヤーでは加算されないため既定バランス不変。CLAUDE.md / roadmap 整備。 フルビルド (g++ -O3 -Werror, BUILD_EXIT=0) / clang-format-18 / validate_json 8/8 で検証済。