### PR TITLE
feat: 敵対するカオスパトロンのプレイヤーへのアライアンス印象値をマイナス

### DIFF
--- a/src/alliance/alliance-khorne.cpp
+++ b/src/alliance/alliance-khorne.cpp
@@ -6,6 +6,7 @@
 #include "monster-floor/monster-summon.h"
 #include "monster-floor/one-monster-placer.h"
 #include "monster-floor/place-monster-types.h"
+#include "player/patron.h"
 #include "spell/summon-types.h"
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
@@ -20,6 +21,11 @@ int AllianceKhorne::calcImpressionPoint(const CreatureEntity &creature) const
     impression += calcIronmanHostilityPenalty();
     // プレイヤーの戦闘力を評価（コーンは戦闘を重視）
     impression += Alliance::calcPlayerPower(creature, 3, 50);
+
+    // 宿敵スラーネッシュをパトロンとするクリーチャーへの嫌悪
+    if (creature.get_patron() == static_cast<int16_t>(PatronType::SLAANESH)) {
+        impression -= 20;
+    }
 
     /*
 

--- a/src/alliance/alliance-nurgle.cpp
+++ b/src/alliance/alliance-nurgle.cpp
@@ -8,6 +8,7 @@
 #include "monster-floor/monster-summon.h"
 #include "monster-floor/one-monster-placer.h"
 #include "monster-floor/place-monster-types.h"
+#include "player/patron.h"
 #include "spell/summon-types.h"
 #include "status/bad-status-setter.h"
 #include "system/creature-entity.h"
@@ -39,6 +40,11 @@ int AllianceNurgle::calcImpressionPoint(const CreatureEntity &creature) const
 
     // 魅力は逆に低い方が好まれる（醜さは美徳）
     impression -= (creature.get_stat_use(A_CHR) - 10) * 4;
+
+    // 宿敵ティーンチをパトロンとするクリーチャーへの嫌悪
+    if (creature.get_patron() == static_cast<int16_t>(PatronType::TZEENTCH)) {
+        impression -= 20;
+    }
 
     // 種族による評価
     switch (creature.prace) {

--- a/src/alliance/alliance-slaanesh.cpp
+++ b/src/alliance/alliance-slaanesh.cpp
@@ -6,6 +6,7 @@
 #include "monster-floor/monster-summon.h"
 #include "monster-floor/one-monster-placer.h"
 #include "monster-floor/place-monster-types.h"
+#include "player/patron.h"
 #include "spell/summon-types.h"
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
@@ -24,6 +25,11 @@ int AllianceSlaanesh::calcImpressionPoint(const CreatureEntity &creature) const
 
     // 魅力による追加ボーナス
     impression += (creature.get_stat_use(A_CHR) - 10) * 5;
+
+    // 宿敵コーンをパトロンとするクリーチャーへの嫌悪
+    if (creature.get_patron() == static_cast<int16_t>(PatronType::KHORNE)) {
+        impression -= 20;
+    }
 
     // 魔法使用による好感度向上（コーンとは逆）
     // if (creature.realm1 != REALM_NONE || creature.realm2 != REALM_NONE) {

--- a/src/alliance/alliance-tzeentch.cpp
+++ b/src/alliance/alliance-tzeentch.cpp
@@ -6,6 +6,7 @@
 #include "monster-floor/monster-summon.h"
 #include "monster-floor/one-monster-placer.h"
 #include "monster-floor/place-monster-types.h"
+#include "player/patron.h"
 #include "spell/summon-types.h"
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
@@ -24,6 +25,11 @@ int AllianceTzeentch::calcImpressionPoint(const CreatureEntity &creature) const
     // 知力と魔法能力による追加評価
     impression += (creature.get_stat_use(A_INT) - 10) * 4;
     impression += (creature.get_stat_use(A_WIS) - 10) * 2;
+
+    // 宿敵ナーグルをパトロンとするクリーチャーへの嫌悪
+    if (creature.get_patron() == static_cast<int16_t>(PatronType::NURGLE)) {
+        impression -= 20;
+    }
 
     /*
     // 魔法使用による大幅な好感度向上

--- a/src/player/patron.h
+++ b/src/player/patron.h
@@ -12,6 +12,9 @@
 enum class PatronType : int16_t {
     NONE = -1, //!< なし
     KHORNE = 11, //!< コーン
+    SLAANESH = 12, //!< スラーネッシュ
+    NURGLE = 13, //!< ナーグル
+    TZEENTCH = 14, //!< ティーンチ
     GETTER = 16, //!< ゲッター
     EFU = 18, //!< 衛府
 };


### PR DESCRIPTION
ウォーハンマーのカオス神の敵対関係に基づき、各カオス神アライアンスが
宿敵をカオスパトロンとするプレイヤーへの印象値を 20 減少させる。

- ティーンチ ← ナーグルをパトロンとするプレイヤー: -20
- ナーグル   ← ティーンチをパトロンとするプレイヤー: -20
- コーン     ← スラーネッシュをパトロンとするプレイヤー: -20
- スラーネッシュ ← コーンをパトロンとするプレイヤー: -20

PatronType enum に SLAANESH(12) / NURGLE(13) / TZEENTCH(14) を追加し、 calcImpressionPoint() 内で creature.get_patron() と比較する。 判定は is_player() ガード付き（パトロンはプレイヤー固有概念のため）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Slaanesh, Nurgle, and Tzeentch as recognized patron types.
  * Alliance reactions now account for rival Chaos patrons when evaluating creatures.
  * Khorne penalizes Slaanesh patrons, Nurgle penalizes Tzeentch patrons, Slaanesh penalizes Khorne patrons, and Tzeentch penalizes Nurgle patrons.
* **Bug Fixes**
  * Improved alliance impression scoring so hostility toward opposing patrons is reflected more accurately in related decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->