### PR TITLE
feat(C5): モンスター突然変異の受動変異反映 (REGEN / ESP) を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -881,8 +881,17 @@ C トラック第 4 弾で、**JSON オプトイン方式**（既定=なし=バ�
   `HealthBarTracker` で再描画）。
 - 発火は `process_world()`（`TURNS_PER_TICK`=10 ゲームターン周期）のプレイヤー変異処理
   直後に変異持ちモンスターを走査して行うため、発動確率はプレイヤー版と同一周期で整合。
-- **未対応の変異は付与しても per-turn では発火しない**（上記 4 種以外）。受動変異
-  （耐性・ESP 等）の反映は将来拡張。スキーマに `mutations` を登録済。
+- **受動変異の反映（常時効果、per-turn 処理ではなく既存クエリ仮想へ OR-in）:**
+  - **REGEN**（急回復）: `has_regen_flag()` のモンスター分岐へ `has_mutation(REGEN)` を
+    OR-in。native `REGENERATE` / 種族由来再生（C1第10弾）と同様に自然回復量を 2 倍化
+    （`compute_regen_amount`）。
+  - **ESP**（テレパシー）: `process_stealth()` の `has_race_granted_telepathy()`（C3第1弾）
+    判定へ `has_mutation(ESP)` を OR-in。忍者の超隠密を無視して常に気付く。
+  - **FEARLESS**（恐れ知らず）は特段の配線不要で既に反映済み。`has_resist_fear()` 仮想が
+    自由関数 `::has_resist_fear(*this)` を呼び、これがクリーチャー共通で `FEARLESS` 変異を
+    参照するため、変異を持つモンスターは自動的に恐怖耐性を得る。
+- **上記以外の未対応の能動変異は付与しても per-turn では発火しない**。その他の受動変異
+  （元素オーラ・AC 修正・能力値修正等）の反映は将来拡張。スキーマに `mutations` を登録済。
 
 ### モンスターの魔法領域詠唱 (`realm_abilities`) — 提案 C6
 

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3465,19 +3465,36 @@ per-turn 変異処理ループの新設（性能・正当性）、(b) 副作用�
     追跡対象時のみ再描画。プレイヤー版同様メッセージ無し）。いずれも死亡経路や
     プレイヤー専用副作用を伴わない純粋自己効果のため安全。プレイヤー版
     (`take_hit` を用いる `HP_TO_SP` 等) はモンスター死亡経路を要するため据え置き。
-- **C5-3（発火）**: `process_world()` のプレイヤー変異処理直後に、変異持ちモンスターを
-  走査して `process_monster_mutation()` を呼ぶ。`process_world` 全体が
-  `TURNS_PER_TICK`(10 ゲームターン)でゲートされるため**プレイヤーと同一周期**で、
-  発動確率(`one_in_(3000)` 等)がそのまま整合。大多数のモンスターは `none()` 即スキップ。
+  - **C5-3（発火）**: `process_world()` のプレイヤー変異処理直後に、変異持ちモンスターを
+    走査して `process_monster_mutation()` を呼ぶ。`process_world` 全体が
+    `TURNS_PER_TICK`(10 ゲームターン)でゲートされるため**プレイヤーと同一周期**で、
+    発動確率(`one_in_(3000)` 等)がそのまま整合。大多数のモンスターは `none()` 即スキップ。
+    HP 変化を伴う能動変異（SP_TO_HP 等）は追跡対象時のみ `HealthBarTracker` で再描画し、
+    メッセージはモンスター視認時のみ。**プレイヤー版 `HP_TO_SP`（`take_hit` で死亡し得る）は
+    モンスターの死亡経路（ドロップ・撃破クレジット等）を避ける必要があるため引き続き据え置きで、
+    モンスターには発火しない**（C5-2b と同方針。将来モンスターに導入する際は現在 HP を 1 残す
+    等の非致死変換ルールが前提となる）。
+  - **C5-2c（受動変異の反映）**: 常時効果の受動変異を、per-turn 処理ではなく
+    既存のクエリ仮想へ OR-in する形で反映（C1 の種族由来フラグ反映と同じ手法）。
+    **REGEN**（`has_regen_flag()` のモンスター分岐へ `has_mutation(REGEN)` を OR-in →
+    自然回復 2 倍化。C1第10弾の `has_race_granted_regeneration()` と同経路）/ **ESP**
+    （`process_stealth()` の `has_race_granted_telepathy()` 判定へ `has_mutation(ESP)` を
+    OR-in → 忍者の超隠密を無視。C3第1弾と同経路）を追加。**FEARLESS** は
+    `has_resist_fear()` 仮想が呼ぶ自由関数 `::has_resist_fear()` がクリーチャー共通で
+    `FEARLESS` 変異を参照するため**追加配線なしで既に反映済み**と確認。いずれも
+    JSON `"mutations"` opt-in（既定は付与個体ゼロ）でバランス不変。元素オーラ
+    （`has_sh_fire` 等はモンスター側が別系統 AuraType 管理）・AC/能力値修正は
+    monster 側メカニクスの差異が大きいため将来拡張。
 
 **バランス:** JSON `"mutations"` を指定した個体のみ発火。既定（未指定）は完全不変。
 **工数:** 中（3 コミット）。**価値:** 中（opt-in 個体に確率的な自己効果を付与）。
 フルビルド (g++ -O3 -Werror) / clang-format-18 / validate_json.py で検証済。
 
-**将来拡張余地:** 対応変異の追加（受動変異の stat/耐性反映等）、モンスター視点での
-より豊かなメッセージ、`HP_TO_SP` 等の死亡経路を伴う変異（`MonsterDamageProcessor`
-経由の自己ダメージ）。現状は能動 6 種の curated セット
-（BERS_RAGE / COWARDICE / RTELEPORT / SPEED_FLUX / INVULN / SP_TO_HP）。
+**将来拡張余地:** 受動変異の stat/AC/元素オーラ反映（monster 側メカニクス差異が大きい）、
+モンスター視点でのより豊かなメッセージ、`MonsterDamageProcessor` 経由で死亡し得る
+自己ダメージ変異の導入（現状の `HP_TO_SP` は非致死ガード付き）。現状は
+**能動 7 種**（BERS_RAGE / COWARDICE / RTELEPORT / SPEED_FLUX / INVULN / SP_TO_HP /
+HP_TO_SP）の curated セット＋**受動 3 種**（REGEN / ESP / FEARLESS）を反映済み。
 
 ---
 

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -55,6 +55,7 @@
 #include "mspell/mspell-attack.h"
 #include "mspell/mspell-judgement.h"
 #include "mspell/mspell-util.h"
+#include "mutation/mutation-flag-types.h"
 #include "object-enchant/trc-types.h"
 #include "object/object-kind-hook.h"
 #include "pet/pet-fall-off.h"
@@ -1044,7 +1045,9 @@ void process_monster(CreatureEntity &creature, MONSTER_IDX m_idx)
 bool process_stealth(CreatureEntity &creature, MONSTER_IDX m_idx)
 {
     // [提案C3第1弾] テレパシーを持つモンスターは忍者の超隠密を無視して常に気付く (opt-in・既定OFF)。
-    if (creature.get_floor()->get_monster(m_idx).has_race_granted_telepathy()) {
+    // [提案C5] テレパシー (ESP) 突然変異を持つモンスターも同様に超隠密を無視する (opt-in・既定OFF)。
+    const auto &stealth_target = creature.get_floor()->get_monster(m_idx);
+    if (stealth_target.has_race_granted_telepathy() || stealth_target.has_mutation(PlayerMutationType::ESP)) {
         return true;
     }
 

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -2468,7 +2468,8 @@ bool CreatureEntity::has_regen_flag() const
 {
     if (this->has_monster_profile()) {
         // [提案C1第10弾] 付与種族の再生 (TR_REGEN) も native REGENERATE と同様に自然回復を倍化 (opt-in・既定OFF)。
-        return this->get_monrace().misc_flags.has(MonsterMiscType::REGENERATE) || this->has_race_granted_regeneration();
+        // [提案C5] 再生 (REGEN) 突然変異を持つモンスターも同様に自然回復を倍化 (opt-in・既定OFF)。
+        return this->get_monrace().misc_flags.has(MonsterMiscType::REGENERATE) || this->has_race_granted_regeneration() || this->has_mutation(PlayerMutationType::REGEN);
     }
     return this->regenerate != 0;
 }


### PR DESCRIPTION
CreatureEntity 統合 C トラック 提案 C5 に受動 (常時効果) 変異の反映を追加。 per-turn の能動処理 (process_monster_mutation) ではなく、C1 種族由来フラグ反映と 同じく既存クエリ仮想へ OR-in する形で実装。

- REGEN (急回復): has_regen_flag() のモンスター分岐へ has_mutation(REGEN) を OR-in。native REGENERATE / 種族由来再生 (C1第10弾) と同経路で自然回復量を 2 倍化する (compute_regen_amount)。
- ESP (テレパシー): process_stealth() の has_race_granted_telepathy() (C3第1弾) 判定へ has_mutation(ESP) を OR-in。忍者の超隠密を無視して常に気付く。

あわせて FEARLESS (恐れ知らず) は has_resist_fear() 仮想が呼ぶ自由関数 ::has_resist_fear() がクリーチャー共通で FEARLESS 変異を参照するため、追加配線 なしで既に反映済みであることを確認・文書化した。

いずれも JSON "mutations" opt-in (現状は付与個体ゼロ) のため既定バランス完全不変。 元素オーラ (has_sh_fire 等はモンスター側が別系統 AuraType 管理) や AC/能力値修正は monster 側メカニクスの差異が大きいため将来拡張として据え置き。

monster-processor.cpp に mutation/mutation-flag-types.h を明示 include (GCC 対応)。 CLAUDE.md / docs/creature-entity-refactoring-roadmap.md の C5 節を更新。 フルビルド (g++ -O3 -Werror -Wall -Wextra) / clang-format-18 で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monsters with the ESP mutation can detect ninja super-stealth.
  * Monsters with the REGEN mutation now benefit from increased natural regeneration.
  * FEARLESS mutation effects continue to provide fear resistance.

* **Documentation**
  * Clarified supported passive and active mutation effects.
  * Documented non-lethal HP-to-spirit handling and updated the mutation roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->