### PR TITLE
feat(C5): モンスター突然変異の受動反映に魔法防御 (MAGIC_RES) を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -897,6 +897,12 @@ C トラック第 4 弾で、**JSON オプトイン方式**（既定=なし=バ�
     直後）へプレイヤー版と同じ加減速値で反映。**XTRA_LEGS**（+3）/ **SHORT_LEG**（-3）/
     **XTRA_FAT**（-2）/ **WEAK_LOWER_BODY**（-2）。変異は `assign_fixed_mutations()` で
     付与済みのため生成時に参照可能。静的な `speed` フィールドへ加算する固定反映。
+  - **魔法防御**（セーヴ）: **MAGIC_RES**。`CreatureEntity::get_save_mutation_bonus()` が
+    プレイヤー版 skill_sav の加算（`15 + level/5`）と同じ補正を返し、レベル基準セーヴ判定の
+    実効レベルへ加算。C2第3弾の `get_save_stat_bonus()`（WIS）と同じ 3 サイト
+    （`spells-diceroll` の魅了/服従・状態異常、`effect-monster-psi`、`effect-monster-util` の
+    `monster_saves_status_by_level`）へ配線。C2 の `applies_stat_combat_bonus` ゲートとは
+    独立（MAGIC_RES 保有のみで発火）。
 - **上記以外の未対応の能動変異は付与しても per-turn では発火しない**。その他の受動変異
   （元素オーラは monster 側が別系統 `MonsterAuraType` 管理・能力値修正等）の反映は将来拡張。
   スキーマに `mutations` を登録済。

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3487,10 +3487,16 @@ per-turn 変異処理ループの新設（性能・正当性）、(b) 副作用�
     （C2第3弾の DEX→AC と同じ get_ac() 分岐）。さらに **加速系変異**（**XTRA_LEGS** +3 /
     **SHORT_LEG** -3 / **XTRA_FAT** -2 / **WEAK_LOWER_BODY** -2）を `place_monster_one()` の
     生成時速度設定（C1第11弾の種族加速の直後、`assign_fixed_mutations()` 後）へ
-    プレイヤー版と同じ加減速値で反映。いずれも JSON `"mutations"` opt-in
-    （既定は付与個体ゼロ）でバランス不変。元素オーラ（`has_sh_fire` 等はモンスター側が
-    別系統 `MonsterAuraType` 管理で、被攻撃時の反撃サブシステムが player 側と逆方向）・
-    能力値修正（生成時 HP ロールとの順序依存があり要設計）は将来拡張。
+    プレイヤー版と同じ加減速値で反映。さらに **魔法防御 MAGIC_RES** を
+    `get_save_mutation_bonus()`（プレイヤー版 skill_sav 加算 `15 + level/5` と同値）で
+    レベル基準セーヴの実効レベルへ加算。C2第3弾の `get_save_stat_bonus()`（WIS）と同じ
+    3 サイト（`spells-diceroll` の魅了/服従・状態異常、`effect-monster-psi`、
+    `effect-monster-util::monster_saves_status_by_level`）へ配線し、C2 の
+    `applies_stat_combat_bonus` ゲートとは独立に MAGIC_RES 保有のみで発火する。
+    いずれも JSON `"mutations"` opt-in（既定は付与個体ゼロ）でバランス不変。元素オーラ
+    （`has_sh_fire` 等はモンスター側が別系統 `MonsterAuraType` 管理で、被攻撃時の反撃
+    サブシステムが player 側と逆方向・複数攻撃サイトを跨ぐ）・能力値修正
+    （生成時 HP ロールとの順序依存があり要設計）は将来拡張。
   走査して `process_monster_mutation()` を呼ぶ。`process_world` 全体が
   `TURNS_PER_TICK`(10 ゲームターン)でゲートされるため**プレイヤーと同一周期**で、
   発動確率(`one_in_(3000)` 等)がそのまま整合。大多数のモンスターは `none()` 即スキップ。
@@ -3504,8 +3510,8 @@ per-turn 変異処理ループの新設（性能・正当性）、(b) 副作用�
 メッセージ、`MonsterDamageProcessor` 経由で死亡し得る自己ダメージ変異の導入
 （現状の `HP_TO_SP` は非致死ガード付き）。現状は **能動 7 種**（BERS_RAGE / COWARDICE /
 RTELEPORT / SPEED_FLUX / INVULN / SP_TO_HP / HP_TO_SP）の curated セット＋
-**受動 10 種**（REGEN / ESP / FEARLESS / WART_SKIN / SCALES / IRON_SKIN /
-XTRA_LEGS / SHORT_LEG / XTRA_FAT / WEAK_LOWER_BODY）を反映済み。
+**受動 11 種**（REGEN / ESP / FEARLESS / WART_SKIN / SCALES / IRON_SKIN /
+XTRA_LEGS / SHORT_LEG / XTRA_FAT / WEAK_LOWER_BODY / MAGIC_RES）を反映済み。
 
 ---
 

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -56,7 +56,8 @@ static bool resisted_psi_because_weird_mind_or_powerful(EffectMonster *em_ptr)
     has_resistance |= em_ptr->monrace->misc_flags.has(MonsterMiscType::WEIRD_MIND);
     has_resistance |= em_ptr->monrace->kind_flags.has(MonsterKindType::ANIMAL);
     // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の個体は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
-    has_resistance |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus()) > randint1(3 * em_ptr->dam));
+    // [提案C5・セーヴ] MAGIC_RES 突然変異のセーヴ補正も実効レベルへ加算 (opt-in・既定OFF)
+    has_resistance |= ((em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus() + em_ptr->m_ptr->get_save_mutation_bonus()) > randint1(3 * em_ptr->dam));
     if (!has_resistance) {
         return false;
     }

--- a/src/effect/effect-monster-util.cpp
+++ b/src/effect/effect-monster-util.cpp
@@ -85,6 +85,7 @@ bool target_race_resists_element(EffectMonster *em_ptr, tr_type res_flag)
 
 bool monster_saves_status_by_level(EffectMonster *em_ptr, int difficulty)
 {
-    const auto effective_level = em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus();
+    // [提案C2第3弾・セーヴ] WIS + [提案C5・セーヴ] MAGIC_RES 突然変異のセーヴ補正を実効レベルへ加算 (いずれも opt-in・既定OFF)
+    const auto effective_level = em_ptr->monrace->level + em_ptr->m_ptr->get_save_stat_bonus() + em_ptr->m_ptr->get_save_mutation_bonus();
     return effective_level > randint1(std::max(1, difficulty - 10)) + 10;
 }

--- a/src/spell/spells-diceroll.cpp
+++ b/src/spell/spells-diceroll.cpp
@@ -51,7 +51,8 @@ static bool common_saving_throw_impl(CreatureEntity &creature, int pow, const Cr
         pow = pow * 2 / 3;
     }
     // [提案C2第3弾・セーヴ] applies_stat_combat_bonus の対象は WIS セーヴ補正を実効レベルへ加算 (opt-in・既定OFF)
-    return ((monrace.level + target.get_save_stat_bonus()) > randint1((pow - 10) < 1 ? 1 : (pow - 10)) + 5);
+    // [提案C5・セーヴ] MAGIC_RES 突然変異のセーヴ補正も実効レベルへ加算 (opt-in・既定OFF)
+    return ((monrace.level + target.get_save_stat_bonus() + target.get_save_mutation_bonus()) > randint1((pow - 10) < 1 ? 1 : (pow - 10)) + 5);
 }
 
 /*!

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -2006,6 +2006,21 @@ int CreatureEntity::get_save_stat_bonus() const
     return static_cast<int>(adj_wis_sav[index]);
 }
 
+int CreatureEntity::get_save_mutation_bonus() const
+{
+    if (!this->has_monster_profile()) {
+        return 0;
+    }
+
+    // [提案C5] 魔法防御 (MAGIC_RES) 突然変異をレベル基準セーヴへ反映 (opt-in・既定OFF)。
+    // プレイヤー版 skill_sav の加算 (15 + level/5) に合わせる。
+    if (this->has_mutation(PlayerMutationType::MAGIC_RES)) {
+        return 15 + this->get_level() / 5;
+    }
+
+    return 0;
+}
+
 /*!
  * @brief 表示用の称号を取得する (提案 E5, 基底 = モンスター既定)
  * @details モンスターは称号を持たないため "なし" を返す。プレイヤーは

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -612,6 +612,16 @@ public:
     int get_save_stat_bonus() const;
 
     /*!
+     * @brief 魔法防御 (MAGIC_RES) 突然変異によるレベル基準セーヴ補正を返す [提案C5]
+     * @return 実効レベルへの加算値 (モンスター・MAGIC_RES 保有時のみ非 0)
+     * @details MAGIC_RES 突然変異を持つモンスターに、プレイヤー版 skill_sav の加算
+     * (15 + level/5) と同じ補正を返す。get_save_stat_bonus() と同じレベル基準セーヴ
+     * 判定 (monrace.level > randint1(...)) の実効レベルへ加算する。JSON "mutations"
+     * opt-in / プレイヤーでは 0 を返すため既定バランス不変。
+     */
+    int get_save_mutation_bonus() const;
+
+    /*!
      * @brief クリーチャーがプレイヤーかどうかを判定
      * @return プレイヤーならtrue、モンスターならfalse
      * @details デフォルトはfalse（モンスター）。PlayerTypeのみtrueを返す。


### PR DESCRIPTION
CreatureEntity 統合 C トラック 提案 C5 の受動変異反映を拡充。魔法防御 (MAGIC_RES) 突然変異をモンスターのレベル基準セーヴへ反映した。

- CreatureEntity::get_save_mutation_bonus() を新設。MAGIC_RES を持つモンスターに プレイヤー版 skill_sav の加算 (15 + level/5) と同じ補正を返す (プレイヤー・ 非保有では 0)。
- C2第3弾の get_save_stat_bonus() (WIS) と同じ 3 サイトへ配線: spells-diceroll (魅了/服従・状態異常)、effect-monster-psi、 effect-monster-util::monster_saves_status_by_level。実効レベル (monrace.level + ...) へ加算する。
- C2 の applies_stat_combat_bonus ゲートとは独立で、MAGIC_RES 保有のみで発火する (別 opt-in 系統のため get_save_stat_bonus とは別メソッドに分離)。

JSON "mutations" opt-in (現状は付与個体ゼロ) のため既定バランス完全不変。

CLAUDE.md / docs/creature-entity-refactoring-roadmap.md の C5 節を更新 (受動反映は 11 種に到達)。フルビルド (g++ -O3 -Werror -Wall -Wextra) / clang-format-18 で検証済。