### PR TITLE
feat: 糞(汚物)のオーラを実装し変態糞土方に付与

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -82838,6 +82838,7 @@
         "IM_POIS",
         "NO_CONF",
         "NO_SLEEP",
+        "AURA_DIRT",
       ],
       "skill": {
         "list": ["BR_FECES"],

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -370,6 +370,17 @@ void process_player_hp_mp(CreatureEntity &creature)
             msg_print(_("冷たい！", "It's cold!"));
             take_hit(creature, DAMAGE_NOESCAPE, damage, _("冷気のオーラ", "Cold aura"));
         }
+
+        if (auras.has(MonsterAuraType::DIRT)) {
+            damage = floor.get_monster(creature.get_riding()).get_monrace().level / 2;
+            if (damage > 0) {
+                msg_print(_("汚い！", "It's filthy!"));
+                // ダメージ倍率(calc_pois_damage_rate)と毒付与は dirt_dam に集約 (重複排除)。
+                // 毒耐性判定(OPPOSE_POIS/MUSIC_RESIST/MUSOU 構え/職業毒耐性)も dirt_dam
+                // 内の is_oppose_pois が保持する。
+                dirt_dam(creature, damage, _("汚物のオーラ", "Filth aura"), true);
+            }
+        }
     }
 
     /* Spectres -- take damage when moving through walls */

--- a/src/info-reader/race-info-tokens-table.cpp
+++ b/src/info-reader/race-info-tokens-table.cpp
@@ -358,6 +358,7 @@ const std::unordered_map<std::string_view, MonsterAuraType> r_info_aura_flags = 
     { "AURA_GRAVITY", MonsterAuraType::GRAVITY },
     { "AURA_VOIDS", MonsterAuraType::VOIDS },
     { "AURA_ABYSS", MonsterAuraType::ABYSS },
+    { "AURA_DIRT", MonsterAuraType::DIRT },
 };
 
 const std::unordered_map<std::string_view, MonsterBehaviorType> r_info_behavior_flags = {

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -168,6 +168,27 @@ static void aura_elec_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
     project(creature, mam_ptr->t_idx, 0, monster.y, monster.x, dam, AttributeType::ELEC, flags);
 }
 
+static void aura_dirt_by_melee(CreatureEntity &creature, mam_type *mam_ptr)
+{
+    const auto &monster = *mam_ptr->m_ptr;
+    auto &monrace_target = mam_ptr->t_ptr->get_monrace();
+    if (monrace_target.aura_flags.has_not(MonsterAuraType::DIRT) || !monster.is_valid()) {
+        return;
+    }
+
+    if (mam_ptr->see_either) {
+        msg_format(_("%s^は汚物にまみれた！", "%s^ is covered with filth!"), mam_ptr->m_name);
+    }
+
+    if (monster.is_visible_on_map() && is_original_ap_and_seen(creature, *mam_ptr->t_ptr)) {
+        monrace_target.r_aura_flags.set(MonsterAuraType::DIRT);
+    }
+
+    const auto dam = Dice::roll(1 + ((monrace_target.level) / 26), 1 + ((monrace_target.level) / 17));
+    constexpr auto flags = PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED;
+    project(creature, mam_ptr->t_idx, 0, monster.y, monster.x, dam, AttributeType::DIRT, flags);
+}
+
 static bool check_same_monster(CreatureEntity &creature, mam_type *mam_ptr)
 {
     if (mam_ptr->m_idx == mam_ptr->t_idx) {
@@ -267,6 +288,7 @@ static void process_monster_attack_effect(CreatureEntity &creature, mam_type *ma
     aura_fire_by_melee(creature, mam_ptr);
     aura_cold_by_melee(creature, mam_ptr);
     aura_elec_by_melee(creature, mam_ptr);
+    aura_dirt_by_melee(creature, mam_ptr);
 }
 
 static void process_melee(CreatureEntity &creature, mam_type *mam_ptr)

--- a/src/monster-race/monster-aura-types.h
+++ b/src/monster-race/monster-aura-types.h
@@ -29,5 +29,6 @@ enum class MonsterAuraType {
     GRAVITY = 21, // 重力.
     VOIDS = 22, // 虚無.
     ABYSS = 23, // 深淵.
+    DIRT = 24, // 汚物(糞).
     MAX,
 };

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -51,6 +51,7 @@
 #include "player/special-defense-types.h"
 #include "racial/racial-android.h"
 #include "save/save.h"
+#include "status/bad-status-setter.h"
 #include "status/base-status.h"
 #include "status/element-resistance.h"
 #include "sv-definition/sv-junk-types.h"
@@ -273,6 +274,32 @@ int cold_dam(CreatureEntity &creature, int dam, std::string_view kb_str, bool au
     int get_damage = take_hit(creature, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str);
     if (!aura && !(double_resist && creature.has_resist_cold())) {
         inventory_damage(creature, BreakerCold(), inv);
+    }
+
+    return get_damage;
+}
+
+/*!
+ * @brief 汚物(糞)属性によるプレイヤー損害処理
+ * Hurt the creature with filth (feces)
+ * @param creature 汚物を浴びたクリーチャーへの参照
+ * @param dam 基本ダメージ量
+ * @param kb_str ダメージ原因記述
+ * @param aura オーラよるダメージが原因ならばTRUE
+ * @return 修正HPダメージ量
+ * @details 毒耐性でダメージを軽減し、耐性が無ければ一定確率で毒状態を付与する。
+ */
+int dirt_dam(CreatureEntity &creature, int dam, std::string_view kb_str, bool aura)
+{
+    bool double_resist = is_oppose_pois(creature);
+    dam = dam * calc_pois_damage_rate(creature) / 100;
+    if (dam <= 0) {
+        return 0;
+    }
+
+    int get_damage = take_hit(creature, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str);
+    if ((aura || !check_multishadow(creature)) && !(double_resist || creature.has_resist_pois())) {
+        (void)BadStatusSetter(creature).mod_poison(randint1(dam) + 1);
     }
 
     return get_damage;
@@ -762,9 +789,11 @@ void touch_zap_player(const CreatureEntity &source, CreatureEntity &creature)
     constexpr auto fire_mes = _("突然とても熱くなった！", "You are suddenly very hot!");
     constexpr auto cold_mes = _("突然とても寒くなった！", "You are suddenly very cold!");
     constexpr auto elec_mes = _("電撃をくらった！", "You get zapped!");
+    constexpr auto dirt_mes = _("汚物にまみれた！", "You are covered with filth!");
     process_aura_damage(source, creature, creature.has_immune_fire() != 0, MonsterAuraType::FIRE, fire_dam, fire_mes);
     process_aura_damage(source, creature, creature.has_immune_cold() != 0, MonsterAuraType::COLD, cold_dam, cold_mes);
     process_aura_damage(source, creature, creature.has_immune_elec() != 0, MonsterAuraType::ELEC, elec_dam, elec_mes);
+    process_aura_damage(source, creature, false, MonsterAuraType::DIRT, dirt_dam, dirt_mes);
 }
 
 /*!

--- a/src/player/player-damage.h
+++ b/src/player/player-damage.h
@@ -16,5 +16,6 @@ int acid_dam(CreatureEntity &creature, int dam, std::string_view kb_str, bool au
 int elec_dam(CreatureEntity &creature, int dam, std::string_view kb_str, bool aura);
 int fire_dam(CreatureEntity &creature, int dam, std::string_view kb_str, bool aura);
 int cold_dam(CreatureEntity &creature, int dam, std::string_view kb_str, bool aura);
+int dirt_dam(CreatureEntity &creature, int dam, std::string_view kb_str, bool aura);
 void touch_zap_player(const CreatureEntity &source, CreatureEntity &creature);
 void player_defecate(CreatureEntity &creature);

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -1235,8 +1235,9 @@ void set_monster_aura_summary(lore_type *lore_ptr)
     auto has_fire_aura = lore_ptr->aura_flags.has(MonsterAuraType::FIRE);
     auto has_cold_aura = lore_ptr->aura_flags.has(MonsterAuraType::COLD);
     auto has_elec_aura = lore_ptr->aura_flags.has(MonsterAuraType::ELEC);
+    auto has_dirt_aura = lore_ptr->aura_flags.has(MonsterAuraType::DIRT);
 
-    if (has_fire_aura || has_elec_aura || has_cold_aura) {
+    if (has_fire_aura || has_elec_aura || has_cold_aura || has_dirt_aura) {
         lore_ptr->lore_msgs.emplace_back(_("オーラ:", "aura:"), TERM_WHITE);
     }
     if (has_fire_aura) {
@@ -1248,7 +1249,10 @@ void set_monster_aura_summary(lore_type *lore_ptr)
     if (has_elec_aura) {
         lore_ptr->lore_msgs.emplace_back(_("電", "elec"), TERM_L_BLUE);
     }
-    if (has_fire_aura || has_elec_aura || has_cold_aura) {
+    if (has_dirt_aura) {
+        lore_ptr->lore_msgs.emplace_back(_("糞", "filth"), TERM_L_DARK);
+    }
+    if (has_fire_aura || has_elec_aura || has_cold_aura || has_dirt_aura) {
         lore_ptr->lore_msgs.emplace_back(" | ", TERM_WHITE);
     }
 }
@@ -1273,6 +1277,10 @@ void display_monster_aura(lore_type *lore_ptr)
         hook_c_roff(TERM_BLUE, format(_("%s^は氷に包まれている。", "%s^ is surrounded by ice.  "), Who::who(lore_ptr->msex).data()));
     } else if (has_elec_aura) {
         hook_c_roff(TERM_L_BLUE, format(_("%s^はスパークに包まれている。", "%s^ is surrounded by electricity.  "), Who::who(lore_ptr->msex).data()));
+    }
+
+    if (lore_ptr->aura_flags.has(MonsterAuraType::DIRT)) {
+        hook_c_roff(TERM_L_DARK, format(_("%s^は汚物にまみれている。", "%s^ is covered with filth.  "), Who::who(lore_ptr->msex).data()));
     }
 }
 


### PR DESCRIPTION
各種オーラ(火炎/冷気/電撃)を参考に、汚物属性(AttributeType::DIRT)を
用いた「糞のオーラ」(MonsterAuraType::DIRT / AURA_DIRT)を実装。

- MonsterAuraType に DIRT を追加、r_info_aura_flags に AURA_DIRT トークン登録
- プレイヤー被害処理 dirt_dam() を追加 (毒耐性で軽減・耐性無しなら毒付与) し touch_zap_player() に配線
- モンスター同士の乱闘 aura_dirt_by_melee() を追加 (DIRT を project)
- 騎乗中モンスターの糞オーラダメージを process_player_hp_mp() に追加
- 思い出表示 (aura summary / display_monster_aura) に糞オーラを追加
- 岡山の文豪『変態糞土方』(id 1307) に AURA_DIRT を付与

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dirt aura for creatures, causing retaliatory filth damage during melee attacks and when mounted creatures are struck.
  * Dirt aura damage may inflict poison, with effects reduced or prevented by relevant resistances.
  * Added support for recognizing and displaying dirt aura information in creature lore and game messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->