### PR TITLE
feat: カオス武器の変身(CE_POLYMORPH)を有効化 (is_unique保護 + 安全な遅延実行)

### DIFF
--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -825,6 +825,19 @@ bakabakaband ではプレイヤーとモンスター双方が `CreatureEntity` �
     monster-attack-monster) の武器ブロック末尾で通常ダメージを上書き
   - **毒針を装備したモンスターは非 UNIQUE モンスターを確率で即死させるが、プレイヤーには
     即死せず 1 ダメージに留まる** (is_unique 保護)
+- **B-2b10**: カオス武器の変身 (CE_POLYMORPH) の有効化 (B-2b8 の保留解除)
+  - `apply_monster_weapon_chaos_effect()` の戻り値を `bool`→`enum ChaosWeaponDeferred`
+    (NONE / EARTHQUAKE / POLYMORPH_TARGET) に変更。混乱・テレポート・吸血は即時、地震・変身は
+    遅延実行に分類
+  - **変身の安全化**: `polymorph_monster()` は対象を delete/再生成し `t_ptr` を無効化するため、
+    `mam_type::do_polymorph` に予約し、`monst_attack_monst()` の**全打撃終了後**に一度だけ
+    (対象が生存していれば) 実行。除外条件はプレイヤーの `attack_polymorph()` と同一
+    (`is_unique()` = プレイヤー・UNIQUE モンスター / QUESTOR / カオス耐性、加えて
+    `randint1(90) > level` 抽選)
+  - **プレイヤーは is_unique により変身対象外**。対プレイヤー経路 (monster-attack-player) は
+    POLYMORPH_TARGET を返さないため do_polymorph を持たない (EARTHQUAKE のみ処理)
+  - **カオス武器を装備したモンスターは非 UNIQUE モンスターを変身させ得るが、プレイヤーは
+    変身しない** (is_unique 保護)
 - **B-2c**: 近接攻撃の命中ボーナス (11058a278)
   - `to_h` を `check_hit_from_monster_to_player` の power に加算
 - **B-4**: look 表示で装備品/パック品を区別 (145f1fb56)

--- a/src/combat/monster-chaos-weapon.cpp
+++ b/src/combat/monster-chaos-weapon.cpp
@@ -10,6 +10,8 @@
 
 #include "combat/monster-chaos-weapon.h"
 #include "combat/slaying.h"
+#include "monster-race/race-misc-flags.h"
+#include "monster-race/race-resistance-mask.h"
 #include "monster/monster-status-setter.h"
 #include "object-enchant/tr-types.h"
 #include "spell-kind/spells-teleport.h"
@@ -19,6 +21,7 @@
 #include "system/creature-timed-effect-types.h"
 #include "system/floor/floor-info.h"
 #include "system/item-entity.h"
+#include "system/monrace/monrace-definition.h"
 #include "term/z-rand.h"
 #include "tracking/health-bar-tracker.h"
 
@@ -52,6 +55,25 @@ void inflict_chaos_teleport(CreatureEntity &target, CreatureEntity &player, MONS
 
     teleport_away(player, target_m_idx, CHAOS_TELEPORT_DISTANCE, TELEPORT_PASSIVE);
 }
+
+/*!
+ * @brief カオス武器による変身の対象になり得るか (プレイヤーの attack_polymorph と同じ除外条件)
+ * @details UNIQUE 扱い (プレイヤー・UNIQUE モンスター) / クエスト対象 / カオス耐性は変身しない。
+ * さらに change_monster_stat と同じ `randint1(90) > level` の抽選を課す。
+ */
+bool can_chaos_polymorph_target(const CreatureEntity &target)
+{
+    if (target.is_unique()) {
+        return false;
+    }
+
+    const auto &monrace = target.get_monrace();
+    if (monrace.misc_flags.has(MonsterMiscType::QUESTOR) || monrace.resistance_flags.has_any_of(RFR_EFF_RESIST_CHAOS_MASK)) {
+        return false;
+    }
+
+    return randint1(90) > monrace.level;
+}
 }
 
 /*!
@@ -63,14 +85,15 @@ void inflict_chaos_teleport(CreatureEntity &target, CreatureEntity &player, MONS
  * @param attacker_m_idx 攻撃側モンスターのインデックス
  * @param target_m_idx 攻撃対象モンスターのインデックス (プレイヤーが標的なら 0)
  * @param weapon_damage calc_weapon_melee_damage() が返した当該打撃の武器ダメージ (吸血量算出用)
- * @return CE_QUAKE を引いた場合は true (呼出側が全打撃終了後の地震を予約する)。それ以外は false
- * @details 確率・効果はプレイヤーの select_chaotic_effect() と一致させる。
+ * @return 全打撃終了後に遅延実行すべき効果 (地震 / 変身)。即時効果のみなら NONE
+ * @details 確率・効果はプレイヤーの select_chaotic_effect() と一致させる。地震・変身は
+ * 打撃ループ途中の実行が危険なため遅延させ、呼出側が全打撃終了後に実行する。
  */
-bool apply_monster_weapon_chaos_effect(CreatureEntity &attacker, const ItemEntity &weapon, CreatureEntity &target,
+ChaosWeaponDeferred apply_monster_weapon_chaos_effect(CreatureEntity &attacker, const ItemEntity &weapon, CreatureEntity &target,
     CreatureEntity &player, MONSTER_IDX attacker_m_idx, MONSTER_IDX target_m_idx, int weapon_damage)
 {
     if (weapon.get_flags().has_not(TR_CHAOTIC) || one_in_(2)) {
-        return false;
+        return ChaosWeaponDeferred::NONE;
     }
 
     // CE_VAMPIRIC: 吸血 (武器の TR_VAMPIRIC 有無に依らず発火)
@@ -80,24 +103,31 @@ bool apply_monster_weapon_chaos_effect(CreatureEntity &attacker, const ItemEntit
             HealthBarTracker::get_instance().set_flag_if_tracking(attacker_m_idx);
         }
 
-        return false;
+        return ChaosWeaponDeferred::NONE;
     }
 
     // CE_QUAKE: 地震 (実発生は全打撃終了後に呼出側が行う)
     if (one_in_(250)) {
-        return true;
+        return ChaosWeaponDeferred::EARTHQUAKE;
     }
 
     // CE_CONFUSION: 混乱
     if (!one_in_(10)) {
         inflict_chaos_confusion(attacker, target, target_m_idx);
-        return false;
+        return ChaosWeaponDeferred::NONE;
     }
 
-    // CE_TELE_AWAY: テレポートアウェイ / CE_POLYMORPH: 変身 (保留)
+    // CE_TELE_AWAY: テレポートアウェイ (即時) / CE_POLYMORPH: 変身 (遅延)
     if (one_in_(2)) {
         inflict_chaos_teleport(target, player, attacker_m_idx, target_m_idx);
+        return ChaosWeaponDeferred::NONE;
     }
 
-    return false;
+    // CE_POLYMORPH: 変身。polymorph_monster は対象を delete/再生成して被害者ポインタを無効化するため、
+    // 実行は全打撃終了後に呼出側へ委ねる。プレイヤーは is_unique により対象外。
+    if (can_chaos_polymorph_target(target)) {
+        return ChaosWeaponDeferred::POLYMORPH_TARGET;
+    }
+
+    return ChaosWeaponDeferred::NONE;
 }

--- a/src/combat/monster-chaos-weapon.h
+++ b/src/combat/monster-chaos-weapon.h
@@ -5,5 +5,16 @@
 class CreatureEntity;
 class ItemEntity;
 
-bool apply_monster_weapon_chaos_effect(CreatureEntity &attacker, const ItemEntity &weapon, CreatureEntity &target,
+/*!
+ * @brief カオス武器効果のうち、打撃ループ途中で実行すると危険なため全打撃終了後へ遅延させる処理の種別
+ * @details 混乱・テレポート・吸血は即時適用され、これらは NONE を返す。地震と変身は被害者ポインタ等の
+ * 無効化を避けるため呼出側が全打撃終了後に実行する。
+ */
+enum class ChaosWeaponDeferred {
+    NONE,
+    EARTHQUAKE,
+    POLYMORPH_TARGET,
+};
+
+ChaosWeaponDeferred apply_monster_weapon_chaos_effect(CreatureEntity &attacker, const ItemEntity &weapon, CreatureEntity &target,
     CreatureEntity &player, MONSTER_IDX attacker_m_idx, MONSTER_IDX target_m_idx, int weapon_damage);

--- a/src/melee/melee-util.h
+++ b/src/melee/melee-util.h
@@ -42,6 +42,7 @@ struct mam_type {
     bool dead = false;
     short weapon_slot_for_blow = -1; //!< 当該打撃で使用する武器スロット (-1 = 武器なし)
     bool do_quake = false; //!< [B-2b5] 地震武器による地震を全打撃終了後に起こすか
+    bool do_polymorph = false; //!< [B-2b10] カオス武器による対象変身を全打撃終了後に行うか
 };
 
 mam_type *initialize_mam_type(CreatureEntity &creature, mam_type *mam_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx);

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -33,6 +33,7 @@
 #include "monster/monster-status.h"
 #include "mutation/mutation-flag-types.h"
 #include "spell-kind/earthquake.h"
+#include "spell-kind/spells-polymorph.h"
 #include "spell-kind/spells-teleport.h"
 #include "spell-realm/spells-hex.h"
 #include "system/creature-entity.h"
@@ -344,10 +345,18 @@ static void process_melee(CreatureEntity &creature, mam_type *mam_ptr)
             mam_ptr->do_quake = true;
         }
 
-        // カオス武器: プレイヤーと同じ確率で吸血/地震/混乱/テレポートの追加効果を与える。
+        // カオス武器: プレイヤーと同じ確率で吸血/地震/混乱/テレポート/変身の追加効果を与える。
         // player コンテキスト (フロア・行為者) は process_melee の creature (プレイヤー)。
-        if (apply_monster_weapon_chaos_effect(*mam_ptr->m_ptr, weapon, *mam_ptr->t_ptr, creature, mam_ptr->m_idx, mam_ptr->t_idx, weapon_damage)) {
+        // 地震・変身は被害者ポインタ無効化を避けるため全打撃終了後に遅延実行する。
+        switch (apply_monster_weapon_chaos_effect(*mam_ptr->m_ptr, weapon, *mam_ptr->t_ptr, creature, mam_ptr->m_idx, mam_ptr->t_idx, weapon_damage)) {
+        case ChaosWeaponDeferred::EARTHQUAKE:
             mam_ptr->do_quake = true;
+            break;
+        case ChaosWeaponDeferred::POLYMORPH_TARGET:
+            mam_ptr->do_polymorph = true;
+            break;
+        case ChaosWeaponDeferred::NONE:
+            break;
         }
 
         // 毒針: 通常ダメージを毒針の即死/1ダメージ判定で上書きする。
@@ -480,6 +489,12 @@ bool monst_attack_monst(CreatureEntity &creature, MONSTER_IDX m_idx, MONSTER_IDX
     }
 
     repeat_melee(creature, mam_ptr);
+
+    // [B-2b10] カオス武器の変身: polymorph_monster は対象を delete/再生成して t_ptr を無効化するため、
+    // 打撃ループ完了後に一度だけ実行する。対象が既に死亡していれば行わない。
+    if (mam_ptr->do_polymorph && mam_ptr->t_ptr->is_valid()) {
+        polymorph_monster(creature, mam_ptr->t_ptr->y, mam_ptr->t_ptr->x);
+    }
 
     // [B-2b5] 地震武器: 全打撃終了後にまとめて地震を起こす (プレイヤーの cause_earthquake 相当)。
     // 打撃ループ中に起こすと floor / monster 参照が無効化されうるため後段で処理する。

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -331,8 +331,9 @@ bool MonsterAttackPlayer::process_monster_attack_hit()
         }
 
         // カオス武器: プレイヤーと同じ確率で吸血/地震/混乱/テレポートの追加効果を与える。
-        // 地震は do_quake 予約に集約する。
-        if (apply_monster_weapon_chaos_effect(*this->m_ptr, weapon, creature, creature, this->m_idx, 0, weapon_damage)) {
+        // 地震は do_quake 予約に集約する。変身 (POLYMORPH_TARGET) はプレイヤーが is_unique の
+        // ため発生しない (念のため無視する)。
+        if (apply_monster_weapon_chaos_effect(*this->m_ptr, weapon, creature, creature, this->m_idx, 0, weapon_damage) == ChaosWeaponDeferred::EARTHQUAKE) {
             this->do_quake = true;
         }
 


### PR DESCRIPTION
B-2b8で保留していたカオス武器の変身効果を、プレイヤーのUNIQUE保護と
被害者ポインタの安全性を確保した上で有効化した。

- apply_monster_weapon_chaos_effect() の戻り値を bool→enum ChaosWeaponDeferred (NONE/EARTHQUAKE/POLYMORPH_TARGET) に変更。混乱/テレポート/吸血は即時、 地震/変身は遅延実行に分類。
- polymorph_monster() は対象を delete/再生成して t_ptr を無効化するため、 mam_type::do_polymorph に予約し monst_attack_monst() の全打撃終了後に一度だけ (対象生存時のみ) 実行。
- 除外条件は attack_polymorph() と同一: is_unique()(プレイヤー・UNIQUE)/QUESTOR/ カオス耐性、加えて randint1(90)>level 抽選。
- プレイヤーは is_unique により変身対象外。対プレイヤー経路は POLYMORPH_TARGET を 返さず EARTHQUAKE のみ処理。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chaos weapons can now polymorph eligible non-unique monsters.
  * Polymorph effects are resolved after all attacks finish, provided the target survives.
* **Bug Fixes**
  * Players remain protected from monster chaos-weapon polymorph effects.
  * Polymorph respects existing protections for unique, quest-related, and chaos-resistant monsters.
  * Deferred earthquake effects now resolve consistently after multi-attack sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->