### PR TITLE
feat: モンスター種族「サイヤ人」(SAIYAN) を追加

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -64524,6 +64524,7 @@
         "DROP_SKELETON",
         "DROP_CORPSE",
         "ALIEN",
+        "SAIYAN",
         "FORCE_MAXHP",
         "KILL_WALL",
         "HUMAN",
@@ -104699,6 +104700,7 @@
         "DROP_SKELETON",
         "DROP_CORPSE",
         "ALIEN",
+        "SAIYAN",
         "OPEN_DOOR",
         "BASH_DOOR",
         "CAN_FLY",
@@ -122775,6 +122777,7 @@
         "DROP_CORPSE",
         "EAT_BERSERKER",
         "ALIEN",
+        "SAIYAN",
       ],
     },
     {

--- a/src/info-reader/race-info-tokens-table.cpp
+++ b/src/info-reader/race-info-tokens-table.cpp
@@ -492,6 +492,7 @@ const std::unordered_map<std::string_view, MonsterKindType> r_info_kind_flags = 
     { "MERFOLK", MonsterKindType::MERFOLK }, // マーフォーク
     { "SHARK", MonsterKindType::SHARK }, // サメ
     { "MESUGAKI", MonsterKindType::MESUGAKI }, // メスガキ
+    { "SAIYAN", MonsterKindType::SAIYAN }, // サイヤ人
     { "HYDRA", MonsterKindType::HYDRA }, // ヒドラ
     { "SHIP", MonsterKindType::SHIP }, // 船舶
     { "SLUG", MonsterKindType::SLUG }, // ナメクジ

--- a/src/monster-race/monster-kind-type-name.cpp
+++ b/src/monster-race/monster-kind-type-name.cpp
@@ -219,6 +219,8 @@ std::string get_monster_kind_type_name(MonsterKindType kind)
         return _("サメ", "shark");
     case MonsterKindType::MESUGAKI:
         return _("メスガキ", "mesugaki");
+    case MonsterKindType::SAIYAN:
+        return _("サイヤ人", "saiyan");
     case MonsterKindType::HYDRA:
         return _("ヒドラ", "hydra");
     case MonsterKindType::SHIP:
@@ -540,6 +542,8 @@ std::string get_monster_kind_type_tag(MonsterKindType kind)
         return "SHARK";
     case MonsterKindType::MESUGAKI:
         return "MESUGAKI";
+    case MonsterKindType::SAIYAN:
+        return "SAIYAN";
     case MonsterKindType::HYDRA:
         return "HYDRA";
     case MonsterKindType::SHIP:

--- a/src/monster-race/race-kind-flags.h
+++ b/src/monster-race/race-kind-flags.h
@@ -157,5 +157,6 @@ enum class MonsterKindType {
     WHEEL = 153, // 車輪
     GREAT_OLD_ONE = 154, // 旧支配者
     MESUGAKI = 155, // メスガキ
+    SAIYAN = 156, // サイヤ人
     MAX,
 };

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -897,6 +897,11 @@ void display_monster_kind(lore_type *lore_ptr)
         has_specific_kind = true;
     }
 
+    if (lore_ptr->kind_flags.has(MonsterKindType::SAIYAN)) {
+        hook_c_roff(TERM_L_RED, _("サイヤ人", " saiyan"));
+        has_specific_kind = true;
+    }
+
     if (lore_ptr->kind_flags.has(MonsterKindType::HYDRA)) {
         hook_c_roff(TERM_L_GREEN, _("ヒドラ", " hydra"));
         has_specific_kind = true;


### PR DESCRIPTION
新しい MonsterKindType::SAIYAN を追加し、既存のサイヤ人モンスター 3 種に 付与した。

- race-kind-flags.h: SAIYAN = 156 を MAX 直前に追加
- race-info-tokens-table.cpp: JSON トークン "SAIYAN" を登録
- monster-kind-type-name.cpp: 表示名 (サイヤ人 / saiyan) とタグ ("SAIYAN") を 両 switch に追加 (exhaustive switch のため -Werror 対応)
- display-lore.cpp: 思い出画面の種族表示に「サイヤ人」を追加
- MonraceDefinitions.jsonc: 該当モンスターに "SAIYAN" フラグを付与
  - 1022 サイヤ人『ナッパ』
  - 1653 惑星戦士『ラディッツ』(サイヤ人の生き残り)
  - 1938 原始サイヤ人

schema の flags は任意文字列のため変更不要。孫悟空 (スーパーモンキー) は
西遊記の孫悟空でありサイヤ人ではないため対象外とした。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the new **Saiyan** monster classification.
  * Saiyan entries can now be recognized, displayed, and labeled in monster information and lore.
  * Added localized naming and visual tag support for Saiyan monsters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->