### PR TITLE
merge: 床上アイテム選択の無限ループを修正（hengband#5494 相当）

### DIFF
--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -665,7 +665,7 @@ tl::optional<short> get_item_floor(CreatureEntity &creature, std::string_view pm
                 break;
             }
 
-            if (grid.o_idx_list.size() < 2) {
+            if (fis.floor_item_index.size() < 2) {
                 break;
             }
 


### PR DESCRIPTION
変愚蛮怒 PR #5494 (#5493 の修正) を bakabakaband 構造に適応してマージ。 床上に item_tester に適合しないアイテムが混在し、生アイテム数が 2 以上でも
適合アイテムが 2 未満のとき、次アイテム参照 (fis.floor_item_index[1]) が 適合アイテムへ回転できず無限ループになる不具合を修正。判定を生の
grid.o_idx_list.size() から適合アイテム数 fis.floor_item_index.size() に変更。

上流コミット: de72f66c8 (hengband/develop)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated floor-item cycling to navigate only through selectable or marked items, providing more accurate item selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->