### PR TITLE
feat:モンスターの地震武器打撃を同化

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -749,6 +749,18 @@ bakabakaband ではプレイヤーとモンスター双方が `CreatureEntity` �
     DRAIN 打撃) が「回復のみ・上限なし」である慣習に合わせて省略。恒久的な最大 HP 減少を
     プレイヤーへ課す挙動は保守的に見送り (将来のバランス判断で追加余地)
   - **吸血武器を装備したモンスターは対プレイヤー・対モンスターとも生命力を吸収して回復する**
+- **B-2b5**: 地震 (アースクエイク武器) の同化
+  - 共通判定 `does_weapon_cause_earthquake(weapon, weapon_damage)` (`src/combat/slaying.cpp`)
+    を追加。`TR_EARTHQUAKE` 武器で武器ダメージ > 50 または 1/7 で地震予約
+    (プレイヤー `does_equip_cause_earthquake()` と同条件)
+  - **発生タイミング**: プレイヤーの `cause_earthquake` 同様、全打撃終了後にまとめて
+    `earthquake(player, 攻撃モンスターの位置, 10, 攻撃モンスターの m_idx)` を発火。
+    打撃ループ中は floor / monster 参照が無効化されうるため、`do_quake` フラグを
+    `MonsterAttackPlayer` / `mam_type` に持たせ、ループ後 (`make_attack_normal` /
+    `monst_attack_monst`) に 1 度だけ起こす
+  - 地震の破壊/巻き込みはプレイヤー版と同一 (`earthquake()` を共用)。震源は攻撃側
+    モンスター、原因 (`m_idx`) も攻撃側モンスターとして正しく帰属
+  - **地震武器を装備したモンスターは対プレイヤー・対モンスターとも地震を起こす**
 - **B-2c**: 近接攻撃の命中ボーナス (11058a278)
   - `to_h` を `check_hit_from_monster_to_player` の power に加算
 - **B-4**: look 表示で装備品/パック品を区別 (145f1fb56)

--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -315,6 +315,25 @@ int apply_weapon_vampiric_drain(CreatureEntity &attacker, const ItemEntity &weap
     return drain_heal;
 }
 
+/*!
+ * @brief 装備武器による近接打撃が地震を起こすか判定する
+ * @param weapon 使用した近接武器
+ * @param weapon_damage calc_weapon_melee_damage() が返した当該打撃の武器ダメージ
+ * @return 地震を起こすなら true
+ * @details
+ * プレイヤーの does_equip_cause_earthquake() と同じく、地震付与武器 (TR_EARTHQUAKE) で
+ * 与えたダメージが 50 を超えるか 1/7 の確率で地震を起こす。実際の地震発生はモンスターの
+ * 全打撃終了後 (打撃ループ中は floor / monster 参照が無効化されうるため) に呼出側が行う。
+ */
+bool does_weapon_cause_earthquake(const ItemEntity &weapon, int weapon_damage)
+{
+    if (!weapon.get_flags().has(TR_EARTHQUAKE)) {
+        return false;
+    }
+
+    return (weapon_damage > 50) || one_in_(7);
+}
+
 AttributeFlags melee_attribute(CreatureEntity &creature, ItemEntity *o_ptr, combat_options mode)
 {
     AttributeFlags attribute_flags{};

--- a/src/combat/slaying.h
+++ b/src/combat/slaying.h
@@ -13,4 +13,5 @@ MULTIPLY mult_brand(CreatureEntity &creature, MULTIPLY mult, const TrFlags &flag
 int calc_attack_damage_with_slay(CreatureEntity &creature, ItemEntity *o_ptr, int tdam, const CreatureEntity &target, combat_options mode, bool thrown);
 int calc_weapon_melee_damage(CreatureEntity &attacker, ItemEntity &weapon, const CreatureEntity &target, int hand);
 int apply_weapon_vampiric_drain(CreatureEntity &attacker, const ItemEntity &weapon, const CreatureEntity &target, int weapon_damage);
+bool does_weapon_cause_earthquake(const ItemEntity &weapon, int weapon_damage);
 AttributeFlags melee_attribute(CreatureEntity &creature, ItemEntity *o_ptr, combat_options mode);

--- a/src/melee/melee-util.h
+++ b/src/melee/melee-util.h
@@ -41,6 +41,7 @@ struct mam_type {
     bool fear = false;
     bool dead = false;
     short weapon_slot_for_blow = -1; //!< 当該打撃で使用する武器スロット (-1 = 武器なし)
+    bool do_quake = false; //!< [B-2b5] 地震武器による地震を全打撃終了後に起こすか
 };
 
 mam_type *initialize_mam_type(CreatureEntity &creature, mam_type *mam_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx);

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -31,6 +31,7 @@
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
 #include "mutation/mutation-flag-types.h"
+#include "spell-kind/earthquake.h"
 #include "spell-kind/spells-teleport.h"
 #include "spell-realm/spells-hex.h"
 #include "system/creature-entity.h"
@@ -336,6 +337,11 @@ static void process_melee(CreatureEntity &creature, mam_type *mam_ptr)
                 msg_format(_("%sは%sから生命力を吸い取った！", "%s^ drains life from %s^!"), mam_ptr->m_name, mam_ptr->t_name);
             }
         }
+
+        // 地震武器: プレイヤーと同じ条件で地震を予約する。実発生は全打撃終了後 (monst_attack_monst)。
+        if (does_weapon_cause_earthquake(weapon, weapon_damage)) {
+            mam_ptr->do_quake = true;
+        }
     }
 
     mam_ptr->attribute = BlowEffectType::NONE;
@@ -461,6 +467,13 @@ bool monst_attack_monst(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX
     }
 
     repeat_melee(creature, mam_ptr);
+
+    // [B-2b5] 地震武器: 全打撃終了後にまとめて地震を起こす (プレイヤーの cause_earthquake 相当)。
+    // 打撃ループ中に起こすと floor / monster 参照が無効化されうるため後段で処理する。
+    if (mam_ptr->do_quake && mam_ptr->m_ptr->is_valid()) {
+        earthquake(creature, mam_ptr->m_ptr->get_position(), 10, mam_ptr->m_idx);
+    }
+
     explode_monster_by_melee(creature, mam_ptr);
     if (!mam_ptr->blinked || !mam_ptr->m_ptr->is_valid()) {
         return true;

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -44,6 +44,7 @@
 #include "player/player-damage.h"
 #include "player/player-skill.h"
 #include "player/special-defense-types.h"
+#include "spell-kind/earthquake.h"
 #include "spell-kind/spells-teleport.h"
 #include "spell-realm/spells-hex.h"
 #include "status/action-setter.h"
@@ -105,12 +106,24 @@ void MonsterAttackPlayer::make_attack_normal()
         return;
     }
 
+    // [B-2b5] 地震武器: 全打撃終了後にまとめて地震を起こす (プレイヤーの cause_earthquake 相当)。
+    // 打撃ループ中に起こすと floor / monster 参照が無効化されうるため後段で処理する。
+    // 打撃が変わり身 (kawarimi) 等で中断されても、ヒット済みで予約された地震は発生させるため、
+    // 通常完了・中断離脱の両経路で共通に実行する。
+    const auto execute_pending_earthquake = [this, &creature]() {
+        if (this->do_quake && this->m_ptr->is_valid()) {
+            earthquake(creature, this->m_ptr->get_position(), 10, this->m_idx);
+        }
+    };
+
     this->blinked = false;
     if (this->process_monster_blows()) {
+        execute_pending_earthquake();
         return;
     }
 
     this->postprocess_monster_blows();
+    execute_pending_earthquake();
 }
 
 /*!
@@ -309,6 +322,11 @@ bool MonsterAttackPlayer::process_monster_attack_hit()
             if (this->m_ptr->is_visible_on_map() && did_heal) {
                 msg_format(_("%s^はあなたから生命力を吸い取った！", "%s^ drains life from you!"), this->m_name);
             }
+        }
+
+        // 地震武器: プレイヤーと同じ条件で地震を予約する。実発生は全打撃終了後 (make_attack_normal)。
+        if (!this->explode && does_weapon_cause_earthquake(weapon, weapon_damage)) {
+            this->do_quake = true;
         }
     }
 

--- a/src/monster-attack/monster-attack-player.h
+++ b/src/monster-attack/monster-attack-player.h
@@ -37,6 +37,7 @@ public:
     bool alive = true;
     bool fear = false;
     short weapon_slot_for_blow = -1; //!< [フェーズ B-2 二刀流] 当該打撃で使用する武器スロット (-1 = 武器なし)
+    bool do_quake = false; //!< [B-2b5] 地震武器による地震を全打撃終了後に起こすか
 
     void make_attack_normal();
 


### PR DESCRIPTION
武器を装備したモンスターが TR_EARTHQUAKE 武器で攻撃した際、プレイヤーと
同じ条件・処理で地震を起こすようにした。

- 共通判定 does_weapon_cause_earthquake(weapon, weapon_damage) を src/combat/slaying.cpp に追加。武器ダメージ > 50 または 1/7 で地震 (does_equip_cause_earthquake と同条件)。
- 発生はプレイヤーの cause_earthquake 同様、全打撃終了後にまとめて 1 度だけ。 打撃ループ中は floor/monster 参照が無効化されうるため、do_quake フラグを MonsterAttackPlayer / mam_type に持たせ、ループ後 (make_attack_normal / monst_attack_monst) で earthquake() を発火。震源=攻撃モンスター位置、 原因 m_idx=攻撃モンスターとして帰属。
- 対プレイヤー / 対モンスターの両経路で発火。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Earthquake weapons can now trigger earthquakes during monster attacks.
  - Earthquakes activate using the same damage and chance conditions as player attacks.
  - The effect occurs once after all attack blows are completed, affecting the appropriate targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->