### PR TITLE
feat(C6): モンスター魔法領域詠唱に第2領域 (realm_abilities2) を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -953,8 +953,19 @@ HISSATSU / HEX）を参照。
   (`src/mspell/mspell-attack-util.cpp` の `add_realm_granted_abilities()`)。
 - 写像表は保守的な初期セット（10 魔法領域。MUSIC/HISSATSU/HEX は未マッピング）で、
   バランス調整・拡張はこの表で行う。
+- **第2弾（`realm_abilities2` 併用）:** `MonraceDefinition::realm_abilities2`
+  （`RealmType`、既定 `NONE`）を追加。`realm_abilities` と併用でき、両 realm 由来の
+  `MonsterAbilityType` 群が `msa_type` 構築時に OR-in される（**二重詠唱者**）。
+  プレイヤーの realm1/realm2 に相当する二領域運用を可能にする。reader は共通ヘルパ
+  `parse_realm_ability_token()` を両フィールドで共用。
+
+  ```jsonc
+  "realm_abilities": "CHAOS",
+  "realm_abilities2": "DEATH"
+  ```
 - 実際に撃たせるには当該 monrace に `freq_spell > 0`（詠唱頻度）が必要。
-- 既定 `NONE` のため実データ・既定バランスは不変。スキーマに `realm_abilities` を登録済。
+- 既定 `NONE` のため実データ・既定バランスは不変。スキーマに `realm_abilities` /
+  `realm_abilities2` を登録済。
 
 ### モンスターの継続毒 (`suffers_poison_dot`) — 提案 D7
 

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3594,7 +3594,22 @@ JSON `"realm_abilities": "CHAOS"` を指定した個体は、詠唱時（`msa_ty
   monrace に `freq_spell > 0` が要る（メンテナのデータ設定）。
 - フルビルド (g++ -O3 -Werror) / clang-format-18 / validate_json.py で検証済。
 
-**将来拡張余地:** 写像表の精緻化、realm2 の併用、realm レベル依存の能力段階化。
+### ✅ 第2弾 完了（realm2 併用）
+
+**完了内容:** `MonraceDefinition::realm_abilities2`（`RealmType`、既定 `NONE`）を追加。
+`realm_abilities` と併用でき、`msa_type` 構築時に両 realm 由来の `MonsterAbilityType` を
+順に OR-in する（**二重詠唱者**＝プレイヤーの realm1/realm2 に相当）。
+
+- reader は共通ヘルパ `parse_realm_ability_token(json, RealmType&)` を新設し、
+  `set_mon_realm_abilities` / `set_mon_realm_abilities2` の両者が共用（重複排除）。
+  schema に `realm_abilities2` を登録。
+- 写像は既存の `add_realm_granted_abilities()` を第2 realm にもそのまま適用するため、
+  10 realm 表をそのまま二領域で再利用（新規写像コードなし）。
+- **既定 `NONE` のため実データ・既定バランス不変。** フルビルド (g++ -O3 -Werror) /
+  clang-format-18 / validate_json.py で検証済。
+
+**将来拡張余地:** 写像表の精緻化、realm レベル依存の能力段階化、MUSIC/HISSATSU/HEX の
+技術領域マッピング（サステイン/技系のため要設計）。
 
 ---
 

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -193,6 +193,10 @@
                         "type": "string",
                         "description": "詠唱能力を付与する魔法領域 (提案C6)。トークンは r_info_realm を参照。指定するとその realm 由来の MonsterAbilityType が詠唱時に追加される。既定=なし=オプトイン。"
                     },
+                    "realm_abilities2": {
+                        "type": "string",
+                        "description": "詠唱能力を付与する第2魔法領域 (提案C6第2弾)。realm_abilities と併用でき、二重詠唱者となる。トークンは r_info_realm を参照。既定=なし=オプトイン。"
+                    },
                     "suffers_poison_dot": {
                         "type": "boolean",
                         "description": "毒攻撃で継続毒(POISON DoT)を受けるか (提案D7)。既定false=オプトイン。trueの個体のみ毒攻撃後に継続ダメージを受ける。"

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -383,15 +383,15 @@ errr RaceReader::set_mon_player_class(const nlohmann::json &class_data, MonraceD
 }
 
 /*!
- * @brief JSON Objectからモンスターの詠唱魔法領域を設定する (提案C6)
+ * @brief JSON Objectからモンスターの詠唱魔法領域トークンを解析する共通ヘルパ (提案C6)
  * @param realm_data 魔法領域情報の格納されたJSON Object (文字列)
- * @param monrace 保管先のモンスター種族構造体
+ * @param target 保管先の RealmType (realm_abilities / realm_abilities2)
  * @return エラーコード
  * @details 未指定 (null) なら RealmType::NONE のまま。指定時は詠唱 (mspell) 実行時に
  *          その realm 由来の MonsterAbilityType 群が能力に追加される (効果反映)。
- *          トークンは r_info_realm を参照。
+ *          トークンは r_info_realm を参照。set_mon_realm_abilities / *2 の両者が使う。
  */
-errr RaceReader::set_mon_realm_abilities(const nlohmann::json &realm_data, MonraceDefinition &monrace)
+static errr parse_realm_ability_token(const nlohmann::json &realm_data, RealmType &target)
 {
     if (realm_data.is_null()) {
         return PARSE_ERROR_NONE;
@@ -404,8 +404,18 @@ errr RaceReader::set_mon_realm_abilities(const nlohmann::json &realm_data, Monra
     if (!info_grab_one_const(realm, r_info_realm, realm_data.get<std::string>())) {
         return PARSE_ERROR_INVALID_FLAG;
     }
-    monrace.realm_abilities = static_cast<RealmType>(realm);
+    target = static_cast<RealmType>(realm);
     return PARSE_ERROR_NONE;
+}
+
+errr RaceReader::set_mon_realm_abilities(const nlohmann::json &realm_data, MonraceDefinition &monrace)
+{
+    return parse_realm_ability_token(realm_data, monrace.realm_abilities);
+}
+
+errr RaceReader::set_mon_realm_abilities2(const nlohmann::json &realm_data, MonraceDefinition &monrace)
+{
+    return parse_realm_ability_token(realm_data, monrace.realm_abilities2);
 }
 
 /*!
@@ -1549,6 +1559,11 @@ errr RaceReader::read()
     err = set_mon_realm_abilities(mon_data["realm_abilities"], monrace);
     if (err) {
         msg_format(_("モンスター魔法領域読込失敗。ID: '%d'。", "Failed to load monster realm_abilities. ID: '%d'."), error_idx);
+        return err;
+    }
+    err = set_mon_realm_abilities2(mon_data["realm_abilities2"], monrace);
+    if (err) {
+        msg_format(_("モンスター第2魔法領域読込失敗。ID: '%d'。", "Failed to load monster realm_abilities2. ID: '%d'."), error_idx);
         return err;
     }
     err = info_set_bool(mon_data["suffers_poison_dot"], monrace.suffers_poison_dot, false);

--- a/src/info-reader/race-reader.h
+++ b/src/info-reader/race-reader.h
@@ -32,6 +32,7 @@ private:
     errr set_mon_player_class(const nlohmann::json &class_data, MonraceDefinition &monrace);
     errr set_mon_mutations(const nlohmann::json &mutations_data, MonraceDefinition &monrace);
     errr set_mon_realm_abilities(const nlohmann::json &realm_data, MonraceDefinition &monrace);
+    errr set_mon_realm_abilities2(const nlohmann::json &realm_data, MonraceDefinition &monrace);
     errr set_mon_materials(const nlohmann::json &materials_data, MonraceDefinition &monrace);
     errr set_mon_body_structure(const nlohmann::json &body_data, MonraceDefinition &monrace);
     errr set_mon_extended_slots(const nlohmann::json &slots_data, MonraceDefinition &monrace);

--- a/src/mspell/mspell-attack-util.cpp
+++ b/src/mspell/mspell-attack-util.cpp
@@ -68,8 +68,12 @@ msa_type::msa_type(CreatureEntity &creature, MONSTER_IDX m_idx)
 
     // [提案 C6] realm_abilities が指定された個体は、その魔法領域由来の
     // モンスター能力を詠唱能力へ加える (恒久的に monrace は変えず、詠唱文脈のみ)。
+    // [提案 C6第2弾] realm_abilities2 も指定されていれば併用し、二重詠唱者となる。
     if (this->monrace->realm_abilities != RealmType::NONE) {
         add_realm_granted_abilities(this->ability_flags, this->monrace->realm_abilities);
+    }
+    if (this->monrace->realm_abilities2 != RealmType::NONE) {
+        add_realm_granted_abilities(this->ability_flags, this->monrace->realm_abilities2);
     }
 }
 

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -137,6 +137,7 @@ public:
     bool consumes_mp = false; //!< 呪文詠唱時に MP を消費するか (提案C4。既定false=オプトイン。既定バランス不変)
     EnumClassFlagGroup<PlayerMutationType> mutations{}; //!< 生成時に付与する突然変異 (提案C5。空=なし=オプトイン)
     RealmType realm_abilities = RealmType::NONE; //!< 詠唱能力を付与する魔法領域 (提案C6。NONE=なし=オプトイン。詠唱時に realm 由来の MonsterAbilityType を追加)
+    RealmType realm_abilities2 = RealmType::NONE; //!< 詠唱能力を付与する第2魔法領域 (提案C6第2弾。NONE=なし=オプトイン。realm_abilities と併用して二重詠唱者に)
     bool suffers_poison_dot = false; //!< 毒攻撃で継続毒(POISON DoT)を受けるか (提案D7。既定false=オプトイン。既定バランス不変)
     bool applies_player_race_resistances = false; //!< 付与された player_race の属性耐性を被ダメージへ反映するか (提案C1第2弾。既定false=オプトイン。既定バランス不変)
     bool applies_player_race_reflection = false; //!< 付与された player_race の反射(TR_REFLECT)をボルト反射へ反映するか (提案C1第8弾。既定false=オプトイン。既定バランス不変)


### PR DESCRIPTION
CreatureEntity 統合 C トラック 提案 C6 (魔法領域詠唱のモンスター運用) の第2弾。 プレイヤーの realm1/realm2 に相当する二領域運用を可能にした。

- MonraceDefinition::realm_abilities2 (RealmType、既定 NONE) を追加。 realm_abilities と併用でき、msa_type 構築時に両 realm 由来の MonsterAbilityType を 順に add_realm_granted_abilities() で OR-in する (二重詠唱者)。
- reader は共通ヘルパ parse_realm_ability_token(json, RealmType&) を新設し、 set_mon_realm_abilities / set_mon_realm_abilities2 の両者が共用 (重複排除)。
- 写像は既存の add_realm_granted_abilities() の 10 realm 表を第2 realm へそのまま 再利用するため、新規写像コードは不要。
- schema に realm_abilities2 を登録。

既定 NONE のため実データ・既定バランス完全不変。恒久的に monrace は書き換えず
詠唱文脈の ability_flags にのみ OR-in する非破壊設計は第1弾を踏襲。

CLAUDE.md / docs/creature-entity-refactoring-roadmap.md の C6 節を更新。 フルビルド (g++ -O3 -Werror -Wall -Wextra) / clang-format-18 / validate_json.py (9/9 成功) で検証済。