### PR TITLE
feat(C6): 魔法領域詠唱をモンスターレベルで段階化 (第3弾)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -953,6 +953,12 @@ HISSATSU / HEX）を参照。
   (`src/mspell/mspell-attack-util.cpp` の `add_realm_granted_abilities()`)。
 - 写像表は保守的な初期セット（10 魔法領域。MUSIC/HISSATSU/HEX は未マッピング）で、
   バランス調整・拡張はこの表で行う。
+- **第3弾（レベル段階化）:** 各 realm の能力を「基本能力（常時）」と「高位能力
+  （モンスター実効レベル >= `REALM_ADVANCED_ABILITY_MIN_LEVEL`=20）」の 2 段階に分け、
+  低レベル個体には過剰な高位能力（ボール/ブレス/召喚/高位 cause 等）を与えない。
+  両段の和集合は従来の全集合と一致するため、**閾値以上の個体は従来と完全同一**。
+  `add_realm_granted_abilities(flags, realm, level)` に `msa_type` 構築時の
+  `m_ptr->get_level()` を渡す（realm_abilities / realm_abilities2 の両者に適用）。
 - **第2弾（`realm_abilities2` 併用）:** `MonraceDefinition::realm_abilities2`
   （`RealmType`、既定 `NONE`）を追加。`realm_abilities` と併用でき、両 realm 由来の
   `MonsterAbilityType` 群が `msa_type` 構築時に OR-in される（**二重詠唱者**）。

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3608,8 +3608,22 @@ JSON `"realm_abilities": "CHAOS"` を指定した個体は、詠唱時（`msa_ty
 - **既定 `NONE` のため実データ・既定バランス不変。** フルビルド (g++ -O3 -Werror) /
   clang-format-18 / validate_json.py で検証済。
 
-**将来拡張余地:** 写像表の精緻化、realm レベル依存の能力段階化、MUSIC/HISSATSU/HEX の
-技術領域マッピング（サステイン/技系のため要設計）。
+### ✅ 第3弾 完了（realm レベル依存の能力段階化）
+
+**完了内容:** `add_realm_granted_abilities()` を各 realm「基本能力 (常時)」＋「高位能力
+(モンスター実効レベル >= `REALM_ADVANCED_ABILITY_MIN_LEVEL`=20)」の 2 段階に再構成。
+低レベルの realm-caster 個体には過剰な高位能力 (ボール/ブレス/召喚/高位 cause 等) を
+与えないようにした。
+
+- **両段の和集合は従来の全集合と一致**するため、閾値以上の個体は従来と完全同一
+  （strict な安全リファイン: 高位能力が低レベル個体から外れるのみ）。
+- 関数に `level` 引数を追加し、`msa_type` 構築時の `m_ptr->get_level()` を渡す
+  （realm_abilities / realm_abilities2 の両者に適用）。閾値は調整用 constexpr。
+- **realm 由来能力は opt-in 個体のみに付くため既定バランス不変。** フルビルド
+  (g++ -O3 -Werror) / clang-format-18 で検証済。
+
+**将来拡張余地:** 写像表の精緻化、MUSIC/HISSATSU/HEX の技術領域マッピング
+（サステイン/技系のため要設計・現状は意図的に未マッピング）。
 
 ---
 

--- a/src/mspell/mspell-attack-util.cpp
+++ b/src/mspell/mspell-attack-util.cpp
@@ -7,46 +7,86 @@
 
 namespace {
 /*!
+ * @brief realm 由来の高位能力を付与する最小モンスターレベル閾値 (提案C6第3弾)
+ * @details これ未満のモンスターは各 realm の基本能力のみを得る。realm 由来能力は
+ *          opt-in 個体のみに付くため、既定バランスには影響しない。調整用定数。
+ */
+constexpr int REALM_ADVANCED_ABILITY_MIN_LEVEL = 20;
+
+/*!
  * @brief 魔法領域に対応する MonsterAbilityType 群を詠唱能力へ加える (提案C6)
+ * @param flags 詠唱能力フラグ (OR-in 先)
+ * @param realm 付与する魔法領域
+ * @param level モンスターの実効レベル (高位能力のレベル段階化に使用、提案C6第3弾)
  * @details realm_abilities が指定されたモンスターの詠唱時に、その realm 由来の
  *          モンスター能力を ability_flags に OR-in する。既存 mspell 経路
  *          (自動ターゲット・MP消費(C4)・耐性・AI) をそのまま利用する。
- *          写像は保守的な初期セット。バランス調整・拡張はこの表で行う。
- *          MUSIC / HISSATSU / HEX / NONE は現状未マッピング。
+ *          各 realm は「基本能力 (常時)」と「高位能力 (level >= 閾値)」の 2 段階に分け、
+ *          低レベル個体には過剰な高位能力 (ボール/ブレス/召喚/高位 cause 等) を与えない。
+ *          両段の和集合は従来の全集合と一致するため、閾値以上の個体は従来と同一。
+ *          写像はバランス調整・拡張の起点。MUSIC / HISSATSU / HEX / NONE は現状未マッピング。
  */
-void add_realm_granted_abilities(EnumClassFlagGroup<MonsterAbilityType> &flags, RealmType realm)
+void add_realm_granted_abilities(EnumClassFlagGroup<MonsterAbilityType> &flags, RealmType realm, int level)
 {
     using Ma = MonsterAbilityType;
+    const auto advanced = level >= REALM_ADVANCED_ABILITY_MIN_LEVEL;
     switch (realm) {
     case RealmType::LIFE:
-        flags.set({ Ma::HEAL, Ma::CAUSE_2, Ma::CAUSE_3 });
+        flags.set({ Ma::HEAL, Ma::CAUSE_2 });
+        if (advanced) {
+            flags.set(Ma::CAUSE_3);
+        }
         break;
     case RealmType::SORCERY:
-        flags.set({ Ma::SLOW, Ma::CONF, Ma::SCARE, Ma::BLINK, Ma::TELE_AWAY });
+        flags.set({ Ma::SLOW, Ma::CONF, Ma::SCARE, Ma::BLINK });
+        if (advanced) {
+            flags.set(Ma::TELE_AWAY);
+        }
         break;
     case RealmType::NATURE:
-        flags.set({ Ma::BA_ELEC, Ma::BA_COLD, Ma::BO_FIRE });
+        flags.set(Ma::BO_FIRE);
+        if (advanced) {
+            flags.set({ Ma::BA_ELEC, Ma::BA_COLD });
+        }
         break;
     case RealmType::CHAOS:
-        flags.set({ Ma::BA_CHAO, Ma::BA_FIRE, Ma::BR_CHAO, Ma::CONF });
+        flags.set({ Ma::CONF, Ma::BA_FIRE });
+        if (advanced) {
+            flags.set({ Ma::BA_CHAO, Ma::BR_CHAO });
+        }
         break;
     case RealmType::DEATH:
-        flags.set({ Ma::CAUSE_3, Ma::CAUSE_4, Ma::BO_NETH, Ma::BA_NETH, Ma::DRAIN_MANA });
+        flags.set({ Ma::CAUSE_3, Ma::BO_NETH, Ma::DRAIN_MANA });
+        if (advanced) {
+            flags.set({ Ma::CAUSE_4, Ma::BA_NETH });
+        }
         break;
     case RealmType::TRUMP:
-        flags.set({ Ma::BLINK, Ma::TPORT, Ma::TELE_TO, Ma::S_MONSTER, Ma::S_KIN });
+        flags.set({ Ma::BLINK, Ma::TPORT, Ma::TELE_TO });
+        if (advanced) {
+            flags.set({ Ma::S_MONSTER, Ma::S_KIN });
+        }
         break;
     case RealmType::ARCANE:
-        flags.set({ Ma::BO_MANA, Ma::BA_MANA, Ma::MIND_BLAST });
+        flags.set({ Ma::BO_MANA, Ma::MIND_BLAST });
+        if (advanced) {
+            flags.set(Ma::BA_MANA);
+        }
         break;
     case RealmType::CRAFT:
         flags.set({ Ma::HASTE, Ma::HEAL });
         break;
     case RealmType::DAEMON:
-        flags.set({ Ma::BA_FIRE, Ma::BR_FIRE, Ma::BA_NETH, Ma::S_DEMON });
+        flags.set(Ma::BA_FIRE);
+        if (advanced) {
+            flags.set({ Ma::BR_FIRE, Ma::BA_NETH, Ma::S_DEMON });
+        }
         break;
     case RealmType::CRUSADE:
-        flags.set({ Ma::BA_LITE, Ma::CAUSE_3, Ma::SCARE });
+        flags.set({ Ma::CAUSE_3, Ma::SCARE });
+        if (advanced) {
+            flags.set(Ma::BA_LITE);
+        }
         break;
     default:
         break;
@@ -69,11 +109,13 @@ msa_type::msa_type(CreatureEntity &creature, MONSTER_IDX m_idx)
     // [提案 C6] realm_abilities が指定された個体は、その魔法領域由来の
     // モンスター能力を詠唱能力へ加える (恒久的に monrace は変えず、詠唱文脈のみ)。
     // [提案 C6第2弾] realm_abilities2 も指定されていれば併用し、二重詠唱者となる。
+    // [提案 C6第3弾] 高位能力はモンスターの実効レベルで段階化する。
+    const auto realm_ability_level = this->m_ptr->get_level();
     if (this->monrace->realm_abilities != RealmType::NONE) {
-        add_realm_granted_abilities(this->ability_flags, this->monrace->realm_abilities);
+        add_realm_granted_abilities(this->ability_flags, this->monrace->realm_abilities, realm_ability_level);
     }
     if (this->monrace->realm_abilities2 != RealmType::NONE) {
-        add_realm_granted_abilities(this->ability_flags, this->monrace->realm_abilities2);
+        add_realm_granted_abilities(this->ability_flags, this->monrace->realm_abilities2, realm_ability_level);
     }
 }
 


### PR DESCRIPTION
CreatureEntity 統合 C トラック 提案 C6 の第3弾。realm 由来の詠唱能力を モンスターの実効レベルで段階化した。

- add_realm_granted_abilities() を各 realm「基本能力 (常時)」＋「高位能力 (level >= REALM_ADVANCED_ABILITY_MIN_LEVEL=20)」の 2 段階に再構成。低レベルの realm-caster 個体には過剰な高位能力 (ボール/ブレス/召喚/高位 cause 等) を与えない。
- 各 realm の基本＋高位の和集合は従来の全集合と一致するため、閾値以上の個体は 従来と完全同一 (strict な安全リファイン: 高位能力が低レベル個体から外れるのみ)。
- 関数に level 引数を追加し、msa_type 構築時の m_ptr->get_level() を渡す (realm_abilities / realm_abilities2 の両者へ適用)。閾値は調整用 constexpr。

realm 由来能力は opt-in 個体のみに付くため既定バランス完全不変。
CLAUDE.md / docs/creature-entity-refactoring-roadmap.md の C6 節を更新。 フルビルド (g++ -O3 -Werror -Wall -Wextra) / clang-format-18 で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Realm-granted monster abilities are now unlocked progressively based on effective level.
  * Basic abilities remain available, while advanced abilities unlock at level 20.
  * Monsters at level 20 or higher retain the complete existing ability set.

* **Documentation**
  * Updated creature refactoring documentation to describe level-based realm ability progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->