### PR TITLE
release: バージョンを 0.0.2.0 (Alpha) に更新

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT(bakabakaband, 0.0.1.4)
+AC_INIT(bakabakaband, 0.0.2.0)
 
 AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_HEADERS(src/autoconf.h)

--- a/doxygen/Bakabakaband.doxyfile
+++ b/doxygen/Bakabakaband.doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = Bakabakaband
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.0.1.4-Alpha
+PROJECT_NUMBER         = 0.0.2.0-Alpha
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -15,8 +15,8 @@ constexpr std::string_view VARIANT_NAME("Bakabaka");
  */
 #define H_VER_MAJOR 0 //!< ゲームのバージョン定義(メジャー番号)
 #define H_VER_MINOR 0 //!< ゲームのバージョン定義(マイナー番号)
-#define H_VER_PATCH 1 //!< ゲームのバージョン定義(パッチ番号)
-#define H_VER_EXTRA 4 //!< ゲームのバージョン定義(エクストラ番号)
+#define H_VER_PATCH 2 //!< ゲームのバージョン定義(パッチ番号)
+#define H_VER_EXTRA 0 //!< ゲームのバージョン定義(エクストラ番号)
 
 /*!
  * @brief セーブファイルのバージョン(3.0.0から導入)


### PR DESCRIPTION
0.0.2.0 α リリースに向けてバージョン表記を更新。

- configure.ac: AC_INIT のバージョンを 0.0.1.4 → 0.0.2.0
- src/system/angband-version.h: H_VER_PATCH 1 → 2 / H_VER_EXTRA 4 → 0 (angband.rc の FILEVERSION / PRODUCTVERSION、ゲーム内表示にも伝播)
- doxygen/Bakabakaband.doxyfile: PROJECT_NUMBER 0.0.1.4-Alpha → 0.0.2.0-Alpha

VERSION_STATUS は ALPHA のままのため、ゲーム内表記は
「馬鹿馬鹿蛮怒 0.0.2.0-Alpha」となる。


Claude-Session: https://claude.ai/code/session_01UvF89NNLNk3wZ5p14kfq1W