### PR TITLE
merge: GitHub Actions のWorkflow バージョンを最新に引き上げた（hengband#5501 相当）

### DIFF
--- a/.github/workflows/build-test-with-msvc.yml
+++ b/.github/workflows/build-test-with-msvc.yml
@@ -5,20 +5,24 @@ on:
   # 手動トリガーを許可
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-2025-vs2026
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Setup NuGet
-        uses: NuGet/setup-nuget@v2
+        uses: NuGet/setup-nuget@v4
 
       - name: Restore Nuget Packages
         run: |

--- a/.github/workflows/build-with-autotools.yml
+++ b/.github/workflows/build-with-autotools.yml
@@ -22,13 +22,17 @@ on:
         type: boolean
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           submodules: true
+          persist-credentials: false
 
       - id: calculate-cache-key
         name: Calculate cache key for ccache
@@ -37,7 +41,7 @@ jobs:
           echo "key=$key" >> $GITHUB_OUTPUT
 
       - if: ${{ inputs.use-ccache }}
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ steps.calculate-cache-key.outputs.key }}
           max-size: "200M"

--- a/.github/workflows/create-cache-for-ccache.yml
+++ b/.github/workflows/create-cache-for-ccache.yml
@@ -8,6 +8,9 @@ on:
   # 手動トリガーを許可
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   clang15_libcpp_without_pch_japanese:
     name: Japanese version with clang 15 -stdlib=libc++ (without using pre-compiled headers)

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,13 +9,18 @@ on:
 
 
 jobs:
-  publish-release-page:
-    name: Publish Release Page
+  build-release-package:
+    name: Build Windows Release Package
     runs-on: windows-2025
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Extract version from configure.ac
         id: get_version
@@ -24,10 +29,10 @@ jobs:
           echo "version=$version" >> $Env:GITHUB_OUTPUT
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Setup NuGet
-        uses: NuGet/setup-nuget@v2
+        uses: NuGet/setup-nuget@v4
 
       - name: Restore Nuget Packages
         run: |
@@ -37,12 +42,34 @@ jobs:
         run: |
           .\Build-Windows-Release-Package.ps1 -Version ${{ steps.get_version.outputs.version }}
 
+      - name: Upload release package
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-release-package
+          path: Bakabakaband-*.zip
+          if-no-files-found: error
+          overwrite: true
+
+  publish-release-page:
+    name: Publish Release Page
+    needs: build-release-package
+    runs-on: windows-2025
+    permissions:
+      contents: write
+    steps:
+      - name: Download release package
+        uses: actions/download-artifact@v8
+        with:
+          name: windows-release-package
+          path: .
+
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: Bakabakaband-*.zip
           fail_on_unmatched_files: true
-          name: ${{ steps.get_version.outputs.version }}
-          tag_name: ${{ steps.get_version.outputs.version }}
+          name: ${{ needs.build-release-package.outputs.version }}
+          tag_name: ${{ needs.build-release-package.outputs.version }}
+          target_commitish: ${{ github.sha }}
           generate_release_notes: true
           draft: true

--- a/.github/workflows/publish-spoiler-page.yml
+++ b/.github/workflows/publish-spoiler-page.yml
@@ -6,14 +6,18 @@ on:
   # 手動トリガーを許可
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   create_spoilers:
     name: Create auto generate spoiler files
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Install required packages
         run: |
@@ -39,25 +43,27 @@ jobs:
         run: nkf -w --in-place ~/.angband/Bakabakaband/*.txt
 
       - name: Upload spoilers
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: spoiler-files
           path: ~/.angband/Bakabakaband/*.txt
+          overwrite: true
 
 
   publish:
     name: Publish GitHub Pages of spoilers
     needs: create_spoilers
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       GITHUB_PAGES_REPOSITORY: bakabakaband/spoiler
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           repository: ${{ env.GITHUB_PAGES_REPOSITORY }}
+          persist-credentials: false
 
       - name: Download spoilers
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: spoiler-files
           path: spoilers
@@ -66,7 +72,7 @@ jobs:
         run: cp -v spoilers/*.txt docs/
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.SPOILER_REPOSITORY_DEPLOY_KEY }}
           publish_dir: ./docs

--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -7,26 +7,35 @@ on:
   # 手動トリガーを許可
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check_bom:
     name: Check the BOM of the source files
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - run: sh ./.github/scripts/check-bom.sh
 
   check_newline:
     name: Check the newline of files
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - run: sh ./.github/scripts/check-newline.sh
 
   check_format:
     name: Check the format of the source files
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Check the format of the cpp source and header files
         run: sh ./.github/scripts/check-cpp-format.sh
       - name: Check the format of the json/jsonc files
@@ -36,7 +45,9 @@ jobs:
     name: Check the include directive style
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Check the include directive style ("" vs <>)
         run: python3 .github/scripts/check-include-style.py
 
@@ -88,12 +99,14 @@ jobs:
     name: JSON Schema Validation (lib/edit + schema)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
-          python-version: '3.12'
+          python-version: '3.14'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
変愚蛮怒 PR #5501 を bakabakaband 構造に適応してマージ。
- 各 workflow の action を最新へ引き上げ (checkout v3/v4/v6→v7, setup-msbuild→v3, setup-nuget→v4, upload/download-artifact→v7/v8, ccache-action→v1.2.23, action-gh-release→v3, actions-gh-pages→v4, setup-python→v7 / Python 3.14)
- 各 workflow に permissions: contents: read を付与し権限を最小化、 checkout に persist-credentials: false を付与
- create-release.yml をビルドジョブとリリースジョブに分離し、 publish 側のみ contents: write を付与 (artifact 受け渡し)
- publish-spoiler-page の runner を ubuntu-22.04→24.04 に引き上げ

bakabakaband 固有の命名 (Bakabakaband.sln / Bakabakaband-*.zip / AC_INIT(bakabakaband / bakabakaband/spoiler / windows-2025 等) と 独自ジョブ構成 (clang15/clang14 22.04, json_schema_validation) は保持。

上流コミット: db3bf0534 e8057b89f d590d4ca3 65427b25f (hengband/develop)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted workflow access to read-only repository contents.
  * Disabled credential persistence during source checkout.

* **Maintenance**
  * Updated build, packaging, artifact, and deployment tooling.
  * Upgraded the validation environment to Python 3.14.

* **Release Improvements**
  * Separated release package building from release publishing.
  * Improved artifact handling and release version coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->