### PR TITLE
feat(C6-R): NPC の魔導書学習ベースへの組み直し (第1段: 学習データ基盤＋学習駆動詠唱)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -974,6 +974,41 @@ HISSATSU / HEX）を参照。
 - 既定 `NONE` のため実データ・既定バランスは不変。スキーマに `realm_abilities` /
   `realm_abilities2` を登録済。
 
+### モンスターの魔導書学習 (`spellbook_realm` / `spellbook_indices`) — 提案 C6-R
+
+提案 C6（realm まるごと付与）に対し、**「NPC がプレイヤー同様、所定の魔導書から
+呪文を学習し、学んだ呪文を使う」** 方針でモンスター詠唱を組み直す第 1 段。学習は
+プレイヤーと同じ `spell_learned` データ構造を用いる（将来のプレイヤー経路詠唱＝案B
+でもそのまま流用できる）。**JSON オプトイン方式**（既定 `NONE`/空でバランス不変）。
+
+```jsonc
+"spellbook_realm": "CHAOS",
+"spellbook_indices": [0, 1]   // 第1・2の魔導書を学習
+```
+
+- **データモデル:** `MonraceDefinition::spellbook_realm`（`RealmType`）＋
+  `spellbook_mask`（`uint8_t`、bit b = 第b書 0..3 を学習）。各魔導書は 8 呪文
+  （4 書 × 8 = 32 = `SPELLS_IN_REALM`）で、第b書は spell_id `[b*8, b*8+8)` を含む。
+- **学習（生成時）:** `place_monster_one()` が `CreatureEntity::learn_realm_spellbooks(realm, mask)`
+  を呼び、`realm1` を設定して指定書の呪文を `spell_learned` / `spell_worked` に登録、
+  `spell_exp` を習得済み相当（`SPELL_EXP_SKILLED`=1200）にする。**プレイヤーの学習と
+  同じフィールドを埋める**。
+- **詠唱（学習駆動）:** `msa_type` 構築時に `add_learned_spellbook_abilities()` が、
+  学習済みの呪文のティアに応じて `MonsterAbilityType` を OR-in する（第1〜2書 spell_id
+  0..15 → 基本能力、第3〜4書 16..31 → 高位能力）。詠唱自体は既存 mspell 経路
+  （自動ターゲット・MP消費(C4)・耐性・smart AI）をそのまま利用。realm→ability 写像は
+  C6 の `add_realm_base_abilities()` / `add_realm_advanced_abilities()` を共用。
+- realm まるごとの `realm_abilities`（C6）とは**独立の経路**で、より忠実な
+  「魔導書から学習した分だけ使える」表現。両者は併用可能（OR-in）。
+- **現状の橋渡し（第1段の限界）:** 学習した個々の呪文は、忠実な PC 詠唱経路
+  （`exe_spell`）ではなく、対応する `MonsterAbilityType` に写像して既存 mspell で
+  撃つ。`exe_spell` の CAST 経路は `get_aim_dir` 等 UI プロンプトを直呼びしヘッドレス
+  不可のため（realm ファイル全体で約 115 箇所）、完全な PC 経路詠唱（案B）は
+  ヘッドレス seam の整備を要する後続段とする。第1段で **学習データ構造は完成** し、
+  案B はこの学習済みデータを消費するだけでよい状態にした。
+- 既定なしのため実データ・既定バランスは不変。スキーマに `spellbook_realm` /
+  `spellbook_indices` を登録済。実際に撃たせるには `freq_spell > 0` が必要。
+
 ### モンスターの継続毒 (`suffers_poison_dot`) — 提案 D7
 
 `MonraceDefinition` に `bool suffers_poison_dot`

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -3643,6 +3643,59 @@ JSON `"realm_abilities": "CHAOS"` を指定した個体は、詠唱時（`msa_ty
 
 ---
 
+## 提案 C6-R: 魔導書学習ベースへの組み直し（NPC が PC 同様に魔導書から学習して使う）
+
+### 方針転換の背景
+
+C6（realm まるごと付与）は「realm を指定すると its ability セットが付く」レンズ方式
+だった。メンテナ要望により、**「NPC がプレイヤーと同様、所定の魔導書から呪文を学習し、
+学んだ呪文を使う」** 方針へ組み直す。学習はプレイヤーと同じ `spell_learned` データ構造を
+用い、将来のプレイヤー経路詠唱（案B）でもそのまま流用できる基盤とする。
+
+### 実コード検証（案B の障壁の再確認）
+
+- `exe_spell(creature, realm, spell, CAST)` → `do_*_spell()` の CAST 経路は
+  `get_aim_dir` / `get_direction` / `get_item` / メニュー等 **UI プロンプトを直呼び**
+  する（realm ファイル全体で約 **115 箇所**）。→ 完全な PC 経路詠唱をモンスターに
+  行わせるには「ヘッドレス seam（対象を事前注入して UI プロンプトを回避）」の整備が要る。
+- ただし `get_aim_dir` は `command_dir` / `use_old_target` + 最終ターゲットが設定済みなら
+  プロンプトを出さずに方向を返す repeat/auto-target 機構を持つ → 将来のヘッドレス化の
+  seam として利用可能（後続段）。
+
+### ✅ 第1段 完了（学習データ基盤 ＋ 学習駆動の詠唱）
+
+- **データモデル:** `MonraceDefinition::spellbook_realm`（`RealmType`）＋
+  `spellbook_mask`（`uint8_t` ビットマスク、bit b=第b書 0..3）。JSON は
+  `"spellbook_realm": "CHAOS", "spellbook_indices": [0,1]`。reader は
+  `parse_realm_ability_token`（realm）＋新設 `set_mon_spellbook_indices`（配列→mask）。
+  schema 登録済。
+- **学習（生成時）:** `place_monster_one()` が `CreatureEntity::learn_realm_spellbooks(realm, mask)`
+  を呼び、`realm1` 設定＋指定書（各8呪文 `[b*8, b*8+8)`）を `spell_learned` /
+  `spell_worked` に登録し `spell_exp` を `SPELL_EXP_SKILLED`(1200) 相当にする。
+  **プレイヤーの学習と同一フィールドを埋める。**
+- **詠唱（学習駆動）:** `add_realm_granted_abilities()` を `add_realm_base_abilities()` /
+  `add_realm_advanced_abilities()` に分解し、新設 `add_learned_spellbook_abilities()` が
+  学習済み呪文のティア（第1〜2書=spell_id 0..15→基本 / 第3〜4書=16..31→高位）に応じて
+  `MonsterAbilityType` を OR-in。詠唱自体は既存 mspell 経路をそのまま利用。C6 の
+  realm_abilities（まるごと）とは独立経路で併用可能。
+- **既定なしのため実データ・既定バランス不変。** フルビルド (g++ -O3 -Werror) /
+  clang-format-18 / validate_json.py(9/9) で検証済。
+
+### 第2段以降（残・案B へ向けて）
+
+- **ヘッドレス詠唱 seam:** `exe_spell` の CAST を、対象を事前注入して UI プロンプトを
+  回避する形でモンスターから呼べるようにする（`get_aim_dir` の auto-target 機構を
+  スコープ付きで利用する RAII ガード等）。まず「方向系のみを使う攻撃/操作呪文」の
+  ホワイトリストから。
+- **castable 判定:** realm 呪文ごとに「モンスターがヘッドレスで安全に撃てるか」
+  （player-only 効果＝探知/地図/帰還等を除外）を表で管理し、学習済みかつ castable な
+  呪文を実際に `exe_spell` 経由で撃たせる。第1段の `spell_learned` をそのまま消費する。
+- **spell_exp の成長・詠唱失敗率:** 学習済み呪文の実運用（熟練度上昇・失敗率）を
+  プレイヤー式に寄せる。
+- **realm2 の学習:** 現状 `learn_realm_spellbooks` は realm1 のみ。二領域学習へ拡張。
+
+---
+
 ## 提案 C7: class_specific_data の限定運用 ✅ 完了（groundwork）
 
 **完了内容:** C1 で `pclass` を付与されたモンスターのうち、モンスター運用に意味の

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -197,6 +197,19 @@
                         "type": "string",
                         "description": "詠唱能力を付与する第2魔法領域 (提案C6第2弾)。realm_abilities と併用でき、二重詠唱者となる。トークンは r_info_realm を参照。既定=なし=オプトイン。"
                     },
+                    "spellbook_realm": {
+                        "type": "string",
+                        "description": "魔導書学習の魔法領域 (提案C6-R)。spellbook_indices の書からこの realm の呪文を生成時に学習し、学習した書のティアに応じて詠唱する。トークンは r_info_realm を参照。既定=なし=オプトイン。"
+                    },
+                    "spellbook_indices": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 3
+                        },
+                        "description": "学習する魔導書の番号 (0..3) の配列 (提案C6-R)。第1〜2書(0,1)で基本呪文、第3〜4書(2,3)で高位呪文を学ぶ。spellbook_realm と併用。既定=なし=オプトイン。"
+                    },
                     "suffers_poison_dot": {
                         "type": "boolean",
                         "description": "毒攻撃で継続毒(POISON DoT)を受けるか (提案D7)。既定false=オプトイン。trueの個体のみ毒攻撃後に継続ダメージを受ける。"

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -419,6 +419,44 @@ errr RaceReader::set_mon_realm_abilities2(const nlohmann::json &realm_data, Monr
 }
 
 /*!
+ * @brief JSON Objectからモンスターの魔導書学習の魔法領域を設定する (提案C6-R)
+ * @details 未指定 (null) なら RealmType::NONE のまま。指定時は spellbook_indices の書から
+ *          その realm の呪文を生成時に学習する。トークンは r_info_realm を参照。
+ */
+errr RaceReader::set_mon_spellbook_realm(const nlohmann::json &realm_data, MonraceDefinition &monrace)
+{
+    return parse_realm_ability_token(realm_data, monrace.spellbook_realm);
+}
+
+/*!
+ * @brief JSON Arrayからモンスターの学習済み魔導書 (書番号 0..3) をビットマスクへ設定する (提案C6-R)
+ * @details 未指定 (null) なら 0 のまま。各要素は 0..3 の書番号。範囲外はエラー。
+ */
+errr RaceReader::set_mon_spellbook_indices(const nlohmann::json &indices_data, MonraceDefinition &monrace)
+{
+    if (indices_data.is_null()) {
+        return PARSE_ERROR_NONE;
+    }
+    if (!indices_data.is_array()) {
+        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    }
+
+    uint8_t mask = 0;
+    for (const auto &element : indices_data) {
+        if (!element.is_number_integer()) {
+            return PARSE_ERROR_INVALID_FLAG;
+        }
+        const auto book = element.get<int>();
+        if ((book < 0) || (book > 3)) {
+            return PARSE_ERROR_INVALID_FLAG;
+        }
+        mask |= static_cast<uint8_t>(1U << book);
+    }
+    monrace.spellbook_mask = mask;
+    return PARSE_ERROR_NONE;
+}
+
+/*!
  * @brief JSON Objectからモンスターに付与する突然変異をセットする (提案C5)
  * @param mutations_data 突然変異情報の格納されたJSON Array (文字列の配列)
  * @param monrace 保管先のモンスター種族構造体
@@ -1564,6 +1602,16 @@ errr RaceReader::read()
     err = set_mon_realm_abilities2(mon_data["realm_abilities2"], monrace);
     if (err) {
         msg_format(_("モンスター第2魔法領域読込失敗。ID: '%d'。", "Failed to load monster realm_abilities2. ID: '%d'."), error_idx);
+        return err;
+    }
+    err = set_mon_spellbook_realm(mon_data["spellbook_realm"], monrace);
+    if (err) {
+        msg_format(_("モンスター魔導書領域読込失敗。ID: '%d'。", "Failed to load monster spellbook_realm. ID: '%d'."), error_idx);
+        return err;
+    }
+    err = set_mon_spellbook_indices(mon_data["spellbook_indices"], monrace);
+    if (err) {
+        msg_format(_("モンスター魔導書番号読込失敗。ID: '%d'。", "Failed to load monster spellbook_indices. ID: '%d'."), error_idx);
         return err;
     }
     err = info_set_bool(mon_data["suffers_poison_dot"], monrace.suffers_poison_dot, false);

--- a/src/info-reader/race-reader.h
+++ b/src/info-reader/race-reader.h
@@ -33,6 +33,8 @@ private:
     errr set_mon_mutations(const nlohmann::json &mutations_data, MonraceDefinition &monrace);
     errr set_mon_realm_abilities(const nlohmann::json &realm_data, MonraceDefinition &monrace);
     errr set_mon_realm_abilities2(const nlohmann::json &realm_data, MonraceDefinition &monrace);
+    errr set_mon_spellbook_realm(const nlohmann::json &realm_data, MonraceDefinition &monrace);
+    errr set_mon_spellbook_indices(const nlohmann::json &indices_data, MonraceDefinition &monrace);
     errr set_mon_materials(const nlohmann::json &materials_data, MonraceDefinition &monrace);
     errr set_mon_body_structure(const nlohmann::json &body_data, MonraceDefinition &monrace);
     errr set_mon_extended_slots(const nlohmann::json &slots_data, MonraceDefinition &monrace);

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -632,6 +632,10 @@ tl::optional<MONSTER_IDX> place_monster_one(CreatureEntity &player, POSITION y, 
         }
     }
 
+    // [提案C6-R] 指定された魔導書からモンスターが realm 呪文を学習する (opt-in・既定OFF)。
+    // プレイヤーと同じ spell_learned データ構造へ登録し、詠唱は学習済みの書に応じて発火する。
+    m_ptr->learn_realm_spellbooks(new_monrace.spellbook_realm, new_monrace.spellbook_mask);
+
     // 種族が指定されている場合、身長・体重を設定
     get_height_weight(*m_ptr);
 

--- a/src/mspell/mspell-attack-util.cpp
+++ b/src/mspell/mspell-attack-util.cpp
@@ -14,95 +14,140 @@ namespace {
 constexpr int REALM_ADVANCED_ABILITY_MIN_LEVEL = 20;
 
 /*!
- * @brief 魔法領域に対応する MonsterAbilityType 群を詠唱能力へ加える (提案C6)
- * @param flags 詠唱能力フラグ (OR-in 先)
- * @param realm 付与する魔法領域
- * @param level モンスターの実効レベル (高位能力のレベル段階化に使用、提案C6第3弾)
- * @details realm_abilities が指定されたモンスターの詠唱時に、その realm 由来の
- *          モンスター能力を ability_flags に OR-in する。既存 mspell 経路
- *          (自動ターゲット・MP消費(C4)・耐性・AI) をそのまま利用する。
- *          各 realm は「基本能力 (常時)」と「高位能力 (level >= 閾値)」の 2 段階に分け、
- *          低レベル個体には過剰な高位能力 (ボール/ブレス/召喚/高位 cause 等) を与えない。
- *          両段の和集合は従来の全集合と一致するため、閾値以上の個体は従来と同一。
- *          写像はバランス調整・拡張の起点。MUSIC / HISSATSU / HEX / NONE は現状未マッピング。
+ * @brief 魔法領域の「基本能力」(第1〜2書相当) を詠唱能力へ加える (提案C6)
+ * @details ボルト・操作・自己強化など低〜中位の能力。realm_abilities の常時分、および
+ *          魔導書学習 (提案C6-R) で第1〜2書を学んだ個体が得る分。
  */
-void add_realm_granted_abilities(EnumClassFlagGroup<MonsterAbilityType> &flags, RealmType realm, int level)
+void add_realm_base_abilities(EnumClassFlagGroup<MonsterAbilityType> &flags, RealmType realm)
 {
     using Ma = MonsterAbilityType;
-    const auto advanced = level >= REALM_ADVANCED_ABILITY_MIN_LEVEL;
     switch (realm) {
-    case RealmType::LIFE:
-        // 生命: 自己回復と対象を蝕む聖なる傷 (cause) の階梯。
+    case RealmType::LIFE: // 生命: 自己回復と聖なる傷 (cause) の基本階梯。
         flags.set({ Ma::HEAL, Ma::CAUSE_1, Ma::CAUSE_2 });
-        if (advanced) {
-            flags.set({ Ma::CAUSE_3, Ma::CAUSE_4 });
-        }
         break;
-    case RealmType::SORCERY:
-        // 仙術: 非属性の操作・妨害・移動。減速/混乱/盲目/恐慌と短距離転移。
+    case RealmType::SORCERY: // 仙術: 非属性の操作・妨害・短距離転移。
         flags.set({ Ma::SLOW, Ma::CONF, Ma::BLIND, Ma::SCARE, Ma::BLINK });
-        if (advanced) {
-            flags.set({ Ma::HOLD, Ma::TELE_TO, Ma::TELE_AWAY });
-        }
         break;
-    case RealmType::NATURE:
-        // 自然: 元素のボルト群を基本に、上位で元素・毒のボール。
+    case RealmType::NATURE: // 自然: 元素のボルト群。
         flags.set({ Ma::BO_FIRE, Ma::BO_COLD, Ma::BO_ELEC });
-        if (advanced) {
-            flags.set({ Ma::BA_ELEC, Ma::BA_COLD, Ma::BA_POIS });
-        }
         break;
-    case RealmType::CHAOS:
-        // 混沌: マジックミサイル・火炎を基本に、上位で火/ログルス球とカオスブレス。
+    case RealmType::CHAOS: // 混沌: マジックミサイル・火炎ボルト・混乱。
         flags.set({ Ma::MISSILE, Ma::BO_FIRE, Ma::CONF });
-        if (advanced) {
-            flags.set({ Ma::BA_FIRE, Ma::BA_CHAO, Ma::BR_CHAO });
-        }
         break;
-    case RealmType::DEATH:
-        // 死: 傷の呪い・地獄の矢・魔力吸収を基本に、上位で高位 cause/地獄球/死者復活。
+    case RealmType::DEATH: // 死: 傷の呪い・地獄の矢・魔力吸収。
         flags.set({ Ma::CAUSE_1, Ma::CAUSE_2, Ma::BO_NETH, Ma::DRAIN_MANA });
-        if (advanced) {
-            flags.set({ Ma::CAUSE_3, Ma::CAUSE_4, Ma::BA_NETH, Ma::S_UNDEAD });
-        }
         break;
-    case RealmType::TRUMP:
-        // トランプ: 転移の万能さを基本に、上位で多様な召喚。
+    case RealmType::TRUMP: // トランプ: 転移の万能さ。
         flags.set({ Ma::BLINK, Ma::TPORT, Ma::TELE_TO, Ma::TELE_AWAY });
-        if (advanced) {
-            flags.set({ Ma::S_MONSTER, Ma::S_MONSTERS, Ma::S_KIN, Ma::S_HOUND });
-        }
         break;
-    case RealmType::ARCANE:
-        // 秘術: 汎用で威力控えめ。ミサイルと短距離転移を基本に、上位で魔力の矢/嵐。
+    case RealmType::ARCANE: // 秘術: 汎用で威力控えめ。ミサイルと短距離転移。
         flags.set({ Ma::MISSILE, Ma::BLINK });
-        if (advanced) {
-            flags.set({ Ma::BO_MANA, Ma::BA_MANA });
-        }
         break;
-    case RealmType::CRAFT:
-        // 匠: 自己強化 (加速・回復) を基本に、上位で無敵化。
+    case RealmType::CRAFT: // 匠: 自己強化 (加速・回復)。
         flags.set({ Ma::HASTE, Ma::HEAL });
-        if (advanced) {
-            flags.set(Ma::INVULNER);
-        }
         break;
-    case RealmType::DAEMON:
-        // 悪魔: 火炎のボルトを基本に、上位で火炎球・火炎ブレス・地獄球・悪魔召喚。
+    case RealmType::DAEMON: // 悪魔: 火炎のボルト (上位は火炎球・ブレス・地獄球・悪魔召喚)。
         flags.set(Ma::BO_FIRE);
-        if (advanced) {
-            flags.set({ Ma::BA_FIRE, Ma::BR_FIRE, Ma::BA_NETH, Ma::S_DEMON });
-        }
         break;
-    case RealmType::CRUSADE:
-        // 破邪: 光のボルト・恐慌・傷の呪いを基本に、上位でスターバースト・秘孔。
+    case RealmType::CRUSADE: // 破邪: 光のボルト・恐慌・傷の呪い。
         flags.set({ Ma::BO_LITE, Ma::SCARE, Ma::CAUSE_2 });
-        if (advanced) {
-            flags.set({ Ma::BA_LITE, Ma::CAUSE_4 });
-        }
         break;
     default:
         break;
+    }
+}
+
+/*!
+ * @brief 魔法領域の「高位能力」(第3〜4書相当) を詠唱能力へ加える (提案C6)
+ * @details ボール・ブレス・召喚・高位 cause・無敵など高位の能力。realm_abilities では
+ *          実効レベルが閾値以上のとき、魔導書学習 (提案C6-R) では第3〜4書を学んだ個体が得る。
+ */
+void add_realm_advanced_abilities(EnumClassFlagGroup<MonsterAbilityType> &flags, RealmType realm)
+{
+    using Ma = MonsterAbilityType;
+    switch (realm) {
+    case RealmType::LIFE:
+        flags.set({ Ma::CAUSE_3, Ma::CAUSE_4 });
+        break;
+    case RealmType::SORCERY:
+        flags.set({ Ma::HOLD, Ma::TELE_TO, Ma::TELE_AWAY });
+        break;
+    case RealmType::NATURE:
+        flags.set({ Ma::BA_ELEC, Ma::BA_COLD, Ma::BA_POIS });
+        break;
+    case RealmType::CHAOS:
+        flags.set({ Ma::BA_FIRE, Ma::BA_CHAO, Ma::BR_CHAO });
+        break;
+    case RealmType::DEATH:
+        flags.set({ Ma::CAUSE_3, Ma::CAUSE_4, Ma::BA_NETH, Ma::S_UNDEAD });
+        break;
+    case RealmType::TRUMP:
+        flags.set({ Ma::S_MONSTER, Ma::S_MONSTERS, Ma::S_KIN, Ma::S_HOUND });
+        break;
+    case RealmType::ARCANE:
+        flags.set({ Ma::BO_MANA, Ma::BA_MANA });
+        break;
+    case RealmType::CRAFT:
+        flags.set(Ma::INVULNER);
+        break;
+    case RealmType::DAEMON:
+        flags.set({ Ma::BA_FIRE, Ma::BR_FIRE, Ma::BA_NETH, Ma::S_DEMON });
+        break;
+    case RealmType::CRUSADE:
+        flags.set({ Ma::BA_LITE, Ma::CAUSE_4 });
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+ * @brief realm_abilities (魔法領域まるごと付与) 由来の詠唱能力を加える (提案C6)
+ * @details 基本能力は常時、高位能力は実効レベルが閾値以上のときに付与する (提案C6第3弾)。
+ */
+void add_realm_granted_abilities(EnumClassFlagGroup<MonsterAbilityType> &flags, RealmType realm, int level)
+{
+    add_realm_base_abilities(flags, realm);
+    if (level >= REALM_ADVANCED_ABILITY_MIN_LEVEL) {
+        add_realm_advanced_abilities(flags, realm);
+    }
+}
+
+/*!
+ * @brief 魔導書学習 (提案C6-R) 由来の詠唱能力を加える
+ * @details プレイヤー同様、モンスターは所定の魔導書から realm 呪文を学習する
+ *          (spell_learned に登録済み)。学習した書のティアに応じて能力を付与する:
+ *          第1〜2書 (spell_id 0..15) を学べば基本能力、第3〜4書 (16..31) を学べば
+ *          高位能力。realm_abilities (まるごと付与) とは独立の、より忠実な経路。
+ *          詠唱自体は既存 mspell (自動ターゲット・MP・耐性・AI) をそのまま用いる。
+ */
+void add_learned_spellbook_abilities(EnumClassFlagGroup<MonsterAbilityType> &flags, const CreatureEntity &caster)
+{
+    const auto realm = caster.get_realm1();
+    if (realm == RealmType::NONE) {
+        return;
+    }
+
+    auto learned_basic = false;
+    for (auto spell_id = 0; spell_id < 16; ++spell_id) {
+        if (caster.has_learned_spell(0, spell_id)) {
+            learned_basic = true;
+            break;
+        }
+    }
+    auto learned_advanced = false;
+    for (auto spell_id = 16; spell_id < 32; ++spell_id) {
+        if (caster.has_learned_spell(0, spell_id)) {
+            learned_advanced = true;
+            break;
+        }
+    }
+
+    if (learned_basic) {
+        add_realm_base_abilities(flags, realm);
+    }
+    if (learned_advanced) {
+        add_realm_advanced_abilities(flags, realm);
     }
 }
 }
@@ -130,6 +175,9 @@ msa_type::msa_type(CreatureEntity &creature, MONSTER_IDX m_idx)
     if (this->monrace->realm_abilities2 != RealmType::NONE) {
         add_realm_granted_abilities(this->ability_flags, this->monrace->realm_abilities2, realm_ability_level);
     }
+
+    // [提案 C6-R] 魔導書から学習した realm 呪文に応じて詠唱能力を加える (学習済みの書のティア準拠)。
+    add_learned_spellbook_abilities(this->ability_flags, *this->m_ptr);
 }
 
 Pos2D msa_type::get_position() const

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -4012,6 +4012,33 @@ void CreatureEntity::set_forgotten_spell(int realm_idx, int spell_id, bool value
     this->set_spell_forgotten_flags(realm_idx, flags);
 }
 
+void CreatureEntity::learn_realm_spellbooks(RealmType realm, uint32_t book_mask)
+{
+    if ((realm == RealmType::NONE) || (book_mask == 0)) {
+        return;
+    }
+
+    // 学習領域を realm1 に設定する。slot 0 (spell_learned1) は realm1 に対応するため、
+    // slot 0 へ書き込む前に realm1 を realm へ揃える (add_learned_spellbook_abilities は
+    // realm1 と slot 0 を対で参照するので、両者の realm が食い違うと別領域の能力を付与してしまう)。
+    this->set_realm1(realm);
+
+    constexpr int spells_per_book = 8; // 各魔導書は 8 呪文 (4 書 × 8 = 32 = SPELLS_IN_REALM)
+    constexpr int books_per_realm = 4;
+    constexpr SUB_EXP learned_spell_exp = 1200; // SPELL_EXP_SKILLED 相当 (熟練度は将来の案B詠唱で使用)
+    for (int book = 0; book < books_per_realm; ++book) {
+        if ((book_mask & (1U << book)) == 0) {
+            continue;
+        }
+        for (int offset = 0; offset < spells_per_book; ++offset) {
+            const int spell_id = (book * spells_per_book) + offset;
+            this->set_learned_spell(0, spell_id, true);
+            this->set_worked_spell(0, spell_id, true);
+            this->set_spell_exp(spell_id, learned_spell_exp);
+        }
+    }
+}
+
 // ==== 提案 E4: creature-entity.h からの inline virtual accessor 本体移設 ====
 
 AllianceType CreatureEntity::get_alliance_idx() const

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -3161,6 +3161,17 @@ public:
     virtual void set_forgotten_spell(int realm_idx, int spell_id, bool value);
     std::vector<int> spell_order_learned{}; /* order spells learned */
 
+    /*!
+     * @brief 指定魔法領域の魔導書 (ビットマスク) からモンスターが呪文を学習する [提案C6-R]
+     * @param realm 学習する魔法領域 (NONE なら何もしない)
+     * @param book_mask 学習済み魔導書のビットマスク (bit b = 第b書。各書8呪文 [b*8, b*8+8))
+     * @details realm1 を設定し、指定書の呪文を spell_learned / spell_worked に登録して
+     *          spell_exp を習得済み相当にする。プレイヤーと同じ学習データ構造を用いるため、
+     *          将来のプレイヤー経路詠唱 (案B) でもそのまま利用できる。opt-in・既定なしで
+     *          呼ばれない (spellbook_realm=NONE) ため既定バランス不変。
+     */
+    void learn_realm_spellbooks(RealmType realm, uint32_t book_mask);
+
     // [A-3] private 化済。get_hp_table(level_index) / set_hp_table(level_index, value) 経由。
     // CreatureEntity 内部の roll_hp_table() 等は this->hp_table を直接操作。
 private:

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -35,6 +35,7 @@
 #include "util/flag-group.h"
 #include "view/display-symbol.h"
 #include <array>
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <tl/optional.hpp>
@@ -138,6 +139,8 @@ public:
     EnumClassFlagGroup<PlayerMutationType> mutations{}; //!< 生成時に付与する突然変異 (提案C5。空=なし=オプトイン)
     RealmType realm_abilities = RealmType::NONE; //!< 詠唱能力を付与する魔法領域 (提案C6。NONE=なし=オプトイン。詠唱時に realm 由来の MonsterAbilityType を追加)
     RealmType realm_abilities2 = RealmType::NONE; //!< 詠唱能力を付与する第2魔法領域 (提案C6第2弾。NONE=なし=オプトイン。realm_abilities と併用して二重詠唱者に)
+    RealmType spellbook_realm = RealmType::NONE; //!< 魔導書学習の魔法領域 (提案C6-R。NONE=なし=オプトイン。生成時に spellbook_mask の書から realm 呪文を学習)
+    uint8_t spellbook_mask = 0; //!< 学習済み魔導書のビットマスク (提案C6-R。bit b = 第b書(0..3)を学習。各書8呪文 [b*8, b*8+8) を spell_learned に登録)
     bool suffers_poison_dot = false; //!< 毒攻撃で継続毒(POISON DoT)を受けるか (提案D7。既定false=オプトイン。既定バランス不変)
     bool applies_player_race_resistances = false; //!< 付与された player_race の属性耐性を被ダメージへ反映するか (提案C1第2弾。既定false=オプトイン。既定バランス不変)
     bool applies_player_race_reflection = false; //!< 付与された player_race の反射(TR_REFLECT)をボルト反射へ反映するか (提案C1第8弾。既定false=オプトイン。既定バランス不変)


### PR DESCRIPTION
「NPC がプレイヤー同様、所定の魔導書から呪文を学習し、学んだ呪文を使う」方針で
モンスター詠唱を組み直す第1段。学習はプレイヤーと同じ spell_learned データ構造を
用い、将来のプレイヤー経路詠唱 (案B) でもそのまま流用できる基盤とする。

データモデル:
- MonraceDefinition::spellbook_realm (RealmType) + spellbook_mask (uint8_t、bit b=第b書)。 JSON: "spellbook_realm": "CHAOS", "spellbook_indices": [0,1]。reader/schema 整備。

学習 (生成時):
- CreatureEntity::learn_realm_spellbooks(realm, mask) を新設。place_monster_one() が呼び、 realm1 を設定し指定書 (各8呪文 [b*8,b*8+8)) を spell_learned/spell_worked へ登録、 spell_exp を SPELL_EXP_SKILLED(1200) 相当にする。プレイヤーの学習と同一フィールドを埋める。

詠唱 (学習駆動):
- add_realm_granted_abilities() を add_realm_base_abilities()/add_realm_advanced_abilities() に分解。新設 add_learned_spellbook_abilities() が学習済み呪文のティア (第1〜2書=基本 / 第3〜4書=高位) に応じて MonsterAbilityType を OR-in。詠唱自体は既存 mspell 経路 (自動ターゲット・MP・耐性・AI) を利用。realm_abilities(C6 まるごと) とは独立経路で併用可。

第1段の限界 (案B へ向けて): 学習した個々の呪文は忠実な PC 詠唱経路 (exe_spell) では なく対応 MonsterAbilityType に写像して撃つ。exe_spell の CAST は get_aim_dir 等 UI プロンプトを直呼びしヘッドレス不可 (realm 全体で約115箇所) のため、完全な PC 経路詠唱は ヘッドレス seam 整備を要する後続段とする。第1段で学習データ構造は完成させ、案B は
この学習済みデータを消費するだけでよい状態にした。

既定なし (spellbook_realm=NONE) のため実データ・既定バランス完全不変。CLAUDE.md / docs に C6-R 節を追加。フルビルド (g++ -O3 -Werror -Wall -Wextra) / clang-format-18 / validate_json.py(9/9) で検証済。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Monsters can now learn spells from selected spellbooks during generation.
  - Monster definitions support configuring a magic realm and one or more spellbooks.
  - Learned spells are registered as available and usable, with corresponding basic and advanced abilities granted based on spell tier.
  - Spellbook-based learning can be used alongside existing realm-based abilities.

- **Documentation**
  - Added guidance and roadmap details for configuring monster spellbook learning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->