### PR TITLE
feat: 新アライアンス「大鷲の一族」を追加

### DIFF
--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
@@ -284,6 +284,7 @@
     <ClCompile Include="..\..\src\alliance\alliance-court-of-chaos.cpp" />
     <ClCompile Include="..\..\src\alliance\alliance-diabolique.cpp" />
     <ClCompile Include="..\..\src\alliance\alliance-dokachans.cpp" />
+    <ClCompile Include="..\..\src\alliance\alliance-eagle-clan.cpp" />
     <ClCompile Include="..\..\src\alliance\alliance-eldrazi.cpp" />
     <ClCompile Include="..\..\src\alliance\alliance-fangfamily.cpp" />
     <ClCompile Include="..\..\src\alliance\alliance-feanor-noldor.cpp" />
@@ -1154,6 +1155,7 @@
     <ClInclude Include="..\..\src\alliance\alliance-court-of-chaos.h" />
     <ClInclude Include="..\..\src\alliance\alliance-diabolique.h" />
     <ClInclude Include="..\..\src\alliance\alliance-dokachans.h" />
+    <ClInclude Include="..\..\src\alliance\alliance-eagle-clan.h" />
     <ClInclude Include="..\..\src\alliance\alliance-eldrazi.h" />
     <ClInclude Include="..\..\src\alliance\alliance-fangfamily.h" />
     <ClInclude Include="..\..\src\alliance\alliance-feanor-noldor.h" />

--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj.filters
@@ -2717,6 +2717,9 @@
     <ClCompile Include="..\..\src\alliance\alliance-dokachans.cpp">
       <Filter>alliance</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\alliance\alliance-eagle-clan.cpp">
+      <Filter>alliance</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\alliance\alliance-gaichi.cpp">
       <Filter>alliance</Filter>
     </ClCompile>
@@ -6005,6 +6008,9 @@
       <Filter>alliance</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\alliance\alliance-dokachans.h">
+      <Filter>alliance</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\alliance\alliance-eagle-clan.h">
       <Filter>alliance</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\alliance\alliance-gaichi.h">

--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -17162,6 +17162,7 @@
         "ja": "マンウェに遣わされた偉大な大鷲は人の言葉を話し、マイアールと同じ魂を持っていると言われる。この大鷲はその一族の一員である。",
         "en": "An agent of supernatural beings, this creature looks like a huge eagle.",
       },
+      "alliance": "EAGLE-CLAN",
       "flags": [
         "CAN_FLY",
         "WILD_ONLY",
@@ -19942,7 +19943,7 @@
         "ja": "マンウェに遣わされた偉大な大鷲は人の言葉を話し、マイアールと同じ魂を持っていると言われる。メネルドールは一族の中でグワイヒアとその弟ランドローバルに継いで速く、疾翼と呼ばれる。",
         "en": "An agent of supernatural beings, this creature looks like a huge eagle.",
       },
-      "alliance": "VALINOR",
+      "alliance": "EAGLE-CLAN",
       "flags": [
         "CAN_FLY",
         "UNIQUE",
@@ -21491,7 +21492,7 @@
         "ja": "マンウェに遣わされた偉大な大鷲は人の言葉を話し、マイアールと同じ魂を持っていると言われる。グワイヒアは大鷲の王であり、一族の中で最も強く、速い。これが風の支配者と呼ばれる所以である。",
         "en": "An agent of supernatural beings, this creature looks like a huge eagle.",
       },
-      "alliance": "VALINOR",
+      "alliance": "EAGLE-CLAN",
       "flags": [
         "CAN_FLY",
         "UNIQUE",
@@ -25044,7 +25045,7 @@
         "ja": "マンウェに遣わされた偉大な大鷲は人の言葉を話し、マイアールと同じ魂を持っていると言われる。ソロンドールは全ての大鷲のうちで最初に現れた者であり、最強かつ最大の王だ。その巨大な体を前にすればメルコールの卑小な召使い達は逃げ惑うことしか出来無い。",
         "en": "An agent of supernatural being, Thorondor is the lord of eagles.",
       },
-      "alliance": "VALINOR",
+      "alliance": "EAGLE-CLAN",
       "flags": [
         "CAN_FLY",
         "UNIQUE",

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -84,6 +84,7 @@ hengband_SOURCES = \
 	alliance/alliance-gondor.cpp alliance/alliance-gondor.h \
 	alliance/alliance-utumno.cpp alliance/alliance-utumno.h \
 	alliance/alliance-valverde.cpp alliance/alliance-valverde.h \
+	alliance/alliance-eagle-clan.cpp alliance/alliance-eagle-clan.h \
 	alliance/alliance-silvan-elf.cpp alliance/alliance-silvan-elf.h \
 	alliance/alliance-soukaiya.cpp alliance/alliance-soukaiya.h \
 	alliance/alliance-arioch.cpp alliance/alliance-arioch.h \

--- a/src/alliance/alliance-eagle-clan.cpp
+++ b/src/alliance/alliance-eagle-clan.cpp
@@ -1,0 +1,58 @@
+#include "alliance/alliance-eagle-clan.h"
+#include "alliance/alliance.h"
+#include "system/creature-entity.h"
+#include "system/enums/monrace/monrace-id.h"
+#include "system/monrace/monrace-definition.h"
+#include "system/monrace/monrace-list.h"
+
+/*!
+ * @brief 大鷲の一族の印象値を計算する
+ * @param creature クリーチャーへの参照
+ * @return 印象値
+ * @details マンウェに遣わされたマイアールの魂を持つ大鷲達は善なる者を好む。
+ * 善の傾向が強いほど印象が良くなり、悪の傾向は強く嫌われる。
+ * 一族の大鷲を殺害している場合は大幅な減点を受ける。
+ */
+int AllianceEagleClan::calcImpressionPoint(const CreatureEntity &creature) const
+{
+    int impression = 0;
+    impression += calcIronmanHostilityPenalty();
+
+    impression += (creature.alignment > 0) ? creature.alignment : creature.alignment * 3;
+
+    // 一族の大鷲を殺害した場合の減点
+    const auto &monrace_list = MonraceList::get_instance();
+    if (monrace_list.get_monrace(MonraceId::THORONDOR).r_pkills > 0) {
+        impression -= 3000; // 大鷲王『ソロンドール』を殺害
+    }
+    if (monrace_list.get_monrace(MonraceId::GWAIHIR).r_pkills > 0) {
+        impression -= 1500; // 風の支配者『グワイヒア』を殺害
+    }
+    if (monrace_list.get_monrace(MonraceId::MENELDOR).r_pkills > 0) {
+        impression -= 1000; // 疾翼『メネルドール』を殺害
+    }
+
+    return impression;
+}
+
+/*!
+ * @brief 大鷲の一族の制裁処理
+ * @param creature クリーチャーへの参照
+ */
+void AllianceEagleClan::panishment(CreatureEntity &creature)
+{
+    auto impression = calcImpressionPoint(creature);
+    if (isAnnihilated() || impression > -40) {
+        return;
+    }
+}
+
+/*!
+ * @brief 大鷲の一族が壊滅しているかを判定する
+ * @return 筆頭たる『ソロンドール』を含む主要な大鷲が全て絶滅していればtrue
+ */
+bool AllianceEagleClan::isAnnihilated()
+{
+    // 筆頭『ソロンドール』とグワイヒア・メネルドールが全て存在しなくなった場合、大鷲の一族は壊滅する
+    return all_monraces_extinct({ MonraceId::THORONDOR, MonraceId::GWAIHIR, MonraceId::MENELDOR });
+}

--- a/src/alliance/alliance-eagle-clan.h
+++ b/src/alliance/alliance-eagle-clan.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "alliance/alliance.h"
+
+class AllianceEagleClan : public Alliance {
+public:
+    using Alliance::Alliance;
+    AllianceEagleClan() = delete;
+    EnumClassFlagGroup<alliance_flags> alliFlags; //!< 陣営特性フラグ
+    int calcImpressionPoint(const CreatureEntity &creature) const override;
+    void panishment(CreatureEntity &creature) override;
+    bool isAnnihilated() override;
+    virtual ~AllianceEagleClan() = default;
+};

--- a/src/alliance/alliance.cpp
+++ b/src/alliance/alliance.cpp
@@ -15,6 +15,7 @@
 #include "alliance/alliance-court-of-chaos.h"
 #include "alliance/alliance-diabolique.h"
 #include "alliance/alliance-dokachans.h"
+#include "alliance/alliance-eagle-clan.h"
 #include "alliance/alliance-eldrazi.h"
 #include "alliance/alliance-fangfamily.h"
 #include "alliance/alliance-feanor-noldor.h"
@@ -157,6 +158,7 @@ const std::map<AllianceType, std::shared_ptr<Alliance>> alliance_list = {
     { AllianceType::DIABOLIQUE, std::make_unique<AllianceDiabolique>(AllianceType::DIABOLIQUE, "DIABOLIQUE", _("\u30c7\u30a2\u30dc\u30ea\u30ab", "Diabolique"), 5000000L) },
     { AllianceType::SOUKAIYA, std::make_unique<AllianceSoukaiya>(AllianceType::SOUKAIYA, "SOUKAIYA", _("ソウカイヤ", "Soukaiya"), 3000000L) },
     { AllianceType::YEEK_KINGDOM, std::make_unique<AllianceYeekKingdom>(AllianceType::YEEK_KINGDOM, "YEEK-KINGDOM", _("イークの王国", "Yeek Kingdom"), 15000L) },
+    { AllianceType::EAGLE_CLAN, std::make_unique<AllianceEagleClan>(AllianceType::EAGLE_CLAN, "EAGLE-CLAN", _("大鷲の一族", "Eagle Clan"), 2500000L, 600L) },
 };
 
 const std::map<std::tuple<AllianceType, AllianceType>, int> each_alliance_impression = {

--- a/src/alliance/alliance.h
+++ b/src/alliance/alliance.h
@@ -87,6 +87,7 @@ enum class AllianceType : int {
     DIABOLIQUE = 69, //!< デアボリカ
     SOUKAIYA = 70, //!< ソウカイヤ
     YEEK_KINGDOM = 71, //!< イークの王国
+    EAGLE_CLAN = 72, //!< 大鷲の一族
     MAX,
 };
 


### PR DESCRIPTION
ソロンドールを筆頭とする大鷲の一族 (Eagle Clan) を新規アライアンスとして追加。

- AllianceType::EAGLE_CLAN (72) を追加
- AllianceEagleClan クラス (alliance-eagle-clan.{h,cpp}) を新規作成
  - calcImpressionPoint: 善傾向を好み、一族の大鷲 (ソロンドール/ グワイヒア/メネルドール) 殺害で減点
  - isAnnihilated: 主要な大鷲が全て絶滅すると壊滅
- alliance_list への登録・Makefile.am・VisualStudio プロジェクトへ追加
- 大鷲系モンスター (Great eagle 335 / Meneldor 384 / Gwaihir 410 / Thorondor 468) を VALINOR から EAGLE-CLAN へ再割当。無所属だった Great eagle にも所属を付与