### PR TITLE
feat(C5): モンスター突然変異の受動反映に能力値修正 13 種を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -902,14 +902,23 @@ C トラック第 4 弾で、**JSON オプトイン方式**（既定=なし=バ�
     直後）へプレイヤー版と同じ加減速値で反映。**XTRA_LEGS**（+3）/ **SHORT_LEG**（-3）/
     **XTRA_FAT**（-2）/ **WEAK_LOWER_BODY**（-2）。変異は `assign_fixed_mutations()` で
     付与済みのため生成時に参照可能。静的な `speed` フィールドへ加算する固定反映。
+  - **能力値修正**（生成時能力値）: `place_monster_one()` の `assign_fixed_mutations()` 直後で、
+    プレイヤー版と同じ表示値を内部 ×10 単位に換算し C1 `stat_modifiers` と同じ機構で
+    `stat_max/cur/max_max/use` へ加算。**HYPER_STR**（腕力+4）/ **PUNY**（腕力-4）/
+    **WEAK_LOWER_BODY**（腕力+2）/ **HYPER_INT**（知能・賢さ+4）/ **MORONIC**（知能・賢さ-4）/
+    **RESILIENT**（耐久+4）/ **XTRA_FAT**（耐久+2）/ **ALBINO**（耐久-4）/
+    **FLESH_ROT**（耐久-2・魅力-1）/ **SILLY_VOI**（魅力-4）/ **BLANK_FAC**（魅力-1）/
+    **LIMBER**（器用+3）/ **ARTHRITIS**（器用-3）。適用位置が所持金・最大MP・最大HP 算出の
+    前段のため、CHR→所持金・INT→最大MP・CON→最大HP に流れ、STR/DEX/WIS は C2 opt-in
+    (`applies_stat_combat_bonus`) の戦闘反映で用いられる。
   - **魔法防御**（セーヴ）: **MAGIC_RES**。`CreatureEntity::get_save_mutation_bonus()` が
     プレイヤー版 skill_sav の加算（`15 + level/5`）と同じ補正を返し、レベル基準セーヴ判定の
     実効レベルへ加算。C2第3弾の `get_save_stat_bonus()`（WIS）と同じ 3 サイト
     （`spells-diceroll` の魅了/服従・状態異常、`effect-monster-psi`、`effect-monster-util` の
     `monster_saves_status_by_level`）へ配線。C2 の `applies_stat_combat_bonus` ゲートとは
     独立（MAGIC_RES 保有のみで発火）。
-- **上記以外の未対応の能動変異は付与しても per-turn では発火しない**。その他の受動変異
-  （元素オーラは monster 側が別系統 `MonsterAuraType` 管理・能力値修正等）の反映は将来拡張。
+- **上記以外の未対応の能動変異は付与しても per-turn では発火しない**。残る主要な未反映は
+  元素オーラ（monster 側が別系統 `MonsterAuraType` 管理・複数攻撃サイトを跨ぐ）。
   スキーマに `mutations` を登録済。
 
 ### モンスターの魔法領域詠唱 (`realm_abilities`) — 提案 C6

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3497,10 +3497,20 @@ per-turn 変異処理ループの新設（性能・正当性）、(b) 副作用�
     3 サイト（`spells-diceroll` の魅了/服従・状態異常、`effect-monster-psi`、
     `effect-monster-util::monster_saves_status_by_level`）へ配線し、C2 の
     `applies_stat_combat_bonus` ゲートとは独立に MAGIC_RES 保有のみで発火する。
-    いずれも JSON `"mutations"` opt-in（既定は付与個体ゼロ）でバランス不変。元素オーラ
-    （`has_sh_fire` 等はモンスター側が別系統 `MonsterAuraType` 管理で、被攻撃時の反撃
-    サブシステムが player 側と逆方向・複数攻撃サイトを跨ぐ）・能力値修正
-    （生成時 HP ロールとの順序依存があり要設計）は将来拡張。
+    いずれも JSON `"mutations"` opt-in（既定は付与個体ゼロ）でバランス不変。
+  - **C5-2d（能力値修正変異）**: `place_monster_one()` の `assign_fixed_mutations()` 直後で、
+    プレイヤー版の表示値を内部 ×10 単位（reader が `modifier * 10` で格納する C1
+    `stat_modifiers` と同一スケール）に換算し、同じ機構で `stat_max/cur/max_max/use` へ加算。
+    16 エントリの表駆動（**HYPER_STR** STR+4 / **PUNY** STR-4 / **WEAK_LOWER_BODY** STR+2 /
+    **HYPER_INT** INT+4・WIS+4 / **MORONIC** INT-4・WIS-4 / **RESILIENT** CON+4 /
+    **XTRA_FAT** CON+2 / **ALBINO** CON-4 / **FLESH_ROT** CON-2・CHR-1 / **SILLY_VOI** CHR-4 /
+    **BLANK_FAC** CHR-1 / **LIMBER** DEX+3 / **ARTHRITIS** DEX-3）。適用位置が所持金
+    (`get_money_for_creature`)・最大MP (`calc_creature_mana`)・最大HP (`calc_max_hp_con_bonus`)
+    算出の前段のため、CHR→所持金・INT→最大MP・CON→最大HP に一貫して流れ、STR/DEX/WIS は
+    C2 opt-in (`applies_stat_combat_bonus`) の戦闘反映で用いられる。スケール対応・順序依存の
+    設計課題を解決して反映。いずれも JSON `"mutations"` opt-in（既定は付与個体ゼロ）で
+    バランス不変。元素オーラ（`has_sh_fire` 等はモンスター側が別系統 `MonsterAuraType` 管理で、
+    被攻撃時の反撃サブシステムが player 側と逆方向・複数攻撃サイトを跨ぐ）は将来拡張。
   走査して `process_monster_mutation()` を呼ぶ。`process_world` 全体が
   `TURNS_PER_TICK`(10 ゲームターン)でゲートされるため**プレイヤーと同一周期**で、
   発動確率(`one_in_(3000)` 等)がそのまま整合。大多数のモンスターは `none()` 即スキップ。
@@ -3514,11 +3524,12 @@ per-turn 変異処理ループの新設（性能・正当性）、(b) 副作用�
 メッセージ、`MonsterDamageProcessor` 経由で死亡し得る自己ダメージ変異の導入
 （現状の `HP_TO_SP` は非致死ガード付き）。現状は **能動 7 種**（BERS_RAGE / COWARDICE /
 RTELEPORT / SPEED_FLUX / INVULN / SP_TO_HP / HP_TO_SP）の curated セット＋
-**受動 13 種**（REGEN / ESP / FEARLESS / VULN_ELEM / MOTION / WART_SKIN / SCALES /
-IRON_SKIN / XTRA_LEGS / SHORT_LEG / XTRA_FAT / WEAK_LOWER_BODY / MAGIC_RES）を反映済み
+**受動 24 種**（REGEN / ESP / FEARLESS / VULN_ELEM / MOTION / WART_SKIN / SCALES /
+IRON_SKIN / XTRA_LEGS / SHORT_LEG / XTRA_FAT / WEAK_LOWER_BODY / MAGIC_RES ＋
+能力値修正 13 種 HYPER_STR / PUNY / HYPER_INT / MORONIC / RESILIENT / ALBINO /
+FLESH_ROT / SILLY_VOI / BLANK_FAC / LIMBER / ARTHRITIS 他）を反映済み
 （FEARLESS / VULN_ELEM は自由関数経由で追加配線なし）。残る主要な未反映は元素オーラ
-（別系統 `MonsterAuraType`・多攻撃サイト）と能力値修正（monster 内部×10 スケールと
-player スケールの対応・生成時 HP ロール順序の設計が必要）。
+（別系統 `MonsterAuraType`・多攻撃サイト）のみ。
 
 ---
 

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -581,6 +581,57 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
     // [提案 C5-1] JSON で突然変異が固定指定されたモンスターに付与 (付与のみ、per-turn 処理は別段)
     m_ptr->assign_fixed_mutations();
 
+    // [提案C5] 能力値修正の突然変異を生成時能力値へ反映 (opt-in・既定OFF)。プレイヤー版と同じ
+    // 表示値を内部 ×10 単位に換算し、C1 stat_modifiers と同じ機構で stat_max/cur/max_max/use へ
+    // 加算する。assign_fixed_mutations() 直後で適用するため、CON 変化は後段の最大HP
+    // (calc_max_hp_con_bonus)、INT 変化は最大MP (calc_creature_mana)、CHR 変化は所持金
+    // (get_money_for_creature) にそれぞれ流れる。STR/DEX/WIS 変化は C2 opt-in
+    // (applies_stat_combat_bonus) の戦闘反映で用いられる。
+    {
+        struct StatMutationMod {
+            PlayerMutationType mutation;
+            int stat;
+            int display_delta; // 表示単位 (内部は ×10)
+        };
+        static constexpr StatMutationMod stat_mutation_table[] = {
+            { PlayerMutationType::HYPER_STR, A_STR, 4 },
+            { PlayerMutationType::PUNY, A_STR, -4 },
+            { PlayerMutationType::WEAK_LOWER_BODY, A_STR, 2 },
+            { PlayerMutationType::HYPER_INT, A_INT, 4 },
+            { PlayerMutationType::HYPER_INT, A_WIS, 4 },
+            { PlayerMutationType::MORONIC, A_INT, -4 },
+            { PlayerMutationType::MORONIC, A_WIS, -4 },
+            { PlayerMutationType::RESILIENT, A_CON, 4 },
+            { PlayerMutationType::XTRA_FAT, A_CON, 2 },
+            { PlayerMutationType::ALBINO, A_CON, -4 },
+            { PlayerMutationType::FLESH_ROT, A_CON, -2 },
+            { PlayerMutationType::FLESH_ROT, A_CHR, -1 },
+            { PlayerMutationType::SILLY_VOI, A_CHR, -4 },
+            { PlayerMutationType::BLANK_FAC, A_CHR, -1 },
+            { PlayerMutationType::LIMBER, A_DEX, 3 },
+            { PlayerMutationType::ARTHRITIS, A_DEX, -3 },
+        };
+        int stat_muta_mod[A_MAX] = {};
+        for (const auto &entry : stat_mutation_table) {
+            if (m_ptr->has_mutation(entry.mutation)) {
+                stat_muta_mod[entry.stat] += entry.display_delta * 10;
+            }
+        }
+        for (auto stat = 0; stat < A_MAX; ++stat) {
+            if (stat_muta_mod[stat] == 0) {
+                continue;
+            }
+            auto adjusted = static_cast<int>(m_ptr->get_stat_max(stat)) + stat_muta_mod[stat];
+            adjusted = std::clamp(adjusted, static_cast<int>(STAT_MIN_VALUE), static_cast<int>(STAT_MAX_VALUE));
+            m_ptr->set_stat_max(stat, static_cast<short>(adjusted));
+            m_ptr->set_stat_cur(stat, static_cast<short>(adjusted));
+            // 突然変異は生得の恒久補正のため、負の変異でも本来の最大値 (stat_max_max) を
+            // 補正後の値へ同期する (「大きい時のみ更新」だと負の変異で ceiling が下がらない)。
+            m_ptr->set_stat_max_max(stat, m_ptr->get_stat_max(stat));
+            m_ptr->set_stat_use(stat, m_ptr->get_stat_max(stat));
+        }
+    }
+
     // 種族が指定されている場合、身長・体重を設定
     get_height_weight(*m_ptr);
 


### PR DESCRIPTION
CreatureEntity 統合 C トラック 提案 C5 の受動変異反映を拡充。能力値修正の突然変異を place_monster_one() の assign_fixed_mutations() 直後で生成時能力値へ反映した。

- 16 エントリの表駆動で以下を反映 (表示値): HYPER_STR(STR+4) / PUNY(STR-4) / WEAK_LOWER_BODY(STR+2) / HYPER_INT(INT+4,WIS+4) / MORONIC(INT-4,WIS-4) / RESILIENT(CON+4) / XTRA_FAT(CON+2) / ALBINO(CON-4) / FLESH_ROT(CON-2,CHR-1) / SILLY_VOI(CHR-4) / BLANK_FAC(CHR-1) / LIMBER(DEX+3) / ARTHRITIS(DEX-3)。

スケール対応: プレイヤー版の表示値を内部 ×10 単位 (reader が modifier*10 で格納する C1 stat_modifiers と同一スケール) に換算し、同じ機構で stat_max/cur/max_max/use へ clamp 付き加算する。適用位置が所持金 (get_money_for_creature)・最大MP (calc_creature_mana)・最大HP (calc_max_hp_con_bonus) 算出の前段のため、CHR→所持金・ INT→最大MP・CON→最大HP に一貫して流れ、STR/DEX/WIS は C2 opt-in
(applies_stat_combat_bonus) の戦闘反映で用いられる。ロードマップが要設計としていた スケール対応・順序依存を解決して反映。

JSON "mutations" opt-in (現状は付与個体ゼロ) のため既定バランス完全不変。C5 受動反映は 24 種に到達し、残る主要未反映は元素オーラ (別系統 MonsterAuraType) のみ。
CLAUDE.md / docs/creature-entity-refactoring-roadmap.md の C5 節を更新。 フルビルド (g++ -O3 -Werror -Wall -Wextra) / clang-format-18 で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monster mutations now apply stat bonuses and penalties when monsters are created.
  * Multiple mutations can affect the same attribute, with results reflected in strength, intelligence, wisdom, constitution, dexterity, and charisma.
  * Adjusted attributes now influence related gameplay values, including health, magic points, money, and combat performance.

* **Documentation**
  * Updated mutation and creature-generation documentation to reflect passive stat modifiers.
  * Clarified that elemental auras and unsupported active mutations remain deferred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->