### PR TITLE
merge: 外部ライブラリ由来の警告を抑制する（hengband#5497 相当）

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1566,7 +1566,7 @@ EXTRA_DIST = \
 	gcc-wrap
 
 DEFAULT_INCLUDES = \
-	-I. -I$(srcdir) -I$(srcdir)/external-lib/include
+	-I. -I$(srcdir) -isystem $(srcdir)/external-lib/include
 
 CPPFLAGS += $(XFT_CFLAGS) $(libcurl_CFLAGS)
 LIBS += $(XFT_LIBS) $(libcurl_LIBS)
@@ -1579,7 +1579,7 @@ endif
 
 if USE_NKF
 CXXCOMPILE_WRAPPER = $(srcdir)/gcc-wrap
-DEFAULT_INCLUDES += -I$(top_builddir)/src -I$(top_builddir)/src/external-lib/include
+DEFAULT_INCLUDES += -I$(top_builddir)/src -isystem $(top_builddir)/src/external-lib/include
 if COMPILER_IS_CLANG
 AM_CXXFLAGS += -Wno-invalid-source-encoding
 endif


### PR DESCRIPTION
変愚蛮怒 PR #5497 を bakabakaband 構造に適応してマージ。
external-lib/include を -I ではなく -isystem で指定し、同梱の
サードパーティヘッダ (fmt / range-v3 / nlohmann 等) 由来の
-Wall -Wextra 警告を抑制する。DEFAULT_INCLUDES の 2 箇所を修正。

上流コミット: c7ac7b1b6 (hengband/develop)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Updated dependency include paths to be treated as system headers, reducing warnings from external dependencies during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->