### PR TITLE
feat: モンスターのスレイ武器をプレイヤーの種族性質に適用 (B-2b6の対称仕上げ)

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -779,6 +779,20 @@ bakabakaband ではプレイヤーとモンスター双方が `CreatureEntity` �
     アンデッド種族プレイヤーへ等) は「属性」ではなく「スレイ」であり本弾の対象外。
     属性ダメージを物理ではなく属性型として被ダメージ経路へ適用する方式 (部分耐性も反映) は、
     そもそも PC のブランドが倍率モデル (部分耐性は素通し) のため PC 挙動と乖離する。よって不採用
+- **B-2b7**: スレイのプレイヤー種族対応 (B-2b6 の対称仕上げ)
+  - **背景**: B-2b6 の属性ブランドと同様、`mult_slaying()` もプレイヤー標的では空 monrace の
+    kind_flags を見るため、スレイ武器 (スレイ・アンデッド等) がプレイヤーの種族性質を無視していた
+  - **修正**: `mult_slaying()` にプレイヤー標的分岐を追加。ヘルパ
+    `player_counts_as_kind(player, MonsterKindType)` で、モンスターの kind_flags 相当を
+    プレイヤーの種族/生死種別/性別/アライメントから判定:
+    - UNDEAD/DEMON: `CreatureRace::life()` (`PlayerRaceLifeType`、ミミック変身を反映)
+    - ORC/TROLL/GIANT/HUMAN: `CreatureRace::equals(PlayerRaceType::…)`、DRAGON: `DRACONIAN`
+    - MALE/FEMALE: `get_psex()`、EVIL/GOOD: `alignment` の善悪境界 (>10 / <-10、表記ラベルと一致)
+    - ANIMAL: 対応するプレイヤー種族が無いため常に非該当
+  - プレイヤーには思い出フラグ (`r_kind_flags`) が無いため記録はしない
+  - `mult_slaying()` の `target` も `CreatureEntity &` に変更 (`CreatureRace` 構築が非 const 参照要求)
+  - **スレイ武器を装備したモンスターは、対応する種族/性別/アライメントのプレイヤーへ
+    スレイ倍率を乗せる** (例: スレイ・ヒューマン武器 → 人間プレイヤー、スレイ・アンデッド → 屍鬼系種族)
 - **B-2c**: 近接攻撃の命中ボーナス (11058a278)
   - `to_h` を `check_hit_from_monster_to_player` の power に加算
 - **B-4**: look 表示で装備品/パック品を区別 (145f1fb56)

--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -9,7 +9,11 @@
 #include "object-enchant/tr-types.h"
 #include "object/tval-types.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
+#include "player-info/race-info.h"
+#include "player-info/race-types.h"
 #include "player/attack-defense-types.h"
+#include "player/player-sex.h"
 #include "realm/realm-hex-numbers.h"
 #include "specific-object/torch.h"
 #include "spell-realm/spells-crusade.h"
@@ -24,6 +28,48 @@
 #include "util/dice.h"
 #include <algorithm>
 
+namespace {
+/*!
+ * @brief プレイヤーがモンスター種別 (MonsterKindType) 相当の性質を持つか判定する
+ * (モンスターの武器攻撃でスレイ判定の標的がプレイヤーの場合に使用)
+ * @details モンスターの kind_flags に相当する概念を、プレイヤーの種族 (CreatureRace) /
+ * 生死種別 (PlayerRaceLifeType) / 性別 (player_sex) / アライメント (alignment) から求める。
+ * 種族由来の性質 (UNDEAD/DEMON/ORC/TROLL/GIANT/DRAGON/HUMAN) はミミック変身を考慮する
+ * (life() / equals() が変身を反映)。EVIL/GOOD はアライメント表記の善悪境界 (>10 / <-10) に合わせる。
+ * ANIMAL は対応するプレイヤー種族が無いため常に false。
+ */
+bool player_counts_as_kind(CreatureEntity &player, MonsterKindType kind)
+{
+    const CreatureRace race(&player);
+    switch (kind) {
+    case MonsterKindType::HUMAN:
+        return race.equals(PlayerRaceType::HUMAN);
+    case MonsterKindType::MALE:
+        return player.get_psex() == player_sex::SEX_MALE;
+    case MonsterKindType::FEMALE:
+        return player.get_psex() == player_sex::SEX_FEMALE;
+    case MonsterKindType::UNDEAD:
+        return race.life() == PlayerRaceLifeType::UNDEAD;
+    case MonsterKindType::DEMON:
+        return race.life() == PlayerRaceLifeType::DEMON;
+    case MonsterKindType::ORC:
+        return race.equals(PlayerRaceType::ORC);
+    case MonsterKindType::TROLL:
+        return race.equals(PlayerRaceType::TROLL);
+    case MonsterKindType::GIANT:
+        return race.equals(PlayerRaceType::GIANT);
+    case MonsterKindType::DRAGON:
+        return race.equals(PlayerRaceType::DRACONIAN);
+    case MonsterKindType::EVIL:
+        return player.alignment < -10;
+    case MonsterKindType::GOOD:
+        return player.alignment > 10;
+    default:
+        return false;
+    }
+}
+}
+
 /*!
  * @brief プレイヤー攻撃の種族スレイング倍率計算
  * @param creature クリーチャーへの参照
@@ -32,7 +78,7 @@
  * @param m_ptr 目標モンスターの構造体参照ポインタ
  * @return スレイング加味後の倍率(/10倍)
  */
-MULTIPLY mult_slaying(CreatureEntity &creature, MULTIPLY mult, const TrFlags &flags, const CreatureEntity &target)
+MULTIPLY mult_slaying(CreatureEntity &creature, MULTIPLY mult, const TrFlags &flags, CreatureEntity &target)
 {
     static const struct slay_table_t {
         tr_type slay_flag;
@@ -69,7 +115,22 @@ MULTIPLY mult_slaying(CreatureEntity &creature, MULTIPLY mult, const TrFlags &fl
     for (size_t i = 0; i < sizeof(slay_table) / sizeof(slay_table[0]); ++i) {
         const struct slay_table_t *p = &slay_table[i];
 
-        if (flags.has_not(p->slay_flag) || monrace.kind_flags.has_not(p->affect_race_flag)) {
+        if (flags.has_not(p->slay_flag)) {
+            continue;
+        }
+
+        // プレイヤーが攻撃対象の場合 (モンスターの武器攻撃) は、モンスター種族定義の
+        // kind_flags の代わりにプレイヤー自身の種族/生死種別/性別/アライメントから
+        // スレイ対象性を判定する。プレイヤーには思い出フラグ (r_kind_flags) が無いため記録はしない。
+        if (target.is_player()) {
+            if (player_counts_as_kind(target, p->affect_race_flag)) {
+                mult = std::max(mult, p->slay_mult);
+            }
+
+            continue;
+        }
+
+        if (monrace.kind_flags.has_not(p->affect_race_flag)) {
             continue;
         }
 

--- a/src/combat/slaying.h
+++ b/src/combat/slaying.h
@@ -8,7 +8,7 @@
 
 class ItemEntity;
 class CreatureEntity;
-MULTIPLY mult_slaying(CreatureEntity &creature, MULTIPLY mult, const TrFlags &flags, const CreatureEntity &target);
+MULTIPLY mult_slaying(CreatureEntity &creature, MULTIPLY mult, const TrFlags &flags, CreatureEntity &target);
 MULTIPLY mult_brand(CreatureEntity &creature, MULTIPLY mult, const TrFlags &flags, CreatureEntity &target);
 int calc_attack_damage_with_slay(CreatureEntity &creature, ItemEntity *o_ptr, int tdam, CreatureEntity &target, combat_options mode, bool thrown);
 int calc_weapon_melee_damage(CreatureEntity &attacker, ItemEntity &weapon, CreatureEntity &target, int hand);


### PR DESCRIPTION
属性ブランド(B-2b6)と同様、mult_slaying() もプレイヤー標的では空 monrace の kind_flags を見るため、スレイ武器がプレイヤーの種族性質を無視していた問題を修正。

- ヘルパ player_counts_as_kind(player, MonsterKindType) を追加。モンスターの kind_flags 相当をプレイヤーの種族/生死種別/性別/アライメントから判定:
  - UNDEAD/DEMON: CreatureRace::life() (ミミック変身反映)
  - ORC/TROLL/GIANT/HUMAN: CreatureRace::equals()、DRAGON: DRACONIAN
  - MALE/FEMALE: get_psex()、EVIL/GOOD: alignment の善悪境界 (>10 / <-10)
  - ANIMAL: 対応種族なしで非該当
- mult_slaying() にプレイヤー標的分岐を追加。プレイヤーには r_kind_flags が 無いため記録はしない。
- mult_slaying() の target を CreatureEntity& に変更 (CreatureRace 構築が 非const参照要求)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slaying weapons now correctly apply their bonuses against player characters based on race, transformed form, life type, gender, and alignment.
  * Fixed cases where player targets were not recognized for relevant slaying effects.

* **Documentation**
  * Added roadmap documentation describing the completed player-race slaying support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->