### PR TITLE
feat: モンスターのカオス武器(TR_CHAOTIC)の追加効果を同化

### DIFF
--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
@@ -833,6 +833,7 @@
     <ClCompile Include="..\..\src\combat\attack-accuracy.cpp" />
     <ClCompile Include="..\..\src\monster-attack\monster-eating.cpp" />
     <ClCompile Include="..\..\src\player-attack\player-attack.cpp" />
+    <ClCompile Include="..\..\src\combat\monster-chaos-weapon.cpp" />
     <ClCompile Include="..\..\src\combat\slaying.cpp" />
     <ClCompile Include="..\..\src\player-attack\blood-sucking-processor.cpp" />
     <ClCompile Include="..\..\src\object-enchant\vorpal-weapon.cpp" />
@@ -1789,6 +1790,7 @@
     <ClInclude Include="..\..\src\combat\attack-accuracy.h" />
     <ClInclude Include="..\..\src\monster-attack\monster-eating.h" />
     <ClInclude Include="..\..\src\player-attack\player-attack.h" />
+    <ClInclude Include="..\..\src\combat\monster-chaos-weapon.h" />
     <ClInclude Include="..\..\src\combat\slaying.h" />
     <ClInclude Include="..\..\src\object-enchant\vorpal-weapon.h" />
     <ClInclude Include="..\..\src\floor\floor-object.h" />

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -793,6 +793,26 @@ bakabakaband ではプレイヤーとモンスター双方が `CreatureEntity` �
   - `mult_slaying()` の `target` も `CreatureEntity &` に変更 (`CreatureRace` 構築が非 const 参照要求)
   - **スレイ武器を装備したモンスターは、対応する種族/性別/アライメントのプレイヤーへ
     スレイ倍率を乗せる** (例: スレイ・ヒューマン武器 → 人間プレイヤー、スレイ・アンデッド → 屍鬼系種族)
+- **B-2b8**: カオス武器 (TR_CHAOTIC) の追加効果の同化
+  - 新規 TU `src/combat/monster-chaos-weapon.{h,cpp}` に
+    `apply_monster_weapon_chaos_effect()` を追加。プレイヤーの `select_chaotic_effect()` と
+    **同一確率**でカオス効果を抽選し (TR_CHAOTIC 保有かつ 1/2 で発動、以降 吸血 3/5 →
+    地震 1/250 → 混乱 9/10 → テレポート/変身)、対プレイヤー・対モンスターそれぞれに適した
+    既存プリミティブへ振り分ける:
+    - **吸血 (CE_VAMPIRIC)**: `drain_life_to_attacker()` (slaying から抽出。TR_VAMPIRIC の
+      有無に依らず発火)。攻撃側 HP バー再描画
+    - **地震 (CE_QUAKE)**: 戻り値 true で B-2b5 の `do_quake` 予約に集約 (全打撃終了後に発火)
+    - **混乱 (CE_CONFUSION)**: プレイヤーは `BadStatusSetter::mod_confusion()`、モンスターは
+      `set_monster_confused()`
+    - **テレポート (CE_TELE_AWAY)**: プレイヤーは `teleport_player_away()`、モンスターは
+      `teleport_away()`
+  - **意図的な保留 (変身 CE_POLYMORPH)**: `polymorph_monster()` は打撃ループ途中で対象を
+    delete/再生成し得て被害者ポインタ (`t_ptr`) を無効化する危険があるため本段では非適用
+    (何も起こさない)。プレイヤーへの変身プリミティブも存在しない。安全な発火点の整備を要する後続段とする
+  - 吸血処理の共通コアを `apply_weapon_vampiric_drain()` から `drain_life_to_attacker()` に
+    切り出し、TR_VAMPIRIC ゲート版とカオス版で共用
+  - **カオス武器を装備したモンスターは対プレイヤー・対モンスターとも吸血/地震/混乱/テレポートを
+    引き起こす** (変身は保留)
 - **B-2c**: 近接攻撃の命中ボーナス (11058a278)
   - `to_h` を `check_hit_from_monster_to_player` の power に加算
 - **B-4**: look 表示で装備品/パック品を区別 (145f1fb56)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -228,6 +228,7 @@ hengband_SOURCES = \
 	combat/martial-arts-style.cpp combat/martial-arts-style.h \
 	combat/attack-accuracy.cpp combat/attack-accuracy.h \
 	combat/slaying.cpp combat/slaying.h \
+	combat/monster-chaos-weapon.cpp combat/monster-chaos-weapon.h \
 	combat/combat-options-type.h \
 	combat/attack-criticality.cpp combat/attack-criticality.h \
 	combat/shoot.cpp combat/shoot.h \

--- a/src/combat/monster-chaos-weapon.cpp
+++ b/src/combat/monster-chaos-weapon.cpp
@@ -1,0 +1,103 @@
+/*!
+ * @brief モンスターが装備したカオス武器 (TR_CHAOTIC) の追加効果処理
+ * @details
+ * プレイヤーの select_chaotic_effect() / change_monster_stat() と同じ確率・効果で、
+ * カオス武器を装備したモンスターの近接打撃に吸血・地震・混乱・テレポートの追加効果を与える。
+ * 対プレイヤー・対モンスターのいずれの標的でも、それぞれに適した既存プリミティブへ振り分ける。
+ * 変身 (CE_POLYMORPH) は、打撃ループ途中で対象モンスターを delete/再生成し得て被害者ポインタを
+ * 無効化する危険があるため本段では保留する (何も起こさない)。
+ */
+
+#include "combat/monster-chaos-weapon.h"
+#include "combat/slaying.h"
+#include "monster/monster-status-setter.h"
+#include "object-enchant/tr-types.h"
+#include "spell-kind/spells-teleport.h"
+#include "spell/spells-util.h"
+#include "status/bad-status-setter.h"
+#include "system/creature-entity.h"
+#include "system/creature-timed-effect-types.h"
+#include "system/floor/floor-info.h"
+#include "system/item-entity.h"
+#include "term/z-rand.h"
+#include "tracking/health-bar-tracker.h"
+
+namespace {
+constexpr auto CHAOS_TELEPORT_DISTANCE = 50;
+
+/*!
+ * @brief カオス武器による混乱を対象へ与える (プレイヤー・モンスター両対応)
+ */
+void inflict_chaos_confusion(CreatureEntity &attacker, CreatureEntity &target, MONSTER_IDX target_m_idx)
+{
+    const auto duration = 10 + randint0(attacker.get_level()) / 5;
+    if (target.is_player()) {
+        BadStatusSetter(target).mod_confusion(static_cast<TIME_EFFECT>(duration));
+        return;
+    }
+
+    const auto current = target.get_timed_effect(CreatureTimedEffect::CONFUSION);
+    set_monster_confused(*attacker.get_floor(), target_m_idx, current + duration);
+}
+
+/*!
+ * @brief カオス武器によるテレポートアウェイを対象へ与える (プレイヤー・モンスター両対応)
+ */
+void inflict_chaos_teleport(CreatureEntity &target, CreatureEntity &player, MONSTER_IDX attacker_m_idx, MONSTER_IDX target_m_idx)
+{
+    if (target.is_player()) {
+        teleport_player_away(attacker_m_idx, target, CHAOS_TELEPORT_DISTANCE, false);
+        return;
+    }
+
+    teleport_away(player, target_m_idx, CHAOS_TELEPORT_DISTANCE, TELEPORT_PASSIVE);
+}
+}
+
+/*!
+ * @brief モンスターの装備カオス武器による近接打撃の追加効果を判定・適用する
+ * @param attacker 攻撃側モンスター
+ * @param weapon 使用した近接武器
+ * @param target 攻撃対象クリーチャー (プレイヤー・モンスターいずれも可)
+ * @param player プレイヤーへの参照 (フロア・行為者コンテキスト用)
+ * @param attacker_m_idx 攻撃側モンスターのインデックス
+ * @param target_m_idx 攻撃対象モンスターのインデックス (プレイヤーが標的なら 0)
+ * @param weapon_damage calc_weapon_melee_damage() が返した当該打撃の武器ダメージ (吸血量算出用)
+ * @return CE_QUAKE を引いた場合は true (呼出側が全打撃終了後の地震を予約する)。それ以外は false
+ * @details 確率・効果はプレイヤーの select_chaotic_effect() と一致させる。
+ */
+bool apply_monster_weapon_chaos_effect(CreatureEntity &attacker, const ItemEntity &weapon, CreatureEntity &target,
+    CreatureEntity &player, MONSTER_IDX attacker_m_idx, MONSTER_IDX target_m_idx, int weapon_damage)
+{
+    if (weapon.get_flags().has_not(TR_CHAOTIC) || one_in_(2)) {
+        return false;
+    }
+
+    // CE_VAMPIRIC: 吸血 (武器の TR_VAMPIRIC 有無に依らず発火)
+    if (randint1(5) < 3) {
+        const auto drained = drain_life_to_attacker(attacker, target, weapon_damage);
+        if (drained > 0) {
+            HealthBarTracker::get_instance().set_flag_if_tracking(attacker_m_idx);
+        }
+
+        return false;
+    }
+
+    // CE_QUAKE: 地震 (実発生は全打撃終了後に呼出側が行う)
+    if (one_in_(250)) {
+        return true;
+    }
+
+    // CE_CONFUSION: 混乱
+    if (!one_in_(10)) {
+        inflict_chaos_confusion(attacker, target, target_m_idx);
+        return false;
+    }
+
+    // CE_TELE_AWAY: テレポートアウェイ / CE_POLYMORPH: 変身 (保留)
+    if (one_in_(2)) {
+        inflict_chaos_teleport(target, player, attacker_m_idx, target_m_idx);
+    }
+
+    return false;
+}

--- a/src/combat/monster-chaos-weapon.h
+++ b/src/combat/monster-chaos-weapon.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "system/angband.h"
+
+class CreatureEntity;
+class ItemEntity;
+
+bool apply_monster_weapon_chaos_effect(CreatureEntity &attacker, const ItemEntity &weapon, CreatureEntity &target,
+    CreatureEntity &player, MONSTER_IDX attacker_m_idx, MONSTER_IDX target_m_idx, int weapon_damage);

--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -414,13 +414,13 @@ int calc_weapon_melee_damage(CreatureEntity &attacker, ItemEntity &weapon, Creat
  * 回復のみである慣習に合わせて行わない。回復量の攻撃全体上限 (MAX_VAMPIRIC_DRAIN) も既存モンスター
  * 吸血同様に設けない。メッセージ表示・体力バー再描画は呼出側が担う。
  */
-int apply_weapon_vampiric_drain(CreatureEntity &attacker, const ItemEntity &weapon, const CreatureEntity &target, int weapon_damage)
+int drain_life_to_attacker(CreatureEntity &attacker, const CreatureEntity &target, int amount)
 {
-    if (!weapon.get_flags().has(TR_VAMPIRIC) || !target.has_living_flag()) {
+    if (!target.has_living_flag()) {
         return 0;
     }
 
-    const auto drain = std::min(weapon_damage, target.get_current_hp());
+    const auto drain = std::min(amount, target.get_current_hp());
     constexpr auto real_drain = 5;
     if (drain <= real_drain) {
         return 0;
@@ -429,6 +429,15 @@ int apply_weapon_vampiric_drain(CreatureEntity &attacker, const ItemEntity &weap
     const auto drain_heal = Dice::roll(2, drain / 6);
     attacker.heal_hp(drain_heal);
     return drain_heal;
+}
+
+int apply_weapon_vampiric_drain(CreatureEntity &attacker, const ItemEntity &weapon, const CreatureEntity &target, int weapon_damage)
+{
+    if (!weapon.get_flags().has(TR_VAMPIRIC)) {
+        return 0;
+    }
+
+    return drain_life_to_attacker(attacker, target, weapon_damage);
 }
 
 /*!

--- a/src/combat/slaying.h
+++ b/src/combat/slaying.h
@@ -12,6 +12,7 @@ MULTIPLY mult_slaying(CreatureEntity &creature, MULTIPLY mult, const TrFlags &fl
 MULTIPLY mult_brand(CreatureEntity &creature, MULTIPLY mult, const TrFlags &flags, CreatureEntity &target);
 int calc_attack_damage_with_slay(CreatureEntity &creature, ItemEntity *o_ptr, int tdam, CreatureEntity &target, combat_options mode, bool thrown);
 int calc_weapon_melee_damage(CreatureEntity &attacker, ItemEntity &weapon, CreatureEntity &target, int hand);
+int drain_life_to_attacker(CreatureEntity &attacker, const CreatureEntity &target, int amount);
 int apply_weapon_vampiric_drain(CreatureEntity &attacker, const ItemEntity &weapon, const CreatureEntity &target, int weapon_damage);
 bool does_weapon_cause_earthquake(const ItemEntity &weapon, int weapon_damage);
 AttributeFlags melee_attribute(CreatureEntity &creature, ItemEntity *o_ptr, combat_options mode);

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -8,6 +8,7 @@
 #include "combat/attack-accuracy.h"
 #include "combat/combat-options-type.h"
 #include "combat/hallucination-attacks-table.h"
+#include "combat/monster-chaos-weapon.h"
 #include "combat/slaying.h"
 #include "core/disturbance.h"
 #include "dungeon/dungeon-flag-types.h"
@@ -340,6 +341,12 @@ static void process_melee(CreatureEntity &creature, mam_type *mam_ptr)
 
         // 地震武器: プレイヤーと同じ条件で地震を予約する。実発生は全打撃終了後 (monst_attack_monst)。
         if (does_weapon_cause_earthquake(weapon, weapon_damage)) {
+            mam_ptr->do_quake = true;
+        }
+
+        // カオス武器: プレイヤーと同じ確率で吸血/地震/混乱/テレポートの追加効果を与える。
+        // player コンテキスト (フロア・行為者) は process_melee の creature (プレイヤー)。
+        if (apply_monster_weapon_chaos_effect(*mam_ptr->m_ptr, weapon, *mam_ptr->t_ptr, creature, mam_ptr->m_idx, mam_ptr->t_idx, weapon_damage)) {
             mam_ptr->do_quake = true;
         }
     }

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -12,6 +12,7 @@
 #include "combat/aura-counterattack.h"
 #include "combat/combat-options-type.h"
 #include "combat/hallucination-attacks-table.h"
+#include "combat/monster-chaos-weapon.h"
 #include "combat/slaying.h"
 #include "core/disturbance.h"
 #include "dungeon/dungeon-flag-types.h"
@@ -326,6 +327,12 @@ bool MonsterAttackPlayer::process_monster_attack_hit()
 
         // 地震武器: プレイヤーと同じ条件で地震を予約する。実発生は全打撃終了後 (make_attack_normal)。
         if (!this->explode && does_weapon_cause_earthquake(weapon, weapon_damage)) {
+            this->do_quake = true;
+        }
+
+        // カオス武器: プレイヤーと同じ確率で吸血/地震/混乱/テレポートの追加効果を与える。
+        // 地震は do_quake 予約に集約する。
+        if (apply_monster_weapon_chaos_effect(*this->m_ptr, weapon, creature, creature, this->m_idx, 0, weapon_damage)) {
             this->do_quake = true;
         }
     }


### PR DESCRIPTION
カオス武器を装備したモンスターの近接打撃に、プレイヤーと同一確率の追加効果
(吸血/地震/混乱/テレポート)を与えるようにした。

- 新規 src/combat/monster-chaos-weapon.{h,cpp} に apply_monster_weapon_chaos_effect() を追加。select_chaotic_effect() と同確率で抽選し、対PC・対NPCそれぞれの既存 プリミティブへ振り分け:
  - 吸血: drain_life_to_attacker() (slaying から抽出、TR_VAMPIRIC 非依存で発火)
  - 地震: 戻り値 true で do_quake 予約に集約 (全打撃終了後に発火)
  - 混乱: BadStatusSetter::mod_confusion() (PC) / set_monster_confused() (NPC)
  - テレポート: teleport_player_away() (PC) / teleport_away() (NPC)
- 変身(CE_POLYMORPH)は打撃ループ途中の対象 delete/再生成でポインタ無効化リスクが あるため本段では保留(非適用)。プレイヤー変身プリミティブも無いため対象外。
- 吸血コアを apply_weapon_vampiric_drain() から drain_life_to_attacker() に切り出し共用。
- 両経路 (monster-attack-player / monster-attack-monster) に配線。Makefile.am 登録済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monsters wielding chaotic weapons can trigger vampiric drain, earthquakes, confusion, or teleportation during melee attacks.
  * Chaotic weapon effects now work against both players and other monsters, with outcomes matching existing player combat behavior.
  * Vampiric effects restore health to the attacking monster when applicable.
* **Bug Fixes**
  * Earthquake effects from monster attacks are now processed correctly after combat.
* **Documentation**
  * Added roadmap coverage for chaotic weapon effects, with polymorph effects remaining deferred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->