### PR TITLE
feat: 崇拝パトロンと一致するアライアンスの印象値を+30

### DIFF
--- a/src/alliance/alliance-khorne.cpp
+++ b/src/alliance/alliance-khorne.cpp
@@ -22,6 +22,11 @@ int AllianceKhorne::calcImpressionPoint(const CreatureEntity &creature) const
     // プレイヤーの戦闘力を評価（コーンは戦闘を重視）
     impression += Alliance::calcPlayerPower(creature, 3, 50);
 
+    // コーンを崇拝するクリーチャーへの好意
+    if (creature.get_patron() == static_cast<int16_t>(PatronType::KHORNE)) {
+        impression += 30;
+    }
+
     // 宿敵スラーネッシュをパトロンとするクリーチャーへの嫌悪
     if (creature.get_patron() == static_cast<int16_t>(PatronType::SLAANESH)) {
         impression -= 20;

--- a/src/alliance/alliance-nurgle.cpp
+++ b/src/alliance/alliance-nurgle.cpp
@@ -41,6 +41,11 @@ int AllianceNurgle::calcImpressionPoint(const CreatureEntity &creature) const
     // 魅力は逆に低い方が好まれる（醜さは美徳）
     impression -= (creature.get_stat_use(A_CHR) - 10) * 4;
 
+    // ナーグルを崇拝するクリーチャーへの好意
+    if (creature.get_patron() == static_cast<int16_t>(PatronType::NURGLE)) {
+        impression += 30;
+    }
+
     // 宿敵ティーンチをパトロンとするクリーチャーへの嫌悪
     if (creature.get_patron() == static_cast<int16_t>(PatronType::TZEENTCH)) {
         impression -= 20;

--- a/src/alliance/alliance-slaanesh.cpp
+++ b/src/alliance/alliance-slaanesh.cpp
@@ -26,6 +26,11 @@ int AllianceSlaanesh::calcImpressionPoint(const CreatureEntity &creature) const
     // 魅力による追加ボーナス
     impression += (creature.get_stat_use(A_CHR) - 10) * 5;
 
+    // スラーネッシュを崇拝するクリーチャーへの好意
+    if (creature.get_patron() == static_cast<int16_t>(PatronType::SLAANESH)) {
+        impression += 30;
+    }
+
     // 宿敵コーンをパトロンとするクリーチャーへの嫌悪
     if (creature.get_patron() == static_cast<int16_t>(PatronType::KHORNE)) {
         impression -= 20;

--- a/src/alliance/alliance-tzeentch.cpp
+++ b/src/alliance/alliance-tzeentch.cpp
@@ -26,6 +26,11 @@ int AllianceTzeentch::calcImpressionPoint(const CreatureEntity &creature) const
     impression += (creature.get_stat_use(A_INT) - 10) * 4;
     impression += (creature.get_stat_use(A_WIS) - 10) * 2;
 
+    // ティーンチを崇拝するクリーチャーへの好意
+    if (creature.get_patron() == static_cast<int16_t>(PatronType::TZEENTCH)) {
+        impression += 30;
+    }
+
     // 宿敵ナーグルをパトロンとするクリーチャーへの嫌悪
     if (creature.get_patron() == static_cast<int16_t>(PatronType::NURGLE)) {
         impression -= 20;


### PR DESCRIPTION
該当カオス神を崇拝(パトロン)するクリーチャーは、その神の
アライアンスから一律+30の印象値ボーナスを得る。敵対神
パトロンへの-20と対になる好意側の反映。