### PR TITLE
feat(C5): モンスター突然変異 curated セットに INVULN / SP_TO_HP を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -874,8 +874,11 @@ C トラック第 4 弾で、**JSON オプトイン方式**（既定=なし=バ�
   が担う。巨大なプレイヤー版（UI プロンプト・脱糞・`BadStatusSetter` の徳/構え副作用等
   深いプレイヤー結合）は改造せず、モンスターに意味のある能動変異のみ curated 実装:
   **BERS_RAGE**（激怒→恐怖解除+加速）/ **COWARDICE**（恐怖）/ **RTELEPORT**
-  （テレポート）/ **SPEED_FLUX**（速度変動）。効果は `set_monster_monfear/fast/slow` /
-  `teleport_away` 等モンスター安全なプリミティブで適用し、メッセージは視認時のみ。
+  （テレポート）/ **SPEED_FLUX**（速度変動）/ **INVULN**（一時無敵）/
+  **SP_TO_HP**（MP を消費して傷を癒す）。効果は `set_monster_monfear/fast/slow` /
+  `set_monster_invulner` / `teleport_away` / `heal_hp`+`sub_current_mp` 等モンスター
+  安全なプリミティブで適用し、メッセージは視認時のみ（HP 変化は視認対象なら
+  `HealthBarTracker` で再描画）。
 - 発火は `process_world()`（`TURNS_PER_TICK`=10 ゲームターン周期）のプレイヤー変異処理
   直後に変異持ちモンスターを走査して行うため、発動確率はプレイヤー版と同一周期で整合。
 - **未対応の変異は付与しても per-turn では発火しない**（上記 4 種以外）。受動変異

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3457,6 +3457,14 @@ per-turn 変異処理ループの新設（性能・正当性）、(b) 副作用�
   ・`teleport_away` 等**モンスター安全なプリミティブ**で適用。`BadStatusSetter`・
   UI プロンプト・脱糞等プレイヤー専用副作用や、モンスターに無意味な変異は扱わない。
   メッセージはモンスター視認時のみ。
+  - **C5-2b（curated セット拡充）**: 純粋にモンスター安全なプリミティブで完結する
+    能動変異 2 種を追加。**INVULN**（`!has_anti_magic()` かつ `one_in_(5000)` で
+    `set_monster_invulner()` により一時無敵化。視認時メッセージ）/ **SP_TO_HP**
+    （`one_in_(2000)` で傷がある場合、`get_current_mp()` を上限に `heal_hp()` で
+    HP を回復し `sub_current_mp()` で MP を消費。HP 変化は `HealthBarTracker` で
+    追跡対象時のみ再描画。プレイヤー版同様メッセージ無し）。いずれも死亡経路や
+    プレイヤー専用副作用を伴わない純粋自己効果のため安全。プレイヤー版
+    (`take_hit` を用いる `HP_TO_SP` 等) はモンスター死亡経路を要するため据え置き。
 - **C5-3（発火）**: `process_world()` のプレイヤー変異処理直後に、変異持ちモンスターを
   走査して `process_monster_mutation()` を呼ぶ。`process_world` 全体が
   `TURNS_PER_TICK`(10 ゲームターン)でゲートされるため**プレイヤーと同一周期**で、
@@ -3467,7 +3475,9 @@ per-turn 変異処理ループの新設（性能・正当性）、(b) 副作用�
 フルビルド (g++ -O3 -Werror) / clang-format-18 / validate_json.py で検証済。
 
 **将来拡張余地:** 対応変異の追加（受動変異の stat/耐性反映等）、モンスター視点での
-より豊かなメッセージ。現状は能動 4 種の最小 curated セット。
+より豊かなメッセージ、`HP_TO_SP` 等の死亡経路を伴う変異（`MonsterDamageProcessor`
+経由の自己ダメージ）。現状は能動 6 種の curated セット
+（BERS_RAGE / COWARDICE / RTELEPORT / SPEED_FLUX / INVULN / SP_TO_HP）。
 
 ---
 

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -56,6 +56,7 @@
 #include "target/target-setter.h"
 #include "target/target-types.h"
 #include "term/screen-processor.h"
+#include "tracking/health-bar-tracker.h"
 #include "view/display-messages.h"
 #include "world/world-collapsion.h"
 #include "world/world.h"
@@ -560,7 +561,7 @@ void process_world_aux_mutation(CreatureEntity &creature)
  * @param monster 対象モンスター
  * @details プレイヤー用 process_world_aux_mutation() とは分離した、モンスターに
  *          意味のある能動突然変異のみを扱う専用処理。効果はモンスター安全な
- *          プリミティブ (set_monster_* / teleport_away) で適用し、プレイヤー専用の
+ *          プリミティブ (set_monster_* / teleport_away / heal_hp 等) で適用し、プレイヤー専用の
  *          副作用 (BadStatusSetter の徳変化・UI プロンプト・脱糞等) は用いない。
  *          メッセージはモンスターが視認可能な時のみ表示する。
  */
@@ -617,6 +618,27 @@ void process_monster_mutation(CreatureEntity &player, CreatureEntity &monster)
             set_monster_fast(floor, m_idx, monster.get_timed_effect(CreatureTimedEffect::ACCELERATION) + randint1(30) + 10);
         }
         notify(_("%sの速度が急に変化した。", "%s^'s speed suddenly changes."));
+    }
+
+    // 一時的無敵 (INVULN)
+    if (muta.has(PlayerMutationType::INVULN) && !monster.has_anti_magic() && one_in_(5000)) {
+        set_monster_invulner(floor, m_idx, randint1(8) + 8, false);
+        notify(_("%sは無敵になった気がしているようだ！", "%s^ seems to feel invincible!"));
+    }
+
+    // MP を HP へ変換して傷を癒す (SP_TO_HP)
+    if (muta.has(PlayerMutationType::SP_TO_HP) && one_in_(2000)) {
+        const auto wounds = monster.get_max_hp() - monster.get_current_hp();
+        if (wounds > 0) {
+            auto healing = monster.get_current_mp();
+            if (healing > wounds) {
+                healing = wounds;
+            }
+
+            monster.heal_hp(healing);
+            monster.sub_current_mp(healing);
+            HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
+        }
     }
 }
 


### PR DESCRIPTION
CreatureEntity 統合 C トラック 提案 C5 の curated 能動変異セット
(process_monster_mutation) を拡充。純粋にモンスター安全なプリミティブで
完結する 2 種を追加した。

- INVULN: !has_anti_magic() かつ one_in_(5000) で set_monster_invulner() により一時無敵化。視認時のみ 3 人称メッセージ。
- SP_TO_HP: one_in_(2000) で傷がある場合、get_current_mp() を上限に heal_hp() で HP を回復し sub_current_mp() で MP を消費。HP 変化は 追跡対象時のみ HealthBarTracker で再描画。プレイヤー版同様メッセージ無し。

いずれも死亡経路やプレイヤー専用副作用を伴わない純粋自己効果のため安全。
既定 (JSON "mutations" 未指定) では発火せずバランス完全不変。プレイヤー版
process_world_aux_mutation() は一切変更していない。HP_TO_SP 等の自己ダメージ (MonsterDamageProcessor 経由の死亡経路) を要する変異は将来拡張として据え置き。

CLAUDE.md / docs/creature-entity-refactoring-roadmap.md の C5 節を更新。 フルビルド (g++ -O3 -Werror -Wall -Wextra) / clang-format-18 で検証済。