### PR TITLE
feat(C5): モンスター突然変異の受動反映に元素オーラ (FIRE_BODY/ELEC_TOUC) を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -917,9 +917,15 @@ C トラック第 4 弾で、**JSON オプトイン方式**（既定=なし=バ�
     （`spells-diceroll` の魅了/服従・状態異常、`effect-monster-psi`、`effect-monster-util` の
     `monster_saves_status_by_level`）へ配線。C2 の `applies_stat_combat_bonus` ゲートとは
     独立（MAGIC_RES 保有のみで発火）。
-- **上記以外の未対応の能動変異は付与しても per-turn では発火しない**。残る主要な未反映は
-  元素オーラ（monster 側が別系統 `MonsterAuraType` 管理・複数攻撃サイトを跨ぐ）。
-  スキーマに `mutations` を登録済。
+  - **元素オーラ**（被攻撃反撃）: **FIRE_BODY**（火オーラ = `MonsterAuraType::FIRE`）/
+    **ELEC_TOUC**（電オーラ = `MonsterAuraType::ELEC`）。native の `aura_flags` を読む 3 経路
+    すべてへ「native オーラ ∨ 対応変異」で OR-in: プレイヤー被弾（`player-damage.cpp`
+    `process_aura_damage`）・モンスター対モンスター（`monster-attack-monster.cpp` の
+    `aura_fire/elec_by_melee`）・騎乗中の騎手被弾（`hp-mp-processor.cpp`）。思い出フラグ
+    (`r_aura_flags`) は **native オーラ時のみ記録**（変異由来は monrace 固有でないため非記録、
+    C1 の native ガードと同方針）。COLD オーラに対応する突然変異は無いため対象外。
+- **上記以外の未対応の能動変異は付与しても per-turn では発火しない**。スキーマに
+  `mutations` を登録済。**C5 の主要な変異反映（能動 7 種＋受動 26 種）は概ね完了。**
 
 ### モンスターの魔法領域詠唱 (`realm_abilities`) — 提案 C6
 

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3509,8 +3509,15 @@ per-turn 変異処理ループの新設（性能・正当性）、(b) 副作用�
     算出の前段のため、CHR→所持金・INT→最大MP・CON→最大HP に一貫して流れ、STR/DEX/WIS は
     C2 opt-in (`applies_stat_combat_bonus`) の戦闘反映で用いられる。スケール対応・順序依存の
     設計課題を解決して反映。いずれも JSON `"mutations"` opt-in（既定は付与個体ゼロ）で
-    バランス不変。元素オーラ（`has_sh_fire` 等はモンスター側が別系統 `MonsterAuraType` 管理で、
-    被攻撃時の反撃サブシステムが player 側と逆方向・複数攻撃サイトを跨ぐ）は将来拡張。
+    バランス不変。
+  - **C5-2e（元素オーラ変異）**: **FIRE_BODY**（火オーラ）/ **ELEC_TOUC**（電オーラ）を、
+    native `aura_flags` を読む 3 経路すべてへ「native オーラ ∨ 対応変異」で OR-in:
+    プレイヤー被弾（`player-damage.cpp::process_aura_damage`）・モンスター対モンスター
+    （`monster-attack-monster.cpp` の `aura_fire/elec_by_melee`）・騎乗中の騎手被弾
+    （`hp-mp-processor.cpp`）。思い出フラグ (`r_aura_flags`) は **native オーラ時のみ記録**
+    （変異由来は monrace 固有でないため非記録、C1 の native ガードと同方針）。COLD オーラに
+    対応する突然変異は無いため対象外。ロードマップが最後に残していた「別系統
+    `MonsterAuraType`・逆方向・多攻撃サイト」の課題を、各サイトへ最小 OR-in する形で解決。
   走査して `process_monster_mutation()` を呼ぶ。`process_world` 全体が
   `TURNS_PER_TICK`(10 ゲームターン)でゲートされるため**プレイヤーと同一周期**で、
   発動確率(`one_in_(3000)` 等)がそのまま整合。大多数のモンスターは `none()` 即スキップ。
@@ -3524,12 +3531,12 @@ per-turn 変異処理ループの新設（性能・正当性）、(b) 副作用�
 メッセージ、`MonsterDamageProcessor` 経由で死亡し得る自己ダメージ変異の導入
 （現状の `HP_TO_SP` は非致死ガード付き）。現状は **能動 7 種**（BERS_RAGE / COWARDICE /
 RTELEPORT / SPEED_FLUX / INVULN / SP_TO_HP / HP_TO_SP）の curated セット＋
-**受動 24 種**（REGEN / ESP / FEARLESS / VULN_ELEM / MOTION / WART_SKIN / SCALES /
-IRON_SKIN / XTRA_LEGS / SHORT_LEG / XTRA_FAT / WEAK_LOWER_BODY / MAGIC_RES ＋
-能力値修正 13 種 HYPER_STR / PUNY / HYPER_INT / MORONIC / RESILIENT / ALBINO /
-FLESH_ROT / SILLY_VOI / BLANK_FAC / LIMBER / ARTHRITIS 他）を反映済み
-（FEARLESS / VULN_ELEM は自由関数経由で追加配線なし）。残る主要な未反映は元素オーラ
-（別系統 `MonsterAuraType`・多攻撃サイト）のみ。
+**受動 26 種**（REGEN / ESP / FEARLESS / VULN_ELEM / MOTION / FIRE_BODY / ELEC_TOUC /
+WART_SKIN / SCALES / IRON_SKIN / XTRA_LEGS / SHORT_LEG / XTRA_FAT / WEAK_LOWER_BODY /
+MAGIC_RES ＋ 能力値修正 13 種 HYPER_STR / PUNY / HYPER_INT / MORONIC / RESILIENT /
+ALBINO / FLESH_ROT / SILLY_VOI / BLANK_FAC / LIMBER / ARTHRITIS 他）を反映済み
+（FEARLESS / VULN_ELEM は自由関数経由で追加配線なし）。**C5 の主要な変異反映は概ね完了。**
+残るのは効果がモンスターに意味を持ちにくい細かな変異（XTRA_EYES 探索・INFRAVIS 等）のみ。
 
 ---
 

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -10,6 +10,7 @@
 #include "inventory/inventory-slot-types.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
+#include "mutation/mutation-flag-types.h"
 #include "object-enchant/object-ego.h"
 #include "object-enchant/tr-types.h"
 #include "object-enchant/trc-types.h"
@@ -314,8 +315,12 @@ void process_player_hp_mp(CreatureEntity &creature)
 
     if (creature.get_riding()) {
         int damage;
-        auto auras = floor.get_monster(creature.get_riding()).get_monrace().aura_flags;
-        if (auras.has(MonsterAuraType::FIRE) && !creature.has_immune_fire()) {
+        const auto &mount = floor.get_monster(creature.get_riding());
+        auto auras = mount.get_monrace().aura_flags;
+        // [提案C5] 騎乗中のモンスターの FIRE_BODY / ELEC_TOUC 突然変異も native オーラと同様に騎手へ反撃 (opt-in・既定OFF)
+        const auto mount_fire_aura = auras.has(MonsterAuraType::FIRE) || mount.has_mutation(PlayerMutationType::FIRE_BODY);
+        const auto mount_elec_aura = auras.has(MonsterAuraType::ELEC) || mount.has_mutation(PlayerMutationType::ELEC_TOUC);
+        if (mount_fire_aura && !creature.has_immune_fire()) {
             damage = floor.get_monster(creature.get_riding()).get_monrace().level / 2;
             if (race.tr_flags().has(TR_VUL_FIRE)) {
                 damage += damage / 3;
@@ -332,7 +337,7 @@ void process_player_hp_mp(CreatureEntity &creature)
             take_hit(creature, DAMAGE_NOESCAPE, damage, _("炎のオーラ", "Fire aura"));
         }
 
-        if (auras.has(MonsterAuraType::ELEC) && !creature.has_immune_elec()) {
+        if (mount_elec_aura && !creature.has_immune_elec()) {
             damage = floor.get_monster(creature.get_riding()).get_monrace().level / 2;
             if (race.tr_flags().has(TR_VUL_ELEC)) {
                 damage += damage / 3;

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -30,6 +30,7 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
+#include "mutation/mutation-flag-types.h"
 #include "spell-kind/spells-teleport.h"
 #include "spell-realm/spells-hex.h"
 #include "system/creature-entity.h"
@@ -85,7 +86,9 @@ static void aura_fire_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
 {
     auto &monrace = mam_ptr->m_ptr->get_monrace();
     auto &monrace_target = mam_ptr->t_ptr->get_monrace();
-    if (monrace_target.aura_flags.has_not(MonsterAuraType::FIRE) || !mam_ptr->m_ptr->is_valid()) {
+    // [提案C5] FIRE_BODY 突然変異も native 火オーラと同様に反撃 (opt-in・既定OFF)
+    const auto has_native_aura = monrace_target.aura_flags.has(MonsterAuraType::FIRE);
+    if ((!has_native_aura && !mam_ptr->t_ptr->has_mutation(PlayerMutationType::FIRE_BODY)) || !mam_ptr->m_ptr->is_valid()) {
         return;
     }
 
@@ -98,7 +101,8 @@ static void aura_fire_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
         msg_format(_("%s^は突然熱くなった！", "%s^ is suddenly very hot!"), mam_ptr->m_name);
     }
 
-    if (mam_ptr->m_ptr->is_visible_on_map() && is_original_ap_and_seen(creature, *mam_ptr->t_ptr)) {
+    // 種族由来 (native) オーラのみ思い出フラグを記録する (mutation 由来は monrace 固有でないため記録しない)
+    if (has_native_aura && mam_ptr->m_ptr->is_visible_on_map() && is_original_ap_and_seen(creature, *mam_ptr->t_ptr)) {
         monrace_target.aura_flags.set(MonsterAuraType::FIRE);
     }
 
@@ -139,7 +143,9 @@ static void aura_elec_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
     const auto &monster = *mam_ptr->m_ptr;
     auto &monrace = monster.get_monrace();
     auto &monrace_target = mam_ptr->t_ptr->get_monrace();
-    if (monrace_target.aura_flags.has_not(MonsterAuraType::ELEC) || !monster.is_valid()) {
+    // [提案C5] ELEC_TOUC 突然変異も native 電オーラと同様に反撃 (opt-in・既定OFF)
+    const auto has_native_aura = monrace_target.aura_flags.has(MonsterAuraType::ELEC);
+    if ((!has_native_aura && !mam_ptr->t_ptr->has_mutation(PlayerMutationType::ELEC_TOUC)) || !monster.is_valid()) {
         return;
     }
 
@@ -152,7 +158,8 @@ static void aura_elec_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
         msg_format(_("%s^は電撃を食らった！", "%s^ gets zapped!"), mam_ptr->m_name);
     }
 
-    if (monster.is_visible_on_map() && is_original_ap_and_seen(creature, *mam_ptr->t_ptr)) {
+    // 種族由来 (native) オーラのみ思い出フラグを記録する (mutation 由来は monrace 固有でないため記録しない)
+    if (has_native_aura && monster.is_visible_on_map() && is_original_ap_and_seen(creature, *mam_ptr->t_ptr)) {
         monrace_target.aura_flags.set(MonsterAuraType::ELEC);
     }
 

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -715,17 +715,37 @@ void PlayerType::on_death(std::string_view cause)
  * @param dam_func ダメージ処理を行う関数の参照ポインタ
  * @param message オーラダメージを受けた際のメッセージ
  */
+/*!
+ * @brief オーラ属性に対応する突然変異をソースが持つか [提案C5]
+ * @details FIRE_BODY→火オーラ / ELEC_TOUC→電オーラ。COLD オーラに対応する突然変異は無い。
+ * opt-in (JSON "mutations") 個体のみ true。プレイヤー・非対応では false。
+ */
+static bool source_has_aura_by_mutation(const CreatureEntity &source, MonsterAuraType aura_flag)
+{
+    switch (aura_flag) {
+    case MonsterAuraType::FIRE:
+        return source.has_mutation(PlayerMutationType::FIRE_BODY);
+    case MonsterAuraType::ELEC:
+        return source.has_mutation(PlayerMutationType::ELEC_TOUC);
+    default:
+        return false;
+    }
+}
+
 static void process_aura_damage(const CreatureEntity &source, CreatureEntity &creature, bool immune, MonsterAuraType aura_flag, dam_func dam_func, concptr message)
 {
     auto &monrace = source.get_monrace();
-    if (monrace.aura_flags.has_not(aura_flag) || immune) {
+    const auto has_native_aura = monrace.aura_flags.has(aura_flag);
+    // [提案C5] FIRE_BODY→火オーラ / ELEC_TOUC→電オーラ 突然変異も native オーラと同様に反撃 (opt-in・既定OFF)
+    if ((!has_native_aura && !source_has_aura_by_mutation(source, aura_flag)) || immune) {
         return;
     }
 
     int aura_damage = Dice::roll(1 + (monrace.level / 26), 1 + (monrace.level / 17));
     msg_print(message);
     (*dam_func)(creature, aura_damage, monster_desc(creature, source, MD_WRONGDOER_NAME).data(), true);
-    if (is_original_ap_and_seen(creature, source)) {
+    // 種族由来 (native) オーラのみ思い出フラグを記録する (mutation 由来は monrace 固有でないため記録しない)
+    if (has_native_aura && is_original_ap_and_seen(creature, source)) {
         monrace.r_aura_flags.set(aura_flag);
     }
 


### PR DESCRIPTION
CreatureEntity 統合 C トラック 提案 C5 の受動変異反映を拡充。元素オーラの突然変異を 被攻撃反撃の 3 経路すべてへ反映し、C5 変異反映の最後の主要課題を解決した。

- FIRE_BODY (火オーラ = MonsterAuraType::FIRE) / ELEC_TOUC (電オーラ = ELEC) を、 native aura_flags を読む 3 経路へ「native オーラ ∨ 対応変異」で OR-in:
  - プレイヤー被弾: player-damage.cpp::process_aura_damage
  - モンスター対モンスター: monster-attack-monster.cpp の aura_fire/elec_by_melee
  - 騎乗中の騎手被弾: hp-mp-processor.cpp
- 思い出フラグ (r_aura_flags) は native オーラ時のみ記録 (変異由来は monrace 固有で ないため非記録。C1 の native ガードと同方針)。
- COLD オーラに対応する突然変異は無いため対象外。

これによりロードマップが最後に残していた「別系統 MonsterAuraType・逆方向・多攻撃
サイト」の課題を、各サイトへ最小 OR-in する形で解決。JSON "mutations" opt-in (現状は付与個体ゼロ) のため既定バランス完全不変。3 ファイルに
mutation/mutation-flag-types.h を明示 include (GCC 対応)。

CLAUDE.md / docs/creature-entity-refactoring-roadmap.md の C5 節を更新 (C5 の主要な 変異反映は概ね完了)。フルビルド (g++ -O3 -Werror -Wall -Wextra) / clang-format-18 で検証済。