### PR TITLE
feat: INVEN_ACTIVATE フラグ付きアイテムを非装備でも始動可能に

### DIFF
--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -34,6 +34,7 @@
 #include "locale/japanese.h"
 #include "mind/snipe-types.h"
 #include "object-activation/activation-switcher.h"
+#include "object-enchant/tr-types.h"
 #include "object-hook/hook-magic.h"
 #include "object-use/quaff/quaff-execution.h"
 #include "object-use/read/read-execution.h"
@@ -307,8 +308,25 @@ void do_cmd_activate(CreatureEntity &creature)
 
     CreatureClass(creature).break_samurai_stance({ SamuraiStanceType::MUSOU, SamuraiStanceType::KOUKIJIN });
     constexpr auto q = _("どのアイテムを始動させますか? ", "Activate which item? ");
-    constexpr auto s = _("始動できるアイテムを装備していない。", "You have nothing to activate.");
-    const auto &[item, i_idx] = choose_item(creature, q, s, (USE_EQUIP | IGNORE_BOTHHAND_SLOT), FuncItemTester(&ItemEntity::is_activatable));
+    constexpr auto s = _("始動できるアイテムを持っていない。", "You have nothing to activate.");
+    auto item_tester = FuncItemTester(
+        [](CreatureEntity &creature, const ItemEntity *o_ptr) {
+            if (!object_is_activatable(o_ptr)) {
+                return false;
+            }
+
+            // 装備中のアイテムはそのまま始動可能
+            for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+                if (creature.inventory[i_idx].get() == o_ptr) {
+                    return true;
+                }
+            }
+
+            // 装備していないアイテムは INVEN_ACTIVATE フラグ付きのみ始動可能
+            return o_ptr->get_flags().has(TR_INVEN_ACTIVATE);
+        },
+        creature);
+    const auto &[item, i_idx] = choose_item(creature, q, s, (USE_EQUIP | USE_INVEN | IGNORE_BOTHHAND_SLOT), item_tester);
     if (!item) {
         return;
     }


### PR DESCRIPTION
do_cmd_activate は従来 USE_EQUIP のみを対象とし、装備中のアイテムしか
始動選択肢に出さなかった。exe_activate 側は既に所持品での始動
(INVEN_ACTIVATE フラグ保持アイテム) を許可していたため、選択肢に
出てこないだけで機能が塞がれていた。

do_cmd_activate に USE_INVEN を追加し、以下を満たすアイテムを
選択肢に出すカスタム ItemTester を導入:
- 装備中のアイテム: 従来通り始動可能 (object_is_activatable)
- 非装備のアイテム: INVEN_ACTIVATE フラグを持つもののみ始動可能

これにより INVEN_ACTIVATE フラグを持つアイテム (スタンガン等) を
装備せずとも 'A' コマンドで始動できるようになった。
併せて空選択時メッセージを装備前提の文言から所持品も含む文言へ修正。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved item activation selection to include eligible inventory items.
  - Equipped activatable items can now be selected directly.
  - Unequipped items are restricted to those explicitly allowed for inventory activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->