### PR TITLE
merge(1/N): 固定クエスト JSONC 移行の基盤ファイル追加（hengband#5486 相当）

### DIFF
--- a/schema/Quest.schema.json
+++ b/schema/Quest.schema.json
@@ -1,0 +1,457 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "Quest.schema.jsonc",
+  "title": "Quest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "id", "name", "definition"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1
+    },
+    "id": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 49
+    },
+    "name": {
+      "$ref": "#/$defs/localizedText"
+    },
+    "definition": {
+      "$ref": "#/$defs/definition"
+    },
+    "descriptions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/descriptionBlock"
+      }
+    },
+    "legend": {
+      "type": "object",
+      "description": "Map symbol (single character) -> grid definition. Local to this quest; does not touch the global letter[] table.",
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 1
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/gridDefinition"
+      }
+    },
+    "map": {
+      "$ref": "#/$defs/mapRows"
+    },
+    "mapVariants": {
+      "type": "array",
+      "description": "Random layout variants (legacy $RANDOMn). One is chosen uniformly at floor generation.",
+      "minItems": 2,
+      "items": {
+        "$ref": "#/$defs/mapRows"
+      }
+    },
+    "start": {
+      "$ref": "#/$defs/position"
+    },
+    "startVariants": {
+      "type": "array",
+      "description": "Player start position selected by the quest being left (legacy $LEAVING_QUEST).",
+      "items": {
+        "$ref": "#/$defs/startVariant"
+      }
+    }
+  },
+  "$defs": {
+    "localizedText": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ja", "en"],
+      "properties": {
+        "ja": {
+          "type": "string"
+        },
+        "en": {
+          "type": "string"
+        }
+      }
+    },
+    "localizedLines": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ja", "en"],
+      "description": "Multi-line localized text; one array element per displayed screen row (legacy per-line Q:T).",
+      "properties": {
+        "ja": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "en": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "definition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "level"],
+      "properties": {
+        "type": {
+          "enum": [
+            "NONE",
+            "KILL_LEVEL",
+            "KILL_ANY_LEVEL",
+            "FIND_ARTIFACT",
+            "FIND_EXIT",
+            "KILL_NUMBER",
+            "KILL_ALL",
+            "RANDOM",
+            "TOWER"
+          ]
+        },
+        "level": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "dungeon": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "DungeonId; 0 = none/quest-local floor."
+        },
+        "monster": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "MonraceId of the quest target (r_idx); 0 = none."
+        },
+        "numMon": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxNum": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Required kill count (KILL_NUMBER)."
+        },
+        "flags": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": ["SILENT", "PRESET", "ONCE", "TOWER"]
+          }
+        },
+        "reward": {
+          "$ref": "#/$defs/reward"
+        }
+      }
+    },
+    "reward": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Artifact reward. Use `artifact` for a fixed one, or `artifacts` for a random pick among still-ungenerated ones (legacy Q:R).",
+      "minProperties": 1,
+      "maxProperties": 1,
+      "properties": {
+        "artifact": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "artifacts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      }
+    },
+    "descriptionBlock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["when", "text"],
+      "properties": {
+        "when": {
+          "$ref": "#/$defs/condition"
+        },
+        "text": {
+          "$ref": "#/$defs/localizedLines"
+        }
+      }
+    },
+    "condition": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "description": "Quest-status/type predicate deciding when a description block is shown (legacy ?:[...] over $QUESTnn / $QUEST_TYPEnn).",
+      "properties": {
+        "statusAtMost": {
+          "$ref": "#/$defs/questStatus",
+          "description": "Legacy [LEQ $QUESTnn s]: shown while status <= s."
+        },
+        "status": {
+          "$ref": "#/$defs/questStatus",
+          "description": "Legacy [EQU $QUESTnn s]: shown when status == s."
+        },
+        "questType": {
+          "$ref": "#/$defs/questKind",
+          "description": "Legacy [EQU $QUEST_TYPEnn t]: additionally require this quest type."
+        }
+      }
+    },
+    "questStatus": {
+      "enum": [
+        "UNTAKEN",
+        "TAKEN",
+        "COMPLETED",
+        "REWARDED",
+        "FINISHED",
+        "FAILED",
+        "FAILED_DONE",
+        "STAGE_COMPLETED"
+      ]
+    },
+    "questKind": {
+      "enum": [
+        "NONE",
+        "KILL_LEVEL",
+        "KILL_ANY_LEVEL",
+        "FIND_ARTIFACT",
+        "FIND_EXIT",
+        "KILL_NUMBER",
+        "KILL_ALL",
+        "RANDOM",
+        "TOWER"
+      ]
+    },
+    "mapRows": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 66,
+      "description": "Dungeon layout, one string per row (at most MAX_HGT=66 rows of MAX_WID=198 characters; floor generation writes rows unchecked, so the cap guards out-of-bounds access). Each character is looked up in `legend` (falling back to the shared quest-preference symbols).",
+      "items": {
+        "type": "string",
+        "maxLength": 198
+      }
+    },
+    "position": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["y", "x"],
+      "properties": {
+        "y": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "x": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "startVariant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["y", "x"],
+      "properties": {
+        "leavingQuest": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "QuestId being left ($LEAVING_QUEST); omit for the default/fallback entry."
+        },
+        "y": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "x": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "gridDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "terrain": {
+          "type": "string",
+          "description": "TerrainTag name (e.g. FLOOR, PERMANENT), or \"*\" for a random feature."
+        },
+        "caveInfo": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": ["MARK", "GLOW", "NO_TELEPORT_DEST", "ROOM", "LITE"]
+          }
+        },
+        "monster": {
+          "$ref": "#/$defs/monsterSpec"
+        },
+        "object": {
+          "$ref": "#/$defs/objectSpec"
+        },
+        "ego": {
+          "$ref": "#/$defs/egoSpec"
+        },
+        "artifact": {
+          "$ref": "#/$defs/artifactSpec"
+        },
+        "trap": {
+          "$ref": "#/$defs/trapSpec"
+        },
+        "special": {
+          "type": "integer"
+        }
+      }
+    },
+    "monsterSpec": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1,
+          "description": "MonraceId."
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["random"],
+          "properties": {
+            "random": {
+              "const": true
+            },
+            "oodLevel": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Out-of-depth level boost (legacy *N)."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["cloneOf"],
+          "properties": {
+            "cloneOf": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Place a clone of this MonraceId (legacy cN)."
+            }
+          }
+        }
+      ]
+    },
+    "objectSpec": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1,
+          "description": "BaseitemId."
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["random"],
+          "properties": {
+            "random": {
+              "const": true
+            },
+            "oodLevel": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Out-of-depth object level boost (legacy *N)."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["questReward"],
+          "properties": {
+            "questReward": {
+              "const": true,
+              "description": "Drop this quest's reward item (legacy !)."
+            }
+          }
+        }
+      ]
+    },
+    "egoSpec": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1,
+          "description": "EgoType id."
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["random"],
+          "properties": {
+            "random": {
+              "const": true
+            },
+            "id": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        }
+      ]
+    },
+    "artifactSpec": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1,
+          "description": "FixedArtifactId."
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["random"],
+          "properties": {
+            "random": {
+              "const": true
+            },
+            "id": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["questReward"],
+          "properties": {
+            "questReward": {
+              "const": true,
+              "description": "Use this quest's reward artifact (legacy !)."
+            }
+          }
+        }
+      ]
+    },
+    "trapSpec": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "TerrainTag name of the trap."
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["random"],
+          "properties": {
+            "random": {
+              "const": true
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schema/QuestPreferences.schema.json
+++ b/schema/QuestPreferences.schema.json
@@ -1,0 +1,209 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "QuestPreferences.schema.jsonc",
+  "title": "QuestPreferences",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "legend"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1
+    },
+    "legend": {
+      "type": "object",
+      "description": "Shared base legend (X/./%/D/< ...). Loaded into the global letter[] table before each quest's own legend overlays it. Uses the same grid definition as a quest legend.",
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 1
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/gridDefinition"
+      }
+    }
+  },
+  "$defs": {
+    "gridDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "terrain": {
+          "type": "string",
+          "description": "TerrainTag name (e.g. FLOOR, PERMANENT), or \"*\" for a random feature."
+        },
+        "caveInfo": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": ["MARK", "GLOW", "NO_TELEPORT_DEST", "ROOM", "LITE"]
+          }
+        },
+        "monster": {
+          "$ref": "#/$defs/monsterSpec"
+        },
+        "object": {
+          "$ref": "#/$defs/objectSpec"
+        },
+        "ego": {
+          "$ref": "#/$defs/egoSpec"
+        },
+        "artifact": {
+          "$ref": "#/$defs/artifactSpec"
+        },
+        "trap": {
+          "$ref": "#/$defs/trapSpec"
+        },
+        "special": {
+          "type": "integer"
+        }
+      }
+    },
+    "monsterSpec": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1,
+          "description": "MonraceId."
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["random"],
+          "properties": {
+            "random": {
+              "const": true
+            },
+            "oodLevel": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Out-of-depth level boost (legacy *N)."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["cloneOf"],
+          "properties": {
+            "cloneOf": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Place a clone of this MonraceId (legacy cN)."
+            }
+          }
+        }
+      ]
+    },
+    "objectSpec": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1,
+          "description": "BaseitemId."
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["random"],
+          "properties": {
+            "random": {
+              "const": true
+            },
+            "oodLevel": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Out-of-depth object level boost (legacy *N)."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["questReward"],
+          "properties": {
+            "questReward": {
+              "const": true,
+              "description": "Drop this quest's reward item (legacy !)."
+            }
+          }
+        }
+      ]
+    },
+    "egoSpec": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1,
+          "description": "EgoType id."
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["random"],
+          "properties": {
+            "random": {
+              "const": true
+            },
+            "id": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        }
+      ]
+    },
+    "artifactSpec": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1,
+          "description": "FixedArtifactId."
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["random"],
+          "properties": {
+            "random": {
+              "const": true
+            },
+            "id": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["questReward"],
+          "properties": {
+            "questReward": {
+              "const": true,
+              "description": "Use this quest's reward artifact (legacy !)."
+            }
+          }
+        }
+      ]
+    },
+    "trapSpec": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "TerrainTag name of the trap."
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["random"],
+          "properties": {
+            "random": {
+              "const": true
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -698,6 +698,7 @@ hengband_SOURCES = \
 	info-reader/message-reader.cpp info-reader/message-reader.h \
 	info-reader/parse-error-types.h \
 	info-reader/party-reader.cpp info-reader/party-reader.h \
+	info-reader/quest-reader.cpp info-reader/quest-reader.h \
 	info-reader/race-info-tokens-table.cpp info-reader/race-info-tokens-table.h \
 	info-reader/race-reader.cpp info-reader/race-reader.h \
 	info-reader/random-grid-effect-types.h \
@@ -1396,6 +1397,7 @@ hengband_SOURCES = \
 	system/dungeon/dungeon-list.cpp system/dungeon/dungeon-list.h \
 	system/dungeon/dungeon-record.cpp system/dungeon/dungeon-record.h \
 	system/dungeon/quest-definition.cpp system/dungeon/quest-definition.h \
+	system/dungeon/quest-fixed-map.cpp system/dungeon/quest-fixed-map.h \
 	\
 	system/enums/grid-flow.h \
 	system/enums/grid-count-kind.h \

--- a/src/info-reader/quest-reader.cpp
+++ b/src/info-reader/quest-reader.cpp
@@ -1,0 +1,464 @@
+#include "info-reader/quest-reader.h"
+#include "artifact/fixed-art-types.h"
+#include "info-reader/json-reader-util.h"
+#include "info-reader/parse-error-types.h"
+#include "info-reader/random-grid-effect-types.h"
+#include "locale/character-encoding.h"
+#include "system/dungeon/quest-definition.h"
+#include "system/dungeon/quest-fixed-map.h"
+#include "system/enums/dungeon/dungeon-id.h"
+#include "system/enums/terrain/terrain-tag.h"
+#include "system/grid-type-definition.h"
+#include "system/terrain/terrain-list.h"
+#include "util/enum-converter.h"
+#include <nlohmann/json.hpp>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace {
+const std::unordered_map<std::string_view, QuestKindType> QUEST_KIND_TOKENS = {
+    { "NONE", QuestKindType::NONE },
+    { "KILL_LEVEL", QuestKindType::KILL_LEVEL },
+    { "KILL_ANY_LEVEL", QuestKindType::KILL_ANY_LEVEL },
+    { "FIND_ARTIFACT", QuestKindType::FIND_ARTIFACT },
+    { "FIND_EXIT", QuestKindType::FIND_EXIT },
+    { "KILL_NUMBER", QuestKindType::KILL_NUMBER },
+    { "KILL_ALL", QuestKindType::KILL_ALL },
+    { "RANDOM", QuestKindType::RANDOM },
+    { "TOWER", QuestKindType::TOWER },
+};
+
+const std::unordered_map<std::string_view, QuestStatusType> QUEST_STATUS_TOKENS = {
+    { "UNTAKEN", QuestStatusType::UNTAKEN },
+    { "TAKEN", QuestStatusType::TAKEN },
+    { "COMPLETED", QuestStatusType::COMPLETED },
+    { "REWARDED", QuestStatusType::REWARDED },
+    { "FINISHED", QuestStatusType::FINISHED },
+    { "FAILED", QuestStatusType::FAILED },
+    { "FAILED_DONE", QuestStatusType::FAILED_DONE },
+    { "STAGE_COMPLETED", QuestStatusType::STAGE_COMPLETED },
+};
+
+const std::unordered_map<std::string_view, uint32_t> QUEST_FLAG_TOKENS = {
+    { "SILENT", QUEST_FLAG_SILENT },
+    { "PRESET", QUEST_FLAG_PRESET },
+    { "ONCE", QUEST_FLAG_ONCE },
+    { "TOWER", QUEST_FLAG_TOWER },
+};
+
+const std::unordered_map<std::string_view, BIT_FLAGS> CAVE_FLAG_TOKENS = {
+    { "MARK", CAVE_MARK },
+    { "GLOW", CAVE_GLOW },
+    { "NO_TELEPORT_DEST", CAVE_NO_TELEPORT_DEST },
+    { "ROOM", CAVE_ROOM },
+    { "LITE", CAVE_LITE },
+};
+
+/*!
+ * @brief JSONの文字列配列を std::vector<std::string> に取り込む (null/欠落は空)
+ * @param localize true の場合、各行を UTF-8 から内部エンコーディングへ変換する (説明文用)。
+ * マップ行のようなASCIIの記号列は変換不要なので false を指定する。
+ */
+void read_string_lines(const nlohmann::json &array_data, std::vector<std::string> &out, bool localize)
+{
+    if (!array_data.is_array()) {
+        return;
+    }
+
+    for (const auto &line : array_data) {
+        if (line.is_string()) {
+            auto value = line.get<std::string>();
+            out.push_back(localize ? utf8_to_local(value) : std::move(value));
+        }
+    }
+}
+
+/*!
+ * @brief JSON値が真偽値 true のときのみ true を返す (存在しても false や非booleanなら無効)
+ */
+bool json_is_true(const nlohmann::json &value)
+{
+    return value.is_boolean() && value.get<bool>();
+}
+}
+
+parse_error_type parse_quest_legend_cell(const nlohmann::json &cell_data, QuestLegendCell &out)
+{
+    if (!cell_data.is_object()) {
+        return PARSE_ERROR_INVALID_TYPE;
+    }
+
+    auto &grid = out.grid;
+    grid.set_terrain_id(TerrainTag::NONE);
+    grid.monster = 0;
+    grid.object = 0;
+    grid.ego = EgoType::NONE;
+    grid.artifact = FixedArtifactId::NONE;
+    grid.set_trap_id(TerrainTag::NONE);
+    grid.cave_info = 0;
+    grid.special = 0;
+    grid.random = RANDOM_NONE;
+    out.object_is_quest_reward = false;
+    out.artifact_is_quest_reward = false;
+
+    const auto &terrains = TerrainList::get_instance();
+
+    const auto &terrain = get_json_value(cell_data, "terrain");
+    if (terrain.is_string()) {
+        const auto tag = terrain.get<std::string>();
+        if (tag == "*") {
+            grid.random |= RANDOM_FEATURE;
+        } else {
+            try {
+                grid.feature = terrains.get_terrain_id(tag);
+            } catch (const std::exception &) {
+                return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
+            }
+        }
+    }
+
+    const auto &cave_info = get_json_value(cell_data, "caveInfo");
+    if (!cave_info.is_null()) {
+        if (!cave_info.is_array()) {
+            return PARSE_ERROR_INVALID_TYPE;
+        }
+        for (const auto &flag : cave_info) {
+            const auto it = CAVE_FLAG_TOKENS.find(flag.get<std::string>());
+            if (it == CAVE_FLAG_TOKENS.end()) {
+                return PARSE_ERROR_INVALID_FLAG;
+            }
+            grid.cave_info |= it->second;
+        }
+    }
+
+    const auto &monster = get_json_value(cell_data, "monster");
+    if (monster.is_number_integer()) {
+        grid.monster = static_cast<MONSTER_IDX>(monster.get<int>());
+    } else if (monster.is_object()) {
+        if (json_is_true(get_json_value(monster, "random"))) {
+            grid.random |= RANDOM_MONSTER;
+            grid.monster = static_cast<MONSTER_IDX>(get_json_value(monster, "oodLevel").is_number_integer() ? get_json_value(monster, "oodLevel").get<int>() : 0);
+        } else {
+            const auto &clone = get_json_value(monster, "cloneOf");
+            if (clone.is_number_integer()) {
+                grid.monster = static_cast<MONSTER_IDX>(-clone.get<int>());
+            }
+        }
+    }
+
+    const auto &object = get_json_value(cell_data, "object");
+    if (object.is_number_integer()) {
+        grid.object = static_cast<OBJECT_IDX>(object.get<int>());
+    } else if (object.is_object()) {
+        if (json_is_true(get_json_value(object, "random"))) {
+            grid.random |= RANDOM_OBJECT;
+            grid.object = static_cast<OBJECT_IDX>(get_json_value(object, "oodLevel").is_number_integer() ? get_json_value(object, "oodLevel").get<int>() : 0);
+        } else if (json_is_true(get_json_value(object, "questReward"))) {
+            out.object_is_quest_reward = true;
+        }
+    }
+
+    const auto &ego = get_json_value(cell_data, "ego");
+    if (ego.is_number_integer()) {
+        grid.ego = i2enum<EgoType>(ego.get<int>());
+    } else if (ego.is_object() && json_is_true(get_json_value(ego, "random"))) {
+        grid.random |= RANDOM_EGO;
+        const auto &id = get_json_value(ego, "id");
+        if (id.is_number_integer()) {
+            grid.ego = i2enum<EgoType>(id.get<int>());
+        }
+    }
+
+    const auto &artifact = get_json_value(cell_data, "artifact");
+    if (artifact.is_number_integer()) {
+        grid.artifact = i2enum<FixedArtifactId>(artifact.get<int>());
+    } else if (artifact.is_object()) {
+        if (json_is_true(get_json_value(artifact, "random"))) {
+            grid.random |= RANDOM_ARTIFACT;
+            const auto &id = get_json_value(artifact, "id");
+            if (id.is_number_integer()) {
+                grid.artifact = i2enum<FixedArtifactId>(id.get<int>());
+            }
+        } else if (json_is_true(get_json_value(artifact, "questReward"))) {
+            out.artifact_is_quest_reward = true;
+        }
+    }
+
+    const auto &trap = get_json_value(cell_data, "trap");
+    if (trap.is_string()) {
+        try {
+            grid.trap = terrains.get_terrain_id(trap.get<std::string>());
+        } catch (const std::exception &) {
+            return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
+        }
+    } else if (trap.is_object() && json_is_true(get_json_value(trap, "random"))) {
+        grid.random |= RANDOM_TRAP;
+    }
+
+    if (const auto err = info_set_integer(get_json_value(cell_data, "special"), grid.special, false); err != PARSE_ERROR_NONE) {
+        return i2enum<parse_error_type>(err);
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
+QuestReader::QuestReader(const nlohmann::json &quest_data, QuestType &quest, QuestFixedMap &fixed_map)
+    : quest_data(quest_data)
+    , quest(quest)
+    , fixed_map(fixed_map)
+{
+}
+
+int QuestReader::read() const
+{
+    if (!this->quest_data.is_object()) {
+        return PARSE_ERROR_INVALID_TYPE;
+    }
+
+    if (const auto err = this->set_name(); err != PARSE_ERROR_NONE) {
+        return err;
+    }
+    if (const auto err = this->set_definition(); err != PARSE_ERROR_NONE) {
+        return err;
+    }
+    if (const auto err = this->set_descriptions(); err != PARSE_ERROR_NONE) {
+        return err;
+    }
+    if (const auto err = this->set_legend(); err != PARSE_ERROR_NONE) {
+        return err;
+    }
+    if (const auto err = this->set_maps(); err != PARSE_ERROR_NONE) {
+        return err;
+    }
+    if (const auto err = this->set_starts(); err != PARSE_ERROR_NONE) {
+        return err;
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
+int QuestReader::set_name() const
+{
+    // info_set_string は {ja, en} オブジェクトを受け取り、ビルド言語に応じた文字列を格納する
+    return info_set_string(get_json_value(this->quest_data, "name"), this->quest.name, true);
+}
+
+int QuestReader::set_definition() const
+{
+    const auto &definition = get_json_value(this->quest_data, "definition");
+    if (!definition.is_object()) {
+        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    }
+
+    auto &meta = this->fixed_map.metadata;
+    meta.present = true;
+
+    const auto &type = get_json_value(definition, "type");
+    if (!type.is_string()) {
+        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    }
+    const auto kind_it = QUEST_KIND_TOKENS.find(type.get<std::string>());
+    if (kind_it == QUEST_KIND_TOKENS.end()) {
+        return PARSE_ERROR_INVALID_FLAG;
+    }
+    meta.type = enum2i(kind_it->second);
+
+    if (const auto err = info_set_integer(get_json_value(definition, "level"), meta.level, true); err != PARSE_ERROR_NONE) {
+        return err;
+    }
+    if (const auto err = info_set_integer(get_json_value(definition, "numMon"), meta.num_mon, false); err != PARSE_ERROR_NONE) {
+        return err;
+    }
+    if (const auto err = info_set_integer(get_json_value(definition, "maxNum"), meta.max_num, false); err != PARSE_ERROR_NONE) {
+        return err;
+    }
+    if (const auto err = info_set_integer(get_json_value(definition, "dungeon"), meta.dungeon, false); err != PARSE_ERROR_NONE) {
+        return err;
+    }
+    if (const auto err = info_set_integer(get_json_value(definition, "monster"), meta.r_idx, false); err != PARSE_ERROR_NONE) {
+        return err;
+    }
+
+    const auto &flags = get_json_value(definition, "flags");
+    if (!flags.is_null()) {
+        if (!flags.is_array()) {
+            return PARSE_ERROR_INVALID_TYPE;
+        }
+        for (const auto &flag : flags) {
+            const auto it = QUEST_FLAG_TOKENS.find(flag.get<std::string>());
+            if (it == QUEST_FLAG_TOKENS.end()) {
+                return PARSE_ERROR_INVALID_FLAG;
+            }
+            meta.flags |= it->second;
+        }
+    }
+
+    const auto &reward = get_json_value(definition, "reward");
+    if (!reward.is_null()) {
+        const auto &artifact = get_json_value(reward, "artifact");
+        if (artifact.is_number_integer()) {
+            meta.reward_artifact = artifact.get<int>();
+        }
+
+        const auto &artifacts = get_json_value(reward, "artifacts");
+        if (!artifacts.is_null()) {
+            if (!artifacts.is_array()) {
+                return PARSE_ERROR_INVALID_TYPE;
+            }
+            for (const auto &candidate : artifacts) {
+                if (candidate.is_number_integer()) {
+                    this->fixed_map.reward_artifact_candidates.push_back(candidate.get<int>());
+                }
+            }
+        }
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
+int QuestReader::set_descriptions() const
+{
+    const auto &descriptions = get_json_value(this->quest_data, "descriptions");
+    if (descriptions.is_null()) {
+        return PARSE_ERROR_NONE;
+    }
+    if (!descriptions.is_array()) {
+        return PARSE_ERROR_INVALID_TYPE;
+    }
+
+    for (const auto &description : descriptions) {
+        QuestDescriptionBlock block;
+
+        const auto &when = get_json_value(description, "when");
+        const auto &status_at_most = get_json_value(when, "statusAtMost");
+        if (status_at_most.is_string()) {
+            const auto it = QUEST_STATUS_TOKENS.find(status_at_most.get<std::string>());
+            if (it == QUEST_STATUS_TOKENS.end()) {
+                return PARSE_ERROR_INVALID_FLAG;
+            }
+            block.status_at_most = it->second;
+        }
+
+        const auto &status = get_json_value(when, "status");
+        if (status.is_string()) {
+            const auto it = QUEST_STATUS_TOKENS.find(status.get<std::string>());
+            if (it == QUEST_STATUS_TOKENS.end()) {
+                return PARSE_ERROR_INVALID_FLAG;
+            }
+            block.status_equals = it->second;
+        }
+
+        const auto &quest_type = get_json_value(when, "questType");
+        if (quest_type.is_string()) {
+            const auto it = QUEST_KIND_TOKENS.find(quest_type.get<std::string>());
+            if (it == QUEST_KIND_TOKENS.end()) {
+                return PARSE_ERROR_INVALID_FLAG;
+            }
+            block.quest_type = it->second;
+        }
+
+        const auto &text = get_json_value(description, "text");
+        read_string_lines(get_json_value(text, "ja"), block.lines_ja, true);
+        read_string_lines(get_json_value(text, "en"), block.lines_en, true);
+
+        this->fixed_map.descriptions.push_back(std::move(block));
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
+int QuestReader::set_legend() const
+{
+    const auto &legend = get_json_value(this->quest_data, "legend");
+    if (legend.is_null()) {
+        return PARSE_ERROR_NONE;
+    }
+    if (!legend.is_object()) {
+        return PARSE_ERROR_INVALID_TYPE;
+    }
+
+    for (const auto &[symbol, cell_data] : legend.items()) {
+        if (symbol.size() != 1) {
+            return PARSE_ERROR_GENERIC;
+        }
+
+        QuestLegendCell cell;
+        if (const auto err = parse_quest_legend_cell(cell_data, cell); err != PARSE_ERROR_NONE) {
+            return err;
+        }
+        this->fixed_map.legend.insert_or_assign(symbol.front(), cell);
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
+int QuestReader::set_maps() const
+{
+    const auto &map = get_json_value(this->quest_data, "map");
+    if (!map.is_null()) {
+        if (!map.is_array()) {
+            return PARSE_ERROR_INVALID_TYPE;
+        }
+        std::vector<std::string> rows;
+        read_string_lines(map, rows, false);
+        this->fixed_map.maps.push_back(std::move(rows));
+        return PARSE_ERROR_NONE;
+    }
+
+    const auto &variants = get_json_value(this->quest_data, "mapVariants");
+    if (!variants.is_null()) {
+        if (!variants.is_array()) {
+            return PARSE_ERROR_INVALID_TYPE;
+        }
+        for (const auto &variant : variants) {
+            if (!variant.is_array()) {
+                return PARSE_ERROR_INVALID_TYPE;
+            }
+            std::vector<std::string> rows;
+            read_string_lines(variant, rows, false);
+            this->fixed_map.maps.push_back(std::move(rows));
+        }
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
+int QuestReader::set_starts() const
+{
+    const auto &start = get_json_value(this->quest_data, "start");
+    if (!start.is_null()) {
+        QuestStartPosition position;
+        if (const auto err = info_set_integer(get_json_value(start, "y"), position.y, true); err != PARSE_ERROR_NONE) {
+            return err;
+        }
+        if (const auto err = info_set_integer(get_json_value(start, "x"), position.x, true); err != PARSE_ERROR_NONE) {
+            return err;
+        }
+        this->fixed_map.starts.push_back(position);
+        return PARSE_ERROR_NONE;
+    }
+
+    const auto &variants = get_json_value(this->quest_data, "startVariants");
+    if (!variants.is_null()) {
+        if (!variants.is_array()) {
+            return PARSE_ERROR_INVALID_TYPE;
+        }
+        for (const auto &variant : variants) {
+            QuestStartPosition position;
+            const auto &leaving_quest = get_json_value(variant, "leavingQuest");
+            if (leaving_quest.is_number_integer()) {
+                position.leaving_quest = leaving_quest.get<int>();
+            }
+            if (const auto err = info_set_integer(get_json_value(variant, "y"), position.y, true); err != PARSE_ERROR_NONE) {
+                return err;
+            }
+            if (const auto err = info_set_integer(get_json_value(variant, "x"), position.x, true); err != PARSE_ERROR_NONE) {
+                return err;
+            }
+            this->fixed_map.starts.push_back(position);
+        }
+    }
+
+    return PARSE_ERROR_NONE;
+}

--- a/src/info-reader/quest-reader.h
+++ b/src/info-reader/quest-reader.h
@@ -1,0 +1,50 @@
+#pragma once
+/*!
+ * @file quest-reader.h
+ * @brief 1つの固定クエスト JSONC を QuestType(メタデータ) と QuestFixedMap(レイアウト) に読み込む
+ */
+
+#include <nlohmann/json.hpp>
+
+enum parse_error_type : int;
+class QuestType;
+struct QuestFixedMap;
+struct QuestLegendCell;
+struct QuestDescriptionBlock;
+
+/*!
+ * @brief 固定クエスト JSONC 読み込みクラス
+ *
+ * 既存の *Reader 群と同じ規約: メンバは const 参照、キーアクセスは get_json_value 経由。
+ * メタデータ(type/level/flags/reward/name 等)を QuestType へ、地形レイアウト
+ * (legend/map/descriptions/start)を QuestFixedMap へ書き込む。
+ */
+class QuestReader {
+public:
+    QuestReader(const nlohmann::json &quest_data, QuestType &quest, QuestFixedMap &fixed_map);
+    QuestReader(nlohmann::json &&, QuestType &, QuestFixedMap &) = delete;
+    QuestReader(const QuestReader &) = delete;
+    QuestReader(QuestReader &&) = delete;
+    QuestReader &operator=(const QuestReader &) = delete;
+    QuestReader &operator=(QuestReader &&) = delete;
+
+    int read() const;
+
+private:
+    int set_name() const;
+    int set_definition() const;
+    int set_descriptions() const;
+    int set_legend() const;
+    int set_maps() const;
+    int set_starts() const;
+
+    const nlohmann::json &quest_data;
+    QuestType &quest;
+    QuestFixedMap &fixed_map;
+};
+
+/*!
+ * @brief JSONC の gridDefinition 1件を凡例セルへ変換する (set_legend から使用)
+ * @return エラーコード
+ */
+parse_error_type parse_quest_legend_cell(const nlohmann::json &cell_data, QuestLegendCell &out);

--- a/src/system/dungeon/quest-fixed-map.cpp
+++ b/src/system/dungeon/quest-fixed-map.cpp
@@ -1,0 +1,122 @@
+#include "system/dungeon/quest-fixed-map.h"
+#include "artifact/fixed-art-types.h"
+#include "monster-race/race-kind-flags.h"
+#include "monster-race/race-misc-flags.h"
+#include "system/artifact/artifact-record.h"
+#include "system/dungeon/quest-definition.h"
+#include "system/enums/dungeon/dungeon-id.h"
+#include "system/monrace/monrace-definition.h"
+#include "term/z-rand.h"
+#include "util/enum-converter.h"
+
+QuestFixedMapList QuestFixedMapList::instance{};
+
+QuestFixedMapList &QuestFixedMapList::get_instance()
+{
+    return instance;
+}
+
+QuestFixedMap &QuestFixedMapList::emplace(QuestId id)
+{
+    return this->maps[id];
+}
+
+tl::optional<QuestFixedMap> QuestFixedMapList::find(QuestId id) const
+{
+    const auto it = this->maps.find(id);
+    if (it == this->maps.end()) {
+        return tl::nullopt;
+    }
+
+    return it->second;
+}
+
+void QuestFixedMapList::clear()
+{
+    this->maps.clear();
+}
+
+void QuestFixedMapList::set_base_legend(std::map<char, QuestLegendCell> legend)
+{
+    this->base_legend = std::move(legend);
+}
+
+const std::map<char, QuestLegendCell> &QuestFixedMapList::get_base_legend() const
+{
+    return this->base_legend;
+}
+
+void apply_quest_metadata(const QuestFixedMap &fixed_map, QuestType &quest)
+{
+    const auto &meta = fixed_map.metadata;
+    if (!meta.present) {
+        return;
+    }
+
+    // type は静的な基本値だが、受託時の resolve_quest_reward が「候補報酬が全て生成済み」の場合に
+    // FIND_ARTIFACT を KILL_ALL へ格下げする (実行時の決定)。apply_quest_metadata は init/reset だけ
+    // でなくフロア生成でも呼ばれるため、既に受託済みで具体的な type が確定している場合は上書きしない
+    // (でないと格下げ後に FIND_ARTIFACT へ戻り、報酬アーティファクト不在の達成不能クエストになる)。
+    if ((quest.status == QuestStatusType::UNTAKEN) || (quest.type == QuestKindType::NONE)) {
+        quest.type = i2enum<QuestKindType>(meta.type);
+    }
+    quest.level = meta.level;
+    quest.num_mon = meta.num_mon;
+    quest.max_num = meta.max_num;
+    quest.r_idx = i2enum<MonraceId>(meta.r_idx);
+    quest.dungeon = i2enum<DungeonId>(meta.dungeon);
+    quest.flags = meta.flags;
+
+    // 旧 parse_qtw_QQ と同じく、UNIQUE のクエスト対象モンスターを QUESTOR にする (クエスト保護・
+    // 最終ボス処理のため)。旧 init_dungeon_quests は birth で parse_fixed_map(QUEST_DEFINITION_LIST)
+    // を INIT_ASSIGN で全クエスト分パースし、全クエストユニークに QUESTOR を立てていた。よって受託時に
+    // 限定せず、init/reset_all で全クエストに設定する (でないとエリック砦等の未受託クエストのユニークが
+    // 通常ダンジョンに出現し、そこで生成されるとクエスト内に出せず達成不能になる)。misc_flags の設定は
+    // 冪等で、reset_all 直後の monrace リセットは kills/出現数のみ戻し misc_flags は消さないため残る。
+    auto &monrace = quest.get_bounty();
+    if (monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
+        monrace.misc_flags.set(MonsterMiscType::QUESTOR);
+    }
+}
+
+void resolve_quest_reward(const QuestFixedMap &fixed_map, QuestType &quest)
+{
+    const auto &meta = fixed_map.metadata;
+    if (!meta.present) {
+        return;
+    }
+
+    // 旧 parse_qtw_QQ 相当: 固定報酬アーティファクトを予約する。
+    if (meta.reward_artifact != 0) {
+        quest.set_reward(i2enum<FixedArtifactId>(meta.reward_artifact));
+    }
+
+    // 旧 parse_qtw_QR 相当: 未生成の候補アーティファクトから1つを報酬に選び set_reward で予約する。
+    // 全て生成済みなら報酬なし + KILL_ALL に格下げする。旧 INIT_ASSIGN と同じく受託時のみ実行する
+    // (assign_json_quest_metadata 経由)。受託は「新規キャラ生成時の全リセットより後・クエスト報酬
+    // アーティファクトの配置(フロア生成)より前・ライフサイクル中に1回」であり、選んだ報酬の予約が
+    // 消えず、生成済みアーティファクトを避けて確定できる。
+    if (!fixed_map.reward_artifact_candidates.empty()) {
+        const auto &artifact_records = ArtifactRecords::get_instance();
+        auto reward_id = FixedArtifactId::NONE;
+        auto count = 0;
+        for (const auto candidate : fixed_map.reward_artifact_candidates) {
+            const auto fa_id = i2enum<FixedArtifactId>(candidate);
+            if ((fa_id == FixedArtifactId::NONE) || artifact_records.get_generated(fa_id)) {
+                continue;
+            }
+
+            count++;
+            if (one_in_(count)) {
+                reward_id = fa_id;
+            }
+        }
+
+        if (reward_id != FixedArtifactId::NONE) {
+            quest.set_reward(reward_id);
+        } else {
+            quest.set_reward(FixedArtifactId::NONE);
+            quest.type = QuestKindType::KILL_ALL;
+        }
+    }
+}

--- a/src/system/dungeon/quest-fixed-map.h
+++ b/src/system/dungeon/quest-fixed-map.h
@@ -1,0 +1,134 @@
+#pragma once
+/*!
+ * @file quest-fixed-map.h
+ * @brief 固定クエストのレイアウト情報 (JSONCから読み込む地形凡例・マップ・説明文・開始位置)
+ *
+ * QuestType はクエストの実行時状態とメタデータを保持するが、フロアを生成するための
+ * 地形レイアウト(legend/map)・段階別説明文・開始位置は保持しない。これらは従来
+ * 各クエストの .txt を毎回パースして得ていたものを、起動時に一度だけ JSONC から
+ * 読み込んで保持するための構造体群である。
+ */
+
+#include "info-reader/general-parser.h" // dungeon_grid
+#include <cstdint>
+#include <map>
+#include <string>
+#include <tl/optional.hpp>
+#include <vector>
+
+class QuestType;
+enum class QuestId : short;
+enum class QuestStatusType : short;
+enum class QuestKindType : short;
+
+/*!
+ * @brief クエストの静的メタデータ (旧 Q:Q)。QuestType::reset() で消えないよう別に保持し、
+ * load 時および reset 後に QuestType へ再適用する。
+ */
+struct QuestMetadata {
+    bool present = false; //!< JSONC から読み込まれたか
+    int type = 0; //!< QuestKindType
+    int level = 0;
+    int num_mon = 0;
+    int max_num = 0;
+    int r_idx = 0; //!< MonraceId
+    int dungeon = 0; //!< DungeonId
+    uint32_t flags = 0;
+    int reward_artifact = 0; //!< FixedArtifactId (0 = なし)
+};
+
+/*!
+ * @brief 地形凡例の1エントリ (記号 -> グリッド生成テンプレート)
+ *
+ * dungeon_grid をそのままテンプレートとして流用する。ただしクエスト報酬を指す
+ * object/artifact (旧 F: の "!") は生成時に解決するため、フラグで遅延解決を示す。
+ */
+struct QuestLegendCell {
+    dungeon_grid grid{}; //!< feature/monster/object/ego/artifact/trap/cave_info/special/random
+    bool object_is_quest_reward = false; //!< object をクエスト報酬アイテムとして生成時に解決する (旧 "!")
+    bool artifact_is_quest_reward = false; //!< artifact をクエスト報酬アーティファクトとして解決する (旧 "!")
+};
+
+/*!
+ * @brief 条件付き説明文ブロック (旧 ?:[...] over $QUESTnn / $QUEST_TYPEnn)
+ *
+ * status_at_most / status_equals はいずれか一方のみを持つ。quest_type を併せ持つ場合は
+ * 「そのクエスト種別のときのみ表示」を追加で要求する (旧 [AND [..$QUESTnn..] [EQU $QUEST_TYPEnn t]])。
+ */
+struct QuestDescriptionBlock {
+    tl::optional<QuestStatusType> status_at_most; //!< [LEQ $QUESTnn s]: status <= s で表示
+    tl::optional<QuestStatusType> status_equals; //!< [EQU $QUESTnn s]: status == s で表示
+    tl::optional<QuestKindType> quest_type; //!< [EQU $QUEST_TYPEnn t]: さらにこの種別を要求
+    std::vector<std::string> lines_ja; //!< 日本語の表示行 (1要素=画面1行)
+    std::vector<std::string> lines_en; //!< 英語の表示行
+};
+
+/*!
+ * @brief プレイヤー開始位置。退出クエスト依存で分岐する場合は複数持つ (旧 $LEAVING_QUEST)。
+ */
+struct QuestStartPosition {
+    tl::optional<int> leaving_quest; //!< $LEAVING_QUEST の一致条件。未設定なら既定(フォールバック)
+    int y = 0;
+    int x = 0;
+};
+
+/*!
+ * @brief 1つの固定クエストのレイアウト情報一式
+ */
+struct QuestFixedMap {
+    QuestMetadata metadata; //!< 静的メタデータ (旧 Q:Q)
+    std::map<char, QuestLegendCell> legend; //!< 記号 -> グリッドテンプレート (共通ベース凡例に上書き)
+    std::vector<std::vector<std::string>> maps; //!< 1個=固定、複数=ランダムバリアント(旧 $RANDOMn) から一様選択
+    std::vector<QuestDescriptionBlock> descriptions; //!< 段階別説明文
+    std::vector<QuestStartPosition> starts; //!< 開始位置 (1個=無条件、複数=退出クエスト分岐)
+    std::vector<int> reward_artifact_candidates; //!< 旧 Q:R: 生成時に未生成のものからランダムに1つ報酬化する候補
+
+    bool has_map() const
+    {
+        return !this->maps.empty();
+    }
+};
+
+/*!
+ * @brief 固定クエストのレイアウト情報ストア (QuestId -> QuestFixedMap)。起動時に構築。
+ */
+class QuestFixedMapList {
+public:
+    QuestFixedMapList(const QuestFixedMapList &) = delete;
+    QuestFixedMapList(QuestFixedMapList &&) = delete;
+    QuestFixedMapList &operator=(const QuestFixedMapList &) = delete;
+    QuestFixedMapList &operator=(QuestFixedMapList &&) = delete;
+
+    static QuestFixedMapList &get_instance();
+
+    QuestFixedMap &emplace(QuestId id); //!< 空エントリを作成/取得 (ローダが読み込み先として使う)
+    tl::optional<QuestFixedMap> find(QuestId id) const; //!< 無ければ nullopt
+    void clear();
+
+    //!< 全クエスト共通のベース凡例 (旧 QuestPreferences.txt)。各クエスト legend より前に letter[] へ適用する。
+    void set_base_legend(std::map<char, QuestLegendCell> legend);
+    const std::map<char, QuestLegendCell> &get_base_legend() const;
+
+private:
+    QuestFixedMapList() = default;
+    static QuestFixedMapList instance;
+    std::map<QuestId, QuestFixedMap> maps;
+    std::map<char, QuestLegendCell> base_legend;
+};
+
+/*!
+ * @brief QuestFixedMap の静的メタデータ (type/level/r_idx 等 + QUESTOR) を QuestType へ適用する
+ * @details load 時 / reset 後 / フロア生成時に呼ばれる冪等な処理。UNIQUE のクエスト対象は QUESTOR に
+ * する (旧 birth の全クエスト INIT_ASSIGN 相当。全クエストで立てないと未受託クエストのユニークが通常
+ * 出現し達成不能化する)。報酬 (アーティファクト予約を伴う) は含めない。予約が reset 直後の
+ * ArtifactRecords リセットで消えないよう、報酬確定は受託時のみの resolve_quest_reward() で行う。
+ */
+void apply_quest_metadata(const QuestFixedMap &fixed_map, QuestType &quest);
+
+/*!
+ * @brief 受託時 (旧 INIT_ASSIGN) の一度きりの処理: 報酬アーティファクトの確定・予約
+ * @details 旧 parse_qtw_QQ (固定報酬) と parse_qtw_QR (候補報酬) 相当。受託時のみ
+ * (assign_json_quest_metadata 経由で) 呼ぶこと。初期化・reset・フロア生成では呼ばない
+ * (報酬予約タイミングが reset 直後の ArtifactRecords リセットとずれるため)。
+ */
+void resolve_quest_reward(const QuestFixedMap &fixed_map, QuestType &quest);


### PR DESCRIPTION
変愚蛮怒 PR #5486「固定クエスト定義の per-quest JSONC 移行」を
bakabakaband へ段階マージする第1段。ランタイム挙動は不変
(新規ファイルはまだどこからも呼ばれない基盤のみ)。

追加:
- schema/Quest.schema.json / schema/QuestPreferences.schema.json 固定クエスト JSONC / 共通凡例の JSON スキーマ (CI 検証用)。
- src/system/dungeon/quest-fixed-map.{h,cpp} QuestFixedMap (legend/map/descriptions/start/metadata) と QuestFixedMapList、apply_quest_metadata()/resolve_quest_reward()。 QuestType の実行時状態と分離し、起動時に一度だけ JSONC から 読み込むレイアウト情報を保持する。
- src/info-reader/quest-reader.{h,cpp} 1つの固定クエスト JSONC を QuestType(メタデータ) と QuestFixedMap(レイアウト) に読み込む QuestReader。

bakabakaband 側の適応:
- 依存プリミティブ (get_json_value/info_set_integer, dungeon_grid, QuestKindType/QuestStatusType, QUEST_FLAG_*, RANDOM_*, TerrainList::get_terrain_id) は既存のものを流用。enum・フラグ値は 上流と完全一致のためトークンマップは無改変。
- src/Makefile.am に新規 2 ファイル対を登録。

後続段: クエストロード経路 (QuestList::initialize) の JSONC 化、
フロア生成のレイアウト消費化、35 クエストの .txt→.jsonc データ変換。