### PR TITLE
feat: モンスターの武器打撃をプレイヤーの打撃処理と完全同化 (会心を追加)

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -711,6 +711,20 @@ bakabakaband ではプレイヤーとモンスター双方が `CreatureEntity` �
     装備品 + ULTIMATE_RESISTANCE 等を反映
 - **B-2b**: 近接攻撃のダメージボーナス (7a9cda1ec)
   - HIT/PUNCH/SLASH/STING 打撃で `weapon.damage_dice.roll() + weapon.to_d` 加算
+  - 後に共通の `calc_attack_damage_with_slay()` でスレイ/ブランドも反映
+- **B-2b2**: 武器ダメージ計算のプレイヤー完全同化 (会心の追加)
+  - B-2b の「ダイス→スレイ/ブランド→ to_d」に**会心 (`critical_norm`)** を追加し、
+    プレイヤーの `process_weapon_attack()` と同一パイプラインに揃えた
+  - 共通ヘルパ `calc_weapon_melee_damage(attacker, weapon, target, hand)`
+    (`src/combat/slaying.cpp`) に集約。対プレイヤー
+    (`monster-attack-player.cpp`) / 対モンスター (`monster-attack-monster.cpp`)
+    の両経路が同一関数を呼ぶ
+  - `critical_norm()` の会心メッセージ・効果音は攻撃者視点の文言のため
+    `creature.is_player()` でガードし、モンスター会心時はダメージのみ反映して
+    表示を抑止 (ダメージ値はプレイヤーと完全同一)
+  - **武器を装備したモンスターは、対プレイヤー・対モンスターのいずれでも
+    プレイヤーと同じ武器打撃ダメージ (会心込み) を与える**。武器ダメージは
+    従来同様、種族固有の innate blow ダメージに**加算**される (B-2b の加算モデルを継承)
 - **B-2c**: 近接攻撃の命中ボーナス (11058a278)
   - `to_h` を `check_hit_from_monster_to_player` の power に加算
 - **B-4**: look 表示で装備品/パック品を区別 (145f1fb56)

--- a/src/combat/attack-criticality.cpp
+++ b/src/combat/attack-criticality.cpp
@@ -71,8 +71,12 @@ int critical_norm(CreatureEntity &creature, WEIGHT weight, int plus, int dam, in
     }
 
     const auto &[critical_dam, msg, battle_sound] = apply_critical_norm_damage(k, dam);
-    sound(battle_sound);
-    msg_print(msg);
+    // クリティカルメッセージ・効果音はプレイヤー攻撃者視点の文言のため、
+    // モンスターが武器で会心を出した場合はダメージ計算のみ共通化し表示は抑止する。
+    if (creature.is_player()) {
+        sound(battle_sound);
+        msg_print(msg);
+    }
     return critical_dam;
 }
 

--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -1,5 +1,6 @@
 #include "combat/slaying.h"
 #include "artifact/fixed-art-types.h"
+#include "combat/attack-criticality.h"
 #include "effect/attribute-types.h"
 #include "mind/mind-samurai.h"
 #include "monster-race/race-flags-resistance.h"
@@ -235,6 +236,31 @@ int calc_attack_damage_with_slay(CreatureEntity &creature, ItemEntity *o_ptr, in
         mult = 150;
     }
     return tdam * mult / 10;
+}
+
+/*!
+ * @brief 武器を装備したクリーチャーの1打撃分の武器ダメージを、プレイヤーの打撃処理と同一の式で算出する
+ * @param attacker 攻撃側クリーチャー (プレイヤー・モンスターいずれも可)
+ * @param weapon 使用する近接武器
+ * @param target 攻撃対象クリーチャー (プレイヤー・モンスターいずれも可)
+ * @param hand 使用する手 (0=利き手 / 1=逆手)。会心判定の基本命中力 (meichuu) 参照に使う
+ * @return 武器ダイス→スレイ/ブランド倍率→会心→武器の to_d までを反映したダメージ値
+ * @details
+ * プレイヤーの process_weapon_attack() が武器から算出する部分
+ * (ダイスロール→calc_attack_damage_with_slay()→critical_norm()→ to_d 加算) と同一の
+ * パイプラインを、攻撃側の種別 (プレイヤー/モンスター) に依らず共通で適用する。
+ * これにより、武器を装備したモンスターは対プレイヤー・対モンスターのいずれでも
+ * プレイヤーと同じ武器打撃ダメージを与える。
+ * プレイヤー固有の追加ダイス (damage_dice_bonus) ・ヴォーパル・get_to_d(hand) 等の
+ * 装備/職業由来ボーナスは呼出側で別途反映される (モンスターは get_melee_stat_damage_bonus() 等)。
+ */
+int calc_weapon_melee_damage(CreatureEntity &attacker, ItemEntity &weapon, const CreatureEntity &target, int hand)
+{
+    auto damage = calc_attack_damage_with_slay(attacker, &weapon, weapon.damage_dice.roll(), target, HISSATSU_NONE, false);
+    const auto do_impact = weapon.get_flags().has(TR_IMPACT);
+    damage = critical_norm(attacker, weapon.weight, weapon.to_h, damage, attacker.get_to_h(hand), HISSATSU_NONE, do_impact);
+    damage += weapon.to_d;
+    return damage;
 }
 
 AttributeFlags melee_attribute(CreatureEntity &creature, ItemEntity *o_ptr, combat_options mode)

--- a/src/combat/slaying.h
+++ b/src/combat/slaying.h
@@ -11,4 +11,5 @@ class CreatureEntity;
 MULTIPLY mult_slaying(CreatureEntity &creature, MULTIPLY mult, const TrFlags &flags, const CreatureEntity &target);
 MULTIPLY mult_brand(CreatureEntity &creature, MULTIPLY mult, const TrFlags &flags, const CreatureEntity &target);
 int calc_attack_damage_with_slay(CreatureEntity &creature, ItemEntity *o_ptr, int tdam, const CreatureEntity &target, combat_options mode, bool thrown);
+int calc_weapon_melee_damage(CreatureEntity &attacker, ItemEntity &weapon, const CreatureEntity &target, int hand);
 AttributeFlags melee_attribute(CreatureEntity &creature, ItemEntity *o_ptr, combat_options mode);

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -315,12 +315,13 @@ static void process_melee(CreatureEntity &creature, mam_type *mam_ptr)
         mam_ptr->damage = 0;
     }
 
-    // 武器を装備している場合、プレイヤーと共通の calc_attack_damage_with_slay() で
-    // スレイ・ブランド効果を反映したダメージを加算する。
+    // 武器を装備している場合、プレイヤーの打撃処理と共通の calc_weapon_melee_damage() で
+    // スレイ・ブランド・会心を反映したダメージを加算する。
+    // 対モンスターでも対プレイヤーと同一の武器ダメージ計算を行う。
     if (!mam_ptr->explode && (mam_ptr->weapon_slot_for_blow >= 0)) {
         auto &weapon = *mam_ptr->m_ptr->inventory[mam_ptr->weapon_slot_for_blow];
-        const auto base_dam = weapon.damage_dice.roll();
-        mam_ptr->damage += calc_attack_damage_with_slay(*mam_ptr->m_ptr, &weapon, base_dam, *mam_ptr->t_ptr, HISSATSU_NONE, false) + weapon.to_d;
+        const auto hand = mam_ptr->weapon_slot_for_blow - enum2i(INVEN_MAIN_HAND);
+        mam_ptr->damage += calc_weapon_melee_damage(*mam_ptr->m_ptr, weapon, *mam_ptr->t_ptr, hand);
     }
 
     mam_ptr->attribute = BlowEffectType::NONE;

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -292,11 +292,12 @@ bool MonsterAttackPlayer::process_monster_attack_hit()
     // [フェーズ B-2b / 二刀流対応] 装備武器によるダメージボーナス
     // weapon_slot_for_blow は process_monster_blows() で設定され、
     // 物理打撃 (HIT/PUNCH/SLASH/STING) かつ武器装備時のみ有効
-    // スレイ・ブランド等はプレイヤーと共通の calc_attack_damage_with_slay() を再利用する。
+    // スレイ・ブランド・会心はプレイヤーの打撃処理と共通の calc_weapon_melee_damage() を再利用し、
+    // 武器を装備したモンスターがプレイヤーと同一の武器ダメージを与えるようにする。
     if (!this->explode && this->weapon_slot_for_blow >= 0) {
         auto &weapon = *this->m_ptr->inventory[this->weapon_slot_for_blow];
-        const auto base_dam = weapon.damage_dice.roll();
-        this->damage += calc_attack_damage_with_slay(*this->m_ptr, &weapon, base_dam, creature, HISSATSU_NONE, false) + weapon.to_d;
+        const auto hand = this->weapon_slot_for_blow - enum2i(INVEN_MAIN_HAND);
+        this->damage += calc_weapon_melee_damage(*this->m_ptr, weapon, creature, hand);
     }
 
     switch_monster_blow_to_player(creature, this);


### PR DESCRIPTION
武器を装備したモンスターの近接ダメージ計算を、プレイヤーの
process_weapon_attack() と同一パイプライン (ダイス→スレイ/ブランド→
会心→武器 to_d) に揃えた。従来はスレイ/ブランドと to_d のみで会心
(critical_norm) が抜けていた。

- 共通ヘルパ calc_weapon_melee_damage(attacker, weapon, target, hand) を src/combat/slaying.cpp に追加。対プレイヤー (monster-attack-player.cpp) / 対モンスター (monster-attack-monster.cpp) の両経路が同一関数を呼び、 武器を装備したモンスターは相手が PC・NPC いずれでも同じ武器ダメージを与える。
- critical_norm() の会心メッセージ・効果音は攻撃者視点の文言のため creature.is_player() でガードし、モンスター会心時はダメージのみ反映。 ダメージ値はプレイヤーと完全同一。
- 武器ダメージは従来同様、種族固有の innate blow に加算するモデルを継承。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Combat Improvements**
  * Monster weapon attacks now use the same damage calculations as player weapon attacks.
  * Monster attacks correctly apply critical hits, slaying bonuses, weapon brands, and weapon bonuses.
  * Weapon damage continues to stack with innate racial attacks.
  * Critical-hit messages and sounds remain hidden for monster attacks while damage is still applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->