### PR TITLE
feat: とくさんレイドイベントを追加 (#2094)

### DIFF
--- a/src/mspell/summon-checker.cpp
+++ b/src/mspell/summon-checker.cpp
@@ -72,6 +72,8 @@ bool check_summon_specific(CreatureEntity &creature, MonraceId summoner_idx, Mon
         return monrace.kind_flags.has(MonsterKindType::PUYO);
     case SUMMON_HOMO:
         return monrace.kind_flags.has(MonsterKindType::HOMO_SEXUAL);
+    case SUMMON_TOKUSAN:
+        return monrace.kind_flags.has(MonsterKindType::HOMO_SEXUAL) && monrace.is_male();
     case SUMMON_PERVERTS:
         return monrace.kind_flags.has(MonsterKindType::PERVERT);
     case SUMMON_WALL:

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -22,6 +22,7 @@
 #include "player-info/equipment-info.h"
 #include "player/digestion-processor.h"
 #include "player/player-damage.h"
+#include "player/player-sex.h"
 #include "player/player-status-flags.h"
 #include "spell-kind/spells-floor.h"
 #include "spell-kind/spells-launcher.h"
@@ -67,6 +68,26 @@ void process_world_aux_sudden_attack(CreatureEntity &creature)
     if (randint1(100) == 36) {
         for (auto a : alliance_list) {
             a.second->panishment(creature);
+        }
+    }
+
+    // とくさんレイドイベント (#2094)
+    // 男性プレイヤーに極低確率で発生する。「とくさんか？」の声に Y/N どちらで答えても、
+    // 敵対的な男性ホモ (HOMO_SEXUAL かつ MALE) のモンスターが召喚される。
+    constexpr auto tokusan_raid_chance = 1919;
+    if (creature.is_player() && (creature.get_psex() == SEX_MALE) && one_in_(tokusan_raid_chance)) {
+        disturb(creature, true, true);
+        msg_print(_("「とくさんか？」", "A voice asks, \"Are you Tokusan?\""));
+        (void)input_check(_("とくさんか？", "Are you Tokusan?"));
+        auto summoned = false;
+        const auto summon_count = randint1(3);
+        for (auto i = 0; i < summon_count; i++) {
+            if (summon_specific(creature, creature.get_y(), creature.get_x(), 100, SUMMON_TOKUSAN, PM_ALLOW_GROUP)) {
+                summoned = true;
+            }
+        }
+        if (summoned) {
+            msg_print(_("はい、皆様の玩具。", "Yes, you are everyone's plaything."));
         }
     }
 

--- a/src/spell/summon-types.h
+++ b/src/spell/summon-types.h
@@ -68,4 +68,5 @@ enum summon_type : int {
     SUMMON_WALL = 82, /*!< 召喚タイプ: 壁 */
     SUMMON_INSECT = 83, /*!< 召喚タイプ: 昆虫 */
     SUMMON_ELDRAZI = 84, /*!< 召喚タイプ: エルドラージ */
+    SUMMON_TOKUSAN = 85, /*!< 召喚タイプ: とくさん (HOMO_SEXUAL かつ MALE) */
 };


### PR DESCRIPTION
ターバンのガキ襲撃と類似のシステムとして、男性プレイヤーに極低確率で
発生する「とくさん」レイドイベントを実装。

- 10 ゲームターン周期の襲撃判定 process_world_aux_sudden_attack 内で、 男性プレイヤー (SEX_MALE) に one_in_(1919) の極低確率で発生。
- 「とくさんか？」と Y/N を問う (input_check) が、どちらを選んでも 結果を無視して敵対的な男性ホモに襲撃される。
- 召喚は新設の SUMMON_TOKUSAN (HOMO_SEXUAL かつ MALE を満たす種族、 該当 101 種) を PM_AMBUSH | PM_ALLOW_GROUP で 1+1d2 体召喚。

確率は tokusan_raid_chance 定数で調整可能。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new, extremely rare in-game raid event that can occur during world events.
  - Eligible characters may be prompted to participate and face one or more special monster summons.
  - Added dedicated summon matching for the new monster type, with eligibility based on monster attributes.
  - Successful encounters now provide additional event feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->