### PR TITLE
feat: プレイヤーのUNIQUE扱い(is_unique)追加 + 毒針の即死を同化

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -813,6 +813,18 @@ bakabakaband ではプレイヤーとモンスター双方が `CreatureEntity` �
     切り出し、TR_VAMPIRIC ゲート版とカオス版で共用
   - **カオス武器を装備したモンスターは対プレイヤー・対モンスターとも吸血/地震/混乱/テレポートを
     引き起こす** (変身は保留)
+- **B-2b9**: プレイヤーの UNIQUE 扱い + 毒針 (SV_POISON_NEEDLE) の即死同化
+  - **`CreatureEntity::is_unique()`** virtual を追加。モンスターは種族 UNIQUE フラグ、
+    **プレイヤーは常に true**。プレイヤーを唯一無二の固有存在として UNIQUE モンスターと同格に扱い、
+    即死・変身等の「UNIQUE には効かない」危険効果からプレイヤーを保護する。これにより
+    モンスターの武器由来の危険効果を導入してもプレイヤー側のバランスが崩れにくい
+  - **毒針の即死**: `poison_needle_blow_damage(weapon, target)` (`slaying.cpp`) を追加。
+    プレイヤーの `critical_attack()` の毒針処理と同じく `randint1(randint1(level/7)+5)==1` で
+    即死 (対象現在 HP+1)、失敗で 1 ダメージ。即死は **`target.is_unique()` (プレイヤー・UNIQUE
+    モンスター) と NO_INSTANTLY_DEATH 耐性を除外**。両経路 (monster-attack-player /
+    monster-attack-monster) の武器ブロック末尾で通常ダメージを上書き
+  - **毒針を装備したモンスターは非 UNIQUE モンスターを確率で即死させるが、プレイヤーには
+    即死せず 1 ダメージに留まる** (is_unique 保護)
 - **B-2c**: 近接攻撃の命中ボーナス (11058a278)
   - `to_h` を `check_hit_from_monster_to_player` の power に加算
 - **B-4**: look 表示で装備品/パック品を区別 (145f1fb56)

--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -18,6 +18,7 @@
 #include "specific-object/torch.h"
 #include "spell-realm/spells-crusade.h"
 #include "spell-realm/spells-hex.h"
+#include "sv-definition/sv-weapon-types.h"
 #include "system/creature-entity.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "system/item-entity.h"
@@ -438,6 +439,32 @@ int apply_weapon_vampiric_drain(CreatureEntity &attacker, const ItemEntity &weap
     }
 
     return drain_life_to_attacker(attacker, target, weapon_damage);
+}
+
+/*!
+ * @brief 毒針 (SV_POISON_NEEDLE) による当該打撃のダメージを求める
+ * @param weapon 使用した近接武器
+ * @param target 攻撃対象クリーチャー (プレイヤー・モンスターいずれも可)
+ * @return 毒針でなければ nullopt。毒針の場合、即死判定成功で対象の現在 HP + 1 (致死)、失敗で 1
+ * @details
+ * プレイヤーの critical_attack() の毒針処理と同じく、`randint1(randint1(level/7)+5) == 1` で即死。
+ * ただし対象が UNIQUE 扱い (プレイヤーおよび UNIQUE モンスター) または NO_INSTANTLY_DEATH 耐性を
+ * 持つ場合は即死せず 1 ダメージに留める。プレイヤーは常に UNIQUE 扱い (is_unique) のため、
+ * モンスターが毒針で攻撃してもプレイヤーが即死することはない。
+ */
+tl::optional<int> poison_needle_blow_damage(const ItemEntity &weapon, const CreatureEntity &target)
+{
+    if (weapon.bi_key != BaseitemKey(ItemKindType::SWORD, SV_POISON_NEEDLE)) {
+        return tl::nullopt;
+    }
+
+    const auto &monrace = target.get_monrace();
+    const auto no_instant_death = target.is_unique() || monrace.resistance_flags.has(MonsterResistanceType::NO_INSTANTLY_DEATH);
+    if (!no_instant_death && (randint1(randint1(monrace.level / 7) + 5) == 1)) {
+        return target.get_current_hp() + 1;
+    }
+
+    return 1;
 }
 
 /*!

--- a/src/combat/slaying.h
+++ b/src/combat/slaying.h
@@ -6,6 +6,8 @@
 #include "effect/attribute-types.h"
 #include "object-enchant/tr-flags.h"
 
+#include <tl/optional.hpp>
+
 class ItemEntity;
 class CreatureEntity;
 MULTIPLY mult_slaying(CreatureEntity &creature, MULTIPLY mult, const TrFlags &flags, CreatureEntity &target);
@@ -14,5 +16,6 @@ int calc_attack_damage_with_slay(CreatureEntity &creature, ItemEntity *o_ptr, in
 int calc_weapon_melee_damage(CreatureEntity &attacker, ItemEntity &weapon, CreatureEntity &target, int hand);
 int drain_life_to_attacker(CreatureEntity &attacker, const CreatureEntity &target, int amount);
 int apply_weapon_vampiric_drain(CreatureEntity &attacker, const ItemEntity &weapon, const CreatureEntity &target, int weapon_damage);
+tl::optional<int> poison_needle_blow_damage(const ItemEntity &weapon, const CreatureEntity &target);
 bool does_weapon_cause_earthquake(const ItemEntity &weapon, int weapon_damage);
 AttributeFlags melee_attribute(CreatureEntity &creature, ItemEntity *o_ptr, combat_options mode);

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -349,6 +349,12 @@ static void process_melee(CreatureEntity &creature, mam_type *mam_ptr)
         if (apply_monster_weapon_chaos_effect(*mam_ptr->m_ptr, weapon, *mam_ptr->t_ptr, creature, mam_ptr->m_idx, mam_ptr->t_idx, weapon_damage)) {
             mam_ptr->do_quake = true;
         }
+
+        // 毒針: 通常ダメージを毒針の即死/1ダメージ判定で上書きする。
+        // UNIQUE (プレイヤー含む) と NO_INSTANTLY_DEATH 耐性の対象は即死しない。
+        if (const auto needle_damage = poison_needle_blow_damage(weapon, *mam_ptr->t_ptr)) {
+            mam_ptr->damage = *needle_damage;
+        }
     }
 
     mam_ptr->attribute = BlowEffectType::NONE;

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -335,6 +335,12 @@ bool MonsterAttackPlayer::process_monster_attack_hit()
         if (apply_monster_weapon_chaos_effect(*this->m_ptr, weapon, creature, creature, this->m_idx, 0, weapon_damage)) {
             this->do_quake = true;
         }
+
+        // 毒針: 通常ダメージを毒針の即死/1ダメージ判定で上書きする。
+        // プレイヤーは UNIQUE 扱い (is_unique) のため即死せず 1 ダメージに抑えられる。
+        if (const auto needle_damage = poison_needle_blow_damage(weapon, creature)) {
+            this->damage = *needle_damage;
+        }
     }
 
     switch_monster_blow_to_player(creature, this);

--- a/src/system/creature-entity.cpp
+++ b/src/system/creature-entity.cpp
@@ -296,6 +296,22 @@ bool CreatureEntity::has_undead_flag(bool is_appearance) const
     return monrace.has_undead_flag();
 }
 
+/*!
+ * @brief 唯一無二の存在 (UNIQUE) として扱うか
+ * @return モンスターは種族の UNIQUE フラグ、プレイヤーは常に true
+ * @details プレイヤーは世界に一人の固有存在であり UNIQUE モンスターと同格に扱う。
+ * これにより即死・変身などの「UNIQUE には効かない」危険効果からプレイヤーが保護され、
+ * モンスターの武器由来の危険効果を導入してもプレイヤー側のゲームバランスが崩れにくくなる。
+ */
+bool CreatureEntity::is_unique() const
+{
+    if (this->is_player()) {
+        return true;
+    }
+
+    return this->get_monrace().kind_flags.has(MonsterKindType::UNIQUE);
+}
+
 bool CreatureEntity::is_explodable() const
 {
     return this->get_monrace().is_explodable();

--- a/src/system/creature-entity.h
+++ b/src/system/creature-entity.h
@@ -536,6 +536,7 @@ public:
     bool has_living_flag(bool is_appearance = false) const;
     bool has_demon_flag(bool is_appearance = false) const;
     bool has_undead_flag(bool is_appearance = false) const;
+    virtual bool is_unique() const;
     bool is_explodable() const;
     std::string get_died_message() const;
     bool can_ring_boss_call_nazgul() const;


### PR DESCRIPTION
危険な武器効果をNPCに導入してもプレイヤー側のバランスが崩れにくいよう、
プレイヤーを唯一無二の固有存在としてUNIQUE同格に扱う保護機構を追加した。

- CreatureEntity::is_unique() virtual を追加。モンスターは種族UNIQUEフラグ、 プレイヤーは常に true。即死・変身等の「UNIQUEには効かない」危険効果から プレイヤーを保護する。
- 毒針(SV_POISON_NEEDLE)の即死を同化: poison_needle_blow_damage() を追加。 critical_attack() の毒針処理と同じく randint1(randint1(level/7)+5)==1 で即死 (対象HP+1)、失敗で1ダメージ。即死は is_unique() (プレイヤー・UNIQUEモンスター) と NO_INSTANTLY_DEATH 耐性を除外。両経路の武器ブロック末尾で通常ダメージを上書き。
- 結果: 毒針モンスターは非UNIQUEモンスターを確率で即死させるが、プレイヤーには 1ダメージに留まる。