### PR TITLE
merge: ArtifactReader をクラス化（hengband#5444 相当）

### DIFF
--- a/src/info-reader/artifact-reader.cpp
+++ b/src/info-reader/artifact-reader.cpp
@@ -13,20 +13,25 @@
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 
+ArtifactReader::ArtifactReader(const nlohmann::json &art_data)
+    : art_data(art_data)
+{
+}
+
 /*!
  * @brief テキストトークンを走査してフラグを一つ得る(アーティファクト用) /
  * Grab one activation index flag
- * @param a_ptr 保管先のアーティファクト構造体参照ポインタ
- * @param what 参照元の文字列ポインタ
+ * @param artifact 保管先のアーティファクト
+ * @param what 参照元の文字列
  * @return 見つかったらtrue
  */
-static bool grab_one_artifact_flag(ArtifactType *a_ptr, std::string_view what)
+bool ArtifactReader::grab_one_artifact_flag(ArtifactType &artifact, std::string_view what) const
 {
-    if (TrFlags::grab_one_flag(a_ptr->flags, baseitem_flags, what)) {
+    if (TrFlags::grab_one_flag(artifact.flags, baseitem_flags, what)) {
         return true;
     }
 
-    if (EnumClassFlagGroup<ItemGenerationTraitType>::grab_one_flag(a_ptr->gen_flags, baseitem_geneneration_flags, what)) {
+    if (EnumClassFlagGroup<ItemGenerationTraitType>::grab_one_flag(artifact.gen_flags, baseitem_geneneration_flags, what)) {
         return true;
     }
 
@@ -36,23 +41,23 @@ static bool grab_one_artifact_flag(ArtifactType *a_ptr, std::string_view what)
 
 /*!
  * @brief JSON Objectから固定アーティファクトのベースアイテムをセットする
- * @param baseitem_data ベースアイテム情報の格納されたJSON Object
  * @param artifact 保管先のアーティファクト
  * @return エラーコード
  */
-static errr set_art_baseitem(nlohmann::json &baseitem_data, ArtifactType &artifact)
+errr ArtifactReader::set_art_baseitem(ArtifactType &artifact) const
 {
+    const auto &baseitem_data = get_json_value(this->art_data, "base_item");
     if (baseitem_data.is_null()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
     ItemKindType type_value;
-    if (auto err = info_set_integer(baseitem_data["type_value"], type_value, true, Range(0, 128))) {
+    if (auto err = info_set_integer(get_json_value(baseitem_data, "type_value"), type_value, true, Range(0, 128))) {
         return err;
     }
 
     int subtype_value;
-    if (auto err = info_set_integer(baseitem_data["subtype_value"], subtype_value, true, Range(0, 128))) {
+    if (auto err = info_set_integer(get_json_value(baseitem_data, "subtype_value"), subtype_value, true, Range(0, 128))) {
         return err;
     }
 
@@ -62,12 +67,12 @@ static errr set_art_baseitem(nlohmann::json &baseitem_data, ArtifactType &artifa
 
 /*!
  * @brief JSON Objectから固定アーティファクトの発動能力をセットする
- * @param act_data 発動能力情報の格納されたJSON Object
  * @param artifact 保管先のアーティファクト
  * @return エラーコード
  */
-static errr set_art_activate(const nlohmann::json &act_data, ArtifactType &artifact)
+errr ArtifactReader::set_art_activate(ArtifactType &artifact) const
 {
+    const auto &act_data = get_json_value(this->art_data, "activate");
     if (!act_data.is_string()) {
         return PARSE_ERROR_NONE;
     }
@@ -84,12 +89,12 @@ static errr set_art_activate(const nlohmann::json &act_data, ArtifactType &artif
 
 /*!
  * @brief JSON Objectからモンスターフラグをセットする
- * @param flag_data モンスターフラグ情報の格納されたJSON Object
  * @param artifact 保管先のアーティファクト
  * @return エラーコード
  */
-static errr set_art_flags(const nlohmann::json &flag_data, ArtifactType &artifact)
+errr ArtifactReader::set_art_flags(ArtifactType &artifact) const
 {
+    const auto &flag_data = get_json_value(this->art_data, "flags");
     if (flag_data.is_null()) {
         return PARSE_ERROR_NONE;
     }
@@ -98,7 +103,7 @@ static errr set_art_flags(const nlohmann::json &flag_data, ArtifactType &artifac
     }
 
     for (auto &flag : flag_data) {
-        if (!grab_one_artifact_flag(&artifact, flag.get<std::string>())) {
+        if (!this->grab_one_artifact_flag(artifact, flag.get<std::string>())) {
             return PARSE_ERROR_INVALID_FLAG;
         }
     }
@@ -107,13 +112,13 @@ static errr set_art_flags(const nlohmann::json &flag_data, ArtifactType &artifac
 
 /*!
  * @brief 固定アーティファクト情報(JSON Object)のパース関数
- * @param art_data 固定アーティファクトデータの格納されたJSON Object
+ * @note ArtifactReader が保持する art_data を参照する
  * @return エラーコード
  */
-errr parse_artifacts_info(nlohmann::json &art_data)
+errr ArtifactReader::read() const
 {
     int int_id;
-    if (auto err = info_set_integer(art_data["id"], int_id, true, Range(0, 9999))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "id"), int_id, true, Range(0, 9999))) {
         return err;
     }
     if (int_id < error_idx) {
@@ -128,197 +133,67 @@ errr parse_artifacts_info(nlohmann::json &art_data)
     artifact.flags.set(TR_IGNORE_FIRE);
     artifact.flags.set(TR_IGNORE_COLD);
 
-    if (auto err = info_set_string(art_data["name"], artifact.name, true)) {
+    if (auto err = info_set_string(get_json_value(this->art_data, "name"), artifact.name, true)) {
         msg_format(_("アーティファクトの名称読込失敗。ID: '%d'。", "Failed to load artifact name. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = set_art_baseitem(art_data["base_item"], artifact)) {
+    if (auto err = this->set_art_baseitem(artifact)) {
         msg_format(_("アーティファクトのベースアイテム読込失敗。ID: '%d'。", "Failed to load base item of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(art_data["parameter_value"], artifact.pval, false, Range(-128, 128))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "parameter_value"), artifact.pval, false, Range(-128, 128))) {
         msg_format(_("アーティファクトのパラメータ値読込失敗。ID: '%d'。", "Failed to load parameter value of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(art_data["level"], artifact.level, true, Range(0, 128))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "level"), artifact.level, true, Range(0, 128))) {
         msg_format(_("アーティファクトのレベル読込失敗。ID: '%d'。", "Failed to load level of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(art_data["rarity"], artifact.rarity, true)) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "rarity"), artifact.rarity, true)) {
         msg_format(_("アーティファクトの希少度読込失敗。ID: '%d'。", "Failed to load rarity of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(art_data["weight"], artifact.weight, true, Range(0, 9999))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "weight"), artifact.weight, true, Range(0, 9999))) {
         msg_format(_("アーティファクトの重量読込失敗。ID: '%d'。", "Failed to load weight of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(art_data["cost"], artifact.cost, true, Range(0, 99999999))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "cost"), artifact.cost, true, Range(0, 99999999))) {
         msg_format(_("アーティファクトの売値読込失敗。ID: '%d'。", "Failed to load cost of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(art_data["base_ac"], artifact.ac, false, Range(-99, 99))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "base_ac"), artifact.ac, false, Range(-99, 99))) {
         msg_format(_("アーティファクトのベースAC読込失敗。ID: '%d'。", "Failed to load base AC of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_dice(art_data["base_dice"], artifact.damage_dice, false)) {
+    if (auto err = info_set_dice(get_json_value(this->art_data, "base_dice"), artifact.damage_dice, false)) {
         msg_format(_("アーティファクトのベースダイス読込失敗。ID: '%d'。", "Failed to load base dice of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(art_data["hit_bonus"], artifact.to_h, false, Range(-99, 99))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "hit_bonus"), artifact.to_h, false, Range(-99, 99))) {
         msg_format(_("アーティファクトの命中補正値読込失敗。ID: '%d'。", "Failed to load hit bonus of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(art_data["damage_bonus"], artifact.to_d, false, Range(-99, 99))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "damage_bonus"), artifact.to_d, false, Range(-99, 99))) {
         msg_format(_("アーティファクトのダメージ補正値読込失敗。ID: '%d'。", "Failed to load damage bonus of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(art_data["ac_bonus"], artifact.to_a, false, Range(-999, 999))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "ac_bonus"), artifact.to_a, false, Range(-999, 999))) {
         msg_format(_("アーティファクトのAC補正値読込失敗。ID: '%d'。", "Failed to load AC bonus of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = set_art_activate(art_data["activate"], artifact)) {
+    if (auto err = this->set_art_activate(artifact)) {
         msg_format(_("アーティファクトの発動能力読込失敗。ID: '%d'。", "Failed to load activate ability of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = set_art_flags(art_data["flags"], artifact)) {
+    if (auto err = this->set_art_flags(artifact)) {
         msg_format(_("アーティファクトの能力フラグ読込失敗。ID: '%d'。", "Failed to load ability flags of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_string(art_data["flavor"], artifact.text, false)) {
+    if (auto err = info_set_string(get_json_value(this->art_data, "flavor"), artifact.text, false)) {
         msg_format(_("アーティファクトのフレーバーテキスト読込失敗。ID: '%d'。", "Failed to load flavor text of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    /*
-        if (tokens[0] == "D") {
-            // D:JapaneseText
-            // D:$EnglishText
-            if (tokens.size() < 2 || buf.length() < 3) {
-                return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
-            }
-    #ifdef JP
-            if (buf[2] == '$') {
-                return PARSE_ERROR_NONE;
-            }
 
-            const auto it = artifacts_info.rbegin();
-            auto &artifact = it->second;
-            artifact.text.append(buf.substr(2));
-    #else
-            if (buf[2] != '$') {
-                return PARSE_ERROR_NONE;
-            }
-            if (buf.length() == 3) {
-                return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
-            }
-
-            const auto it = artifacts_info.rbegin();
-            auto &artifact = it->second;
-            append_english_text(artifact.text, buf.substr(3));
-    #endif
-            return PARSE_ERROR_NONE;
-        }
-
-        if (tokens[0] == "I") {
-            // I:tval:sval:pval
-            if (tokens.size() < 4) {
-                return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-            }
-
-            const auto it = artifacts_info.rbegin();
-            auto &artifact = it->second;
-            constexpr auto base = 10;
-            const auto tval = i2enum<ItemKindType>(std::stoi(tokens[1], nullptr, base));
-            const auto sval = std::stoi(tokens[2], nullptr, base);
-            artifact.bi_key = { tval, sval };
-            info_set_value(artifact.pval, tokens[3]);
-            return PARSE_ERROR_NONE;
-        }
-
-        if (tokens[0] == "W") {
-            // W:level:ratiry:weight:cost
-            if (tokens.size() < 5) {
-                return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-            }
-
-            const auto it = artifacts_info.rbegin();
-            auto &artifact = it->second;
-            info_set_value(artifact.level, tokens[1]);
-            info_set_value(artifact.rarity, tokens[2]);
-            info_set_value(artifact.weight, tokens[3]);
-            info_set_value(artifact.cost, tokens[4]);
-            return PARSE_ERROR_NONE;
-        }
-
-        if (tokens[0] == "P") {
-            // P:ac:dd:ds:to_h:to_d:to_a
-            if (tokens.size() < 6) {
-                return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-            }
-
-            const auto &dice = str_split(tokens[2], 'd', false, 2);
-            if (dice.size() != 2) {
-                return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
-            }
-
-            const auto it = artifacts_info.rbegin();
-            auto &artifact = it->second;
-            info_set_value(artifact.ac, tokens[1]);
-            info_set_value(artifact.dd, dice[0]);
-            info_set_value(artifact.ds, dice[1]);
-            info_set_value(artifact.to_h, tokens[3]);
-            info_set_value(artifact.to_d, tokens[4]);
-            info_set_value(artifact.to_a, tokens[5]);
-            return PARSE_ERROR_NONE;
-        }
-
-        if (tokens[0] == "U") {
-            // U:activation_flag
-            if (tokens.size() < 2 || tokens[1].size() == 0) {
-                return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-            }
-
-            auto n = grab_one_activation_flag(tokens[1]);
-            if (n <= RandomArtActType::NONE) {
-                return PARSE_ERROR_INVALID_FLAG;
-            }
-
-            const auto it = artifacts_info.rbegin();
-            auto &artifact = it->second;
-            artifact.act_idx = n;
-            return PARSE_ERROR_NONE;
-        }
-
-        if (tokens[0] == "F") {
-            // F:flags
-            if (tokens.size() < 2 || tokens[1].size() == 0) {
-                return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-            }
-
-            const auto &flags = str_split(tokens[1], '|', true, 10);
-            for (const auto &f : flags) {
-                if (f.size() == 0) {
-                    continue;
-                }
-
-                const auto it = artifacts_info.rbegin();
-                auto *a_ptr = &it->second;
-                if (!grab_one_artifact_flag(a_ptr, f)) {
-                    return PARSE_ERROR_INVALID_FLAG;
-                }
-            }
-
-        } else if (tokens[0] == "B") {
-            // B:activate broken rate
-            if (tokens.size() < 2 || tokens[1].size() == 0) {
-                return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-            }
-            const auto it = artifacts_info.rbegin();
-            auto *a_ptr = &it->second;
-            info_set_value(a_ptr->broken_rate, tokens[1]);
-        } else {
-            return PARSE_ERROR_UNDEFINED_DIRECTIVE;
-        }
-    */
     ArtifactList::get_instance().emplace(artifact_id, std::move(artifact));
     return PARSE_ERROR_NONE;
 }

--- a/src/info-reader/artifact-reader.h
+++ b/src/info-reader/artifact-reader.h
@@ -4,4 +4,24 @@
 #include <nlohmann/json.hpp>
 #include <string_view>
 
-errr parse_artifacts_info(nlohmann::json &element);
+class ArtifactType;
+
+class ArtifactReader {
+public:
+    explicit ArtifactReader(const nlohmann::json &art_data);
+    ArtifactReader(nlohmann::json &&) = delete;
+    ArtifactReader(const ArtifactReader &) = delete;
+    ArtifactReader(ArtifactReader &&) = delete;
+    ArtifactReader &operator=(const ArtifactReader &) = delete;
+    ArtifactReader &operator=(ArtifactReader &&) = delete;
+
+    errr read() const;
+
+private:
+    bool grab_one_artifact_flag(ArtifactType &artifact, std::string_view what) const;
+    errr set_art_baseitem(ArtifactType &artifact) const;
+    errr set_art_activate(ArtifactType &artifact) const;
+    errr set_art_flags(ArtifactType &artifact) const;
+
+    const nlohmann::json &art_data;
+};

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -164,7 +164,10 @@ static void init_json(std::string_view filename, std::string_view keyname, Defin
  */
 void init_artifacts_info()
 {
-    init_json("ArtifactDefinitions.jsonc", "artifacts", DefinitionHashDataType::ARTIFACTS, ArtifactList::get_instance(), parse_artifacts_info);
+    auto parser = [](nlohmann::json &art_data) {
+        return ArtifactReader(art_data).read();
+    };
+    init_json("ArtifactDefinitions.jsonc", "artifacts", DefinitionHashDataType::ARTIFACTS, ArtifactList::get_instance(), parser);
 }
 
 /*!


### PR DESCRIPTION
変愚蛮怒 PR #5444「[Refactor] ArtifactReaderをクラス化」の内容を
bakabakaband の既存 reader クラス規約（BaseitemReader 等）に合わせて実装。

- free 関数 parse_artifacts_info() を ArtifactReader クラスへ変換 （explicit ArtifactReader(const nlohmann::json &) ＋ read() public、 private に grab_one_artifact_flag / set_art_baseitem / set_art_activate / set_art_flags、コピー/ムーブ禁止＋ Reader(nlohmann::json&&)=delete ガード）
- JSON 読み取りを非 const operator[] から get_json_value() ベースへ 変更し art_data を const 参照で保持（欠落キーは null 扱い、挙動不変）
- info-initializer.cpp の init_artifacts_info() を他 reader と同形の ラムダ経由呼出に統一（後続の init_json_reader 共通化 hengband#5480 の前提）
- 旧 txt パーサ由来の巨大なコメントアウト済みデッドコードを除去

対応 ISSUE: deskull-m/bakabakaband#8519
上流コミット: 5417f6465 / 98d015b28 (hengband/develop)