### PR TITLE
feat(C6): realm→ability 写像表の精緻化 (第4弾)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -951,8 +951,9 @@ HISSATSU / HEX）を参照。
   で mspell に読まれるため、恒久的に monrace を書き換えず、詠唱文脈
   (`msa_type` 構築時) の `ability_flags` にのみ realm 由来能力を **OR-in** する
   (`src/mspell/mspell-attack-util.cpp` の `add_realm_granted_abilities()`)。
-- 写像表は保守的な初期セット（10 魔法領域。MUSIC/HISSATSU/HEX は未マッピング）で、
-  バランス調整・拡張はこの表で行う。
+- 写像表は各 realm の呪文性格に沿って thematic 化済み（10 魔法領域。MUSIC/HISSATSU/HEX は
+  技術領域のため未マッピング）。基本/高位のティア規律（ボルト・操作・自己強化＝基本、
+  ボール・ブレス・召喚・高位 cause・無敵＝高位）を保ちつつ拡充。バランス調整はこの表で行う。
 - **第3弾（レベル段階化）:** 各 realm の能力を「基本能力（常時）」と「高位能力
   （モンスター実効レベル >= `REALM_ADVANCED_ABILITY_MIN_LEVEL`=20）」の 2 段階に分け、
   低レベル個体には過剰な高位能力（ボール/ブレス/召喚/高位 cause 等）を与えない。

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3622,8 +3622,24 @@ JSON `"realm_abilities": "CHAOS"` を指定した個体は、詠唱時（`msa_ty
 - **realm 由来能力は opt-in 個体のみに付くため既定バランス不変。** フルビルド
   (g++ -O3 -Werror) / clang-format-18 で検証済。
 
-**将来拡張余地:** 写像表の精緻化、MUSIC/HISSATSU/HEX の技術領域マッピング
-（サステイン/技系のため要設計・現状は意図的に未マッピング）。
+### ✅ 第4弾 完了（写像表の精緻化）
+
+**完了内容:** `add_realm_granted_abilities()` の realm→ability 写像を、各 realm の実際の
+呪文性格に沿って拡充・thematic 化した。豊富な `MonsterAbilityType` 語彙を活用しつつ、
+基本/高位のティア規律（ボルト・操作・自己強化＝基本、ボール・ブレス・召喚・高位 cause・
+無敵＝高位）を維持。
+
+- 主な精緻化: NATURE=元素ボルト三種→上位で元素・毒ボール / CHAOS=マジックミサイル起点 /
+  DEATH=cause 階梯＋地獄＋魔力吸収→上位で死者復活 (S_UNDEAD) / TRUMP=転移＋多様な召喚
+  (S_MONSTERS/S_HOUND) / SORCERY=減速/混乱/盲目/恐慌＋上位で麻痺・両転移 /
+  CRAFT=加速/回復→上位で無敵 (INVULNER) / CRUSADE=光のボルト・恐慌→上位でスターバースト /
+  ARCANE=汎用弱め (ミサイル＋転移→上位で魔力の矢/嵐) / LIFE=回復＋cause 階梯 /
+  DAEMON=火炎ボルト→上位で火炎球・ブレス・地獄球・悪魔召喚。
+- **realm 由来能力は opt-in 個体のみに付くため既定バランス不変。** バランス調整は
+  引き続きこの表で行う。フルビルド (g++ -O3 -Werror) / clang-format-18 で検証済。
+
+**将来拡張余地:** MUSIC/HISSATSU/HEX の技術領域マッピング（サステイン/技系のため
+要設計・現状は意図的に未マッピング）、詠唱頻度/コストの realm 別調整。
 
 ---
 

--- a/src/mspell/mspell-attack-util.cpp
+++ b/src/mspell/mspell-attack-util.cpp
@@ -32,60 +32,73 @@ void add_realm_granted_abilities(EnumClassFlagGroup<MonsterAbilityType> &flags, 
     const auto advanced = level >= REALM_ADVANCED_ABILITY_MIN_LEVEL;
     switch (realm) {
     case RealmType::LIFE:
-        flags.set({ Ma::HEAL, Ma::CAUSE_2 });
+        // 生命: 自己回復と対象を蝕む聖なる傷 (cause) の階梯。
+        flags.set({ Ma::HEAL, Ma::CAUSE_1, Ma::CAUSE_2 });
         if (advanced) {
-            flags.set(Ma::CAUSE_3);
+            flags.set({ Ma::CAUSE_3, Ma::CAUSE_4 });
         }
         break;
     case RealmType::SORCERY:
-        flags.set({ Ma::SLOW, Ma::CONF, Ma::SCARE, Ma::BLINK });
+        // 仙術: 非属性の操作・妨害・移動。減速/混乱/盲目/恐慌と短距離転移。
+        flags.set({ Ma::SLOW, Ma::CONF, Ma::BLIND, Ma::SCARE, Ma::BLINK });
         if (advanced) {
-            flags.set(Ma::TELE_AWAY);
+            flags.set({ Ma::HOLD, Ma::TELE_TO, Ma::TELE_AWAY });
         }
         break;
     case RealmType::NATURE:
-        flags.set(Ma::BO_FIRE);
+        // 自然: 元素のボルト群を基本に、上位で元素・毒のボール。
+        flags.set({ Ma::BO_FIRE, Ma::BO_COLD, Ma::BO_ELEC });
         if (advanced) {
-            flags.set({ Ma::BA_ELEC, Ma::BA_COLD });
+            flags.set({ Ma::BA_ELEC, Ma::BA_COLD, Ma::BA_POIS });
         }
         break;
     case RealmType::CHAOS:
-        flags.set({ Ma::CONF, Ma::BA_FIRE });
+        // 混沌: マジックミサイル・火炎を基本に、上位で火/ログルス球とカオスブレス。
+        flags.set({ Ma::MISSILE, Ma::BO_FIRE, Ma::CONF });
         if (advanced) {
-            flags.set({ Ma::BA_CHAO, Ma::BR_CHAO });
+            flags.set({ Ma::BA_FIRE, Ma::BA_CHAO, Ma::BR_CHAO });
         }
         break;
     case RealmType::DEATH:
-        flags.set({ Ma::CAUSE_3, Ma::BO_NETH, Ma::DRAIN_MANA });
+        // 死: 傷の呪い・地獄の矢・魔力吸収を基本に、上位で高位 cause/地獄球/死者復活。
+        flags.set({ Ma::CAUSE_1, Ma::CAUSE_2, Ma::BO_NETH, Ma::DRAIN_MANA });
         if (advanced) {
-            flags.set({ Ma::CAUSE_4, Ma::BA_NETH });
+            flags.set({ Ma::CAUSE_3, Ma::CAUSE_4, Ma::BA_NETH, Ma::S_UNDEAD });
         }
         break;
     case RealmType::TRUMP:
-        flags.set({ Ma::BLINK, Ma::TPORT, Ma::TELE_TO });
+        // トランプ: 転移の万能さを基本に、上位で多様な召喚。
+        flags.set({ Ma::BLINK, Ma::TPORT, Ma::TELE_TO, Ma::TELE_AWAY });
         if (advanced) {
-            flags.set({ Ma::S_MONSTER, Ma::S_KIN });
+            flags.set({ Ma::S_MONSTER, Ma::S_MONSTERS, Ma::S_KIN, Ma::S_HOUND });
         }
         break;
     case RealmType::ARCANE:
-        flags.set({ Ma::BO_MANA, Ma::MIND_BLAST });
+        // 秘術: 汎用で威力控えめ。ミサイルと短距離転移を基本に、上位で魔力の矢/嵐。
+        flags.set({ Ma::MISSILE, Ma::BLINK });
         if (advanced) {
-            flags.set(Ma::BA_MANA);
+            flags.set({ Ma::BO_MANA, Ma::BA_MANA });
         }
         break;
     case RealmType::CRAFT:
+        // 匠: 自己強化 (加速・回復) を基本に、上位で無敵化。
         flags.set({ Ma::HASTE, Ma::HEAL });
+        if (advanced) {
+            flags.set(Ma::INVULNER);
+        }
         break;
     case RealmType::DAEMON:
-        flags.set(Ma::BA_FIRE);
+        // 悪魔: 火炎のボルトを基本に、上位で火炎球・火炎ブレス・地獄球・悪魔召喚。
+        flags.set(Ma::BO_FIRE);
         if (advanced) {
-            flags.set({ Ma::BR_FIRE, Ma::BA_NETH, Ma::S_DEMON });
+            flags.set({ Ma::BA_FIRE, Ma::BR_FIRE, Ma::BA_NETH, Ma::S_DEMON });
         }
         break;
     case RealmType::CRUSADE:
-        flags.set({ Ma::CAUSE_3, Ma::SCARE });
+        // 破邪: 光のボルト・恐慌・傷の呪いを基本に、上位でスターバースト・秘孔。
+        flags.set({ Ma::BO_LITE, Ma::SCARE, Ma::CAUSE_2 });
         if (advanced) {
-            flags.set(Ma::BA_LITE);
+            flags.set({ Ma::BA_LITE, Ma::CAUSE_4 });
         }
         break;
     default:


### PR DESCRIPTION
CreatureEntity 統合 C トラック 提案 C6 の第4弾。realm 由来詠唱能力の写像表を、 各 realm の実際の呪文性格に沿って thematic に拡充した。豊富な MonsterAbilityType 語彙を活用しつつ、第3弾で導入した基本/高位のティア規律 (ボルト・操作・自己強化=基本、
ボール・ブレス・召喚・高位 cause・無敵=高位) を維持。

主な精緻化:
- NATURE: 元素ボルト三種 → 上位で元素・毒ボール
- CHAOS: マジックミサイル起点 → 上位で火/ログルス球・カオスブレス
- DEATH: cause 階梯＋地獄＋魔力吸収 → 上位で死者復活 (S_UNDEAD)
- TRUMP: 転移の万能さ → 上位で多様な召喚 (S_MONSTERS/S_HOUND)
- SORCERY: 減速/混乱/盲目/恐慌 → 上位で麻痺・両方向転移
- CRAFT: 加速/回復 → 上位で無敵 (INVULNER)
- CRUSADE: 光のボルト・恐慌 → 上位でスターバースト・秘孔
- ARCANE: 汎用弱め (ミサイル＋転移 → 上位で魔力の矢/嵐)
- LIFE: 回復＋cause 階梯 / DAEMON: 火炎ボルト/ボール → 上位でブレス・地獄球・悪魔召喚

realm 由来能力は opt-in 個体のみに付くため既定バランス完全不変。バランス調整は
引き続きこの写像表で行う。CLAUDE.md / docs/creature-entity-refactoring-roadmap.md の C6 節を更新。フルビルド (g++ -O3 -Werror -Wall -Wextra) / clang-format-18 で検証済

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded realm-based monster abilities across multiple realms, including control, elemental, curse, teleportation, summoning, and defensive effects.
  * Updated ability tiers, making some abilities available earlier while reserving others for higher levels.
  * Added more specific ability associations for NATURE, CHAOS, DEATH, TRUMP, SORCERY, CRAFT, CRUSADE, ARCANE, LIFE, and DAEMON.
* **Documentation**
  * Updated realm-to-ability documentation to reflect the expanded mappings.
  * MUSIC, HISSATSU, and HEX remain without mapped abilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->