### PR TITLE
feat: トールキン善玉陣営の印象値にアライメント補正を追加

### DIFF
--- a/src/alliance/alliance-avarin-lords.cpp
+++ b/src/alliance/alliance-avarin-lords.cpp
@@ -10,6 +10,9 @@ int AllianceAvarinLords::calcImpressionPoint(const CreatureEntity &creature) con
     impression += Alliance::calcPlayerPower(creature, 10, 23);
     impression += calcIronmanHostilityPenalty();
 
+    // トールキンの善玉陣営: 善のアライメントほどそこそこプラス、悪の場合は大きめにマイナス
+    impression += (creature.alignment > 0) ? creature.alignment : creature.alignment * 3;
+
     // アヴァリ諸侯同盟のモンスター撃破による印象値低下
     const auto &monrace_list = MonraceList::get_instance();
 

--- a/src/alliance/alliance-feanor-noldor.cpp
+++ b/src/alliance/alliance-feanor-noldor.cpp
@@ -17,6 +17,9 @@ int AllianceFeanorNoldor::calcImpressionPoint(const CreatureEntity &creature) co
     impression += Alliance::calcPlayerPower(creature, 19, 26);
     impression += calcIronmanHostilityPenalty();
 
+    // トールキンの善玉陣営: 善のアライメントほどそこそこプラス、悪の場合は大きめにマイナス
+    impression += (creature.alignment > 0) ? creature.alignment : creature.alignment * 3;
+
     return impression;
 }
 

--- a/src/alliance/alliance-fingolfin-noldor.cpp
+++ b/src/alliance/alliance-fingolfin-noldor.cpp
@@ -18,6 +18,9 @@ int AllianceFingolfinNoldor::calcImpressionPoint(const CreatureEntity &creature)
     impression += Alliance::calcPlayerPower(creature, 17, 24);
     impression += calcIronmanHostilityPenalty();
 
+    // トールキンの善玉陣営: 善のアライメントほどそこそこプラス、悪の場合は大きめにマイナス
+    impression += (creature.alignment > 0) ? creature.alignment : creature.alignment * 3;
+
     return impression;
 }
 

--- a/src/alliance/alliance-gondor.cpp
+++ b/src/alliance/alliance-gondor.cpp
@@ -9,12 +9,14 @@
  * @return 印象ポイント
  * @details 現在は空実装
  */
-int AllianceGondor::calcImpressionPoint([[maybe_unused]] const CreatureEntity &creature) const
+int AllianceGondor::calcImpressionPoint(const CreatureEntity &creature) const
 {
     int impression = 0;
     impression += calcIronmanHostilityPenalty();
 
-    // TODO: ゴンドールの価値観に基づく印象ポイント計算を実装
+    // トールキンの善玉陣営: 善のアライメントほどそこそこプラス、悪の場合は大きめにマイナス
+    impression += (creature.alignment > 0) ? creature.alignment : creature.alignment * 3;
+
     return impression;
 }
 

--- a/src/alliance/alliance-shire.cpp
+++ b/src/alliance/alliance-shire.cpp
@@ -13,6 +13,9 @@ int AllianceTheShire::calcImpressionPoint([[maybe_unused]] const CreatureEntity 
 
     impression += Alliance::calcPlayerPower(creature, -10, 1);
 
+    // トールキンの善玉陣営: 善のアライメントほどそこそこプラス、悪の場合は大きめにマイナス
+    impression += (creature.alignment > 0) ? creature.alignment : creature.alignment * 3;
+
     // THE-SHIRE所属モンスターの殺害による印象値減少
     const std::string shire_tag = get_alliance_type_tag(AllianceType::THE_SHIRE);
     const std::string kill_key = "KILL/ALLIANCE/" + shire_tag;

--- a/src/alliance/alliance-silvan-elf.cpp
+++ b/src/alliance/alliance-silvan-elf.cpp
@@ -10,6 +10,9 @@ int AllianceSilvanElf::calcImpressionPoint(const CreatureEntity &creature) const
 
     impression += Alliance::calcPlayerPower(creature, 12, 25);
 
+    // トールキンの善玉陣営: 善のアライメントほどそこそこプラス、悪の場合は大きめにマイナス
+    impression += (creature.alignment > 0) ? creature.alignment : creature.alignment * 3;
+
     // シルヴァンエルフの指導者を殺害した場合の大幅減点
     const auto &monrace_list = MonraceList::get_instance();
     if (monrace_list.get_monrace(MonraceId::THRANDUIL).r_pkills > 0) {

--- a/src/alliance/alliance-valinor.cpp
+++ b/src/alliance/alliance-valinor.cpp
@@ -19,7 +19,8 @@ int AllianceValinor::calcImpressionPoint(const CreatureEntity &creature) const
     int impression = 0;
     impression += calcIronmanHostilityPenalty();
 
-    impression += (creature.alignment > 0) ? creature.alignment : -creature.alignment * 3;
+    // トールキンの善玉陣営: 善のアライメントほどそこそこプラス、悪の場合は大きめにマイナス
+    impression += (creature.alignment > 0) ? creature.alignment : creature.alignment * 3;
     impression += Alliance::calcPlayerPower(creature, -16, 30);
     return impression;
 }


### PR DESCRIPTION
トールキンの善玉陣営（ヴァリノール・ホビット庄・ゴンドール・
シルヴァン・エルフ・アヴァリ諸侯・フェアノール統/フィンゴルフィン統
ノルドール）の印象値計算に、プレイヤーのアライメントによる補正を追加。
善のアライメントほどそこそこプラス（+alignment）、悪の場合は
大きめにマイナス（alignment*3）を与える（大鷲の一族と同一の式）。

ヴァリノールは既存の三項演算子が悪アライメント時に
`-creature.alignment * 3`（負×負×3＝正）となり、悪のプレイヤーに
プラスを与える不具合があったため `creature.alignment * 3` に修正。

ゴンドールは空実装（TODO）だったため本補正で初期実装。