### PR TITLE
merge: TerrainDefinitions スキーマ整備と make dist 同梱（hengband#5361 相当）

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,8 @@ schema_files = \
 	schema/DungeonDefinitions.schema.json \
 	schema/MonraceDefinitions.schema.json \
 	schema/MonsterMessages.schema.json \
-	schema/SpellDefinitions.schema.json
+	schema/SpellDefinitions.schema.json \
+	schema/TerrainDefinitions.schema.json
 
 EXTRA_DIST = \
 	autopick.txt \

--- a/schema/TerrainDefinitions.schema.json
+++ b/schema/TerrainDefinitions.schema.json
@@ -1,0 +1,185 @@
+{
+  "type": "object",
+  "required": ["version", "terrains"],
+  "properties": {
+    "version": {
+      "type": "number",
+      "description": "Version情報"
+    },
+    "terrains": {
+      "type": "array",
+      "description": "地形情報定義の配列",
+      "items": {
+        "type": "object",
+        "required": ["id", "key", "name", "symbol", "flags"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "key": {
+            "description": "地形の識別子",
+            "type": "string",
+            "minLength": 1
+          },
+          "name": {
+            "type": "object",
+            "description": "地形のゲーム内表記",
+            "required": ["ja", "en"],
+            "properties": {
+              "ja": {
+                "type": "string"
+              },
+              "en": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "symbol": {
+            "type": "object",
+            "description": "地形の表示シンボル",
+            "required": ["character", "color", "lit"],
+            "properties": {
+              "character": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 1
+              },
+              "color": {
+                "type": "string"
+              },
+              "lit": {
+                "description": "地形が明るいかどうか",
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "mimic": {
+            "description": "他の地形への模倣 例:罠→床",
+            "type": ["string", "null"],
+            "minLength": 1
+          },
+          "map_priority": {
+            "description": "マップ表示優先度",
+            "type": ["integer", "null"]
+          },
+          "flags": {
+            "description": "地形フラグ (bakabakaband独自拡張の POWER_* / SUBTYPE_* / C-PRIORITY_* / HYGIENE_* 等のパラメトリックフラグを含むため enum では制約しない)",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "DROP_GOLD": {
+            "description": "採掘時に得られる財宝量のダイス表記 (例: 2d2)",
+            "type": "string",
+            "pattern": "^[1-9][0-9]*d[1-9][0-9]*$"
+          },
+          "random_change": {
+            "description": "ターン経過による確率的な地形変化",
+            "type": "object",
+            "required": ["prob", "tag"],
+            "properties": {
+              "prob": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "tag": {
+                "description": "変化先の地形識別子",
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "additionalProperties": false
+          },
+          "generation": {
+            "description": "フロア生成時の地形変化定義",
+            "type": ["object", "null"],
+            "required": ["changes"],
+            "properties": {
+              "changes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["terrain", "probability"],
+                  "properties": {
+                    "terrain": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "probability": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 100
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "interactions": {
+            "type": "object",
+            "description": "特定行動後の地形変化定義 (値は変化先の地形識別子)",
+            "properties": {
+              "BASH": {
+                "type": "string",
+                "minLength": 1
+              },
+              "CLOSE": {
+                "type": "string",
+                "minLength": 1
+              },
+              "DESTROYED": {
+                "type": "string",
+                "minLength": 1
+              },
+              "DISARM": {
+                "type": "string",
+                "minLength": 1
+              },
+              "ENSECRET": {
+                "type": "string",
+                "minLength": 1
+              },
+              "HIT_TRAP": {
+                "type": "string",
+                "minLength": 1
+              },
+              "MAY_HAVE_GOLD": {
+                "type": "string",
+                "minLength": 1
+              },
+              "OPEN": {
+                "type": "string",
+                "minLength": 1
+              },
+              "SECRET": {
+                "type": "string",
+                "minLength": 1
+              },
+              "SHAFT": {
+                "type": "string",
+                "minLength": 1
+              },
+              "SPIKE": {
+                "type": "string",
+                "minLength": 1
+              },
+              "UNPERM": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
変愚蛮怒 PR #5361「Include schema/TerrainDefinitions.schema.json in the result from "make dist"」を bakabakaband 構造に適応してマージ。

前提差異: bakabakaband には schema/TerrainDefinitions.schema.json が 未整備で、lib/edit/TerrainDefinitions.jsonc は validate_json.py の 「対応スキーマ無し=skip」ルールで CI 検証対象外だった。そのため上流の
dist 追加 1 行を適用する前に、スキーマ本体を新規整備する。

- schema/TerrainDefinitions.schema.json を新規追加。上流スキーマを土台に bakabakaband の実データ(291 地形)へ精査・適応:
  - flags は bakabakaband 独自のパラメトリックフラグ(POWER_* / SUBTYPE_* / C-PRIORITY_* / HYGIENE_* 等 147 種)を含むため、既存 Dungeon スキーマ 同様に enum 列挙せず array of string とする
  - bakabakaband 固有の top-level キー DROP_GOLD(ダイス表記) / random_change (prob+tag) を追加。上流固有の trap/door/tunnel/pattern/store/building/ convert(bakabakaband では flags で表現)は不使用のため除外
  - interactions は実使用の 12 キーに限定
  - 全 291 地形を validate_json.py で検証し 9/9 成功を確認
- Makefile.am の schema_files に TerrainDefinitions.schema.json を追加 (make dist 同梱。#5361 本来の変更)

対応 ISSUE: deskull-m/bakabakaband#8298
上流コミット: ff8e5fcff (hengband/develop)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON schema validation for terrain definitions, covering required fields like identifiers, localized names, symbols, flags, interactions, and optional generation/mimic/map priority rules.
  * Expanded the project’s bundled schema set to include terrain definition schema alongside existing definition schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->