### PR TITLE
feat(C5): モンスター突然変異の受動反映に加速系 (生成時速度) を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -893,6 +893,10 @@ C トラック第 4 弾で、**JSON オプトイン方式**（既定=なし=バ�
   - **AC 修正**（皮膚系）: `get_ac()` のモンスター分岐へプレイヤー版 `calc_to_ac()` と
     同じ加算値で反映。**WART_SKIN**（イボ肌 +5）/ **SCALES**（鱗肌 +10）/
     **IRON_SKIN**（鉄の肌 +25）。C2第3弾の DEX→AC 反映と同じ get_ac() 分岐。
+  - **加速修正**（生成時速度）: `place_monster_one()` の速度設定（C1第11弾の種族加速の
+    直後）へプレイヤー版と同じ加減速値で反映。**XTRA_LEGS**（+3）/ **SHORT_LEG**（-3）/
+    **XTRA_FAT**（-2）/ **WEAK_LOWER_BODY**（-2）。変異は `assign_fixed_mutations()` で
+    付与済みのため生成時に参照可能。静的な `speed` フィールドへ加算する固定反映。
 - **上記以外の未対応の能動変異は付与しても per-turn では発火しない**。その他の受動変異
   （元素オーラは monster 側が別系統 `MonsterAuraType` 管理・能力値修正等）の反映は将来拡張。
   スキーマに `mutations` を登録済。

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3484,10 +3484,13 @@ per-turn 変異処理ループの新設（性能・正当性）、(b) 副作用�
     `FEARLESS` 変異を参照するため**追加配線なしで既に反映済み**と確認。さらに
     **AC 修正の皮膚系変異**（**WART_SKIN** +5 / **SCALES** +10 / **IRON_SKIN** +25）を
     `get_ac()` のモンスター分岐へ、プレイヤー版 `calc_to_ac()` と同じ加算値で反映
-    （C2第3弾の DEX→AC と同じ get_ac() 分岐）。いずれも JSON `"mutations"` opt-in
+    （C2第3弾の DEX→AC と同じ get_ac() 分岐）。さらに **加速系変異**（**XTRA_LEGS** +3 /
+    **SHORT_LEG** -3 / **XTRA_FAT** -2 / **WEAK_LOWER_BODY** -2）を `place_monster_one()` の
+    生成時速度設定（C1第11弾の種族加速の直後、`assign_fixed_mutations()` 後）へ
+    プレイヤー版と同じ加減速値で反映。いずれも JSON `"mutations"` opt-in
     （既定は付与個体ゼロ）でバランス不変。元素オーラ（`has_sh_fire` 等はモンスター側が
     別系統 `MonsterAuraType` 管理で、被攻撃時の反撃サブシステムが player 側と逆方向）・
-    能力値修正は monster 側メカニクスの差異が大きいため将来拡張。
+    能力値修正（生成時 HP ロールとの順序依存があり要設計）は将来拡張。
   走査して `process_monster_mutation()` を呼ぶ。`process_world` 全体が
   `TURNS_PER_TICK`(10 ゲームターン)でゲートされるため**プレイヤーと同一周期**で、
   発動確率(`one_in_(3000)` 等)がそのまま整合。大多数のモンスターは `none()` 即スキップ。
@@ -3501,7 +3504,8 @@ per-turn 変異処理ループの新設（性能・正当性）、(b) 副作用�
 メッセージ、`MonsterDamageProcessor` 経由で死亡し得る自己ダメージ変異の導入
 （現状の `HP_TO_SP` は非致死ガード付き）。現状は **能動 7 種**（BERS_RAGE / COWARDICE /
 RTELEPORT / SPEED_FLUX / INVULN / SP_TO_HP / HP_TO_SP）の curated セット＋
-**受動 6 種**（REGEN / ESP / FEARLESS / WART_SKIN / SCALES / IRON_SKIN）を反映済み。
+**受動 10 種**（REGEN / ESP / FEARLESS / WART_SKIN / SCALES / IRON_SKIN /
+XTRA_LEGS / SHORT_LEG / XTRA_FAT / WEAK_LOWER_BODY）を反映済み。
 
 ---
 

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -32,6 +32,7 @@
 #include "monster/monster-timed-effects.h"
 #include "monster/monster-update.h"
 #include "monster/monster-util.h"
+#include "mutation/mutation-flag-types.h"
 #include "object/warning.h"
 #include "player-ability/player-ability-types.h"
 #include "player-base/player-class.h"
@@ -737,6 +738,22 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     if (m_ptr->has_race_granted_speed()) {
         constexpr short race_granted_speed_bonus = 3;
         m_ptr->speed += race_granted_speed_bonus;
+    }
+
+    // [提案C5] 加速系の突然変異を生成時速度へ反映 (opt-in・既定OFF)。
+    // プレイヤー版と同じ加減速値 (XTRA_LEGS +3 / SHORT_LEG -3 / XTRA_FAT -2 / WEAK_LOWER_BODY -2)。
+    // 変異は assign_fixed_mutations() (上記) で付与済みのためここで参照できる。
+    if (m_ptr->has_mutation(PlayerMutationType::XTRA_LEGS)) {
+        m_ptr->speed += 3;
+    }
+    if (m_ptr->has_mutation(PlayerMutationType::SHORT_LEG)) {
+        m_ptr->speed -= 3;
+    }
+    if (m_ptr->has_mutation(PlayerMutationType::XTRA_FAT)) {
+        m_ptr->speed -= 2;
+    }
+    if (m_ptr->has_mutation(PlayerMutationType::WEAK_LOWER_BODY)) {
+        m_ptr->speed -= 2;
     }
 
     if (any_bits(mode, PM_HASTE)) {


### PR DESCRIPTION
CreatureEntity 統合 C トラック 提案 C5 の受動変異反映を拡充。加速系の突然変異を place_monster_one() の生成時速度設定へ反映した (C1第11弾の種族加速の直後、 assign_fixed_mutations() 後で変異は付与済み)。

- XTRA_LEGS (余分な脚): +3 speed
- SHORT_LEG (短い脚): -3 speed
- XTRA_FAT (異常な肥満): -2 speed
- WEAK_LOWER_BODY (貧弱な下半身): -2 speed

加減速値はプレイヤー版と同一。静的な speed フィールドへ加算する固定反映で、
C1第11弾の種族加速 (+3) と同じ生成時アプローチ。

JSON "mutations" opt-in (現状は付与個体ゼロ) のため既定バランス完全不変。 能力値修正変異 (HYPER_STR 等) は生成時 HP ロール (CON 依存) との順序依存があり 要設計のため将来拡張として据え置き。one-monster-placer.cpp に
mutation/mutation-flag-types.h を明示 include (GCC 対応)。

CLAUDE.md / docs/creature-entity-refactoring-roadmap.md の C5 節を更新 (受動反映は 10 種に到達: REGEN / ESP / FEARLESS / WART_SKIN / SCALES / IRON_SKIN / XTRA_LEGS / SHORT_LEG / XTRA_FAT / WEAK_LOWER_BODY)。 フルビルド (g++ -O3 -Werror -Wall -Wextra) / clang-format-18 で検証済。