### PR TITLE
feat: モンスターの種族テレパシー(TR_TELEPATHY)をAI索敵へ opt-in 反映（提案C3第1弾）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -707,6 +707,16 @@ UNIQUE フラグ付きモンスターは生成時に `creature.name = monrace.na
   TR_SPEED フラグ自体は速度値を持たない（多くの動物種族は表示用）。モンスター速度は
   静的な `speed` フィールドで動くため、動的反映は侵襲的すぎるとして**保守的な固定近似
   (+3)** を採用（`one-monster-placer.cpp` の調整用 constexpr）。
+- **反映対象（C3第1弾: テレパシー＝AI 索敵）:** テレパシー `TR_TELEPATHY`。**別フラグ
+  `applies_player_race_telepathy`（既定 `false`=オプトイン）**。`process_stealth`
+  （`monster-processor.cpp`、モンスターがプレイヤーに気付くか判定）の冒頭で
+  `has_race_granted_telepathy()` が真なら `return true`（常に気付く）。効果は**忍者の
+  超隠密状態（`ninja_data->s_stealth`）を無視**する点に限定される（通常時はモンスターは
+  元々プレイヤー位置を把握しているため、awareness ギャップは超隠密のみ）。**C トラックで
+  初めて AI 挙動に触れた反映**。壁越し感知・睡眠中の感知等のより広い ESP は新規 AI・
+  バランス判断を要するため将来段（roadmap C3 参照）。プレイヤー無敵化（透明）は本ゲームで
+  モンスター AI 要因でないため see_invis 反映は対象外。述語 `has_race_granted_telepathy()`
+  は共通ヘルパ `race_grants_tr_flag(TR_TELEPATHY)` ＋有効化フラグ。
 - **共通述語の配置:** `target_race_resists_element(EffectMonster*, tr_type)` は
   `effect-monster-util.{h,cpp}` に配置（属性ダメージ／状態異常の両 TU から使う共通述語）。
   ダメージ軽減 `apply_monster_race_resistance(em_ptr)`（基本 5 属性用の 1/3 軽減）は

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3380,6 +3380,22 @@ one-monster-placer 等）がプレイヤーを渡すことを確認済。**モ�
 **工数:** 中〜大（新規 AI）。**価値:** 中（AI に深みは出るが実装は非自明）。
 **リスク:** 中〜高（AI 挙動変更）。→ **当初「最優先」としたが基盤誤認により降格。**
 
+### ✅ 第1弾 完了（テレパシー→超隠密無視、保守的スコープ）
+
+**実コード再調査の結論:** モンスター AI の「awareness（プレイヤーに気付くか）」ギャップは
+実質 `process_stealth`（`monster-processor.cpp`）の**忍者の超隠密（`s_stealth`）判定のみ**。
+通常時モンスターはプレイヤー位置を把握しており「壁越し感知」で埋めるギャップは無い。
+プレイヤー無敵化（透明）もモンスター AI 要因ではない（see_invis 反映は対象外）。
+
+→ よって tractable な C3 の第1弾として、**テレパシー `TR_TELEPATHY` を持つモンスターは
+超隠密を無視して常に気付く**を実装。`process_stealth` 冒頭で `has_race_granted_telepathy()`
+が真なら `return true`。独立フラグ `applies_player_race_telepathy`（既定 false）＋述語は
+共通ヘルパ `race_grants_tr_flag(TR_TELEPATHY)`。**C トラックで初めて AI 挙動に触れた反映**
+（効果は超隠密無視に限定＝低リスク）。フルビルド (BUILD_EXIT=0) / validate_json 8/8 で検証済。
+
+**残（第2弾以降・大）:** 睡眠中モンスターの ESP による覚醒、種族別 ESP（esp_evil 等）で
+プレイヤー種別を感知、壁越し索敵距離等。いずれも新規 AI ＋バランス判断を要する大物。
+
 ---
 
 ## 提案 C4: MP 消費詠唱 ✅ 完了（opt-in・レベル比例コスト）

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -213,6 +213,10 @@
                         "type": "boolean",
                         "description": "付与された player_race の加速(TR_SPEED)を生成時の速度へ反映するか (提案C1第11弾)。既定false=オプトイン。trueかつ種族が加速を持つ個体のみ、生成時に控えめな加速ボーナス(+3)を得る。プレイヤーの種族速度は種族依存・動的なため、モンスターには保守的な固定近似を用いる。"
                     },
+                    "applies_player_race_telepathy": {
+                        "type": "boolean",
+                        "description": "付与された player_race のテレパシー(TR_TELEPATHY)を AI 索敵へ反映するか (提案C3第1弾)。既定false=オプトイン。trueかつ種族がテレパシーを持つ個体のみ、忍者の超隠密状態を無視して常にプレイヤーに気付く。"
+                    },
                     "grows_melee_proficiency": {
                         "type": "boolean",
                         "description": "レベルアップで得た戦闘習熟を近接命中へ反映するか (提案C2第2弾)。既定false=オプトイン。trueの個体は、生成時レベルを超えて成長した分だけ近接攻撃の命中判定が向上する。"

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -1576,6 +1576,11 @@ errr RaceReader::read()
         msg_format(_("モンスター種族加速反映フラグ読込失敗。ID: '%d'。", "Failed to load monster applies_player_race_speed. ID: '%d'."), error_idx);
         return err;
     }
+    err = info_set_bool(mon_data["applies_player_race_telepathy"], monrace.applies_player_race_telepathy, false);
+    if (err) {
+        msg_format(_("モンスター種族テレパシー反映フラグ読込失敗。ID: '%d'。", "Failed to load monster applies_player_race_telepathy. ID: '%d'."), error_idx);
+        return err;
+    }
     err = info_set_bool(mon_data["grows_melee_proficiency"], monrace.grows_melee_proficiency, false);
     if (err) {
         msg_format(_("モンスター戦闘習熟フラグ読込失敗。ID: '%d'。", "Failed to load monster grows_melee_proficiency. ID: '%d'."), error_idx);

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -1008,6 +1008,10 @@ void process_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
  */
 bool process_stealth(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
+    // [提案C3第1弾] テレパシーを持つモンスターは忍者の超隠密を無視して常に気付く (opt-in・既定OFF)。
+    if (creature.get_floor()->get_monster(m_idx).has_race_granted_telepathy()) {
+        return true;
+    }
 
     auto ninja_data = CreatureClass(creature).get_specific_data<ninja_data_type>();
     if (!ninja_data || !ninja_data->s_stealth) {

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -2381,6 +2381,12 @@ bool CreatureEntity::has_race_granted_speed() const
     // [提案C1第11弾] 付与種族の加速を生成時速度へ反映 (opt-in・既定OFF・モンスター専用)
     return this->race_grants_tr_flag(TR_SPEED) && this->get_monrace().applies_player_race_speed;
 }
+
+bool CreatureEntity::has_race_granted_telepathy() const
+{
+    // [提案C3第1弾] 付与種族のテレパシーを AI 索敵へ反映 (opt-in・既定OFF・モンスター専用)
+    return this->race_grants_tr_flag(TR_TELEPATHY) && this->get_monrace().applies_player_race_telepathy;
+}
 bool CreatureEntity::has_two_handed_weapons()
 {
     if (this->has_monster_profile()) {

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -2224,6 +2224,8 @@ public:
     bool has_race_granted_regeneration() const;
     //! 付与された player_race 由来の加速 (TR_SPEED) を持つか (提案C1第11弾。opt-in・既定OFF・モンスター専用)
     bool has_race_granted_speed() const;
+    //! 付与された player_race 由来のテレパシー (TR_TELEPATHY) を AI 索敵で使えるか (提案C3第1弾。opt-in・既定OFF・モンスター専用)
+    bool has_race_granted_telepathy() const;
     virtual bool has_two_handed_weapons();
     virtual BIT_FLAGS has_sh_fire();
     virtual BIT_FLAGS has_sh_elec();

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -142,6 +142,7 @@ public:
     bool applies_player_race_reflection = false; //!< 付与された player_race の反射(TR_REFLECT)をボルト反射へ反映するか (提案C1第8弾。既定false=オプトイン。既定バランス不変)
     bool applies_player_race_regeneration = false; //!< 付与された player_race の再生(TR_REGEN)を自然回復倍化へ反映するか (提案C1第10弾。既定false=オプトイン。既定バランス不変)
     bool applies_player_race_speed = false; //!< 付与された player_race の加速(TR_SPEED)を生成時の速度へ反映するか (提案C1第11弾。既定false=オプトイン。既定バランス不変)
+    bool applies_player_race_telepathy = false; //!< 付与された player_race のテレパシー(TR_TELEPATHY)を AI 索敵へ反映するか (提案C3第1弾。既定false=オプトイン。既定バランス不変)
     bool grows_melee_proficiency = false; //!< レベルアップで得た戦闘習熟を近接命中へ反映するか (提案C2第2弾。既定false=オプトイン。既定バランス不変)
     bool applies_stat_combat_bonus = false; //!< 能力値(STR)を近接ダメージへ反映するか (提案C2第3弾。既定false=オプトイン。既定バランス不変)
     EnumClassFlagGroup<MonsterFeedType> meat_feed_flags;


### PR DESCRIPTION
C トラックで初めて AI 挙動に触れる反映。付与種族がテレパシー(TR_TELEPATHY)を持つ モンスターは、忍者の超隠密状態を無視して常にプレイヤーに気付く。

実コード再調査の結論:
- モンスター AI の awareness ギャップは実質 process_stealth の忍者超隠密(s_stealth)判定のみ。 通常時モンスターはプレイヤー位置を把握しており「壁越し感知」で埋めるギャップは無い。
- プレイヤー透明化もモンスター AI 要因でないため see_invis 反映は対象外。 → tractable な第1弾として超隠密無視のみを実装 (低リスク・効果限定)。

実装:
- MonraceDefinition::applies_player_race_telepathy を追加、reader / schema 整備。
- CreatureEntity::has_race_granted_telepathy() を新設 (共通ヘルパ race_grants_tr_flag(TR_TELEPATHY) + 有効化フラグ)。
- process_stealth 冒頭で has_race_granted_telepathy() が真なら return true (常に気付く)。

残 (第2弾以降・大): 睡眠中の ESP 覚醒、種族別 ESP でのプレイヤー種別感知、壁越し索敵等 (いずれも新規 AI + バランス判断を要する)。

既定 false・プレイヤーでは反映されないため既定バランス不変。CLAUDE.md / roadmap 整備。 フルビルド (g++ -O3 -Werror, BUILD_EXIT=0) / clang-format-18 / validate_json 8/8 で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monsters can now optionally inherit a player race’s telepathy.
  * Telepathic monsters always detect players, including those using ninja super-stealth.
  * Added configuration support for enabling this behavior per monster type.

* **Documentation**
  * Documented the telepathy-based detection behavior and its current scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->