### PR TITLE
モンスターの吸血武器打撃を同化 (ヴァンパイア武器のHP吸収)

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -736,6 +736,19 @@ bakabakaband ではプレイヤーとモンスター双方が `CreatureEntity` �
     (ダメージのみ反映)。ルーンソード呪唱 (術者状態) ・斬鉄剣無効化 (対象非切断) 等の
     文脈依存分岐は武器固有プロパティのみに限定 (`TR_VORPAL` フラグ判定のみ)
   - **ヴォーパル武器を装備したモンスターもプレイヤーと同じメッタ斬りダメージを与える**
+- **B-2b4**: 吸血 (ヴァンパイア武器) の同化
+  - 共通関数 `apply_weapon_vampiric_drain(attacker, weapon, target, weapon_damage)`
+    (`src/combat/slaying.cpp`) を追加。`TR_VAMPIRIC` 武器で生命のある対象
+    (`has_living_flag`) を攻撃した場合、与えた武器ダメージ (対象残 HP が上限) を元に
+    `2d(drain/6)` の HP を攻撃側へ回復 (プレイヤー `blood-sucking-processor.cpp` と同式)
+  - 吸血はダメージ倍率を持たず回復のみ (プレイヤー版と同様に `mult_brand` 非関与)
+  - 対プレイヤー (`monster-attack-player.cpp`) / 対モンスター
+    (`monster-attack-monster.cpp`) の両経路で発火。体力バー再描画・視認時メッセージを付随
+  - **意図的な簡略化**: プレイヤー版の対象最大 HP 減少 (weaken) と攻撃全体の回復上限
+    (`MAX_VAMPIRIC_DRAIN`=50) は、既存モンスター吸血 (`heal_monster_by_melee`、innate
+    DRAIN 打撃) が「回復のみ・上限なし」である慣習に合わせて省略。恒久的な最大 HP 減少を
+    プレイヤーへ課す挙動は保守的に見送り (将来のバランス判断で追加余地)
+  - **吸血武器を装備したモンスターは対プレイヤー・対モンスターとも生命力を吸収して回復する**
 - **B-2c**: 近接攻撃の命中ボーナス (11058a278)
   - `to_h` を `check_hit_from_monster_to_player` の power に加算
 - **B-4**: look 表示で装備品/パック品を区別 (145f1fb56)

--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -21,6 +21,8 @@
 #include "system/redrawing-flags-updater.h"
 #include "term/z-rand.h"
 #include "util/bit-flags-calculator.h"
+#include "util/dice.h"
+#include <algorithm>
 
 /*!
  * @brief プレイヤー攻撃の種族スレイング倍率計算
@@ -279,6 +281,38 @@ int calc_weapon_melee_damage(CreatureEntity &attacker, ItemEntity &weapon, const
 
     damage += weapon.to_d;
     return damage;
+}
+
+/*!
+ * @brief 吸血武器を装備したクリーチャーの近接打撃による吸血 (HP 吸収) を適用する
+ * @param attacker 攻撃側クリーチャー (プレイヤー・モンスターいずれも可)
+ * @param weapon 使用した近接武器
+ * @param target 攻撃対象クリーチャー (プレイヤー・モンスターいずれも可)
+ * @param weapon_damage calc_weapon_melee_damage() が返した当該打撃の武器ダメージ
+ * @return 吸収して回復した (ロールした) HP 量。0 なら吸血が発生しなかった
+ * @details
+ * プレイヤーの吸血処理 (blood-sucking-processor.cpp) と同じく、TR_VAMPIRIC を持つ武器で
+ * 生命のある対象 (has_living_flag) を攻撃した場合に、与えた武器ダメージ (対象の残 HP が上限) を
+ * 元に 2d(drain/6) の HP を攻撃側へ回復する。吸血はダメージ倍率を持たず回復のみ (プレイヤー版と同様)。
+ * プレイヤー版が行う対象最大 HP 減少 (weaken) は、既存のモンスター吸血 (heal_monster_by_melee) が
+ * 回復のみである慣習に合わせて行わない。回復量の攻撃全体上限 (MAX_VAMPIRIC_DRAIN) も既存モンスター
+ * 吸血同様に設けない。メッセージ表示・体力バー再描画は呼出側が担う。
+ */
+int apply_weapon_vampiric_drain(CreatureEntity &attacker, const ItemEntity &weapon, const CreatureEntity &target, int weapon_damage)
+{
+    if (!weapon.get_flags().has(TR_VAMPIRIC) || !target.has_living_flag()) {
+        return 0;
+    }
+
+    const auto drain = std::min(weapon_damage, target.get_current_hp());
+    constexpr auto real_drain = 5;
+    if (drain <= real_drain) {
+        return 0;
+    }
+
+    const auto drain_heal = Dice::roll(2, drain / 6);
+    attacker.heal_hp(drain_heal);
+    return drain_heal;
 }
 
 AttributeFlags melee_attribute(CreatureEntity &creature, ItemEntity *o_ptr, combat_options mode)

--- a/src/combat/slaying.h
+++ b/src/combat/slaying.h
@@ -12,4 +12,5 @@ MULTIPLY mult_slaying(CreatureEntity &creature, MULTIPLY mult, const TrFlags &fl
 MULTIPLY mult_brand(CreatureEntity &creature, MULTIPLY mult, const TrFlags &flags, const CreatureEntity &target);
 int calc_attack_damage_with_slay(CreatureEntity &creature, ItemEntity *o_ptr, int tdam, const CreatureEntity &target, combat_options mode, bool thrown);
 int calc_weapon_melee_damage(CreatureEntity &attacker, ItemEntity &weapon, const CreatureEntity &target, int hand);
+int apply_weapon_vampiric_drain(CreatureEntity &attacker, const ItemEntity &weapon, const CreatureEntity &target, int weapon_damage);
 AttributeFlags melee_attribute(CreatureEntity &creature, ItemEntity *o_ptr, combat_options mode);

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -316,12 +316,26 @@ static void process_melee(CreatureEntity &creature, mam_type *mam_ptr)
     }
 
     // 武器を装備している場合、プレイヤーの打撃処理と共通の calc_weapon_melee_damage() で
-    // スレイ・ブランド・会心を反映したダメージを加算する。
+    // スレイ・ブランド・会心・ヴォーパルを反映したダメージを加算する。
     // 対モンスターでも対プレイヤーと同一の武器ダメージ計算を行う。
     if (!mam_ptr->explode && (mam_ptr->weapon_slot_for_blow >= 0)) {
         auto &weapon = *mam_ptr->m_ptr->inventory[mam_ptr->weapon_slot_for_blow];
         const auto hand = mam_ptr->weapon_slot_for_blow - enum2i(INVEN_MAIN_HAND);
-        mam_ptr->damage += calc_weapon_melee_damage(*mam_ptr->m_ptr, weapon, *mam_ptr->t_ptr, hand);
+        const auto weapon_damage = calc_weapon_melee_damage(*mam_ptr->m_ptr, weapon, *mam_ptr->t_ptr, hand);
+        mam_ptr->damage += weapon_damage;
+
+        // 吸血武器: プレイヤーの吸血処理と同じく、生命のある対象から HP を吸収して回復する。
+        const auto did_heal = mam_ptr->m_ptr->get_current_hp() < mam_ptr->m_ptr->get_max_hp();
+        const auto drained = apply_weapon_vampiric_drain(*mam_ptr->m_ptr, weapon, *mam_ptr->t_ptr, weapon_damage);
+        if (drained > 0) {
+            HealthBarTracker::get_instance().set_flag_if_tracking(mam_ptr->m_idx);
+            if (mam_ptr->m_ptr->is_riding()) {
+                RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
+            }
+            if (mam_ptr->see_m && did_heal) {
+                msg_format(_("%sは%sから生命力を吸い取った！", "%s^ drains life from %s^!"), mam_ptr->m_name, mam_ptr->t_name);
+            }
+        }
     }
 
     mam_ptr->attribute = BlowEffectType::NONE;

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -58,6 +58,7 @@
 #include "system/redrawing-flags-updater.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-stun.h"
+#include "tracking/health-bar-tracker.h"
 #include "util/bit-flags-calculator.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
@@ -292,12 +293,23 @@ bool MonsterAttackPlayer::process_monster_attack_hit()
     // [フェーズ B-2b / 二刀流対応] 装備武器によるダメージボーナス
     // weapon_slot_for_blow は process_monster_blows() で設定され、
     // 物理打撃 (HIT/PUNCH/SLASH/STING) かつ武器装備時のみ有効
-    // スレイ・ブランド・会心はプレイヤーの打撃処理と共通の calc_weapon_melee_damage() を再利用し、
-    // 武器を装備したモンスターがプレイヤーと同一の武器ダメージを与えるようにする。
+    // スレイ・ブランド・会心・ヴォーパルはプレイヤーの打撃処理と共通の calc_weapon_melee_damage() を
+    // 再利用し、武器を装備したモンスターがプレイヤーと同一の武器ダメージを与えるようにする。
     if (!this->explode && this->weapon_slot_for_blow >= 0) {
         auto &weapon = *this->m_ptr->inventory[this->weapon_slot_for_blow];
         const auto hand = this->weapon_slot_for_blow - enum2i(INVEN_MAIN_HAND);
-        this->damage += calc_weapon_melee_damage(*this->m_ptr, weapon, creature, hand);
+        const auto weapon_damage = calc_weapon_melee_damage(*this->m_ptr, weapon, creature, hand);
+        this->damage += weapon_damage;
+
+        // 吸血武器: プレイヤーの吸血処理と同じく、生命のあるプレイヤーから HP を吸収して回復する。
+        const auto did_heal = this->m_ptr->get_current_hp() < this->m_ptr->get_max_hp();
+        const auto drained = apply_weapon_vampiric_drain(*this->m_ptr, weapon, creature, weapon_damage);
+        if (drained > 0) {
+            HealthBarTracker::get_instance().set_flag_if_tracking(this->m_idx);
+            if (this->m_ptr->is_visible_on_map() && did_heal) {
+                msg_format(_("%s^はあなたから生命力を吸い取った！", "%s^ drains life from you!"), this->m_name);
+            }
+        }
     }
 
     switch_monster_blow_to_player(creature, this);


### PR DESCRIPTION
武器を装備したモンスターが TR_VAMPIRIC 武器で生命のある対象を攻撃した際、
プレイヤーの吸血処理と同じく対象からHPを吸収して回復するようにした。

- 共通関数 apply_weapon_vampiric_drain(attacker, weapon, target, weapon_damage) を src/combat/slaying.cpp に追加。drain = min(武器ダメージ, 対象残HP) が 5 超で 2d(drain/6) を攻撃側へ回復 (blood-sucking-processor.cpp と同式)。吸血は ダメージ倍率を持たず回復のみ。
- 対プレイヤー (monster-attack-player.cpp) / 対モンスター (monster-attack-monster.cpp) の両経路で発火。体力バー再描画・視認時メッセージ付き。
- プレイヤー版の対象最大HP減少(weaken)と回復上限(MAX_VAMPIRIC_DRAIN)は、既存の モンスター吸血 heal_monster_by_melee が「回復のみ・上限なし」である慣習に合わせて省略。