### PR TITLE
docs: Godot (GDExtension/SCons) ビルド方法をドキュメントに追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1100,6 +1100,44 @@ MSVC ビルドは `.github/workflows/build-test-with-msvc.yml` を参照。
 MSBuild -warnAsError .\VisualStudio\Bakabakaband.sln /t:Rebuild /p:Configuration=Debug
 ```
 
+#### Godot (GDExtension / SCons) ビルド確認
+
+Godot 4.x 版 (`src/main-godot/` の GDExtension バックエンド) はゲームコア
+(`src/`) を共有 DLL/共有ライブラリとしてビルドし、`godot_project/` から
+ロードする。autotools / MSVC の端末版ビルドとは**独立**しており、CI には
+組み込んでいない。ビルドシステムはリポジトリルートの `SConstruct` (SCons)。
+
+```bash
+# 依存ツール: SCons 4.x / Python 3.8+ / C++20 対応コンパイラ
+#   (Ubuntu 例) sudo apt-get install scons python3
+#   (pip 経由)  pip install scons
+
+# 1. godot-cpp サブモジュール (branch 4.3) を取得
+git submodule update --init godot-cpp
+
+# 2. GDExtension ライブラリをビルド
+scons platform=linux target=template_debug      # Linux デバッグ
+scons platform=windows target=template_debug    # Windows デバッグ (既定)
+scons platform=linux target=template_release     # リリース
+# 並列ビルドは -j$(nproc) を付与
+
+# 3. Godot から起動
+godot --path godot_project
+```
+
+- ビルド成果物は `bin/bakabakaband.<platform>.<target>.x86_64.<so|dll>` に
+  出力され、`godot_project/bakabakaband.gdextension` の `libraries` パスと
+  一致する (`.gitignore` 対象)。
+- `SConstruct` はゲームコアを glob 収集し、端末版バックエンド
+  (`main-win` / `main-unix` / `main-x11` / `main-gcu` 等)・`src/net/`
+  (libcurl 依存)・`src/test/` を除外する。GCC では godot-cpp 既定の
+  `-fno-exceptions` を除去し `-fexceptions` を付与する等の差異があるため、
+  ソース追加・除外時は `SConstruct` の `exclude_*` 集合を更新すること。
+- `USE_GODOT` / `GODOT_RICH_UI` マクロで端末ステータス描画を抑制し Godot 側の
+  StatusPanel に委ねる分岐が入る (通常ビルドではマクロ未定義で無効)。
+- 詳細な設計・移植改変点・既知の制限は
+  [`docs/godot-interface.md`](docs/godot-interface.md) を参照。
+
 ---
 
 ## 変愚蛮怒（上流）からのマージ指針

--- a/docs/godot-interface.md
+++ b/docs/godot-interface.md
@@ -45,7 +45,8 @@ bakabakaband/
 │   ├── godot-player-status.{cpp,h}    # プレイヤーステータスのブリッジ
 │   ├── save-file-scanner.{cpp,h}      # タイトル画面用セーブファイル一覧
 │   ├── term-color-map.{cpp,h}         # 端末カラー → Godot Color 変換
-│   └── stack-trace-godot.cpp          # スタックトレース (Godot 版スタブ)
+│   ├── stack-trace-godot.cpp          # スタックトレース (Godot 版スタブ)
+│   └── win-exception-tracer.cpp       # Windows 例外トレーサ
 ├── godot_project/           # Godot プロジェクト
 │   ├── project.godot
 │   ├── bakabakaband.gdextension
@@ -68,7 +69,19 @@ bakabakaband/
 | Python | 3.8 以上 | SCons 実行環境 |
 | C++ コンパイラ | C++20 対応 (MSVC v143+ / g++ / clang++) | コンパイル |
 
+SCons が未インストールの場合は次のいずれかで導入する。
+
+```bash
+# Ubuntu / Debian
+sudo apt-get install scons python3
+# または pip 経由 (任意の OS)
+pip install scons
+```
+
 ### 1. サブモジュールの取得
+
+`godot-cpp` (branch 4.3) をサブモジュールとして取得する。`SConstruct` は
+先頭で `godot-cpp/SConstruct` を読み込むため、これが無いとビルドできない。
 
 ```bash
 git submodule update --init godot-cpp
@@ -76,26 +89,48 @@ git submodule update --init godot-cpp
 
 ### 2. GDExtension ライブラリのビルド
 
+`SConstruct` のオプションは godot-cpp 準拠 (`platform` / `target` /
+`arch` 等)。並列ビルドは標準の `-j` を付与する。
+
 ```bash
-# Windows デバッグビルド (既定)
+# Windows デバッグビルド (既定: platform=windows target=template_debug)
 scons platform=windows target=template_debug
 
 # Linux ビルド
 scons platform=linux target=template_debug
 
 # リリースビルド
-scons target=template_release
+scons platform=linux target=template_release
+
+# 並列ビルド (推奨)
+scons platform=linux target=template_debug -j$(nproc)
 ```
 
-ビルド成果物は `bin/bakabakaband.<platform>.<target>.x86_64.<so|dll>` に出力される。
+ビルド成果物は `bin/bakabakaband.<platform>.<target>.x86_64.<so|dll>` に出力され、
+`godot_project/bakabakaband.gdextension` の `[libraries]` パス
+(`res://../bin/bakabakaband.<platform>.<target>.x86_64.<so|dll>`) と一致する。
+`bin/` は `.gitignore` 対象。
+
+`SConstruct` はゲームコアを glob で収集し、端末版バックエンド
+(`main-win` / `main-unix` / `main-x11` / `main-gcu` / `main-cap`)・`src/net/`
+(libcurl 依存)・`src/test/`・autotools の Makefile.am 未収録の孤立ソースを
+除外する。ソースを追加・除外する際は `SConstruct` の `exclude_dirs` /
+`exclude_files` / `exclude_paths` を合わせて更新すること。プラットフォーム
+別のチャーセット・例外・マクロ設定 (Windows: `/source-charset:utf-8` /
+CP932 実行文字コード / `WINDOWS`・`WIN32`・`JP`・`SJIS`、Linux: `-fexceptions`
+再付与 / POSIX フィーチャマクロ) も同スクリプトに集約されている。
 
 ### 3. Godot からの起動
 
-`godot_project/project.godot` を Godot エディタで開いて実行するか、
+`godot_project/project.godot` を Godot エディタ (4.3 以上) で開いて実行するか、
 
 ```bash
 godot --path godot_project
 ```
+
+`.gdextension` の `compatibility_minimum` は 4.3。ライブラリ (`bin/`) が
+未ビルドだと Godot 起動時に GDExtension のロードに失敗するため、先に
+ステップ 2 を済ませておくこと。
 
 ## bakabakaband への移植にあたっての改変点
 


### PR DESCRIPTION
現在実装されている Godot 4.x 版 (src/main-godot GDExtension バックエンド) の ビルド手順を開発者向けドキュメントへ追記した。

- CLAUDE.md「ビルド確認」節に Godot (SCons) ビルドの手順を追加 (autotools/MSVC のみだったビルド節に Godot 経路を補完し、 docs/godot-interface.md へ相互参照)
- docs/godot-interface.md のビルド節を実装通りに補強 (SCons 導入コマンド / godot-cpp サブモジュール branch 4.3 の注記 / 並列ビルド -j / bin 出力と .gdextension libraries パスの対応 / SConstruct の除外集合・プラットフォーム別設定の説明 / 起動前にライブラリビルドが必要な旨)
- ファイル一覧に実在する win-exception-tracer.cpp を追加