### PR TITLE
feat(C5): モンスター突然変異の受動反映に自由行動 (MOTION) を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -887,9 +887,14 @@ C トラック第 4 弾で、**JSON オプトイン方式**（既定=なし=バ�
     （`compute_regen_amount`）。
   - **ESP**（テレパシー）: `process_stealth()` の `has_race_granted_telepathy()`（C3第1弾）
     判定へ `has_mutation(ESP)` を OR-in。忍者の超隠密を無視して常に気付く。
-  - **FEARLESS**（恐れ知らず）は特段の配線不要で既に反映済み。`has_resist_fear()` 仮想が
-    自由関数 `::has_resist_fear(*this)` を呼び、これがクリーチャー共通で `FEARLESS` 変異を
-    参照するため、変異を持つモンスターは自動的に恐怖耐性を得る。
+  - **自由行動**（睡眠/拘束耐性）: **MOTION**（正確で力強い動作＝`TR_FREE_ACT`）。
+    C1第5弾で `TR_FREE_ACT` を配線済みの `effect_monster_old_sleep` / `effect_monster_stasis`
+    （`effect-monster-oldies.cpp`）の `has_resistance` 集約へ `has_mutation(MOTION)` を OR-in。
+    魔法睡眠・拘束を無効化する。
+  - **FEARLESS**（恐れ知らず）/ **VULN_ELEM**（元素弱点）は特段の配線不要で既に反映済み。
+    `has_resist_fear()` / `has_vuln_fire()` 等の仮想が自由関数 `::has_resist_fear(*this)` /
+    `::has_vuln_X(*this)` を呼び、これらがクリーチャー共通で `FEARLESS` / `VULN_ELEM` 変異を
+    参照するため、変異を持つモンスターは自動的に恐怖耐性 / 元素弱点を得る。
   - **AC 修正**（皮膚系）: `get_ac()` のモンスター分岐へプレイヤー版 `calc_to_ac()` と
     同じ加算値で反映。**WART_SKIN**（イボ肌 +5）/ **SCALES**（鱗肌 +10）/
     **IRON_SKIN**（鉄の肌 +25）。C2第3弾の DEX→AC 反映と同じ get_ac() 分岐。

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3481,7 +3481,11 @@ per-turn 変異処理ループの新設（性能・正当性）、(b) 副作用�
     （`process_stealth()` の `has_race_granted_telepathy()` 判定へ `has_mutation(ESP)` を
     OR-in → 忍者の超隠密を無視。C3第1弾と同経路）を追加。**FEARLESS** は
     `has_resist_fear()` 仮想が呼ぶ自由関数 `::has_resist_fear()` がクリーチャー共通で
-    `FEARLESS` 変異を参照するため**追加配線なしで既に反映済み**と確認。さらに
+    `FEARLESS` 変異を参照するため**追加配線なしで既に反映済み**と確認（同様に **VULN_ELEM**
+    元素弱点も `has_vuln_*()` が自由関数経由で参照するため反映済み）。**MOTION**（正確で
+    力強い動作＝`TR_FREE_ACT`）は C1第5弾で `TR_FREE_ACT` を配線済みの
+    `effect_monster_old_sleep` / `effect_monster_stasis` の `has_resistance` 集約へ
+    `has_mutation(MOTION)` を OR-in し、魔法睡眠・拘束を無効化するよう追加。さらに
     **AC 修正の皮膚系変異**（**WART_SKIN** +5 / **SCALES** +10 / **IRON_SKIN** +25）を
     `get_ac()` のモンスター分岐へ、プレイヤー版 `calc_to_ac()` と同じ加算値で反映
     （C2第3弾の DEX→AC と同じ get_ac() 分岐）。さらに **加速系変異**（**XTRA_LEGS** +3 /
@@ -3510,8 +3514,11 @@ per-turn 変異処理ループの新設（性能・正当性）、(b) 副作用�
 メッセージ、`MonsterDamageProcessor` 経由で死亡し得る自己ダメージ変異の導入
 （現状の `HP_TO_SP` は非致死ガード付き）。現状は **能動 7 種**（BERS_RAGE / COWARDICE /
 RTELEPORT / SPEED_FLUX / INVULN / SP_TO_HP / HP_TO_SP）の curated セット＋
-**受動 11 種**（REGEN / ESP / FEARLESS / WART_SKIN / SCALES / IRON_SKIN /
-XTRA_LEGS / SHORT_LEG / XTRA_FAT / WEAK_LOWER_BODY / MAGIC_RES）を反映済み。
+**受動 13 種**（REGEN / ESP / FEARLESS / VULN_ELEM / MOTION / WART_SKIN / SCALES /
+IRON_SKIN / XTRA_LEGS / SHORT_LEG / XTRA_FAT / WEAK_LOWER_BODY / MAGIC_RES）を反映済み
+（FEARLESS / VULN_ELEM は自由関数経由で追加配線なし）。残る主要な未反映は元素オーラ
+（別系統 `MonsterAuraType`・多攻撃サイト）と能力値修正（monster 内部×10 スケールと
+player スケールの対応・生成時 HP ロール順序の設計が必要）。
 
 ---
 

--- a/src/effect/effect-monster-oldies.cpp
+++ b/src/effect/effect-monster-oldies.cpp
@@ -6,6 +6,7 @@
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
 #include "monster/monster-util.h"
+#include "mutation/mutation-flag-types.h"
 #include "object-enchant/tr-types.h"
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
@@ -244,6 +245,8 @@ ProcessResult effect_monster_old_sleep(CreatureEntity &creature, EffectMonster *
     has_resistance |= em_ptr->monrace->resistance_flags.has(MonsterResistanceType::NO_SLEEP);
     // [提案C1第5弾] 付与種族が自由行動 (TR_FREE_ACT) を持てば魔法睡眠を無効化 (opt-in・既定OFF)
     has_resistance |= target_race_resists_element(em_ptr, TR_FREE_ACT);
+    // [提案C5] 正確で力強い動作 (MOTION) 突然変異も自由行動として魔法睡眠を無効化 (opt-in・既定OFF)
+    has_resistance |= em_ptr->m_ptr->has_mutation(PlayerMutationType::MOTION);
     has_resistance |= monster_saves_status_by_level(em_ptr, em_ptr->dam);
 
     if (has_resistance) {
@@ -305,6 +308,8 @@ ProcessResult effect_monster_stasis(EffectMonster *em_ptr, bool to_evil)
     has_resistance |= monster_saves_status_by_level(em_ptr, em_ptr->dam);
     // [提案C1第5弾] 付与種族が自由行動 (TR_FREE_ACT) を持てば拘束(stasis)を無効化 (opt-in・既定OFF)
     has_resistance |= target_race_resists_element(em_ptr, TR_FREE_ACT);
+    // [提案C5] 正確で力強い動作 (MOTION) 突然変異も自由行動として拘束(stasis)を無効化 (opt-in・既定OFF)
+    has_resistance |= em_ptr->m_ptr->has_mutation(PlayerMutationType::MOTION);
     if (to_evil) {
         has_resistance |= em_ptr->monrace->kind_flags.has_not(MonsterKindType::EVIL);
     }


### PR DESCRIPTION
CreatureEntity 統合 C トラック 提案 C5 の受動変異反映を拡充。正確で力強い動作 (MOTION) 突然変異 (= TR_FREE_ACT 相当) を、C1第5弾で TR_FREE_ACT を配線済みの effect_monster_old_sleep / effect_monster_stasis (effect-monster-oldies.cpp) の has_resistance 集約へ has_mutation(MOTION) として OR-in。魔法睡眠・拘束を無効化する。

あわせて調査で判明した既反映変異を文書化: FEARLESS (恐怖耐性) と VULN_ELEM
(元素弱点) は has_resist_fear() / has_vuln_*() 仮想が自由関数を経由して クリーチャー共通で当該変異を参照するため、追加配線なしで既にモンスターへ反映済み。

JSON "mutations" opt-in (現状は付与個体ゼロ) のため既定バランス完全不変。 effect-monster-oldies.cpp に mutation/mutation-flag-types.h を明示 include (GCC 対応)。

CLAUDE.md / docs/creature-entity-refactoring-roadmap.md の C5 節を更新 (受動反映は 13 種に到達)。残る主要未反映は元素オーラ (別系統 MonsterAuraType) と 能力値修正 (スケール対応・HP ロール順序の設計要)。
フルビルド (g++ -O3 -Werror -Wall -Wextra) / clang-format-18 で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Creatures with the MOTION mutation are now immune to sleep and stasis effects.

* **Documentation**
  * Updated mutation documentation to clarify MOTION’s sleep/restraint immunity.
  * Clarified that elemental vulnerability is already applied through existing resistance and weakness handling.
  * Updated the passive mutation implementation roadmap and status counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->