### PR TITLE
merge: English: clarify rejected spell selection message（hengband#5496 相当）

### DIFF
--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -486,7 +486,7 @@ static int get_spell(CreatureEntity &creature, SPELL_IDX *sn, std::string_view p
 #ifdef JP
             msg_format("その%sを%sことはできません。", spell_category.data(), prompt_verb.data());
 #else
-            msg_format("You may not %s that %s.", prompt.data(), spell_category.data());
+            msg_format("You may not %s that %s.", prompt_verb.data(), spell_category.data());
 #endif
 
             continue;


### PR DESCRIPTION
変愚蛮怒 PR #5496 の内容を bakabakaband 構造に適応してマージ。

呪文選択の拒否時に表示される英語メッセージ "You may not %s that %s." が、 動詞 (prompt_verb) の代わりに整形済みプロンプト文字列全体 (prompt) を
第1引数に渡していたため、意味の通らない文言になっていた不具合を修正。
prompt.data() → prompt_verb.data() に修正。

上流コミット: c8c28729a (hengband/develop)
上流は prompt.data() → prompt_verb.data() の変更。bakabakaband 側は 既に引数名が prompt_verb にリネーム済みのため同一の置換で適用可能。

refs #8692 (hengband#5496)