### PR TITLE
feat: モンスターの魔術ブランド(TR_BRAND_MAGIC)の追加効果を同化

### DIFF
--- a/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
+++ b/VisualStudio/Bakabakaband/Bakabakaband.vcxproj
@@ -834,6 +834,7 @@
     <ClCompile Include="..\..\src\monster-attack\monster-eating.cpp" />
     <ClCompile Include="..\..\src\player-attack\player-attack.cpp" />
     <ClCompile Include="..\..\src\combat\monster-chaos-weapon.cpp" />
+    <ClCompile Include="..\..\src\combat\monster-magical-brand.cpp" />
     <ClCompile Include="..\..\src\combat\slaying.cpp" />
     <ClCompile Include="..\..\src\player-attack\blood-sucking-processor.cpp" />
     <ClCompile Include="..\..\src\object-enchant\vorpal-weapon.cpp" />
@@ -1791,6 +1792,7 @@
     <ClInclude Include="..\..\src\monster-attack\monster-eating.h" />
     <ClInclude Include="..\..\src\player-attack\player-attack.h" />
     <ClInclude Include="..\..\src\combat\monster-chaos-weapon.h" />
+    <ClInclude Include="..\..\src\combat\monster-magical-brand.h" />
     <ClInclude Include="..\..\src\combat\slaying.h" />
     <ClInclude Include="..\..\src\object-enchant\vorpal-weapon.h" />
     <ClInclude Include="..\..\src\floor\floor-object.h" />

--- a/docs/creature-entity-refactoring-roadmap.md
+++ b/docs/creature-entity-refactoring-roadmap.md
@@ -838,6 +838,25 @@ bakabakaband ではプレイヤーとモンスター双方が `CreatureEntity` �
     POLYMORPH_TARGET を返さないため do_polymorph を持たない (EARTHQUAKE のみ処理)
   - **カオス武器を装備したモンスターは非 UNIQUE モンスターを変身させ得るが、プレイヤーは
     変身しない** (is_unique 保護)
+- **B-2b11**: 魔術ブランド (TR_BRAND_MAGIC) の追加効果の同化
+  - 新規 TU `src/combat/monster-magical-brand.{h,cpp}` に
+    `roll_monster_magical_brand_effect()` / `monster_magical_brand_extra_dice()` /
+    `apply_monster_magical_brand_status()` を追加。プレイヤーの `select_magical_brand_effect()` と
+    **同一確率**で効果を抽選 (1/5 STUN → 1/5 SCARE → 1/10 DISPELL → 1/16 PROBE → EXTRA):
+    - **EXTRA (追加ダイス)**: `calc_weapon_melee_damage()` に `extra_damage_dice` 引数を追加し、
+      EXTRA=+1 / STUN・SCARE・DISPELL・PROBE=+2 ダイスを**基本ロールに含めて**スレイ/会心倍率を通す
+      (プレイヤーの `magical_brand_extra_dice` と同じく全効果で追加ダイスが乗る)
+    - **STUN (朦朧)**: プレイヤーは `BadStatusSetter::mod_stun()`、モンスターは NO_STUN・レベル抵抗を
+      経て `set_monster_stunned()`
+    - **SCARE (恐怖)**: プレイヤーは `BadStatusSetter::mod_fear()`、モンスターは NO_FEAR・レベル抵抗を
+      経て `set_monster_monfear()`
+    - **DISPELL (魔力吸収)**: 攻撃能力を持つモンスター標的のみ、`dispel_monster_status()` で強化解除し
+      攻撃側モンスターが `Dice::roll(dd,8)` の MP を回復 (プレイヤーの `attack_dispel` と同式)
+  - **意図的な非適用**: **PROBE** はプレイヤーへの情報提示効果でモンスター攻撃者には無意味なため非適用。
+    **プレイヤー標的への DISPELL** はプレイヤーバフ解呪の単純プリミティブが無いため非適用 (追加ダイス・
+    朦朧・恐怖はプレイヤーにも適用)
+  - **魔術ブランド武器を装備したモンスターは対プレイヤー・対モンスターとも追加ダメージ + 朦朧/恐怖を
+    与え、対モンスターでは魔力吸収も行う**
 - **B-2c**: 近接攻撃の命中ボーナス (11058a278)
   - `to_h` を `check_hit_from_monster_to_player` の power に加算
 - **B-4**: look 表示で装備品/パック品を区別 (145f1fb56)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -229,6 +229,7 @@ hengband_SOURCES = \
 	combat/attack-accuracy.cpp combat/attack-accuracy.h \
 	combat/slaying.cpp combat/slaying.h \
 	combat/monster-chaos-weapon.cpp combat/monster-chaos-weapon.h \
+	combat/monster-magical-brand.cpp combat/monster-magical-brand.h \
 	combat/combat-options-type.h \
 	combat/attack-criticality.cpp combat/attack-criticality.h \
 	combat/shoot.cpp combat/shoot.h \

--- a/src/combat/monster-magical-brand.cpp
+++ b/src/combat/monster-magical-brand.cpp
@@ -1,0 +1,173 @@
+/*!
+ * @brief モンスターが装備した魔術ブランド武器 (TR_BRAND_MAGIC) の追加効果処理
+ * @details
+ * プレイヤーの select_magical_brand_effect() / change_monster_stat() と同じ確率・効果で、
+ * 魔術ブランド武器を装備したモンスターの近接打撃に追加ダイス・朦朧・恐怖・魔力吸収を与える。
+ * 調査 (PROBE) はプレイヤーへの情報提示効果でモンスター攻撃者には意味が無いため非適用。
+ * プレイヤー標的への魔力吸収 (DISPELL) はプレイヤーバフ解呪の単純プリミティブが無いため非適用。
+ */
+
+#include "combat/monster-magical-brand.h"
+#include "monster-race/race-ability-mask.h"
+#include "monster-race/race-flags-resistance.h"
+#include "monster/monster-status-setter.h"
+#include "monster/monster-status.h"
+#include "object-enchant/tr-types.h"
+#include "player-attack/player-attack.h"
+#include "status/bad-status-setter.h"
+#include "system/creature-entity.h"
+#include "system/creature-timed-effect-types.h"
+#include "system/floor/floor-info.h"
+#include "system/item-entity.h"
+#include "system/monrace/monrace-definition.h"
+#include "term/z-rand.h"
+#include "util/dice.h"
+#include <algorithm>
+
+namespace {
+/*!
+ * @brief 状態異常の基本強度 (プレイヤーの attack_stun/scare/confuse と同じ算出)
+ */
+int magical_brand_status_power(CreatureEntity &attacker)
+{
+    return 10 + randint0(attacker.get_level()) / 5;
+}
+
+/*!
+ * @brief 魔術ブランドによる朦朧を対象へ与える (プレイヤー・モンスター両対応)
+ */
+void inflict_magical_stun(CreatureEntity &attacker, CreatureEntity &target, MONSTER_IDX target_m_idx)
+{
+    const auto power = magical_brand_status_power(attacker);
+    if (target.is_player()) {
+        BadStatusSetter(target).mod_stun(static_cast<TIME_EFFECT>(power));
+        return;
+    }
+
+    const auto &monrace = target.get_monrace();
+    if (monrace.resistance_flags.has(MonsterResistanceType::NO_STUN) || evaluate_percent(monrace.level)) {
+        return;
+    }
+
+    set_monster_stunned(*attacker.get_floor(), target_m_idx, target.get_remaining_stun() + power);
+}
+
+/*!
+ * @brief 魔術ブランドによる恐怖を対象へ与える (プレイヤー・モンスター両対応)
+ */
+void inflict_magical_scare(CreatureEntity &attacker, CreatureEntity &target, MONSTER_IDX target_m_idx)
+{
+    const auto power = magical_brand_status_power(attacker);
+    if (target.is_player()) {
+        BadStatusSetter(target).mod_fear(static_cast<TIME_EFFECT>(power));
+        return;
+    }
+
+    const auto &monrace = target.get_monrace();
+    if (monrace.resistance_flags.has(MonsterResistanceType::NO_FEAR) || evaluate_percent(monrace.level)) {
+        return;
+    }
+
+    set_monster_monfear(*attacker.get_floor(), target_m_idx, target.get_remaining_fear() + power);
+}
+
+/*!
+ * @brief 魔術ブランドによる魔力吸収 (対象の強化解除 + 攻撃側の MP 回復)
+ * @details プレイヤーの attack_dispel と同じく、攻撃能力を持つモンスターのみ対象。プレイヤー標的は
+ * バフ解呪の単純プリミティブが無いため非適用。
+ */
+void inflict_magical_dispel(CreatureEntity &attacker, CreatureEntity &target, CreatureEntity &player, MONSTER_IDX target_m_idx)
+{
+    if (target.is_player()) {
+        return;
+    }
+
+    const auto &monrace = target.get_monrace();
+    if (monrace.ability_flags.has_none_of(RF_ABILITY_ATTACK_MASK) && monrace.ability_flags.has_none_of(RF_ABILITY_INDIRECT_MASK)) {
+        return;
+    }
+
+    auto dd = 2;
+    if (target.get_timed_effect(CreatureTimedEffect::DECELERATION)) {
+        dd += 1;
+    }
+    if (target.get_timed_effect(CreatureTimedEffect::ACCELERATION)) {
+        dd += 2;
+    }
+    if (target.get_timed_effect(CreatureTimedEffect::INVULNERABILITY)) {
+        dd += 3;
+    }
+
+    dispel_monster_status(player, target_m_idx);
+    const auto sp = Dice::roll(dd, 8);
+    attacker.set_current_mp(std::min(attacker.get_max_mp(), attacker.get_current_mp() + sp));
+}
+}
+
+/*!
+ * @brief 魔術ブランド (TR_BRAND_MAGIC) の効果を抽選する
+ * @return 抽選された魔術効果。TR_BRAND_MAGIC を持たなければ NONE
+ * @details 確率はプレイヤーの select_magical_brand_effect() と一致させる。
+ */
+MagicalBrandEffectType roll_monster_magical_brand_effect(const ItemEntity &weapon)
+{
+    if (weapon.get_flags().has_not(TR_BRAND_MAGIC)) {
+        return MagicalBrandEffectType::NONE;
+    }
+
+    if (one_in_(5)) {
+        return MagicalBrandEffectType::STUN;
+    }
+
+    if (one_in_(5)) {
+        return MagicalBrandEffectType::SCARE;
+    }
+
+    if (one_in_(10)) {
+        return MagicalBrandEffectType::DISPELL;
+    }
+
+    if (one_in_(16)) {
+        return MagicalBrandEffectType::PROBE;
+    }
+
+    return MagicalBrandEffectType::EXTRA;
+}
+
+/*!
+ * @brief 魔術効果が与える追加ダメージダイス数 (プレイヤーの magical_brand_extra_dice と同じ)
+ */
+int monster_magical_brand_extra_dice(MagicalBrandEffectType effect)
+{
+    switch (effect) {
+    case MagicalBrandEffectType::NONE:
+        return 0;
+    case MagicalBrandEffectType::EXTRA:
+        return 1;
+    default:
+        return 2;
+    }
+}
+
+/*!
+ * @brief 魔術ブランドの状態異常効果 (朦朧/恐怖/魔力吸収) を対象へ適用する
+ * @details 調査 (PROBE) と追加ダイス (EXTRA) は状態異常を伴わないため何もしない
+ * (追加ダイスは calc_weapon_melee_damage 側で反映済み)。
+ */
+void apply_monster_magical_brand_status(CreatureEntity &attacker, MagicalBrandEffectType effect, CreatureEntity &target,
+    CreatureEntity &player, MONSTER_IDX target_m_idx)
+{
+    switch (effect) {
+    case MagicalBrandEffectType::STUN:
+        inflict_magical_stun(attacker, target, target_m_idx);
+        break;
+    case MagicalBrandEffectType::SCARE:
+        inflict_magical_scare(attacker, target, target_m_idx);
+        break;
+    case MagicalBrandEffectType::DISPELL:
+        inflict_magical_dispel(attacker, target, player, target_m_idx);
+        break;
+    default:
+        break;
+    }
+}

--- a/src/combat/monster-magical-brand.h
+++ b/src/combat/monster-magical-brand.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "system/angband.h"
+
+enum class MagicalBrandEffectType;
+class CreatureEntity;
+class ItemEntity;
+
+MagicalBrandEffectType roll_monster_magical_brand_effect(const ItemEntity &weapon);
+int monster_magical_brand_extra_dice(MagicalBrandEffectType effect);
+void apply_monster_magical_brand_status(CreatureEntity &attacker, MagicalBrandEffectType effect, CreatureEntity &target,
+    CreatureEntity &player, MONSTER_IDX target_m_idx);

--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -376,10 +376,13 @@ int calc_attack_damage_with_slay(CreatureEntity &creature, ItemEntity *o_ptr, in
  * ヴォーパルの倍率算出はプレイヤーと同一だが、ルーンソード呪唱 (術者状態) や
  * 斬鉄剣無効化 (対象が非切断) 等の術者/対象文脈依存分岐は武器固有プロパティのみに限定する。
  */
-int calc_weapon_melee_damage(CreatureEntity &attacker, ItemEntity &weapon, CreatureEntity &target, int hand)
+int calc_weapon_melee_damage(CreatureEntity &attacker, ItemEntity &weapon, CreatureEntity &target, int hand, int extra_damage_dice)
 {
     const auto flags = weapon.get_flags();
-    auto damage = calc_attack_damage_with_slay(attacker, &weapon, weapon.damage_dice.roll(), target, HISSATSU_NONE, false);
+    // 魔術ブランド (TR_BRAND_MAGIC) 等による追加ダイスは、プレイヤーと同じく基本ロールに含めて
+    // スレイ/ブランド/会心の各倍率を通す。
+    const auto base_roll = Dice::roll(weapon.damage_dice.num + extra_damage_dice, weapon.damage_dice.sides);
+    auto damage = calc_attack_damage_with_slay(attacker, &weapon, base_roll, target, HISSATSU_NONE, false);
     damage = critical_norm(attacker, weapon.weight, weapon.to_h, damage, attacker.get_to_h(hand), HISSATSU_NONE, flags.has(TR_IMPACT));
 
     // ヴォーパル (メッタ斬り): プレイヤーの process_vorpal_attack() と同一の倍率算出。

--- a/src/combat/slaying.h
+++ b/src/combat/slaying.h
@@ -13,7 +13,7 @@ class CreatureEntity;
 MULTIPLY mult_slaying(CreatureEntity &creature, MULTIPLY mult, const TrFlags &flags, CreatureEntity &target);
 MULTIPLY mult_brand(CreatureEntity &creature, MULTIPLY mult, const TrFlags &flags, CreatureEntity &target);
 int calc_attack_damage_with_slay(CreatureEntity &creature, ItemEntity *o_ptr, int tdam, CreatureEntity &target, combat_options mode, bool thrown);
-int calc_weapon_melee_damage(CreatureEntity &attacker, ItemEntity &weapon, CreatureEntity &target, int hand);
+int calc_weapon_melee_damage(CreatureEntity &attacker, ItemEntity &weapon, CreatureEntity &target, int hand, int extra_damage_dice = 0);
 int drain_life_to_attacker(CreatureEntity &attacker, const CreatureEntity &target, int amount);
 int apply_weapon_vampiric_drain(CreatureEntity &attacker, const ItemEntity &weapon, const CreatureEntity &target, int weapon_damage);
 tl::optional<int> poison_needle_blow_damage(const ItemEntity &weapon, const CreatureEntity &target);

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -9,6 +9,7 @@
 #include "combat/combat-options-type.h"
 #include "combat/hallucination-attacks-table.h"
 #include "combat/monster-chaos-weapon.h"
+#include "combat/monster-magical-brand.h"
 #include "combat/slaying.h"
 #include "core/disturbance.h"
 #include "dungeon/dungeon-flag-types.h"
@@ -324,7 +325,9 @@ static void process_melee(CreatureEntity &creature, mam_type *mam_ptr)
     if (!mam_ptr->explode && (mam_ptr->weapon_slot_for_blow >= 0)) {
         auto &weapon = *mam_ptr->m_ptr->inventory[mam_ptr->weapon_slot_for_blow];
         const auto hand = mam_ptr->weapon_slot_for_blow - enum2i(INVEN_MAIN_HAND);
-        const auto weapon_damage = calc_weapon_melee_damage(*mam_ptr->m_ptr, weapon, *mam_ptr->t_ptr, hand);
+        // 魔術ブランド (TR_BRAND_MAGIC): 効果を抽選し、追加ダイスを武器ダメージへ含める。
+        const auto magical_effect = roll_monster_magical_brand_effect(weapon);
+        const auto weapon_damage = calc_weapon_melee_damage(*mam_ptr->m_ptr, weapon, *mam_ptr->t_ptr, hand, monster_magical_brand_extra_dice(magical_effect));
         mam_ptr->damage += weapon_damage;
 
         // 吸血武器: プレイヤーの吸血処理と同じく、生命のある対象から HP を吸収して回復する。
@@ -358,6 +361,9 @@ static void process_melee(CreatureEntity &creature, mam_type *mam_ptr)
         case ChaosWeaponDeferred::NONE:
             break;
         }
+
+        // 魔術ブランド: 追加ダイスは上で反映済み。朦朧/恐怖/魔力吸収の状態異常を適用する。
+        apply_monster_magical_brand_status(*mam_ptr->m_ptr, magical_effect, *mam_ptr->t_ptr, creature, mam_ptr->t_idx);
 
         // 毒針: 通常ダメージを毒針の即死/1ダメージ判定で上書きする。
         // UNIQUE (プレイヤー含む) と NO_INSTANTLY_DEATH 耐性の対象は即死しない。

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -13,6 +13,7 @@
 #include "combat/combat-options-type.h"
 #include "combat/hallucination-attacks-table.h"
 #include "combat/monster-chaos-weapon.h"
+#include "combat/monster-magical-brand.h"
 #include "combat/slaying.h"
 #include "core/disturbance.h"
 #include "dungeon/dungeon-flag-types.h"
@@ -312,7 +313,9 @@ bool MonsterAttackPlayer::process_monster_attack_hit()
     if (!this->explode && this->weapon_slot_for_blow >= 0) {
         auto &weapon = *this->m_ptr->inventory[this->weapon_slot_for_blow];
         const auto hand = this->weapon_slot_for_blow - enum2i(INVEN_MAIN_HAND);
-        const auto weapon_damage = calc_weapon_melee_damage(*this->m_ptr, weapon, creature, hand);
+        // 魔術ブランド (TR_BRAND_MAGIC): 効果を抽選し、追加ダイスを武器ダメージへ含める。
+        const auto magical_effect = roll_monster_magical_brand_effect(weapon);
+        const auto weapon_damage = calc_weapon_melee_damage(*this->m_ptr, weapon, creature, hand, monster_magical_brand_extra_dice(magical_effect));
         this->damage += weapon_damage;
 
         // 吸血武器: プレイヤーの吸血処理と同じく、生命のあるプレイヤーから HP を吸収して回復する。
@@ -336,6 +339,10 @@ bool MonsterAttackPlayer::process_monster_attack_hit()
         if (apply_monster_weapon_chaos_effect(*this->m_ptr, weapon, creature, creature, this->m_idx, 0, weapon_damage) == ChaosWeaponDeferred::EARTHQUAKE) {
             this->do_quake = true;
         }
+
+        // 魔術ブランド: 追加ダイスは上で反映済み。朦朧/恐怖の状態異常を適用する
+        // (魔力吸収 DISPELL はプレイヤーバフ解呪プリミティブが無いため非対象)。
+        apply_monster_magical_brand_status(*this->m_ptr, magical_effect, creature, creature, this->m_idx);
 
         // 毒針: 通常ダメージを毒針の即死/1ダメージ判定で上書きする。
         // プレイヤーは UNIQUE 扱い (is_unique) のため即死せず 1 ダメージに抑えられる。


### PR DESCRIPTION
魔術ブランド武器を装備したモンスターの近接打撃に、プレイヤーと同一確率の
追加効果(追加ダイス/朦朧/恐怖/魔力吸収)を与えるようにした。

- 新規 src/combat/monster-magical-brand.{h,cpp} に効果抽選/追加ダイス/状態異常適用を追加。 select_magical_brand_effect() と同確率 (1/5 STUN, 1/5 SCARE, 1/10 DISPELL, 1/16 PROBE, else EXTRA)。
- EXTRA(追加ダイス): calc_weapon_melee_damage() に extra_damage_dice 引数を追加し、 EXTRA=+1 / 他=+2 ダイスを基本ロールに含めてスレイ/会心倍率を通す。
- STUN: BadStatusSetter::mod_stun() (PC) / set_monster_stunned() (NPC, NO_STUN・レベル抵抗)。
- SCARE: BadStatusSetter::mod_fear() (PC) / set_monster_monfear() (NPC, NO_FEAR・レベル抵抗)。
- DISPELL: 攻撃能力持ちモンスター標的のみ dispel_monster_status() + 攻撃側 MP 回復。
- 非適用: PROBE(プレイヤー情報提示で攻撃者に無意味) / プレイヤー標的への DISPELL (バフ解呪プリミティブ無し)。追加ダイス・朦朧・恐怖はプレイヤーにも適用。
- 両経路に配線。Makefile.am 登録済み。